### PR TITLE
UNR-137: Removed the hardcoded output folder in Interop codegen

### DIFF
--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SpatialGDKEditorInteropCodeGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SpatialGDKEditorInteropCodeGenerator.cpp
@@ -71,7 +71,7 @@ bool CheckClassNameListValidity(const ClassHeaderMap& Classes)
 
 const FConfigFile* GetConfigFile(const FString& ConfigFilePath)
 {
-	const auto* ConfigFile = GConfig->Find(ConfigFilePath, false);
+	const FConfigFile* ConfigFile = GConfig->Find(ConfigFilePath, false);
 	if (!ConfigFile)
 	{
 		UE_LOG(LogSpatialGDKInteropCodeGenerator, Error, TEXT("Could not open .ini file: \"%s\""), *ConfigFilePath);
@@ -82,10 +82,10 @@ const FConfigFile* GetConfigFile(const FString& ConfigFilePath)
 
 const FConfigSection* GetConfigSection(const FString& ConfigFilePath, const FString& SectionName)
 {
-	if (const auto* ConfigFile = GetConfigFile(ConfigFilePath))
+	if (const FConfigFile* ConfigFile = GetConfigFile(ConfigFilePath))
 	{
 		// Get the key-value pairs in the InteropCodeGenSection.
-		if (const auto* Section = ConfigFile->Find(SectionName))
+		if (const FConfigSection* Section = ConfigFile->Find(SectionName))
 		{
 			return Section;
 		}
@@ -125,9 +125,9 @@ const FString GetOutputPath(const FString& ConfigFilePath)
 {
 	FString OutputPath = FString::Printf(TEXT("%s/Generated/"), FApp::GetProjectName());
 	const FString SettingsSectionName = "InteropCodeGen.Settings";
-	if (const auto* SettingsSection = GetConfigSection(ConfigFilePath, SettingsSectionName))
+	if (const FConfigSection* SettingsSection = GetConfigSection(ConfigFilePath, SettingsSectionName))
 	{
-		if (const auto* OutputModuleSetting = SettingsSection->Find("OutputPath"))
+		if (const FConfigValue* OutputModuleSetting = SettingsSection->Find("OutputPath"))
 		{
 			OutputPath = OutputModuleSetting->GetValue();
 		}
@@ -145,9 +145,9 @@ void SpatialGDKGenerateInteropCode()
 	GConfig->LoadFile(ConfigFilePath);
 
 	const FString UserClassesSectionName = "InteropCodeGen.ClassesToGenerate";
-	if (const auto* UserInteropCodeGenSection = GetConfigSection(ConfigFilePath, UserClassesSectionName))
+	if (const FConfigSection* UserInteropCodeGenSection = GetConfigSection(ConfigFilePath, UserClassesSectionName))
 	{
-		const auto Classes = GenerateClassHeaderMap(UserInteropCodeGenSection);
+		const ClassHeaderMap Classes = GenerateClassHeaderMap(UserInteropCodeGenSection);
 		if (!CheckClassNameListValidity(Classes))
 		{
 			return;

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SpatialGDKEditorInteropCodeGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SpatialGDKEditorInteropCodeGenerator.cpp
@@ -121,19 +121,19 @@ const ClassHeaderMap GenerateClassHeaderMap(const FConfigSection* UserInteropCod
 	return Classes;
 }
 
-const FString GetOutputModulePath(const FString& ConfigFilePath)
+const FString GetOutputPath(const FString& ConfigFilePath)
 {
-	FString OutputModule = FApp::GetProjectName();
+	FString OutputPath = FString::Printf(TEXT("%s/Generated/"), FApp::GetProjectName());
 	const FString SettingsSectionName = "InteropCodeGen.Settings";
 	if (const auto* SettingsSection = GetConfigSection(ConfigFilePath, SettingsSectionName))
 	{
-		if (const auto* OutputModuleSetting = SettingsSection->Find("OutputModule"))
+		if (const auto* OutputModuleSetting = SettingsSection->Find("OutputPath"))
 		{
-			OutputModule = OutputModuleSetting->GetValue();
+			OutputPath = OutputModuleSetting->GetValue();
 		}
 	}
 
-	return FString::Printf(TEXT("%s/Generated/"), *OutputModule);
+	return OutputPath;
 }
 
 void SpatialGDKGenerateInteropCode()
@@ -156,7 +156,7 @@ void SpatialGDKGenerateInteropCode()
 		FString CombinedSchemaPath = FPaths::Combine(*FPaths::GetPath(FPaths::GetProjectFilePath()), TEXT("../../../schema/improbable/unreal/generated/"));
 		FString AbsoluteCombinedSchemaPath = FPaths::ConvertRelativePathToFull(CombinedSchemaPath);
 
-		FString CombinedForwardingCodePath = FPaths::Combine(*FPaths::GetPath(FPaths::GameSourceDir()), *GetOutputModulePath(ConfigFilePath));
+		FString CombinedForwardingCodePath = FPaths::Combine(*FPaths::GetPath(FPaths::GameSourceDir()), *GetOutputPath(ConfigFilePath));
 		FString AbsoluteCombinedForwardingCodePath = FPaths::ConvertRelativePathToFull(CombinedForwardingCodePath);
 
 		UE_LOG(LogSpatialGDKInteropCodeGenerator, Display, TEXT("Schema path %s - Forwarding code path %s"), *AbsoluteCombinedSchemaPath, *AbsoluteCombinedForwardingCodePath);


### PR DESCRIPTION
#### Description

It is now possible to specify the module where the interop codegen will be written to. By default it will use the project name as the modulename for the output foler, however it is also possible to override this with the DefaultEditorSpatialGDK.ini and the section 

`[InteropCodeGen.Settings]
OutputModule=<Output module>`

#### Tests
This PR has been tested manually. However, it should be possible to add automated tests for this once we have merged the testing solution.

#### Documentation
* Jira ticket: https://improbableio.atlassian.net/browse/UNR-137
* Docs for this task has been updated in the [SDK readme draft](https://docs.google.com/document/d/1Ufnso5WiUIxB2lOW6U8BtqQpO9vleXKX94Z4tPTJ928/edit#bookmark=id.py12edq38qhk)

#### Primary reviewers
@m-samiec and @improbable-valentyn 
