### PR TITLE
Remove unused Actor reference

### DIFF
--- a/Source/SpatialGDK/Private/SpatialPackageMapClient.cpp
+++ b/Source/SpatialGDK/Private/SpatialPackageMapClient.cpp
@@ -199,7 +199,6 @@ FNetworkGUID FSpatialNetGUIDCache::AssignNewStablyNamedObjectNetGUID(const UObje
 void FSpatialNetGUIDCache::RemoveEntityNetGUID(worker::EntityId EntityId)
 {
 	FNetworkGUID EntityNetGUID = GetNetGUIDFromEntityId(EntityId);
-	AActor* Actor = Cast<AActor>(GetObjectFromNetGUID(EntityNetGUID, false));
 	RemoveNetGUID(EntityNetGUID);
 }
 


### PR DESCRIPTION
#### Description
The editor could crash on closing a play-in-editor session, due to trying to find a removed actor.
#### Tests
Closed a PIE session and it did not crash.
#### Documentation
None
#### Primary reviewers
@m-samiec @Vatyx 