### PR TITLE
Fixing underscores in command names.

### DIFF
--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SchemaGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SchemaGenerator.cpp
@@ -56,9 +56,9 @@ FString SchemaFieldName(const TSharedPtr<FUnrealProperty> Property)
 FString SchemaCommandName(UClass* Class, UFunction* Function)
 {
 	// Prepending the name of the class to the command name enables sibling classes. 
-	FString CommandName = Class->GetName().ToLower().Replace(TEXT("_"), TEXT(""));
+	FString CommandName = Class->GetName() + Function->GetName();
 	// Note: Removing underscores to avoid naming mismatch between how schema compiler and interop generator process schema identifiers.
-	CommandName += Function->GetName().ToLower().Replace(TEXT("_"), TEXT(""));
+	CommandName = UnrealNameToSchemaTypeName(CommandName.ToLower());
 	return CommandName;
 }
 

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SchemaGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SchemaGenerator.cpp
@@ -56,7 +56,7 @@ FString SchemaFieldName(const TSharedPtr<FUnrealProperty> Property)
 FString SchemaCommandName(UClass* Class, UFunction* Function)
 {
 	// Prepending the name of the class to the command name enables sibling classes. 
-	FString CommandName = Class->GetName().ToLower();
+	FString CommandName = Class->GetName().ToLower().Replace(TEXT("_"), TEXT(""));
 	// Note: Removing underscores to avoid naming mismatch between how schema compiler and interop generator process schema identifiers.
 	CommandName += Function->GetName().ToLower().Replace(TEXT("_"), TEXT(""));
 	return CommandName;


### PR DESCRIPTION
This PR fixes a bug I introduced when I added support for sibling classes. I did not remove underscores from the classnames before I used them in generating the schema command name.