### PR TITLE
Don't send component updates unless you have authority

### DIFF
--- a/SpatialGDK/Source/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialActorChannel.cpp
@@ -715,7 +715,7 @@ void USpatialActorChannel::SpatialViewTick()
 					bFirstTick = false;
 				}
 			}
-			else if(!NetDriver->IsServer())
+			else if (!NetDriver->IsServer())
 			{
 				Sender->SendComponentInterest(Actor, GetEntityId());
 

--- a/SpatialGDK/Source/Private/Interop/GlobalStateManager.cpp
+++ b/SpatialGDK/Source/Private/Interop/GlobalStateManager.cpp
@@ -121,7 +121,7 @@ void UGlobalStateManager::UpdateSingletonEntityId(const FString& ClassName, cons
 
 	if (!NetDriver->StaticComponentView->HasAuthority(SpatialConstants::GLOBAL_STATE_MANAGER, SpatialConstants::GLOBAL_STATE_MANAGER_COMPONENT_ID))
 	{
-		UE_LOG(LogGlobalStateManager, Warning, TEXT("UpdateSingletonEntityId: no authority over the GSM! Singleton class: %s, entity: %lld"), *ClassName, SingletonEntityId);
+		UE_LOG(LogGlobalStateManager, Warning, TEXT("UpdateSingletonEntityId: no authority over the GSM! Update will not be sent. Singleton class: %s, entity: %lld"), *ClassName, SingletonEntityId);
 		return;
 	}
 

--- a/SpatialGDK/Source/Private/Interop/GlobalStateManager.cpp
+++ b/SpatialGDK/Source/Private/Interop/GlobalStateManager.cpp
@@ -119,6 +119,12 @@ void UGlobalStateManager::UpdateSingletonEntityId(const FString& ClassName, cons
 {
 	SingletonNameToEntityId[ClassName] = SingletonEntityId;
 
+	if (!NetDriver->StaticComponentView->HasAuthority(SpatialConstants::GLOBAL_STATE_MANAGER, SpatialConstants::GLOBAL_STATE_MANAGER_COMPONENT_ID))
+	{
+		UE_LOG(LogGlobalStateManager, Warning, TEXT("UpdateSingletonEntityId: no authority over the GSM! Singleton class: %s, entity: %lld"), *ClassName, SingletonEntityId);
+		return;
+	}
+
 	Worker_ComponentUpdate Update = {};
 	Update.component_id = SpatialConstants::GLOBAL_STATE_MANAGER_COMPONENT_ID;
 	Update.schema_type = Schema_CreateComponentUpdate(SpatialConstants::GLOBAL_STATE_MANAGER_COMPONENT_ID);

--- a/SpatialGDK/Source/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialSender.cpp
@@ -240,7 +240,7 @@ void USpatialSender::SendComponentUpdates(UObject* Object, USpatialActorChannel*
 	{
 		if (!NetDriver->StaticComponentView->HasAuthority(EntityId, Update.component_id))
 		{
-			UE_LOG(LogSpatialSender, Warning, TEXT("Trying to send component update but don't have authority! Component Id: %d, entity: %lld"), Update.component_id, EntityId);
+			UE_LOG(LogSpatialSender, Warning, TEXT("Trying to send component update but don't have authority! Update will not be sent. Component Id: %d, entity: %lld"), Update.component_id, EntityId);
 			continue;
 		}
 
@@ -286,11 +286,13 @@ void USpatialSender::SendComponentInterest(AActor* Actor, Worker_EntityId Entity
 
 void USpatialSender::SendPositionUpdate(Worker_EntityId EntityId, const FVector& Location)
 {
+#if !UE_BUILD_SHIPPING
 	if (!NetDriver->StaticComponentView->HasAuthority(EntityId, SpatialConstants::POSITION_COMPONENT_ID))
 	{
-		UE_LOG(LogSpatialSender, Warning, TEXT("Trying to send Position component update but don't have authority! Entity: %lld"), EntityId);
+		UE_LOG(LogSpatialSender, Warning, TEXT("Trying to send Position component update but don't have authority! Update will not be sent. Entity: %lld"), EntityId);
 		return;
 	}
+#endif
 
 	Worker_ComponentUpdate Update = improbable::Position::CreatePositionUpdate(improbable::Coordinates::FromFVector(Location));
 	Connection->SendComponentUpdate(EntityId, &Update);
@@ -298,11 +300,13 @@ void USpatialSender::SendPositionUpdate(Worker_EntityId EntityId, const FVector&
 
 void USpatialSender::SendRotationUpdate(Worker_EntityId EntityId, const FRotator& Rotation)
 {
+#if !UE_BUILD_SHIPPING
 	if (!NetDriver->StaticComponentView->HasAuthority(EntityId, SpatialConstants::ROTATION_COMPONENT_ID))
 	{
-		UE_LOG(LogSpatialSender, Warning, TEXT("Trying to send Rotation component update but don't have authority! Entity: %lld"), EntityId);
+		UE_LOG(LogSpatialSender, Warning, TEXT("Trying to send Rotation component update but don't have authority! Update will not be sent. Entity: %lld"), EntityId);
 		return;
 	}
+#endif
 
 	Worker_ComponentUpdate Update = improbable::Rotation(Rotation).CreateRotationUpdate();
 	Connection->SendComponentUpdate(EntityId, &Update);
@@ -360,9 +364,10 @@ void USpatialSender::SendRPC(TSharedRef<FPendingRPCParams> Params)
 
 			if (!NetDriver->StaticComponentView->HasAuthority(EntityId, ComponentUpdate.component_id))
 			{
-				UE_LOG(LogSpatialSender, Warning, TEXT("Trying to send MulticastRPC component update but don't have authority! Entity: %lld"), EntityId);
+				UE_LOG(LogSpatialSender, Warning, TEXT("Trying to send MulticastRPC component update but don't have authority! Update will not be sent. Entity: %lld"), EntityId);
 				return;
 			}
+
 			Connection->SendComponentUpdate(EntityId, &ComponentUpdate);
 		}
 		break;
@@ -718,7 +723,7 @@ bool USpatialSender::UpdateEntityACLs(AActor* Actor, Worker_EntityId EntityId)
 
 	if (!NetDriver->StaticComponentView->HasAuthority(EntityId, SpatialConstants::ENTITY_ACL_COMPONENT_ID))
 	{
-		UE_LOG(LogSpatialSender, Warning, TEXT("Trying to update EntityACL but don't have authority! Entity: %lld"), EntityId);
+		UE_LOG(LogSpatialSender, Warning, TEXT("Trying to update EntityACL but don't have authority! Update will not be sent. Entity: %lld"), EntityId);
 		return false;
 	}
 

--- a/SpatialGDKEditorToolbar/Source/Private/SpatialGDKEditorGenerateSnapshot.cpp
+++ b/SpatialGDKEditorToolbar/Source/Private/SpatialGDKEditorGenerateSnapshot.cpp
@@ -283,6 +283,7 @@ bool CreateStartupActor(Worker_SnapshotOutputStream* OutputStream, AActor* Actor
 	WriteAclMap ComponentWriteAcl;
 	ComponentWriteAcl.Add(SpatialConstants::POSITION_COMPONENT_ID, UnrealServerPermission);
 	ComponentWriteAcl.Add(SpatialConstants::ROTATION_COMPONENT_ID, UnrealServerPermission);
+	ComponentWriteAcl.Add(SpatialConstants::ENTITY_ACL_COMPONENT_ID, UnrealServerPermission);
 	ComponentWriteAcl.Add(ActorInfo->SingleClientComponent, UnrealServerPermission);
 	ComponentWriteAcl.Add(ActorInfo->MultiClientComponent, UnrealServerPermission);
 	ComponentWriteAcl.Add(ActorInfo->HandoverComponent, UnrealServerPermission);


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Don't send component updates unless you have authority and warn if we're trying to do so. This was causing the bug in the ThirdPersonShooter where the shot effect RPCs would be looped on the non-authoritative server, and broadcasted to the clients whenever the shooter crossed the server boundary.
Also, add the EntityACL component write ACL to the EntityACL component (EntityACLception).
#### Primary reviewers
@m-samiec @Vatyx 