### PR TITLE
Use spatial fast array serialize

### DIFF
--- a/SpatialGDK/Source/Private/Utils/ComponentReader.cpp
+++ b/SpatialGDK/Source/Private/Utils/ComponentReader.cpp
@@ -106,6 +106,7 @@ void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject*
 					UArrayProperty* ArrayProperty = Cast<UArrayProperty>(Cmd.Property);
 					bool bProcessedArray = false;
 
+					// Check if this is a FastArraySerializer array so we can simulate the FFastArraySerializerItem PreReplicatedRemove and PostReplicatedAdd calls.
 					if (UStructProperty* ParentStruct = Cast<UStructProperty>(Parent.Property))
 					{
 						if (ParentStruct->Struct->IsChildOf(FFastArraySerializer::StaticStruct()))
@@ -127,6 +128,8 @@ void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject*
 								UScriptStruct::ICppStructOps* CppStructOps = ParentStruct->Struct->GetCppStructOps();
 								check(CppStructOps);
 
+								// This call resolves into FFastArraySerializer::SpatialFastArrayDeltaSerialize where our custom FFastArraySerializerItem
+								// callback are triggered.
 								CppStructOps->NetDeltaSerialize(Parms, ParentStruct->ContainerPtrToValuePtr<void>(Object, Parent.ArrayIndex));
 							}
 						}


### PR DESCRIPTION
#### Description
As we don't support net delta serialization within spatial, to enable functionality of the FFastArraySerializerItem callbacks (see NetSerialization.h), we do a dummy serialize which does a brute check on the array elements and calls the appropriate add/remove callbacks. As we've lost the array context, it's not possible to deduce a change event. We could add this by including the replication id with each element, but as we're only supporting the ability system component, hopefully this will suffice.

This change set also requires a engine change - https://github.com/improbableio/UnrealEngine/pull/23

#### Tests
Works with my local ability system test, but ideally we test this against scavengers.

#### Documentation
Incoming - I'll add a section on us not supporting Net Delta Serialize.

#### Primary reviewers
@improbable-valentyn @Vatyx 