### PR TITLE
Prefixed "Spatial" to all hand written components

### DIFF
--- a/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorGenerateSnapshot.cpp
+++ b/Plugins/SpatialGDK/SpatialGDKEditorToolbar/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorGenerateSnapshot.cpp
@@ -53,12 +53,12 @@ bool CreateSpawnerEntity(Worker_SnapshotOutputStream* OutputStream)
 	ComponentWriteAcl.Add(ENTITY_ACL_COMPONENT_ID, UnrealWorkerPermission);
 	ComponentWriteAcl.Add(SpatialConstants::PLAYER_SPAWNER_COMPONENT_ID, UnrealWorkerPermission);
 
-	Components.Add(Position(Origin).CreatePositionData());
-	Components.Add(Metadata(TEXT("SpatialSpawner")).CreateMetadataData());
-	Components.Add(Persistence().CreatePersistenceData());
-	Components.Add(UnrealMetadata().CreateUnrealMetadataData());
+	Components.Add(SpatialPosition(Origin).CreatePositionData());
+	Components.Add(SpatialMetadata(TEXT("SpatialSpawner")).CreateMetadataData());
+	Components.Add(SpatialPersistence().CreatePersistenceData());
+	Components.Add(SpatialUnrealMetadata().CreateUnrealMetadataData());
 	Components.Add(PlayerSpawnerData);
-	Components.Add(EntityAcl(AnyWorkerPermission, ComponentWriteAcl).CreateEntityAclData());
+	Components.Add(SpatialEntityAcl(AnyWorkerPermission, ComponentWriteAcl).CreateEntityAclData());
 
 	SpawnerEntity.component_count = Components.Num();
 	SpawnerEntity.components = Components.GetData();
@@ -116,12 +116,12 @@ bool CreateGlobalStateManager(Worker_SnapshotOutputStream* OutputStream)
 	ComponentWriteAcl.Add(ENTITY_ACL_COMPONENT_ID, UnrealWorkerPermission);
 	ComponentWriteAcl.Add(SpatialConstants::GLOBAL_STATE_MANAGER_COMPONENT_ID, UnrealWorkerPermission);
 
-	Components.Add(Position(Origin).CreatePositionData());
-	Components.Add(Metadata(TEXT("GlobalStateManager")).CreateMetadataData());
-	Components.Add(Persistence().CreatePersistenceData());
-	Components.Add(UnrealMetadata().CreateUnrealMetadataData());
+	Components.Add(SpatialPosition(Origin).CreatePositionData());
+	Components.Add(SpatialMetadata(TEXT("GlobalStateManager")).CreateMetadataData());
+	Components.Add(SpatialPersistence().CreatePersistenceData());
+	Components.Add(SpatialUnrealMetadata().CreateUnrealMetadataData());
 	Components.Add(CreateGlobalStateManagerData());
-	Components.Add(EntityAcl(UnrealWorkerPermission, ComponentWriteAcl).CreateEntityAclData());
+	Components.Add(SpatialEntityAcl(UnrealWorkerPermission, ComponentWriteAcl).CreateEntityAclData());
 
 	GSM.component_count = Components.Num();
 	GSM.components = Components.GetData();
@@ -156,11 +156,11 @@ bool CreatePlaceholders(Worker_SnapshotOutputStream* OutputStream)
 			ComponentWriteAcl.Add(UNREAL_METADATA_COMPONENT_ID, UnrealWorkerPermission);
 			ComponentWriteAcl.Add(ENTITY_ACL_COMPONENT_ID, UnrealWorkerPermission);
 
-			Components.Add(Position(PlaceholderPosition).CreatePositionData());
-			Components.Add(Metadata(TEXT("Placeholder")).CreateMetadataData());
-			Components.Add(Persistence().CreatePersistenceData());
-			Components.Add(UnrealMetadata().CreateUnrealMetadataData());
-			Components.Add(EntityAcl(UnrealWorkerPermission, ComponentWriteAcl).CreateEntityAclData());
+			Components.Add(SpatialPosition(PlaceholderPosition).CreatePositionData());
+			Components.Add(SpatialMetadata(TEXT("Placeholder")).CreateMetadataData());
+			Components.Add(SpatialPersistence().CreatePersistenceData());
+			Components.Add(SpatialUnrealMetadata().CreateUnrealMetadataData());
+			Components.Add(SpatialEntityAcl(UnrealWorkerPermission, ComponentWriteAcl).CreateEntityAclData());
 
 			Placeholder.component_count = Components.Num();
 			Placeholder.components = Components.GetData();
