### PR TITLE
Bugfix/unr 384 fix actor migration

### DIFF
--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeStructure.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeStructure.cpp
@@ -453,12 +453,12 @@ TSharedPtr<FUnrealType> CreateUnrealTypeInfo(UStruct* Type, uint32 ParentChecksu
 
 	// Find the handover properties.
 	uint16 MigratableDataHandle = 1;
-	VisitAllProperties(TypeNode, [&MigratableDataHandle](TSharedPtr<FUnrealProperty> Property)
+	VisitAllProperties(TypeNode, [&MigratableDataHandle](TSharedPtr<FUnrealProperty> PropertyInfo)
 	{
-		if (Property->Property->PropertyFlags & CPF_Handover)
+		if (PropertyInfo->Property->PropertyFlags & CPF_Handover)
 		{
-			Property->MigratableData = MakeShared<FUnrealMigratableData>();
-			Property->MigratableData->Handle = MigratableDataHandle++;
+			PropertyInfo->MigratableData = MakeShared<FUnrealMigratableData>();
+			PropertyInfo->MigratableData->Handle = MigratableDataHandle++;
 		}
 		return true;
 	}, true);

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeStructure.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeStructure.cpp
@@ -453,12 +453,12 @@ TSharedPtr<FUnrealType> CreateUnrealTypeInfo(UStruct* Type, uint32 ParentChecksu
 
 	// Find the handover properties.
 	uint16 MigratableDataHandle = 1;
-	VisitAllProperties(TypeNode, [&MigratableDataHandle](TSharedPtr<FUnrealProperty> PropertyInfo)
+	VisitAllProperties(TypeNode, [&MigratableDataHandle](TSharedPtr<FUnrealProperty> Property)
 	{
-		if (PropertyInfo->Property->PropertyFlags & CPF_Handover)
+		if (Property->Property->PropertyFlags & CPF_Handover)
 		{
-			PropertyInfo->MigratableData = MakeShared<FUnrealMigratableData>();
-			PropertyInfo->MigratableData->Handle = MigratableDataHandle++;
+			Property->MigratableData = MakeShared<FUnrealMigratableData>();
+			Property->MigratableData->Handle = MigratableDataHandle++;
 		}
 		return true;
 	}, true);

--- a/Source/SpatialGDK/Private/SpatialActorChannel.cpp
+++ b/Source/SpatialGDK/Private/SpatialActorChannel.cpp
@@ -116,17 +116,20 @@ void USpatialActorChannel::UnbindFromSpatialView() const
 void USpatialActorChannel::DeleteEntityIfAuthoritative()
 {
 	bool bHasAuthority = false;
+	USpatialInterop* Interop = SpatialNetDriver->GetSpatialInterop();
 
 	TSharedPtr<worker::View> PinnedView = WorkerView.Pin();
 	if (PinnedView.IsValid())
 	{
-		bHasAuthority = PinnedView->GetAuthority<improbable::Position>(ActorEntityId.ToSpatialEntityId()) == worker::Authority::kAuthoritative;
+		bHasAuthority =		Interop->IsAuthoritiveDestruction()
+						&&	PinnedView->GetAuthority<improbable::Position>(ActorEntityId.ToSpatialEntityId()) == worker::Authority::kAuthoritative;
 	}
+
+	UE_LOG(LogSpatialGDKActorChannel, Log, TEXT("Delete Entity request on %d. Has authority: %d "), ActorEntityId.ToSpatialEntityId(), bHasAuthority);
 
 	// If we have authority and aren't trying to delete the spawner, delete the entity
 	if (bHasAuthority && ActorEntityId.ToSpatialEntityId() != SpatialConstants::EntityIds::SPAWNER_ENTITY_ID)
-	{
-		USpatialInterop* Interop = SpatialNetDriver->GetSpatialInterop();
+	{		
 		Interop->DeleteEntity(ActorEntityId);
 	}
 }

--- a/Source/SpatialGDK/Private/SpatialActorChannel.cpp
+++ b/Source/SpatialGDK/Private/SpatialActorChannel.cpp
@@ -121,7 +121,7 @@ void USpatialActorChannel::DeleteEntityIfAuthoritative()
 	TSharedPtr<worker::View> PinnedView = WorkerView.Pin();
 	if (PinnedView.IsValid())
 	{
-		bHasAuthority =		Interop->IsAuthoritiveDestruction()
+		bHasAuthority =		Interop->IsAuthoritativeDestructionAllowed()
 						&&	PinnedView->GetAuthority<improbable::Position>(ActorEntityId.ToSpatialEntityId()) == worker::Authority::kAuthoritative;
 	}
 

--- a/Source/SpatialGDK/Private/SpatialInterop.cpp
+++ b/Source/SpatialGDK/Private/SpatialInterop.cpp
@@ -29,7 +29,7 @@ void USpatialInterop::Init(USpatialOS* Instance, USpatialNetDriver* Driver, FTim
 	NetDriver = Driver;
 	TimerManager = InTimerManager;
 	PackageMap = Cast<USpatialPackageMapClient>(Driver->GetSpatialOSNetConnection()->PackageMap);
-	bAuthoritiveDestruction = true;
+	bAuthoritativeDestruction = false;
 
 	// Collect all type binding classes.
 	TArray<UClass*> TypeBindingClasses;
@@ -231,7 +231,7 @@ void USpatialInterop::ResolvePendingOperations(UObject* Object, const improbable
 
 void USpatialInterop::ResolveQueuedPendingOperations()
 {
-	for (auto it : PendingOperationsQueue)
+	for (auto& it : PendingOperationsQueue)
 	{
 		ResolvePendingOperations_Internal(it.Key, it.Value);
 	}

--- a/Source/SpatialGDK/Private/SpatialInterop.cpp
+++ b/Source/SpatialGDK/Private/SpatialInterop.cpp
@@ -222,21 +222,21 @@ void USpatialInterop::ResolvePendingOperations(UObject* Object, const improbable
 {
 	if (NetDriver->InteropPipelineBlock->IsInCriticalSection())
 	{
-		PendingOperationsQueue.Add(TPair<UObject*, const improbable::unreal::UnrealObjectRef>{ Object, ObjectRef });
+		ResolvedObjectQueue.Add(TPair<UObject*, const improbable::unreal::UnrealObjectRef>{ Object, ObjectRef });
 		return;
 	}
 
 	ResolvePendingOperations_Internal(Object, ObjectRef);
 }
 
-void USpatialInterop::ResolveQueuedPendingOperations()
+void USpatialInterop::OnLeaveCriticalSection()
 {
-	for (auto& it : PendingOperationsQueue)
+	for (auto& It : ResolvedObjectQueue)
 	{
-		ResolvePendingOperations_Internal(it.Key, it.Value);
+		ResolvePendingOperations_Internal(It.Key, It.Value);
 	}
 
-	PendingOperationsQueue.Empty();
+	ResolvedObjectQueue.Empty();
 }
 
 void USpatialInterop::ResolvePendingOperations_Internal(UObject* Object, const improbable::unreal::UnrealObjectRef& ObjectRef)

--- a/Source/SpatialGDK/Private/SpatialInteropPipelineBlock.cpp
+++ b/Source/SpatialGDK/Private/SpatialInteropPipelineBlock.cpp
@@ -266,12 +266,11 @@ void USpatialInteropPipelineBlock::RemoveEntityImpl(const FEntityId& EntityId)
 {
 	AActor* Actor = EntityRegistry->GetActorFromEntityId(EntityId);
 
-	UE_LOG(LogTemp, Warning, TEXT("USpatialInteropPipelineBlock::RemoveEntityImpl %s %d"), Actor ? *Actor->GetName() : TEXT("Actor invalid"), EntityId.ToSpatialEntityId());
+	UE_LOG(LogSpatialGDKInteropPipelineBlock, Verbose, TEXT("USpatialInteropPipelineBlock: Remove Entity Impl: %s %d"), Actor ? *Actor->GetName() : TEXT("nullptr"), EntityId.ToSpatialEntityId());
 
 	// Actor already deleted (this worker was most likely authoritative over it and deleted it earlier).
 	if (!Actor || Actor->IsPendingKill())
 	{
-		UE_LOG(LogTemp, Warning, TEXT("CleanupDeletedEntity called on actor %s %d"), Actor ? *Actor->GetName() : TEXT("Actor invalid"), EntityId.ToSpatialEntityId());
 		CleanupDeletedEntity(EntityId);
 		return;
 	}

--- a/Source/SpatialGDK/Private/SpatialInteropPipelineBlock.cpp
+++ b/Source/SpatialGDK/Private/SpatialInteropPipelineBlock.cpp
@@ -281,23 +281,23 @@ void USpatialInteropPipelineBlock::RemoveEntityImpl(const FEntityId& EntityId)
 		PC->Player = nullptr;
 	}
 
-	// Destruction of actors can cause the destruction of associative actors (eg. Character > Controller). Actor destroy
+	// Destruction of actors can cause the destruction of associated actors (eg. Character > Controller). Actor destroy
 	// calls will eventually find their way into USpatialActorChannel::DeleteEntityIfAuthoritative() which checks if the entity
-	// is currently owned by this worker before issuing a entity delete request. If the associative entity hasn't migrated off 
+	// is currently owned by this worker before issuing a entity delete request. If the associated entity hasn't migrated off 
 	// this server just yet, we need to make sure this client doesn't issue a entity delete request, as this entity is really 
-	// migrating, it's just a few frames behind it's associative entity. 
+	// migrating, it's just a few frames behind it's associated entity. 
 	// We make the assumption that if we're destroying actors here (due to a remove entity op), then this is only due to two
 	// situations;
 	// 1. Actor's entity has migrated off this server
 	// 2. The Actor was deleted on another server
-	// In neither situation do we want to delete associative entities, so prevent them from being issued.
-	// TODO: fix this with working sets
-	NetDriver->GetSpatialInterop()->SetAuthoritiveDestruction(false);
+	// In neither situation do we want to delete associated entities, so prevent them from being issued.
+	// TODO: fix this with working sets (UNR-411)
+	NetDriver->GetSpatialInterop()->BeginIgnoringAuthoritativeDestruction();
 	if (World->DestroyActor(Actor, true) == false)
 	{
 		UE_LOG(LogSpatialGDKInteropPipelineBlock, Error, TEXT("World->DestroyActor failed on RemoveEntity %s %d"), *Actor->GetName(), EntityId.ToSpatialEntityId());
 	}
-	NetDriver->GetSpatialInterop()->SetAuthoritiveDestruction(true);
+	NetDriver->GetSpatialInterop()->StopIgnoringAuthoritativeDestruction();
 
 	CleanupDeletedEntity(EntityId);
 }

--- a/Source/SpatialGDK/Private/SpatialInteropPipelineBlock.cpp
+++ b/Source/SpatialGDK/Private/SpatialInteropPipelineBlock.cpp
@@ -292,7 +292,7 @@ void USpatialInteropPipelineBlock::RemoveEntityImpl(const FEntityId& EntityId)
 	// 2. The Actor was deleted on another server
 	// In neither situation do we want to delete associated entities, so prevent them from being issued.
 	// TODO: fix this with working sets (UNR-411)
-	NetDriver->GetSpatialInterop()->BeginIgnoringAuthoritativeDestruction();
+	NetDriver->GetSpatialInterop()->StartIgnoringAuthoritativeDestruction();
 	if (World->DestroyActor(Actor, true) == false)
 	{
 		UE_LOG(LogSpatialGDKInteropPipelineBlock, Error, TEXT("World->DestroyActor failed on RemoveEntity %s %d"), *Actor->GetName(), EntityId.ToSpatialEntityId());

--- a/Source/SpatialGDK/Private/SpatialInteropPipelineBlock.cpp
+++ b/Source/SpatialGDK/Private/SpatialInteropPipelineBlock.cpp
@@ -185,7 +185,7 @@ void USpatialInteropPipelineBlock::LeaveCriticalSection()
 		RemoveEntityImpl(PendingRemoveEntity);
 	}
 
-	NetDriver->GetSpatialInterop()->ResolveQueuedPendingOperations();
+	NetDriver->GetSpatialInterop()->OnLeaveCriticalSection();
 
 	// Mark that we've left the critical section.
 	bInCriticalSection = false;

--- a/Source/SpatialGDK/Public/SpatialInterop.h
+++ b/Source/SpatialGDK/Public/SpatialInterop.h
@@ -173,7 +173,7 @@ public:
 	void ResolvePendingOperations_Internal(UObject* Object, const improbable::unreal::UnrealObjectRef& ObjectRef);
 
 	bool IsAuthoritativeDestructionAllowed() const { return bAuthoritativeDestruction; }
-	void BeginIgnoringAuthoritativeDestruction() { bAuthoritativeDestruction = false; };
+	void StartIgnoringAuthoritativeDestruction() { bAuthoritativeDestruction = false; };
 	void StopIgnoringAuthoritativeDestruction() { bAuthoritativeDestruction = true; }
 
 	// Called by USpatialInteropPipelineBlock when an actor channel is opened on the client.

--- a/Source/SpatialGDK/Public/SpatialInterop.h
+++ b/Source/SpatialGDK/Public/SpatialInterop.h
@@ -172,8 +172,9 @@ public:
 	void ResolveQueuedPendingOperations();
 	void ResolvePendingOperations_Internal(UObject* Object, const improbable::unreal::UnrealObjectRef& ObjectRef);
 
-	void SetAuthoritiveDestruction(bool bValue) { bAuthoritiveDestruction = bValue; }
-	bool IsAuthoritiveDestruction() const { return bAuthoritiveDestruction; }
+	bool IsAuthoritativeDestructionAllowed() const { return bAuthoritativeDestruction; }
+	void BeginIgnoringAuthoritativeDestruction() { bAuthoritativeDestruction = false; };
+	void StopIgnoringAuthoritativeDestruction() { bAuthoritativeDestruction = true; }
 
 	// Called by USpatialInteropPipelineBlock when an actor channel is opened on the client.
 	void AddActorChannel(const FEntityId& EntityId, USpatialActorChannel* Channel);
@@ -255,7 +256,7 @@ private:
 	// Used to queue up pending operations when resolved in critical section
 	FPendingOperationsQueue PendingOperationsQueue;
 
-	bool bAuthoritiveDestruction;
+	bool bAuthoritativeDestruction;
 
 
 private:

--- a/Source/SpatialGDK/Public/SpatialInteropPipelineBlock.h
+++ b/Source/SpatialGDK/Public/SpatialInteropPipelineBlock.h
@@ -63,6 +63,8 @@ public:
 
 	void CleanupDeletedEntity(const FEntityId& EntityId);
 
+	bool IsInCriticalSection() const { return bInCriticalSection; }
+
 private:
 	bool bInCriticalSection;
 

--- a/Source/SpatialGDK/SpatialGDK.Build.cs
+++ b/Source/SpatialGDK/SpatialGDK.Build.cs
@@ -66,7 +66,6 @@ public class SpatialGDK : ModuleRules
                 ImportLibSuffix = SharedLibSuffix = ".dylib";
                 break;
             case UnrealTargetPlatform.Linux:
-                CoreSdkLibraryDir = "";
                 LibPrefix = "lib";
                 ImportLibSuffix = SharedLibSuffix = ".so";
                 break;


### PR DESCRIPTION
#### Description
Improved actor migration stability. Two main changes in this PR -
1. When resolving pending actor operations within a critical section (unresolved UObject* is resolved), wait until the new UObject has been setup before informing reliant objects about its presence. This prevent crashes in the On_Rep callbacks where it assumes the replicated object is fully formed.
2. Don't issue delete entity requests recursively when responding to a entity removal operation. See code for detailed explanation.

#### Tests
Spawned multiple clients and had each cross the worker boundary multiple times. Observed no crashes. 

#### Primary reviewers
@danielimprobable @improbable-valentyn

unreal-gdk-sample-game PR - https://github.com/improbable/unreal-gdk-sample-game/pull/72
