### PR TITLE
docs/setup-and-installing.md: add step to open StarterProject.sln

### DIFF
--- a/docs/setup-and-installing.md
+++ b/docs/setup-and-installing.md
@@ -127,6 +127,7 @@ Build the Unreal GDK module dependencies which the Starter Project needs to work
     1. In File Explorer, navigate to the root directory of the Unreal GDK Starter Project repository, and then to the **Game** directory within it.
     1. Right-click **StarterProject.uproject** and select **Switch Unreal Engine version**.
     1. Select the path to the Unreal Engine fork you cloned earlier.
+1. In the same directory, open **StarterProject.sln** in Visual Studio.
 1. In the Solution Explorer window, right-click on **StarterProject** and select **Build**.
 1. Open **StarterProject.uproject** in the Unreal Editor and click [**Codegen**](content/interop.md) to generate [type bindings](content/glossary.md#type-bindings).
 1. Close the Unreal Editor and build the project again in Visual Studio.


### PR DESCRIPTION
#### Description
Clarify Unreal GDK installation instructions by adding a step which seemed missing while I was following them. The following step refers to building the project from Solution explorer, but nothing mentions opening the generated solution before that.