@@ -308,12 +308,12 @@ bool CreateStartupActor(Worker_SnapshotOutputStream* OutputStream, AActor* Actor
 	FString StaticPath = Actor->GetPathName(nullptr);
 
 	TArray<Worker_ComponentData> Components;
-	Components.Add(Position(Coordinates::FromFVector(Channel->GetActorSpatialPosition(Actor))).CreatePositionData());
-	Components.Add(Metadata(FSoftClassPath(ActorClass).ToString()).CreateMetadataData());
-	Components.Add(EntityAcl(AnyWorkerPermission, ComponentWriteAcl).CreateEntityAclData());
-	Components.Add(Persistence().CreatePersistenceData());
-	Components.Add(Rotation(Actor->GetActorRotation()).CreateRotationData());
-	Components.Add(UnrealMetadata(StaticPath, {}, SubobjectNameToOffset).CreateUnrealMetadataData());
+	Components.Add(SpatialPosition(Coordinates::FromFVector(Channel->GetActorSpatialPosition(Actor))).CreatePositionData());
+	Components.Add(SpatialMetadata(FSoftClassPath(ActorClass).ToString()).CreateMetadataData());
+	Components.Add(SpatialEntityAcl(AnyWorkerPermission, ComponentWriteAcl).CreateEntityAclData());
+	Components.Add(SpatialPersistence().CreatePersistenceData());
+	Components.Add(SpatialRotation(Actor->GetActorRotation()).CreateRotationData());
+	Components.Add(SpatialUnrealMetadata(StaticPath, {}, SubobjectNameToOffset).CreateUnrealMetadataData());
 
 	Components.Append(CreateStartupActorData(Channel, Actor, TypebindingManager, Cast<USpatialNetDriver>(NetConnection->Driver)));
 

--- a/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -80,7 +80,7 @@ void USpatialActorChannel::DeleteEntityIfAuthoritative()
 		return;
 	}
 
-	bool bHasAuthority = NetDriver->IsAuthoritativeDestructionAllowed() && NetDriver->View->GetAuthority(EntityId, Position::ComponentId) == WORKER_AUTHORITY_AUTHORITATIVE;
+	bool bHasAuthority = NetDriver->IsAuthoritativeDestructionAllowed() && NetDriver->View->GetAuthority(EntityId, SpatialPosition::ComponentId) == WORKER_AUTHORITY_AUTHORITATIVE;
 
 	UE_LOG(LogTemp, Log, TEXT("Delete entity request on %lld. Has authority: %d"), EntityId, (int)bHasAuthority);
 

--- a/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
+++ b/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
@@ -75,7 +75,7 @@ void UGlobalStateManager::LinkExistingSingletonActors()
 		Channel->SetChannelActor(SingletonActor);
 
 
-		UnrealMetadata* Metadata = View->GetUnrealMetadata(SingletonEntityId);
+		SpatialUnrealMetadata* Metadata = View->GetUnrealMetadata(SingletonEntityId);
 		if (Metadata == nullptr)
 		{
 			// Don't have entity checked out

--- a/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
+++ b/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
@@ -75,15 +75,15 @@ void UGlobalStateManager::LinkExistingSingletonActors()
 		Channel->SetChannelActor(SingletonActor);
 
 
-		SpatialUnrealMetadata* Metadata = View->GetUnrealMetadata(SingletonEntityId);
-		if (Metadata == nullptr)
+		SpatialUnrealMetadata* UnrealMetadata = View->GetUnrealMetadata(SingletonEntityId);
+		if (UnrealMetadata == nullptr)
 		{
 			// Don't have entity checked out
 			continue;
 		}
 
 		// Since the entity already exists, we have to handle setting up the PackageMap properly for this Actor
-		NetDriver->PackageMap->ResolveEntityActor(SingletonActor, SingletonEntityId, Metadata->SubobjectNameToOffset);
+		NetDriver->PackageMap->ResolveEntityActor(SingletonActor, SingletonEntityId, UnrealMetadata->SubobjectNameToOffset);
 		UE_LOG(LogTemp, Log, TEXT("Linked Singleton Actor %s with id %d"), *SingletonActor->GetClass()->GetName(), SingletonEntityId);
 	}
 }

--- a/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -180,30 +180,30 @@ void USpatialReceiver::CreateActor(Worker_EntityId EntityId)
 	UEntityRegistry* EntityRegistry = NetDriver->GetEntityRegistry();
 	check(EntityRegistry);
 
-	SpatialPosition* PositionComponent = GetComponentData<SpatialPosition>(*this, EntityId);
-	SpatialMetadata* MetadataComponent = GetComponentData<SpatialMetadata>(*this, EntityId);
-	SpatialRotation* RotationComponent = GetComponentData<SpatialRotation>(*this, EntityId);
+	SpatialPosition* Position = GetComponentData<SpatialPosition>(*this, EntityId);
+	SpatialMetadata* Metadata = GetComponentData<SpatialMetadata>(*this, EntityId);
+	SpatialRotation* Rotation = GetComponentData<SpatialRotation>(*this, EntityId);
 
