### PR TITLE
Support Blueprint Defined Rep Structs

### DIFF
--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SpatialGDKEditorInteropCodeGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SpatialGDKEditorInteropCodeGenerator.cpp
@@ -44,7 +44,7 @@ int GenerateCompleteSchemaFromClass(const FString& SchemaPath, const FString& Fo
 	OutputSchema.WriteToFile(FString::Printf(TEXT("%s%s.schema"), *SchemaPath, *SchemaFilename));
 
 	// Generate forwarding code.
-	TMap<FString, FString> GeneratedStructInfo;
+	BPStructTypesAndPaths GeneratedStructInfo;
 	GenerateTypeBindingHeader(OutputHeader, SchemaFilename, TypeBindingFilename, Class, TypeInfo, GeneratedStructInfo);
 	GenerateTypeBindingSource(OutputSource, SchemaFilename, TypeBindingFilename, Class, TypeInfo, TypeBindingHeaders, bIsSingleton, InteropGeneratedClasses, GeneratedStructInfo);
 	OutputHeader.WriteToFile(FString::Printf(TEXT("%s%s.h"), *ForwardingCodePath, *TypeBindingFilename));

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SpatialGDKEditorInteropCodeGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SpatialGDKEditorInteropCodeGenerator.cpp
@@ -44,8 +44,9 @@ int GenerateCompleteSchemaFromClass(const FString& SchemaPath, const FString& Fo
 	OutputSchema.WriteToFile(FString::Printf(TEXT("%s%s.schema"), *SchemaPath, *SchemaFilename));
 
 	// Generate forwarding code.
-	GenerateTypeBindingHeader(OutputHeader, SchemaFilename, TypeBindingFilename, Class, TypeInfo);
-	GenerateTypeBindingSource(OutputSource, SchemaFilename, TypeBindingFilename, Class, TypeInfo, TypeBindingHeaders, bIsSingleton, InteropGeneratedClasses);
+	TMap<FString, FString> GeneratedStructInfo;
+	GenerateTypeBindingHeader(OutputHeader, SchemaFilename, TypeBindingFilename, Class, TypeInfo, GeneratedStructInfo);
+	GenerateTypeBindingSource(OutputSource, SchemaFilename, TypeBindingFilename, Class, TypeInfo, TypeBindingHeaders, bIsSingleton, InteropGeneratedClasses, GeneratedStructInfo);
 	OutputHeader.WriteToFile(FString::Printf(TEXT("%s%s.h"), *ForwardingCodePath, *TypeBindingFilename));
 	OutputSource.WriteToFile(FString::Printf(TEXT("%s%s.cpp"), *ForwardingCodePath, *TypeBindingFilename));
 

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
@@ -225,12 +225,10 @@ void GenerateBlueprintStructEnumDefinition(FCodeWriter& Writer, UProperty* Prope
 		Writer.Printf("enum %s", *Enum->GetName());
 		Writer.Printf("{").Indent();
 
-		int ind = 0;
-		for (; ind < Enum->NumEnums() - 1; ind++)
+		for (int ind = 0; ind < Enum->NumEnums(); ind++)
 		{
-			Writer.Printf("%s,", *Enum->GetNameStringByIndex(ind));
+			Writer.Printf("%s,", *Enum->GetNameStringByIndex(ind));  // This will put a trailing comma on the last Enum but this is deemed okay in Unreal
 		}
-		Writer.Printf("%s", *Enum->GetNameStringByIndex(ind));  // Last enum has no comma
 		Writer.Outdent().Printf("};");
 	}
 }

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
@@ -40,7 +40,8 @@ void GenerateTypeBindingHeader(
 	FString SchemaFilename,
 	FString InteropFilename,
 	UClass* Class,
-	const TSharedPtr<FUnrealType> TypeInfo);
+	const TSharedPtr<FUnrealType> TypeInfo,
+	TMap<FString, FString>& GeneratedStructInfo);
 
 // Generates the source file of a type binding.
 void GenerateTypeBindingSource(
@@ -51,13 +52,14 @@ void GenerateTypeBindingSource(
 	const TSharedPtr<FUnrealType>& TypeInfo,
 	const TArray<FString>& TypeBindingHeaders,
 	bool bIsSingleton,
-	const ClassHeaderMap& InteropGeneratedClasses);
+	const ClassHeaderMap& InteropGeneratedClasses,
+	TMap<FString, FString>& GeneratedStructInfo);
 
 // Helper functions used when generating the source file.
 void GenerateFunction_GetRepHandlePropertyMap(FCodeWriter& SourceWriter, UClass* Class);
 void GenerateFunction_GetHandoverHandlePropertyMap(FCodeWriter& SourceWriter, UClass* Class);
 void GenerateFunction_GetBoundClass(FCodeWriter& SourceWriter, UClass* Class);
