### PR TITLE
UNR-298: Added ActorChannel cleanup in SpatialInterop

### DIFF
--- a/Source/SpatialGDK/Legacy/EntityRegistry.cpp
+++ b/Source/SpatialGDK/Legacy/EntityRegistry.cpp
@@ -45,7 +45,7 @@ UClass** UEntityRegistry::GetRegisteredEntityClass(const FString& ClassName)
   auto ClassToSpawn = ClassMap.Find(ClassName);
   if (ClassToSpawn == nullptr)
   {
-    UE_LOG(LogEntityRegistry, Warning, TEXT("No UClass is associated with ClassName('%s')."),
+    UE_LOG(LogEntityRegistry, Log, TEXT("No UClass is associated with ClassName('%s')."),
            *ClassName);
     return nullptr;
   }

--- a/Source/SpatialGDK/Private/SpatialActorChannel.cpp
+++ b/Source/SpatialGDK/Private/SpatialActorChannel.cpp
@@ -486,6 +486,9 @@ void USpatialActorChannel::SetChannelActor(AActor* InActor)
 	else
 	{
 		UE_LOG(LogSpatialGDKActorChannel, Log, TEXT("Opened channel for actor %s with existing entity ID %lld."), *InActor->GetName(), ActorEntityId.ToSpatialEntityId());
+
+		// Inform USpatialInterop of this new actor channel/entity pairing
+		SpatialNetDriver->GetSpatialInterop()->AddActorChannel(ActorEntityId.ToSpatialEntityId(), this);
 	}
 }
 
@@ -523,6 +526,9 @@ void USpatialActorChannel::OnReserveEntityIdResponse(const worker::ReserveEntity
 	ActorEntityId = *Op.EntityId;
 
 	SpatialNetDriver->GetEntityRegistry()->AddToRegistry(ActorEntityId, GetActor());
+
+	// Inform USpatialInterop of this new actor channel/entity pairing
+	SpatialNetDriver->GetSpatialInterop()->AddActorChannel(ActorEntityId.ToSpatialEntityId(), this);
 }
 
 void USpatialActorChannel::OnCreateEntityResponse(const worker::CreateEntityResponseOp& Op)

--- a/Source/SpatialGDK/Private/SpatialActorChannel.cpp
+++ b/Source/SpatialGDK/Private/SpatialActorChannel.cpp
@@ -521,8 +521,6 @@ void USpatialActorChannel::OnReserveEntityIdResponse(const worker::ReserveEntity
 		PinnedView->Remove(ReserveEntityCallback);
 	}
 
-	USpatialPackageMapClient* PackageMap = Cast<USpatialPackageMapClient>(Connection->PackageMap);
-	check(PackageMap);
 	ActorEntityId = *Op.EntityId;
 
 	SpatialNetDriver->GetEntityRegistry()->AddToRegistry(ActorEntityId, GetActor());

--- a/Source/SpatialGDK/Private/SpatialInteropPipelineBlock.cpp
+++ b/Source/SpatialGDK/Private/SpatialInteropPipelineBlock.cpp
@@ -270,7 +270,7 @@ void USpatialInteropPipelineBlock::RemoveEntityImpl(const FEntityId& EntityId)
 		return;
 	}
 
-	Actor->GetWorld()->DestroyActor(Actor, true);
+	World->DestroyActor(Actor, true);
 
 	CleanupDeletedEntity(EntityId);
 }
@@ -323,6 +323,9 @@ AActor* USpatialInteropPipelineBlock::GetOrCreateActor(TSharedPtr<worker::Connec
 
 		FNetworkGUID NetGUID = PackageMap->ResolveEntityActor(EntityActor, EntityId, UnrealMetadataComponent->subobject_name_to_offset());
 		UE_LOG(LogSpatialGDKInteropPipelineBlock, Log, TEXT("Received create entity response op for %d"), EntityId.ToSpatialEntityId());
+		
+		// actor channel/entity mapping should be registered by this point
+		check(NetDriver->GetSpatialInterop()->GetActorChannelByEntityId(EntityId.ToSpatialEntityId()));
 	}
 	else
 	{
@@ -395,9 +398,6 @@ AActor* USpatialInteropPipelineBlock::GetOrCreateActor(TSharedPtr<worker::Connec
 
 			PackageMap->ResolveEntityActor(EntityActor, EntityId, UnrealMetadataComponent->subobject_name_to_offset());
 			Channel->SetChannelActor(EntityActor);
-
-			// Inform USpatialInterop of this new actor channel.
-			NetDriver->GetSpatialInterop()->AddActorChannel(EntityId.ToSpatialEntityId(), Channel);
 
 			// Apply initial replicated properties.
 			for (FPendingAddComponentWrapper& PendingAddComponent : PendingAddComponents)

--- a/Source/SpatialGDK/Public/SpatialInteropPipelineBlock.h
+++ b/Source/SpatialGDK/Public/SpatialInteropPipelineBlock.h
@@ -22,13 +22,9 @@ namespace improbable
 	class PositionData;
 }
 
-class UMetadataAddComponentOp;
-class UPositionAddComponentOp;
 class UCallbackDispatcher;
 class UEntityRegistry;
-class UEntityPipeline;
 class USpatialOsComponent;
-class USpatialActorChannel;
 class USpatialNetDriver;
 
 DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKInteropPipelineBlock, Log, All);


### PR DESCRIPTION
#### Description
Actor channels are now cleanup up correctly in the spatial interop layer. Previously destroyed actor channels could be left dangling in pending unresolved object containers. There are also a few small driveby cleanups in this PR.

#### Tests
Testing this was painful. I had to fake an unresolved replicated object, and then delete the object that held that replication. This was done be creating/destroying actors, and pointing them at each other at runtime. I also manually modified the typebinding to when setting the property, assume the netguid is invalid and add it to a fabricated invalid guid list. This can then be resolved on command after the related object was deleted.

![image](https://user-images.githubusercontent.com/35926786/41932712-a8cbddb2-7979-11e8-807f-11978fb4a31e.png)

#### Primary reviewers
@improbable-valentyn @danielimprobable 
