### PR TITLE
Feature/enable non actor component subobject replication

### DIFF
--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.cpp
@@ -1876,10 +1876,26 @@ void GenerateFunction_ReceiveUpdate_RepData(FCodeWriter& SourceWriter, UClass* C
 			UActorComponent* TargetObject = ActorChannel->Actor->FindComponentByClass<%s>();)""",
 			*GetFullCPPName(Class));
 	}
-	else
+	else if (Class->IsChildOf(AActor::StaticClass()))
 	{
 		SourceWriter.Printf(R"""(
 			AActor* TargetObject = ActorChannel->Actor;)""");
+	}
+	else
+	{
+		SourceWriter.Printf(R"""(
+			UObject* TargetObject = nullptr;
+			TArray<UObject*> DefaultSubobjects;
+			ActorChannel->Actor->GetDefaultSubobjects(DefaultSubobjects);
+			for (auto Subobject : DefaultSubobjects)
+			{
+				if (Subobject->GetClass() == GetBoundClass())
+				{
+					TargetObject = Subobject;
+					break;
+				}
+			}
+			check(TargetObject);)""");
 	}
 
 	SourceWriter.Printf(R"""(

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeBindingGenerator.h
@@ -59,7 +59,7 @@ void GenerateFunction_Init(FCodeWriter& SourceWriter, UClass* Class, const FUnre
 void GenerateFunction_BindToView(FCodeWriter& SourceWriter, UClass* Class, const FUnrealRPCsByType& RPCsByType);
 void GenerateFunction_UnbindFromView(FCodeWriter& SourceWriter, UClass* Class);
 void GenerateFunction_CreateActorEntity(FCodeWriter& SourceWriter, UClass* Class, const TArray<UClass*>& Components);
-void GenerateBody_SpatialComponents(FCodeWriter& SourceWriter, UClass* Class, TArray<FString>& SpatialComponents);
+void GenerateBody_SpatialComponents(FCodeWriter& SourceWriter, UClass* Class, UClass* OwnerClass, TArray<FString>& SpatialComponents);
 void GenerateFunction_SendComponentUpdates(FCodeWriter& SourceWriter, UClass* Class);
 void GenerateFunction_SendRPCCommand(FCodeWriter& SourceWriter, UClass* Class);
 void GenerateFunction_ReceiveAddComponent(FCodeWriter& SourceWriter, UClass* Class, const TArray<UClass*>& Components);

--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeStructure.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/InteropCodeGenerator/TypeStructure.cpp
@@ -372,12 +372,13 @@ TSharedPtr<FUnrealType> CreateUnrealTypeInfo(UStruct* Type, uint32 ParentChecksu
 	for (int CmdIndex = 0; CmdIndex < RepLayout.Cmds.Num(); ++CmdIndex)
 	{
 		FRepLayoutCmd& Cmd = RepLayout.Cmds[CmdIndex];
-		FRepParentCmd& Parent = RepLayout.Parents[Cmd.ParentIndex];
 
 		if (Cmd.Type == REPCMD_Return || Cmd.Property == nullptr)
 		{
 			continue;
 		}
+
+		FRepParentCmd& Parent = RepLayout.Parents[Cmd.ParentIndex];
 
 		// In a FRepLayout, all the root level replicated properties in a class are stored in the Parents array.
 		// The Cmds array is an expanded version of the Parents array. This usually maps 1:1 with the Parents array (as most properties
@@ -597,6 +598,17 @@ TArray<UClass*> GetAllSupportedComponents(UClass* Class)
 
 					AddComponentClassToSet(Node->ComponentTemplate->GetClass(), ComponentClasses, Class);
 				}
+			}
+		}
+
+		// Iterate over all subobjects and add any non ActorComponents
+		TArray<UObject*> DefaultSubobjects;
+		ContainerCDO->GetDefaultSubobjects(DefaultSubobjects);
+		for (auto Subobject : DefaultSubobjects)
+		{
+			if (Cast<UActorComponent>(Subobject) == nullptr)
+			{
+				AddComponentClassToSet(Subobject->GetClass(), ComponentClasses, Class);
 			}
 		}
 	}

