### PR TITLE
Implement arrays of UObject* with queuing only on sending side

### DIFF
--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
@@ -1554,8 +1554,9 @@ void GenerateBody_ReceiveUpdate_RepDataProperty(FCodeWriter& SourceWriter, uint1
 	else if (Property->IsA<UArrayProperty>())
 	{
 		UArrayProperty* ArrayProperty = Cast<UArrayProperty>(Property);
-		SourceWriter.Printf("TArray<%s> %s = *(reinterpret_cast<TArray<%s> *>(PropertyData));", *(ArrayProperty->Inner->GetCPPType()), *PropertyValueName, *(ArrayProperty->Inner->GetCPPType()));
-		if (ArrayProperty->Inner->IsA<UObjectPropertyBase>())
+		UProperty* InnerProperty = ArrayProperty->Inner;
+		SourceWriter.Printf("TArray<%s> %s = *(reinterpret_cast<TArray<%s> *>(PropertyData));", *(InnerProperty->GetCPPType()), *PropertyValueName, *(InnerProperty->GetCPPType()));
+		if (InnerProperty->IsA<UObjectPropertyBase>())
 		{
 			bIsArrayOfObjects = true;
 		}
@@ -1593,6 +1594,8 @@ void GenerateBody_ReceiveUpdate_RepDataProperty(FCodeWriter& SourceWriter, uint1
 			// This callback is called on the inner property of an array of objects. In the future, we need a way to track this property
 			// as an unmapped object reference and update its value once the object is resolved. Until then, ignore this object ref.
 			SourceWriter.Print(R"""(
+				// Pre-alpha limitation: if a UObject* in an array property is unresolved, we currently don't have a way to update it once
+				// it is resolved. It will remain null and will only be updated when the server replicates this array again (when it changes).
 				UE_LOG(LogSpatialOSInterop, Warning, TEXT("%s: Ignoring unresolved object property. Value: %s. actor %s (%lld), property %s (handle %d)"),
 					*Interop->GetSpatialOS()->GetWorkerId(),
 					*ObjectRefToString(ObjectRef),

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
@@ -18,9 +18,18 @@ FString GetNativeClassName(const UObjectPropertyBase* Property);
 void GenerateUnrealToSchemaConversion(
 	FCodeWriter& Writer,
 	const FString& Update,
-	const UProperty* Property,
+	UProperty* Property,
 	const FString& PropertyValue,
 	TFunction<void(const FString&)> ObjectResolveFailureGenerator);
+
+// Generates code to handle the queueing of an array of UObject* if it contains unresolved objects.
+// Currently only supports replicated properties (i.e. does not support migratable properties or RPC arguments).
+void GenerateUObjectArrayToSchemaConversion(
+	FCodeWriter& Writer,
+	const FString& Update,
+	UArrayProperty* Property,
+	const FString& PropertyValue,
+	uint16 Handle);
 
 // Generates code to extract property data from a SpatialOS component update object and write it to an Unreal 'PropertyValue'
 void GeneratePropertyToUnrealConversion(

--- a/Source/SpatialGDK/Private/SpatialInterop.cpp
+++ b/Source/SpatialGDK/Private/SpatialInterop.cpp
@@ -378,6 +378,10 @@ void USpatialInterop::QueueIncomingRPC_Internal(const improbable::unreal::Unreal
 
 void USpatialInterop::ResetOutgoingArrayRepUpdate_Internal(USpatialActorChannel* DependentChannel, uint16 Handle)
 {
+	// This is called when trying to send an update on a given property on a given USpatialActorChannel. In case there
+	// was a pending outgoing update queued up before, it will now be obsolete, e.g. it's possible that unresolved
+	// objects that were queued up are no longer in the array, or there may be new unresolved objects present.
+
 	check(DependentChannel);
 
 	FHandleToOPARMap* HandleToOPARMap = PropertyToOPAR.Find(DependentChannel);
@@ -430,7 +434,7 @@ void USpatialInterop::QueueOutgoingArrayRepUpdate_Internal(const TSet<const UObj
 	UE_LOG(LogSpatialOSPackageMap, Log, TEXT("Added pending outgoing array: channel: %s, handle: %d. Depending on objects:"),
 		*DependentChannel->GetName(), Handle);
 
-	TSharedPtr<FOutgoingPendingArrayRegister> OPAR(new FOutgoingPendingArrayRegister());
+	TSharedPtr<FOutgoingPendingArrayRegister> OPAR = MakeShared<FOutgoingPendingArrayRegister>();
 	OPAR->UnresolvedObjects = UnresolvedObjects;
 
 	// Add reference from the property's actor channel and handle to the new OPAR.
@@ -446,6 +450,7 @@ void USpatialInterop::QueueOutgoingArrayRepUpdate_Internal(const TSet<const UObj
 		check(AnotherHandleToOPARMap.Find(Handle) == nullptr);
 		AnotherHandleToOPARMap.Add(Handle, OPAR);
 
+		// Following up on the previous log: listing the unresolved objects
 		UE_LOG(LogSpatialOSPackageMap, Log, TEXT("%s"), *UnresolvedObject->GetName());
 	}
 }


### PR DESCRIPTION
#### Description
This implements the queuing mechanism for arrays of `UObject*` on the sending side, and adds support for arrays of `UObject*` in the type binding generator.
Functionally, the outgoing updates of such arrays will be delayed if any object in that array is unresolved. Once all such objects are resolved, the update will be sent.
On the receiving end, the unresolved object refs are treated as null.
For the single server scenario that we have right now, this will handle most cases, except the initial checkout of the objects, where some references might be uninitialized.
The proper solution for the unresolved object refs on the receiving side is still being designed, but it is more relevant in the context of multiple workers and migration.
#### Tests
Changes to the generated code on the test branch of sample game `feature/UNR-189-arrays-of-uobjects-demo`: https://github.com/improbable/unreal-gdk-sample-game/commit/44b7ee44e91fcbcee2e4e93f1b3b1376caccd960
The sample game builds and runs, and the array replication behavior is as expected.

#### Documentation
https://improbableio.atlassian.net/browse/UNR-189
The code has comments explaining the mechanism of queuing. Comments were added wherever deemed necessary. Please mark places that need additional comments if there are any.
#### Primary reviewers
@girayimprobable, @m-samiec 
