### PR TITLE
Load URL override from command line for clients

### DIFF
--- a/SpatialGDK/Source/Public/EngineClasses/SpatialGameInstance.h
+++ b/SpatialGDK/Source/Public/EngineClasses/SpatialGameInstance.h
@@ -25,7 +25,7 @@ protected:
 	// Can be used to decide whether to use Unreal networking or SpatialOS networking.
 	bool HasSpatialNetDriver() const;
 	// Helper function that bypasses some of the Unreal flow (which won't work with the SpatialOS model) when launching a new game as a client.
-	bool StartGameInstance_SpatialGDKClient(FString& Error);
+	bool StartGameInstance_SpatialGDKClient(bool bIsPIE, FString& Error);
 
 	// Builds a URL for initial connection, similar to what UGameInstance::StartGameInstance does.
 	FURL GetInitialGameURL() const;

--- a/SpatialGDK/Source/Public/EngineClasses/SpatialGameInstance.h
+++ b/SpatialGDK/Source/Public/EngineClasses/SpatialGameInstance.h
@@ -26,4 +26,7 @@ protected:
 	bool HasSpatialNetDriver() const;
 	// Helper function that bypasses some of the Unreal flow (which won't work with the SpatialOS model) when launching a new game as a client.
 	bool StartGameInstance_SpatialGDKClient(FString& Error);
+
+	// Builds a URL for initial connection, similar to what UGameInstance::StartGameInstance does.
+	FURL GetInitialGameURL() const;
 };


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Command-line URL overrides were being ignored for clients. Fix this by reading them explicitly.

#### Tests
Tested manually with a map override in the command line when launching a client.

#### Documentation
n/a

#### Primary reviewers
@Vatyx @joshuahuburn 