### PR TITLE
UNR-231 Structs with NetSerialize now get serialized correctly when used as an RPC argument

### DIFF
--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SchemaGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SchemaGenerator.cpp
@@ -99,9 +99,15 @@ FString PropertyToSchemaType(UProperty* Property)
 		{
 			DataType = TEXT("UnrealFPlane");
 		}
+		else if (Struct->StructFlags & STRUCT_NetSerializeNative)
+		{
+			// Specifically when NetSerialize is implemented for a struct we want to use 'bytes'.
+			// This includes RepMovement and UniqueNetId.
+			DataType = TEXT("bytes");
+		}
 		else
 		{
-			DataType = TEXT("bytes"); //this includes RepMovement and UniqueNetId
+			DataType = TEXT("bytes");
 		}
 	}
 	else if (Property->IsA(UBoolProperty::StaticClass()))


### PR DESCRIPTION
#### Description
Structs with NetSerialize now get serialized correctly when used as an RPC argument
Essentially before this change we would flatten structs used as RPC arguments even when they had NetSerialize implemented.
Now we correctly replicate them as bytes and use NetSerialize to handle the rest.

#### Tests
Made a custom struct in SampleGameCharacter which had a serialized int and a non-serialized int.
The serialized int was handled by the NetSerialize for the struct. 
Made it so the int within this struct was incremented on a button press, the struct was then used as a 'server' RPC argument and printed on the server side.
Link to SampleGame branch changes: https://github.com/improbable/unreal-gdk-sample-game/pull/44
Please check the SampleGame changes to see the usage.

#### Documentation
https://improbableio.atlassian.net/browse/UNR-231
Documented the use of NetSerialize in TypeStructure.cpp and SchemaGenerator.cpp
