### PR TITLE
UNR-189: Enable support for replicated arrays of UObjects

### DIFF
--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
@@ -18,12 +18,18 @@ FString GetNativeClassName(const UObjectPropertyBase* Property);
 void GenerateUnrealToSchemaConversion(
 	FCodeWriter& Writer,
 	const FString& Update,
-	const UProperty* Property,
+	UProperty* Property,
 	const FString& PropertyValue,
-	TFunction<void(const FString&)> ObjectResolveFailureGenerator,
-	const FString& PrepareArrayOfObjects,
-	TFunction<void(const FString&)> ArrayOfObjectsResolveFailureGenerator,
-	TFunction<void(const FString&)> FinishArrayOfObjectsGenerator);
+	TFunction<void(const FString&)> ObjectResolveFailureGenerator);
+
+// Generates code to handle the queueing of an array of UObject* if it contains unresolved objects.
+// Currently only supports replicated properties (i.e. does not support migratable properties or RPC arguments).
+void GenerateUObjectArrayToSchemaConversion(
+	FCodeWriter& Writer,
+	const FString& Update,
+	UArrayProperty* Property,
+	const FString& PropertyValue,
+	uint16 Handle);
 
 // Generates code to extract property data from a SpatialOS component update object and write it to an Unreal 'PropertyValue'
 void GeneratePropertyToUnrealConversion(

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
@@ -20,7 +20,10 @@ void GenerateUnrealToSchemaConversion(
 	const FString& Update,
 	const UProperty* Property,
 	const FString& PropertyValue,
-	TFunction<void(const FString&)> ObjectResolveFailureGenerator);
+	TFunction<void(const FString&)> ObjectResolveFailureGenerator,
+	const FString& PrepareArrayOfObjects,
+	TFunction<void(const FString&)> ArrayOfObjectsResolveFailureGenerator,
+	TFunction<void(const FString&)> FinishArrayOfObjectsGenerator);
 
 // Generates code to extract property data from a SpatialOS component update object and write it to an Unreal 'PropertyValue'
 void GeneratePropertyToUnrealConversion(

--- a/Source/SpatialGDK/Private/SpatialInterop.cpp
+++ b/Source/SpatialGDK/Private/SpatialInterop.cpp
@@ -209,8 +209,10 @@ void USpatialInterop::ResolvePendingOperations(UObject* Object, const improbable
 	UE_LOG(LogSpatialOSInterop, Log, TEXT("Resolving pending object refs and RPCs which depend on object: %s %s."), *Object->GetName(), *ObjectRefToString(ObjectRef));
 	ResolvePendingOutgoingObjectUpdates(Object);
 	ResolvePendingOutgoingRPCs(Object);
+	ResolvePendingOutgoingArrayUpdates(Object);
 	ResolvePendingIncomingObjectUpdates(Object, ObjectRef);
 	ResolvePendingIncomingRPCs(ObjectRef);
+	ResolvePendingIncomingArrayUpdates(Object, ObjectRef);
 }
 
 void USpatialInterop::AddActorChannel(const FEntityId& EntityId, USpatialActorChannel* Channel)
@@ -375,6 +377,170 @@ void USpatialInterop::QueueIncomingRPC_Internal(const improbable::unreal::Unreal
 	PendingIncomingRPCs.FindOrAdd(UnresolvedObjectRef).Add(Responder);
 }
 
+void USpatialInterop::ResetOutgoingArrayRepUpdate_Internal(USpatialActorChannel* DependentChannel, uint16 Handle)
+{
+	check(DependentChannel);
+
+	FHandleToOPARMap* HandleToOPARMap = PropertyToOPAR.Find(DependentChannel);
+	if (HandleToOPARMap == nullptr)
+	{
+		return;
+	}
+
+	TSharedPtr<FOutgoingPendingArrayRegister>* OPARPtr = HandleToOPARMap->Find(Handle);
+	if (OPARPtr == nullptr)
+	{
+		return;
+	}
+
+	// Sanity check that we are not changing the container from here while resolving an object.
+	check(!bDebugOutgoingArraySafety);
+
+	TSharedPtr<FOutgoingPendingArrayRegister>& OPAR = *OPARPtr;
+
+	check(OPAR.IsValid());
+
+	UE_LOG(LogSpatialOSPackageMap, Log, TEXT("Resetting pending outgoing array depending on channel: %s, handle: %d."), *DependentChannel->GetName(), Handle);
+
+	// Remove the references from indiviual unresolved objects to this OPAR.
+	for (const UObject* UnresolvedObject : OPAR->UnresolvedObjects)
+	{
+		FChannelToHandleToOPARMap& ChannelToHandleToOPARMap = ObjectToOPAR.FindChecked(UnresolvedObject);
+		FHandleToOPARMap& RelevantHandles = ChannelToHandleToOPARMap.FindChecked(DependentChannel);
+
+		RelevantHandles.Remove(Handle);
+		if (RelevantHandles.Num() == 0)
+		{
+			ChannelToHandleToOPARMap.Remove(DependentChannel);
+			if (ChannelToHandleToOPARMap.Num() == 0)
+			{
+				ObjectToOPAR.Remove(UnresolvedObject);
+			}
+		}
+	}
+
+	// Remove the reference from the property's actor channel and handle to this OPAR.
+	HandleToOPARMap->Remove(Handle);
+	if (HandleToOPARMap->Num() == 0)
+	{
+		PropertyToOPAR.Remove(DependentChannel);
+	}
+}
+
+void USpatialInterop::ResetIncomingArrayRepUpdate_Internal(USpatialActorChannel* DependentChannel, uint16 Handle)
+{
+	check(DependentChannel);
+
+	FHandleToIPARMap* HandleToIPARMap = PropertyToIPAR.Find(DependentChannel);
+	if (HandleToIPARMap == nullptr)
+	{
+		return;
+	}
+
+	TSharedPtr<FIncomingPendingArrayRegister>* IPARPtr = HandleToIPARMap->Find(Handle);
+	if (IPARPtr == nullptr)
+	{
+		return;
+	}
+
+	TSharedPtr<FIncomingPendingArrayRegister>& IPAR = *IPARPtr;
+
+	check(IPAR.IsValid());
+
+	UE_LOG(LogSpatialOSPackageMap, Log, TEXT("Resetting pending incoming array depending on channel: %s, handle: %d."), *DependentChannel->GetName(), Handle);
+
+	// Remove the references from individual unresolved object refs to this IPAR.
+	TArray<FHashableUnrealObjectRef> ObjectRefsArray;
+	IPAR->ObjectRefs.GetKeys(ObjectRefsArray);
+
+	for (const FHashableUnrealObjectRef& ObjectRef : ObjectRefsArray)
+	{
+		FChannelToHandleToIPARMap& ChannelToHandleToIPARMap = ObjectRefToIPAR.FindChecked(ObjectRef);
+		FHandleToIPARMap& RelevantHandles = ChannelToHandleToIPARMap.FindChecked(DependentChannel);
+
+		RelevantHandles.Remove(Handle);
+		if (RelevantHandles.Num() == 0)
+		{
+			ChannelToHandleToIPARMap.Remove(DependentChannel);
+			if (ChannelToHandleToIPARMap.Num() == 0)
+			{
+				ObjectRefToIPAR.Remove(ObjectRef);
+			}
+		}
+	}
+
+	// Destroys the object pointed to by IPAR->Data.
+	IPAR->DataDestructor();
+
+	// Remove the reference from the property's actor channel and handle to this IPAR.
+	HandleToIPARMap->Remove(Handle);
+	if (HandleToIPARMap->Num() == 0)
+	{
+		PropertyToIPAR.Remove(DependentChannel);
+	}
+}
+
+void USpatialInterop::QueueOutgoingArrayRepUpdate_Internal(const TSet<const UObject*>& UnresolvedObjects, USpatialActorChannel* DependentChannel, uint16 Handle)
+{
+	check(DependentChannel);
+
+	UE_LOG(LogSpatialOSPackageMap, Log, TEXT("Added pending outgoing array: channel: %s, handle: %d. Depending on objects:"),
+		*DependentChannel->GetName(), Handle);
+
+	TSharedPtr<FOutgoingPendingArrayRegister> OPAR(new FOutgoingPendingArrayRegister());
+	OPAR->UnresolvedObjects = UnresolvedObjects;
+
+	// Add reference from the property's actor channel and handle to the new OPAR.
+	FHandleToOPARMap& HandleToOPARMap = PropertyToOPAR.FindOrAdd(DependentChannel);
+	// If there was an array queued for the same channel and handle before, it should have been removed in ResetOutgoingArrayRepUpdate_Internal.
+	check(HandleToOPARMap.Find(Handle) == nullptr);
+	HandleToOPARMap.Add(Handle, OPAR);
+
+	// Add references from individual unresolved objects to this OPAR.
+	for (const UObject* UnresolvedObject : UnresolvedObjects)
+	{
+		FHandleToOPARMap& AnotherHandleToOPARMap = ObjectToOPAR.FindOrAdd(UnresolvedObject).FindOrAdd(DependentChannel);
+		check(AnotherHandleToOPARMap.Find(Handle) == nullptr);
+		AnotherHandleToOPARMap.Add(Handle, OPAR);
+
+		UE_LOG(LogSpatialOSPackageMap, Log, TEXT("%s"), *UnresolvedObject->GetName());
+	}
+}
+
+void USpatialInterop::QueueIncomingArrayRepUpdate_Internal(const TMultiMap<FHashableUnrealObjectRef, UObject**>& UnresolvedObjectRefs, USpatialActorChannel* DependentChannel, uint16 Handle, const FRepHandleData* RepHandleData, void* Data, TFunction<void()> DataDestructor)
+{
+	check(DependentChannel);
+	check(RepHandleData);
+	check(Data);
+
+	UE_LOG(LogSpatialOSPackageMap, Log, TEXT("Added pending incoming array: channel: %s, property: %s. Depending on object refs:"),
+		*DependentChannel->GetName(), *RepHandleData->Property->GetName());
+
+	TSharedPtr<FIncomingPendingArrayRegister> IPAR(new FIncomingPendingArrayRegister);
+	IPAR->Data = Data;
+	IPAR->DataDestructor = DataDestructor;
+	IPAR->HandleData = RepHandleData;
+	IPAR->ObjectRefs = UnresolvedObjectRefs;
+
+	// Add reference from the property's actor channel and handle to the new IPAR.
+	FHandleToIPARMap& HandleToIPARMap = PropertyToIPAR.FindOrAdd(DependentChannel);
+	// If there was an array queued for the same channel and handle before, it should have been removed in ResetIncomingArrayRepUpdate_Internal.
+	check(HandleToIPARMap.Find(Handle) == nullptr);
+	HandleToIPARMap.Add(Handle, IPAR);
+
+	// Add references from individual unresolved object refs to this IPAR.
+	TArray<FHashableUnrealObjectRef> UnresolvedRefsArray;
+	UnresolvedObjectRefs.GetKeys(UnresolvedRefsArray);
+	for (const FHashableUnrealObjectRef& ObjectRef : UnresolvedRefsArray)
+	{
+		FHandleToIPARMap& AnotherHandleToIPARMap = ObjectRefToIPAR.FindOrAdd(ObjectRef).FindOrAdd(DependentChannel);
+		check(AnotherHandleToIPARMap.Find(Handle) == nullptr);
+		AnotherHandleToIPARMap.Add(Handle, IPAR);
+
+		UE_LOG(LogSpatialOSPackageMap, Log, TEXT("%s"), *ObjectRefToString(ObjectRef));
+	}
+}
+
 void USpatialInterop::RegisterInteropType(UClass* Class, USpatialTypeBinding* Binding)
 {
 	Binding->Init(this, PackageMap);
@@ -448,14 +614,14 @@ void USpatialInterop::ResolvePendingIncomingObjectUpdates(UObject* Object, const
 		// Trigger pending updates.
 		PreReceiveSpatialUpdate(DependentChannel);
 		TSet<UProperty*> RepNotifies;
-		for (const FRepHandleData* MigData : Properties.Key)
+		for (const FRepHandleData* RepData : Properties.Key)
 		{
-			ApplyIncomingReplicatedPropertyUpdate(*MigData, DependentChannel->Actor, &Object, RepNotifies);
+			ApplyIncomingReplicatedPropertyUpdate(*RepData, DependentChannel->Actor, &Object, RepNotifies);
 			UE_LOG(LogSpatialOSInterop, Log, TEXT("%s: Received queued object replicated property update. actor %s (%lld), property %s"),
 				*SpatialOSInstance->GetWorkerId(),
 				*DependentChannel->Actor->GetName(),
 				DependentChannel->GetEntityId().ToSpatialEntityId(),
-				*MigData->Property->GetName());
+				*RepData->Property->GetName());
 		}
 		for (const FMigratableHandleData* MigData : Properties.Value)
 		{
@@ -485,4 +651,127 @@ void USpatialInterop::ResolvePendingIncomingRPCs(const improbable::unreal::Unrea
 		}
 		PendingIncomingRPCs.Remove(ObjectRef);
 	}
+}
+
+void USpatialInterop::ResolvePendingOutgoingArrayUpdates(UObject* Object)
+{
+	FChannelToHandleToOPARMap* ChannelToHandleToOPARMap = ObjectToOPAR.Find(Object);
+	if (ChannelToHandleToOPARMap == nullptr)
+	{
+		return;
+	}
+
+	for (auto& ChannelProperties : *ChannelToHandleToOPARMap)
+	{
+		USpatialActorChannel* DependentChannel = ChannelProperties.Key;
+		FHandleToOPARMap& HandleToOPARMap = ChannelProperties.Value;
+
+		TArray<uint16> Properties;
+
+		for (auto& HandleOPARPair : HandleToOPARMap)
+		{
+			uint16 Handle = HandleOPARPair.Key;
+			TSharedPtr<FOutgoingPendingArrayRegister>& OPAR = HandleOPARPair.Value;
+
+			// This object is no longer unresolved. If this was the last one, we can now send this array and remove the OPAR.
+			OPAR->UnresolvedObjects.Remove(Object);
+			if (OPAR->UnresolvedObjects.Num() == 0)
+			{
+				Properties.Add(Handle);
+
+				// Remove the reference from the property's channel and handle to this OPAR.
+				FHandleToOPARMap& AnotherHandleToOPARMap = PropertyToOPAR.FindChecked(DependentChannel);
+				AnotherHandleToOPARMap.Remove(Handle);
+				if (AnotherHandleToOPARMap.Num() == 0)
+				{
+					PropertyToOPAR.Remove(DependentChannel);
+				}
+			}
+		}
+
+		if (Properties.Num() > 0)
+		{
+			bDebugOutgoingArraySafety = true;
+
+			SendSpatialUpdate(DependentChannel, Properties, TArray<uint16>());
+
+			bDebugOutgoingArraySafety = false;
+		}
+	}
+
+	// For any array that was resolved in this function, this will remove the last instances of the shared ptrs of
+	// the OPARs, which will destroy them.
+	ObjectToOPAR.Remove(Object);
+}
+
+void USpatialInterop::ResolvePendingIncomingArrayUpdates(UObject* Object, const improbable::unreal::UnrealObjectRef& ObjectRef)
+{
+	FChannelToHandleToIPARMap* ChannelToHandleToIPARMap = ObjectRefToIPAR.Find(ObjectRef);
+	if (ChannelToHandleToIPARMap == nullptr)
+	{
+		return;
+	}
+
+	for (auto& ChannelProperties : *ChannelToHandleToIPARMap)
+	{
+		USpatialActorChannel* DependentChannel = ChannelProperties.Key;
+		FHandleToIPARMap& HandleToIPARMap = ChannelProperties.Value;
+
+		bool bDoReplicate = false;
+		TSet<UProperty*> RepNotifies;
+
+		for (auto& HandleIPARPair : HandleToIPARMap)
+		{
+			uint16 Handle = HandleIPARPair.Key;
+			TSharedPtr<FIncomingPendingArrayRegister>& IPAR = HandleIPARPair.Value;
+
+			// Update each memory location that is waiting on this object.
+			TArray<UObject**> LocationsToWrite;
+			IPAR->ObjectRefs.MultiFind(ObjectRef, LocationsToWrite);
+			for (UObject** Location : LocationsToWrite)
+			{
+				*Location = Object;
+			}
+			IPAR->ObjectRefs.Remove(ObjectRef);
+
+			// If this was the last unresolved object ref, we can apply the whole array to the actor that is waiting for it.
+			if (IPAR->ObjectRefs.Num() == 0)
+			{
+				if (!bDoReplicate)
+				{
+					// PreReceiveSpatialUpdate followed by applying updates followed by PostReceiveSpatialUpdate
+					// is needed to let the object respond to specific properties changing.
+					bDoReplicate = true;
+					PreReceiveSpatialUpdate(DependentChannel);
+				}
+
+				ApplyIncomingReplicatedPropertyUpdate(*IPAR->HandleData, DependentChannel->Actor, IPAR->Data, RepNotifies);
+				UE_LOG(LogSpatialOSInterop, Log, TEXT("%s: Received queued array replicated property update. actor %s (%lld), property %s"),
+					*SpatialOSInstance->GetWorkerId(),
+					*DependentChannel->Actor->GetName(),
+					DependentChannel->GetEntityId().ToSpatialEntityId(),
+					*IPAR->HandleData->Property->GetName());
+
+				// Destroys the object pointed to by IPAR->Data.
+				IPAR->DataDestructor();
+
+				// Remove the reference from the property's channel and handle to this IPAR.
+				FHandleToIPARMap& AnotherHandleToIPARMap = PropertyToIPAR.FindChecked(DependentChannel);
+				AnotherHandleToIPARMap.Remove(Handle);
+				if (AnotherHandleToIPARMap.Num() == 0)
+				{
+					PropertyToIPAR.Remove(DependentChannel);
+				}
+			}
+		}
+
+		if (bDoReplicate)
+		{
+			PostReceiveSpatialUpdate(DependentChannel, RepNotifies.Array());
+		}
+	}
+
+	// For any array that was resolved in this function, this will remove the last instances of the shared ptrs of
+	// the IPARs, which will destroy them.
+	ObjectRefToIPAR.Remove(ObjectRef);
 }

--- a/Source/SpatialGDK/Private/SpatialInterop.cpp
+++ b/Source/SpatialGDK/Private/SpatialInterop.cpp
@@ -678,6 +678,9 @@ void USpatialInterop::ResolvePendingOutgoingArrayUpdates(UObject* Object)
 			if (OPAR->UnresolvedObjects.Num() == 0)
 			{
 				Properties.Add(Handle);
+				// We don't need to add handles for the array elements, but we need to put 0 for the number of array element handles, as well as null terminator for the array.
+				Properties.Add(0);
+				Properties.Add(0);
 
 				// Remove the reference from the property's channel and handle to this OPAR.
 				FHandleToOPARMap& AnotherHandleToOPARMap = PropertyToOPAR.FindChecked(DependentChannel);
@@ -691,6 +694,9 @@ void USpatialInterop::ResolvePendingOutgoingArrayUpdates(UObject* Object)
 
 		if (Properties.Num() > 0)
 		{
+			// End with zero to indicate the end of the list of handles.
+			Properties.Add(0);
+
 			bDebugOutgoingArraySafety = true;
 
 			SendSpatialUpdate(DependentChannel, Properties, TArray<uint16>());


### PR DESCRIPTION
`TypeBindingGenerator.h` and `TypeBindingGenerator.cpp` should be considered WIP in terms of code structure. This part will be revisited and improved.

This PR implements functionality to delay sending and receiving arrays of UObjects when there are unresolved objects contained, which makes it possible to replicate such arrays correctly. This means that the clients will not receive a nullptr instead of unresolved object, but queue up the update until all the contained objects are resolved.
The implementation in the `SpatialInterop` was guided by the intention to also use the same functionality for the arrays of structs that contain UObjects. There is additional work to make that work in the code generation (UNR-180).