### PR TITLE
Fix bitreader overflow error

### DIFF
--- a/SpatialGDK/Private/SpatialInteropPipelineBlock.cpp
+++ b/SpatialGDK/Private/SpatialInteropPipelineBlock.cpp
@@ -402,7 +402,8 @@ AActor* USpatialInteropPipelineBlock::GetOrCreateActor(TSharedPtr<worker::Connec
 				if (EntityActor->IsA(APlayerController::StaticClass()))
 				{
 					uint8 PlayerIndex = 0;
-					FInBunch Bunch(NetDriver->ServerConnection, &PlayerIndex, sizeof(PlayerIndex));
+					// FInBunch takes size in bits not bytes
+					FInBunch Bunch(NetDriver->ServerConnection, &PlayerIndex, sizeof(PlayerIndex)*8);
 					EntityActor->OnActorChannelOpen(Bunch, NetDriver->ServerConnection);
 				}
 				else


### PR DESCRIPTION
Bit reader overflow error fix in initial actor channel bunch for player controllers.

When the bunch was de-serialised, it expects 8 bits for the player index, but only 1 was available. This occurs in APlayerController::OnActorChannelOpen() on the NetPlayerIndex serialise.