### PR TITLE
Workaround for missing BoundClass when Blueprint class not referenced

### DIFF
--- a/Source/SpatialGDK/Private/SpatialInterop.cpp
+++ b/Source/SpatialGDK/Private/SpatialInterop.cpp
@@ -42,15 +42,14 @@ void USpatialInterop::Init(USpatialOS* Instance, USpatialNetDriver* Driver, FTim
 	// Register type binding classes.
 	for (UClass* TypeBindingClass : TypeBindingClasses)
 	{
-		UClass* BoundClass = TypeBindingClass->GetDefaultObject<USpatialTypeBinding>()->GetBoundClass();
-		if (BoundClass)
+		if (UClass* BoundClass = TypeBindingClass->GetDefaultObject<USpatialTypeBinding>()->GetBoundClass())
 		{
 			UE_LOG(LogSpatialOSInterop, Log, TEXT("Registered type binding class %s handling replicated properties of %s."), *TypeBindingClass->GetName(), *BoundClass->GetName());
 			RegisterInteropType(BoundClass, NewObject<USpatialTypeBinding>(this, TypeBindingClass));
-		} 
-		else 
+		}
+		else
 		{
-			UE_LOG(LogSpatialOSInterop, Warning, TEXT("Could not find 'bound class' for type binding class %s, not registering. If this is a blueprint class, make sure it is referenced by the world."), *TypeBindingClass->GetName());
+			UE_LOG(LogSpatialOSInterop, Warning, TEXT("Could not find and register 'bound class' for type binding class %s. If this is a blueprint class, make sure it is referenced by the world."), *TypeBindingClass->GetName());
 		}
 	}
 }

--- a/Source/SpatialGDK/Private/SpatialInterop.cpp
+++ b/Source/SpatialGDK/Private/SpatialInterop.cpp
@@ -43,8 +43,15 @@ void USpatialInterop::Init(USpatialOS* Instance, USpatialNetDriver* Driver, FTim
 	for (UClass* TypeBindingClass : TypeBindingClasses)
 	{
 		UClass* BoundClass = TypeBindingClass->GetDefaultObject<USpatialTypeBinding>()->GetBoundClass();
-		UE_LOG(LogSpatialOSInterop, Log, TEXT("Registered type binding class %s handling replicated properties of %s."), *TypeBindingClass->GetName(), *BoundClass->GetName());
-		RegisterInteropType(BoundClass, NewObject<USpatialTypeBinding>(this, TypeBindingClass));
+		if (BoundClass)
+		{
+			UE_LOG(LogSpatialOSInterop, Log, TEXT("Registered type binding class %s handling replicated properties of %s."), *TypeBindingClass->GetName(), *BoundClass->GetName());
+			RegisterInteropType(BoundClass, NewObject<USpatialTypeBinding>(this, TypeBindingClass));
+		} 
+		else 
+		{
+			UE_LOG(LogSpatialOSInterop, Warning, TEXT("Could not find 'bound class' for type binding class %s, not registering. If this is a blueprint class, make sure it is referenced by the world."), *TypeBindingClass->GetName());
+		}
 	}
 }
 


### PR DESCRIPTION
What?
Workaround for the issue discovered here: https://improbableio.atlassian.net/browse/UNR-273
Basically if a Blueprint class that you have generated typebindings for does not exist in the world, then it will fail to register as the BoundClass is missing.
We believe this to be an UnrealOptimisation but may be a deeper issue.

How?
Do not attempt to register a type binding class for anything which does not have a bound class.

Tested?
Prevented issues over at Scavengers when we had blueprints for Bears but did not have any bears in the world.