### PR TITLE
Use path instead of class name in GSM update

### DIFF
--- a/Source/SpatialGDK/Private/SpatialActorChannel.cpp
+++ b/Source/SpatialGDK/Private/SpatialActorChannel.cpp
@@ -617,7 +617,7 @@ void USpatialActorChannel::OnReserveEntityIdResponse(const worker::ReserveEntity
 	// If a Singleton was created, update the GSM with the proper Id.
 	if (Interop->IsSingletonClass(Actor->GetClass()))
 	{
-		Interop->UpdateGlobalStateManager(Actor->GetClass()->GetName(), ActorEntityId);
+		Interop->UpdateGlobalStateManager(Actor->GetClass()->GetPathName(), ActorEntityId);
 	}
 }
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
We have incorrectly provided the class name instead of path name in `UpdateGlobalStateManager`. This PR fixes that.

#### Primary reviewers
@Vatyx @improbable-valentyn 