### PR TITLE
Fixed check for subobject

### DIFF
--- a/SpatialGDK/Source/Private/Interop/SpatialTypebindingManager.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialTypebindingManager.cpp
@@ -212,7 +212,7 @@ void USpatialTypebindingManager::AddSubobjectClass(FClassInfo& ClassInfo, UClass
 {
 	if (IsSupportedClass(Class))
 	{
-		if(ClassInfo.SubobjectClasses.Find(Class) == nullptr)
+		if(ClassInfo.SubobjectClasses.Find(Class) != nullptr)
 		{
 			return;
 		};

--- a/SpatialGDK/Source/Private/Interop/SpatialTypebindingManager.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialTypebindingManager.cpp
@@ -212,7 +212,11 @@ void USpatialTypebindingManager::AddSubobjectClass(FClassInfo& ClassInfo, UClass
 {
 	if (IsSupportedClass(Class))
 	{
-		checkf(ClassInfo.SubobjectClasses.Find(Class) == nullptr, TEXT("Invalid class layout, duplicate subobject type found - %s"), *Class->GetName());
+		if(ClassInfo.SubobjectClasses.Find(Class) == nullptr)
+		{
+			return;
+		};
+		
 		ClassInfo.SubobjectClasses.Add(Class);
 	}
 }


### PR DESCRIPTION
Check should not crash if subobject is duplicated. Should just return.