### PR TITLE
GSM component updates weren't applied correctly

### DIFF
--- a/SpatialGDK/Source/Private/Interop/GlobalStateManager.cpp
+++ b/SpatialGDK/Source/Private/Interop/GlobalStateManager.cpp
@@ -33,7 +33,7 @@ void UGlobalStateManager::ApplyUpdate(const Worker_ComponentUpdate& Update)
 {
 	Schema_Object* ComponentObject = Schema_GetComponentUpdateFields(Update.schema_type);
 
-	if (Schema_GetObjectCount(ComponentObject, 1) == 1)
+	if (Schema_GetObjectCount(ComponentObject, 1) > 0)
 	{
 		SingletonNameToEntityId = GetStringToEntityMapFromSchema(ComponentObject, 1);
 	}


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
GSM component updates weren't applied correctly if there was more than 1 element in the string to singleton entity ID map.
#### Primary reviewers
@Vatyx @m-samiec 