### PR TITLE
Only include core_types.schema if it's needed

### DIFF
--- a/SpatialGDK/Source/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -173,8 +173,14 @@ void FSpatialNetGUIDCache::RemoveEntityNetGUID(Worker_EntityId EntityId)
 {
 	// Remove actor subobjects.
 	USpatialNetDriver* SpatialNetDriver = Cast<USpatialNetDriver>(Driver);
-	const SubobjectToOffsetMap& SubobjectNameToOffset = SpatialNetDriver->View->GetUnrealMetadata(EntityId)->SubobjectNameToOffset;
 
+	improbable::UnrealMetadata* UnrealMetadata = SpatialNetDriver->View->GetUnrealMetadata(EntityId);
+	if (UnrealMetadata == nullptr)
+	{
+		return;
+	}
+
+	const SubobjectToOffsetMap& SubobjectNameToOffset = UnrealMetadata->SubobjectNameToOffset;
 	for (const auto& Pair : SubobjectNameToOffset)
 	{
 		FUnrealObjectRef SubobjectRef(EntityId, Pair.Value);

--- a/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/SchemaGenerator.cpp
+++ b/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/SchemaGenerator.cpp
@@ -54,56 +54,56 @@ FString PropertyToSchemaType(UProperty* Property, bool bIsRPCProperty)
 	}
 	else if (Property->IsA(UInt8Property::StaticClass()))
 	{
-	DataType = TEXT("int32");
+		DataType = TEXT("int32");
 	}
 	else if (Property->IsA(UInt16Property::StaticClass()))
 	{
-	DataType = TEXT("int32");
+		DataType = TEXT("int32");
 	}
 	else if (Property->IsA(UIntProperty::StaticClass()))
 	{
-	DataType = TEXT("int32");
+		DataType = TEXT("int32");
 	}
 	else if (Property->IsA(UInt64Property::StaticClass()))
 	{
-	DataType = TEXT("int64");
+		DataType = TEXT("int64");
 	}
 	else if (Property->IsA(UByteProperty::StaticClass()))
 	{
-	DataType = TEXT("uint32"); // uint8 not supported in schema.
+		DataType = TEXT("uint32"); // uint8 not supported in schema.
 	}
 	else if (Property->IsA(UUInt16Property::StaticClass()))
 	{
-	DataType = TEXT("uint32");
+		DataType = TEXT("uint32");
 	}
 	else if (Property->IsA(UUInt32Property::StaticClass()))
 	{
-	DataType = TEXT("uint32");
+		DataType = TEXT("uint32");
 	}
 	else if (Property->IsA(UUInt64Property::StaticClass()))
 	{
-	DataType = TEXT("uint64");
+		DataType = TEXT("uint64");
 	}
 	else if (Property->IsA(UNameProperty::StaticClass()) || Property->IsA(UStrProperty::StaticClass()) || Property->IsA(UTextProperty::StaticClass()))
 	{
-	DataType = TEXT("string");
+		DataType = TEXT("string");
 	}
 	else if (Property->IsA(UObjectPropertyBase::StaticClass()))
 	{
-	DataType = TEXT("UnrealObjectRef");
+		DataType = TEXT("UnrealObjectRef");
 	}
 	else if (Property->IsA(UArrayProperty::StaticClass()))
 	{
-	DataType = PropertyToSchemaType(Cast<UArrayProperty>(Property)->Inner, bIsRPCProperty);
-	DataType = FString::Printf(TEXT("list<%s>"), *DataType);
+		DataType = PropertyToSchemaType(Cast<UArrayProperty>(Property)->Inner, bIsRPCProperty);
+		DataType = FString::Printf(TEXT("list<%s>"), *DataType);
 	}
 	else if (Property->IsA(UEnumProperty::StaticClass()))
 	{
-	DataType = GetEnumDataType(Cast<UEnumProperty>(Property));
+		DataType = GetEnumDataType(Cast<UEnumProperty>(Property));
 	}
 	else
 	{
-	DataType = TEXT("bytes");
+		DataType = TEXT("bytes");
 	}
 
 	return DataType;
@@ -138,10 +138,10 @@ void WriteSchemaRPCField(TSharedPtr<FCodeWriter> Writer, const TSharedPtr<FUnrea
 	);
 }
 
