### PR TITLE
Error log if SpatialNetDriver not set up correctly

### DIFF
--- a/SpatialGDK/Source/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialGameInstance.cpp
@@ -40,6 +40,11 @@ bool USpatialGameInstance::HasSpatialNetDriver() const
 		}
 	}
 
+	if (GEngine->IsUsingSpatialNetDriver() && !bHasSpatialNetDriver)
+	{
+		UE_LOG(LogSpatialGDK, Error, TEXT("Could not find SpatialNetDriver even though Spatial networking is switched on! Please make sure you set up the net driver definitions as specified in the porting guide."));
+	}
+
 	return bHasSpatialNetDriver;
 }
 

--- a/SpatialGDK/Source/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialGameInstance.cpp
@@ -42,7 +42,9 @@ bool USpatialGameInstance::HasSpatialNetDriver() const
 
 	if (GEngine->IsUsingSpatialNetDriver() && !bHasSpatialNetDriver)
 	{
-		UE_LOG(LogSpatialGDK, Error, TEXT("Could not find SpatialNetDriver even though Spatial networking is switched on! Please make sure you set up the net driver definitions as specified in the porting guide."));
+		UE_LOG(LogSpatialGDK, Error, TEXT("Could not find SpatialNetDriver even though Spatial networking is switched on! "
+										  "Please make sure you set up the net driver definitions as specified in the porting "
+										  "guide and that you don't override the main net driver."));
 	}
 
 	return bHasSpatialNetDriver;


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Log an error when you have `Spatial Networking` checked but `SpatialNetDriver` is not found so it's easier for developers to notice if they didn't set up the GDK correctly.
#### Primary reviewers
@m-samiec @danielimprobable 