### PR TITLE
Early-out of connection attempt if getting deployment list fails.

### DIFF
--- a/SpatialGDK/Source/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialNetDriver.cpp
@@ -139,6 +139,10 @@ void USpatialNetDriver::OnMapLoaded(UWorld* LoadedWorld)
 void USpatialNetDriver::Connect()
 {
 	Connection->OnConnected.BindUFunction(this, FName("OnConnected"));
+	Connection->OnConnectFailed.BindLambda([this](FString Reason)
+	{
+		this->OnSpatialOSConnectFailed(Reason);
+	});
 
 	Connection->Connect(bConnectAsClient);
 }

--- a/SpatialGDK/Source/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialNetDriver.cpp
@@ -139,10 +139,7 @@ void USpatialNetDriver::OnMapLoaded(UWorld* LoadedWorld)
 void USpatialNetDriver::Connect()
 {
 	Connection->OnConnected.BindUFunction(this, FName("OnConnected"));
-	Connection->OnConnectFailed.BindLambda([this](FString Reason)
-	{
-		this->OnSpatialOSConnectFailed(Reason);
-	});
+	Connection->OnConnectFailed.BindUFunction(this, FName("OnConnectFailed"));
 
 	Connection->Connect(bConnectAsClient);
 }
@@ -199,12 +196,7 @@ void USpatialNetDriver::OnConnected()
 	GlobalStateManager->Init(this);
 }
 
-void USpatialNetDriver::OnSpatialOSDisconnected(const FString& Reason)
-{
-	UE_LOG(LogSpatialOSNetDriver, Warning, TEXT("Disconnected from SpatialOS. Reason: %s"), *Reason);
-}
-
-void USpatialNetDriver::OnSpatialOSConnectFailed(const FString& Reason)
+void USpatialNetDriver::OnConnectFailed(FString Reason)
 {
 	UE_LOG(LogSpatialOSNetDriver, Error, TEXT("Could not connect to SpatialOS. Reason: %s"), *Reason);
 }

--- a/SpatialGDK/Source/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialNetDriver.cpp
@@ -138,8 +138,14 @@ void USpatialNetDriver::OnMapLoaded(UWorld* LoadedWorld)
 
 void USpatialNetDriver::Connect()
 {
-	Connection->OnConnected.BindUFunction(this, FName("OnConnected"));
-	Connection->OnConnectFailed.BindUFunction(this, FName("OnConnectFailed"));
+	Connection->OnConnected.BindLambda([this]
+	{
+		OnConnected();
+	});
+	Connection->OnConnectFailed.BindLambda([this](const FString& Reason)
+	{
+		OnConnectFailed(Reason);
+	});
 
 	Connection->Connect(bConnectAsClient);
 }
@@ -196,7 +202,7 @@ void USpatialNetDriver::OnConnected()
 	GlobalStateManager->Init(this);
 }
 
-void USpatialNetDriver::OnConnectFailed(FString Reason)
+void USpatialNetDriver::OnConnectFailed(const FString& Reason)
 {
 	UE_LOG(LogSpatialOSNetDriver, Error, TEXT("Could not connect to SpatialOS. Reason: %s"), *Reason);
 }

--- a/SpatialGDK/Source/Private/Interop/Connection/SpatialWorkerConnection.cpp
+++ b/SpatialGDK/Source/Private/Interop/Connection/SpatialWorkerConnection.cpp
@@ -127,11 +127,13 @@ void USpatialWorkerConnection::ConnectToLocator()
 		if (DeploymentList->error != nullptr)
 		{
 			UE_LOG(LogSpatialWorkerConnection, Error, TEXT("Error fetching deployment list: %s"), UTF8_TO_TCHAR(DeploymentList->error));
+			return;
 		}
 
 		if (DeploymentList->deployment_count == 0)
 		{
 			UE_LOG(LogSpatialWorkerConnection, Error, TEXT("Received empty list of deployments. Failed to connect."));
+			return;
 		}
 
 		USpatialWorkerConnection* SpatialConnection = static_cast<USpatialWorkerConnection*>(UserData);
@@ -174,8 +176,15 @@ void USpatialWorkerConnection::ConnectToLocator()
 
 			AsyncTask(ENamedThreads::GameThread, [SpatialConnection]
 			{
-				SpatialConnection->bIsConnected = true;
-				SpatialConnection->OnConnected.ExecuteIfBound();
+				if (SpatialConnection->WorkerConnection == nullptr)
+				{
+					SpatialConnection->bIsConnected = false;
+				}
+				else
+				{
+					SpatialConnection->bIsConnected = true;
+					SpatialConnection->OnConnected.ExecuteIfBound();
+				}
 			});
 		});
 	});

--- a/SpatialGDK/Source/Private/Interop/Connection/SpatialWorkerConnection.cpp
+++ b/SpatialGDK/Source/Private/Interop/Connection/SpatialWorkerConnection.cpp
@@ -81,7 +81,6 @@ void USpatialWorkerConnection::ConnectToReceptionist(bool bConnectAsClient)
 		}
 		else
 		{
-			bIsConnected = false;
 			Worker_OpList* OpList = Worker_Connection_GetOpList(WorkerConnection, 0);
 			for (int i = 0; i < (int)OpList->op_count; i++)
 			{
@@ -205,7 +204,6 @@ void USpatialWorkerConnection::ConnectToLocator()
 			}
 			else
 			{
-				SpatialConnection->bIsConnected = false;
 				Worker_OpList* OpList = Worker_Connection_GetOpList(SpatialConnection->WorkerConnection, 0);
 				for (int i = 0; i < (int)OpList->op_count; i++)
 				{

--- a/SpatialGDK/Source/Private/Interop/Connection/SpatialWorkerConnection.cpp
+++ b/SpatialGDK/Source/Private/Interop/Connection/SpatialWorkerConnection.cpp
@@ -214,6 +214,7 @@ void USpatialWorkerConnection::GetAndPrintConnectionFailureMessage()
 				UE_LOG(LogSpatialWorkerConnection, Error, TEXT("Failed to connect to SpatialOS: %s"), *ErrorMessage);
 				OnConnectFailed.ExecuteIfBound(ErrorMessage);
 			});
+			break;
 		}
 	}
 }

