### PR TITLE
Fix TypeStructure ComponentClasses

### DIFF
--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeStructure.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeStructure.cpp
@@ -600,7 +600,7 @@ TArray<UClass*> GetAllSupportedComponents(UClass* Class, const ClassHeaderMap& I
 
 void AddComponentClassToSet(UClass* ComponentClass, TSet<UClass*>& ComponentClasses, UClass* ActorClass, const ClassHeaderMap& InteropGeneratedClasses)
 {
-	if (InteropGeneratedClasses.Find(ComponentClass->GetName()))
+	if (InteropGeneratedClasses.Find(ComponentClass->GetPathName()))
 	{
 		if (ComponentClasses.Find(ComponentClass) == nullptr)
 		{


### PR DESCRIPTION
#### Description
Fixes a missed ```GetName()``` -> ```GetPathName()``` for recognising components in Actors and their associated spatial type binding files.
#### Tests
Manually tested with vehicles to see that the WheeledVehicleMovementComponent4W replicates (automated tests broken for now).
#### Documentation
No documentation needed
#### Primary reviewers
@danielimprobable 