### PR TITLE
UNR-271 Snapshot generation fix

### DIFF
--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorGenerateSnapshot.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorGenerateSnapshot.cpp
@@ -75,8 +75,6 @@ worker::Map<worker::EntityId, worker::Entity> CreateLevelEntities(UWorld* World)
 
 bool SpatialGDKGenerateSnapshot(FString SavePath, UWorld* World)
 {
-	UE_LOG(LogSpatialGDKSnapshot, Display, TEXT("Save path: %s"), *SavePath);
-
 	if (!FPaths::CollapseRelativeDirectories(SavePath))
 	{
 		UE_LOG(LogSpatialGDKSnapshot, Error, TEXT("Invalid path: %s - snapshot not generated"), *SavePath);


### PR DESCRIPTION
#### Description
The current snapshot generation fails when the path to the `/snapshots` folder does not exist. Also, the way of saving entities in the snapshot is deprecated as per [ C++ docs ](https://docs.improbable.io/reference/13.1/cppsdk/api-reference). These changes ensure that when the path does not exist, we try to recursively create it and now we make use of the updated way of storing snapshots through `SnapshotOutputStream`.

#### Tests

I generated snapshots with and without the `/snapshots` folder. Both ways worked.

#### Documentation
Jira link: https://improbableio.atlassian.net/browse/UNR-271

#### Primary reviewers
@danielimprobable @m-samiec
