### PR TITLE
Dynamic component interest

### DIFF
--- a/SpatialGDK/Source/Private/Interop/Connection/SpatialWorkerConnection.cpp
+++ b/SpatialGDK/Source/Private/Interop/Connection/SpatialWorkerConnection.cpp
@@ -226,6 +226,11 @@ void USpatialWorkerConnection::SendLogMessage(const uint8_t Level, const char* L
 	Worker_Connection_SendLogMessage(WorkerConnection, &LogMessage);
 }
 
+void USpatialWorkerConnection::SendComponentInterest(Worker_EntityId EntityId, const TArray<Worker_InterestOverride>& ComponentInterest)
+{
+	Worker_Connection_SendComponentInterest(WorkerConnection, EntityId, ComponentInterest.GetData(), ComponentInterest.Num());
+}
+
 FString USpatialWorkerConnection::GetWorkerId() const
 {
 	return FString(UTF8_TO_TCHAR(Worker_Connection_GetWorkerId(WorkerConnection)));

--- a/SpatialGDK/Source/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialReceiver.cpp
@@ -8,6 +8,7 @@
 #include "EngineClasses/SpatialActorChannel.h"
 #include "EngineClasses/SpatialNetConnection.h"
 #include "EngineClasses/SpatialPackageMapClient.h"
+#include "Interop/Connection/SpatialWorkerConnection.h"
 #include "Interop/GlobalStateManager.h"
 #include "Interop/SpatialPlayerSpawner.h"
 #include "Interop/SpatialSender.h"
@@ -288,13 +289,13 @@ void USpatialReceiver::ReceiveActor(Worker_EntityId EntityId)
 			}
 		}
 
