### PR TITLE
UNR216 - Add replicating blueprint class support

### DIFF
--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
@@ -1303,6 +1303,7 @@ void GenerateFunction_ServerSendUpdate_RepData(FCodeWriter& SourceWriter, UClass
 			}
 			else if (Property->IsA<UClassProperty>())
 			{
+				// This is the same as the default case, but as UClassProperty extends from UObjectPropertyBase, we need to catch them here.
 				SourceWriter.Printf("%s %s = *(reinterpret_cast<%s const*>(Data));", *PropertyValueCppType, *PropertyValueName, *PropertyValueCppType);
 			}
 			else if (Property->IsA<UObjectPropertyBase>())
@@ -1471,6 +1472,7 @@ void GenerateFunction_ReceiveUpdate_RepData(FCodeWriter& SourceWriter, UClass* C
 			}
 			else if (Property->IsA<UClassProperty>())
 			{
+				// This is the same as the default case, but as UClassProperty extends from UObjectPropertyBase, we need to catch them here.
 				SourceWriter.Printf("%s %s = *(reinterpret_cast<%s const*>(PropertyData));", *PropertyValueCppType, *PropertyValueName, *PropertyValueCppType);
 			}
 			else if (Property->IsA<UObjectPropertyBase>())

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
@@ -17,7 +17,7 @@ FString TypeBindingName(UClass* Class)
 	return FString::Printf(TEXT("USpatialTypeBinding_%s"), *Class->GetName());
 }
 
-FString NativeClassName(const UObjectPropertyBase* Property)
+FString GetNativeClassName(const UObjectPropertyBase* Property)
 {
 	const UClass* Class = Property->PropertyClass;
 	while (!Class->HasAnyClassFlags(CLASS_Native))
@@ -376,7 +376,7 @@ void GeneratePropertyToUnrealConversion(FCodeWriter& Writer, const FString& Upda
 				checkf(Object_Raw, TEXT("An object ref %%s should map to a valid object."), *ObjectRefToString(ObjectRef));
 				%s = Cast<%s>(Object_Raw);
 				checkf(%s, TEXT("Object ref %%s maps to object %%s with the wrong class."), *ObjectRefToString(ObjectRef), *Object_Raw->GetFullName());
-			})""", *PropertyValue, *NativeClassName(Cast<UObjectPropertyBase>(Property)), *PropertyValue);
+			})""", *PropertyValue, *GetNativeClassName(Cast<UObjectPropertyBase>(Property)), *PropertyValue);
 		Writer.Print("else");
 		Writer.BeginScope();
 		ObjectResolveFailureGenerator(*PropertyValue);
@@ -1307,7 +1307,7 @@ void GenerateFunction_ServerSendUpdate_RepData(FCodeWriter& SourceWriter, UClass
 			}
 			else if (Property->IsA<UObjectPropertyBase>())
 			{
-				FString ClassName = NativeClassName(Cast<UObjectPropertyBase>(Property));
+				FString ClassName = GetNativeClassName(Cast<UObjectPropertyBase>(Property));
 				SourceWriter.Printf("%s* %s = *(reinterpret_cast<%s* const*>(Data));", *ClassName, *PropertyValueName, *ClassName);
 			}
 			else
@@ -1475,7 +1475,7 @@ void GenerateFunction_ReceiveUpdate_RepData(FCodeWriter& SourceWriter, UClass* C
 			}
 			else if (Property->IsA<UObjectPropertyBase>())
 			{
-				FString ClassName = NativeClassName(Cast<UObjectPropertyBase>(Property));
+				FString ClassName = GetNativeClassName(Cast<UObjectPropertyBase>(Property));
 				SourceWriter.Printf("%s* %s = *(reinterpret_cast<%s* const*>(PropertyData));", *ClassName, *PropertyValueName, *ClassName);
 			}
 			else

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
@@ -12,7 +12,7 @@ class FCodeWriter;
 FString TypeBindingName(UClass* Class);
 
 // Given an UObjectProperty, return the string of the first native class in the inheritance hierarchy.
-FString NativeClassName(const UObjectPropertyBase* Property);
+FString GetNativeClassName(const UObjectPropertyBase* Property);
 
 // Generates code to copy an Unreal 'PropertyValue' and write it to a SpatialOS component update object 'Update'.
 void GenerateUnrealToSchemaConversion(

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
@@ -11,6 +11,9 @@ class FCodeWriter;
 // For example: USpatialTypeBinding_Character.
 FString TypeBindingName(UClass* Class);
 
+// Given an UObjectProperty, return the string of the first native class in the inheritance hierarchy.
+FString NativeClassName(const UObjectPropertyBase* Property);
+
 // Generates code to copy an Unreal 'PropertyValue' and write it to a SpatialOS component update object 'Update'.
 void GenerateUnrealToSchemaConversion(
 	FCodeWriter& Writer,


### PR DESCRIPTION
Previously we were attempting to define a blueprint class type in the typebinding. This switches that type to the most derived native class in the blueprint class hierarchy. 

Primary reviews: @improbable-valentyn @danielimprobable 