### PR TITLE
UNR-526 Fixed RPCTypeOwners overwriting correct Schema Types file

### DIFF
--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeStructure.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeStructure.cpp
@@ -547,7 +547,7 @@ TArray<FString> GetRPCTypeOwners(TSharedPtr<FUnrealType> TypeInfo)
 			UE_LOG(LogSpatialGDKInteropCodeGenerator, Log, TEXT("RPC Type Owner Found - %s ::  %s"), *RPCOwnerName, *RPC.Value->Function->GetName());
 		}
 		return true;
-	}, true);
+	}, false);
 	return RPCTypeOwners;
 }
 


### PR DESCRIPTION
#### Description
Based on the bug report from UNR-526, there was a bug with subobject classes having their correct SchemaTypes file being overwritten by the recursive call of `GetRPCTypeOwners`. This bugfix simply prevents the recursive call so the correct file is always present and not overwritten.
#### Tests
Added a subobject component to TestSuiteCharacter and confirmed that the SchemaTypes file is correctly generated after the fix.
TestSuite still runs correctly.
#### Primary reviewers
@improbable-valentyn @m-samiec 