-		// Update interest on the entity's components after receiving initial component data (so Role and RemoteRole are properly set).
-		//NetDriver->GetSpatialInterop()->SendComponentInterests(Channel, EntityId.ToSpatialEntityId());
-
-		// This is a bit of a hack unfortunately, among the core classes only PlayerController implements this function and it requires
-		// a player index. For now we don't support split screen, so the number is always 0.
-		if (NetDriver->ServerConnection)
+		if (!NetDriver->IsServer())
 		{
+			// Update interest on the entity's components after receiving initial component data (so Role and RemoteRole are properly set).
+			Sender->SendComponentInterest(EntityActor, EntityId);
+
+			// This is a bit of a hack unfortunately, among the core classes only PlayerController implements this function and it requires
+			// a player index. For now we don't support split screen, so the number is always 0.
 			if (EntityActor->IsA(APlayerController::StaticClass()))
 			{
 				uint8 PlayerIndex = 0;

--- a/SpatialGDK/Source/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/Public/EngineClasses/SpatialActorChannel.h
@@ -82,6 +82,7 @@ public:
 	// For an object that is replicated by this channel (i.e. this channel's actor or its component), find out whether a given handle is an array.
 	bool IsDynamicArrayHandle(UObject* Object, uint16 Handle);
 
+	void SpatialViewTick();
 	FObjectReplicator& PreReceiveSpatialUpdate(UObject* TargetObject);
 	void PostReceiveSpatialUpdate(UObject* TargetObject, const TArray<UProperty*>& RepNotifies);
 
@@ -109,6 +110,8 @@ private:
 
 private:
 	Worker_EntityId EntityId;
+	bool bFirstTick;
+	bool bNetOwned;
 
 	UPROPERTY(transient)
 	USpatialNetDriver* NetDriver;
@@ -130,5 +133,4 @@ private:
 
 	// If this actor channel is responsible for creating a new entity, this will be set to true during initial replication.
 	bool bCreatingNewEntity;
-
 };

--- a/SpatialGDK/Source/Public/Interop/Connection/SpatialWorkerConnection.h
+++ b/SpatialGDK/Source/Public/Interop/Connection/SpatialWorkerConnection.h
@@ -34,6 +34,7 @@ public:
 	Worker_RequestId SendCommandRequest(Worker_EntityId EntityId, const Worker_CommandRequest* Request, uint32_t CommandId);
 	void SendCommandResponse(Worker_RequestId RequestId, const Worker_CommandResponse* Response);
 	void SendLogMessage(const uint8_t Level, const char* LoggerName, const char* Message);
+	void SendComponentInterest(Worker_EntityId EntityId, const TArray<Worker_InterestOverride>& ComponentInterest);
 	FString GetWorkerId() const;
 
 	OnConnectedDelegate OnConnected;

--- a/SpatialGDK/Source/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/Public/Interop/SpatialSender.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 
+#include "SpatialTypebindingManager.h"
 #include "Utils/RepDataUtils.h"
 
 #include <improbable/c_schema.h>
@@ -14,6 +15,7 @@
 DECLARE_LOG_CATEGORY_EXTERN(LogSpatialSender, Log, All);
 
 class USpatialNetDriver;
+class USpatialView;
 class USpatialWorkerConnection;
 class USpatialActorChannel;
 class USpatialPackageMapClient;
@@ -51,6 +53,7 @@ public:
 
 	// Actor Updates
 	void SendComponentUpdates(UObject* Object, USpatialActorChannel* Channel, const FRepChangeState* RepChanges, const FHandoverChangeState* HandoverChanges);
+	void SendComponentInterest(AActor* Actor, Worker_EntityId EntityId);
 	void SendPositionUpdate(Worker_EntityId EntityId, const FVector& Location);
 	void SendRotationUpdate(Worker_EntityId EntityId, const FRotator& Rotation);
 	void SendRPC(TSharedRef<FPendingRPCParams> Params);
@@ -64,6 +67,7 @@ public:
 	void ResolveOutgoingOperations(UObject* Object, bool bIsHandover);
 	void ResolveOutgoingRPCs(UObject* Object);
 
+	bool UpdateEntityACLs(AActor* Actor, Worker_EntityId EntityId);
 private:
 	// Actor Lifecycle
 	Worker_RequestId CreateEntity(const FString& ClientWorkerId, const FString& Metadata, USpatialActorChannel* Channel);
@@ -77,8 +81,11 @@ private:
 	Worker_CommandRequest CreateRPCCommandRequest(UObject* TargetObject, UFunction* Function, void* Parameters, Worker_ComponentId ComponentId, Schema_FieldId CommandIndex, Worker_EntityId& OutEntityId, const UObject*& OutUnresolvedObject);
 	Worker_ComponentUpdate CreateMulticastUpdate(UObject* TargetObject, UFunction* Function, void* Parameters, Worker_ComponentId ComponentId, Schema_FieldId EventIndex, Worker_EntityId& OutEntityId, const UObject*& OutUnresolvedObject);
 
+	TArray<Worker_InterestOverride> CreateComponentInterest(AActor* Actor);
+
 private:
 	USpatialNetDriver* NetDriver;
+	USpatialView* View;
 	USpatialWorkerConnection* Connection;
 	USpatialReceiver* Receiver;
 	USpatialPackageMapClient* PackageMap;

--- a/SpatialGDK/Source/Public/Interop/SpatialView.h
+++ b/SpatialGDK/Source/Public/Interop/SpatialView.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 
+#include "Schema/StandardLibrary.h"
 #include "Schema/UnrealMetadata.h"
 #include "SpatialConstants.h"
 
@@ -16,6 +17,7 @@ DECLARE_LOG_CATEGORY_EXTERN(LogSpatialView, Log, All);
 
 class USpatialNetDriver;
 class USpatialReceiver;
+class USpatialSender;
 
 UCLASS()
 class SPATIALGDK_API USpatialView : public UObject
@@ -28,14 +30,19 @@ public:
 
 	Worker_Authority GetAuthority(Worker_EntityId EntityId, Worker_ComponentId ComponentId);
 	improbable::UnrealMetadata* GetUnrealMetadata(Worker_EntityId EntityId);
+	improbable::EntityAcl* GetEntityACL(Worker_EntityId EntityId);
 
 private:
 	void OnAddComponent(const Worker_AddComponentOp& Op);
 	void OnRemoveEntity(const Worker_RemoveEntityOp& Op);
+	void OnComponentUpdate(const Worker_ComponentUpdateOp& Op);
 	void OnAuthorityChange(const Worker_AuthorityChangeOp& Op);
 
+	USpatialNetDriver* NetDriver;
 	USpatialReceiver* Receiver;
+	USpatialSender* Sender;
 
 	TMap<Worker_EntityId_Key, TMap<Worker_ComponentId, Worker_Authority>> EntityComponentAuthorityMap;
 	TMap<Worker_EntityId_Key, TSharedPtr<improbable::UnrealMetadata>> EntityUnrealMetadataMap;
+	TMap<Worker_EntityId_Key, TSharedPtr<improbable::EntityAcl>> EntityACLMap;
 };


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Implemented the component interest. The logic is pretty much the same as in static typebindings, except this also takes subobjects into account.
There is a race condition caused by checking out the entity before having authority, which is also present in the master. [Miron's fix](https://github.com/spatialos/UnrealGDK/pull/309) for it is in review.
It may make sense to port the fix onto DTB and add it do this branch before merging this PR.
#### Tests
1. Add a replicated property with a condition `OwnerOnly`.
1. Increment it on the server.
1. Observe that only the owning client sees the change.
(Unfortunately, because of the race condition, sometimes none of the clients would see the change)
#### Primary reviewers
@m-samiec @Vatyx 