### PR TITLE
Fix broken stuff

### DIFF
--- a/SpatialGDK/Source/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/Public/EngineClasses/SpatialNetDriver.h
@@ -107,7 +107,7 @@ public:
 	USpatialPackageMapClient* PackageMap;
 	UPROPERTY()
 	USpatialStaticComponentView* StaticComponentView;
-
+	UPROPERTY()
 	UEntityRegistry* EntityRegistry;
 
 	TMap<UClass*, TPair<AActor*, USpatialActorChannel*>> SingletonActorChannels;

--- a/SpatialGDK/Source/Public/Schema/Component.h
+++ b/SpatialGDK/Source/Public/Schema/Component.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <improbable/c_worker.h>
+
 namespace improbable
 {
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
TL;DR: Stuff was broken. This fixes it.

The first one is the compilation error hidden by unity build.
The second is a crash caused by `UPROPERTY` being removed from `EntityRegistry`, which results in `EntityRegistry` being garbage collected.
#### Primary reviewers
@m-samiec @Vatyx 