### PR TITLE
Fix corruption caused by replication of obj references in arrays

### DIFF
--- a/SpatialGDK/Source/Public/Utils/ComponentReader.h
+++ b/SpatialGDK/Source/Public/Utils/ComponentReader.h
@@ -20,8 +20,8 @@ private:
 	void ApplySchemaObject(Schema_Object* ComponentObject, UObject* Object, USpatialActorChannel* Channel, bool bIsInitialData, TArray<Schema_FieldId>* ClearedIds = nullptr);
 	void ApplyHandoverSchemaObject(Schema_Object* ComponentObject, UObject* Object, USpatialActorChannel* Channel, bool bIsInitialData, TArray<Schema_FieldId>* ClearedIds = nullptr);
 
-	void ApplyProperty(Schema_Object* Object, Schema_FieldId FieldId, uint32 Index, UProperty* Property, uint8* Data, int32 Offset, int32 ParentIndex);
-	void ApplyArray(Schema_Object* Object, Schema_FieldId FieldId, UArrayProperty* Property, uint8* Data, int32 Offset, int32 ParentIndex);
+	void ApplyProperty(Schema_Object* Object, Schema_FieldId FieldId, FObjectReferencesMap& InObjectReferencesMap, uint32 Index, UProperty* Property, uint8* Data, int32 Offset, int32 ParentIndex);
+	void ApplyArray(Schema_Object* Object, Schema_FieldId FieldId, FObjectReferencesMap& InObjectReferencesMap, UArrayProperty* Property, uint8* Data, int32 Offset, int32 ParentIndex);
 
 	uint32 GetPropertyCount(const Schema_Object* Object, Schema_FieldId Id, UProperty* Property);
 
@@ -29,7 +29,7 @@ private:
 	class USpatialPackageMapClient* PackageMap;
 	class USpatialNetDriver* NetDriver;
 	class USpatialTypebindingManager* TypebindingManager;
-	FObjectReferencesMap& ObjectReferencesMap;
+	FObjectReferencesMap& RootObjectReferencesMap;
 	TSet<FUnrealObjectRef>& UnresolvedRefs;
 };
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
We were using the same ObjectReferencesMap (in `ComponentReader`) to mark unresolved references to root level objects and the ones within arrays. Which meant that upon resolution, `SpatialReceiver` just memcpy'd using the in-array offset, which is usually where the `vtable` of the parent object would be. Now we properly use a hierarchy of ObjectReferenceMaps.
#### Tests
Made a branch of StarterProject (`gym-array-of-uobjects`) that exhibits the behavior, verified that references got replicated correctly afterwards. 
What automated tests are included in this PR?
#### Documentation
No need
#### Primary reviewers
@davedolben @Vatyx @improbable-valentyn 