### PR TITLE
fixed numbering of list in singleton actors doc page

### DIFF
--- a/SpatialGDK/Documentation/content/singleton-actors.md
+++ b/SpatialGDK/Documentation/content/singleton-actors.md
@@ -19,7 +19,7 @@ Due to Unreal server-workers spawning their own instances of each Singleton Acto
 
 To set up Singleton Actors for your project, you need to:
 1. Register Singleton Actors by tagging them with the `SpatialType=Singleton` class attribute.
-1. Add the generated components to the UnrealWorker worker configuration file.
+2. Add the generated components to the UnrealWorker worker configuration file.
 
 ## How to tag classes with Singleton Actor identifiers
 

--- a/SpatialGDK/Documentation/content/singleton-actors.md
+++ b/SpatialGDK/Documentation/content/singleton-actors.md
@@ -18,8 +18,9 @@ Due to Unreal server-workers spawning their own instances of each Singleton Acto
 ## Setting up Singleton Actors
 
 To set up Singleton Actors for your project, you need to:
+
 1. Register Singleton Actors by tagging them with the `SpatialType=Singleton` class attribute.
-2. Add the generated components to the UnrealWorker worker configuration file.
+1. Add the generated components to the UnrealWorker worker configuration file.
 
 ## How to tag classes with Singleton Actor identifiers
 


### PR DESCRIPTION
This doesn't show up as an error on the github version of the docs because I guess it automatically detects a list then generates the numbers, but on the Spatial Docs page both numbers of the list are "1."