### PR TITLE
Make external IP setting explicit in Unreal URLs

### DIFF
--- a/SpatialGDK/Source/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialNetDriver.cpp
@@ -123,14 +123,7 @@ void USpatialNetDriver::OnMapLoaded(UWorld* LoadedWorld)
 			Connection->ReceptionistConfig.ReceptionistPort = LoadedWorld->URL.Port;
 		}
 
-		if (Connection->ReceptionistConfig.ReceptionistHost.Compare(SpatialConstants::LOCAL_HOST) == 0)
-		{
-			Connection->ReceptionistConfig.UseExternalIp = false;
-		}
-		else
-		{
-			Connection->ReceptionistConfig.UseExternalIp = true;
-		}
+		Connection->ReceptionistConfig.UseExternalIp = LoadedWorld->URL.HasOption(TEXT("useExternalIpForBridge"));
 	}
 
 	Connect();


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Require explicitly setting `useExternalIpForBridge` option in Unreal URLs for the receptionist flow instead of trying to infer its value. This is necessary because, to properly use `spatial cloud connect external`, you must connect to localhost with external IP enabled, meaning the only case in which we could properly infer it is actually ambiguous.

#### Tests
Tested with receptionist flow for local deployment and cloud deployment.

#### Documentation
not yet documented

#### Primary reviewers
@Vatyx @joshuahuburn 