### PR TITLE
[UNR-171] Removing Spawner blueprint requirement.

### DIFF
--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorGenerateSnapshot.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorGenerateSnapshot.cpp
@@ -28,13 +28,26 @@ namespace {
 worker::Entity CreateSpawnerEntity()
 {
 	const Coordinates InitialPosition{0, 0, 0};
+	improbable::WorkerAttributeSet WorkerAttribute{ { worker::List<std::string>{"UnrealWorker"} } };
+	improbable::WorkerRequirementSet WorkersOnly{ { WorkerAttribute } };
+
+	improbable::unreal::UnrealMetadata::Data UnrealMetadata;
+	//if (Channel->Actor->IsFullNameStableForNetworking())
+	//{
+	//	UnrealMetadata.set_static_path({ std::string{ TCHAR_TO_UTF8(*Channel->Actor->GetPathName(Channel->Actor->GetWorld())) } });
+	//}
+	//if (!ClientWorkerIdString.empty())
+	//{
+	//	UnrealMetadata.set_owner_worker_id({ ClientWorkerIdString });
+	//}
 
 	return improbable::unreal::FEntityBuilder::Begin()
 		.AddPositionComponent(Position::Data{InitialPosition}, UnrealWorkerWritePermission)
-		.AddMetadataComponent(Metadata::Data("Spawner"))
+		.AddMetadataComponent(Metadata::Data("SpatialSpawner"))
 		.SetPersistence(true)
 		.SetReadAcl(AnyWorkerReadPermission)
 		.AddComponent<unreal::PlayerSpawner>(unreal::PlayerSpawner::Data{}, UnrealWorkerWritePermission)
+		.AddComponent<improbable::unreal::UnrealMetadata>(UnrealMetadata, WorkersOnly)
 		.Build();
 }
 

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorGenerateSnapshot.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorGenerateSnapshot.cpp
@@ -30,16 +30,7 @@ worker::Entity CreateSpawnerEntity()
 	const Coordinates InitialPosition{0, 0, 0};
 	improbable::WorkerAttributeSet WorkerAttribute{ { worker::List<std::string>{"UnrealWorker"} } };
 	improbable::WorkerRequirementSet WorkersOnly{ { WorkerAttribute } };
-
 	improbable::unreal::UnrealMetadata::Data UnrealMetadata;
-	//if (Channel->Actor->IsFullNameStableForNetworking())
-	//{
-	//	UnrealMetadata.set_static_path({ std::string{ TCHAR_TO_UTF8(*Channel->Actor->GetPathName(Channel->Actor->GetWorld())) } });
-	//}
-	//if (!ClientWorkerIdString.empty())
-	//{
-	//	UnrealMetadata.set_owner_worker_id({ ClientWorkerIdString });
-	//}
 
 	return improbable::unreal::FEntityBuilder::Begin()
 		.AddPositionComponent(Position::Data{InitialPosition}, UnrealWorkerWritePermission)

--- a/SpatialGDK/Private/SpatialInteropPipelineBlock.cpp
+++ b/SpatialGDK/Private/SpatialInteropPipelineBlock.cpp
@@ -301,6 +301,7 @@ AActor* USpatialInteropPipelineBlock::GetOrCreateActor(TSharedPtr<worker::Connec
 	// 3) A SpawnActor() call that was initiated from a different worker, which means we need to find and spawn the corresponding "native" actor that corresponds to it.
 	//	  This can happen on either the client (for all actors) or server (for actors which were spawned by a different server worker, or are migrated).
 
+	// This is the worker which made the actor.=, so it just associates the entityID with the actor.
 	if (EntityActor)
 	{
 		// Option 1
@@ -319,6 +320,7 @@ AActor* USpatialInteropPipelineBlock::GetOrCreateActor(TSharedPtr<worker::Connec
 	else
 	{
 		UClass* ActorClass = nullptr;
+		// GetRegisteredEntityClass is the part looking for a blueprint.
 		if ((ActorClass = GetRegisteredEntityClass(MetadataComponent)) != nullptr)
 		{
 			// Option 2
@@ -326,7 +328,8 @@ AActor* USpatialInteropPipelineBlock::GetOrCreateActor(TSharedPtr<worker::Connec
 			EntityActor = SpawnNewEntity(PositionComponent, ActorClass);
 			EntityRegistry->AddToRegistry(EntityId, EntityActor);
 		}
-		else if ((ActorClass = GetNativeEntityClass(MetadataComponent)) != nullptr)
+		// This finds an UnrealClass, doesn't have to be a blueprint.
+		else if ((ActorClass = GetNativeEntityClass(MetadataComponent)) != nullptr) // Conditional hack to detect that we are creating a player spawner.
 		{
 			// Option 3
 			UNetConnection* Connection = nullptr;

--- a/SpatialGDK/Private/SpatialInteropPipelineBlock.cpp
+++ b/SpatialGDK/Private/SpatialInteropPipelineBlock.cpp
@@ -300,6 +300,7 @@ AActor* USpatialInteropPipelineBlock::GetOrCreateActor(TSharedPtr<worker::Connec
 	// 2) A "pure" Spatial create entity request, which means we need to spawn an actor that was manually registered to correspond to it.
 	// 3) A SpawnActor() call that was initiated from a different worker, which means we need to find and spawn the corresponding "native" actor that corresponds to it.
 	//	  This can happen on either the client (for all actors) or server (for actors which were spawned by a different server worker, or are migrated).
+
 	if (EntityActor)
 	{
 		// Option 1

--- a/SpatialGDK/Private/SpatialInteropPipelineBlock.cpp
+++ b/SpatialGDK/Private/SpatialInteropPipelineBlock.cpp
@@ -300,8 +300,6 @@ AActor* USpatialInteropPipelineBlock::GetOrCreateActor(TSharedPtr<worker::Connec
 	// 2) A "pure" Spatial create entity request, which means we need to spawn an actor that was manually registered to correspond to it.
 	// 3) A SpawnActor() call that was initiated from a different worker, which means we need to find and spawn the corresponding "native" actor that corresponds to it.
 	//	  This can happen on either the client (for all actors) or server (for actors which were spawned by a different server worker, or are migrated).
-
-	// This is the worker which made the actor.=, so it just associates the entityID with the actor.
 	if (EntityActor)
 	{
 		// Option 1
@@ -320,7 +318,6 @@ AActor* USpatialInteropPipelineBlock::GetOrCreateActor(TSharedPtr<worker::Connec
 	else
 	{
 		UClass* ActorClass = nullptr;
-		// GetRegisteredEntityClass is the part looking for a blueprint.
 		if ((ActorClass = GetRegisteredEntityClass(MetadataComponent)) != nullptr)
 		{
 			// Option 2
@@ -328,8 +325,7 @@ AActor* USpatialInteropPipelineBlock::GetOrCreateActor(TSharedPtr<worker::Connec
 			EntityActor = SpawnNewEntity(PositionComponent, ActorClass);
 			EntityRegistry->AddToRegistry(EntityId, EntityActor);
 		}
-		// This finds an UnrealClass, doesn't have to be a blueprint.
-		else if ((ActorClass = GetNativeEntityClass(MetadataComponent)) != nullptr) // Conditional hack to detect that we are creating a player spawner.
+		else if ((ActorClass = GetNativeEntityClass(MetadataComponent)) != nullptr)
 		{
 			// Option 3
 			UNetConnection* Connection = nullptr;


### PR DESCRIPTION
What?
https://improbableio.atlassian.net/browse/UNR-171
This PR edits the snapshot generator to not require a Spawner blueprint in order to create a Spawner.
In conjunction with PR: https://github.com/improbable/unreal-gdk-sample-game/pull/12

Test
Built and ran SampleGame, remade the snapshot and deleted the Spawner blueprint. Ran two clients as before with no change in functionality.