### PR TITLE
Furthered blueprint typebinding support

### DIFF
--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SpatialGDKEditorInteropCodeGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/SpatialGDKEditorInteropCodeGenerator.cpp
@@ -44,9 +44,8 @@ int GenerateCompleteSchemaFromClass(const FString& SchemaPath, const FString& Fo
 	OutputSchema.WriteToFile(FString::Printf(TEXT("%s%s.schema"), *SchemaPath, *SchemaFilename));
 
 	// Generate forwarding code.
-	BPStructTypesAndPaths GeneratedStructInfo;
-	GenerateTypeBindingHeader(OutputHeader, SchemaFilename, TypeBindingFilename, Class, TypeInfo, GeneratedStructInfo);
-	GenerateTypeBindingSource(OutputSource, SchemaFilename, TypeBindingFilename, Class, TypeInfo, GeneratedStructInfo);
+	GenerateTypeBindingHeader(OutputHeader, SchemaFilename, TypeBindingFilename, Class, TypeInfo);
+	GenerateTypeBindingSource(OutputSource, SchemaFilename, TypeBindingFilename, Class, TypeInfo);
 	OutputHeader.WriteToFile(FString::Printf(TEXT("%s%s.h"), *ForwardingCodePath, *TypeBindingFilename));
 	OutputSource.WriteToFile(FString::Printf(TEXT("%s%s.cpp"), *ForwardingCodePath, *TypeBindingFilename));
 

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
@@ -661,7 +661,7 @@ void AddIncludePath(const UProperty* UnrealProperty, TArray<FString>& HeaderIncl
 	}
 }
 
-void GenerateTypeBindingHeader(FCodeWriter& HeaderWriter, FString SchemaFilename, FString InteropFilename, UClass* Class, const TSharedPtr<FUnrealType> TypeInfo)
+void GenerateTypeBindingHeader(FCodeWriter& HeaderWriter, FString SchemaFilename, FString InteropFilename, UClass* Class, const TSharedPtr<FUnrealType>& TypeInfo)
 {
 	HeaderWriter.Printf(R"""(
 		// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
@@ -1815,7 +1815,7 @@ void GenerateFunction_ServerSendUpdate_HandoverData(FCodeWriter& SourceWriter, U
 
 		for (const auto& HandoverProp : HandoverData)
 		{
-			uint64 Handle = HandoverProp.Key;
+			uint16 Handle = HandoverProp.Key;
 			UProperty* Property = HandoverProp.Value->Property;
 
 			SourceWriter.Printf("case %d: // %s", Handle, *SchemaFieldName(HandoverProp.Value));
@@ -2085,7 +2085,7 @@ void GenerateFunction_ReceiveUpdate_HandoverData(FCodeWriter& SourceWriter, UCla
 		SourceWriter.PrintNewLine();
 		for (const auto& HandoverProp : HandoverData)
 		{
-			uint64 Handle = HandoverProp.Key;
+			uint16 Handle = HandoverProp.Key;
 			UProperty* Property = HandoverProp.Value->Property;
 
 			// Check if this property is in the update.

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
@@ -40,7 +40,7 @@ void GenerateTypeBindingHeader(
 	FString SchemaFilename,
 	FString InteropFilename,
 	UClass* Class,
-	const TSharedPtr<FUnrealType> TypeInfo);
+	const TSharedPtr<FUnrealType>& TypeInfo);
 
 // Generates the source file of a type binding.
 void GenerateTypeBindingSource(

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
@@ -40,8 +40,7 @@ void GenerateTypeBindingHeader(
 	FString SchemaFilename,
 	FString InteropFilename,
 	UClass* Class,
-	const TSharedPtr<FUnrealType> TypeInfo,
-	BPStructTypesAndPaths& GeneratedStructInfo);
+	const TSharedPtr<FUnrealType> TypeInfo);
 
 // Generates the source file of a type binding.
 void GenerateTypeBindingSource(
@@ -49,8 +48,7 @@ void GenerateTypeBindingSource(
 	FString SchemaFilename,
 	FString InteropFilename,
 	UClass* Class,
-	const TSharedPtr<FUnrealType>& TypeInfo,
-	BPStructTypesAndPaths& GeneratedStructInfo);
+	const TSharedPtr<FUnrealType>& TypeInfo);
 
 // Helper functions used when generating the source file.
 void GenerateHeaderIncludes_Source(FCodeWriter& SourceWriter, const FString& InteropFilename, UClass* Class, const FUnrealRPCsByType& RPCsByType, const FUnrealFlatRepData& RepData, const TArray<UClass*>& Components);

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
@@ -55,7 +55,7 @@ void GenerateHeaderIncludes_Source(FCodeWriter& SourceWriter, const FString& Int
 void GenerateFunction_GetRepHandlePropertyMap(FCodeWriter& SourceWriter, UClass* Class);
 void GenerateFunction_GetHandoverHandlePropertyMap(FCodeWriter& SourceWriter, UClass* Class);
 void GenerateFunction_GetBoundClass(FCodeWriter& SourceWriter, UClass* Class);
-void GenerateFunction_Init(FCodeWriter& SourceWriter, UClass* Class, const FUnrealRPCsByType& RPCsByType, const FUnrealFlatRepData& RepData, const FCmdHandlePropertyMap& HandoverData, BPStructTypesAndPaths& GeneratedStructInfo);
+void GenerateFunction_Init(FCodeWriter& SourceWriter, UClass* Class, const FUnrealRPCsByType& RPCsByType, const FUnrealFlatRepData& RepData, const FCmdHandlePropertyMap& HandoverData);
 void GenerateFunction_BindToView(FCodeWriter& SourceWriter, UClass* Class, const FUnrealRPCsByType& RPCsByType);
 void GenerateFunction_UnbindFromView(FCodeWriter& SourceWriter, UClass* Class);
 void GenerateFunction_CreateActorEntity(FCodeWriter& SourceWriter, UClass* Class, const TArray<UClass*>& Components);

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeStructure.h
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeStructure.h
@@ -232,5 +232,3 @@ TArray<TSharedPtr<FUnrealProperty>> GetFlatRPCParameters(TSharedPtr<FUnrealRPC> 
 // Given a property, traverse up to the root property and create a list of properties needed to reach the leaf property.
 // For example: foo->bar->baz becomes {"foo", "bar", "baz"}.
 TArray<TSharedPtr<FUnrealProperty>> GetPropertyChain(TSharedPtr<FUnrealProperty> LeafProperty);
-
-using BPStructTypesAndPaths = TMap<FString, FString>;  // Storing the blueprint struct's CPPType and Asset Path


### PR DESCRIPTION
#### Description
Blueprint class typebindings had compile errors when referencing other blueprint actors and structs in certain permutations. Further support has been added.

This change also moved the dependent header includes to the header file so they can be utilized by the forward blueprint type declarations.

Testsuite PR: https://github.com/spatialos/UnrealGDKTestSuite/pull/100

#### Tests
Testing blueprint classes with -
Replicated blueprint structs that contain blueprint actors
Replicated blueprint structs that contain blueprint structs
Rpcs with blueprint actors
Rpcs with blueprint structs

#### Primary reviewers
@improbable-valentyn @wanqizhu 