### PR TITLE
Fix linux build support - Removed uneeded typename identifiers

### DIFF
--- a/SpatialGDK/Source/Private/Interop/SpatialStaticComponentView.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialStaticComponentView.cpp
@@ -22,7 +22,7 @@ bool USpatialStaticComponentView::HasAuthority(Worker_EntityId EntityId, Worker_
 }
 
 template <typename T>
-typename T* USpatialStaticComponentView::GetComponentData(Worker_EntityId EntityId)
+T* USpatialStaticComponentView::GetComponentData(Worker_EntityId EntityId)
 {
 	if (TMap<Worker_ComponentId, TUniquePtr<ComponentStorageBase>>* ComponentStorageMap = EntityComponentMap.Find(EntityId))
 	{

--- a/SpatialGDK/Source/Public/Interop/SpatialStaticComponentView.h
+++ b/SpatialGDK/Source/Public/Interop/SpatialStaticComponentView.h
@@ -22,7 +22,9 @@ class SPATIALGDK_API USpatialStaticComponentView : public UObject
 public:
 	Worker_Authority GetAuthority(Worker_EntityId EntityId, Worker_ComponentId ComponentId);
 	bool HasAuthority(Worker_EntityId EntityId, Worker_ComponentId ComponentId);
-	template <typename T> typename  T* GetComponentData(Worker_EntityId EntityId);
+
+	template <class T> T* GetComponentData(Worker_EntityId EntityId);
+
 	void OnAddComponent(const Worker_AddComponentOp& Op);
 	void OnRemoveEntity(const Worker_RemoveEntityOp& Op);
 	void OnComponentUpdate(const Worker_ComponentUpdateOp& Op);

--- a/SpatialGDK/Source/Public/Schema/Component.h
+++ b/SpatialGDK/Source/Public/Schema/Component.h
@@ -26,8 +26,8 @@ template <typename T>
 class ComponentStorage : public ComponentStorageBase
 {
 public:
-	explicit ComponentStorage(const typename T& data) : data{data} {}
-	explicit ComponentStorage(typename T&& data) : data{std::move(data)} {}
+	explicit ComponentStorage(const T& data) : data{data} {}
+	explicit ComponentStorage(T&& data) : data{std::move(data)} {}
 	~ComponentStorage() override {}
 
 	TUniquePtr<ComponentStorageBase> Copy() const override
@@ -35,13 +35,13 @@ public:
 		return TUniquePtr<ComponentStorageBase>{new ComponentStorage{data}};
 	}
 
-	typename T& Get()
+	T& Get()
 	{
 		return data;
 	}
 
 private:
-	typename T data;
+	T data;
 };
 
 }


### PR DESCRIPTION
Fixes Linux build support.

Klang compiler was not happy with uneeded `typename` identifiers in `Component.h` and `SpatialStaticComponentView.h`

Tested? Linux Development works on my machine.jpeg

Reviewers:
@danielimprobable @Vatyx 