### PR TITLE
Add callback for classes with typebindings

### DIFF
--- a/Source/SpatialGDK/Private/SpatialInterop.cpp
+++ b/Source/SpatialGDK/Private/SpatialInterop.cpp
@@ -126,6 +126,7 @@ worker::RequestId<worker::CreateEntityRequest> USpatialInterop::SendCreateEntity
 		{
 			auto Entity = TypeBinding->CreateActorEntity(PlayerWorkerId, Location, PathStr, Channel->GetChangeState(RepChanged, HandoverChanged), Channel);
 			CreateEntityRequestId = PinnedConnection->SendCreateEntityRequest(Entity, Channel->GetEntityId().ToSpatialEntityId(), 0);
+			AddPendingActorRequest(CreateEntityRequestId.Id, Channel);
 		}
 		else
 		{

--- a/Source/SpatialGDK/Private/SpatialInterop.cpp
+++ b/Source/SpatialGDK/Private/SpatialInterop.cpp
@@ -122,9 +122,11 @@ worker::RequestId<worker::CreateEntityRequest> USpatialInterop::SendCreateEntity
 		FStringAssetReference ActorClassRef(Actor->GetClass());
 		FString PathStr = ActorClassRef.ToString();
 
+		worker::Entity Entity;
+
 		if (TypeBinding)
 		{
-			auto Entity = TypeBinding->CreateActorEntity(PlayerWorkerId, Location, PathStr, Channel->GetChangeState(RepChanged, HandoverChanged), Channel);
+			Entity = TypeBinding->CreateActorEntity(PlayerWorkerId, Location, PathStr, Channel->GetChangeState(RepChanged, HandoverChanged), Channel);
 		}
 		else
 		{
@@ -166,7 +168,7 @@ worker::RequestId<worker::CreateEntityRequest> USpatialInterop::SendCreateEntity
 			// Build entity.
 			const improbable::Coordinates SpatialPosition = SpatialConstants::LocationToSpatialOSCoordinates(Location);
 
-			auto Entity = improbable::unreal::FEntityBuilder::Begin()
+			Entity = improbable::unreal::FEntityBuilder::Begin()
 				.AddPositionComponent(SpatialPosition, WorkersOnly)
 				.AddMetadataComponent(improbable::Metadata::Data{TCHAR_TO_UTF8(*PathStr)})
 				.SetPersistence(true)

--- a/Source/SpatialGDK/Private/SpatialInterop.cpp
+++ b/Source/SpatialGDK/Private/SpatialInterop.cpp
@@ -125,8 +125,6 @@ worker::RequestId<worker::CreateEntityRequest> USpatialInterop::SendCreateEntity
 		if (TypeBinding)
 		{
 			auto Entity = TypeBinding->CreateActorEntity(PlayerWorkerId, Location, PathStr, Channel->GetChangeState(RepChanged, HandoverChanged), Channel);
-			CreateEntityRequestId = PinnedConnection->SendCreateEntityRequest(Entity, Channel->GetEntityId().ToSpatialEntityId(), 0);
-			AddPendingActorRequest(CreateEntityRequestId.Id, Channel);
 		}
 		else
 		{
@@ -178,10 +176,11 @@ worker::RequestId<worker::CreateEntityRequest> USpatialInterop::SendCreateEntity
 				// todo-giray: Remove once we're using proper (generated) entity templates here.
 				.AddComponent<improbable::unreal::PlayerControlClient>(improbable::unreal::PlayerControlClient::Data{}, OwnClientOnly)
 				.Build();
-
-			CreateEntityRequestId = PinnedConnection->SendCreateEntityRequest(Entity, Channel->GetEntityId().ToSpatialEntityId(), 0);
-			AddPendingActorRequest(CreateEntityRequestId.Id, Channel);
 		}
+
+		CreateEntityRequestId = PinnedConnection->SendCreateEntityRequest(Entity, Channel->GetEntityId().ToSpatialEntityId(), 0);
+		AddPendingActorRequest(CreateEntityRequestId.Id, Channel);
+
 		UE_LOG(LogSpatialGDKInterop, Log, TEXT("%s: Creating entity for actor %s (%lld) using initial changelist. Request ID: %d"),
 			*SpatialOSInstance->GetWorkerId(), *Actor->GetName(), Channel->GetEntityId().ToSpatialEntityId(), CreateEntityRequestId.Id);
 	}


### PR DESCRIPTION
#### Description
Fixes a small bug with UNR-493, where classes which have typebindings never call OnCreateEntityResponse().
#### Tests
Manually tested with a class which had typebindings and observed that OnCreateEntityResponse was called.
#### Documentation
No documentation needed.
#### Primary reviewers
@mpmisko 