### PR TITLE
[UNR-556] Re-add resending reliable RPCs

### DIFF
--- a/SpatialGDK/Source/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialNetDriver.cpp
@@ -191,7 +191,7 @@ void USpatialNetDriver::OnConnected()
 
 	View->Init(this);
 	Sender->Init(this);
-	Receiver->Init(this);
+	Receiver->Init(this, TimerManager);
 	GlobalStateManager->Init(this);
 }
 
@@ -860,7 +860,7 @@ void USpatialNetDriver::ProcessRemoteFunction(
 
 	if (Function->FunctionFlags & FUNC_Net)
 	{
-		Sender->SendRPC(CallingObject, Function, Parameters, false);
+		Sender->SendRPC(MakeShared<FPendingRPCParams>(CallingObject, Function, Parameters));
 	}
 }
 

--- a/SpatialGDK/Source/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -7,6 +7,7 @@
 
 #include "EngineClasses/SpatialActorChannel.h"
 #include "EngineClasses/SpatialNetDriver.h"
+#include "Interop/Connection/SpatialWorkerConnection.h"
 #include "Interop/SpatialReceiver.h"
 #include "Interop/SpatialSender.h"
 #include "Schema/UnrealObjectRef.h"

--- a/SpatialGDK/Source/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialReceiver.cpp
@@ -606,7 +606,6 @@ void USpatialReceiver::ReceiveCommandResponse(Worker_CommandResponseOp& Op)
 			FTimerHandle RetryTimer;
 			TimerManager->SetTimer(RetryTimer, [this, ReliableRPC]()
 			{
-				ReliableRPC->Attempts++;
 				Sender->SendRPC(ReliableRPC);
 			}, WaitTime, false);
 		}

--- a/SpatialGDK/Source/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialSender.cpp
@@ -21,6 +21,28 @@ DEFINE_LOG_CATEGORY(LogSpatialSender);
 
 using namespace improbable;
 
