### PR TITLE
Fix PlayerController NetConnection Initialization after Handover

### DIFF
--- a/Source/SpatialGDK/Private/SpatialInteropPipelineBlock.cpp
+++ b/Source/SpatialGDK/Private/SpatialInteropPipelineBlock.cpp
@@ -401,7 +401,7 @@ void USpatialInteropPipelineBlock::CreateActor(TSharedPtr<worker::Connection> Lo
 			bool bDoingDeferredSpawn = false;
 
 			// If we're checking out a player controller, spawn it via "USpatialNetDriver::AcceptNewPlayer"
-			if (NetDriver->IsServer() && ActorClass == APlayerController::StaticClass())
+			if (NetDriver->IsServer() && ActorClass->IsChildOf(APlayerController::StaticClass()))
 			{
 				checkf(!UnrealMetadataComponent->owner_worker_id().empty(), TEXT("A player controller entity must have an owner worker ID."));
 				FString URLString = FURL().ToString();


### PR DESCRIPTION
#### Description
Right now, derived PlayerController classes are not being picked up after handover, so `USpatialNetDriver::AcceptNewPlayer` is never called.

See https://improbableio.atlassian.net/browse/UNR-476 for why this is bad.

This also fixes UNR-409: no more warning messages unless connection is lost (which still erratically happens upon handover, but is a separate issue).

#### Primary reviewers
@m-samiec 