### PR TITLE
Do spatial position update before early out of ReplicateActor

### DIFF
--- a/Source/SpatialGDK/Private/SpatialActorChannel.cpp
+++ b/Source/SpatialGDK/Private/SpatialActorChannel.cpp
@@ -192,6 +192,12 @@ bool USpatialActorChannel::ReplicateActor()
 	{
 		PlayerController->SendClientAdjustment();
 	}
+
+	// Update SpatialOS position.
+	if (!PlayerController && !Cast<APlayerState>(Actor))
+	{
+		UpdateSpatialPosition();
+	}
 	
 	// Update the replicated property change list.
 	FRepChangelistState* ChangelistState = ActorReplicator->ChangelistMgr->GetRepChangelistState();
@@ -323,12 +329,6 @@ bool USpatialActorChannel::ReplicateActor()
 			ActorReplicator->RepState->HistoryEnd++;
 		}
 		UpdateChangelistHistory(ActorReplicator->RepState);
-	}
-
-	// Update SpatialOS position.
-	if (!PlayerController && !Cast<APlayerState>(Actor))
-	{
-		UpdateSpatialPosition();
 	}
 
 	ActorReplicator->RepState->LastChangelistIndex = ChangelistState->HistoryEnd;


### PR DESCRIPTION
#### Description
Moved spatial position update to before the early out due to no replicated properties. This catches attached actors that haven't had any replicated changes on themselves, but have had their position updated through their root attachment.

#### Tests
Ran locally with one and two clients, spawned an actor and called AttachTo on it with the Character. Then moved the character, and witnessed the spawned actor moving in the spatial inspector.

#### Primary reviewers
@improbable-valentyn @girayimprobable @davedolben 
