### PR TITLE
Feature/unr 363 find classes smartly in interop codegen

### DIFF
--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SpatialGDKEditorInteropCodeGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SpatialGDKEditorInteropCodeGenerator.cpp
@@ -112,7 +112,7 @@ bool ValidateClassNameWithCorrectionForBlueprints(FString& ClassName)
 
 	UE_LOG(LogSpatialGDKInteropCodeGenerator, Verbose, TEXT("Could not find unreal class for interop code generation: '%s', trying to find %s_C..."), *ClassName, *ClassName);
 
-	if (FindObject<UClass>(ANY_PACKAGE, *(ClassName + "_C")))
+	if (FindObject<UClass>(ANY_PACKAGE, *(ClassName + TEXT("_C"))))
 	{
 		// Correct for user mistake: add _C to ClassName so we return the valid blueprint name
 		ClassName.Append(TEXT("_C"));


### PR DESCRIPTION
#### Description

Currently if you attempt to generate type bindings for a blueprint class and forget to append the invisible '_c' to the end of the class name, interop won't find your class.

I moved looking-for-class-existence logic inside `GenerateClassHeaderMap()`, which parses the `.ini` file for the list of classes. When we encounter a class that doesn't exist, automatically add '_C' to it and try again. If the class still doesn't exist, we return an error (though it's easy to change this behaviour to raise warning and continue); otherwise, we continue generating code as if the user wrote `BLUEPRINTNAME_BP_C`.

This allows the following code to work:
`MyBlueprint_BP=inherited_class.h`



#### Tests

Ran on https://github.com/improbable/unreal-gdk-sample-game/tree/wanqi-playground, which has replicated custom blueprint class `MyCube_BP_C`. Interop Codegen worked with either

`MyCube_BP_C=PickupAndRotateActor.h` or `MyCube_BP=PickupAndRotateActor.h`, with appropriate warning messages for the latter. Wrong formatting still throws a 'Interop Code Generation Failure' message.



#### Documentation
Jira: https://improbableio.atlassian.net/secure/RapidBoard.jspa?rapidView=383&projectKey=UNR&view=planning&selectedIssue=UNR-363

See logic flow by starting at `GenerateInteropFromClasses()`

#### Primary reviewers
@danielimprobable @m-samiec 
