### PR TITLE
TSchemaOption Implementation :eyes:

### DIFF
--- a/BuildGDK.bat
+++ b/BuildGDK.bat
@@ -71,7 +71,6 @@ call :MarkStartOfBlock "Retrieve dependencies"
 call :MarkEndOfBlock "Retrieve dependencies"
 
 call :MarkStartOfBlock "Unpack dependencies"
-    powershell -Command "Expand-Archive -Path \"%CORE_SDK_DIR%\cpp-static-x86_64-msvc_mtd-win32.zip\"                   -DestinationPath \"%CORE_SDK_DIR%\cpp-src\" -Force; "^
                         "Expand-Archive -Path \"%CORE_SDK_DIR%\worker_sdk\c-dynamic-x86-msvc_md-win32.zip\"             -DestinationPath \"%BINARIES_DIR%\Win32\" -Force; "^
                         "Expand-Archive -Path \"%CORE_SDK_DIR%\worker_sdk\c-dynamic-x86_64-msvc_md-win32.zip\"          -DestinationPath \"%BINARIES_DIR%\Win64\" -Force; "^
                         "Expand-Archive -Path \"%CORE_SDK_DIR%\worker_sdk\c-dynamic-x86_64-gcc_libstdcpp-linux.zip\"    -DestinationPath \"%BINARIES_DIR%\Linux\" -Force; "^

--- a/BuildGDK.bat
+++ b/BuildGDK.bat
@@ -68,8 +68,6 @@ call :MarkStartOfBlock "Retrieve dependencies"
     spatial package retrieve worker_sdk      c-dynamic-x86-msvc_md-win32            %PINNED_CORE_SDK_VERSION%       "%CORE_SDK_DIR%\worker_sdk\c-dynamic-x86-msvc_md-win32.zip"
     spatial package retrieve worker_sdk      c-dynamic-x86_64-msvc_md-win32         %PINNED_CORE_SDK_VERSION%       "%CORE_SDK_DIR%\worker_sdk\c-dynamic-x86_64-msvc_md-win32.zip"
     spatial package retrieve worker_sdk      c-dynamic-x86_64-gcc_libstdcpp-linux   %PINNED_CORE_SDK_VERSION%       "%CORE_SDK_DIR%\worker_sdk\c-dynamic-x86_64-gcc_libstdcpp-linux.zip"
-    rem Download the C++ SDK for its headers, only.
-    spatial package retrieve worker_sdk      cpp-static-x86_64-msvc_mtd-win32 %PINNED_CORE_SDK_VERSION%       "%CORE_SDK_DIR%\cpp-static-x86_64-msvc_mtd-win32.zip"
 call :MarkEndOfBlock "Retrieve dependencies"
 
 call :MarkStartOfBlock "Unpack dependencies"

--- a/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitWriter.cpp
+++ b/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitWriter.cpp
@@ -18,14 +18,14 @@ void FSpatialNetBitWriter::SerializeObjectRef(UnrealObjectRef& ObjectRef)
 	*this << ObjectRef.Entity;
 	*this << ObjectRef.Offset;
 
-	uint8 HasPath = !ObjectRef.Path.IsSet();
+	uint8 HasPath = ObjectRef.Path.IsSet();
 	SerializeBits(&HasPath, 1);
 	if (HasPath)
 	{
 		*this << ObjectRef.Path.GetValue();
 	}
 
