### PR TITLE
Be able to spawn on workers which don't have authority over the spawner

### DIFF
--- a/SpatialGDK/Source/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialActorChannel.cpp
@@ -678,7 +678,16 @@ void USpatialActorChannel::SpatialViewTick()
 	if (Actor != nullptr && !Actor->IsPendingKill() && IsReadyForReplication())
 	{
 		bool bOldNetOwned = bNetOwned;
-		bNetOwned = Actor->GetNetConnection() != nullptr;
+
+		bNetOwned = false;
+		if (UNetConnection* Connection = Actor->GetNetConnection())
+		{
+			if (APlayerController* PlayerController = Connection->PlayerController)
+			{
+				bNetOwned = PlayerController->PlayerState != nullptr;
+			}
+		}
+
 		if (bFirstTick || bOldNetOwned != bNetOwned)
 		{
 			if (IsAuthoritativeServer())

--- a/SpatialGDK/Source/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialSender.cpp
@@ -697,14 +697,7 @@ bool USpatialSender::UpdateEntityACLs(AActor* Actor, Worker_EntityId EntityId)
 	WorkerAttributeSet OwningClientAttribute = { OwnerWorkerAttribute };
 	WorkerRequirementSet OwningClientOnly = { OwningClientAttribute };
 
-	if (EntityACL->ComponentWriteAcl.Contains(Info->RPCComponents[RPC_Client]))
-	{
-		EntityACL->ComponentWriteAcl[Info->RPCComponents[RPC_Client]] = OwningClientOnly;
-	}
-	else
-	{
-		EntityACL->ComponentWriteAcl.Add(Info->RPCComponents[RPC_Client], OwningClientOnly);
-	}
+	EntityACL->ComponentWriteAcl.Add(Info->RPCComponents[RPC_Client], OwningClientOnly);
 
 	Worker_ComponentUpdate Update = EntityACL->CreateEntityAclUpdate();
 


### PR DESCRIPTION
#### Description
When spawning on a server which wasn't authortative over the spawner, the PlayerState wasn't resolved by the time `SpatialActorChannel::SpatialViewTick` was called the first time, leading the client to lose authority over the character. This fixes that by making the condition for `bNetOwned` to be true to be when an Actor has a corresponding PlayerState.

#### Primary reviewers
@improbable-valentyn @danielimprobable 