### PR TITLE
Prevented auto connect, and removed receptionist flag to allow defaul…

### DIFF
--- a/SpatialGDK/Source/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialGameInstance.cpp
@@ -143,18 +143,5 @@ void USpatialGameInstance::StartGameInstance()
 		SpatialConnection = NewObject<USpatialWorkerConnection>();
 	}
 
-	if (!GIsClient || !HasSpatialNetDriver())
-	{
-		Super::StartGameInstance();
-	}
-	else
-	{
-		FString Error;
-
-		if (!StartGameInstance_SpatialGDKClient(Error))
-		{
-			UE_LOG(LogSpatialGameInstance, Fatal, TEXT("Unable to browse to starting map: %s. Application will now exit."), *Error);
-			FPlatformMisc::RequestExit(false);
-		}
-	}
+	Super::StartGameInstance();
 }

--- a/SpatialGDK/Source/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialNetDriver.cpp
@@ -115,7 +115,7 @@ void USpatialNetDriver::OnMapLoaded(UWorld* LoadedWorld)
 		Connection->LocatorConfig.LoginToken = LoadedWorld->URL.GetOption(TEXT("token="), TEXT(""));
 		Connection->LocatorConfig.UseExternalIp = true;
 	}
-	else if (LoadedWorld->URL.HasOption(TEXT("receptionist")))
+	else
 	{
 		// Check for overrides in the travel URL.
 		if (!LoadedWorld->URL.Host.IsEmpty())


### PR DESCRIPTION
#### Description
Prevent auto-connection when booting in standalone mode. Editor/PIE connection has not changed and can still be toggled via the `auto connect to server` flag. We can update LaunchClient script to auto connect if we prefer. Also removed the receptionist flag to match native unreal behaviour when using the `open` command.

#### Tests
Tested PIE and standalone deployments.

#### Primary reviewers
@joshuahuburn @Vatyx 