--- a/SpatialGDK/Source/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/Public/EngineClasses/SpatialNetDriver.h
@@ -135,7 +135,7 @@ private:
 	void OnConnected();
 
 	UFUNCTION()
-	void OnConnectFailed(FString Reason);
+	void OnConnectFailed(const FString& Reason);
 		
 #if WITH_SERVER_CODE
 	//SpatialGDK: These functions all exist in UNetDriver, but we need to modify/simplify them in certain ways.

--- a/SpatialGDK/Source/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/Public/EngineClasses/SpatialNetDriver.h
@@ -135,10 +135,7 @@ private:
 	void OnConnected();
 
 	UFUNCTION()
-	void OnSpatialOSConnectFailed(const FString& Reason);
-
-	UFUNCTION()
-	void OnSpatialOSDisconnected(const FString& Reason);
+	void OnConnectFailed(FString Reason);
 		
 #if WITH_SERVER_CODE
 	//SpatialGDK: These functions all exist in UNetDriver, but we need to modify/simplify them in certain ways.

--- a/SpatialGDK/Source/Public/Interop/Connection/SpatialWorkerConnection.h
+++ b/SpatialGDK/Source/Public/Interop/Connection/SpatialWorkerConnection.h
@@ -53,7 +53,6 @@ private:
 
 	void GetAndPrintConnectionFailureMessage();
 
-private:
 	Worker_Connection* WorkerConnection;
 	Worker_Locator* WorkerLocator;
 

--- a/SpatialGDK/Source/Public/Interop/Connection/SpatialWorkerConnection.h
+++ b/SpatialGDK/Source/Public/Interop/Connection/SpatialWorkerConnection.h
@@ -10,8 +10,8 @@
 
 DECLARE_LOG_CATEGORY_EXTERN(LogSpatialWorkerConnection, Log, All);
 
-DECLARE_DELEGATE(OnConnectedDelegate);
-DECLARE_DELEGATE_OneParam(OnConnectFailedDelegate, FString);
+DECLARE_DELEGATE(FOnConnectedDelegate);
+DECLARE_DELEGATE_OneParam(FOnConnectFailedDelegate, const FString&);
 
 UCLASS()
 class SPATIALGDK_API USpatialWorkerConnection : public UObject
@@ -38,8 +38,8 @@ public:
 	void SendComponentInterest(Worker_EntityId EntityId, const TArray<Worker_InterestOverride>& ComponentInterest);
 	FString GetWorkerId() const;
 
-	OnConnectedDelegate OnConnected;
-	OnConnectFailedDelegate OnConnectFailed;
+	FOnConnectedDelegate OnConnected;
+	FOnConnectFailedDelegate OnConnectFailed;
 
 	FReceptionistConfig ReceptionistConfig;
 	FLocatorConfig LocatorConfig;

--- a/SpatialGDK/Source/Public/Interop/Connection/SpatialWorkerConnection.h
+++ b/SpatialGDK/Source/Public/Interop/Connection/SpatialWorkerConnection.h
@@ -51,6 +51,8 @@ private:
 	Worker_ConnectionParameters CreateConnectionParameters(FConnectionConfig& Config);
 	bool ShouldConnectWithLocator();
 
+	void GetAndPrintConnectionFailureMessage();
+
 private:
 	Worker_Connection* WorkerConnection;
 	Worker_Locator* WorkerLocator;

--- a/SpatialGDK/Source/Public/Interop/Connection/SpatialWorkerConnection.h
+++ b/SpatialGDK/Source/Public/Interop/Connection/SpatialWorkerConnection.h
@@ -10,7 +10,8 @@
 
 DECLARE_LOG_CATEGORY_EXTERN(LogSpatialWorkerConnection, Log, All);
 
-DECLARE_DELEGATE(OnConnectedDelegate)
+DECLARE_DELEGATE(OnConnectedDelegate);
+DECLARE_DELEGATE_OneParam(OnConnectFailedDelegate, FString);
 
 UCLASS()
 class SPATIALGDK_API USpatialWorkerConnection : public UObject
@@ -38,6 +39,7 @@ public:
 	FString GetWorkerId() const;
 
 	OnConnectedDelegate OnConnected;
+	OnConnectFailedDelegate OnConnectFailed;
 
 	FReceptionistConfig ReceptionistConfig;
 	FLocatorConfig LocatorConfig;


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
In the locator connection flow, If getting the deployment list fails, it will continue to attempt to connect and usually crash with a cryptic error. This is a temporary fix that just early-outs from the connection attempt, as a workaround until a proper solution for UNR-576 is completed.

#### Tests
Tested manually by connecting with a bad login token, and to a deployment that doesn't exist.

#### Documentation
n/a

#### Primary reviewers
@m-samiec @girayimprobable 