### PR TITLE
Fixed managed workers deploying

### DIFF
--- a/Scripts/Build.cs
+++ b/Scripts/Build.cs
@@ -24,7 +24,7 @@ gosu $NEW_USER ""${SCRIPT}"" ""$@"" 2> >(grep -v xdg-user-dir >&2)`";
 
         private const string RunEditorScript =
             @"setlocal ENABLEDELAYEDEXPANSION
-%%UNREAL_HOME%%\Engine\Binaries\Win64\UE4Editor.exe ""{0}"" %%*
+%UNREAL_HOME%\Engine\Binaries\Win64\UE4Editor.exe ""{0}"" %*
 exit /b !ERRORLEVEL!
 ";
 
@@ -89,7 +89,7 @@ exit /b !ERRORLEVEL!
 
                 // Write a simple batch file to launch the Editor as a managed worker.
                 File.WriteAllText(Path.Combine(windowsEditorPath, "StartEditor.bat"),
-                    string.Format(RunEditorScript, projectFile), Encoding.UTF8);
+                    string.Format(RunEditorScript, projectFile), new UTF8Encoding(false));
 
                 // The runtime currently requires all workers to be in zip files. Zip the batch file.
                 Common.RunRedirected(@"%UNREAL_HOME%\Engine\Build\BatchFiles\RunUAT.bat", new[]
@@ -171,7 +171,7 @@ exit /b !ERRORLEVEL!
                 // Write out the wrapper shell script to work around issues between UnrealEngine and our cloud Linux environments.
                 var linuxServerPath = Path.Combine(stagingDir, "LinuxServer");
                 File.WriteAllText(Path.Combine(linuxServerPath, "StartWorker.sh"), UnrealWorkerShellScript,
-                    Encoding.UTF8);
+                    new UTF8Encoding(false));
 
                 Common.RunRedirected(@"%UNREAL_HOME%\Engine\Build\BatchFiles\RunUAT.bat", new[]
                 {

--- a/Source/SpatialGDK/Private/SpatialPackageMapClient.cpp
+++ b/Source/SpatialGDK/Private/SpatialPackageMapClient.cpp
@@ -20,9 +20,18 @@ void GetSubobjects(UObject* Object, TArray<UObject*>& InSubobjects)
 		// Objects can only be allocated NetGUIDs if this is true.
 		if (Object->IsSupportedForNetworking() && !Object->IsPendingKill() && !Object->IsEditorOnly())
 		{
+			UObject* Outer = Object->GetOuter();
+			while (Outer != nullptr)
+			{
+				if (Outer->IsPendingKill())
+				{
+					return;
+				}
+				Outer = Outer->GetOuter();
+			}
 			InSubobjects.Add(Object);
 		}
-	});
+	}, true, RF_NoFlags, EInternalObjectFlags::PendingKill);
 
 	InSubobjects.StableSort([](UObject& A, UObject& B)
 	{

--- a/Source/SpatialGDK/Private/SpatialPackageMapClient.cpp
+++ b/Source/SpatialGDK/Private/SpatialPackageMapClient.cpp
@@ -20,6 +20,11 @@ void GetSubobjects(UObject* Object, TArray<UObject*>& InSubobjects)
 		// Objects can only be allocated NetGUIDs if this is true.
 		if (Object->IsSupportedForNetworking() && !Object->IsPendingKill() && !Object->IsEditorOnly())
 		{
+			// Walk up the outer chain and ensure that no object is PendingKill. This is required because although
+			// EInternalObjectFlags::PendingKill prevents objects that are PendingKill themselves from getting added
+			// to the list, it'll still add children of PendingKill objects. This then causes an assertion within 
+			// FNetGUIDCache::RegisterNetGUID_Server where it again iterates up the object's owner chain, assigning
+			// ids and ensuring that no object is set to PendingKill in the process.
 			UObject* Outer = Object->GetOuter();
 			while (Outer != nullptr)
 			{


### PR DESCRIPTION
#### Description
Fixed assembly bat file generation and prevented pending kill objects getting added to netguid generated list. This was causing a problem in FNetGUIDCache::RegisterNetGUID_Server where it checks for pending death not just on the passed in object, but all the objects outers also.

#### Tests
Locally, I updated default_launch.json to launch one managed worker, I then ran 'spatial local launch'.

#### Primary reviewers
@girayimprobable @danielimprobable 
