### PR TITLE
Added a retry for reserving an entity

### DIFF
--- a/SpatialGDK/Source/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialActorChannel.cpp
@@ -59,7 +59,6 @@ USpatialActorChannel::USpatialActorChannel(const FObjectInitializer& ObjectIniti
 	, EntityId(0)
 	, NetDriver(nullptr)
 {
-	bCoreActor = true;
 	bCreatingNewEntity = false;
 }
 
@@ -292,38 +291,10 @@ bool USpatialActorChannel::ReplicateActor()
 	{		
 		if (bCreatingNewEntity)
 		{
-			// TODO SAHIL: CHECK IF YOU PROPERLY FIX THIS
-			//check(!Actor->IsFullNameStableForNetworking() || Interop->CanSpawnReplicatedStablyNamedActors());
+			// TODO: This check potentially isn't needed any more due to deleting startup actors but need to check
+			//check(!Actor->IsFullNameStableForNetworking());
 
-			// When a player is connected, a FUniqueNetIdRepl is created with the players worker ID. This eventually gets stored
-			// inside APlayerState::UniqueId when UWorld::SpawnPlayActor is called. If this actor channel is managing a pawn or a 
-			// player controller, get the player state.
-			FString PlayerWorkerId;
-			APlayerState* PlayerState = Cast<APlayerState>(Actor);
-			if (!PlayerState)
-			{
-				if (APawn* Pawn = Cast<APawn>(Actor))
-				{
-					PlayerState = Pawn->PlayerState;
-				}
-			}
-			if (!PlayerState)
-			{
-				if (PlayerController)
-				{
-					PlayerState = PlayerController->PlayerState;
-				}
-			}
-			if (PlayerState)
-			{
-				PlayerWorkerId = PlayerState->UniqueId.ToString();
-			}
-			else
-			{
-				UE_LOG(LogSpatialGDKActorChannel, Log, TEXT("Unable to find PlayerState for %s, this usually means that this actor is not owned by a player."), *Actor->GetClass()->GetName());
-			}
-
-			Sender->SendCreateEntityRequest(this, PlayerWorkerId);
+			Sender->SendCreateEntityRequest(this, GetPlayerWorkerId());
 		}
 		else
 		{
@@ -504,7 +475,7 @@ void USpatialActorChannel::SetChannelActor(AActor* InActor)
 {
 	Super::SetChannelActor(InActor);
 
-	if (!bCoreActor)
+	if (NetDriver->TypebindingManager->FindClassInfoByClass(InActor->GetClass()) == nullptr)
 	{
 		return;
 	}
@@ -606,7 +577,7 @@ void USpatialActorChannel::OnReserveEntityIdResponse(const Worker_ReserveEntityI
 		Sender->SendReserveEntityIdRequest(this);
 		return;
 	}
-	UE_LOG(LogSpatialGDKActorChannel, Log, TEXT("Received entity id (%lld) for: %s."), Op.entity_id, *Actor->GetName());
+	UE_LOG(LogSpatialGDKActorChannel, Verbose, TEXT("Received entity id (%lld) for: %s."), Op.entity_id, *Actor->GetName());
 	EntityId = Op.entity_id;
 	RegisterEntityId(EntityId);
 }
@@ -617,18 +588,12 @@ void USpatialActorChannel::OnCreateEntityResponse(const Worker_CreateEntityRespo
 
 	if (Op.status_code != WORKER_STATUS_CODE_SUCCESS)
 	{
-		UE_LOG(LogSpatialGDKActorChannel, Error, TEXT("!!! Failed to create entity for actor %s: %s"), *Actor->GetName(), UTF8_TO_TCHAR(Op.message));
-		// TODO: From now on, this actor channel will be useless. We need better error handling, or a retry mechanism here.
+		UE_LOG(LogSpatialGDKActorChannel, Error, TEXT("Failed to create entity for actor %s: %s"), *Actor->GetName(), UTF8_TO_TCHAR(Op.message));
+		Sender->SendCreateEntityRequest(this, GetPlayerWorkerId());
 		return;
 	}
-	UE_LOG(LogSpatialGDKActorChannel, Log, TEXT("!!! Created entity (%lld) for: %s."), EntityId, *Actor->GetName());
 
-	// If a replicated stably named actor was created, update the GSM with the proper path and entity id
-	// This ensures each stably named actor is only created once
-	if (Actor->IsFullNameStableForNetworking())
-	{
-		//SpatialNetDriver->GetSpatialInterop()->AddReplicatedStablyNamedActorToGSM(FEntityId(ActorEntityId), Actor);
-	}
+	UE_LOG(LogSpatialGDKActorChannel, Verbose, TEXT("Created entity (%lld) for: %s."), EntityId, *Actor->GetName());
 }
 
 void USpatialActorChannel::UpdateSpatialPosition()
@@ -692,4 +657,36 @@ FVector USpatialActorChannel::GetActorSpatialPosition(AActor* Actor)
 	{
 		return FVector::ZeroVector;
 	}
+}
+
+FString USpatialActorChannel::GetPlayerWorkerId()
+{
+	// When a player is connected, a FUniqueNetIdRepl is created with the players worker ID. This eventually gets stored
+	// inside APlayerState::UniqueId when UWorld::SpawnPlayActor is called. If this actor channel is managing a pawn or a 
+	// player controller, get the player state.
+	FString PlayerWorkerId;
+	APlayerState* PlayerState = Cast<APlayerState>(Actor);
+
+	if (PlayerState == nullptr)
+	{
+		if (APawn* Pawn = Cast<APawn>(Actor))
+		{
+			PlayerState = Pawn->PlayerState;
+		}
+	}
+
+	if (PlayerState == nullptr)
+	{
+		if(APlayerController* PlayerController = Cast<APlayerController>(Actor))
+		{
+			PlayerState = PlayerController->PlayerState;
+		}
+	}
+
+	if (PlayerState != nullptr)
+	{
+		PlayerWorkerId = PlayerState->UniqueId.ToString();
+	}
+	
+	return PlayerWorkerId;
 }

--- a/SpatialGDK/Source/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialActorChannel.cpp
@@ -292,7 +292,7 @@ bool USpatialActorChannel::ReplicateActor()
 	{		
 		if (bCreatingNewEntity)
 		{
-			// SAHIL: CHECK IF YOU PROPERLY FIX THIS
+			// TODO SAHIL: CHECK IF YOU PROPERLY FIX THIS
 			//check(!Actor->IsFullNameStableForNetworking() || Interop->CanSpawnReplicatedStablyNamedActors());
 
 			// When a player is connected, a FUniqueNetIdRepl is created with the players worker ID. This eventually gets stored
@@ -569,7 +569,7 @@ void USpatialActorChannel::RegisterEntityId(const Worker_EntityId& ActorEntityId
 {
 	NetDriver->GetEntityRegistry()->AddToRegistry(ActorEntityId, GetActor());
 
-	// Inform USpatialInterop of this new actor channel/entity pairing
+	// Inform USpatialNetDriver of this new actor channel/entity pairing
 	NetDriver->AddActorChannel(ActorEntityId, this);
 
 	// If a Singleton was created, update the GSM with the proper Id.
@@ -603,7 +603,7 @@ void USpatialActorChannel::OnReserveEntityIdResponse(const Worker_ReserveEntityI
 	if (Op.status_code != WORKER_STATUS_CODE_SUCCESS)
 	{
 		UE_LOG(LogSpatialGDKActorChannel, Error, TEXT("Failed to reserve entity id. Reason: %s"), UTF8_TO_TCHAR(Op.message));
-		// TODO: From now on, this actor channel will be useless. We need better error handling, or a retry mechanism here.
+		Sender->SendReserveEntityIdRequest(this);
 		return;
 	}
 	UE_LOG(LogSpatialGDKActorChannel, Log, TEXT("Received entity id (%lld) for: %s."), Op.entity_id, *Actor->GetName());

--- a/SpatialGDK/Source/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialGameInstance.cpp
@@ -41,12 +41,12 @@ bool USpatialGameInstance::HasSpatialNetDriver() const
 		}
 	}
 
-	if (GetDefault<UGeneralProjectSettings>()->bSpatialNetworking && !bHasSpatialNetDriver)
-	{
-		UE_LOG(LogSpatialGDK, Error, TEXT("Could not find SpatialNetDriver even though Spatial networking is switched on! "
-										  "Please make sure you set up the net driver definitions as specified in the porting "
-										  "guide and that you don't override the main net driver."));
-	}
+	//if (GetDefault<UGeneralProjectSettings>()->bSpatialNetworking && !bHasSpatialNetDriver)
+	//{
+	//	UE_LOG(LogSpatialGDK, Error, TEXT("Could not find SpatialNetDriver even though Spatial networking is switched on! "
+	//									  "Please make sure you set up the net driver definitions as specified in the porting "
+	//									  "guide and that you don't override the main net driver."));
+	//}
 
 	return bHasSpatialNetDriver;
 }

--- a/SpatialGDK/Source/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialGameInstance.cpp
@@ -41,12 +41,12 @@ bool USpatialGameInstance::HasSpatialNetDriver() const
 		}
 	}
 
-	//if (GetDefault<UGeneralProjectSettings>()->bSpatialNetworking && !bHasSpatialNetDriver)
-	//{
-	//	UE_LOG(LogSpatialGDK, Error, TEXT("Could not find SpatialNetDriver even though Spatial networking is switched on! "
-	//									  "Please make sure you set up the net driver definitions as specified in the porting "
-	//									  "guide and that you don't override the main net driver."));
-	//}
+	if (GetDefault<UGeneralProjectSettings>()->bSpatialNetworking && !bHasSpatialNetDriver)
+	{
+		UE_LOG(LogSpatialGDK, Error, TEXT("Could not find SpatialNetDriver even though Spatial networking is switched on! "
+										  "Please make sure you set up the net driver definitions as specified in the porting "
+										  "guide and that you don't override the main net driver."));
+	}
 
 	return bHasSpatialNetDriver;
 }

--- a/SpatialGDK/Source/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialNetDriver.cpp
@@ -522,11 +522,6 @@ int32 USpatialNetDriver::ServerReplicateActors_ProcessPrioritizedActors(UNetConn
 					Channel = (USpatialActorChannel*)InConnection->CreateChannel(CHTYPE_Actor, 1);
 					if (Channel)
 					{
-						if (TypebindingManager->FindClassInfoByClass(Actor->GetClass()) == nullptr)
-						{
-							Channel->bCoreActor = false;
-						}
-
 						if (Actor->GetClass()->HasAnySpatialClassFlags(SPATIALCLASS_Singleton))
 						{
 							SingletonActorChannels.Add(Actor->GetClass(), TPair<AActor*, USpatialActorChannel*>(Actor, Channel));

--- a/SpatialGDK/Source/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/Public/EngineClasses/SpatialActorChannel.h
@@ -105,11 +105,7 @@ private:
 	void InitializeHandoverShadowData(TArray<uint8>& ShadowData, UObject* Object);
 	FHandoverChangeState GetHandoverChangeList(TArray<uint8>& ShadowData, UObject* Object);
 
-public:
-	// Distinguishes between channels created for actors that went through the "old" pipeline vs actors that are triggered through SpawnActor() calls.
-	//In the future we may not use an actor channel for non-core actors.
-	UPROPERTY(transient)
-	bool bCoreActor;
+	FString GetPlayerWorkerId();
 
 private:
 	Worker_EntityId EntityId;
@@ -133,7 +129,6 @@ private:
 	TMap<TWeakObjectPtr<UObject>, TSharedRef<TArray<uint8>>> HandoverShadowDataMap;
 
 	// If this actor channel is responsible for creating a new entity, this will be set to true during initial replication.
-	UPROPERTY(Transient)
 	bool bCreatingNewEntity;
 
 };


### PR DESCRIPTION
Added a retry for reserving an entity id for an Actor channel. Since this should be reliable, it will keep on retrying until it succeeds. I've added this since I would see reserve entity ids fail in Scavengers due to the large amount of processing that happens at startup.