### PR TITLE
Added check for timed out player spawning if in editor

### DIFF
--- a/SpatialGDK/Source/Private/Interop/SpatialPlayerSpawner.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialPlayerSpawner.cpp
@@ -62,6 +62,12 @@ void USpatialPlayerSpawner::ReceivePlayerSpawnResponse(Worker_CommandResponseOp&
 	{
 		UE_LOG(LogSpatialPlayerSpawner, Display, TEXT("Player spawned sucessfully"));
 	}
+#if WITH_EDITOR
+	else if (Op.status_code == WORKER_STATUS_CODE_TIMEOUT)
+	{
+		UE_LOG(LogSpatialPlayerSpawner, Warning, TEXT("Player spawn request timed out in editor. This is probably due the server taking a long time to start up. The player should spawn once it's finished loading."));
+	}
+#endif
 	else if (NumberOfAttempts < SpatialConstants::MAX_NUMBER_COMMAND_ATTEMPTS)
 	{
 		UE_LOG(LogSpatialPlayerSpawner, Warning, TEXT("Player spawn request failed: \"%s\""),


### PR DESCRIPTION
#### Description
This stops there being multiple spawn requests for a client when launching a PIE server that takes a long time to start up.

#### Primary reviewers
@girayimprobable @improbable-valentyn 