### PR TITLE
UNR-659 Clean up actor channels

### DIFF
--- a/SpatialGDK/Source/Private/Interop/GlobalStateManager.cpp
+++ b/SpatialGDK/Source/Private/Interop/GlobalStateManager.cpp
@@ -178,7 +178,10 @@ void UGlobalStateManager::GetSingletonActorAndChannel(FString ClassName, AActor*
 	USpatialNetConnection* Connection = Cast<USpatialNetConnection>(NetDriver->ClientConnections[0]);
 
 	OutChannel = (USpatialActorChannel*)Connection->CreateChannel(CHTYPE_Actor, 1);
-	NetDriver->SingletonActorChannels.Add(SingletonActorClass, TPair<AActor*, USpatialActorChannel*>(OutActor, OutChannel));
+	if (OutChannel)
+	{
+		NetDriver->SingletonActorChannels.Add(SingletonActorClass, TPair<AActor*, USpatialActorChannel*>(OutActor, OutChannel));
+	}
 }
 
 bool UGlobalStateManager::IsSingletonEntity(Worker_EntityId EntityId)

--- a/SpatialGDK/Source/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialReceiver.cpp
@@ -317,6 +317,7 @@ void USpatialReceiver::ReceiveActor(Worker_EntityId EntityId)
 		USpatialActorChannel* Channel = Cast<USpatialActorChannel>(Connection->CreateChannel(CHTYPE_Actor, NetDriver->IsServer()));
 		if (!Channel)
 		{
+			UE_LOG(LogSpatialReceiver, Warning, TEXT("Failed to create an actor channel when receiving entity %lld. The actor will not be spawned."), EntityId);
 			EntityActor->Destroy(true);
 			return;
 		}


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
We weren't cleaning up actor channels when destroying actors as a result of a remove entity op, which resulted in us running out of channels and crashing.
The fix makes sure the channels are cleaned up when the entities are destroyed or go out of view, and also we don't crash if we run out of channels (though you won't be able to replicate that many actors).
#### Documentation
https://improbableio.atlassian.net/browse/UNR-659
#### Primary reviewers
@davedolben @m-samiec 