### PR TITLE
Fixed shadowed Property variable

### DIFF
--- a/SpatialGDK/Public/SpatialTypeBinding.h
+++ b/SpatialGDK/Public/SpatialTypeBinding.h
@@ -139,14 +139,14 @@ public:
 			{
 				Offset += Property->GetOffset_ForInternal();
 			}
-			UStructProperty* StructProperty = Cast<UStructProperty>(Property);
+			UStructProperty* StructProperty = Cast<UStructProperty>(CurProperty);
 			if (StructProperty)
 			{
 				CurrentContainerType = StructProperty->Struct;
 			}
 			else
 			{
-				UObjectProperty* ObjectProperty = Cast<UObjectProperty>(Property);
+				UObjectProperty* ObjectProperty = Cast<UObjectProperty>(CurProperty);
 				if (ObjectProperty)
 				{
 					CurrentContainerType = ObjectProperty->PropertyClass;


### PR DESCRIPTION
`Property` was both a member variable and a local variable, generating warnings and confusion.

This is a trivial PR, but @davedissian please confirm I modified the right variables.