### PR TITLE
Remove subobject NetGUIDs during RemoveComponent

### DIFF
--- a/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -60,13 +60,22 @@ FNetworkGUID USpatialPackageMapClient::ResolveEntityActor(AActor* Actor, Worker_
 	return NetGUID;
 }
 
-void USpatialPackageMapClient::RemoveEntityActor(const Worker_EntityId& EntityId)
+void USpatialPackageMapClient::RemoveEntityActor(const Worker_EntityId EntityId)
 {
 	FSpatialNetGUIDCache* SpatialGuidCache = static_cast<FSpatialNetGUIDCache*>(GuidCache.Get());
 
 	if (SpatialGuidCache->GetNetGUIDFromEntityId(EntityId).IsValid())
 	{
 		SpatialGuidCache->RemoveEntityNetGUID(EntityId);
+	}
+}
+
+void USpatialPackageMapClient::RemoveEntitySubobjects(const Worker_EntityId EntityId)
+{
+	FSpatialNetGUIDCache* SpatialGuidCache = static_cast<FSpatialNetGUIDCache*>(GuidCache.Get());
+	if (SpatialGuidCache->GetNetGUIDFromEntityId(EntityId).IsValid())
+	{
+		SpatialGuidCache->RemoveEntitySubobjectsNetGUIDs(EntityId);
 	}
 }
 
@@ -175,7 +184,10 @@ void FSpatialNetGUIDCache::RemoveEntityNetGUID(Worker_EntityId EntityId)
 	UnrealObjectRef* ActorRef = NetGUIDToUnrealObjectRef.Find(EntityNetGUID);
 	NetGUIDToUnrealObjectRef.Remove(EntityNetGUID);
 	UnrealObjectRefToNetGUID.Remove(*ActorRef);
+}
 
+void FSpatialNetGUIDCache::RemoveEntitySubobjectsNetGUIDs(Worker_EntityId EntityId)
+{
 	USpatialNetDriver* SpatialNetDriver = Cast<USpatialNetDriver>(Driver);
 	SubobjectToOffsetMap SubobjectNameToOffset = SpatialNetDriver->View->GetUnrealMetadata(EntityId)->SubobjectNameToOffset;
 

--- a/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -60,7 +60,7 @@ FNetworkGUID USpatialPackageMapClient::ResolveEntityActor(AActor* Actor, Worker_
 	return NetGUID;
 }
 
-void USpatialPackageMapClient::RemoveEntityActor(const Worker_EntityId EntityId)
+void USpatialPackageMapClient::RemoveEntityActor(Worker_EntityId EntityId)
 {
 	FSpatialNetGUIDCache* SpatialGuidCache = static_cast<FSpatialNetGUIDCache*>(GuidCache.Get());
 
@@ -70,7 +70,7 @@ void USpatialPackageMapClient::RemoveEntityActor(const Worker_EntityId EntityId)
 	}
 }
 
-void USpatialPackageMapClient::RemoveEntitySubobjects(const Worker_EntityId EntityId)
+void USpatialPackageMapClient::RemoveEntitySubobjects(Worker_EntityId EntityId)
 {
 	FSpatialNetGUIDCache* SpatialGuidCache = static_cast<FSpatialNetGUIDCache*>(GuidCache.Get());
 	if (SpatialGuidCache->GetNetGUIDFromEntityId(EntityId).IsValid())

--- a/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -139,7 +139,7 @@ void USpatialReceiver::OnAddComponent(Worker_AddComponentOp& Op)
 
 void USpatialReceiver::OnRemoveComponent(Worker_RemoveComponentOp& Op)
 {
-	if(Op.component_id == UnrealMetadata::ComponentId)
+	if (Op.component_id == UnrealMetadata::ComponentId)
 	{
 		PackageMap->RemoveEntitySubobjects(Op.entity_id);
 	}

--- a/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -137,6 +137,14 @@ void USpatialReceiver::OnAddComponent(Worker_AddComponentOp& Op)
 	PendingAddComponents.Emplace(Op.entity_id, Op.data.component_id, Data);
 }
 
+void USpatialReceiver::OnRemoveComponent(Worker_RemoveComponentOp& Op)
+{
+	if(Op.component_id == UnrealMetadata::ComponentId)
+	{
+		PackageMap->RemoveEntitySubobjects(Op.entity_id);
+	}
+}
+
 void USpatialReceiver::OnRemoveEntity(Worker_RemoveEntityOp& Op)
 {
 	UE_LOG(LogTemp, Log, TEXT("CAPIPipelineBlock: RemoveEntity: %lld"), Op.entity_id);

--- a/Source/SpatialGDK/Private/Interop/SpatialView.cpp
+++ b/Source/SpatialGDK/Private/Interop/SpatialView.cpp
@@ -30,7 +30,6 @@ void USpatialView::ProcessOps(Worker_OpList* OpList)
 			break;
 		case WORKER_OP_TYPE_REMOVE_ENTITY:
 			Receiver->OnRemoveEntity(Op->remove_entity);
-			OnRemoveEntity(Op->remove_entity);
 			break;
 
 		// Components
@@ -39,6 +38,8 @@ void USpatialView::ProcessOps(Worker_OpList* OpList)
 			Receiver->OnAddComponent(Op->add_component);
 			break;
 		case WORKER_OP_TYPE_REMOVE_COMPONENT:
+			Receiver->OnRemoveComponent(Op->remove_component);
+			OnRemoveComponent(Op->remove_component);
 			break;
 
 		case WORKER_OP_TYPE_COMPONENT_UPDATE:
@@ -133,7 +134,10 @@ void USpatialView::OnAddComponent(const Worker_AddComponentOp& Op)
 	}
 }
 