--- a/Source/SpatialGDK/Private/SpatialActorChannel.cpp
+++ b/Source/SpatialGDK/Private/SpatialActorChannel.cpp
@@ -384,13 +384,10 @@ bool USpatialActorChannel::ReplicateActor()
 
 		for (UActorComponent* ActorComp : Actor->GetReplicatedComponents())
 		{
-			if (ActorComp && ActorComp->GetIsReplicated()) // Only replicated subobjects with type bindings
+			if (ActorComp && ActorComp->GetIsReplicated())
 			{
-				if(Interop->GetTypeBindingByClass(ActorComp->GetClass()))
-				{
-					bWroteSomethingImportant |= ReplicateSubobject(ActorComp, RepFlags);
-					bWroteSomethingImportant |= ActorComp->ReplicateSubobjects(this, &DummyOutBunch, &RepFlags);
-				}
+				bWroteSomethingImportant |= ReplicateSubobject(ActorComp, RepFlags);
+				bWroteSomethingImportant |= ActorComp->ReplicateSubobjects(this, &DummyOutBunch, &RepFlags);
 			}
 		}
 	}
@@ -453,8 +450,6 @@ bool USpatialActorChannel::ReplicateSubobject(UObject *Obj, const FReplicationFl
 
 	if (RepChanged.Num() > 0)
 	{
-		USpatialInterop* Interop = SpatialNetDriver->GetSpatialInterop();
-		check(Interop);
 		Interop->SendSpatialUpdateSubobject(this, Obj, &Replicator, RepChanged, TArray<uint16>());
 		Replicator.RepState->HistoryEnd++;
 	}

--- a/Source/SpatialGDK/Private/SpatialActorChannel.cpp
+++ b/Source/SpatialGDK/Private/SpatialActorChannel.cpp
@@ -611,15 +611,6 @@ void USpatialActorChannel::RegisterEntityId(const FEntityId& ActorEntityId)
 		});
 
 		PackageMap->ResolveEntityActor(Actor, ActorEntityId, SubobjectNameToOffset);
-		UE_LOG(LogTemp, Log, TEXT("MCS: Full name stable for networking: %s"), *Actor->GetName());
-	}
-	else if (Actor->IsNameStableForNetworking())
-	{
-		UE_LOG(LogTemp, Log, TEXT("MCS: Name stable for networking: %s"), *Actor->GetName());
-	}
-	else
-	{
-		UE_LOG(LogTemp, Log, TEXT("MCS: Name NOT stable for networking: %s"), *Actor->GetName());
 	}
 }
 

--- a/Source/SpatialGDK/Private/SpatialTypeBinding.cpp
+++ b/Source/SpatialGDK/Private/SpatialTypeBinding.cpp
@@ -3,6 +3,7 @@
 #include "SpatialTypeBinding.h"
 #include "SpatialPackageMapClient.h"
 #include "SpatialInterop.h"
+#include "SpatialNetDriver.h"
 
 void USpatialTypeBinding::Init(USpatialInterop* InInterop, USpatialPackageMapClient* InPackageMap)
 {

--- a/Source/SpatialGDK/Public/SpatialActorChannel.h
+++ b/Source/SpatialGDK/Public/SpatialActorChannel.h
@@ -96,7 +96,8 @@ public:
 	void SendReserveEntityIdRequest();
 	void RegisterEntityId(const FEntityId& ActorEntityId);
 	bool ReplicateSubobject(UObject *Obj, const FReplicationFlags &RepFlags);
-	FPropertyChangeState CreateSubobjectChangeState(UActorComponent* Component);
+	virtual bool ReplicateSubobject(UObject *Obj, FOutBunch &Bunch, const FReplicationFlags &RepFlags) override;
+	FPropertyChangeState CreateSubobjectChangeState(UObject* Subobject);
 	TArray<uint16> SkipOverChangelistArrays(FObjectReplicator& Replicator);
 
 	// Called by SpatialInterop when receiving an update.


### PR DESCRIPTION
#### Description
Enables subobject replication of static subobjects. This was added specifically to support the AbilitySystem.

In the SpatialActorChannel, we now call into ActorComponent::ReplicateSubobjects() for all components which allows them to replicate any relevant subobjects. This is how unreal supports subobject replication (check out `UAbilitySystemComponent::ReplicateSubobjects` for an example). These calls will usually route back into SpatialActorChannel::ReplicateSubobject() where we replicate it like a normal subobject.

#### Tests
Implemented a local version of the ability system component, with replicating attribute sets, and validate that they work. 
I'll work to move these tests into the test suite soon.

#### Primary reviewers
@Vatyx @improbable-valentyn