### PR TITLE
Update the setup.bat to include a pause

### DIFF
--- a/Setup.bat
+++ b/Setup.bat
@@ -102,7 +102,13 @@ call :MarkEndOfBlock "%~0"
 popd
 
 echo UnrealGDK build completed successfully^!
-if not defined TEAMCITY_CAPTURE_ENV pause
+
+if not defined NO_PAUSE (
+    if not defined TEAMCITY_CAPTURE_ENV (
+        pause
+    ) 
+)
+
 exit /b %ERRORLEVEL%
 
 :MarkStartOfBlock


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
This is following feedback that pause is triggered at the end of the Setup.bat
#### Tests
Run the command `set NO_PAUSE=1 && Setup.bat` successfully without a pause and ran Setup.bat without additional variable with a pause.

#### Documentation
No docs required
#### Primary reviewers
@joshuahuburn @improbable-valentyn 