### PR TITLE
UNR-210: Added setup script for installing GDK to a Unreal GDK game

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -21,12 +21,12 @@ INSTALL_PATH="$1"
 BUILT_PLUGINSPATH="Plugins\SpatialGDK"
 BUILT_MODULEPATH="Source\SpatialGDK"
 BUILT_SCRIPTSPATH="Scripts"
-BUILT_BINARIESPATH="Binaries\ThirdParty\Improbable"
+BUILT_BINARIESPATH="Binaries"
 
 TARGET_PLUGINSPATH="${INSTALL_PATH}\workers\unreal\Game\Plugins"
 TARGET_MODULEPATH="${INSTALL_PATH}\workers\unreal\Game\Source"
-TARGET_SCRIPTSPATH="${INSTALL_PATH}\workers\unreal\Game\Scripts"
-TARGET_BINARIESPATH="${INSTALL_PATH}\workers\unreal\Game\Binaries\ThirdParty\Improbable"
+TARGET_SCRIPTSPATH="${INSTALL_PATH}\workers\unreal\Game"
+TARGET_BINARIESPATH="${INSTALL_PATH}\workers\unreal\Game"
 
 markStartOfBlock "$0"
 


### PR DESCRIPTION
This script is helps a user to install the GDK into their game by having them provide the path to their game root directory. This currently assumes the folder structure that we impose, but could be changed to be more flexible in the future.

This script will be called by the SampleGame CI(PR to come).

Tested by running the script with the SampleGame Locally.

Primary reviewers: @m-samiec @improbable-valentyn 