### PR TITLE
[UNR-294] Fix loss of input when connecting

### DIFF
--- a/Source/SpatialGDK/Private/SpatialInterop.cpp
+++ b/Source/SpatialGDK/Private/SpatialInterop.cpp
@@ -477,7 +477,7 @@ void USpatialInterop::QueueOutgoingArrayRepUpdate_Internal(const TSet<const UObj
 void USpatialInterop::RegisterInteropType(UClass* Class, USpatialTypeBinding* Binding)
 {
 	Binding->Init(this, PackageMap);
-	Binding->BindToView();
+	Binding->BindToView(NetDriver->GetNetMode() == NM_Client);
 	TypeBindings.Add(Class, Binding);
 }
 

--- a/Source/SpatialGDK/Public/SpatialTypeBinding.h
+++ b/Source/SpatialGDK/Public/SpatialTypeBinding.h
@@ -228,7 +228,7 @@ public:
 		PURE_VIRTUAL(USpatialTypeBinding::GetMigratableHandlePropertyMap, static FMigratableHandlePropertyMap Map; return Map; );
 
 	virtual void Init(USpatialInterop* Interop, USpatialPackageMapClient* PackageMap);
-	virtual void BindToView() PURE_VIRTUAL(USpatialTypeBinding::BindToView, );
+	virtual void BindToView(bool bIsClient) PURE_VIRTUAL(USpatialTypeBinding::BindToView, );
 	virtual void UnbindFromView() PURE_VIRTUAL(USpatialTypeBinding::UnbindFromView, );
 	virtual UClass* GetBoundClass() const PURE_VIRTUAL(USpatialTypeBinding::GetBoundClass, return nullptr; );
 


### PR DESCRIPTION
#### Description
`unreal-gdk-sample-game` PR: https://github.com/improbable/unreal-gdk-sample-game/pull/60

The loss of input when connecting to SpatialOS was caused by `PlayerController->AcknowledgedPawn` being overwritten with `nullptr` on the client. This happened because when doing the initial checkout, before the component interests are applied, the clients applied the `AcknowledgedPawn` migratable property.
This didn't happen consistently because sometimes `ClientRestart` RPC was executed after this initial checkout in which case `AcknowledgedPawn` would be set to the correct value.

My approach was to stop the clients from registering the callback for the migratable properties. There are other possible ways to accomplish the same, so let me know if you prefer a different approach.
#### Tests
Run sample game. `AcknowledgedPawn` field is not overwritten (tested with a memory breakpoint).
The loss of input issue does not happen anymore.
#### Documentation
https://improbableio.atlassian.net/browse/UNR-294
#### Primary reviewers
@girayimprobable @m-samiec 
