### PR TITLE
Add git hooks to run ci/build.sh

### DIFF
--- a/ci/hooks/post-checkout
+++ b/ci/hooks/post-checkout
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e -u -o pipefail
+
+PREV_HEAD=$1
+NEW_HEAD=$2
+CHECKOUT_FLAG=$3
+
+if [ "${PREV_HEAD}" != "${NEW_HEAD}" ] && [ "${CHECKOUT_FLAG}" == "1" ]; then
+  ci/build.sh
+fi

--- a/ci/hooks/post-merge
+++ b/ci/hooks/post-merge
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e -u -o pipefail
+
+ci/build.sh

--- a/ci/setup-hooks.sh
+++ b/ci/setup-hooks.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e -u -o pipefail
+
+cd "$(dirname "$0")/../"
+
+HOOK_SOURCE="$(pwd)/ci/hooks/post-merge"
+HOOK_TARGET="$(pwd)/.git/hooks/post-merge"
+
+if [ ! -e "${HOOK_TARGET}" ]; then
+    echo "Copying the post-merge hook ${HOOK_SOURCE} -> ${HOOK_TARGET}."
+    cp "${HOOK_SOURCE}" "${HOOK_TARGET}"
+else
+    echo "A post-merge hook already exists at ${HOOK_TARGET}."
+fi
+
+HOOK_SOURCE="$(pwd)/ci/hooks/post-checkout"
+HOOK_TARGET="$(pwd)/.git/hooks/post-checkout"
+
+if [ ! -e "${HOOK_TARGET}" ]; then
+    echo "Copying the post-checkout hook ${HOOK_SOURCE} -> ${HOOK_TARGET}."
+    cp "${HOOK_SOURCE}" "${HOOK_TARGET}"
+else
+    echo "A post-checkout hook already exists at ${HOOK_TARGET}."
+fi


### PR DESCRIPTION
#### Description
When C# utilities or Unreal SDK codegen are updated, you need to run `ci/build.sh` so your binaries are up to date. It's really easy to forget to do that, or not even know you need to do that if something was merged into master and you're just pulling. If your binaries are outdated, you might end up spending valuable time trying to find the problem in your code even when there isn't one.
To avoid this, these hooks will run `ci/build.sh` on `post-merge` and `post-checkout` (effectively, whenever you pull or switch a branch).
Later we could add a check to only build binaries if the source changed.

The git hooks are opt-in: to set them up, run `ci/setup-hooks.sh`.
#### Primary reviewers
@girayimprobable @m-samiec 