### PR TITLE
Remove actor channel from EntityToActorChannel map on cleanup

### DIFF
--- a/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -87,8 +87,9 @@ void USpatialActorChannel::DeleteEntityIfAuthoritative()
 	if (bHasAuthority && !IsSingletonEntity())
 	{
 		Sender->SendDeleteEntityRequest(EntityId);
-		Receiver->CleanupDeletedEntity(EntityId);
 	}
+
+	Receiver->CleanupDeletedEntity(EntityId);
 }
 
 bool USpatialActorChannel::IsSingletonEntity()

--- a/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1136,12 +1136,23 @@ void USpatialPendingNetGame::SendJoin()
 	bSentJoinRequest = true;
 }
 
-void USpatialNetDriver::AddActorChannel(const Worker_EntityId& EntityId, USpatialActorChannel* Channel)
+void USpatialNetDriver::AddActorChannel(Worker_EntityId EntityId, USpatialActorChannel* Channel)
 {
 	EntityToActorChannel.Add(EntityId, Channel);
 }
 
-USpatialActorChannel* USpatialNetDriver::GetActorChannelByEntityId(const Worker_EntityId& EntityId) const
+void USpatialNetDriver::RemoveActorChannel(Worker_EntityId EntityId)
+{
+	if (!EntityToActorChannel.Contains(EntityId))
+	{
+		UE_LOG(LogSpatialOSNetDriver, Warning, TEXT("Failed to find entity/channel mapping for entity %lld."), EntityId);
+		return;
+	}
+
+	EntityToActorChannel.FindAndRemoveChecked(EntityId);
+}
+
+USpatialActorChannel* USpatialNetDriver::GetActorChannelByEntityId(Worker_EntityId EntityId) const
 {
 	return EntityToActorChannel.FindRef(EntityId);
 }

--- a/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1145,7 +1145,7 @@ void USpatialNetDriver::RemoveActorChannel(Worker_EntityId EntityId)
 {
 	if (!EntityToActorChannel.Contains(EntityId))
 	{
-		UE_LOG(LogSpatialOSNetDriver, Warning, TEXT("Failed to find entity/channel mapping for entity %lld."), EntityId);
+		UE_LOG(LogSpatialOSNetDriver, Warning, TEXT("RemoveActorChannel: Failed to find entity/channel mapping for entity %lld."), EntityId);
 		return;
 	}
 

--- a/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -377,6 +377,7 @@ void USpatialReceiver::RemoveActor(Worker_EntityId EntityId)
 void USpatialReceiver::CleanupDeletedEntity(Worker_EntityId EntityId)
 {
 	NetDriver->GetEntityRegistry()->RemoveFromRegistry(EntityId);
+	NetDriver->RemoveActorChannel(EntityId);
 	Cast<USpatialPackageMapClient>(NetDriver->GetSpatialOSNetConnection()->PackageMap)->RemoveEntityActor(EntityId);
 }
 

--- a/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -82,8 +82,10 @@ public:
 	// Used by USpatialSpawner (when new players join the game) and USpatialInteropPipelineBlock (when player controllers are migrated).
 	USpatialNetConnection* AcceptNewPlayer(const FURL& InUrl, bool bExistingPlayer);
 
-	void AddActorChannel(const Worker_EntityId& EntityId, USpatialActorChannel* Channel);
-	USpatialActorChannel* GetActorChannelByEntityId(const Worker_EntityId& EntityId) const;
+	void AddActorChannel(Worker_EntityId EntityId, USpatialActorChannel* Channel);
+	void RemoveActorChannel(Worker_EntityId EntityId);
+
+	USpatialActorChannel* GetActorChannelByEntityId(Worker_EntityId EntityId) const;
 
 	UPROPERTY()
 	USpatialWorkerConnection* Connection;


### PR DESCRIPTION
If we don't remove it from the map, you later retrieve the pointer to a channel that was or is being destroyed.