### PR TITLE
Removed the dependency on IMPROBABLE_TOOLS.

### DIFF
--- a/ci/pinned-tools.sh
+++ b/ci/pinned-tools.sh
@@ -9,11 +9,6 @@ error() {
 }
 trap 'error "${BASH_SOURCE}" "${LINENO}"' ERR
 
-if [ -z "$IMPROBABLE_TOOLS" ]; then
-    echo "The internal tools share is not set up correctly on this machine. Please follow the setup instructions here before running build.sh: https://brevi.link/internal-tools-share"
-    exit 1
-fi
-
 function isLinux() {
   [[ "$(uname -s)" == "Linux" ]];
 }
@@ -81,10 +76,7 @@ MSBUILD="${PROGRAMFILES_X86}\MSBuild\14.0\Bin\MSBuild.exe"
 
 TOOLS_OS="$(getPlatformName)"
 IMP_NUGET_VERSION="20180320.121538.4d07aa9573"
-IMP_NUGET="${IMPROBABLE_TOOLS}/imp-nuget/${IMP_NUGET_VERSION}/${TOOLS_OS}/imp-nuget"
-
-IMP_LINT_VERSION="20171129.134829.183d8f6"
-IMP_LINT_BIN="${IMPROBABLE_TOOLS}/imp_lint/${IMP_LINT_VERSION}/${TOOLS_OS}/imp_lint"
+IMP_NUGET="$(pwd)/imp-nuget"
 
 GOPATH="$(pwd)/go"
 


### PR DESCRIPTION
What?
Our `build.sh` required Improbable Tools which is an environment variable on Improbable dev machines containing some binaries.

How?
We only required `imp-nuget` which is just a small binary which does `nuget` downloads. Copied this into the unreal-gdk repository and updated the `build.sh` to reflect this?

Tested?
You can now build the GDK on a non-improbable machine (like the one at Midwinter).