+FPendingRPCParams::FPendingRPCParams(UObject* InTargetObject, UFunction* InFunction, void* InParameters)
+	: TargetObject(InTargetObject)
+	, Function(InFunction)
+	, Attempts(1)
+{
+	Parameters.SetNumZeroed(Function->ParmsSize);
+
+	for (TFieldIterator<UProperty> It(Function); It && It->HasAnyPropertyFlags(CPF_Parm); ++It)
+	{
+		It->InitializeValue_InContainer(Parameters.GetData());
+		It->CopyCompleteValue_InContainer(Parameters.GetData(), InParameters);
+	}
+}
+
+FPendingRPCParams::~FPendingRPCParams()
+{
+	for (TFieldIterator<UProperty> It(Function); It && It->HasAnyPropertyFlags(CPF_Parm); ++It)
+	{
+		It->DestroyValue_InContainer(Parameters.GetData());
+	}
+}
+
 void USpatialSender::Init(USpatialNetDriver* InNetDriver)
 {
 	NetDriver = InNetDriver;
@@ -264,18 +286,24 @@ void USpatialSender::SendRotationUpdate(Worker_EntityId EntityId, const FRotator
 	Connection->SendComponentUpdate(EntityId, &Update);
 }
 
-void USpatialSender::SendRPC(UObject* TargetObject, UFunction* Function, void* Parameters, bool bOwnParameters)
+void USpatialSender::SendRPC(TSharedRef<FPendingRPCParams> Params)
 {
-	FClassInfo* Info = TypebindingManager->FindClassInfoByClass(TargetObject->GetClass());
+	if (!Params->TargetObject.IsValid())
+	{
+		// Target object was destroyed before the RPC could be (re)sent
+		return;
+	}
+
+	FClassInfo* Info = TypebindingManager->FindClassInfoByClass(Params->TargetObject->GetClass());
 	if (Info == nullptr)
 	{
 		return;
 	}
 
-	FRPCInfo* RPCInfo = Info->RPCInfoMap.Find(Function);
+	FRPCInfo* RPCInfo = Info->RPCInfoMap.Find(Params->Function);
 	check(RPCInfo);
 
-	Worker_EntityId EntityId = 0;
+	Worker_EntityId EntityId = SpatialConstants::INVALID_ENTITY_ID;
 	const UObject* UnresolvedObject = nullptr;
 
 	switch (RPCInfo->Type)
@@ -284,18 +312,23 @@ void USpatialSender::SendRPC(UObject* TargetObject, UFunction* Function, void* P
 	case RPC_Server:
 	case RPC_CrossServer:
 	{
-		Worker_CommandRequest CommandRequest = CreateRPCCommandRequest(TargetObject, Function, Parameters, Info->RPCComponents[RPCInfo->Type], RPCInfo->Index + 1, EntityId, UnresolvedObject);
+		Worker_CommandRequest CommandRequest = CreateRPCCommandRequest(Params->TargetObject.Get(), Params->Function, Params->Parameters.GetData(), Info->RPCComponents[RPCInfo->Type], RPCInfo->Index + 1, EntityId, UnresolvedObject);
 
 		if (!UnresolvedObject)
 		{
 			check(EntityId > 0);
-			Connection->SendCommandRequest(EntityId, &CommandRequest, RPCInfo->Index + 1); 
+			Worker_RequestId RequestId = Connection->SendCommandRequest(EntityId, &CommandRequest, RPCInfo->Index + 1);
+
+			if (Params->Function->HasAnyFunctionFlags(FUNC_NetReliable))
+			{
+				Receiver->AddPendingReliableRPC(RequestId, Params);
+			}
 		}
 		break;
 	}
 	case RPC_NetMulticast:
 	{
-		Worker_ComponentUpdate ComponentUpdate = CreateMulticastUpdate(TargetObject, Function, Parameters, Info->RPCComponents[RPCInfo->Type], RPCInfo->Index + 1, EntityId, UnresolvedObject);
+		Worker_ComponentUpdate ComponentUpdate = CreateMulticastUpdate(Params->TargetObject.Get(), Params->Function, Params->Parameters.GetData(), Info->RPCComponents[RPCInfo->Type], RPCInfo->Index + 1, EntityId, UnresolvedObject);
 
 		if (!UnresolvedObject)
 		{
@@ -311,29 +344,7 @@ void USpatialSender::SendRPC(UObject* TargetObject, UFunction* Function, void* P
 
 	if (UnresolvedObject)
 	{
-		void* NewParameters = Parameters;
-		if (!bOwnParameters)
-		{
-			// Copy parameters
-			NewParameters = new uint8[Function->ParmsSize];
-			FMemory::Memzero(NewParameters, Function->ParmsSize); // Not sure if needed considering we're copying everything from Parameters
-
-			for (TFieldIterator<UProperty> It(Function); It && It->HasAnyPropertyFlags(CPF_Parm); ++It)
-			{
-				It->CopyCompleteValue_InContainer(NewParameters, Parameters);
-			}
-		}
-
-		QueueOutgoingRPC(UnresolvedObject, TargetObject, Function, NewParameters);
-	}
-	else if (bOwnParameters)
-	{
-		// Destroy parameters
-		for (TFieldIterator<UProperty> It(Function); It && It->HasAnyPropertyFlags(CPF_Parm); ++It)
-		{
-			It->DestroyValue_InContainer(Parameters);
-		}
-		delete[] (uint8*)Parameters;
+		QueueOutgoingRPC(UnresolvedObject, Params);
 	}
 }
 
@@ -442,11 +453,11 @@ void USpatialSender::QueueOutgoingUpdate(USpatialActorChannel* DependentChannel,
 	}
 }
 
-void USpatialSender::QueueOutgoingRPC(const UObject* UnresolvedObject, UObject* TargetObject, UFunction* Function, void* Parameters)
+void USpatialSender::QueueOutgoingRPC(const UObject* UnresolvedObject, TSharedRef<FPendingRPCParams> Params)
 {
 	check(UnresolvedObject);
-	UE_LOG(LogSpatialSender, Log, TEXT("Added pending outgoing RPC depending on object: %s, target: %s, function: %s"), *UnresolvedObject->GetName(), *TargetObject->GetName(), *Function->GetName());
-	OutgoingRPCs.FindOrAdd(UnresolvedObject).Add(FPendingRPCParams(TargetObject, Function, Parameters));
+	UE_LOG(LogSpatialSender, Log, TEXT("Added pending outgoing RPC depending on object: %s, target: %s, function: %s"), *UnresolvedObject->GetName(), *Params->TargetObject->GetName(), *Params->Function->GetName());
+	OutgoingRPCs.FindOrAdd(UnresolvedObject).Add(Params);
 }
 
 Worker_CommandRequest USpatialSender::CreateRPCCommandRequest(UObject* TargetObject, UFunction* Function, void* Parameters, Worker_ComponentId ComponentId, Schema_FieldId CommandIndex, Worker_EntityId& OutEntityId, const UObject*& OutUnresolvedObject)
@@ -601,15 +612,21 @@ void USpatialSender::ResolveOutgoingOperations(UObject* Object, bool bIsHandover
 
 void USpatialSender::ResolveOutgoingRPCs(UObject* Object)
 {
-	TArray<FPendingRPCParams>* RPCList = OutgoingRPCs.Find(Object);
+	TArray<TSharedRef<FPendingRPCParams>>* RPCList = OutgoingRPCs.Find(Object);
 	if (RPCList)
 	{
-		for (FPendingRPCParams& RPCParams : *RPCList)
+		for (TSharedRef<FPendingRPCParams>& RPCParams : *RPCList)
 		{
+			if (!RPCParams->TargetObject.IsValid())
+			{
+				// The target object was destroyed before we could send the RPC.
+				continue;
+			}
+
 			// We can guarantee that SendRPC won't populate OutgoingRPCs[Object] whilst we're iterating through it,
 			// because Object has been resolved when we call ResolveOutgoingRPCs.
-			UE_LOG(LogSpatialSender, Log, TEXT("Resolving outgoing RPC depending on object: %s, target: %s, function: %s"), *Object->GetName(), *RPCParams.TargetObject->GetName(), *RPCParams.Function->GetName());
-			SendRPC(RPCParams.TargetObject, RPCParams.Function, RPCParams.Parameters, true);
+			UE_LOG(LogSpatialSender, Log, TEXT("Resolving outgoing RPC depending on object: %s, target: %s, function: %s"), *Object->GetName(), *RPCParams->TargetObject->GetName(), *RPCParams->Function->GetName());
+			SendRPC(RPCParams);
 		}
 		OutgoingRPCs.Remove(Object);
 	}

--- a/SpatialGDK/Source/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/Public/Interop/SpatialSender.h
@@ -24,18 +24,19 @@ class USpatialReceiver;
 
 struct FPendingRPCParams
 {
-	FPendingRPCParams(UObject* InTargetObject, UFunction* InFunction, void* InParameters)
-		: TargetObject(InTargetObject), Function(InFunction), Parameters(InParameters) {}
+	FPendingRPCParams(UObject* InTargetObject, UFunction* InFunction, void* InParameters);
+	~FPendingRPCParams();
 
-	UObject* TargetObject;
+	TWeakObjectPtr<UObject> TargetObject;
 	UFunction* Function;
-	void* Parameters;
+	TArray<uint8> Parameters;
+	int Attempts; // For reliable RPCs
 };
 
 // TODO: Clear TMap entries when USpatialActorChannel gets deleted - UNR:100
 // care for actor getting deleted before actor channel
 using FChannelObjectPair = TPair<TWeakObjectPtr<USpatialActorChannel>, TWeakObjectPtr<UObject>>;
-using FOutgoingRPCMap = TMap<const UObject*, TArray<FPendingRPCParams>>;
+using FOutgoingRPCMap = TMap<const UObject*, TArray<TSharedRef<FPendingRPCParams>>>;
 using FUnresolvedEntry = TSharedPtr<TSet<const UObject*>>;
 using FHandleToUnresolved = TMap<uint16, FUnresolvedEntry>;
 using FChannelToHandleToUnresolved = TMap<FChannelObjectPair, FHandleToUnresolved>;
@@ -47,14 +48,14 @@ class SPATIALGDK_API USpatialSender : public UObject
 	GENERATED_BODY()
 
 public:
-	void Init(USpatialNetDriver* NetDriver);
+	void Init(USpatialNetDriver* InNetDriver);
 
 	// Actor Updates
 	void SendComponentUpdates(UObject* Object, USpatialActorChannel* Channel, const FRepChangeState* RepChanges, const FHandoverChangeState* HandoverChanges);
 	void SendComponentInterest(AActor* Actor, Worker_EntityId EntityId);
 	void SendPositionUpdate(Worker_EntityId EntityId, const FVector& Location);
 	void SendRotationUpdate(Worker_EntityId EntityId, const FRotator& Rotation);
-	void SendRPC(UObject* TargetObject, UFunction* Function, void* Parameters, bool bOwnParameters);
+	void SendRPC(TSharedRef<FPendingRPCParams> Params);
 	void SendCommandResponse(Worker_RequestId request_id, Worker_CommandResponse& Response);
 
 	void SendReserveEntityIdRequest(USpatialActorChannel* Channel);
@@ -72,7 +73,7 @@ private:
 	// Queuing
 	void ResetOutgoingUpdate(USpatialActorChannel* DependentChannel, UObject* ReplicatedObject, int16 Handle, bool bIsHandover);
 	void QueueOutgoingUpdate(USpatialActorChannel* DependentChannel, UObject* ReplicatedObject, int16 Handle, const TSet<const UObject*>& UnresolvedObjects, bool bIsHandover);
-	void QueueOutgoingRPC(const UObject* UnresolvedObject, UObject* TargetObject, UFunction* Function, void* Parameters);
+	void QueueOutgoingRPC(const UObject* UnresolvedObject, TSharedRef<FPendingRPCParams> Params);
 
 	// RPC Construction
 	Worker_CommandRequest CreateRPCCommandRequest(UObject* TargetObject, UFunction* Function, void* Parameters, Worker_ComponentId ComponentId, Schema_FieldId CommandIndex, Worker_EntityId& OutEntityId, const UObject*& OutUnresolvedObject);

--- a/SpatialGDK/Source/Public/Schema/StandardLibrary.h
+++ b/SpatialGDK/Source/Public/Schema/StandardLibrary.h
@@ -5,6 +5,7 @@
 #include "Platform.h"
 
 #include "Schema/Component.h"
+#include "SpatialConstants.h"
 #include "Utils/SchemaUtils.h"
 
 #include <improbable/c_schema.h>


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Re-adding the functionality for resending reliable RPCs.
The crash observed by @Vatyx was fixed by initializing the RPC params before copying. `SpatialSender.cpp:33`

Also took the opportunity to move the response handling into the `SpatialReceiver`, as well as add some missing includes that went unnoticed because of unity build.
#### Primary reviewers
@m-samiec @Vatyx 