### PR TITLE
Include blueprint inherited components in a Class's subobjects

### DIFF
--- a/SpatialGDK/Source/Private/Interop/SpatialTypebindingManager.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialTypebindingManager.cpp
@@ -132,7 +132,8 @@ void USpatialTypebindingManager::CreateTypebindings()
 				}
 
 				// Components that are added in a blueprint won't appear in the CDO.
-				if (UBlueprintGeneratedClass* BGC = Cast<UBlueprintGeneratedClass>(Class))
+				UClass* BlueprintClass = Class;
+				while (UBlueprintGeneratedClass* BGC = Cast<UBlueprintGeneratedClass>(BlueprintClass))
 				{
 					if (USimpleConstructionScript* SCS = BGC->SimpleConstructionScript)
 					{
@@ -146,6 +147,8 @@ void USpatialTypebindingManager::CreateTypebindings()
 							AddSubobjectClass(Info, Node->ComponentTemplate->GetClass());
 						}
 					}
+
+					BlueprintClass = BlueprintClass->GetSuperClass();
 				}
 			}
 		}


### PR DESCRIPTION
#### Description
We weren't including blueprint inherited components in a Class's subobject, so we weren't attaching the proper Spatial components. This fixes that.

#### Primary reviewers
@m-samiec @improbable-valentyn 