### PR TITLE
UNR-280 -> Fix serialization of nested arrays

### DIFF
--- a/Source/SpatialGDK/Private/SpatialActorChannel.cpp
+++ b/Source/SpatialGDK/Private/SpatialActorChannel.cpp
@@ -1,6 +1,5 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
-#pragma optimize("", off)
 
 #include "SpatialActorChannel.h"
 #include "Engine/DemoNetDriver.h"
@@ -572,5 +571,3 @@ FVector USpatialActorChannel::GetActorSpatialPosition(AActor* Actor)
 		return FVector::ZeroVector;
 	}
 }
-
-#pragma optimize("", on)

--- a/Source/SpatialGDK/Private/SpatialActorChannel.cpp
+++ b/Source/SpatialGDK/Private/SpatialActorChannel.cpp
@@ -1,5 +1,7 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
+#pragma optimize("", off)
+
 #include "SpatialActorChannel.h"
 #include "Engine/DemoNetDriver.h"
 #include "EntityRegistry.h"
@@ -291,8 +293,9 @@ bool USpatialActorChannel::ReplicateActor()
 			// Ensure that the initial changelist contains _every_ property. This ensures that the default properties are written to the entity template.
 			// Otherwise, there will be a mismatch between the rep state shadow data used by CompareProperties and the entity in SpatialOS.
 			TArray<uint16> InitialRepChanged;
-			bool bInDynamicArray = false;
-			for (uint16 CmdIdx = 0; CmdIdx < ActorReplicator->RepLayout->Cmds.Num(); ++CmdIdx)
+			int32 DynamicArrayDepth = 0;
+			const int32 CmdCount = ActorReplicator->RepLayout->Cmds.Num();
+			for (uint16 CmdIdx = 0; CmdIdx < CmdCount; ++CmdIdx)
 			{
 				const auto& Cmd = ActorReplicator->RepLayout->Cmds[CmdIdx];
 
@@ -300,16 +303,21 @@ bool USpatialActorChannel::ReplicateActor()
 
 				if (Cmd.Type == REPCMD_DynamicArray)
 				{
-					checkf(!bInDynamicArray, TEXT("Encountered nested array"));
-					bInDynamicArray = true;
-					// Add the number of array properties to comform to Unreal's RepLayout design and 
+					DynamicArrayDepth++;
+
+					// For the first layer of each dynamic array encountered at the root level
+					// add the number of array properties to conform to Unreal's RepLayout design and 
 					// allow FRepHandleIterator to jump over arrays. Cmd.EndCmd is an index into 
 					// RepLayout->Cmds[] that points to the value after the termination NULL of this array.
-					InitialRepChanged.Add((Cmd.EndCmd - CmdIdx) - 2);
+					if (DynamicArrayDepth == 1)
+					{
+						InitialRepChanged.Add((Cmd.EndCmd - CmdIdx) - 2);
+					}
 				}
 				else if (Cmd.Type == REPCMD_Return)
 				{
-					bInDynamicArray = false;
+					DynamicArrayDepth--;
+					checkf(DynamicArrayDepth >= 0 || CmdIdx == CmdCount - 1, TEXT("Encountered erroneous RepLayout"));
 				}
 			}
 
@@ -564,3 +572,5 @@ FVector USpatialActorChannel::GetActorSpatialPosition(AActor* Actor)
 		return FVector::ZeroVector;
 	}
 }
+
+#pragma optimize("", on)

--- a/Source/SpatialGDK/Private/SpatialActorChannel.cpp
+++ b/Source/SpatialGDK/Private/SpatialActorChannel.cpp
@@ -1,6 +1,5 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
-
 #include "SpatialActorChannel.h"
 #include "Engine/DemoNetDriver.h"
 #include "EntityRegistry.h"


### PR DESCRIPTION
#### Description
Nested array/structs were asserting when their owning actor was replicated. This assertion is unnecessary as replication of arrays is handled either via custom NetSerialize() code, or via the default SerializeBin(), which recurses into member properties and does a full replicate. This is clearly less than optimal however, as it means that any change to anything within the subtype will force the entire parent type to be replicated. Fixing this is will require changing how we track replicated changes within the type bindings as we currently only track the root level properties (and default expanded root member structs).

I'll create a Jira task for this and tag it.

#### Tests
`USTRUCT(BlueprintType)
struct FFoo
{
    GENERATED_BODY()

    UPROPERTY()
    int FooMember;
};

USTRUCT(BlueprintType)
struct FBar
{
	GENERATED_BODY()

	UPROPERTY()
	TArray<FFoo> CanReplicateThisMember;
}

...

UPROPERTY(replicated)
TArray<FBar> BarArray;
`

Changes to FooMember within CanReplicateThisMember are replicated correctly across the network.

#### Primary reviewers
@girayimprobable @joshuahuburn 