-// core_types.schema should only be included if the component has
+// core_types.schema should only be included if any components in the file have
 // 1. An UnrealObjectRef
-// 2. A List of UnrealObjectRefs
-// 3. Any RPCs
+// 2. A list of UnrealObjectRefs
+// 3. A RPC
 bool ShouldIncludeCoreTypes(TSharedPtr<FUnrealType>& TypeInfo)
 {
 	FUnrealFlatRepData RepData = GetFlatRepData(TypeInfo);
@@ -178,8 +178,6 @@ int GenerateTypeBindingSchema(FCodeWriter& Writer, int ComponentId, UClass* Clas
 {
 	FComponentIdGenerator IdGenerator(ComponentId);
 
-	FUnrealFlatRepData RepData = GetFlatRepData(TypeInfo);
-
 	Writer.Printf(R"""(
 		// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 		// Note that this file has been generated automatically
@@ -193,6 +191,8 @@ int GenerateTypeBindingSchema(FCodeWriter& Writer, int ComponentId, UClass* Clas
 	}
 
 	Writer.PrintNewLine();
+
+	FUnrealFlatRepData RepData = GetFlatRepData(TypeInfo);
 
 	// Client-server replicated properties.
 	for (EReplicatedPropertyGroup Group : GetAllReplicatedPropertyGroups())

--- a/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/SchemaGenerator.cpp
+++ b/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/SchemaGenerator.cpp
@@ -141,7 +141,7 @@ void WriteSchemaRPCField(TSharedPtr<FCodeWriter> Writer, const TSharedPtr<FUnrea
 // core_types.schema should only be included if any components in the file have
 // 1. An UnrealObjectRef
 // 2. A list of UnrealObjectRefs
-// 3. A RPC
+// 3. An RPC
 bool ShouldIncludeCoreTypes(TSharedPtr<FUnrealType>& TypeInfo)
 {
 	FUnrealFlatRepData RepData = GetFlatRepData(TypeInfo);
@@ -151,14 +151,14 @@ bool ShouldIncludeCoreTypes(TSharedPtr<FUnrealType>& TypeInfo)
 		for (auto& PropertyPair : PropertyGroup.Value)
 		{
 			UProperty* Property = PropertyPair.Value->Property;
-			if(Property->IsA(UObjectPropertyBase::StaticClass()))
+			if(Property->IsA<UObjectPropertyBase>())
 			{
 				return true;
 			}
 
-			if (Property->IsA(UArrayProperty::StaticClass()))
+			if (Property->IsA<UArrayProperty>())
 			{
-				if (Cast<UArrayProperty>(Property)->Inner->IsA(UObjectPropertyBase::StaticClass()))
+				if (Cast<UArrayProperty>(Property)->Inner->IsA<UObjectPropertyBase>())
 				{
 					return true;
 				}

--- a/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/SchemaGenerator.cpp
+++ b/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/SchemaGenerator.cpp
@@ -54,56 +54,56 @@ FString PropertyToSchemaType(UProperty* Property, bool bIsRPCProperty)
 	}
 	else if (Property->IsA(UInt8Property::StaticClass()))
 	{
-		DataType = TEXT("int32");
+	DataType = TEXT("int32");
 	}
 	else if (Property->IsA(UInt16Property::StaticClass()))
 	{
-		DataType = TEXT("int32");
+	DataType = TEXT("int32");
 	}
 	else if (Property->IsA(UIntProperty::StaticClass()))
 	{
-		DataType = TEXT("int32");
+	DataType = TEXT("int32");
 	}
 	else if (Property->IsA(UInt64Property::StaticClass()))
 	{
-		DataType = TEXT("int64");
+	DataType = TEXT("int64");
 	}
 	else if (Property->IsA(UByteProperty::StaticClass()))
 	{
-		DataType = TEXT("uint32"); // uint8 not supported in schema.
+	DataType = TEXT("uint32"); // uint8 not supported in schema.
 	}
 	else if (Property->IsA(UUInt16Property::StaticClass()))
 	{
-		DataType = TEXT("uint32");
+	DataType = TEXT("uint32");
 	}
 	else if (Property->IsA(UUInt32Property::StaticClass()))
 	{
-		DataType = TEXT("uint32");
+	DataType = TEXT("uint32");
 	}
 	else if (Property->IsA(UUInt64Property::StaticClass()))
 	{
-		DataType = TEXT("uint64");
+	DataType = TEXT("uint64");
 	}
 	else if (Property->IsA(UNameProperty::StaticClass()) || Property->IsA(UStrProperty::StaticClass()) || Property->IsA(UTextProperty::StaticClass()))
 	{
-		DataType = TEXT("string");
+	DataType = TEXT("string");
 	}
 	else if (Property->IsA(UObjectPropertyBase::StaticClass()))
 	{
-		DataType = TEXT("UnrealObjectRef");
+	DataType = TEXT("UnrealObjectRef");
 	}
 	else if (Property->IsA(UArrayProperty::StaticClass()))
 	{
-		DataType = PropertyToSchemaType(Cast<UArrayProperty>(Property)->Inner, bIsRPCProperty);
-		DataType = FString::Printf(TEXT("list<%s>"), *DataType);
+	DataType = PropertyToSchemaType(Cast<UArrayProperty>(Property)->Inner, bIsRPCProperty);
+	DataType = FString::Printf(TEXT("list<%s>"), *DataType);
 	}
 	else if (Property->IsA(UEnumProperty::StaticClass()))
 	{
-		DataType = GetEnumDataType(Cast<UEnumProperty>(Property));
+	DataType = GetEnumDataType(Cast<UEnumProperty>(Property));
 	}
 	else
 	{
-		DataType = TEXT("bytes");
+	DataType = TEXT("bytes");
 	}
 
 	return DataType;
@@ -138,19 +138,61 @@ void WriteSchemaRPCField(TSharedPtr<FCodeWriter> Writer, const TSharedPtr<FUnrea
 	);
 }
 
+// core_types.schema should only be included if the component has
+// 1. An UnrealObjectRef
+// 2. A List of UnrealObjectRefs
+// 3. Any RPCs
+bool ShouldIncludeCoreTypes(TSharedPtr<FUnrealType>& TypeInfo)
+{
+	FUnrealFlatRepData RepData = GetFlatRepData(TypeInfo);
+
+	for (auto& PropertyGroup : RepData)
+	{
+		for (auto& PropertyPair : PropertyGroup.Value)
+		{
+			UProperty* Property = PropertyPair.Value->Property;
+			if(Property->IsA(UObjectPropertyBase::StaticClass()))
+			{
+				return true;
+			}
+
+			if (Property->IsA(UArrayProperty::StaticClass()))
+			{
+				if (Cast<UArrayProperty>(Property)->Inner->IsA(UObjectPropertyBase::StaticClass()))
+				{
+					return true;
+				}
+			}
+		}
+	}
+
+	if (TypeInfo->RPCs.Num() > 0)
+	{
+		return true;
+	}
+
+	return false;
+}
+
 int GenerateTypeBindingSchema(FCodeWriter& Writer, int ComponentId, UClass* Class, TSharedPtr<FUnrealType> TypeInfo, FString SchemaPath)
 {
 	FComponentIdGenerator IdGenerator(ComponentId);
 
+	FUnrealFlatRepData RepData = GetFlatRepData(TypeInfo);
+
 	Writer.Printf(R"""(
 		// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 		// Note that this file has been generated automatically
-		package improbable.unreal.generated.%s;
+		package improbable.unreal.generated.%s;)""",
+		*UnrealNameToSchemaTypeName(Class->GetName().ToLower()));
 
-		import "improbable/unreal/gdk/core_types.schema";)""", *UnrealNameToSchemaTypeName(Class->GetName().ToLower()));
+	if (ShouldIncludeCoreTypes(TypeInfo))
+	{
+		Writer.PrintNewLine();
+		Writer.Printf("import \"improbable/unreal/gdk/core_types.schema\";");
+	}
+
 	Writer.PrintNewLine();
-
-	FUnrealFlatRepData RepData = GetFlatRepData(TypeInfo);
 
 	// Client-server replicated properties.
 	for (EReplicatedPropertyGroup Group : GetAllReplicatedPropertyGroups())


### PR DESCRIPTION
#### Description
This removes the red warnings we get when launching Spatial since we were including core_types.schema when it didn't need to be.

#### Primary reviewers
@joshuahuburn @improbable-valentyn 