### PR TITLE
UNR-353: Delete entity in channel Close(), do authority check via View

### DIFF
--- a/Source/SpatialGDK/Private/SpatialActorChannel.cpp
+++ b/Source/SpatialGDK/Private/SpatialActorChannel.cpp
@@ -113,7 +113,7 @@ void USpatialActorChannel::UnbindFromSpatialView() const
 	PinnedView->Remove(CreateEntityCallback);*/
 }
 
-void USpatialActorChannel::DeleteActorEntityIfAuthoritative()
+void USpatialActorChannel::DeleteEntityIfAuthoritative()
 {
 	bool bHasAuthority = false;
 
@@ -139,7 +139,7 @@ bool USpatialActorChannel::CleanUp(const bool bForDestroy)
 
 void USpatialActorChannel::Close()
 {
-	DeleteActorEntityIfAuthoritative();
+	DeleteEntityIfAuthoritative();
 }
 
 bool USpatialActorChannel::ReplicateActor()

--- a/Source/SpatialGDK/Public/SpatialActorChannel.h
+++ b/Source/SpatialGDK/Public/SpatialActorChannel.h
@@ -95,7 +95,7 @@ private:
 	void UnbindFromSpatialView() const;
 
 	// Sends a DeleteEntity request to SpatialOS for the underlying entity, if we have authority to do so.
-	void DeleteActorEntityIfAuthoritative();
+	void DeleteEntityIfAuthoritative();
 
 	void OnReserveEntityIdResponse(const worker::ReserveEntityIdResponseOp& Op);
 	void OnCreateEntityResponse(const worker::CreateEntityResponseOp& Op);


### PR DESCRIPTION
#### Description
* Move entity deletion code from `CleanUp()` to `Close()`, which is called directly as a result of `UWorld::DestroyActor`
* Modify entity deletion code to check authority using the View, if the actor pointer has already been set to null

Note that this means entities will no longer be deleted when the worker is shutting down. For now, I think this is reasonable behavior until we define expected behavior in a multi-worker world, but let me know if anyone thinks differently.

#### Tests
* Verified using the TestCube_BP, AWeapon, and ASampleGameCharacter classes in the Titanium Tiger repository

#### Documentation
Jira: [UNR-353](https://improbableio.atlassian.net/browse/UNR-353)