-void USpatialView::OnRemoveEntity(const Worker_RemoveEntityOp& Op)
+void USpatialView::OnRemoveComponent(const Worker_RemoveComponentOp& Op)
 {
-	EntityUnrealMetadataMap.Remove(Op.entity_id);
+	if(Op.component_id == UnrealMetadata::ComponentId)
+	{
+		EntityUnrealMetadataMap.Remove(Op.entity_id);
+	}
 }

--- a/Source/SpatialGDK/Private/Interop/SpatialView.cpp
+++ b/Source/SpatialGDK/Private/Interop/SpatialView.cpp
@@ -136,7 +136,7 @@ void USpatialView::OnAddComponent(const Worker_AddComponentOp& Op)
 
 void USpatialView::OnRemoveComponent(const Worker_RemoveComponentOp& Op)
 {
-	if(Op.component_id == UnrealMetadata::ComponentId)
+	if (Op.component_id == UnrealMetadata::ComponentId)
 	{
 		EntityUnrealMetadataMap.Remove(Op.entity_id);
 	}

--- a/Source/SpatialGDK/Public/EngineClasses/SpatialPackageMapClient.h
+++ b/Source/SpatialGDK/Public/EngineClasses/SpatialPackageMapClient.h
@@ -20,9 +20,9 @@ class SPATIALGDK_API USpatialPackageMapClient : public UPackageMapClient
 	GENERATED_BODY()		
 public:
 	FNetworkGUID ResolveEntityActor(AActor* Actor, Worker_EntityId EntityId, const SubobjectToOffsetMap& SubobjectToOffset);
-	void RemoveEntityActor(const Worker_EntityId& EntityId);
+	void RemoveEntityActor(const Worker_EntityId EntityId);
+	void RemoveEntitySubobjects(const Worker_EntityId EntityId);
 
-	void RemoveEntitySubobjects(const Worker_EntityId& EntityId, const SubobjectToOffsetMap& SubobjectToOffset);
 	FNetworkGUID ResolveStablyNamedObject(const UObject* Object);
 	
 	UnrealObjectRef GetUnrealObjectRefFromNetGUID(const FNetworkGUID& NetGUID) const;
@@ -39,7 +39,7 @@ public:
 		
 	FNetworkGUID AssignNewEntityActorNetGUID(AActor* Actor, const SubobjectToOffsetMap& SubobjectToOffset);
 	void RemoveEntityNetGUID(Worker_EntityId EntityId);
-	void RemoveEntitySubobjectsNetGUIDs(Worker_EntityId EntityId, const SubobjectToOffsetMap& SubobjectToOffset);
+	void RemoveEntitySubobjectsNetGUIDs(Worker_EntityId EntityId);
 	void RemoveNetGUID(const FNetworkGUID& NetGUID);
 
 	FNetworkGUID AssignNewStablyNamedObjectNetGUID(const UObject* Object);

--- a/Source/SpatialGDK/Public/EngineClasses/SpatialPackageMapClient.h
+++ b/Source/SpatialGDK/Public/EngineClasses/SpatialPackageMapClient.h
@@ -20,8 +20,8 @@ class SPATIALGDK_API USpatialPackageMapClient : public UPackageMapClient
 	GENERATED_BODY()		
 public:
 	FNetworkGUID ResolveEntityActor(AActor* Actor, Worker_EntityId EntityId, const SubobjectToOffsetMap& SubobjectToOffset);
-	void RemoveEntityActor(const Worker_EntityId EntityId);
-	void RemoveEntitySubobjects(const Worker_EntityId EntityId);
+	void RemoveEntityActor(Worker_EntityId EntityId);
+	void RemoveEntitySubobjects(Worker_EntityId EntityId);
 
 	FNetworkGUID ResolveStablyNamedObject(const UObject* Object);
 	

--- a/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -98,6 +98,7 @@ public:
 	void OnCriticalSection(bool InCriticalSection);
 	void OnAddEntity(Worker_AddEntityOp& Op);
 	void OnAddComponent(Worker_AddComponentOp& Op);
+	void OnRemoveComponent(Worker_RemoveComponentOp& Op);
 	void OnRemoveEntity(Worker_RemoveEntityOp& Op);
 	void OnAuthorityChange(Worker_AuthorityChangeOp& Op);
 

--- a/Source/SpatialGDK/Public/Interop/SpatialView.h
+++ b/Source/SpatialGDK/Public/Interop/SpatialView.h
@@ -28,7 +28,7 @@ public:
 
 private:
 	void OnAddComponent(const Worker_AddComponentOp& add_component);
-	void OnRemoveEntity(const Worker_RemoveEntityOp& remove_entity);
+	void OnRemoveComponent(const Worker_RemoveComponentOp& Op);
 	void OnAuthorityChange(const Worker_AuthorityChangeOp& Op);
 
 	USpatialReceiver* Receiver;

--- a/Source/SpatialGDK/Public/Interop/SpatialView.h
+++ b/Source/SpatialGDK/Public/Interop/SpatialView.h
@@ -27,7 +27,7 @@ public:
 	UnrealMetadata* GetUnrealMetadata(Worker_EntityId EntityId);
 
 private:
-	void OnAddComponent(const Worker_AddComponentOp& add_component);
+	void OnAddComponent(const Worker_AddComponentOp& Op);
 	void OnRemoveComponent(const Worker_RemoveComponentOp& Op);
 	void OnAuthorityChange(const Worker_AuthorityChangeOp& Op);
 


### PR DESCRIPTION
This is what was happening before dynamic typebindings. Backported the code.