### PR TITLE
Use Owner for Spatial Position

### DIFF
--- a/SpatialGDK/Source/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialActorChannel.cpp
@@ -658,13 +658,13 @@ FVector USpatialActorChannel::GetActorSpatialPosition(AActor* Actor)
 	// If the actor has a well defined location then use that
 	// Otherwise if it has a parent use its location
 	// Otherwise use the origin
-	if (Actor->GetRootComponent()) 
-	{
-		return Actor->GetRootComponent()->GetComponentLocation();
-	}
-	else if (Actor->GetOwner())
+	if (Actor->GetOwner())
 	{
 		return GetActorSpatialPosition(Actor->GetOwner());
+	}
+	else if (Actor->GetRootComponent()) 
+	{
+		return Actor->GetRootComponent()->GetComponentLocation();
 	}
 	else
 	{

--- a/SpatialGDK/Source/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialActorChannel.cpp
@@ -652,11 +652,8 @@ void USpatialActorChannel::UpdateSpatialRotation()
 
 FVector USpatialActorChannel::GetActorSpatialPosition(AActor* Actor)
 {
-	// Preferentially uses the owner location over the origin
-	// This is to enable actors like PlayerState to follow their corresponding character
-
-	// If the actor has a well defined location then use that
-	// Otherwise if it has a parent use its location
+	// If the Actor has an Owner, use its position.
+	// Otherwise if the Actor has a well defined location then use that
 	// Otherwise use the origin
 	if (Actor->GetOwner())
 	{


### PR DESCRIPTION
#### Description
If the actor has an owner, use the owner to dictate it's spatial position. Fixes position issues in Scavengers.

#### Primary reviewers
@girayimprobable @m-samiec 