### PR TITLE
UNR-185 Support sibling classes

### DIFF
--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SchemaGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SchemaGenerator.cpp
@@ -56,9 +56,10 @@ FString SchemaFieldName(const TSharedPtr<FUnrealProperty> Property)
 FString SchemaCommandName(UClass* Class, UFunction* Function)
 {
 	// Prepending the name of the class to the command name enables sibling classes. 
-	FString ClassName = Class->GetName().ToLower();
+	FString CommandName = Class->GetName().ToLower();
 	// Note: Removing underscores to avoid naming mismatch between how schema compiler and interop generator process schema identifiers.
-	return ClassName += Function->GetName().ToLower().Replace(TEXT("_"), TEXT(""));
+	CommandName += Function->GetName().ToLower().Replace(TEXT("_"), TEXT(""));
+	return CommandName;
 }
 
 FString CPPCommandClassName(UClass* Class, UFunction* Function)

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SchemaGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SchemaGenerator.cpp
@@ -59,9 +59,11 @@ FString SchemaCommandName(UFunction* Function)
 	return Function->GetName().ToLower().Replace(TEXT("_"), TEXT(""));
 }
 
-FString CPPCommandClassName(UFunction* Function)
+FString CPPCommandClassName(UClass* Class, UFunction* Function)
 {
-	FString SchemaName = SchemaCommandName(Function);
+	// Prepending the name of the class to the command name enables sibling classes. 
+	FString SchemaName = Class->GetName().ToLower();
+	SchemaName += SchemaCommandName(Function);
 	SchemaName[0] = FChar::ToUpper(SchemaName[0]);
 	return SchemaName;
 }
@@ -138,6 +140,7 @@ FString PropertyToSchemaType(UProperty* Property)
 	}
 	else
 	{
+		// Here the enum is being translated to bytes
 		DataType = TEXT("bytes");
 	}
 
@@ -304,7 +307,8 @@ int GenerateTypeBindingSchema(FCodeWriter& Writer, int ComponentId, UClass* Clas
 		Writer.Printf("id = %i;", IdGenerator.GetNextAvailableId());
 		for (auto& RPC : RPCsByType[Group])
 		{
-			Writer.Printf("command UnrealRPCCommandResponse %s(%s);",
+			Writer.Printf("command UnrealRPCCommandResponse %s%s(%s);",
+				*Class->GetName().ToLower(),
 				*SchemaCommandName(RPC->Function),
 				*SchemaRPCRequestType(RPC->Function));
 		}

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SchemaGenerator.h
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SchemaGenerator.h
@@ -39,7 +39,7 @@ FString SchemaFieldName(const TSharedPtr<FUnrealProperty> Property);
 FString SchemaCommandName(UFunction* Function);
 
 // Given a UFunction, generates the c++ command name. Identical to the schema name with the first letter being uppercase.
-FString CPPCommandClassName(UFunction* Function);
+FString CPPCommandClassName(UClass* Class, UFunction* Function);
 
 // Given a RepLayout cmd type (a data type supported by the replication system). Generates the corresponding
 // type used in schema.

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SchemaGenerator.h
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SchemaGenerator.h
@@ -36,7 +36,7 @@ FString SchemaRPCResponseType(UFunction* Function);
 FString SchemaFieldName(const TSharedPtr<FUnrealProperty> Property);
 
 // Given a UFunction, generates the schema command name. Currently just returns the function name in lowercase.
-FString SchemaCommandName(UFunction* Function);
+FString SchemaCommandName(UClass* Class, UFunction* Function);
 
 // Given a UFunction, generates the c++ command name. Identical to the schema name with the first letter being uppercase.
 FString CPPCommandClassName(UClass* Class, UFunction* Function);

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
@@ -583,7 +583,7 @@ void GenerateTypeBindingHeader(FCodeWriter& HeaderWriter, FString SchemaFilename
 			HeaderWriter.Printf("void %s_OnCommandRequest(const worker::CommandRequestOp<improbable::unreal::generated::%s::Commands::%s>& Op);",
 				*RPC->Function->GetName(),
 				*SchemaRPCComponentName(Group, Class),
-				*CPPCommandClassName(RPC->Function));
+				*CPPCommandClassName(Class, RPC->Function));
 		}
 	}
 
@@ -597,7 +597,7 @@ void GenerateTypeBindingHeader(FCodeWriter& HeaderWriter, FString SchemaFilename
 			HeaderWriter.Printf("void %s_OnCommandResponse(const worker::CommandResponseOp<improbable::unreal::generated::%s::Commands::%s>& Op);",
 				*RPC->Function->GetName(),
 				*SchemaRPCComponentName(Group, Class),
-				*CPPCommandClassName(RPC->Function));
+				*CPPCommandClassName(Class, RPC->Function));
 		}
 	}
 	HeaderWriter.Outdent();