-void GenerateFunction_Init(FCodeWriter& SourceWriter, UClass* Class, const FUnrealRPCsByType& RPCsByType, const FUnrealFlatRepData& RepData, const FCmdHandlePropertyMap& HandoverData, bool bIsSingleton);
+void GenerateFunction_Init(FCodeWriter& SourceWriter, UClass* Class, const FUnrealRPCsByType& RPCsByType, const FUnrealFlatRepData& RepData, const FCmdHandlePropertyMap& HandoverData, bool bIsSingleton, TMap<FString, FString>& GeneratedStructInfo);
 void GenerateFunction_BindToView(FCodeWriter& SourceWriter, UClass* Class, const FUnrealRPCsByType& RPCsByType);
 void GenerateFunction_UnbindFromView(FCodeWriter& SourceWriter, UClass* Class);
 void GenerateFunction_CreateActorEntity(FCodeWriter& SourceWriter, UClass* Class, TArray<UClass*> Components);

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
@@ -41,7 +41,7 @@ void GenerateTypeBindingHeader(
 	FString InteropFilename,
 	UClass* Class,
 	const TSharedPtr<FUnrealType> TypeInfo,
-	TMap<FString, FString>& GeneratedStructInfo);
+	BPStructTypesAndPaths& GeneratedStructInfo);
 
 // Generates the source file of a type binding.
 void GenerateTypeBindingSource(
@@ -53,13 +53,13 @@ void GenerateTypeBindingSource(
 	const TArray<FString>& TypeBindingHeaders,
 	bool bIsSingleton,
 	const ClassHeaderMap& InteropGeneratedClasses,
-	TMap<FString, FString>& GeneratedStructInfo);
+	BPStructTypesAndPaths& GeneratedStructInfo);
 
 // Helper functions used when generating the source file.
 void GenerateFunction_GetRepHandlePropertyMap(FCodeWriter& SourceWriter, UClass* Class);
 void GenerateFunction_GetHandoverHandlePropertyMap(FCodeWriter& SourceWriter, UClass* Class);
 void GenerateFunction_GetBoundClass(FCodeWriter& SourceWriter, UClass* Class);
-void GenerateFunction_Init(FCodeWriter& SourceWriter, UClass* Class, const FUnrealRPCsByType& RPCsByType, const FUnrealFlatRepData& RepData, const FCmdHandlePropertyMap& HandoverData, bool bIsSingleton, TMap<FString, FString>& GeneratedStructInfo);
+void GenerateFunction_Init(FCodeWriter& SourceWriter, UClass* Class, const FUnrealRPCsByType& RPCsByType, const FUnrealFlatRepData& RepData, const FCmdHandlePropertyMap& HandoverData, bool bIsSingleton, BPStructTypesAndPaths& GeneratedStructInfo);
 void GenerateFunction_BindToView(FCodeWriter& SourceWriter, UClass* Class, const FUnrealRPCsByType& RPCsByType);
 void GenerateFunction_UnbindFromView(FCodeWriter& SourceWriter, UClass* Class);
 void GenerateFunction_CreateActorEntity(FCodeWriter& SourceWriter, UClass* Class, TArray<UClass*> Components);

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeStructure.h
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeStructure.h
@@ -232,3 +232,5 @@ TArray<TSharedPtr<FUnrealProperty>> GetFlatRPCParameters(TSharedPtr<FUnrealRPC> 
 // Given a property, traverse up to the root property and create a list of properties needed to reach the leaf property.
 // For example: foo->bar->baz becomes {"foo", "bar", "baz"}.
 TArray<TSharedPtr<FUnrealProperty>> GetPropertyChain(TSharedPtr<FUnrealProperty> LeafProperty);
+
+using BPStructTypesAndPaths = TMap<FString, FString>;  // Storing the blueprint struct's CPPType and Asset Path


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
https://improbableio.atlassian.net/browse/UNR-499

Currently, if you nest a blueprint-defined struct in an array (or array of structs of arrays of structs...), our generated typebinding will contain invalid Types which refer to the blueprint struct in memory. The same problem happens with passing in blueprint-defined structs to RPC calls.

Since BP structs don't get compiled into C++ code, we will generate their definition manually inside the header file of generated typebindings. To get `SerializedBin` to work, we will load the BP asset at runtime instead of calling `::StaticClass` for cpp structs.

#### Tests
Pull this branch to test and see generated typebinding in action: https://github.com/spatialos/UnrealGDKStarterProject/tree/feature/UNR-499-Support-Blueprint-Replicated-Structs

Tested with RPCs taking struct inputs, nested array of structs of array of structs (up to 4 levels deep), changing values in editor and through server RPC calls and seeing the change propagate to Spatial and local client.

When testsuite is fixed, we probably want to merge some of those tests into TestSuite.

*Known Issue*: user can enter invalid names in blueprint struct/variable names, e.g. names containing `!`. https://improbableio.atlassian.net/browse/UNR-507

#### Documentation
#### Primary reviewers
@Vatyx @improbable-valentyn 

*Edit*: Added support for replicating blueprint Enums and Structs (& array of structs etc.) containing Enums!