### PR TITLE
Use ensure instead of check when testing for reliable multicast RPCs

### DIFF
--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SchemaGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SchemaGenerator.cpp
@@ -290,7 +290,12 @@ int GenerateTypeBindingSchema(FCodeWriter& Writer, int ComponentId, UClass* Clas
 		{
 			if (Group == ERPCType::RPC_NetMulticast)
 			{
-				ensureMsgf(RPC->bReliable == false, TEXT("%s::%s: Unreal GDK currently does not support Reliable Multicast RPCs. This RPC will be treated as Unreliable."), *GetFullCPPName(Class), *RPC->Function->GetName());
+				if (RPC->bReliable)
+				{
+					FMessageDialog::Debugf(FText::FromString(FString::Printf(TEXT("%s::%s: Unreal GDK currently does not support Reliable Multicast RPCs. This RPC will be treated as Unreliable."),
+						*GetFullCPPName(Class),
+						*RPC->Function->GetName())));
+				}
 
 				Writer.Printf("event %s.%s %s;",
 					*UnrealNameToSchemaTypeName(*RPC->Function->GetOuter()->GetName()).ToLower(),


### PR DESCRIPTION
#### Description
Using `ensure` instead of `check` will make it so a reliable multicast RPC will still trigger a breakpoint when generating interop, but the user will be able to continue and the engine will not crash.
#### Tests
Test generating interop with a reliable multicast RPC, observe that a breakpoint is triggered on the `ensure` statement, press F5 to resume generating interop. The engine didn't crash.
#### Documentation
https://improbableio.atlassian.net/browse/UNR-404
#### Primary reviewers
@m-samiec @girayimprobable 