### PR TITLE
Schema for a specific class has to be generated for it to replicate

### DIFF
--- a/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -678,7 +678,7 @@ UObject* USpatialReceiver::GetTargetObjectFromChannelAndClass(USpatialActorChann
 		Channel->Actor->GetDefaultSubobjects(DefaultSubobjects);
 		UObject** FoundSubobject = DefaultSubobjects.FindByPredicate([Class](const UObject* Obj)
 		{
-			return Obj->IsA(Class);
+			return Obj->GetClass() == Class;
 		});
 		check(FoundSubobject);
 		TargetObject = *FoundSubobject;

--- a/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -143,7 +143,7 @@ Worker_RequestId USpatialSender::CreateEntity(const FString& ClientWorkerId, con
 
 		UObject** FoundSubobject = DefaultSubobjects.FindByPredicate([SubobjectClass](const UObject* Obj)
 		{
-			return Obj->IsA(SubobjectClass);
+			return Obj->GetClass() == SubobjectClass;
 		});
 		check(FoundSubobject);
 		UObject* Subobject = *FoundSubobject;

--- a/Source/SpatialGDK/Private/Interop/SpatialTypebindingManager.cpp
+++ b/Source/SpatialGDK/Private/Interop/SpatialTypebindingManager.cpp
@@ -201,15 +201,7 @@ UClass* USpatialTypebindingManager::FindClassByComponentId(Worker_ComponentId Co
 
 bool USpatialTypebindingManager::IsSupportedClass(UClass* Class)
 {
-	for (UClass* SupportedClass : SupportedClasses)
-	{
-		if (Class->IsChildOf(SupportedClass))
-		{
-			return true;
-		}
-	}
-
-	return false;
+	return SupportedClasses.Contains(Class);
 }
 
 TArray<UObject*> USpatialTypebindingManager::GetHandoverSubobjects(AActor* Actor)

--- a/Source/SpatialGDK/Private/Interop/SpatialTypebindingManager.cpp
+++ b/Source/SpatialGDK/Private/Interop/SpatialTypebindingManager.cpp
@@ -219,7 +219,7 @@ TArray<UObject*> USpatialTypebindingManager::GetHandoverSubobjects(AActor* Actor
 
 		UObject** FoundSubobject = DefaultSubobjects.FindByPredicate([SubobjectClass](const UObject* Obj)
 		{
-			return Obj->IsA(SubobjectClass);
+			return Obj->GetClass() == SubobjectClass;
 		});
 		check(FoundSubobject);
 		FoundSubobjects.Add(*FoundSubobject);

--- a/Source/SpatialGDK/Private/Interop/SpatialTypebindingManager.cpp
+++ b/Source/SpatialGDK/Private/Interop/SpatialTypebindingManager.cpp
@@ -19,7 +19,7 @@ void USpatialTypebindingManager::Init()
 
 	if (SchemaDatabase == nullptr)
 	{
-		FMessageDialog::Debugf(FText::FromString(TEXT("SchemaDatabase not found! No classes will be supported for SpatialOS replication")));
+		FMessageDialog::Debugf(FText::FromString(TEXT("SchemaDatabase not found! No classes will be supported for SpatialOS replication.")));
 		return;
 	}
 
@@ -176,15 +176,7 @@ void USpatialTypebindingManager::CreateTypebindings()
 
 FClassInfo* USpatialTypebindingManager::FindClassInfoByClass(UClass* Class)
 {
-	for (UClass* CurrentClass = Class; CurrentClass; CurrentClass = CurrentClass->GetSuperClass())
-	{
-		FClassInfo* Info = ClassInfoMap.Find(CurrentClass);
-		if (Info)
-		{
-			return Info;
-		}
-	}
-	return nullptr;
+	return ClassInfoMap.Find(Class);
 }
 
 FClassInfo* USpatialTypebindingManager::FindClassInfoByComponentId(Worker_ComponentId ComponentId)


### PR DESCRIPTION
Reasons for this change:

1. Lets say there was Actor Component `AnimalComponent` and `DogComponent` and `CatComponent` both extend off of it but you only generate typebindings for `AnimalComponent` and `CatComponent`. You put a `DogComponent` and `CatComponent` on an Actor. You then receive an update for `AnimalComponent`. Which Actor Component does this update belong to?

2. If a derived class has more replicated properties, and is using base class schema, it won't work due to handle checking.