### PR TITLE
Include cleanup for compilation at MW

### DIFF
--- a/Source/SpatialGDK/Legacy/EntityRegistry.cpp
+++ b/Source/SpatialGDK/Legacy/EntityRegistry.cpp
@@ -2,6 +2,7 @@
 
 #include "EntityRegistry.h"
 #include "EngineUtils.h"
+#include "Engine/BlueprintGeneratedClass.h"
 
 DECLARE_LOG_CATEGORY_EXTERN(LogEntityRegistry, Log, All);
 DEFINE_LOG_CATEGORY(LogEntityRegistry);

--- a/Source/SpatialGDK/Legacy/SpatialOS.cpp
+++ b/Source/SpatialGDK/Legacy/SpatialOS.cpp
@@ -7,6 +7,7 @@
 #include "SpatialGDKSettings.h"
 #include "SpatialGDKViewTypes.h"
 #include "SpatialGDKWorkerTypes.h"
+#include "Engine/Engine.h"
 
 DEFINE_LOG_CATEGORY(LogSpatialOS);
 

--- a/Source/SpatialGDK/Legacy/SpatialOS.h
+++ b/Source/SpatialGDK/Legacy/SpatialOS.h
@@ -15,6 +15,7 @@ DECLARE_LOG_CATEGORY_EXTERN(LogSpatialOS, Log, All);
 
 class UCallbackDispatcher;
 class UEntityPipeline;
+struct FWorldContext;
 
 // clang-format off
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnConnectedDelegate);

--- a/Source/SpatialGDK/Legacy/WorkerConnection.h
+++ b/Source/SpatialGDK/Legacy/WorkerConnection.h
@@ -6,6 +6,7 @@
 #include "SpatialGDKLoader.h"
 #include "SpatialGDKViewTypes.h"
 #include "SpatialGDKWorkerConfiguration.h"
+#include "Engine/EngineTypes.h"
 
 namespace improbable
 {

--- a/Source/SpatialGDK/Private/SpatialNetDriver.cpp
+++ b/Source/SpatialGDK/Private/SpatialNetDriver.cpp
@@ -5,6 +5,7 @@
 #include "Engine/ActorChannel.h"
 #include "Engine/ChildConnection.h"
 #include "Engine/NetworkObjectList.h"
+#include "EngineGlobals.h"
 #include "EntityPipeline.h"
 #include "EntityRegistry.h"
 #include "GameFramework/GameNetworkManager.h"

--- a/Source/SpatialGDK/Public/SpatialNetDriver.h
+++ b/Source/SpatialGDK/Public/SpatialNetDriver.h
@@ -3,6 +3,8 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "CoreOnline.h"
+#include "Engine.h"
 #include "IpNetDriver.h"
 #include "PlayerSpawnRequestSender.h"
 #include "SpatialGDKWorkerConfigurationData.h"


### PR DESCRIPTION
What?
Due to how Unity (cpp Unity not the game engine) files work, we encounter compilations issues at Midwinter due to missing includes.

How?
Found the locations of the missing includes and added them back in

Tested?
Fixed a load of cryptic issues here at MW.