### PR TITLE
Stop crashing on dynamic components

### DIFF
--- a/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -99,7 +99,10 @@ void USpatialReceiver::OnAddComponent(Worker_AddComponentOp& Op)
 	UE_LOG(LogTemp, Log, TEXT("SpatialReceiver: AddComponent component ID: %u entity ID: %lld"),
 		Op.data.component_id, Op.entity_id);
 
-	check(bInCriticalSection);
+	if(!bInCriticalSection)
+	{
+		return; // Received an update for a dynamic component which aren't supported.
+	}
 
 	TSharedPtr<Component> Data;
 
@@ -479,15 +482,13 @@ void USpatialReceiver::OnComponentUpdate(Worker_ComponentUpdateOp& Op)
 		return;
 	}
 
-	if (Op.update.component_id == Info->SingleClientComponent)
+	if (Op.update.component_id == Info->SingleClientComponent || Op.update.component_id == Info->MultiClientComponent)
 	{
 		UObject* TargetObject = GetTargetObjectFromChannelAndClass(ActorChannel, Class);
-		ApplyComponentUpdate(Op.update, TargetObject, ActorChannel);
-	}
-	else if (Op.update.component_id == Info->MultiClientComponent)
-	{
-		UObject* TargetObject = GetTargetObjectFromChannelAndClass(ActorChannel, Class);
-		ApplyComponentUpdate(Op.update, TargetObject, ActorChannel);
+		if(TargetObject != nullptr)
+		{
+			ApplyComponentUpdate(Op.update, TargetObject, ActorChannel);
+		}
 	}
 	else if (Op.update.component_id == Info->HandoverComponent)
 	{
@@ -653,7 +654,10 @@ UObject* USpatialReceiver::GetTargetObjectFromChannelAndClass(USpatialActorChann
 	{
 		FClassInfo* ActorInfo = TypebindingManager->FindClassInfoByClass(Channel->Actor->GetClass());
 		check(ActorInfo);
-		check(ActorInfo->SubobjectClasses.Find(Class));
+		if(ActorInfo->SubobjectClasses.Find(Class) == nullptr)
+		{
+			return nullptr; // Unsupported Subobject due to being a dynamic component
+		}
 
 		TArray<UObject*> DefaultSubobjects;
 		Channel->Actor->GetDefaultSubobjects(DefaultSubobjects);
@@ -665,7 +669,6 @@ UObject* USpatialReceiver::GetTargetObjectFromChannelAndClass(USpatialActorChann
 		TargetObject = *FoundSubobject;
 	}
 
-	check(TargetObject);
 	return TargetObject;
 }
 


### PR DESCRIPTION
At the moment, if you send an update to Spatial for a component that doesn't exist on an entity, it will add a component to the entity and broadcast an update. This can somewhat be used to implement dynamic actor components but there is still an issue of removing a component and receiving authority over this component, so at the moment this PR makes it so that if typebindings are created for a dynamic component, the GDK doesn't crash.