@@ -919,7 +919,7 @@ void GenerateFunction_BindToView(FCodeWriter& SourceWriter, UClass* Class, const
 			{
 				SourceWriter.Printf("ViewCallbacks.Add(View->OnCommandRequest<%sRPCCommandTypes::%s>(std::bind(&%s::%s_OnCommandRequest, this, std::placeholders::_1)));",
 					*GetRPCTypeName(Group),
-					*CPPCommandClassName(RPC->Function),
+					*CPPCommandClassName(Class, RPC->Function),
 					*TypeBindingName(Class),
 					*RPC->Function->GetName());
 			}
@@ -927,7 +927,7 @@ void GenerateFunction_BindToView(FCodeWriter& SourceWriter, UClass* Class, const
 			{
 				SourceWriter.Printf("ViewCallbacks.Add(View->OnCommandResponse<%sRPCCommandTypes::%s>(std::bind(&%s::%s_OnCommandResponse, this, std::placeholders::_1)));",
 					*GetRPCTypeName(Group),
-					*CPPCommandClassName(RPC->Function),
+					*CPPCommandClassName(Class, RPC->Function),
 					*TypeBindingName(Class),
 					*RPC->Function->GetName());
 			}
@@ -1721,7 +1721,7 @@ void GenerateFunction_RPCSendCommand(FCodeWriter& SourceWriter, UClass* Class, c
 		return {RequestId.Id};)""",
 		*RPC->Function->GetName(),
 		*SchemaRPCComponentName(RPC->Type, Class),
-		*CPPCommandClassName(RPC->Function));
+		*CPPCommandClassName(Class, RPC->Function));
 	SourceWriter.Outdent().Print("};");
 	SourceWriter.Printf("Interop->SendCommandRequest_Internal(Sender, %s);", RPC->bReliable ? TEXT("/*bReliable*/ true") : TEXT("/*bReliable*/ false"));
 
@@ -1733,7 +1733,7 @@ void GenerateFunction_RPCOnCommandRequest(FCodeWriter& SourceWriter, UClass* Cla
 	FString RequestFuncName = FString::Printf(TEXT("%s_OnCommandRequest(const worker::CommandRequestOp<improbable::unreal::generated::%s::Commands::%s>& Op)"),
 		*RPC->Function->GetName(),
 		*SchemaRPCComponentName(RPC->Type, Class),
-		*CPPCommandClassName(RPC->Function));
+		*CPPCommandClassName(Class, RPC->Function));
 	SourceWriter.BeginFunction({"void", RequestFuncName}, TypeBindingName(Class));
 
 	// Generate receiver function.
@@ -1835,7 +1835,7 @@ void GenerateFunction_RPCOnCommandRequest(FCodeWriter& SourceWriter, UClass* Cla
 	SourceWriter.Print("TSharedPtr<worker::Connection> Connection = Interop->GetSpatialOS()->GetConnection().Pin();");
 	SourceWriter.Printf("Connection->SendCommandResponse<improbable::unreal::generated::%s::Commands::%s>(Op.RequestId, {});",
 		*SchemaRPCComponentName(RPC->Type, Class),
-		*CPPCommandClassName(RPC->Function));
+		*CPPCommandClassName(Class, RPC->Function));
 	SourceWriter.Print("return {};");
 	SourceWriter.Outdent().Print("};");
 
@@ -1849,7 +1849,7 @@ void GenerateFunction_RPCOnCommandResponse(FCodeWriter& SourceWriter, UClass* Cl
 	FString ResponseFuncName = FString::Printf(TEXT("%s_OnCommandResponse(const worker::CommandResponseOp<improbable::unreal::generated::%s::Commands::%s>& Op)"),
 		*RPC->Function->GetName(),
 		*SchemaRPCComponentName(RPC->Type, Class),
-		*CPPCommandClassName(RPC->Function));
+		*CPPCommandClassName(Class, RPC->Function));
 
 	SourceWriter.BeginFunction({"void", ResponseFuncName}, TypeBindingName(Class));
 	SourceWriter.Printf("Interop->HandleCommandResponse_Internal(TEXT(\"%s\"), Op.RequestId.Id, Op.EntityId, Op.StatusCode, FString(UTF8_TO_TCHAR(Op.Message.c_str())));",


### PR DESCRIPTION
What? 
This PR enables sibling classes for code generation in the UnrealGDK. Corresponding SampleGame PR: https://github.com/improbable/unreal-gdk-sample-game/pull/26

How?
It does this by prepending the class name of the class code is being generated for to the command name that is being made for RPCs.

Tested?
Created a clone of the SampleGameCharacter and called it SampleGameCharacterSibling, did a find-replace on the entire class to SampleGameCharacterSibling and then made a blueprint which parented from this. Then I generated code for both SampleGameCharacter and SampleGameCharacterSibling. Then I added a SampleGameCharacterSibling to the SampleGame, both SampleGameCharacter and SampleGameCharacterSibling spawned fine and operated fine. Then I added a custom property to the SampleGameCharacterSibling and tested that it does indeed get replicated as desired. 