### PR TITLE
UNR-334 Support duplicated property types in nested structs

### DIFF
--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SpatialGDKEditorInteropCodeGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SpatialGDKEditorInteropCodeGenerator.cpp
@@ -29,7 +29,7 @@ int GenerateCompleteSchemaFromClass(const FString& SchemaPath, const FString& Fo
 	FString TypeBindingFilename = FString::Printf(TEXT("SpatialTypeBinding_%s"), *Class->GetName());
 
 	// Parent and static array index start at 0 for checksum calculations.
-	TSharedPtr<FUnrealType> TypeInfo = CreateUnrealTypeInfo(Class, MigratableProperties, 0, 0, false);
+	TSharedPtr<FUnrealType> TypeInfo = CreateUnrealTypeInfo(Class, MigratableProperties, 0);
 
 	// Generate schema.
 	int NumComponents = GenerateTypeBindingSchema(OutputSchema, ComponentId, Class, TypeInfo, SchemaPath);

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeStructure.h
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeStructure.h
@@ -194,7 +194,7 @@ uint32 GenerateChecksum(UProperty* Property, TSharedPtr<FUnrealProperty> Propert
 //	   {"OtherProperty", "PropertyWithinOtherProperty"}
 //   }
 // In the future, we can get this information directly from the UStruct*.
-TSharedPtr<FUnrealType> CreateUnrealTypeInfo(UStruct* Type, const TArray<TArray<FName>>& MigratableProperties, uint32 ParentChecksum, uint32 StaticArrayIndex, bool bIsStaticArray);
+TSharedPtr<FUnrealType> CreateUnrealTypeInfo(UStruct* Type, const TArray<TArray<FName>>& MigratableProperties, uint32 ParentChecksum);
 
 // Takes an FUnrealProperty (which is a Spatial wrapper around UProperties for replicated properties) and compares its parents against
 // the parents found in a 'RepLayout.Cmd.ParentPropertyChain' (Improbable engine modification to track parent properties when generating a RepLayout).


### PR DESCRIPTION
#### Description
As described in [UNR-334](https://improbableio.atlassian.net/browse/UNR-334) we originally had no way to distinguish fields in structs when two structs of a same type exist in a container etc. 

This required an engine modification which must be reviewed in conjunction: https://github.com/improbable/UnrealEngine/pull/7

TLDR: We now store a list of parent properties in the `Cmds` that come from (and we use to map to) `RepLayout`. We map this parent chain to our own which we have in the `FUnrealProperty` (which needs a new name btw).

I looked at many other ways of doing this without engine modification but could not find a reasonable solution. 

#### Tests
Tested extensively in SampleGame : https://github.com/improbable/unreal-gdk-sample-game/pull/57
Please take a look at this for reference of what we can now support.
This enables structs such as :
![image](https://user-images.githubusercontent.com/31517089/41555379-70ef91ea-732f-11e8-8277-c2cd257b6827.png)

In the schema they look like :
```
	int32 field_testcontainerstruct_structred_rootprop = 44; 
	int32 field_testcontainerstruct_structblue_rootprop = 45;
```
More examples visible in the SampleGame Pr: https://github.com/improbable/unreal-gdk-sample-game/pull/57

#### Primary reviewers
@girayimprobable @m-samiec 