### PR TITLE
UNR-353: Added Super::Close() call to USpatialActorChannel::Close()

### DIFF
--- a/Source/SpatialGDK/Private/SpatialActorChannel.cpp
+++ b/Source/SpatialGDK/Private/SpatialActorChannel.cpp
@@ -140,6 +140,7 @@ bool USpatialActorChannel::CleanUp(const bool bForDestroy)
 void USpatialActorChannel::Close()
 {
 	DeleteEntityIfAuthoritative();
+	Super::Close();
 }
 
 bool USpatialActorChannel::ReplicateActor()


### PR DESCRIPTION
#### Description
Follow up to this PR: https://github.com/improbable/unreal-gdk/pull/162
Quick fix for bug where Close() doesn't call Super::Close()

#### Tests
Validated against Titanium Tiger. Successfully deletes the TestCube_BP.
