### PR TITLE
UNR-658: Switch checkfs to early-outs on failed statically-named actor resolution

### DIFF
--- a/SpatialGDK/Source/Private/EngineClasses/SpatialNetBitReader.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialNetBitReader.cpp
@@ -53,7 +53,12 @@ FArchive& FSpatialNetBitReader::operator<<(UObject*& Value)
 		if (NetGUID.IsValid())
 		{
 			Value = PackageMapClient->GetObjectFromNetGUID(NetGUID, true);
-			checkf(Value, TEXT("An object ref %s should map to a valid object."), *ObjectRef.ToString());
+			//checkf(Value, TEXT("An object ref %s should map to a valid object."), *ObjectRef.ToString());
+			if (!Value)
+			{
+				UE_LOG(LogTemp, Error, TEXT("An object ref %s %s should map to a valid object."), *ObjectRef.ToString(), ObjectRef.Path.IsSet() ? **ObjectRef.Path : TEXT("NO PATH"));
+				Value = nullptr;
+			}
 		}
 		else
 		{

--- a/SpatialGDK/Source/Private/EngineClasses/SpatialNetBitReader.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialNetBitReader.cpp
@@ -55,13 +55,14 @@ FArchive& FSpatialNetBitReader::operator<<(UObject*& Value)
 		if (NetGUID.IsValid())
 		{
 			Value = PackageMapClient->GetObjectFromNetGUID(NetGUID, true);
-			if (!Value)
+			if (Value == nullptr)
 			{
 				// At this point, we're unable to resolve a stably-named actor by path. This likely means either the actor doesn't exist, or
 				// it's part of a streaming level that hasn't been streamed in. In either case, there's nothing we can do.
+				FString FullPath;
+				improbable::GetFullPathFromUnrealObjectReference(ObjectRef, FullPath);
 				UE_LOG(LogSpatialNetBitReader, Warning, TEXT("Object ref did not map to valid object, will be set to nullptr: %s %s"),
-					*ObjectRef.ToString(), ObjectRef.Path.IsSet() ? **ObjectRef.Path : TEXT("[NO PATH]"));
-				Value = nullptr;
+					*ObjectRef.ToString(), FullPath.IsEmpty() ? TEXT("[NO PATH]") : *FullPath);
 			}
 		}
 		else

