### PR TITLE
[UNR-337] Improve the codegen time by not recompiling C# utilities every time

### DIFF
--- a/Scripts/Build.bat
+++ b/Scripts/Build.bat
@@ -4,11 +4,14 @@ pushd "%~dp0..\"
 
 call "Scripts\BuildWorkerConfig.bat"
 
-if not exist "Intermediate\Improbable" mkdir "Intermediate\Improbable"
+set BUILD_EXE_PATH="Binaries\ThirdParty\Improbable\Programs\Build.exe"
 
-csc "Scripts/Build.cs" "Scripts/Codegen.cs" "Scripts/Common.cs" /main:"Improbable.Build" /nologo /out:"Intermediate\Improbable\Build.exe" || exit /b 1
+if not exist %BUILD_EXE_PATH% (
+	echo Error: Build executable not found! Please run ci/build.sh in your SpatialGDK directory to generate it.
+	exit /b 1
+)
 
-Intermediate\Improbable\Build.exe %*
+%BUILD_EXE_PATH% %*
 
 popd
 

--- a/Scripts/Codegen.bat
+++ b/Scripts/Codegen.bat
@@ -2,10 +2,15 @@
 
 pushd "%~dp0..\"
 
-if not exist "Intermediate\Improbable" mkdir "Intermediate\Improbable"
+set CODEGEN_PATH="Binaries\ThirdParty\Improbable\Programs\Codegen.exe"
 
-csc "Scripts/Codegen.cs" "Scripts/Common.cs" /nologo /out:"Intermediate\Improbable\Codegen.exe" || exit /b 1
+if not exist %CODEGEN_PATH% (
+	echo Error: Codegen executable not found! Please run ci/build.sh in your SpatialGDK directory to generate it.
+	exit /b 1
+)
 
-Intermediate\Improbable\Codegen.exe %*
+%CODEGEN_PATH% %*
+
+popd
 
 exit /b %ERRORLEVEL%

--- a/Scripts/DiffCopy.bat
+++ b/Scripts/DiffCopy.bat
@@ -2,11 +2,14 @@
 
 pushd "%~dp0..\"
 
-if not exist "Intermediate\Improbable" mkdir "Intermediate\Improbable"
+set DIFFCOPY_PATH="Binaries\ThirdParty\Improbable\Programs\DiffCopy.exe"
 
-csc "Scripts/DiffCopy.cs" /nologo /out:"Intermediate\Improbable\DiffCopy.exe" || exit /b 1
+if not exist %DIFFCOPY_PATH% (
+	echo Error: DiffCopy executable not found! Please run ci/build.sh in your SpatialGDK directory to generate it.
+	exit /b 1
+)
 
-Intermediate\Improbable\DiffCopy.exe %*
+%DIFFCOPY_PATH% %*
 
 popd
 

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -112,6 +112,10 @@ markStartOfBlock "Build CodeGeneration"
 cp -a "Source/Programs/Improbable.Unreal.CodeGeneration/bin/Release/"*.dll "${UNREAL_GDK_DIR}/Binaries/ThirdParty/Improbable/Programs"
 cp -a "Source/Programs/Improbable.Unreal.CodeGeneration/bin/Release/"*.exe "${UNREAL_GDK_DIR}/Binaries/ThirdParty/Improbable/Programs"
 
+csc "Scripts/Build.cs" "Scripts/Codegen.cs" "Scripts/Common.cs" -main:"Improbable.Build" -nologo -out:"${UNREAL_GDK_DIR}/Binaries/ThirdParty/Improbable/Programs/Build.exe"
+csc "Scripts/Codegen.cs" "Scripts/Common.cs"                                             -nologo -out:"${UNREAL_GDK_DIR}/Binaries/ThirdParty/Improbable/Programs/Codegen.exe"
+csc "Scripts/DiffCopy.cs"                                                                -nologo -out:"${UNREAL_GDK_DIR}/Binaries/ThirdParty/Improbable/Programs/DiffCopy.exe"
+
 markEndOfBlock "Build CodeGeneration"
 
 markEndOfBlock "$0"


### PR DESCRIPTION
#### Description
Make codegen faster. On my machine it used to take ~15-20 seconds, now takes 3.
After this is merged you'll need to run `ci/build.sh` in your UnrealGDK repo before you can run Codegen.
Also, any changes to the C# utilities will now require running `ci/build.sh` to reflect the changes, but it should be pretty rare at this point.
#### Tests
Run `ci/build.sh` locally, find `Build`, `Codegen`, and `DiffCopy` executables in `Binaries/ThirdParty/Improbable/Programs`.
Remove the `Generated` folder in `Game/Source/SpatialGDK`, run `Game/Scripts/Codegen.bat`. It took about 2 seconds, and the `Generated` folder was regenerated.
Build the editor, remove the `Generated` folder in `Game/Source/SampleGame`, press Interop Codegen button. It took about 3 seconds, and the `Generated` folder was regenerated.

Also, ran `unreal-gdk-sample-game` CI on `master` against this branch of `unreal-gdk`, and it's green. [Link to CI build](http://teamcity.corp-eu1.internal.improbable.io/viewLog.html?buildId=1463970&tab=buildResultsDiv&buildTypeId=Develop_UnrealGdk_BuildSampleGame)
#### Primary reviewers
@m-samiec @joshuahuburn 
