### PR TITLE
Fix multicast rpcs so they can be issued without an owner on servers

### DIFF
--- a/Source/SpatialGDK/Private/SpatialNetDriver.cpp
+++ b/Source/SpatialGDK/Private/SpatialNetDriver.cpp
@@ -769,8 +769,8 @@ void USpatialNetDriver::ProcessRemoteFunction(
 	// The function GetNetConnection() goes up the AActor ownership chain until it reaches an AActor that is possesed by an AController and
 	// hence a UNetConnection. Server RPCs should only be sent by AActor instances that either are possessed by a UNetConnection or are owned by
 	// other AActor instances possessed by a UNetConnection. For native Unreal reference see ProcessRemoteFunction() of IpNetDriver.cpp.
-	// However if we are on the server, and the RPC is a CrossServer RPC, this can be invoked without an owner.
-	if (!Actor->GetNetConnection() && !(Function->FunctionFlags & FUNC_NetCrossServer && IsServer()))
+	// However if we are on the server, and the RPC is a CrossServer or NetMulticast RPC, this can be invoked without an owner.
+	if (!Actor->GetNetConnection() && !(Function->FunctionFlags & (FUNC_NetCrossServer | FUNC_NetMulticast) && IsServer()))
 	{
 		UE_LOG(LogSpatialOSNetDriver, Warning, TEXT("No owning connection for actor %s. Function %s will not be processed."), *Actor->GetName(), *Function->GetName());
 		return;


### PR DESCRIPTION
#### Description
Allowed multicast RPCs to be invoked from servers on objects that don't have owners. This corresponds to native Unreal's functionality.

Testsuite PR: https://github.com/spatialos/UnrealGDKTestSuite/pull/98

#### Tests
TestSuite already has suitable tests, which now run correctly.

#### Primary reviewers
@Vatyx @improbable-valentyn 