### PR TITLE
Fix native networking not working after running with Spatial networking once

### DIFF
--- a/SpatialGDK/Source/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialGameInstance.cpp
@@ -53,9 +53,6 @@ bool USpatialGameInstance::HasSpatialNetDriver() const
 
 bool USpatialGameInstance::StartGameInstance_SpatialGDKClient(FString& Error)
 {
-	// Set the PendingNetGameClass in the Engine so that the correct SpatialPendingNetGame is used for UEngine::Browse (client travel).
-	GetEngine()->PendingNetGameClass = USpatialPendingNetGame::StaticClass();
-
 	if (WorldContext->PendingNetGame)
 	{
 		if (WorldContext->PendingNetGame->NetDriver && WorldContext->PendingNetGame->NetDriver->ServerConnection)


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Fix native networking not working after running with Spatial networking once.
UnrealEngine PR: https://github.com/improbableio/UnrealEngine/pull/26
#### Tests
1. Run with Spatial networking.
1. Toggle Spatial networking.
1. Run with native networking, observe it doesn't break.
1. Run with Spatial networking, observe it still works.
#### Primary reviewers
@joshuahuburn 