### PR TITLE
Bugfix/unr 327: move copystep to codegen cs

### DIFF
--- a/Scripts/Codegen.bat
+++ b/Scripts/Codegen.bat
@@ -2,15 +2,6 @@
 
 pushd "%~dp0..\"
 
-:: Back compat: ensure that the standard schema is available for the `spatial upload` command.
-:: It's distributed with the CodeGenerator, so it's copied from there into the expected location.
-
-set SPATIAL_DEPENDENCY_DIR=".\..\spatial\build\dependencies\schema\standard_library"
-if exist "%SPATIAL_DEPENDENCY_DIR%" rd /S /Q "%SPATIAL_DEPENDENCY_DIR%"
-if not exist "%SPATIAL_DEPENDENCY_DIR%" mkdir "%SPATIAL_DEPENDENCY_DIR%"
-echo Installing standard library schema.
-xcopy /S /Y /Q "Binaries\ThirdParty\Improbable\Programs\schema" "%SPATIAL_DEPENDENCY_DIR%"
-
 if not exist "Intermediate\Improbable" mkdir "Intermediate\Improbable"
 
 csc "Scripts/Codegen.cs" "Scripts/Common.cs" /nologo /out:"Intermediate\Improbable\Codegen.exe" || exit /b 1

--- a/Scripts/Codegen.cs
+++ b/Scripts/Codegen.cs
@@ -9,6 +9,21 @@ namespace Improbable
         {
             Common.EnsureDirectoryEmpty(@"Intermediate\Improbable\Json");
 
+            // Copy the Schema dependencies from the worker sdk to the spatial folder.
+            var spatialDependencyDir = new DirectoryInfo(@"..\spatial\build\dependencies\schema\standard_library");
+
+            if(!spatialDependencyDir.Exists)
+            {
+                spatialDependencyDir.Delete(true);
+                spatialDependencyDir.Create();
+            }
+
+            Common.RunRedirected(@"Scripts\DiffCopy.bat", new[]
+            {
+                @"Binaries\ThirdParty\Improbable\Programs\schema",
+                $"{spatialDependencyDir.FullName}"
+            });
+
             var files = Directory.GetFiles(@"..\spatial\schema", "*.schema", SearchOption.AllDirectories).Union(
                 Directory.GetFiles(@"Binaries\ThirdParty\Improbable\Programs\schema", "*.schema",
                     SearchOption.AllDirectories));

--- a/Scripts/Codegen.cs
+++ b/Scripts/Codegen.cs
@@ -9,19 +9,12 @@ namespace Improbable
         {
             Common.EnsureDirectoryEmpty(@"Intermediate\Improbable\Json");
 
-            // Copy the Schema dependencies from the worker sdk to the spatial folder.
-            var spatialDependencyDir = new DirectoryInfo(@"..\spatial\build\dependencies\schema\standard_library");
-
-            if(!spatialDependencyDir.Exists)
-            {
-                spatialDependencyDir.Delete(true);
-                spatialDependencyDir.Create();
-            }
-
+            // Back compat: ensure that the standard schema is available for the `spatial upload` command.
+            // It's distributed with the CodeGenerator, so it's copied from there into the expected location.
             Common.RunRedirected(@"Scripts\DiffCopy.bat", new[]
             {
                 @"Binaries\ThirdParty\Improbable\Programs\schema",
-                $"{spatialDependencyDir.FullName}"
+                @"..\spatial\build\dependencies\schema\standard_library"
             });
 
             var files = Directory.GetFiles(@"..\spatial\schema", "*.schema", SearchOption.AllDirectories).Union(


### PR DESCRIPTION
#### Description

Moved the copystep from `Codegen.bat` to `Codegen.cs`. This will allow local launch to work from within the editor.

#### Tests
Tested codegen.bat manually and when triggered through the ide.

#### Documentation
* Please provide the JIRA link for this task.
* Please provide the Google Docs link for any documentation associated with this task.
* Please note if the documentation is in code.
* Please explain if documentation is not needed.
#### Primary reviewers
@improbable-valentyn @m-samiec 
