### PR TITLE
UNR-349: Added disconnect reason

### DIFF
--- a/Source/SpatialGDK/Legacy/SpatialOS.cpp
+++ b/Source/SpatialGDK/Legacy/SpatialOS.cpp
@@ -124,12 +124,6 @@ void USpatialOS::Connect()
       CallbackDispatcher->Init(GetView());
       EntityPipeline->Init(GetView(), CallbackDispatcher);
     }
-    else
-    {
-      UE_LOG(LogSpatialOS, Error, TEXT("Failed to connect to SpatialOS"));
-      OnConnectionFailedDelegate.Broadcast();
-      OnDisconnectInternal();
-    }
   });
 
   improbable::unreal::core::FQueueStatusDelegate OnQueueStatus;
@@ -170,7 +164,7 @@ void USpatialOS::Disconnect()
     WorkerConnection.Disconnect();
 
     // Manually broadcast OnDisconnected callbacks as Dispatcher->OnDisconnected will not be called.
-    OnDisconnectedDelegate.Broadcast();
+    OnDisconnectedDelegate.Broadcast("SpatialOS was manually disconnected.");
   }
   OnDisconnectInternal();
 }
@@ -276,11 +270,11 @@ void USpatialOS::OnDisconnectDispatcherCallback(const worker::DisconnectOp& Op)
 {
   if (bConnectionWasSuccessful)
   {
-    OnDisconnectedDelegate.Broadcast();
+    OnDisconnectedDelegate.Broadcast(Op.Reason.c_str());
   }
   else
   {
-    OnConnectionFailedDelegate.Broadcast();
+    OnConnectionFailedDelegate.Broadcast(Op.Reason.c_str());
   }
   OnDisconnectInternal();
 }

--- a/Source/SpatialGDK/Legacy/SpatialOS.h
+++ b/Source/SpatialGDK/Legacy/SpatialOS.h
@@ -19,8 +19,8 @@ struct FWorldContext;
 
 // clang-format off
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnConnectedDelegate);
-DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnDisconnectedDelegate);
-DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnConnectionFailedDelegate);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnDisconnectedDelegate, const FString&, Reason);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnConnectionFailedDelegate, const FString&, Reason);
 // clang-format on
 
 /**

--- a/Source/SpatialGDK/Legacy/WorkerConnection.cpp
+++ b/Source/SpatialGDK/Legacy/WorkerConnection.cpp
@@ -250,12 +250,11 @@ void FWorkerConnection::WaitForConnectionFuture(
 {
   if (ConnectionFuture.Wait(TimeoutMillis))
   {
-    auto WorkerConnection =
+    Connection =
         TSharedPtr<SpatialOSConnection>(new SpatialOSConnection{ConnectionFuture.Get()});
-    if (WorkerConnection->IsConnected())
+    if (Connection->IsConnected())
     {
-      AsyncTask(ENamedThreads::GameThread, [OnConnectedCallback, WorkerConnection, this]() {
-        Connection = WorkerConnection;
+      AsyncTask(ENamedThreads::GameThread, [OnConnectedCallback, this]() {
         OnConnectedCallback.Execute(true);
       });
       UE_LOG(LogSpatialOS, Log, TEXT("Connected."));

--- a/Source/SpatialGDK/Private/SpatialNetDriver.cpp
+++ b/Source/SpatialGDK/Private/SpatialNetDriver.cpp
@@ -153,14 +153,14 @@ void USpatialNetDriver::OnSpatialOSConnected()
 	Interop->Init(SpatialOSInstance, this, TimerManager);
 }
 
-void USpatialNetDriver::OnSpatialOSDisconnected()
+void USpatialNetDriver::OnSpatialOSDisconnected(const FString& Reason)
 {
-	UE_LOG(LogSpatialOSNetDriver, Warning, TEXT("Disconnected from SpatialOS."));
+	UE_LOG(LogSpatialOSNetDriver, Warning, TEXT("Disconnected from SpatialOS. Reason: %s"), *Reason);
 }
 
-void USpatialNetDriver::OnSpatialOSConnectFailed()
+void USpatialNetDriver::OnSpatialOSConnectFailed(const FString& Reason)
 {
-	UE_LOG(LogSpatialOSNetDriver, Error, TEXT("Could not connect to SpatialOS."));
+	UE_LOG(LogSpatialOSNetDriver, Error, TEXT("Could not connect to SpatialOS. Reason: %s"), *Reason);
 }
 
 bool USpatialNetDriver::IsLevelInitializedForActor(const AActor* InActor, const UNetConnection* InConnection) const

--- a/Source/SpatialGDK/Public/SpatialNetDriver.h
+++ b/Source/SpatialGDK/Public/SpatialNetDriver.h
@@ -109,10 +109,10 @@ protected:
 	void OnSpatialOSConnected();
 
 	UFUNCTION()
-	void OnSpatialOSConnectFailed();
+	void OnSpatialOSConnectFailed(const FString& Reason);
 
 	UFUNCTION()
-	void OnSpatialOSDisconnected();
+	void OnSpatialOSDisconnected(const FString& Reason);
 		
 #if WITH_SERVER_CODE
 	//SpatialGDK: These functions all exist in UNetDriver, but we need to modify/simplify them in certain ways.


### PR DESCRIPTION
#### Description
Added the disconnect reason and connection failed reason
#### Tests
This was tested using manual testing. The test cases used were:

1. Attempting to connect when no spatial instance is running
Expected error: Could not connect to SpatialOS. Reason: Disconnected: RakNet never connected.
2 Running a local instance of spatial with the workers connected and then taking down the spatial local instance.
Expected error: Disconnected: RakNet connection lost.

Successful TC run:
https://teamcity.corp-eu1.internal.improbable.io/viewLog.html?buildId=1481751&tab=buildResultsDiv&buildTypeId=Develop_UnrealGdk_BuildUnrealGdk


#### Documentation
* Please provide the JIRA link for this task.
https://improbableio.atlassian.net/browse/UNR-349

#### Primary reviewers
@m-samiec @joshuahuburn 
