### PR TITLE
Fixed lingering Subobject GUIDs when an Actor is deleted

### DIFF
--- a/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -174,6 +174,16 @@ void FSpatialNetGUIDCache::RemoveEntityNetGUID(Worker_EntityId EntityId)
 	UnrealObjectRef* ActorRef = NetGUIDToUnrealObjectRef.Find(EntityNetGUID);
 	NetGUIDToUnrealObjectRef.Remove(EntityNetGUID);
 	UnrealObjectRefToNetGUID.Remove(*ActorRef);
+
+	UnrealObjectRef SubobjectRef(ActorRef->Entity, ActorRef->Offset + 1);
+	while(UnrealObjectRefToNetGUID.Contains(SubobjectRef))
+	{
+		FNetworkGUID SubobjectNetGUID = UnrealObjectRefToNetGUID[SubobjectRef];
+		NetGUIDToUnrealObjectRef.Remove(SubobjectNetGUID);
+		UnrealObjectRefToNetGUID.Remove(SubobjectRef);
+
+		SubobjectRef.Offset++;
+	}
 }
 
 FNetworkGUID FSpatialNetGUIDCache::GetNetGUIDFromUnrealObjectRef(const UnrealObjectRef& ObjectRef)

--- a/Source/SpatialGDK/Private/Interop/SpatialView.cpp
+++ b/Source/SpatialGDK/Private/Interop/SpatialView.cpp
@@ -30,6 +30,7 @@ void USpatialView::ProcessOps(Worker_OpList* OpList)
 			break;
 		case WORKER_OP_TYPE_REMOVE_ENTITY:
 			Receiver->OnRemoveEntity(Op->remove_entity);
+			OnRemoveEntity(Op->remove_entity);
 			break;
 
 		// Components
@@ -38,7 +39,6 @@ void USpatialView::ProcessOps(Worker_OpList* OpList)
 			Receiver->OnAddComponent(Op->add_component);
 			break;
 		case WORKER_OP_TYPE_REMOVE_COMPONENT:
-			OnRemoveComponent(Op->remove_component);
 			break;
 
 		case WORKER_OP_TYPE_COMPONENT_UPDATE:
@@ -125,7 +125,7 @@ void USpatialView::OnAuthorityChange(const Worker_AuthorityChangeOp& Op)
 	EntityComponentAuthorityMap.FindOrAdd(Op.entity_id).FindOrAdd(Op.component_id) = (Worker_Authority)Op.authority;
 }
 
-void USpatialView::OnAddComponent(Worker_AddComponentOp& Op)
+void USpatialView::OnAddComponent(const Worker_AddComponentOp& Op)
 {
 	if (Op.data.component_id == UnrealMetadata::ComponentId)
 	{
@@ -133,10 +133,7 @@ void USpatialView::OnAddComponent(Worker_AddComponentOp& Op)
 	}
 }
 
-void USpatialView::OnRemoveComponent(Worker_RemoveComponentOp& Op)
+void USpatialView::OnRemoveEntity(const Worker_RemoveEntityOp& Op)
 {
-	if (Op.component_id == UnrealMetadata::ComponentId)
-	{
-		EntityUnrealMetadataMap.Remove(Op.entity_id);
-	}
+	EntityUnrealMetadataMap.Remove(Op.entity_id);
 }

--- a/Source/SpatialGDK/Public/Interop/SpatialView.h
+++ b/Source/SpatialGDK/Public/Interop/SpatialView.h
@@ -27,8 +27,8 @@ public:
 	UnrealMetadata* GetUnrealMetadata(Worker_EntityId EntityId);
 
 private:
-	void OnAddComponent(Worker_AddComponentOp& add_component);
-	void OnRemoveComponent(Worker_RemoveComponentOp& remove_component);
+	void OnAddComponent(const Worker_AddComponentOp& add_component);
+	void OnRemoveEntity(const Worker_RemoveEntityOp& remove_entity);
 	void OnAuthorityChange(const Worker_AuthorityChangeOp& Op);
 
 	USpatialReceiver* Receiver;


### PR DESCRIPTION
I was running into this issue during the last Scavengers visit but I just commented out the checkf which was the problem and moved on. Finally found it.

Anytime a entity is moving between a checkout radius, when the entity came back, the subobjects would clash with their pre existing NetGUIDS

@improbable-valentyn @m-samiec 