### PR TITLE
Fix crash for when subobject doesn't exist

### DIFF
--- a/SpatialGDK/Source/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialReceiver.cpp
@@ -806,6 +806,7 @@ UObject* USpatialReceiver::GetTargetObjectFromChannelAndClass(USpatialActorChann
 		{
 			return Obj->GetClass() == Class;
 		});
+
 		if (FoundSubobject != nullptr)
 		{
 			TargetObject = *FoundSubobject;

--- a/SpatialGDK/Source/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialReceiver.cpp
@@ -806,7 +806,6 @@ UObject* USpatialReceiver::GetTargetObjectFromChannelAndClass(USpatialActorChann
 		{
 			return Obj->GetClass() == Class;
 		});
-		
 		if (FoundSubobject != nullptr)
 		{
 			TargetObject = *FoundSubobject;

--- a/SpatialGDK/Source/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialReceiver.cpp
@@ -813,7 +813,7 @@ UObject* USpatialReceiver::GetTargetObjectFromChannelAndClass(USpatialActorChann
 		}
 		else
 		{
-			UE_LOG(LogSpatialReceiver, Warning, TEXT("No target object for Class %s on Actor %s. Most likely this subobject was deleted?"),
+			UE_LOG(LogSpatialReceiver, Warning, TEXT("No target object for Class %s on Actor %s. Was this subobject was deleted?"),
 				*Class->GetName(), *Channel->Actor->GetName());
 		}
 	}

--- a/SpatialGDK/Source/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialReceiver.cpp
@@ -806,8 +806,16 @@ UObject* USpatialReceiver::GetTargetObjectFromChannelAndClass(USpatialActorChann
 		{
 			return Obj->GetClass() == Class;
 		});
-		check(FoundSubobject);
-		TargetObject = *FoundSubobject;
+		
+		if (FoundSubobject != nullptr)
+		{
+			TargetObject = *FoundSubobject;
+		}
+		else
+		{
+			UE_LOG(LogSpatialReceiver, Warning, TEXT("No target object for Class %s on Actor %s. Most likely this subobject was deleted?"),
+				*Class->GetName(), *Channel->Actor->GetName());
+		}
 	}
 
 	return TargetObject;

--- a/SpatialGDK/Source/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialReceiver.cpp
@@ -813,7 +813,7 @@ UObject* USpatialReceiver::GetTargetObjectFromChannelAndClass(USpatialActorChann
 		}
 		else
 		{
-			UE_LOG(LogSpatialReceiver, Warning, TEXT("No target object for Class %s on Actor %s. Was this subobject was deleted?"),
+			UE_LOG(LogSpatialReceiver, Warning, TEXT("No target object for Class %s on Actor %s. Was this subobject deleted?"),
 				*Class->GetName(), *Channel->Actor->GetName());
 		}
 	}


### PR DESCRIPTION
#### Description
If a subobject is deleted locally, it can still receive updates from Spatial. In that case we shouldn't crash.