### PR TITLE
UNR-228 Replicated Enum Support

### DIFF
--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SchemaGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SchemaGenerator.cpp
@@ -106,17 +106,33 @@ FString PropertyToSchemaType(UProperty* Property)
 	{
 		DataType = TEXT("float");
 	}
+	else if (Property->IsA(UDoubleProperty::StaticClass()))
+	{
+		DataType = TEXT("double");
+	}
+	else if (Property->IsA(UInt8Property::StaticClass()))
+	{
+		DataType = TEXT("int32");
+	}
+	else if (Property->IsA(UInt16Property::StaticClass()))
+	{
+		DataType = TEXT("int32");
+	}
 	else if (Property->IsA(UIntProperty::StaticClass()))
 	{
 		DataType = TEXT("int32");
+	}
+	else if (Property->IsA(UInt64Property::StaticClass()))
+	{
+		DataType = TEXT("int64");
 	}
 	else if (Property->IsA(UByteProperty::StaticClass()))
 	{
 		DataType = TEXT("uint32"); // uint8 not supported in schema.
 	}
-	else if (Property->IsA(UNameProperty::StaticClass()) || Property->IsA(UStrProperty::StaticClass()))
+	else if (Property->IsA(UUInt16Property::StaticClass()))
 	{
-		DataType = TEXT("string");
+		DataType = TEXT("uint32");
 	}
 	else if (Property->IsA(UUInt32Property::StaticClass()))
 	{
@@ -124,7 +140,11 @@ FString PropertyToSchemaType(UProperty* Property)
 	}
 	else if (Property->IsA(UUInt64Property::StaticClass()))
 	{
-		DataType = TEXT("bytes");
+		DataType = TEXT("uint64");
+	}
+	else if (Property->IsA(UNameProperty::StaticClass()) || Property->IsA(UStrProperty::StaticClass()))
+	{
+		DataType = TEXT("string");
 	}
 	else if (Property->IsA(UClassProperty::StaticClass()))
 	{
@@ -138,6 +158,19 @@ FString PropertyToSchemaType(UProperty* Property)
 	{
 		DataType = PropertyToSchemaType(Cast<UArrayProperty>(Property)->Inner);
 		DataType = FString::Printf(TEXT("list<%s>"), *DataType);
+	}
+	else if (Property->IsA(UEnumProperty::StaticClass()))
+	{
+		UEnumProperty* EnumProp = Cast<UEnumProperty>(Property);
+
+		if (EnumProp->ElementSize < 4)
+		{
+			DataType = TEXT("uint32");
+		}
+		else
+		{
+			DataType = EnumProp->GetUnderlyingProperty()->GetCPPType();
+		}
 	}
 	else
 	{

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SchemaGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SchemaGenerator.cpp
@@ -7,6 +7,7 @@
 
 #include "Utils/CodeWriter.h"
 #include "Utils/ComponentIdGenerator.h"
+#include "Utils/DataTypeUtilities.h"
 
 FString UnrealNameToSchemaTypeName(const FString& UnrealName)
 {
@@ -161,16 +162,7 @@ FString PropertyToSchemaType(UProperty* Property)
 	}
 	else if (Property->IsA(UEnumProperty::StaticClass()))
 	{
-		UEnumProperty* EnumProp = Cast<UEnumProperty>(Property);
-
-		if (EnumProp->ElementSize < 4)
-		{
-			DataType = TEXT("uint32");
-		}
-		else
-		{
-			DataType = EnumProp->GetUnderlyingProperty()->GetCPPType();
-		}
+		DataType = GetEnumDataType(Cast<UEnumProperty>(Property));
 	}
 	else
 	{

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
@@ -5,6 +5,7 @@
 #include "TypeStructure.h"
 
 #include "Utils/CodeWriter.h"
+#include "Utils/DataTypeUtilities.h"
 
 // Needed for Algo::Transform
 #include "Algo/Transform.h"
@@ -143,16 +144,7 @@ FString PropertyToWorkerSDKType(UProperty* Property)
 	}
 	else if (Property->IsA(UEnumProperty::StaticClass()))
 	{
-		UEnumProperty* EnumProp = Cast<UEnumProperty>(Property);
-
-		if (EnumProp->ElementSize < 4)
-		{
-			DataType = TEXT("uint32");
-		}
-		else
-		{
-			DataType = EnumProp->GetUnderlyingProperty()->GetCPPType();
-		}
+		DataType = GetEnumDataType(Cast<UEnumProperty>(Property));
 	}
 	else
 	{
@@ -307,18 +299,7 @@ void GenerateUnrealToSchemaConversion(FCodeWriter& Writer, const FString& Update
 	} 
 	else if (Property->IsA(UEnumProperty::StaticClass()))
 	{
-		UEnumProperty* EnumProp = Cast<UEnumProperty>(Property);
-
-		FString DataType;
-		if (EnumProp->ElementSize < 4)
-		{
-			DataType = TEXT("uint32");
-		}
-		else
-		{
-			DataType = EnumProp->GetUnderlyingProperty()->GetCPPType();
-		}
-
+		FString DataType = GetEnumDataType(Cast<UEnumProperty>(Property));
 		Writer.Printf("%s(%s(%s));", *Update, *DataType, *PropertyValue);
 	}
 	else

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
@@ -121,6 +121,10 @@ FString PropertyToWorkerSDKType(UProperty* Property)
 		DataType = PropertyToWorkerSDKType(Cast<UArrayProperty>(Property)->Inner);
 		DataType = FString::Printf(TEXT("::worker::List<%s>"), *DataType);
 	}
+	else if (Property->IsA(UEnumProperty::StaticClass()))
+	{
+		DataType = FString::Printf(TEXT("std::string"));
+	}
 	else
 	{
 		DataType = TEXT("std::string");
@@ -134,7 +138,9 @@ void GenerateUnrealToSchemaConversion(FCodeWriter& Writer, const FString& Update
 	// Get result type.
 	if (UEnumProperty* EnumProperty = Cast<UEnumProperty>(Property))
 	{
-		Writer.Printf("// UNSUPPORTED UEnumProperty %s(%s);", *Update, *PropertyValue);
+		Writer.Printf("// GenerateUnrealToSchemaConversion");
+		Writer.Printf("char EnumValue = (char)Value[i];");
+		Writer.Printf("List.emplace_back(std::string(EnumValue, sizeof(char)));");
 		//Writer.Print(FString::Printf(TEXT("auto Underlying = %s.GetValue()"), *PropertyValue));
 		//return GenerateUnrealToSchemaConversion(Writer, EnumProperty->GetUnderlyingProperty(), TEXT("Underlying"), ResultName, Handle);
 	}
@@ -273,7 +279,10 @@ void GeneratePropertyToUnrealConversion(FCodeWriter& Writer, const FString& Upda
 	// Get result type.
 	if (const UEnumProperty* EnumProperty = Cast<UEnumProperty>(Property))
 	{
-		Writer.Printf("// UNSUPPORTED UEnumProperty %s %s", *PropertyValue, *Update);
+		Writer.Printf("// GeneratePropertyToUnrealConversion");
+
+		Writer.Printf("char EnumValue = List[i].data()[0];");
+		Writer.Printf("%s = static_cast<%s>(EnumValue);", *PropertyValue, *PropertyType);
 	}
 
 	// Try to special case to custom types we know about

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/Utils/DataTypeUtilities.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/Utils/DataTypeUtilities.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "DataTypeUtilities.h"
+
+
+FString GetEnumDataType(const UEnumProperty* EnumProperty)
+{
+	FString DataType;
+
+	if (EnumProperty->ElementSize < 4)
+	{
+		// schema types don't include support for 8 or 16 bit data types
+		DataType = TEXT("uint32");
+	}
+	else
+	{
+		DataType = EnumProperty->GetUnderlyingProperty()->GetCPPType();
+	}
+
+	return DataType;
+}

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/Utils/DataTypeUtilities.h
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/Utils/DataTypeUtilities.h
@@ -1,0 +1,6 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+// Return the string representation of the underlying data type of an enum property
+FString GetEnumDataType(const UEnumProperty* EnumProperty);

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/Utils/DataTypeUtilities.h
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/Utils/DataTypeUtilities.h
@@ -2,5 +2,7 @@
 
 #pragma once
 
+#include "CoreMinimal.h"
+
 // Return the string representation of the underlying data type of an enum property
 FString GetEnumDataType(const UEnumProperty* EnumProperty);

--- a/Source/Programs/Improbable.Unreal.CodeGeneration/Model/UnrealTypeMappings.cs
+++ b/Source/Programs/Improbable.Unreal.CodeGeneration/Model/UnrealTypeMappings.cs
@@ -47,6 +47,8 @@ namespace Improbable.Unreal.CodeGeneration.Model
         {
             { cppFloat, "float" },
             { cppInt32, "int" },
+            { cppInt64, "int64" },
+            { cppUint64, "int64" },
             { cppBool, "bool" },
             { cppString, "FString" },
             { cppEntityId, "FEntityId" },
@@ -139,8 +141,6 @@ namespace Improbable.Unreal.CodeGeneration.Model
 
         public static readonly HashSet<string> UnsupportedSchemaTypes = new HashSet<string>()
         {
-            { BuiltInTypeConstants.builtInUint64 },
-            { BuiltInTypeConstants.builtInInt64 },
             { BuiltInTypeConstants.builtInSint32 },
             { BuiltInTypeConstants.builtInSint64 },
             { BuiltInTypeConstants.builtInFixed32 },


### PR DESCRIPTION
NEW - PLEASE READ

From m-samiec - I've taken on this task as Josh was focused on MW priorities and is on holiday this week. In hindsight I should have created a new PR.

What?
Support is added for multibyte enums, as well as 8/16/64 bit integer types and doubles. The later types were part of a separate ticket (UNR-190), but I've done them here as they were touching the same code areas.

How?
Enums are replicated via their underlying datatype, unless they are a 8 or 16 bit, in which case they are cast to a 32 bit int before transforming them into Spatial's data layer. This is because Spatial doesn't support those types.

Tested?
I've added a ton of test replicated properties to the scratch_pad branch. Including 8/16/32/64 bit enums/int/uint types and verified their data is replicated correctly between clients.

Reviewers: @girayimprobable @danielimprobable 
