### PR TITLE
Fixed error message around unknown components

### DIFF
--- a/SpatialGDK/Source/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialReceiver.cpp
@@ -396,7 +396,7 @@ AActor* USpatialReceiver::CreateActor(improbable::Position* Position, improbable
 void USpatialReceiver::ApplyComponentData(Worker_EntityId EntityId, Worker_ComponentData& Data, USpatialActorChannel* Channel)
 {
 	UClass* Class = TypebindingManager->FindClassByComponentId(Data.component_id);
-	checkf(Class, TEXT("Component %d isn't hand-written and not present in ComponentToClassMap."));
+	checkf(Class, TEXT("Component %d isn't hand-written and not present in ComponentToClassMap."), Data.component_id);
 
 	UObject* TargetObject = GetTargetObjectFromChannelAndClass(Channel, Class);
 	if (!TargetObject)


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
An error message when receiving component data for unknown components wasn't properly printing out the component ID.
#### Tests
Manually tested with missing components in the snapshot.
#### Primary reviewers
@Vatyx @girayimprobable 