### PR TITLE
UNR-408: Prevent camera loss on player migration

### DIFF
--- a/Source/SpatialGDK/Private/SpatialInterop.cpp
+++ b/Source/SpatialGDK/Private/SpatialInterop.cpp
@@ -29,7 +29,7 @@ void USpatialInterop::Init(USpatialOS* Instance, USpatialNetDriver* Driver, FTim
 	NetDriver = Driver;
 	TimerManager = InTimerManager;
 	PackageMap = Cast<USpatialPackageMapClient>(Driver->GetSpatialOSNetConnection()->PackageMap);
-	bAuthoritativeDestruction = false;
+	bAuthoritativeDestruction = true;
 
 	// Collect all type binding classes.
 	TArray<UClass*> TypeBindingClasses;

--- a/Source/SpatialGDK/Private/SpatialInteropPipelineBlock.cpp
+++ b/Source/SpatialGDK/Private/SpatialInteropPipelineBlock.cpp
@@ -286,15 +286,11 @@ void USpatialInteropPipelineBlock::RemoveEntityImpl(const FEntityId& EntityId)
 	// TODO: This should be solved properly by working sets (UNR-411)
 	if (APawn* Pawn = Cast<APawn>(Actor))
 	{
-		TSharedPtr<worker::View> PinnedView = NetDriver->GetSpatialOS()->GetView().Pin();
 		AController* Controller = Pawn->Controller;
 
-		if (PinnedView.IsValid() && Controller != nullptr)
+		if (Controller != nullptr && Controller->HasAuthority())
 		{
-			if (PinnedView->GetAuthority<improbable::Position>(NetDriver->GetEntityRegistry()->GetEntityIdFromActor(Controller).ToSpatialEntityId()) == worker::Authority::kAuthoritative)
-			{
-				Pawn->Controller = nullptr;
-			}
+			Pawn->Controller = nullptr;
 		}
 	}
 

--- a/Source/SpatialGDK/Private/SpatialInteropPipelineBlock.cpp
+++ b/Source/SpatialGDK/Private/SpatialInteropPipelineBlock.cpp
@@ -282,7 +282,7 @@ void USpatialInteropPipelineBlock::RemoveEntityImpl(const FEntityId& EntityId)
 	}
 
 	// Workaround for camera loss on migration: prevent UnPossess() (non-authoritative destruction of pawn, while being authoritative over the controller)
-	// TODO: Check how AI controllers are affected by this
+	// TODO: Check how AI controllers are affected by this (UNR-430)
 	// TODO: This should be solved properly by working sets (UNR-411)
 	if (APawn* Pawn = Cast<APawn>(Actor))
 	{


### PR DESCRIPTION
On the leaving server worker, the pawn could be destroyed before the
player controller is migrated, causing client RPCs for the controller to
reach the client worker, breaking the camera.

#### Description
Prevents UnPossess() from being called on the Controller of a pawn on migration.
#### Tests
Manually tested by moving across the boundary back-and-forth at least 20 times with both vehicles and characters.
#### Documentation
https://improbableio.atlassian.net/projects/UNR/issues/UNR-408
#### Primary reviewers
@m-samiec 
