### PR TITLE
unr-351: Replace use of UStruct::SerializeBin() with custom SerializeStruct

### DIFF
--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
@@ -287,7 +287,7 @@ void GenerateUnrealToSchemaConversion(FCodeWriter& Writer, const FString& Update
 		else
 		{
 			// We do a basic binary serialization for the generic struct.
-			Writer.Printf("%s%s->SerializeBin(ValueDataWriter, reinterpret_cast<void*>(const_cast<%s*>(&%s)));", *Property->GetCPPType(), (Struct->IsA<UUserDefinedStruct>() ? TEXT("_Struct") : TEXT("::StaticStruct()")), *Property->GetCPPType(), *PropertyValue);
+			Writer.Printf("SerializeStruct(%s%s, ValueDataWriter, reinterpret_cast<void*>(const_cast<%s*>(&%s)));", *Property->GetCPPType(), (Struct->IsA<UUserDefinedStruct>() ? TEXT("_Struct") : TEXT("::StaticStruct()")), *Property->GetCPPType(), *PropertyValue);
 		}
 
 		Writer.Printf("%s(std::string(reinterpret_cast<char*>(ValueData.GetData()), ValueData.Num()));", *Update);
@@ -447,7 +447,7 @@ void GeneratePropertyToUnrealConversion(FCodeWriter& Writer, const FString& Upda
 				TArray<uint8> ValueData;
 				ValueData.Append(reinterpret_cast<const uint8*>(ValueDataStr.data()), ValueDataStr.size());
 				FSpatialMemoryReader ValueDataReader(ValueData, PackageMap);
-				%s%s->SerializeBin(ValueDataReader, reinterpret_cast<void*>(&%s));)""", *Update, *PropertyType, (Struct->IsA<UUserDefinedStruct>() ? TEXT("_Struct") : TEXT("::StaticStruct()")), *PropertyValue);
+				SerializeStruct(%s%s, ValueDataReader, reinterpret_cast<void*>(&%s));)""", *Update, *PropertyType, (Struct->IsA<UUserDefinedStruct>() ? TEXT("_Struct") : TEXT("::StaticStruct()")), *PropertyValue);
 		}
 	}
 	else if (Property->IsA(UBoolProperty::StaticClass()))
