### PR TITLE
Fix crash on missing UnrealMetadata when closing PIE instance

### DIFF
--- a/SpatialGDK/Source/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialActorChannel.cpp
@@ -100,7 +100,8 @@ bool USpatialActorChannel::IsSingletonEntity()
 
 bool USpatialActorChannel::IsStablyNamedEntity()
 {
-	return !NetDriver->View->GetUnrealMetadata(EntityId)->StaticPath.IsEmpty();
+	SpatialUnrealMetadata* UnrealMetadata = NetDriver->View->GetUnrealMetadata(EntityId);
+	return UnrealMetadata ? !UnrealMetadata->StaticPath.IsEmpty() : false;
 }
 
 bool USpatialActorChannel::CleanUp(const bool bForDestroy)


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Fix crash on missing UnrealMetadata when closing PIE instance.
This still has the problem of deleting the stably replicated entities.
#### Primary reviewers
@joshuahuburn 