-	check(PositionComponent && MetadataComponent);
+	check(Position && Metadata);
 
 	AActor* EntityActor = EntityRegistry->GetActorFromEntityId(EntityId);
 	UE_LOG(LogTemp, Log, TEXT("!!! Checked out entity with entity ID %lld"), EntityId);
 
 	if (EntityActor)
 	{
-		UClass* ActorClass = GetNativeEntityClass(MetadataComponent);
+		UClass* ActorClass = GetNativeEntityClass(Metadata);
 
 		// Option 1
 		UE_LOG(LogTemp, Log, TEXT("Entity for core actor %s has been checked out on the worker which spawned it."), *EntityActor->GetName());
 
-		SpatialUnrealMetadata* UnrealMetadataComponent = GetComponentData<SpatialUnrealMetadata>(*this, EntityId);
-		check(UnrealMetadataComponent);
+		SpatialUnrealMetadata* UnrealMetadata = GetComponentData<SpatialUnrealMetadata>(*this, EntityId);
+		check(UnrealMetadata);
 
 		USpatialPackageMapClient* SpatialPackageMap = Cast<USpatialPackageMapClient>(NetDriver->GetSpatialOSNetConnection()->PackageMap);
 		check(SpatialPackageMap);
 
 		SubobjectToOffsetMap SubobjectNameToOffset;
-		for (auto& Pair : UnrealMetadataComponent->SubobjectNameToOffset)
+		for (auto& Pair : UnrealMetadata->SubobjectNameToOffset)
 		{
 			SubobjectNameToOffset.Add(Pair.Key, Pair.Value);
 		}
@@ -213,7 +213,7 @@ void USpatialReceiver::CreateActor(Worker_EntityId EntityId)
 	}
 	else
 	{
-		UClass* ActorClass = GetNativeEntityClass(MetadataComponent);
+		UClass* ActorClass = GetNativeEntityClass(Metadata);
 
 		if (ActorClass == nullptr)
 		{
@@ -245,7 +245,7 @@ void USpatialReceiver::CreateActor(Worker_EntityId EntityId)
 		else
 		{
 			UE_LOG(LogTemp, Log, TEXT("!!! Spawning a native dynamic %s whilst checking out an entity."), *ActorClass->GetFullName());
-			EntityActor = SpawnNewEntity(PositionComponent, RotationComponent, ActorClass, true);
+			EntityActor = SpawnNewEntity(Position, Rotation, ActorClass, true);
 			bDoingDeferredSpawn = true;
 
 			check(EntityActor);
@@ -275,9 +275,9 @@ void USpatialReceiver::CreateActor(Worker_EntityId EntityId)
 
 		if (bDoingDeferredSpawn)
 		{
-			FVector InitialLocation = Coordinates::ToFVector(PositionComponent->Coords);
+			FVector InitialLocation = Coordinates::ToFVector(Position->Coords);
 			FVector SpawnLocation = FRepMovement::RebaseOntoLocalOrigin(InitialLocation, World->OriginLocation);
-			EntityActor->FinishSpawning(FTransform(RotationComponent->ToFRotator(), SpawnLocation));
+			EntityActor->FinishSpawning(FTransform(Rotation->ToFRotator(), SpawnLocation));
 		}
 
 		SubobjectToOffsetMap SubobjectNameToOffset;

--- a/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -386,18 +386,18 @@ void USpatialReceiver::CleanupDeletedEntity(Worker_EntityId EntityId)
 	Cast<USpatialPackageMapClient>(NetDriver->GetSpatialOSNetConnection()->PackageMap)->RemoveEntityActor(EntityId);
 }
 
-UClass* USpatialReceiver::GetNativeEntityClass(SpatialMetadata* MetadataComponent)
+UClass* USpatialReceiver::GetNativeEntityClass(SpatialMetadata* Metadata)
 {
-	UClass* Class = FindObject<UClass>(ANY_PACKAGE, *MetadataComponent->EntityType);
+	UClass* Class = FindObject<UClass>(ANY_PACKAGE, *Metadata->EntityType);
 	return Class->IsChildOf<AActor>() ? Class : nullptr;
 }
 
 // Note that in SpatialGDK, this function will not be called on the spawning worker.
 // It's only for client, and in the future, other workers.
-AActor* USpatialReceiver::SpawnNewEntity(SpatialPosition* PositionComponent, SpatialRotation* RotationComponent, UClass* ActorClass, bool bDeferred)
+AActor* USpatialReceiver::SpawnNewEntity(SpatialPosition* Position, SpatialRotation* Rotation, UClass* ActorClass, bool bDeferred)
 {
-	FVector InitialLocation = Coordinates::ToFVector(PositionComponent->Coords);
-	FRotator InitialRotation = RotationComponent->ToFRotator();
+	FVector InitialLocation = Coordinates::ToFVector(Position->Coords);
+	FRotator InitialRotation = Rotation->ToFRotator();
 	AActor* NewActor = nullptr;
 	if (ActorClass)
 	{

--- a/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -107,27 +107,27 @@ void USpatialReceiver::OnAddComponent(Worker_AddComponentOp& Op)
 		return;
 	}
 
-	TSharedPtr<Component> Data;
+	TSharedPtr<SpatialComponent> Data;
 
 	switch (Op.data.component_id)
 	{
 	case ENTITY_ACL_COMPONENT_ID:
-		Data = MakeShared<EntityAcl>(Op.data);
+		Data = MakeShared<SpatialEntityAcl>(Op.data);
 		break;
 	case METADATA_COMPONENT_ID:
-		Data = MakeShared<Metadata>(Op.data);
+		Data = MakeShared<SpatialMetadata>(Op.data);
 		break;
 	case POSITION_COMPONENT_ID:
-		Data = MakeShared<Position>(Op.data);
+		Data = MakeShared<SpatialPosition>(Op.data);
 		break;
 	case PERSISTENCE_COMPONENT_ID:
-		Data = MakeShared<Persistence>(Op.data);
+		Data = MakeShared<SpatialPersistence>(Op.data);
 		break;
 	case ROTATION_COMPONENT_ID:
-		Data = MakeShared<Rotation>(Op.data);
+		Data = MakeShared<SpatialRotation>(Op.data);
 		break;
 	case UNREAL_METADATA_COMPONENT_ID:
-		Data = MakeShared<UnrealMetadata>(Op.data);
+		Data = MakeShared<SpatialUnrealMetadata>(Op.data);
 		break;
 	case SpatialConstants::GLOBAL_STATE_MANAGER_COMPONENT_ID:
 		GlobalStateManager->ApplyData(Op.data);
@@ -143,7 +143,7 @@ void USpatialReceiver::OnAddComponent(Worker_AddComponentOp& Op)
 
 void USpatialReceiver::OnRemoveComponent(Worker_RemoveComponentOp& Op)
 {
-	if (Op.component_id == UnrealMetadata::ComponentId)
+	if (Op.component_id == SpatialUnrealMetadata::ComponentId)
 	{
 		PackageMap->RemoveEntitySubobjects(Op.entity_id);
 	}
@@ -180,9 +180,9 @@ void USpatialReceiver::CreateActor(Worker_EntityId EntityId)
 	UEntityRegistry* EntityRegistry = NetDriver->GetEntityRegistry();
 	check(EntityRegistry);
 
-	Position* PositionComponent = GetComponentData<Position>(*this, EntityId);
-	Metadata* MetadataComponent = GetComponentData<Metadata>(*this, EntityId);
-	Rotation* RotationComponent = GetComponentData<Rotation>(*this, EntityId);
+	SpatialPosition* PositionComponent = GetComponentData<SpatialPosition>(*this, EntityId);
+	SpatialMetadata* MetadataComponent = GetComponentData<SpatialMetadata>(*this, EntityId);
+	SpatialRotation* RotationComponent = GetComponentData<SpatialRotation>(*this, EntityId);
 
 	check(PositionComponent && MetadataComponent);
 
@@ -196,7 +196,7 @@ void USpatialReceiver::CreateActor(Worker_EntityId EntityId)
 		// Option 1
 		UE_LOG(LogTemp, Log, TEXT("Entity for core actor %s has been checked out on the worker which spawned it."), *EntityActor->GetName());
 
-		UnrealMetadata* UnrealMetadataComponent = GetComponentData<UnrealMetadata>(*this, EntityId);
+		SpatialUnrealMetadata* UnrealMetadataComponent = GetComponentData<SpatialUnrealMetadata>(*this, EntityId);
 		check(UnrealMetadataComponent);
 
 		USpatialPackageMapClient* SpatialPackageMap = Cast<USpatialPackageMapClient>(NetDriver->GetSpatialOSNetConnection()->PackageMap);
@@ -227,7 +227,7 @@ void USpatialReceiver::CreateActor(Worker_EntityId EntityId)
 		//}
 
 		UNetConnection* Connection = nullptr;
-		UnrealMetadata* UnrealMetadataComponent = GetComponentData<UnrealMetadata>(*this, EntityId);
+		SpatialUnrealMetadata* UnrealMetadataComponent = GetComponentData<SpatialUnrealMetadata>(*this, EntityId);
 		check(UnrealMetadataComponent);
 		bool bDoingDeferredSpawn = false;
 
@@ -386,7 +386,7 @@ void USpatialReceiver::CleanupDeletedEntity(Worker_EntityId EntityId)
 	Cast<USpatialPackageMapClient>(NetDriver->GetSpatialOSNetConnection()->PackageMap)->RemoveEntityActor(EntityId);
 }
 
-UClass* USpatialReceiver::GetNativeEntityClass(Metadata* MetadataComponent)
+UClass* USpatialReceiver::GetNativeEntityClass(SpatialMetadata* MetadataComponent)
 {
 	UClass* Class = FindObject<UClass>(ANY_PACKAGE, *MetadataComponent->EntityType);
 	return Class->IsChildOf<AActor>() ? Class : nullptr;
@@ -394,7 +394,7 @@ UClass* USpatialReceiver::GetNativeEntityClass(Metadata* MetadataComponent)
 
 // Note that in SpatialGDK, this function will not be called on the spawning worker.
 // It's only for client, and in the future, other workers.
-AActor* USpatialReceiver::SpawnNewEntity(Position* PositionComponent, Rotation* RotationComponent, UClass* ActorClass, bool bDeferred)
+AActor* USpatialReceiver::SpawnNewEntity(SpatialPosition* PositionComponent, SpatialRotation* RotationComponent, UClass* ActorClass, bool bDeferred)
 {
 	FVector InitialLocation = Coordinates::ToFVector(PositionComponent->Coords);
 	FRotator InitialRotation = RotationComponent->ToFRotator();

--- a/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -227,9 +227,9 @@ void USpatialSender::SendPositionUpdate(Worker_EntityId EntityId, const FVector&
 	Connection->SendComponentUpdate(EntityId, &Update);
 }
 
-void USpatialSender::SendRotationUpdate(Worker_EntityId EntityId, const FRotator& Rot)
+void USpatialSender::SendRotationUpdate(Worker_EntityId EntityId, const FRotator& Rotation)
 {
-	Worker_ComponentUpdate Update = SpatialRotation(Rot).CreateRotationUpdate();
+	Worker_ComponentUpdate Update = SpatialRotation(Rotation).CreateRotationUpdate();
 	Connection->SendComponentUpdate(EntityId, &Update);
 }
 

--- a/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -94,12 +94,12 @@ Worker_RequestId USpatialSender::CreateEntity(const FString& ClientWorkerId, con
 	});
 
 	TArray<Worker_ComponentData> ComponentDatas;
-	ComponentDatas.Add(Position(Coordinates::FromFVector(Channel->GetActorSpatialPosition(Actor))).CreatePositionData());
-	ComponentDatas.Add(Metadata(EntityType).CreateMetadataData());
-	ComponentDatas.Add(EntityAcl(ReadAcl, ComponentWriteAcl).CreateEntityAclData());
-	ComponentDatas.Add(Persistence().CreatePersistenceData());
-	ComponentDatas.Add(Rotation(Actor->GetActorRotation()).CreateRotationData());
-	ComponentDatas.Add(UnrealMetadata({}, ClientWorkerId, SubobjectNameToOffset).CreateUnrealMetadataData());
+	ComponentDatas.Add(SpatialPosition(Coordinates::FromFVector(Channel->GetActorSpatialPosition(Actor))).CreatePositionData());
+	ComponentDatas.Add(SpatialMetadata(EntityType).CreateMetadataData());
+	ComponentDatas.Add(SpatialEntityAcl(ReadAcl, ComponentWriteAcl).CreateEntityAclData());
+	ComponentDatas.Add(SpatialPersistence().CreatePersistenceData());
+	ComponentDatas.Add(SpatialRotation(Actor->GetActorRotation()).CreateRotationData());
+	ComponentDatas.Add(SpatialUnrealMetadata({}, ClientWorkerId, SubobjectNameToOffset).CreateUnrealMetadataData());
 
 	FUnresolvedObjectsMap UnresolvedObjectsMap;
 	FUnresolvedObjectsMap HandoverUnresolvedObjectsMap;
@@ -223,13 +223,13 @@ void USpatialSender::SendComponentUpdates(UObject* Object, USpatialActorChannel*
 
 void USpatialSender::SendPositionUpdate(Worker_EntityId EntityId, const FVector& Location)
 {
-	Worker_ComponentUpdate Update = Position::CreatePositionUpdate(Coordinates::FromFVector(Location));
+	Worker_ComponentUpdate Update = SpatialPosition::CreatePositionUpdate(Coordinates::FromFVector(Location));
 	Connection->SendComponentUpdate(EntityId, &Update);
 }
 
 void USpatialSender::SendRotationUpdate(Worker_EntityId EntityId, const FRotator& Rot)
 {
-	Worker_ComponentUpdate Update = Rotation(Rot).CreateRotationUpdate();
+	Worker_ComponentUpdate Update = SpatialRotation(Rot).CreateRotationUpdate();
 	Connection->SendComponentUpdate(EntityId, &Update);
 }
 

--- a/Source/SpatialGDK/Private/Interop/SpatialView.cpp
+++ b/Source/SpatialGDK/Private/Interop/SpatialView.cpp
@@ -111,9 +111,9 @@ Worker_Authority USpatialView::GetAuthority(Worker_EntityId EntityId, Worker_Com
 	return WORKER_AUTHORITY_NOT_AUTHORITATIVE;
 }
 
-UnrealMetadata* USpatialView::GetUnrealMetadata(Worker_EntityId EntityId)
+SpatialUnrealMetadata* USpatialView::GetUnrealMetadata(Worker_EntityId EntityId)
 {
-	if (TSharedPtr<UnrealMetadata>* UnrealMetadataPtr = EntityUnrealMetadataMap.Find(EntityId))
+	if (TSharedPtr<SpatialUnrealMetadata>* UnrealMetadataPtr = EntityUnrealMetadataMap.Find(EntityId))
 	{
 		return UnrealMetadataPtr->Get();
 	}
@@ -128,15 +128,15 @@ void USpatialView::OnAuthorityChange(const Worker_AuthorityChangeOp& Op)
 
 void USpatialView::OnAddComponent(const Worker_AddComponentOp& Op)
 {
-	if (Op.data.component_id == UnrealMetadata::ComponentId)
+	if (Op.data.component_id == SpatialUnrealMetadata::ComponentId)
 	{
-		EntityUnrealMetadataMap.Add(Op.entity_id, MakeShared<UnrealMetadata>(Op.data));
+		EntityUnrealMetadataMap.Add(Op.entity_id, MakeShared<SpatialUnrealMetadata>(Op.data));
 	}
 }
 
 void USpatialView::OnRemoveComponent(const Worker_RemoveComponentOp& Op)
 {
-	if (Op.component_id == UnrealMetadata::ComponentId)
+	if (Op.component_id == SpatialUnrealMetadata::ComponentId)
 	{
 		EntityUnrealMetadataMap.Remove(Op.entity_id);
 	}

--- a/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -74,7 +74,7 @@ public:
 
 	void RegisterEntityId(const Worker_EntityId& ActorEntityId);
 	bool ReplicateSubobject(UObject* Obj, const FReplicationFlags& RepFlags);
-	virtual bool ReplicateSubobject(UObject* Obj, FOutBunch& Bunch, const FReplicationFlags& RepFlags) override;
+	virtual bool ReplicateSubobject(UObject* Obj, FOutBunch& Bunch, const FReplicationFlags& RepFlags);
 
 	FRepChangeState CreateInitialRepChangeState(UObject* Object);
 	FHandoverChangeState CreateInitialHandoverChangeState(FClassInfo* ClassInfo);

--- a/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -74,7 +74,7 @@ public:
 
 	void RegisterEntityId(const Worker_EntityId& ActorEntityId);
 	bool ReplicateSubobject(UObject* Obj, const FReplicationFlags& RepFlags);
-	virtual bool ReplicateSubobject(UObject* Obj, FOutBunch& Bunch, const FReplicationFlags& RepFlags);
+	virtual bool ReplicateSubobject(UObject* Obj, FOutBunch& Bunch, const FReplicationFlags& RepFlags) override;
 
 	FRepChangeState CreateInitialRepChangeState(UObject* Object);
 	FHandoverChangeState CreateInitialHandoverChangeState(FClassInfo* ClassInfo);

--- a/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -26,12 +26,12 @@ using FObjectReferencesMap = TMap<int32, FObjectReferences>;
 struct PendingAddComponentWrapper
 {
 	PendingAddComponentWrapper() = default;
-	PendingAddComponentWrapper(Worker_EntityId InEntityId, Worker_ComponentId InComponentId, const TSharedPtr<Component>& InData)
+	PendingAddComponentWrapper(Worker_EntityId InEntityId, Worker_ComponentId InComponentId, const TSharedPtr<SpatialComponent>& InData)
 		: EntityId(InEntityId), ComponentId(InComponentId), Data(InData) {}
 
 	Worker_EntityId EntityId;
 	Worker_ComponentId ComponentId;
-	TSharedPtr<Component> Data;
+	TSharedPtr<SpatialComponent> Data;
 };
 
 struct FObjectReferences
@@ -121,8 +121,8 @@ private:
 
 	void CreateActor(Worker_EntityId EntityId);
 	void RemoveActor(Worker_EntityId EntityId);
-	AActor* SpawnNewEntity(Position* PositionComponent, struct Rotation* RotationComponent, UClass* ActorClass, bool bDeferred);
-	UClass* GetNativeEntityClass(Metadata* MetadataComponent);
+	AActor* SpawnNewEntity(SpatialPosition* PositionComponent, struct SpatialRotation* RotationComponent, UClass* ActorClass, bool bDeferred);
+	UClass* GetNativeEntityClass(SpatialMetadata* MetadataComponent);
 
 	void ApplyComponentData(Worker_EntityId EntityId, Worker_ComponentData& Data, USpatialActorChannel* Channel);
 	void ApplyComponentUpdate(const Worker_ComponentUpdate& ComponentUpdate, UObject* TargetObject, USpatialActorChannel* Channel, bool bIsHandover);

--- a/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -121,8 +121,8 @@ private:
 
 	void CreateActor(Worker_EntityId EntityId);
 	void RemoveActor(Worker_EntityId EntityId);
-	AActor* SpawnNewEntity(SpatialPosition* PositionComponent, struct SpatialRotation* RotationComponent, UClass* ActorClass, bool bDeferred);
-	UClass* GetNativeEntityClass(SpatialMetadata* MetadataComponent);
+	AActor* SpawnNewEntity(SpatialPosition* Position, struct SpatialRotation* Rotation, UClass* ActorClass, bool bDeferred);
+	UClass* GetNativeEntityClass(SpatialMetadata* Metadata);
 
 	void ApplyComponentData(Worker_EntityId EntityId, Worker_ComponentData& Data, USpatialActorChannel* Channel);
 	void ApplyComponentUpdate(const Worker_ComponentUpdate& ComponentUpdate, UObject* TargetObject, USpatialActorChannel* Channel, bool bIsHandover);

--- a/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -48,7 +48,7 @@ public:
 	// Actor Updates
 	void SendComponentUpdates(UObject* Object, USpatialActorChannel* Channel, const FRepChangeState* RepChanges, const FHandoverChangeState* HandoverChanges);
 	void SendPositionUpdate(Worker_EntityId EntityId, const FVector& Location);
-	void SendRotationUpdate(Worker_EntityId EntityId, const FRotator& Rot);
+	void SendRotationUpdate(Worker_EntityId EntityId, const FRotator& Rotation);
 	void SendRPC(UObject* TargetObject, UFunction* Function, void* Parameters, bool bOwnParameters);
 	void SendCommandResponse(Worker_RequestId request_id, Worker_CommandResponse& Response);
 

--- a/Source/SpatialGDK/Public/Interop/SpatialView.h
+++ b/Source/SpatialGDK/Public/Interop/SpatialView.h
@@ -25,7 +25,7 @@ public:
 	void ProcessOps(Worker_OpList* OpList);
 
 	Worker_Authority GetAuthority(Worker_EntityId EntityId, Worker_ComponentId ComponentId);
-	UnrealMetadata* GetUnrealMetadata(Worker_EntityId EntityId);
+	SpatialUnrealMetadata* GetUnrealMetadata(Worker_EntityId EntityId);
 
 private:
 	void OnAddComponent(const Worker_AddComponentOp& Op);
@@ -35,5 +35,5 @@ private:
 	USpatialReceiver* Receiver;
 
 	TMap<Worker_EntityId_Key, TMap<Worker_ComponentId, Worker_Authority>> EntityComponentAuthorityMap;
-	TMap<Worker_EntityId_Key, TSharedPtr<UnrealMetadata>> EntityUnrealMetadataMap;
+	TMap<Worker_EntityId_Key, TSharedPtr<SpatialUnrealMetadata>> EntityUnrealMetadataMap;
 };

--- a/Source/SpatialGDK/Public/Schema/Component.h
+++ b/Source/SpatialGDK/Public/Schema/Component.h
@@ -2,9 +2,9 @@
 
 #pragma once
 
-struct Component
+struct SpatialComponent
 {
-	virtual ~Component() {}
+	virtual ~SpatialComponent() {}
 
 	bool bIsDynamic = false;
 };

--- a/Source/SpatialGDK/Public/Schema/DynamicComponent.h
+++ b/Source/SpatialGDK/Public/Schema/DynamicComponent.h
@@ -11,7 +11,7 @@
 #include <improbable/c_worker.h>
 
 // Represents any Unreal rep component
-struct DynamicComponent : Component
+struct DynamicComponent : SpatialComponent
 {
 	DynamicComponent()
 	{

--- a/Source/SpatialGDK/Public/Schema/Rotation.h
+++ b/Source/SpatialGDK/Public/Schema/Rotation.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include "Platform.h"
-
 #include "Schema/Component.h"
 #include "Utils/SchemaUtils.h"
 

--- a/Source/SpatialGDK/Public/Schema/Rotation.h
+++ b/Source/SpatialGDK/Public/Schema/Rotation.h
@@ -12,19 +12,19 @@
 
 const Worker_ComponentId ROTATION_COMPONENT_ID = 100001;
 
-struct Rotation : Component
+struct SpatialRotation : SpatialComponent
 {
 	static const Worker_ComponentId ComponentId = ROTATION_COMPONENT_ID;
 
-	Rotation() = default;
+	SpatialRotation() = default;
 
-	Rotation(float InPitch, float InYaw, float InRoll)
+	SpatialRotation(float InPitch, float InYaw, float InRoll)
 		: Pitch(InPitch), Yaw(InYaw), Roll(InRoll) {}
 
-	Rotation(const FRotator& Rotator)
+	SpatialRotation(const FRotator& Rotator)
 		: Pitch(Rotator.Pitch), Yaw(Rotator.Yaw), Roll(Rotator.Roll) {}
 
-	Rotation(const Worker_ComponentData& Data)
+	SpatialRotation(const Worker_ComponentData& Data)
 	{
 		Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
 

--- a/Source/SpatialGDK/Public/Schema/StandardLibrary.h
+++ b/Source/SpatialGDK/Public/Schema/StandardLibrary.h
@@ -39,16 +39,16 @@ struct Coordinates
 
 const Worker_ComponentId POSITION_COMPONENT_ID = 54;
 
-struct Position : Component
+struct SpatialPosition : SpatialComponent
 {
 	static const Worker_ComponentId ComponentId = POSITION_COMPONENT_ID;
 
-	Position() = default;
+	SpatialPosition() = default;
 
-	Position(const Coordinates& InCoords)
+	SpatialPosition(const Coordinates& InCoords)
 		: Coords(InCoords) {}
 
-	Position(const Worker_ComponentData& Data)
+	SpatialPosition(const Worker_ComponentData& Data)
 	{
 		Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
 
@@ -98,16 +98,16 @@ using WriteAclMap = TMap<Worker_ComponentId, WorkerRequirementSet>;
 
 const Worker_ComponentId ENTITY_ACL_COMPONENT_ID = 50;
 
-struct EntityAcl : Component
+struct SpatialEntityAcl : SpatialComponent
 {
 	static const Worker_ComponentId ComponentId = ENTITY_ACL_COMPONENT_ID;
 
-	EntityAcl() = default;
+	SpatialEntityAcl() = default;
 
-	EntityAcl(const WorkerRequirementSet& InReadAcl, const WriteAclMap& InComponentWriteAcl)
+	SpatialEntityAcl(const WorkerRequirementSet& InReadAcl, const WriteAclMap& InComponentWriteAcl)
 		: ReadAcl(InReadAcl), ComponentWriteAcl(InComponentWriteAcl) {}
 
-	EntityAcl(const Worker_ComponentData& Data)
+	SpatialEntityAcl(const Worker_ComponentData& Data)
 	{
 		Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
 
@@ -149,16 +149,16 @@ struct EntityAcl : Component
 
 const Worker_ComponentId METADATA_COMPONENT_ID = 53;
 
-struct Metadata : Component
+struct SpatialMetadata : SpatialComponent
 {
 	static const Worker_ComponentId ComponentId = METADATA_COMPONENT_ID;
 
-	Metadata() = default;
+	SpatialMetadata() = default;
 
-	Metadata(const FString& InEntityType)
+	SpatialMetadata(const FString& InEntityType)
 		: EntityType(InEntityType) {}
 
-	Metadata(const Worker_ComponentData& Data)
+	SpatialMetadata(const Worker_ComponentData& Data)
 	{
 		Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
 
@@ -182,12 +182,12 @@ struct Metadata : Component
 
 const Worker_ComponentId PERSISTENCE_COMPONENT_ID = 55;
 
-struct Persistence : Component
+struct SpatialPersistence : SpatialComponent
 {
 	static const Worker_ComponentId ComponentId = PERSISTENCE_COMPONENT_ID;
 
-	Persistence() = default;
-	Persistence(const Worker_ComponentData& Data)
+	SpatialPersistence() = default;
+	SpatialPersistence(const Worker_ComponentData& Data)
 	{
 	}
 

--- a/Source/SpatialGDK/Public/Schema/UnrealMetadata.h
+++ b/Source/SpatialGDK/Public/Schema/UnrealMetadata.h
@@ -14,16 +14,16 @@ using SubobjectToOffsetMap = TMap<FString, uint32>;
 
 const Worker_ComponentId UNREAL_METADATA_COMPONENT_ID = 100004;
 
-struct UnrealMetadata : Component
+struct SpatialUnrealMetadata : SpatialComponent
 {
 	static const Worker_ComponentId ComponentId = UNREAL_METADATA_COMPONENT_ID;
 
-	UnrealMetadata() = default;
+	SpatialUnrealMetadata() = default;
 
-	UnrealMetadata(const FString& InStaticPath, const FString& InOwnerWorkerId, const SubobjectToOffsetMap& InSubobjectNameToOffset)
+	SpatialUnrealMetadata(const FString& InStaticPath, const FString& InOwnerWorkerId, const SubobjectToOffsetMap& InSubobjectNameToOffset)
 		: StaticPath(InStaticPath), OwnerWorkerId(InOwnerWorkerId), SubobjectNameToOffset(InSubobjectNameToOffset) {}
 
-	UnrealMetadata(const Worker_ComponentData& Data)
+	SpatialUnrealMetadata(const Worker_ComponentData& Data)
 	{
 		Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
 


### PR DESCRIPTION
Reason for the change is that the `Metadata` component was clashing with a symbol found in some Xbox libs.