--- a/SpatialGDK/Source/Private/EngineClasses/SpatialNetBitReader.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialNetBitReader.cpp
@@ -53,7 +53,6 @@ FArchive& FSpatialNetBitReader::operator<<(UObject*& Value)
 		if (NetGUID.IsValid())
 		{
 			Value = PackageMapClient->GetObjectFromNetGUID(NetGUID, true);
-			//checkf(Value, TEXT("An object ref %s should map to a valid object."), *ObjectRef.ToString());
 			if (!Value)
 			{
 				UE_LOG(LogTemp, Error, TEXT("An object ref %s %s should map to a valid object."), *ObjectRef.ToString(), ObjectRef.Path.IsSet() ? **ObjectRef.Path : TEXT("NO PATH"));

--- a/SpatialGDK/Source/Private/Utils/ComponentReader.cpp
+++ b/SpatialGDK/Source/Private/Utils/ComponentReader.cpp
@@ -297,12 +297,15 @@ void ComponentReader::ApplyProperty(Schema_Object* Object, Schema_FieldId FieldI
 			if (NetGUID.IsValid())
 			{
 				UObject* ObjectValue = PackageMap->GetObjectFromNetGUID(NetGUID, true);
-				if (!ObjectValue)
+				if (ObjectValue == nullptr)
 				{
 					// At this point, we're unable to resolve a stably-named actor by path. This likely means either the actor doesn't exist, or
 					// it's part of a streaming level that hasn't been streamed in. In either case, there's nothing we can do.
+					FString FullPath;
+					improbable::GetFullPathFromUnrealObjectReference(ObjectRef, FullPath);
 					UE_LOG(LogSpatialComponentReader, Warning, TEXT("Object ref did not map to valid object, will be set to nullptr: %s %s"),
-						*ObjectRef.ToString(), ObjectRef.Path.IsSet() ? **ObjectRef.Path : TEXT("[NO PATH]"));
+						*ObjectRef.ToString(), FullPath.IsEmpty() ? TEXT("[NO PATH]") : *FullPath);
+					ObjectProperty->SetObjectPropertyValue(Data, nullptr);
 					return;
 				}
 				checkf(ObjectValue->IsA(ObjectProperty->PropertyClass), TEXT("Object ref %s maps to object %s with the wrong class."), *ObjectRef.ToString(), *ObjectValue->GetFullName());

--- a/SpatialGDK/Source/Private/Utils/ComponentReader.cpp
+++ b/SpatialGDK/Source/Private/Utils/ComponentReader.cpp
@@ -11,6 +11,8 @@
 #include "Utils/SchemaUtils.h"
 #include "Utils/RepLayoutUtils.h"
 
+DEFINE_LOG_CATEGORY(LogSpatialComponentReader);
+
 namespace improbable
 {
 
@@ -299,7 +301,8 @@ void ComponentReader::ApplyProperty(Schema_Object* Object, Schema_FieldId FieldI
 				{
 					// At this point, we're unable to resolve a stably-named actor by path. This likely means either the actor doesn't exist, or
 					// it's part of a streaming level that hasn't been streamed in. In either case, there's nothing we can do.
-					UE_LOG(LogTemp, Error, TEXT("An object ref %s %s should map to a valid object."), *ObjectRef.ToString(), ObjectRef.Path.IsSet() ? **ObjectRef.Path : TEXT("NO PATH"));
+					UE_LOG(LogSpatialComponentReader, Warning, TEXT("Object ref did not map to valid object, will be set to nullptr: %s %s"),
+						*ObjectRef.ToString(), ObjectRef.Path.IsSet() ? **ObjectRef.Path : TEXT("[NO PATH]"));
 					return;
 				}
 				checkf(ObjectValue->IsA(ObjectProperty->PropertyClass), TEXT("Object ref %s maps to object %s with the wrong class."), *ObjectRef.ToString(), *ObjectValue->GetFullName());

--- a/SpatialGDK/Source/Private/Utils/ComponentReader.cpp
+++ b/SpatialGDK/Source/Private/Utils/ComponentReader.cpp
@@ -295,9 +295,10 @@ void ComponentReader::ApplyProperty(Schema_Object* Object, Schema_FieldId FieldI
 			if (NetGUID.IsValid())
 			{
 				UObject* ObjectValue = PackageMap->GetObjectFromNetGUID(NetGUID, true);
-				//checkf(ObjectValue, TEXT("An object ref %s should map to a valid object."), *ObjectRef.ToString());
 				if (!ObjectValue)
 				{
+					// At this point, we're unable to resolve a stably-named actor by path. This likely means either the actor doesn't exist, or
+					// it's part of a streaming level that hasn't been streamed in. In either case, there's nothing we can do.
 					UE_LOG(LogTemp, Error, TEXT("An object ref %s %s should map to a valid object."), *ObjectRef.ToString(), ObjectRef.Path.IsSet() ? **ObjectRef.Path : TEXT("NO PATH"));
 					return;
 				}

--- a/SpatialGDK/Source/Private/Utils/ComponentReader.cpp
+++ b/SpatialGDK/Source/Private/Utils/ComponentReader.cpp
@@ -295,7 +295,12 @@ void ComponentReader::ApplyProperty(Schema_Object* Object, Schema_FieldId FieldI
 			if (NetGUID.IsValid())
 			{
 				UObject* ObjectValue = PackageMap->GetObjectFromNetGUID(NetGUID, true);
-				checkf(ObjectValue, TEXT("An object ref %s should map to a valid object."), *ObjectRef.ToString());
+				//checkf(ObjectValue, TEXT("An object ref %s should map to a valid object."), *ObjectRef.ToString());
+				if (!ObjectValue)
+				{
+					UE_LOG(LogTemp, Error, TEXT("An object ref %s %s should map to a valid object."), *ObjectRef.ToString(), ObjectRef.Path.IsSet() ? **ObjectRef.Path : TEXT("NO PATH"));
+					return;
+				}
 				checkf(ObjectValue->IsA(ObjectProperty->PropertyClass), TEXT("Object ref %s maps to object %s with the wrong class."), *ObjectRef.ToString(), *ObjectValue->GetFullName());
 				ObjectProperty->SetObjectPropertyValue(Data, ObjectValue);
 			}

--- a/SpatialGDK/Source/Private/Utils/SchemaUtils.cpp
+++ b/SpatialGDK/Source/Private/Utils/SchemaUtils.cpp
@@ -4,10 +4,11 @@
 
 #include "improbable/UnrealObjectRef.h"
 
+namespace improbable
+{
 
-namespace improbable {
-
-void GetFullPathFromUnrealObjectReference(const FUnrealObjectRef& ObjectRef, FString& OutPath) {
+void GetFullPathFromUnrealObjectReference(const FUnrealObjectRef& ObjectRef, FString& OutPath)
+{
 	if (!ObjectRef.Path.IsSet())
 	{
 		return;

--- a/SpatialGDK/Source/Private/Utils/SchemaUtils.cpp
+++ b/SpatialGDK/Source/Private/Utils/SchemaUtils.cpp
@@ -1,0 +1,25 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "Utils/SchemaUtils.h"
+
+#include "improbable/UnrealObjectRef.h"
+
+
+namespace improbable {
+
+void GetFullPathFromUnrealObjectReference(const FUnrealObjectRef& ObjectRef, FString& OutPath) {
+	if (!ObjectRef.Path.IsSet())
+	{
+		return;
+	}
+
+	if (ObjectRef.Outer.IsSet())
+	{
+		GetFullPathFromUnrealObjectReference(*ObjectRef.Outer, OutPath);
+		OutPath.Append(TEXT("."));
+	}
+
+	OutPath.Append(*ObjectRef.Path);
+}
+
+}  // namespace improbable

--- a/SpatialGDK/Source/Public/EngineClasses/SpatialNetBitReader.h
+++ b/SpatialGDK/Source/Public/EngineClasses/SpatialNetBitReader.h
@@ -7,6 +7,8 @@
 
 #include "improbable/UnrealObjectRef.h"
 
+DECLARE_LOG_CATEGORY_EXTERN(LogSpatialNetBitReader, All, All);
+
 class USpatialPackageMapClient;
 
 class SPATIALGDK_API FSpatialNetBitReader : public FNetBitReader

--- a/SpatialGDK/Source/Public/Utils/ComponentReader.h
+++ b/SpatialGDK/Source/Public/Utils/ComponentReader.h
@@ -5,6 +5,8 @@
 #include "EngineClasses/SpatialNetBitReader.h"
 #include "Interop/SpatialReceiver.h"
 
+DECLARE_LOG_CATEGORY_EXTERN(LogSpatialComponentReader, All, All);
+
 namespace improbable
 {
 

--- a/SpatialGDK/Source/Public/Utils/SchemaUtils.h
+++ b/SpatialGDK/Source/Public/Utils/SchemaUtils.h
@@ -167,4 +167,8 @@ inline StringToEntityMap GetStringToEntityMapFromSchema(Schema_Object* Object, S
 	return Map;
 }
 
+// Generates the full path from an ObjectRef, if it has paths. Writes the result to OutPath.
+// Does not clear OutPath first.
+void GetFullPathFromUnrealObjectReference(const FUnrealObjectRef& ObjectRef, FString& OutPath);
+
 }


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Stably-named actor resolution can fail if the referred actor is in a streaming level that hasn't been loaded yet. Change checkfs that would crash under these circumstances to early outs with error logs.

#### Tests
Validated against local streaming level test case and Scavengers, where the problem was initially discovered.

#### Documentation
n/a

#### Primary reviewers
@Vatyx @girayimprobable 