### PR TITLE
Resolve actors as soon as possible

### DIFF
--- a/SpatialGDK/Source/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialActorChannel.cpp
@@ -568,6 +568,9 @@ void USpatialActorChannel::OnReserveEntityIdResponse(const Worker_ReserveEntityI
   
 	EntityId = Op.entity_id;
 	RegisterEntityId(EntityId);
+
+	// Register Actor with package map since we know what the entity id is.
+	NetDriver->PackageMap ->ResolveEntityActor(Actor, EntityId, improbable::CreateOffsetMapFromActor(Actor));
 }
 
 void USpatialActorChannel::OnCreateEntityResponse(const Worker_CreateEntityResponseOp& Op)

--- a/SpatialGDK/Source/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialReceiver.cpp
@@ -243,17 +243,7 @@ void USpatialReceiver::ReceiveActor(Worker_EntityId EntityId)
 
 	if (AActor* EntityActor = EntityRegistry->GetActorFromEntityId(EntityId))
 	{
-		UClass* ActorClass = GetNativeEntityClass(Metadata);
-
 		UE_LOG(LogSpatialReceiver, Log, TEXT("Entity for actor %s has been checked out on the worker which spawned it."), *EntityActor->GetName());
-
-		improbable::UnrealMetadata* UnrealMetadata = GetComponentData<improbable::UnrealMetadata>(*this, EntityId);
-		check(UnrealMetadata);
-
-		USpatialPackageMapClient* SpatialPackageMap = Cast<USpatialPackageMapClient>(NetDriver->GetSpatialOSNetConnection()->PackageMap);
-		check(SpatialPackageMap);
-
-		FNetworkGUID NetGUID = SpatialPackageMap->ResolveEntityActor(EntityActor, EntityId, UnrealMetadata->SubobjectNameToOffset);
 
 		// Assume SimulatedProxy until we've been delegated Authority
 		bool bAuthority = View->GetAuthority(EntityId, improbable::Position::ComponentId) == WORKER_AUTHORITY_AUTHORITATIVE;


### PR DESCRIPTION
#### Description
As soon as we know the entity id for an actor, we can at this point refer to it and all of its subobjects through UnrealObjRefs. Therefore we can register an Actor with the PackageMap on entity id reservation rather than during the AddEntityOp.

#### Primary reviewers
@improbable-valentyn @m-samiec 