@@ -1144,7 +1144,7 @@ void GenerateFunction_Init(FCodeWriter& SourceWriter, UClass* Class, const FUnre
 
 	SourceWriter.PrintNewLine();
 
-	// Since BP structs don't exist in C++ compile time, we will load the blueprint struct at runtime and call SerializeBin() from it.
+	// Since BP structs don't exist in C++ compile time, we will load the blueprint struct at runtime and call SerializeStruct() for it.
 	// Iterate over blueprint-defined structures and write out source file details
 	VisitAllBlueprintDefinedStructures(RPCsByType, RepData, [&SourceWriter](const UProperty* Property, const UField* ContextField)
 	{

--- a/Source/SpatialGDK/Private/SpatialTypeBinding.cpp
+++ b/Source/SpatialGDK/Private/SpatialTypeBinding.cpp
@@ -2,6 +2,7 @@
 
 #include "SpatialTypeBinding.h"
 #include "SpatialPackageMapClient.h"
+#include "SpatialInterop.h"
 
 void USpatialTypeBinding::Init(USpatialInterop* InInterop, USpatialPackageMapClient* InPackageMap)
 {
@@ -9,4 +10,75 @@ void USpatialTypeBinding::Init(USpatialInterop* InInterop, USpatialPackageMapCli
 	check(InPackageMap);
 	Interop = InInterop;
 	PackageMap = InPackageMap;
+}
+
+void USpatialTypeBinding::SerializeStruct(UStruct* Struct, FArchive& Ar, void* Data) const
+{
+	TSharedPtr<FRepLayout> RepLayout = Interop->GetNetDriver()->GetStructRepLayout(Struct);
+	bool bHasUnmapped = false;
+	SerializePropertiesForStruct(*RepLayout.Get(), Ar, Data, bHasUnmapped);
+}
+
+void USpatialTypeBinding::SerializeProperties_DynamicArray(FRepLayout& RepLayout, FArchive& Ar, UPackageMap* Map, const int32 CmdIndex, uint8* Data, bool& bHasUnmapped) const
+{
+	const FRepLayoutCmd& Cmd = RepLayout.Cmds[CmdIndex];
+
+	FScriptArray* Array = (FScriptArray*)Data;
+
+	uint16 OutArrayNum = Array->Num();
+	Ar << OutArrayNum;
+
+	// If loading from the archive, OutArrayNum will contain the number of elements.
+	// Otherwise, use the input number of elements.
+	const int32 ArrayNum = Ar.IsLoading() ? (int32)OutArrayNum : Array->Num();
+
+	// When loading, we may need to resize the array to properly fit the number of elements.
+	if (Ar.IsLoading() && OutArrayNum != Array->Num())
+	{
+		FScriptArrayHelper ArrayHelper((UArrayProperty*)Cmd.Property, Data);
+		ArrayHelper.Resize(OutArrayNum);
+	}
+
+	Data = (uint8*)Array->GetData();
+
+	for (int32 i = 0; i < Array->Num() && !Ar.IsError(); i++)
+	{
+		SerializeProperties(RepLayout, Ar, Map, CmdIndex + 1, Cmd.EndCmd - 1, Data + i * Cmd.ElementSize, bHasUnmapped);
+	}
+}
+
+void USpatialTypeBinding::SerializeProperties(FRepLayout& RepLayout, FArchive& Ar, UPackageMap* Map, const int32 CmdStart, const int32 CmdEnd, void* Data, bool& bHasUnmapped) const
+{
+	for (int32 CmdIndex = CmdStart; CmdIndex < CmdEnd && !Ar.IsError(); CmdIndex++)
+	{
+		const FRepLayoutCmd& Cmd = RepLayout.Cmds[CmdIndex];
+
+		check(Cmd.Type != REPCMD_Return);
+
+		if (Cmd.Type == REPCMD_DynamicArray)
+		{
+			SerializeProperties_DynamicArray(RepLayout, Ar, Map, CmdIndex, (uint8*)Data + Cmd.Offset, bHasUnmapped);
+			CmdIndex = Cmd.EndCmd - 1;		// The -1 to handle the ++ in the for loop
+			continue;
+		}
+
+		if (!Cmd.Property->NetSerializeItem(Ar, Map, (void*)((uint8*)Data + Cmd.Offset)))
+		{
+			bHasUnmapped = true;
+		}
+	}
+}
+
+void USpatialTypeBinding::SerializePropertiesForStruct(FRepLayout& RepLayout, FArchive& Ar, void* Data, bool& bHasUnmapped) const
+{
+	TArray<FRepParentCmd>& Parents = RepLayout.Parents;
+	for (int32 i = 0; i < Parents.Num(); i++)
+	{
+		SerializeProperties(RepLayout, Ar, PackageMap, Parents[i].CmdStart, Parents[i].CmdEnd, Data, bHasUnmapped);
+
+		if (Ar.IsError())
+		{
+			return;
+		}
+	}
 }

--- a/Source/SpatialGDK/Public/SpatialTypeBinding.h
+++ b/Source/SpatialGDK/Public/SpatialTypeBinding.h
@@ -242,7 +242,14 @@ public:
 	virtual void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const PURE_VIRTUAL(USpatialTypeBinding::ReceiveAddComponent, );
 	virtual worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const PURE_VIRTUAL(USpatialTypeBinding::GetInterestOverrideMap, return {}; );
 
+	void SerializeStruct(UStruct* Struct, FArchive& Ar, void* Data) const;
+
 protected:
+
+	void SerializeProperties_DynamicArray(FRepLayout& RepLayout, FArchive& Ar, UPackageMap* Map, const int32 CmdIndex, uint8* Data, bool& bHasUnmapped) const;
+	void SerializeProperties(FRepLayout& RepLayout, FArchive& Ar, UPackageMap* Map, const int32 CmdStart, const int32 CmdEnd, void* Data, bool& bHasUnmapped) const;
+	void SerializePropertiesForStruct(FRepLayout& RepLayout, FArchive& Ar, void* Data, bool& bHasUnmapped) const;
+
 	UPROPERTY()
 	USpatialInterop* Interop;
 


### PR DESCRIPTION
#### Description
UStruct::SerializeBin() doesn't respect replicated properties. Replace it with the implementation that was created by @improbable-valentyn for dynamic type bindings.
This was also required for the ability system component.

#### Tests
Ran TestSuite, and it's all okay.

#### Primary reviewers
@Vatyx @improbable-valentyn 