### PR TITLE
Only call MergeChangeList if something has changed

### DIFF
--- a/SpatialGDK/Source/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialActorChannel.cpp
@@ -279,7 +279,11 @@ bool USpatialActorChannel::ReplicateActor()
 		const int32 HistoryIndex = i % FRepChangelistState::MAX_CHANGE_HISTORY;
 		FRepChangedHistory& HistoryItem = ChangelistState->ChangeHistory[HistoryIndex];
 		TArray<uint16> Temp = RepChanged;
-		ActorReplicator->RepLayout->MergeChangeList((uint8*)Actor, HistoryItem.Changed, Temp, RepChanged);
+
+		if (HistoryItem.Changed.Num() > 0)
+		{
+			ActorReplicator->RepLayout->MergeChangeList((uint8*)Actor, HistoryItem.Changed, Temp, RepChanged);
+		}
 	}
 
 	ActorReplicator->RepState->LastCompareIndex = ChangelistState->CompareIndex;
@@ -382,7 +386,11 @@ bool USpatialActorChannel::ReplicateSubobject(UObject* Object, const FReplicatio
 		const int32 HistoryIndex = i % FRepChangelistState::MAX_CHANGE_HISTORY;
 		FRepChangedHistory& HistoryItem = ChangelistState->ChangeHistory[HistoryIndex];
 		TArray<uint16> Temp = RepChanged;
-		Replicator.RepLayout->MergeChangeList((uint8*)Object, HistoryItem.Changed, Temp, RepChanged);
+
+		if (HistoryItem.Changed.Num() > 0)
+		{
+			Replicator.RepLayout->MergeChangeList((uint8*)Object, HistoryItem.Changed, Temp, RepChanged);
+		}
 	}
 
 	Replicator.RepState->LastCompareIndex = ChangelistState->CompareIndex;

--- a/SpatialGDK/Source/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialActorChannel.cpp
@@ -284,6 +284,10 @@ bool USpatialActorChannel::ReplicateActor()
 		{
 			ActorReplicator->RepLayout->MergeChangeList((uint8*)Actor, HistoryItem.Changed, Temp, RepChanged);
 		}
+		else
+		{
+			UE_LOG(LogSpatialActorChannel, Warning, TEXT("EntityId: %lld Actor: %s Changelist with index %d has no changed items"), EntityId, *Actor->GetName(), i);
+		}
 	}
 
 	ActorReplicator->RepState->LastCompareIndex = ChangelistState->CompareIndex;
@@ -390,6 +394,10 @@ bool USpatialActorChannel::ReplicateSubobject(UObject* Object, const FReplicatio
 		if (HistoryItem.Changed.Num() > 0)
 		{
 			Replicator.RepLayout->MergeChangeList((uint8*)Object, HistoryItem.Changed, Temp, RepChanged);
+		}
+		else
+		{
+			UE_LOG(LogSpatialActorChannel, Warning, TEXT("EntityId: %lld Actor: %s Subobject: %s Changelist with index %d has no changed items"), EntityId, *Actor->GetName(), *Object->GetName(), i);
 		}
 	}
 


### PR DESCRIPTION
#### Description
Was causing a crash in Scavengers. We should only be merging changelists if something has changed.