### PR TITLE
UNR-529: Increased scope of type binding includes.

### DIFF
--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
@@ -699,21 +699,12 @@ void GenerateTypeBindingHeader(FCodeWriter& HeaderWriter, FString SchemaFilename
 	{
 		for (const auto& RepProp : RepData[Group])
 		{
+			// NB: Previously we were checking the owner of each property, and if it was a native object (ie. CLASS_Native or STRUCT_Native), we
+			// were ignoring it. This enables blueprints to include everything they need, without polluting include definitions of native classes.
+			// However this doesn't work if replicated property types are forward declared in the 'Class' definition, so now we just include
+			// all properties regardless of if they're native sourced or not. This will all go away when we have dynamic type bindings.
 			UProperty* UnrealProperty = RepProp.Value->Property;
-			if (UClass* RepClass = UnrealProperty->GetOwnerClass())
-			{
-				if (!RepClass->HasAnyClassFlags(CLASS_Native))
-				{
-					AddIncludePath(UnrealProperty, HeaderIncludes);
-				}
-			}
-			else if (UScriptStruct* RepStruct = Cast<UScriptStruct>(UnrealProperty->GetOwnerStruct()))
-			{
-				if (!(RepStruct->StructFlags & STRUCT_Native))
-				{
-					AddIncludePath(UnrealProperty, HeaderIncludes);
-				}
-			}
+ 			AddIncludePath(UnrealProperty, HeaderIncludes);
 		}
 	}
 

--- a/Source/SpatialGDK/Private/SpatialMemoryWriter.cpp
+++ b/Source/SpatialGDK/Private/SpatialMemoryWriter.cpp
@@ -32,6 +32,13 @@ FArchive& FSpatialMemoryWriter::operator<<(UObject*& Value)
 	if (Value != nullptr)
 	{
 		FNetworkGUID NetGUID = PackageMap->GetNetGUIDFromObject(Value);
+		if (!NetGUID.IsValid())
+		{
+			if (Value->IsFullNameStableForNetworking())
+			{
+				NetGUID = PackageMap->ResolveStablyNamedObject(Value);
+			}
+		}
 		ObjectRef = PackageMap->GetUnrealObjectRefFromNetGUID(NetGUID);
 		if (ObjectRef == SpatialConstants::UNRESOLVED_OBJECT_REF)
 		{


### PR DESCRIPTION
#### Description
Include all replicated property includes, not just those originating from a non-native class.
This PR also includes a drive-by for spatial memory writer creating stably named references that I discovered when investigating the ability system compatibility.

#### Tests
Ran testsuite tests.

#### Primary reviewers
@girayimprobable @danielimprobable 