### PR TITLE
UNR-521 & UNR-522: Correct runtime ACLs and component interests based on ownership

### DIFF
--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
@@ -747,7 +747,8 @@ void GenerateTypeBindingHeader(FCodeWriter& HeaderWriter, FString SchemaFilename
 		void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
 
 		void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
-		worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;)""");
+		worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const override;
+		void UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const override;)""");
 
 	HeaderWriter.PrintNewLine();
 
@@ -939,6 +940,9 @@ void GenerateTypeBindingSource(FCodeWriter& SourceWriter, FString SchemaFilename
 
 	SourceWriter.PrintNewLine();
 	GenerateFunction_GetInterestOverrideMap(SourceWriter, Class);
+
+	SourceWriter.PrintNewLine();
+	GenerateFunction_UpdateEntityACL(SourceWriter, Class);
 
 	SourceWriter.PrintNewLine();
 	GenerateFunction_BuildSpatialComponentUpdate(SourceWriter, Class);
@@ -1561,21 +1565,53 @@ void GenerateFunction_ReceiveAddComponent(FCodeWriter& SourceWriter, UClass* Cla
 void GenerateFunction_GetInterestOverrideMap(FCodeWriter& SourceWriter, UClass* Class)
 {
 	SourceWriter.BeginFunction(
-		{"worker::Map<worker::ComponentId, worker::InterestOverride>", "GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const"},
+		{"worker::Map<worker::ComponentId, worker::InterestOverride>", "GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const"},
 		TypeBindingName(Class));
 	SourceWriter.Printf(R"""(
 		worker::Map<worker::ComponentId, worker::InterestOverride> Interest;
 		if (bIsClient)
 		{
-			if (!bAutonomousProxy)
-			{
-				Interest.emplace(%s::ComponentId, worker::InterestOverride{false});
-			}
+			Interest.emplace(%s::ComponentId, worker::InterestOverride{bNetOwned});
 			Interest.emplace(%s::ComponentId, worker::InterestOverride{false});
 		}
 		return Interest;)""",
 		*SchemaReplicatedDataName(REP_SingleClient, Class, true),
 		*SchemaHandoverDataName(Class, true));
+	SourceWriter.End();
+}
+
+void GenerateFunction_UpdateEntityACL(FCodeWriter& SourceWriter, UClass* Class)
+{
+	SourceWriter.BeginFunction(
+	{ "void", "UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const" },
+		TypeBindingName(Class));
+	SourceWriter.Printf(R"""(
+		TSharedPtr<worker::Connection> PinnedConnection = Interop->GetSpatialOS()->GetConnection().Pin();
+		TSharedPtr<worker::View> PinnedView = Interop->GetSpatialOS()->GetView().Pin();
+		worker::EntityId Id = Channel->GetEntityId().ToSpatialEntityId();
+
+		if (PinnedConnection.IsValid() && PinnedView.IsValid())
+		{
+			worker::Option<improbable::EntityAcl::Data &> Data = PinnedView->Entities[Id].Get<improbable::EntityAcl>();
+			if (Data.empty()) return;
+			worker::Map<uint32_t, improbable::WorkerRequirementSet> WriteACL = Data->component_write_acl();
+
+			std::string PlayerWorkerId;
+			if (bNetOwned)
+			{
+				PlayerWorkerId = TCHAR_TO_UTF8(*Channel->Connection->PlayerController->PlayerState->UniqueId.ToString());
+			}
+
+			improbable::WorkerAttributeSet OwningClientAttribute{ { "workerId:" + PlayerWorkerId } };
+			improbable::WorkerRequirementSet OwningClientOnly{ { OwningClientAttribute } };
+
+			WriteACL[%s::ComponentId] = OwningClientOnly;
+
+			improbable::EntityAcl::Update Update;
+			Update.set_component_write_acl(WriteACL);
+			PinnedConnection->SendComponentUpdate<improbable::EntityAcl>(Id, Update);
+		})""",
+		*SchemaRPCComponentName(ERPCType::RPC_Client, Class, true));
 	SourceWriter.End();
 }
 

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
@@ -64,6 +64,7 @@ void GenerateFunction_SendComponentUpdates(FCodeWriter& SourceWriter, UClass* Cl
 void GenerateFunction_SendRPCCommand(FCodeWriter& SourceWriter, UClass* Class);
 void GenerateFunction_ReceiveAddComponent(FCodeWriter& SourceWriter, UClass* Class, const TArray<UClass*>& Components);
 void GenerateFunction_GetInterestOverrideMap(FCodeWriter& SourceWriter, UClass* Class);
+void GenerateFunction_UpdateEntityACL(FCodeWriter& SourceWriter, UClass* Class);
 void GenerateFunction_BuildSpatialComponentUpdate(FCodeWriter& SourceWriter, UClass* Class);
 void GenerateFunction_ServerSendUpdate_RepData(FCodeWriter& SourceWriter, UClass* Class, const FUnrealFlatRepData& RepData, EReplicatedPropertyGroup Group);
 void GenerateBody_SendUpdate_RepDataProperty(FCodeWriter& SourceWriter, uint16 Handle, TSharedPtr<FUnrealProperty> PropertyInfo);

--- a/Source/SpatialGDK/Private/SpatialActorChannel.cpp
+++ b/Source/SpatialGDK/Private/SpatialActorChannel.cpp
@@ -251,8 +251,10 @@ bool USpatialActorChannel::ReplicateActor()
 
 		if (bIsNetOwned != bOldIsOwned || bFirstReplication)
 		{
-			Binding->UpdateEntityACL(this, bIsNetOwned);
-			bFirstReplication = false;
+			if (Binding->UpdateEntityACL(this, bIsNetOwned))
+			{
+				bFirstReplication = false;
+			}
 		}
 	}
 
@@ -552,6 +554,8 @@ void USpatialActorChannel::PostReceiveSpatialUpdate(UObject* TargetObject, const
 
 		FEntityId ActorEntityId = GetEntityId();
 
+		// Check whether the InterestOverrideMap has changed since the last spatial update
+		// Done by comparing the old map to the new one, element by element
 		bool bMapsMatch = true;
 		if (OldInterestOverrideMap.size() != InterestOverrideMap.size())
 		{

--- a/Source/SpatialGDK/Private/SpatialActorChannel.cpp
+++ b/Source/SpatialGDK/Private/SpatialActorChannel.cpp
@@ -55,6 +55,8 @@ USpatialActorChannel::USpatialActorChannel(const FObjectInitializer& ObjectIniti
 	: Super(ObjectInitializer)
 	, ActorEntityId(0)
 	, SpatialNetDriver(nullptr)
+	, bIsNetOwned(false)
+	, bFirstReplication(true)
 {
 	bCoreActor = true;
 	bCreatingNewEntity = false;
@@ -241,6 +243,19 @@ bool USpatialActorChannel::ReplicateActor()
 
 	FMemMark MemMark(FMemStack::Get());	// The calls to ReplicateProperties will allocate memory on FMemStack::Get(), and use it in ::PostSendBunch. we free it below
 
+	USpatialTypeBinding* Binding = Interop->GetTypeBindingByClass(Actor->GetClass());
+	if (Binding)
+	{
+		bool bOldIsOwned = bIsNetOwned;
+		bIsNetOwned = Actor->GetNetConnection() != nullptr;
+
+		if (bIsNetOwned != bOldIsOwned || bFirstReplication)
+		{
+			Binding->UpdateEntityACL(this, bIsNetOwned);
+			bFirstReplication = false;
+		}
+	}
+
 	// ----------------------------------------------------------
 	// Replicate Actor and Component properties and RPCs
 	// ----------------------------------------------------------
@@ -281,7 +296,6 @@ bool USpatialActorChannel::ReplicateActor()
 	ActorReplicator->RepState->LastCompareIndex = ChangelistState->CompareIndex;
 
 	// Update the handover property change list.
-	USpatialTypeBinding* Binding = Interop->GetTypeBindingByClass(Actor->GetClass());
 	TArray<uint16> HandoverChanged;
 	if (Binding)
 	{
@@ -327,24 +341,13 @@ bool USpatialActorChannel::ReplicateActor()
 			// inside APlayerState::UniqueId when UWorld::SpawnPlayActor is called. If this actor channel is managing a pawn or a 
 			// player controller, get the player state.
 			FString PlayerWorkerId;
-			APlayerState* PlayerState = Cast<APlayerState>(Actor);
-			if (!PlayerState)
+
+			// Native unreal version: OwningConnection == Connection || (OwningConnection != NULL && OwningConnection->IsA(UChildConnection::StaticClass()) && ((UChildConnection*)OwningConnection)->Parent == Connection)
+			// But since we do not have multiple connections, this should be equal to the above flow
+			bIsNetOwned = Actor->GetNetConnection() != nullptr;
+			if (bIsNetOwned)
 			{
-				if (APawn* Pawn = Cast<APawn>(Actor))
-				{
-					PlayerState = Pawn->PlayerState;
-				}
-			}
-			if (!PlayerState)
-			{
-				if (PlayerController)
-				{
-					PlayerState = PlayerController->PlayerState;
-				}
-			}
-			if (PlayerState)
-			{
-				PlayerWorkerId = PlayerState->UniqueId.ToString();
+				PlayerWorkerId = Connection->PlayerController->PlayerState->UniqueId.ToString();
 			}
 			else
 			{
@@ -541,6 +544,38 @@ void USpatialActorChannel::PreReceiveSpatialUpdate(UObject* TargetObject)
 
 void USpatialActorChannel::PostReceiveSpatialUpdate(UObject* TargetObject, const TArray<UProperty*>& RepNotifies)
 {
+	const USpatialTypeBinding* Binding = SpatialNetDriver->GetSpatialInterop()->GetTypeBindingByClass(Actor->GetClass());
+	if (Binding)
+	{
+		worker::Map<worker::ComponentId, worker::InterestOverride> OldInterestOverrideMap = InterestOverrideMap;
+		InterestOverrideMap = Binding->GetInterestOverrideMap(SpatialNetDriver->GetNetMode() == NM_Client, Actor->GetNetConnection() != nullptr);
+
+		FEntityId ActorEntityId = GetEntityId();
+
+		bool bMapsMatch = true;
+		if (OldInterestOverrideMap.size() != InterestOverrideMap.size())
+		{
+			bMapsMatch = false;
+		}
+		else
+		{
+			for (const auto& Pair : OldInterestOverrideMap)
+			{
+				if (!InterestOverrideMap.count(Pair.first) ||
+					Pair.second.IsInterested != InterestOverrideMap[Pair.first].IsInterested)
+				{
+					bMapsMatch = false;
+					break;
+				}
+			}
+		}
+
+		if (!bMapsMatch && ActorEntityId != FEntityId{})
+		{
+			SpatialNetDriver->GetSpatialOS()->GetConnection().Pin()->SendComponentInterest(ActorEntityId.ToSpatialEntityId(), InterestOverrideMap);
+		}
+	}
+
 	FNetworkGUID ObjectNetGUID = Connection->Driver->GuidCache->GetOrAssignNetGUID(TargetObject);
 	if (!ObjectNetGUID.IsDefault() && ObjectNetGUID.IsValid())
 	{

--- a/Source/SpatialGDK/Private/SpatialInterop.cpp
+++ b/Source/SpatialGDK/Private/SpatialInterop.cpp
@@ -363,7 +363,8 @@ void USpatialInterop::SendComponentInterests(USpatialActorChannel* ActorChannel,
 	const USpatialTypeBinding* Binding = GetTypeBindingByClass(ActorClass);
 	if (Binding)
 	{
-		auto Interest = Binding->GetInterestOverrideMap(NetDriver->GetNetMode() == NM_Client, ActorChannel->Actor->Role == ROLE_AutonomousProxy);
+		auto Interest = Binding->GetInterestOverrideMap(NetDriver->GetNetMode() == NM_Client, ActorChannel->GetActor()->GetNetConnection() != nullptr);
+
 		SpatialOSInstance->GetConnection().Pin()->SendComponentInterest(EntityId.ToSpatialEntityId(), Interest);
 	}
 }

--- a/Source/SpatialGDK/Public/SpatialActorChannel.h
+++ b/Source/SpatialGDK/Public/SpatialActorChannel.h
@@ -128,6 +128,9 @@ private:
 	UPROPERTY(transient)
 	USpatialNetDriver* SpatialNetDriver;
 
+	worker::Map<worker::ComponentId, worker::InterestOverride> InterestOverrideMap;
+	bool bIsNetOwned;
+	bool bFirstReplication;
 	FVector LastSpatialPosition;
 	TArray<uint8> HandoverPropertyShadowData;
 

--- a/Source/SpatialGDK/Public/SpatialTypeBinding.h
+++ b/Source/SpatialGDK/Public/SpatialTypeBinding.h
@@ -241,7 +241,7 @@ public:
 
 	virtual void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const PURE_VIRTUAL(USpatialTypeBinding::ReceiveAddComponent, );
 	virtual worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const PURE_VIRTUAL(USpatialTypeBinding::GetInterestOverrideMap, return {}; );
-	virtual void UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const PURE_VIRTUAL(USpatialTypeBinding::UpdateEntityACL, );
+	virtual bool UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const PURE_VIRTUAL(USpatialTypeBinding::UpdateEntityACL, return false; );
 
 	void SerializeStruct(UStruct* Struct, FArchive& Ar, void* Data) const;
 

--- a/Source/SpatialGDK/Public/SpatialTypeBinding.h
+++ b/Source/SpatialGDK/Public/SpatialTypeBinding.h
@@ -240,7 +240,8 @@ public:
 	virtual void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) PURE_VIRTUAL(USpatialTypeBinding::SendRPCCommand, );
 
 	virtual void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const PURE_VIRTUAL(USpatialTypeBinding::ReceiveAddComponent, );
-	virtual worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const PURE_VIRTUAL(USpatialTypeBinding::GetInterestOverrideMap, return {}; );
+	virtual worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const PURE_VIRTUAL(USpatialTypeBinding::GetInterestOverrideMap, return {}; );
+	virtual void UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const PURE_VIRTUAL(USpatialTypeBinding::UpdateEntityACL, );
 
 	void SerializeStruct(UStruct* Struct, FArchive& Ar, void* Data) const;
 


### PR DESCRIPTION
#### Description
Previously, changing an Actor's owner at runtime would not change whether it receives updates for properties marked as OWNER_ONLY - similarly it would also not affect whether it could receive ClientRPCs. There was also a desync between how we determine ownership, and how native Unreal does it, which this PR addresses.
#### Tests
Tested with gaining and losing ownership over an actor repeatedly, and observing changes in the inspector and in the editor.
#### Documentation
In-code
#### Primary reviewers
@girayimprobable , @improbable-valentyn , @Vatyx 