### PR TITLE
Delete PIE entities on actor channel shutdown

### DIFF
--- a/Source/SpatialGDK/Private/SpatialActorChannel.cpp
+++ b/Source/SpatialGDK/Private/SpatialActorChannel.cpp
@@ -135,7 +135,7 @@ bool USpatialActorChannel::CleanUp(const bool bForDestroy)
 {
 	UnbindFromSpatialView();
 
-#ifdef WITH_EDITOR
+#if WITH_EDITOR
 	if (SpatialNetDriver->IsServer() &&
 		SpatialNetDriver->GetWorld()->WorldType == EWorldType::PIE &&
 		SpatialNetDriver->GetEntityRegistry()->GetActorFromEntityId(ActorEntityId.ToSpatialEntityId()))


### PR DESCRIPTION
#### Description
If we're running in PIE mode, delete non-spawner entities when the dedicated server shuts down.

Note that this will also delete entities in the snapshot, so this issue will have to be resolved ([UNR-362](https://improbableio.atlassian.net/browse/UNR-362))

#### Tests
Validated that PIE server shutdown deletes entities and standalone client (connected to a local deployment) does not. Force-killing a local managed server worker also does _not_ delete entities, although that isn't necessarily representative of a problem case. Worker boundary crossing is currently broken for Titanium Tiger, so I was unable to verify that that doesn't delete the actor.

#### Primary reviewers
@Vatyx 
