### PR TITLE
Resolve singletons on non-authoritative servers

### DIFF
--- a/SpatialGDK/Source/Private/Interop/GlobalStateManager.cpp
+++ b/SpatialGDK/Source/Private/Interop/GlobalStateManager.cpp
@@ -75,15 +75,8 @@ void UGlobalStateManager::LinkExistingSingletonActors()
 
 		Channel->SetChannelActor(SingletonActor);
 
-		improbable::UnrealMetadata* UnrealMetadata = StaticComponentView->GetComponentData<improbable::UnrealMetadata>(SingletonEntityId);
-		if (UnrealMetadata == nullptr)
-		{
-			// Don't have entity checked out
-			continue;
-		}
-
 		// Since the entity already exists, we have to handle setting up the PackageMap properly for this Actor
-		NetDriver->PackageMap->ResolveEntityActor(SingletonActor, SingletonEntityId, UnrealMetadata->SubobjectNameToOffset);
+		NetDriver->PackageMap->ResolveEntityActor(SingletonActor, SingletonEntityId, improbable::CreateOffsetMapFromActor(SingletonActor));
 		UE_LOG(LogGlobalStateManager, Log, TEXT("Linked Singleton Actor %s with id %d"), *SingletonActor->GetClass()->GetName(), SingletonEntityId);
 	}
 }

--- a/SpatialGDK/Source/Public/Interop/SpatialStaticComponentView.h
+++ b/SpatialGDK/Source/Public/Interop/SpatialStaticComponentView.h
@@ -23,13 +23,15 @@ public:
 	Worker_Authority GetAuthority(Worker_EntityId EntityId, Worker_ComponentId ComponentId);
 	bool HasAuthority(Worker_EntityId EntityId, Worker_ComponentId ComponentId);
 
-	template <class T> T* GetComponentData(Worker_EntityId EntityId);
+	template <typename T>
+	T* GetComponentData(Worker_EntityId EntityId);
 
 	void OnAddComponent(const Worker_AddComponentOp& Op);
 	void OnRemoveEntity(const Worker_RemoveEntityOp& Op);
 	void OnComponentUpdate(const Worker_ComponentUpdateOp& Op);
 	void OnAuthorityChange(const Worker_AuthorityChangeOp& Op);
 
+private:
 	TMap<Worker_EntityId_Key, TMap<Worker_ComponentId, Worker_Authority>> EntityComponentAuthorityMap;
 	TMap<Worker_EntityId_Key, TMap<Worker_ComponentId, TUniquePtr<improbable::ComponentStorageBase>>> EntityComponentMap;
 };


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Singletons were not resolved on non-authoritative servers because the call to `ResolveEntityActor` was removed from the bit in `ReceiveActor` where the actor already exists.
#### Primary reviewers
@Vatyx @m-samiec 