### PR TITLE
4.19 compatibility (UNR-127)

### DIFF
--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
@@ -1696,8 +1696,10 @@ void GenerateFunction_RPCOnCommandRequest(FCodeWriter& SourceWriter, UClass* Cla
 			FString PropertyValueCppType = Param.Value->Property->GetCPPType(&PropertyTemplateType);
 			FString PropertyValueName = Param.Value->Property->GetNameCPP();
 
-			// TODO: UNR-152
-			if (PropertyTemplateType.Len() > 0) {
+			// TODO: UNR-152 - this should be factored out to a utility function somewhere
+			if (Param.Value->Property->IsA(UArrayProperty::StaticClass()) && PropertyTemplateType.Len() > 0)
+			{
+				// Append the template type if it exists.
 				SourceWriter.Printf("%s%s %s;", *PropertyValueCppType, *PropertyTemplateType, *PropertyValueName);
 			}
 			else {
@@ -1714,9 +1716,10 @@ void GenerateFunction_RPCOnCommandRequest(FCodeWriter& SourceWriter, UClass* Cla
 		for (auto Param : GetFlatRPCParameters(RPC))
 		{
 			// TODO: UNR-152
-			FString PropertyValueCppType = Param->Property->GetCPPType();
-			FString PropertyValueName = Param->Property->GetNameCPP();
-			if (PropertyValueCppType.Equals(FString("TArray"))) {
+			if (Param->Property->IsA(UArrayProperty::StaticClass()))
+			{
+				FString PropertyValueCppType = Param->Property->GetCPPType();
+				FString PropertyValueName = Param->Property->GetNameCPP();
 				SourceWriter.Printf("// UNSUPPORTED TArray parameters (%s %s)", *PropertyValueCppType, *PropertyValueName);
 				continue;
 			}

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
@@ -1554,7 +1554,8 @@ void GenerateFunction_RPCSendCommand(FCodeWriter& SourceWriter, UClass* Class, c
 		for (TFieldIterator<UProperty> Param(RPC->Function); Param; ++Param)
 		{
 			// TODO: UNR-152
-			if (Param->IsA(UArrayProperty::StaticClass())) {
+			if (Param->IsA(UArrayProperty::StaticClass()))
+			{
 				FString ParamTypeName = GetFullCPPName((*Param)->GetClass());
 				FString ParamName = (*Param)->GetName();
 				SourceWriter.Printf("// UNSUPPORTED TArray parameters (%s %s)", *ParamTypeName, *ParamName);
@@ -1572,7 +1573,10 @@ void GenerateFunction_RPCSendCommand(FCodeWriter& SourceWriter, UClass* Class, c
 	for (TFieldIterator<UProperty> Param(RPC->Function); Param; ++Param)
 	{
 		// TODO: UNR-152
-		if (Param->IsA(UArrayProperty::StaticClass())) continue;
+		if (Param->IsA(UArrayProperty::StaticClass()))
+		{
+			continue;
+		}
 
 		CapturedArguments.Add((*Param)->GetName());
 	}
@@ -1595,7 +1599,8 @@ void GenerateFunction_RPCSendCommand(FCodeWriter& SourceWriter, UClass* Class, c
 	for (auto Param : RPCParameters)
 	{
 		// TODO: UNR-152
-		if (Param->Property->IsA(UArrayProperty::StaticClass())) {
+		if (Param->Property->IsA(UArrayProperty::StaticClass()))
+		{
 			FString ParamName = CPPFieldName(Param);
 			SourceWriter.Printf("// UNSUPPORTED TArray parameters (%s)", *ParamName);
 			continue;

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
@@ -1553,6 +1553,14 @@ void GenerateFunction_RPCSendCommand(FCodeWriter& SourceWriter, UClass* Class, c
 		SourceWriter.Print("FFrame& Stack = *RPCFrame;");
 		for (TFieldIterator<UProperty> Param(RPC->Function); Param; ++Param)
 		{
+			// TODO: UNR-152
+			if (Param->IsA(UArrayProperty::StaticClass())) {
+				FString ParamTypeName = GetFullCPPName((*Param)->GetClass());
+				FString ParamName = (*Param)->GetName();
+				SourceWriter.Printf("// UNSUPPORTED TArray parameters (%s %s)", *ParamTypeName, *ParamName);
+				continue;
+			}
+
 			SourceWriter.Print(*GenerateFFramePropertyReader(*Param));
 		}
 		SourceWriter.PrintNewLine();
@@ -1563,6 +1571,9 @@ void GenerateFunction_RPCSendCommand(FCodeWriter& SourceWriter, UClass* Class, c
 	CapturedArguments.Add(TEXT("TargetObject"));
 	for (TFieldIterator<UProperty> Param(RPC->Function); Param; ++Param)
 	{
+		// TODO: UNR-152
+		if (Param->IsA(UArrayProperty::StaticClass())) continue;
+
 		CapturedArguments.Add((*Param)->GetName());
 	}
 	SourceWriter.Printf("auto Sender = [this, Connection, %s]() mutable -> FRPCCommandRequestResult", *FString::Join(CapturedArguments, TEXT(", ")));
@@ -1583,6 +1594,13 @@ void GenerateFunction_RPCSendCommand(FCodeWriter& SourceWriter, UClass* Class, c
 	TArray<TSharedPtr<FUnrealProperty>> RPCParameters = GetFlatRPCParameters(RPC);
 	for (auto Param : RPCParameters)
 	{
+		// TODO: UNR-152
+		if (Param->Property->IsA(UArrayProperty::StaticClass())) {
+			FString ParamName = CPPFieldName(Param);
+			SourceWriter.Printf("// UNSUPPORTED TArray parameters (%s)", *ParamName);
+			continue;
+		}
+
 		FString SpatialValueSetter = TEXT("Request.set_") + SchemaFieldName(Param);
 
 		GenerateUnrealToSchemaConversion(
@@ -1674,9 +1692,18 @@ void GenerateFunction_RPCOnCommandRequest(FCodeWriter& SourceWriter, UClass* Cla
 		SourceWriter.Print("// Declare parameters.");
 		for (auto Param : RPC->Parameters)
 		{
-			FString PropertyValueCppType = Param.Value->Property->GetCPPType();
+			FString PropertyTemplateType;
+			FString PropertyValueCppType = Param.Value->Property->GetCPPType(&PropertyTemplateType);
 			FString PropertyValueName = Param.Value->Property->GetNameCPP();
-			SourceWriter.Printf("%s %s;", *PropertyValueCppType, *PropertyValueName);
+
+			// TODO: UNR-152
+			if (PropertyTemplateType.Len() > 0) {
+				SourceWriter.Printf("%s%s %s;", *PropertyValueCppType, *PropertyTemplateType, *PropertyValueName);
+			}
+			else {
+				SourceWriter.Printf("%s %s;", *PropertyValueCppType, *PropertyValueName);
+			}
+
 			RPCParameters.Add(PropertyValueName);
 		}
 
@@ -1686,6 +1713,14 @@ void GenerateFunction_RPCOnCommandRequest(FCodeWriter& SourceWriter, UClass* Cla
 		
 		for (auto Param : GetFlatRPCParameters(RPC))
 		{
+			// TODO: UNR-152
+			FString PropertyValueCppType = Param->Property->GetCPPType();
+			FString PropertyValueName = Param->Property->GetNameCPP();
+			if (PropertyValueCppType.Equals(FString("TArray"))) {
+				SourceWriter.Printf("// UNSUPPORTED TArray parameters (%s %s)", *PropertyValueCppType, *PropertyValueName);
+				continue;
+			}
+
 			FString SpatialValue = FString::Printf(TEXT("%s.%s()"), TEXT("Op.Request"), *SchemaFieldName(Param));
 
 			GeneratePropertyToUnrealConversion(

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Note that a majority of the items below are on our short term roadmap.
 
 ## Engine changes:
 
-There is a small number of changes to UE4 source code we have to make. These changes are mostly limited in scope and they only consist of class access, polymorphism, and dll export related changes. We will attempt to consolidate and remove (or submit as PR to Epic) as many of these changes as possible. Our changes can be seen in our `UnrealEngine` repo, `UnrealEngine417_NUF` branch. 
+There is a small number of changes to UE4 source code we have to make. These changes are mostly limited in scope and they only consist of class access, polymorphism, and dll export related changes. We will attempt to consolidate and remove (or submit as PR to Epic) as many of these changes as possible. Our changes can be seen in our `UnrealEngine` repo, `UnrealEngine419_SpatialGDK` branch. 
 
 ## How to use:
 

--- a/SpatialGDK/Private/SpatialNetConnection.cpp
+++ b/SpatialGDK/Private/SpatialNetConnection.cpp
@@ -38,7 +38,7 @@ void USpatialNetConnection::InitRemoteConnection(UNetDriver* InDriver, class FSo
 
 }
 
-bool USpatialNetConnection::ClientHasInitializedLevelFor(const UObject* TestObject) const
+bool USpatialNetConnection::ClientHasInitializedLevelFor(const AActor* TestActor) const
 {
 	check(Driver->IsServer());
 	return true;

--- a/SpatialGDK/Private/SpatialNetDriver.cpp
+++ b/SpatialGDK/Private/SpatialNetDriver.cpp
@@ -32,7 +32,7 @@ bool USpatialNetDriver::InitBase(bool bInitAsClient, FNetworkNotify* InNotify, c
 	FCoreUObjectDelegates::PostLoadMapWithWorld.AddUObject(this, &USpatialNetDriver::OnMapLoaded);
 
 	// Make absolutely sure that the actor channel that we are using is our Spatial actor channel
-	UChannel::ChannelClasses[CHTYPE_Actor] = USpatialActorChannel::StaticClass();
+	ChannelClasses[CHTYPE_Actor] = USpatialActorChannel::StaticClass();
 
 	// Create SpatialOS instance and setup callbacks.
 	SpatialOSInstance = NewObject<USpatialOS>(this);
@@ -862,7 +862,7 @@ USpatialNetConnection* USpatialNetDriver::AcceptNewPlayer(const FURL& InUrl, boo
 	if (bOk)
 	{
 		FString LevelName = GetWorld()->GetCurrentLevel()->GetOutermost()->GetName();
-		Connection->ClientWorldPackageName = GetWorld()->GetCurrentLevel()->GetOutermost()->GetFName();
+		Connection->SetClientWorldPackageName(GetWorld()->GetCurrentLevel()->GetOutermost()->GetFName());
 
 		FString GameName;
 		FString RedirectURL;

--- a/SpatialGDK/Public/SpatialNetConnection.h
+++ b/SpatialGDK/Public/SpatialNetConnection.h
@@ -20,7 +20,7 @@ public:
 	virtual void InitRemoteConnection(UNetDriver* InDriver, class FSocket* InSocket, const FURL& InURL, const class FInternetAddr& InRemoteAddr, EConnectionState InState, int32 InMaxPacket = 0, int32 InPacketOverhead = 0) override;
 	virtual void InitLocalConnection(UNetDriver* InDriver, class FSocket* InSocket, const FURL& InURL, EConnectionState InState, int32 InMaxPacket = 0, int32 InPacketOverhead = 0) override;
 	virtual void LowLevelSend(void* Data, int32 CountBytes, int32 CountBits) override;
-	virtual bool ClientHasInitializedLevelFor(const UObject* TestObject) const override;
+	virtual bool ClientHasInitializedLevelFor(const AActor* TestActor) const override;
 	virtual void Tick() override;
 	
 	// These functions don't make a lot of sense in a SpatialOS implementation.

--- a/SpatialGDK/SpatialGDK.Build.cs
+++ b/SpatialGDK/SpatialGDK.Build.cs
@@ -38,7 +38,8 @@ public class SpatialGDK : ModuleRules
                 "InputCore"
             });
 
-		if (UEBuildConfiguration.bBuildEditor == true)
+		// Check if we're building in the editor.
+		if (Target.bBuildEditor)
 		{
 			// Required by USpatialGameInstance::StartPlayInEditorGameInstance.
 			PublicDependencyModuleNames.Add("UnrealEd");


### PR DESCRIPTION
Mainly C++ fixes for 4.19 compatibility.

UE 4.18 or 4.19 introduced an RPC to `ACharacter` with a `TArray` argument, so I had to disable generating RPC argument interop for `TArray` arguments because of a few compile errors in the generated code. Documented those issues in JIRA in UNR-152 and UNR-153.

See engine changes in github.com/improbable/UnrealEngine branch UnrealEngine419_SpatialGDK

Sample Game README changes in https://github.com/improbable/unreal-gdk-sample-game/pull/6