### PR TITLE
Remove unused clean script

### DIFF
--- a/Scripts/Clean.bat
+++ b/Scripts/Clean.bat
@@ -1,5 +1,0 @@
-@echo off
-
-Game\Binaries\ThirdParty\Improbable\Programs\clean^
- "Game/Intermediate/Improbable"^
- "Game/Source/SpatialGDK/Generated/UClasses" || exit /b 1


### PR DESCRIPTION
#### Description
`Scripts\Clean.bat` is not usable since we no longer generate `clean` utility. The equivalent functionality is provided with the project via `CleanGeneratedFiles.bat` and `SafeClean.bat` scripts.
#### Primary reviewers
@joshuahuburn @danielimprobable 