### PR TITLE
[UNR-95] - User defined classes and header includes via .ini file.

### DIFF
--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SchemaGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SchemaGenerator.cpp
@@ -230,6 +230,13 @@ int GenerateTypeBindingSchema(FCodeWriter& Writer, int ComponentId, UClass* Clas
 	// RPC components.
 	FUnrealRPCsByType RPCsByType = GetAllRPCsByType(TypeInfo);
 	TArray<FString> RPCTypeOwners = GetRPCTypeOwners(TypeInfo);
+
+	// Remove underscores
+	for(auto& RPCTypeOwner : RPCTypeOwners)
+	{
+		RPCTypeOwner = UnrealNameToSchemaTypeName(RPCTypeOwner);
+	}
+
 	TMap<FString, TSharedPtr<FCodeWriter>> RPCTypeCodeWriterMap;
 
 	for (auto& RPCTypeOwner : RPCTypeOwners)

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
@@ -563,7 +563,7 @@ void GenerateTypeBindingHeader(FCodeWriter& HeaderWriter, FString SchemaFilename
 	HeaderWriter.Print("};");
 }
 
-void GenerateTypeBindingSource(FCodeWriter& SourceWriter, FString SchemaFilename, FString InteropFilename, UClass* Class, const TSharedPtr<FUnrealType> TypeInfo, const TArray<FString>& TypeBindingHeaders)
+void GenerateTypeBindingSource(FCodeWriter& SourceWriter, FString SchemaFilename, FString InteropFilename, UClass* Class, const TSharedPtr<FUnrealType>& TypeInfo, const TArray<FString>& TypeBindingHeaders)
 {
 	SourceWriter.Printf(R"""(
 		// Copyright (c) Improbable Worlds Ltd, All Rights Reserved

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
@@ -563,7 +563,7 @@ void GenerateTypeBindingHeader(FCodeWriter& HeaderWriter, FString SchemaFilename
 	HeaderWriter.Print("};");
 }
 
-void GenerateTypeBindingSource(FCodeWriter& SourceWriter, FString SchemaFilename, FString InteropFilename, UClass* Class, const TSharedPtr<FUnrealType> TypeInfo, TArray<FString> TypeBindingHeaders)
+void GenerateTypeBindingSource(FCodeWriter& SourceWriter, FString SchemaFilename, FString InteropFilename, UClass* Class, const TSharedPtr<FUnrealType> TypeInfo, const TArray<FString>& TypeBindingHeaders)
 {
 	SourceWriter.Printf(R"""(
 		// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
@@ -586,7 +586,7 @@ void GenerateTypeBindingSource(FCodeWriter& SourceWriter, FString SchemaFilename
 		#include "SpatialInterop.h")""", *InteropFilename);
 
 	// Add the header files specified in DefaultEditorSpatialGDK.ini.
-	for (FString& Header : TypeBindingHeaders)
+	for (const FString& Header : TypeBindingHeaders)
 	{
 		if (!Header.IsEmpty())
 		{

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
@@ -563,7 +563,7 @@ void GenerateTypeBindingHeader(FCodeWriter& HeaderWriter, FString SchemaFilename
 	HeaderWriter.Print("};");
 }
 
-void GenerateTypeBindingSource(FCodeWriter& SourceWriter, FString SchemaFilename, FString InteropFilename, UClass* Class, const TSharedPtr<FUnrealType> TypeInfo)
+void GenerateTypeBindingSource(FCodeWriter& SourceWriter, FString SchemaFilename, FString InteropFilename, UClass* Class, const TSharedPtr<FUnrealType> TypeInfo, TArray<FString> TypeBindingHeaders)
 {
 	SourceWriter.Printf(R"""(
 		// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
@@ -585,17 +585,13 @@ void GenerateTypeBindingSource(FCodeWriter& SourceWriter, FString SchemaFilename
 		#include "SpatialNetDriver.h"
 		#include "SpatialInterop.h")""", *InteropFilename);
 
-	// TODO: Temporary Hack, need to come up with generic solution. See TIG-138
-	if (Class->GetName().Contains("WheeledVehicle"))
+	// Add the header files specified in DefaultEditorSpatialGDK.ini.
+	for (FString& Header : TypeBindingHeaders)
 	{
-		SourceWriter.Printf(R"""(
-		#include "WheeledVehicle.h"
-		#include "WheeledVehicleMovementComponent.h")""");
-	}
-	else if (Class->GetName().Contains("PlayerController"))
-	{
-		SourceWriter.Printf(R"""(
-		#include "Camera/CameraAnim.h")""");
+		if (!Header.IsEmpty())
+		{
+			SourceWriter.Printf("#include \"%s\"", *Header);
+		}
 	}
 
 	SourceWriter.PrintNewLine();

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
@@ -48,7 +48,7 @@ void GenerateTypeBindingSource(
 	FString InteropFilename,
 	UClass* Class,
 	const TSharedPtr<FUnrealType> TypeInfo,
-	TArray<FString> TypeBindingHeaders);
+	const TArray<FString>& TypeBindingHeaders);
 
 // Helper functions used when generating the source file.
 void GenerateFunction_GetRepHandlePropertyMap(FCodeWriter& SourceWriter, UClass* Class, const FUnrealFlatRepData& RepData);

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
@@ -47,7 +47,7 @@ void GenerateTypeBindingSource(
 	FString SchemaFilename,
 	FString InteropFilename,
 	UClass* Class,
-	const TSharedPtr<FUnrealType> TypeInfo,
+	const TSharedPtr<FUnrealType>& TypeInfo,
 	const TArray<FString>& TypeBindingHeaders);
 
 // Helper functions used when generating the source file.

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
@@ -47,7 +47,8 @@ void GenerateTypeBindingSource(
 	FString SchemaFilename,
 	FString InteropFilename,
 	UClass* Class,
-	const TSharedPtr<FUnrealType> TypeInfo);
+	const TSharedPtr<FUnrealType> TypeInfo,
+	TArray<FString> TypeBindingHeaders);
 
 // Helper functions used when generating the source file.
 void GenerateFunction_GetRepHandlePropertyMap(FCodeWriter& SourceWriter, UClass* Class, const FUnrealFlatRepData& RepData);


### PR DESCRIPTION
What?
Threw together a solution for the .ini file idea specified in :https://docs.google.com/document/d/1ucVykJFN5dDTTrSrcRgmqI3F7wRKb5yt4pZQR4c3cSk/edit#heading=h.bdey6ri4av70

https://improbableio.atlassian.net/browse/UNR-95

How?
Using Unreal's ini file handling we just parse the "DefaultEditorSpatialGDK.ini" and get the section "UserInteropCodeGenSettings". Here we have defined class names and associated headers, see SampleGame PR: 
https://github.com/improbable/unreal-gdk-sample-game/pull/14

Tested?
Works exactly the same as the hard-coded version but now you can just edit the ini file whenever you want :D