### PR TITLE
Add step to run BuildWorkerConfig.

### DIFF
--- a/docs/setup-and-installing.md
+++ b/docs/setup-and-installing.md
@@ -124,6 +124,7 @@ Build the Unreal GDK module dependencies which the Starter Project needs to work
 1. Build the project.
 1. Open **StarterProject.uproject** in the Unreal Editor and click [**Codegen**](content/interop.md) to generate [type bindings](content/glossary.md#type-bindings). 
 1. Close the Unreal Editor and build the project again in Visual Studio.
+1. In File Explorer, navigate to `UnrealGDKStarterProject\Game\Scripts` and run BuildWorkerConfig.bat.
 
 ### Running the Starter Project locally
 


### PR DESCRIPTION
#### Description
Add step to run BuildWorkerConfig.
#### Tests
I ran the steps without this and clients would not connect to the deployment. This step fixes that.
#### Documentation
This is documentation.