-	uint8 HasOuter = !ObjectRef.Outer.IsSet();
+	uint8 HasOuter = ObjectRef.Outer.IsSet();
 	SerializeBits(&HasOuter, 1);
 	if (HasOuter)
 	{

--- a/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitWriter.cpp
+++ b/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitWriter.cpp
@@ -18,14 +18,14 @@ void FSpatialNetBitWriter::SerializeObjectRef(UnrealObjectRef& ObjectRef)
 	*this << ObjectRef.Entity;
 	*this << ObjectRef.Offset;
 
-	uint8 HasPath = !ObjectRef.Path.empty();
+	uint8 HasPath = !ObjectRef.Path.IsSet();
 	SerializeBits(&HasPath, 1);
 	if (HasPath)
 	{
-		*this << *ObjectRef.Path.data();
+		*this << ObjectRef.Path.GetValue();
 	}
 
-	uint8 HasOuter = !ObjectRef.Outer.empty();
+	uint8 HasOuter = !ObjectRef.Outer.IsSet();
 	SerializeBits(&HasOuter, 1);
 	if (HasOuter)
 	{

--- a/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -206,10 +206,10 @@ FNetworkGUID FSpatialNetGUIDCache::GetNetGUIDFromUnrealObjectRef(const UnrealObj
 {
 	FNetworkGUID* CachedGUID = UnrealObjectRefToNetGUID.Find(ObjectRef);
 	FNetworkGUID NetGUID = CachedGUID ? *CachedGUID : FNetworkGUID{};
-	if (!NetGUID.IsValid() && !ObjectRef.Path.IsSet())
+	if (!NetGUID.IsValid() && ObjectRef.Path.IsSet())
 	{
 		FNetworkGUID OuterGUID;
-		if (!ObjectRef.Outer.IsSet())
+		if (ObjectRef.Outer.IsSet())
 		{
 			OuterGUID = GetNetGUIDFromUnrealObjectRef(ObjectRef.Outer.GetValue());
 		}

--- a/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -206,14 +206,14 @@ FNetworkGUID FSpatialNetGUIDCache::GetNetGUIDFromUnrealObjectRef(const UnrealObj
 {
 	FNetworkGUID* CachedGUID = UnrealObjectRefToNetGUID.Find(ObjectRef);
 	FNetworkGUID NetGUID = CachedGUID ? *CachedGUID : FNetworkGUID{};
-	if (!NetGUID.IsValid() && !ObjectRef.Path.empty())
+	if (!NetGUID.IsValid() && !ObjectRef.Path.IsSet())
 	{
 		FNetworkGUID OuterGUID;
-		if (!ObjectRef.Outer.empty())
+		if (!ObjectRef.Outer.IsSet())
 		{
-			OuterGUID = GetNetGUIDFromUnrealObjectRef(*ObjectRef.Outer.data());
+			OuterGUID = GetNetGUIDFromUnrealObjectRef(ObjectRef.Outer.GetValue());
 		}
-		NetGUID = RegisterNetGUIDFromPath(*ObjectRef.Path.data(), OuterGUID);
+		NetGUID = RegisterNetGUIDFromPath(ObjectRef.Path.GetValue(), OuterGUID);
 		RegisterObjectRef(NetGUID, ObjectRef);
 	}
 	return NetGUID;

--- a/Source/SpatialGDK/Private/Interop/SpatialPlayerSpawner.cpp
+++ b/Source/SpatialGDK/Private/Interop/SpatialPlayerSpawner.cpp
@@ -14,8 +14,6 @@
 #include <improbable/c_schema.h>
 #include <improbable/c_worker.h>
 
-using namespace worker;
-
 DEFINE_LOG_CATEGORY(LogSpatialGDKPlayerSpawner);
 
 void USpatialPlayerSpawner::Init(USpatialNetDriver* InNetDriver, FTimerManager* InTimerManager)

--- a/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
+++ b/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
@@ -135,7 +135,7 @@ void ComponentFactory::AddProperty(Schema_Object* Object, Schema_FieldId Id, UPr
 	}
 	else if (UBoolProperty* BoolProperty = Cast<UBoolProperty>(Property))
 	{
-		Schema_AddBool(Object, Id, (std::uint8_t)BoolProperty->GetPropertyValue(Data));
+		Schema_AddBool(Object, Id, (uint8)BoolProperty->GetPropertyValue(Data));
 	}
 	else if (UFloatProperty* FloatProperty = Cast<UFloatProperty>(Property))
 	{
@@ -147,11 +147,11 @@ void ComponentFactory::AddProperty(Schema_Object* Object, Schema_FieldId Id, UPr
 	}
 	else if (UInt8Property* Int8Property = Cast<UInt8Property>(Property))
 	{
-		Schema_AddInt32(Object, Id, (std::int32_t)Int8Property->GetPropertyValue(Data));
+		Schema_AddInt32(Object, Id, (int32)Int8Property->GetPropertyValue(Data));
 	}
 	else if (UInt16Property* Int16Property = Cast<UInt16Property>(Property))
 	{
-		Schema_AddInt32(Object, Id, (std::int32_t)Int16Property->GetPropertyValue(Data));
+		Schema_AddInt32(Object, Id, (int32)Int16Property->GetPropertyValue(Data));
 	}
 	else if (UIntProperty* IntProperty = Cast<UIntProperty>(Property))
 	{
@@ -163,11 +163,11 @@ void ComponentFactory::AddProperty(Schema_Object* Object, Schema_FieldId Id, UPr
 	}
 	else if (UByteProperty* ByteProperty = Cast<UByteProperty>(Property))
 	{
-		Schema_AddUint32(Object, Id, (std::uint32_t)ByteProperty->GetPropertyValue(Data));
+		Schema_AddUint32(Object, Id, (uint32)ByteProperty->GetPropertyValue(Data));
 	}
 	else if (UUInt16Property* UInt16Property = Cast<UUInt16Property>(Property))
 	{
-		Schema_AddUint32(Object, Id, (std::uint32_t)UInt16Property->GetPropertyValue(Data));
+		Schema_AddUint32(Object, Id, (uint32)UInt16Property->GetPropertyValue(Data));
 	}
 	else if (UUInt32Property* UInt32Property = Cast<UUInt32Property>(Property))
 	{
@@ -233,7 +233,7 @@ void ComponentFactory::AddProperty(Schema_Object* Object, Schema_FieldId Id, UPr
 	{
 		if (EnumProperty->ElementSize < 4)
 		{
-			Schema_AddUint32(Object, Id, (std::uint32_t)EnumProperty->GetUnderlyingProperty()->GetUnsignedIntPropertyValue(Data));
+			Schema_AddUint32(Object, Id, (uint32)EnumProperty->GetUnderlyingProperty()->GetUnsignedIntPropertyValue(Data));
 		}
 		else
 		{

--- a/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
+++ b/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
@@ -56,7 +56,7 @@ void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject*
 {
 	bool bAutonomousProxy = Channel->IsClientAutonomousProxy();
 
-	TArray<std::uint32_t> UpdateFields;
+	TArray<uint32> UpdateFields;
 	UpdateFields.SetNum(Schema_GetUniqueFieldIdCount(ComponentObject));
 	Schema_GetUniqueFieldIds(ComponentObject, UpdateFields.GetData());
 
@@ -77,7 +77,7 @@ void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject*
 
 	TArray<UProperty*> RepNotifies;
 
-	for (std::uint32_t FieldId : UpdateFields)
+	for (uint32 FieldId : UpdateFields)
 	{
 		// FieldId is the same as rep handle
 		check(FieldId > 0 && (int)FieldId - 1 < BaseHandleToCmdIndex.Num());
@@ -130,7 +130,7 @@ void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject*
 
 void ComponentReader::ApplyHandoverSchemaObject(Schema_Object* ComponentObject, UObject* Object, USpatialActorChannel* Channel, bool bIsInitialData, TArray<Schema_FieldId>* ClearedIds)
 {
-	TArray<std::uint32_t> UpdateFields;
+	TArray<uint32> UpdateFields;
 	UpdateFields.SetNum(Schema_GetUniqueFieldIdCount(ComponentObject));
 	Schema_GetUniqueFieldIds(ComponentObject, UpdateFields.GetData());
 
@@ -144,7 +144,7 @@ void ComponentReader::ApplyHandoverSchemaObject(Schema_Object* ComponentObject, 
 
 	Channel->PreReceiveSpatialUpdate(Object);
 
-	for (std::uint32_t FieldId : UpdateFields)
+	for (uint32 FieldId : UpdateFields)
 	{
 		// FieldId is the same as handover handle
 		check(FieldId > 0 && (int)FieldId - 1 < ClassInfo->HandoverProperties.Num());
@@ -168,7 +168,7 @@ void ComponentReader::ApplyHandoverSchemaObject(Schema_Object* ComponentObject, 
 	Channel->PostReceiveSpatialUpdate(Object, TArray<UProperty*>());
 }
 
-void ComponentReader::ApplyProperty(Schema_Object* Object, Schema_FieldId Id, std::uint32_t Index, UProperty* Property, uint8* Data, int32 Offset, int32 ParentIndex)
+void ComponentReader::ApplyProperty(Schema_Object* Object, Schema_FieldId Id, uint32 Index, UProperty* Property, uint8* Data, int32 Offset, int32 ParentIndex)
 {
 	if (UStructProperty* StructProperty = Cast<UStructProperty>(Property))
 	{
@@ -345,7 +345,7 @@ void ComponentReader::ApplyArray(Schema_Object* Object, Schema_FieldId Id, UArra
 	}
 }
 
-std::uint32_t ComponentReader::GetPropertyCount(const Schema_Object* Object, Schema_FieldId Id, UProperty* Property)
+uint32 ComponentReader::GetPropertyCount(const Schema_Object* Object, Schema_FieldId Id, UProperty* Property)
 {
 	if (UStructProperty* StructProperty = Cast<UStructProperty>(Property))
 	{

--- a/Source/SpatialGDK/Public/Schema/UnrealObjectRef.h
+++ b/Source/SpatialGDK/Public/Schema/UnrealObjectRef.h
@@ -67,8 +67,8 @@ inline uint32 GetTypeHash(const UnrealObjectRef& ObjectRef)
 	uint32 Result = 1327u;
 	Result = (Result * 977u) + GetTypeHash(static_cast<int64>(ObjectRef.Entity));
 	Result = (Result * 977u) + GetTypeHash(ObjectRef.Offset);
-	Result = (Result * 977u) + GetTypeHash(ObjectRef.Path);
-	Result = (Result * 977u) + GetTypeHash(ObjectRef.Outer);
+	Result = (Result * 977u) + (ObjectRef.Path ? 1327u * (GetTypeHash(*ObjectRef.Path) + 977u) : 977u);
+	Result = (Result * 977u) + (ObjectRef.Outer ? 1327u * (GetTypeHash(*ObjectRef.Outer) + 977u) : 977u);
 	return Result;
 }
 

--- a/Source/SpatialGDK/Public/Schema/UnrealObjectRef.h
+++ b/Source/SpatialGDK/Public/Schema/UnrealObjectRef.h
@@ -67,8 +67,8 @@ inline uint32 GetTypeHash(const UnrealObjectRef& ObjectRef)
 	uint32 Result = 1327u;
 	Result = (Result * 977u) + GetTypeHash(static_cast<int64>(ObjectRef.Entity));
 	Result = (Result * 977u) + GetTypeHash(ObjectRef.Offset);
-	Result = (Result * 977u) + (ObjectRef.Path ? 1327u * (GetTypeHash(*ObjectRef.Path) + 977u) : 977u);
-	Result = (Result * 977u) + (ObjectRef.Outer ? 1327u * (GetTypeHash(*ObjectRef.Outer) + 977u) : 977u);
+	Result = (Result * 977u) + GetTypeHash(ObjectRef.Path);
+	Result = (Result * 977u) + GetTypeHash(ObjectRef.Outer);
 	return Result;
 }
 

--- a/Source/SpatialGDK/Public/Schema/UnrealObjectRef.h
+++ b/Source/SpatialGDK/Public/Schema/UnrealObjectRef.h
@@ -2,8 +2,7 @@
 
 #pragma once
 
-#include <improbable/c_worker.h>
-#include <improbable/collections.h>
+#include "SchemaOption.h"
 
 struct UnrealObjectRef
 {
@@ -59,9 +58,8 @@ struct UnrealObjectRef
 
 	Worker_EntityId Entity;
 	uint32 Offset;
-	// TODO: Write our own Option class
-	worker::Option<FString> Path;
-	worker::Option<UnrealObjectRef> Outer;
+	TSchemaOption<FString> Path;
+	TSchemaOption<UnrealObjectRef> Outer;
 };
 
 inline uint32 GetTypeHash(const UnrealObjectRef& ObjectRef)

--- a/Source/SpatialGDK/Public/Utils/ComponentReader.h
+++ b/Source/SpatialGDK/Public/Utils/ComponentReader.h
@@ -17,10 +17,10 @@ private:
 	void ApplySchemaObject(Schema_Object* ComponentObject, UObject* Object, USpatialActorChannel* Channel, bool bIsInitialData, TArray<Schema_FieldId>* ClearedIds = nullptr);
 	void ApplyHandoverSchemaObject(Schema_Object* ComponentObject, UObject* Object, USpatialActorChannel* Channel, bool bIsInitialData, TArray<Schema_FieldId>* ClearedIds = nullptr);
 
-	void ApplyProperty(Schema_Object* Object, Schema_FieldId Id, std::uint32_t Index, UProperty* Property, uint8* Data, int32 Offset, int32 ParentIndex);
+	void ApplyProperty(Schema_Object* Object, Schema_FieldId Id, uint32 Index, UProperty* Property, uint8* Data, int32 Offset, int32 ParentIndex);
 	void ApplyArray(Schema_Object* Object, Schema_FieldId Id, UArrayProperty* Property, uint8* Data, int32 Offset, int32 ParentIndex);
 
-	std::uint32_t GetPropertyCount(const Schema_Object* Object, Schema_FieldId Id, UProperty* Property);
+	uint32 GetPropertyCount(const Schema_Object* Object, Schema_FieldId Id, UProperty* Property);
 
 private:
 	class USpatialPackageMapClient* PackageMap;

--- a/Source/SpatialGDK/Public/Utils/SchemaOption.h
+++ b/Source/SpatialGDK/Public/Utils/SchemaOption.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include "Platform.h"
+
+template <typename T>
+class TSchemaOption {
+public:
+
+	TSchemaOption() = default;
+	~TSchemaOption() = default;
+
+	TSchemaOption(const T& InValue)
+	{
+		Value = MakeUnique<T>(InValue);
+	}
+
+	TSchemaOption(T&& InValue)
+	{
+		Value = MakeUnique<T>(MoveTemp(InValue));
+	}
+
+	TSchemaOption(const TSchemaOption& InValue)
+	{
+		*this = InValue;
+	}
+
+	TSchemaOption& operator=(const TSchemaOption& InValue)
+	{
+		if (this != &InValue)
+		{
+			if (InValue)
+			{
+				Value = MakeUnique<T>(*InValue);
+			}
+			else
+			{
+				Value.Reset();
+			}
+		}
+
+		return *this;
+	}
+
+	TSchemaOption(TSchemaOption&&) = default;
+	TSchemaOption& operator=(TSchemaOption&&) = default;
+
+	FORCEINLINE bool IsSet() const
+	{
+		return Value.IsValid();
+	}
+
+	FORCEINLINE explicit operator bool() const
+	{
+		return IsSet();
+	}
+
+	const T& GetValue() const
+	{
+		checkf(IsSet(), TEXT("It is an error to call GetValue() on an unset TOptional. Please either check IsSet() or use Get(DefaultValue) instead."));
+		return *Value;
+	}
+
+	T& GetValue()
+	{
+		checkf(IsSet(), TEXT("It is an error to call GetValue() on an unset TOptional. Please either check IsSet() or use Get(DefaultValue) instead."));
+		return *Value;
+	}
+
+	bool operator==(const TSchemaOption& InValue) const
+	{
+		if (IsSet() != InValue.IsSet())
+		{
+			return false;
+		}
+
+		if (!IsSet())
+		{
+			return true;
+		}
+
+		return GetValue() == InValue.GetValue();
+	}
+
+	bool operator!=(const TSchemaOption& InValue) const
+	{
+		return !operator==(InValue);
+	}
+
+	T& operator*() const
+	{
+		return *Value;
+	}
+
+	const T* operator->() const
+	{
+		return Value.Get();
+	}
+
+	T* operator->()
+	{
+		return Value.Get();
+	}
+
+private:
+	TUniquePtr<T> Value;
+};

--- a/Source/SpatialGDK/Public/Utils/SchemaOption.h
+++ b/Source/SpatialGDK/Public/Utils/SchemaOption.h
@@ -11,14 +11,12 @@ public:
 	~TSchemaOption() = default;
 
 	TSchemaOption(const T& InValue)
-	{
-		Value = MakeUnique<T>(InValue);
-	}
+		: Value(MakeUnique<T>(InValue))
+	{}
 
 	TSchemaOption(T&& InValue)
-	{
-		Value = MakeUnique<T>(MoveTemp(InValue));
-	}
+		: Value(MakeUnique<T>(MoveTemp(InValue)))
+	{}
 
 	TSchemaOption(const TSchemaOption& InValue)
 	{
@@ -58,13 +56,13 @@ public:
 
 	const T& GetValue() const
 	{
-		checkf(IsSet(), TEXT("It is an error to call GetValue() on an unset TSchemaOptional. Please check IsSet()."));
+		checkf(IsSet(), TEXT("It is an error to call GetValue() on an unset TSchemaOption. Please check IsSet()."));
 		return *Value;
 	}
 
 	T& GetValue()
 	{
-		checkf(IsSet(), TEXT("It is an error to call GetValue() on an unset TSchemaOptional. Please check IsSet()."));
+		checkf(IsSet(), TEXT("It is an error to call GetValue() on an unset TSchemaOption. Please check IsSet()."));
 		return *Value;
 	}
 

--- a/Source/SpatialGDK/Public/Utils/SchemaOption.h
+++ b/Source/SpatialGDK/Public/Utils/SchemaOption.h
@@ -101,12 +101,6 @@ public:
 		return Value.Get();
 	}
 
-	template <typename T>
-	FORCEINLINE friend uint32 GetTypeHash(TSchemaOption<T>& SchemaOption)
-	{
-		return SchemaOption ? 1327u * (GetTypeHash(*Value) + 977u) : 977u;
-	}
-
 private:
 	TUniquePtr<T> Value;
 };

--- a/Source/SpatialGDK/Public/Utils/SchemaOption.h
+++ b/Source/SpatialGDK/Public/Utils/SchemaOption.h
@@ -101,6 +101,12 @@ public:
 		return Value.Get();
 	}
 
+	template <typename T>
+	FORCEINLINE friend uint32 GetTypeHash(TSchemaOption<T>& SchemaOption)
+	{
+		return SchemaOption ? 1327u * (GetTypeHash(*Value) + 977u) : 977u;
+	}
+
 private:
 	TUniquePtr<T> Value;
 };

--- a/Source/SpatialGDK/Public/Utils/SchemaOption.h
+++ b/Source/SpatialGDK/Public/Utils/SchemaOption.h
@@ -1,11 +1,12 @@
 #pragma once
 
-#include "Platform.h"
+#include <improbable/c_worker.h>
+#include "UniquePtr.h"
 
 template <typename T>
-class TSchemaOption {
+class TSchemaOption
+{
 public:
-
 	TSchemaOption() = default;
 	~TSchemaOption() = default;
 
@@ -24,6 +25,8 @@ public:
 		*this = InValue;
 	}
 
+	TSchemaOption(TSchemaOption&&) = default;
+
 	TSchemaOption& operator=(const TSchemaOption& InValue)
 	{
 		if (this != &InValue)
@@ -41,7 +44,6 @@ public:
 		return *this;
 	}
 
-	TSchemaOption(TSchemaOption&&) = default;
 	TSchemaOption& operator=(TSchemaOption&&) = default;
 
 	FORCEINLINE bool IsSet() const
@@ -56,13 +58,13 @@ public:
 
 	const T& GetValue() const
 	{
-		checkf(IsSet(), TEXT("It is an error to call GetValue() on an unset TOptional. Please either check IsSet() or use Get(DefaultValue) instead."));
+		checkf(IsSet(), TEXT("It is an error to call GetValue() on an unset TSchemaOptional. Please check IsSet()."));
 		return *Value;
 	}
 
 	T& GetValue()
 	{
-		checkf(IsSet(), TEXT("It is an error to call GetValue() on an unset TOptional. Please either check IsSet() or use Get(DefaultValue) instead."));
+		checkf(IsSet(), TEXT("It is an error to call GetValue() on an unset TSchemaOptional. Please check IsSet()."));
 		return *Value;
 	}
 

--- a/Source/SpatialGDK/Public/Utils/SchemaUtils.h
+++ b/Source/SpatialGDK/Public/Utils/SchemaUtils.h
@@ -11,13 +11,13 @@
 inline void Schema_AddString(Schema_Object* Object, Schema_FieldId Id, const FString& Value)
 {
 	FTCHARToUTF8 CStrConvertion(*Value);
-	std::uint32_t StringLength = CStrConvertion.Length();
-	std::uint8_t* StringBuffer = Schema_AllocateBuffer(Object, sizeof(char) * StringLength);
+	uint32 StringLength = CStrConvertion.Length();
+	uint8* StringBuffer = Schema_AllocateBuffer(Object, sizeof(char) * StringLength);
 	FMemory::Memcpy(StringBuffer, CStrConvertion.Get(), sizeof(char) * StringLength);
 	Schema_AddBytes(Object, Id, StringBuffer, sizeof(char) * StringLength);
 }
 
-inline FString Schema_IndexString(const Schema_Object* Object, Schema_FieldId Id, std::uint32_t Index)
+inline FString Schema_IndexString(const Schema_Object* Object, Schema_FieldId Id, uint32 Index)
 {
 	int32 StringLength = (int32)Schema_IndexBytesLength(Object, Id, Index);
 	return FString(StringLength, UTF8_TO_TCHAR(Schema_IndexBytes(Object, Id, Index)));
@@ -30,13 +30,13 @@ inline FString Schema_GetString(const Schema_Object* Object, Schema_FieldId Id)
 
 inline void Schema_AddPayload(Schema_Object* Object, Schema_FieldId Id, FSpatialNetBitWriter& Writer)
 {
-	std::uint32_t PayloadSize = Writer.GetNumBytes();
-	std::uint8_t* PayloadBuffer = Schema_AllocateBuffer(Object, sizeof(char) * PayloadSize);
+	uint32 PayloadSize = Writer.GetNumBytes();
+	uint8* PayloadBuffer = Schema_AllocateBuffer(Object, sizeof(char) * PayloadSize);
 	FMemory::Memcpy(PayloadBuffer, Writer.GetData(), sizeof(char) * PayloadSize);
 	Schema_AddBytes(Object, Id, PayloadBuffer, sizeof(char) * PayloadSize);
 }
 
-inline TArray<uint8> Schema_IndexPayload(const Schema_Object* Object, Schema_FieldId Id, std::uint32_t Index)
+inline TArray<uint8> Schema_IndexPayload(const Schema_Object* Object, Schema_FieldId Id, uint32 Index)
 {
 	int32 PayloadSize = (int32)Schema_IndexBytesLength(Object, Id, Index);
 	return TArray<uint8>((const uint8*)Schema_IndexBytes(Object, Id, Index), PayloadSize);
@@ -109,7 +109,7 @@ inline void Schema_AddObjectRef(Schema_Object* Object, Schema_FieldId Id, const 
 
 UnrealObjectRef Schema_GetObjectRef(Schema_Object* Object, Schema_FieldId Id);
 
-inline UnrealObjectRef Schema_IndexObjectRef(Schema_Object* Object, Schema_FieldId Id, std::uint32_t Index)
+inline UnrealObjectRef Schema_IndexObjectRef(Schema_Object* Object, Schema_FieldId Id, uint32 Index)
 {
 	UnrealObjectRef ObjectRef;
 


### PR DESCRIPTION
#### Description
This PR introduces our own in-house GDK `Option` type called `TSchemaOption`, which will be used to represent `option` in schema types and components.

**Why are we introducing our own type?**

Since dynamic typebindings has let us completely switch over to the C API, we're trying to remove our dependency on the C++ worker SDK. `worker::Option` was one of the last places we were depending on it.

**Why aren't we using `TOptional` which comes with Unreal?**

`TOptional` would be great to use but unfortunately is implemented by holding an instance of `T` rather than a pointer to `T`. Which means a `TOptional` can't hold a type which has a `TOptional` of itself, which is exactly what UnrealObjectRef does so it's not suitable for our use case.

**Why not use TUniquePtr?**

`TUniquePtr` would satisfy all of the places `TSchemaOption` is used but is not great for readability or context. Using an explicit `Option` type makes it clear that not having a value is a valid state and that this type is the C++ analog to schema's `option` (Just like `TMap` representing `map` and `TArray` representing `list`).

**How is TSchemaOption implemented?**

It's a mixture of `TOptional` and `worker::Option`. Definitely doesn't do anything fancy.

**I don't like the name of it**

Suggest another name!

#### Primary reviewers
@improbable-valentyn @davedissian 