### PR TITLE
UNR-621: Call `CallPreReplication` before saving out actor's in the snapshot

### DIFF
--- a/SpatialGDK/Source/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialReceiver.cpp
@@ -551,8 +551,8 @@ void USpatialReceiver::OnComponentUpdate(Worker_ComponentUpdateOp& Op)
 		UE_LOG(LogSpatialReceiver, Verbose, TEXT("Entity: %d Component: %d - Skipping because this is hand-written Spatial component"), Op.entity_id, Op.update.component_id);
 		return;
 	case SpatialConstants::GLOBAL_STATE_MANAGER_COMPONENT_ID:
-		NetDriver->GlobalStateManager->ApplyUpdate(Op.update);
-		NetDriver->GlobalStateManager->LinkExistingSingletonActors();
+		GlobalStateManager->ApplyUpdate(Op.update);
+		GlobalStateManager->LinkExistingSingletonActors();
 		return;
 	}
 

--- a/SpatialGDKEditorToolbar/Source/Private/SpatialGDKEditorGenerateSnapshot.cpp
+++ b/SpatialGDKEditorToolbar/Source/Private/SpatialGDKEditorGenerateSnapshot.cpp
@@ -222,6 +222,11 @@ TArray<Worker_ComponentData> CreateStartupActorData(USpatialActorChannel* Channe
 	FClassInfo* Info = TypebindingManager->FindClassInfoByClass(Actor->GetClass());
 	check(Info);
 
+	// This ensures that the Actor has prepared it's replicated fields before replicating. For instance, the simulate physics on a UPrimitiveComponent
+	// will be queried and set the Actor's ReplicatedMovement.bRepPhysics field. These fields are then serialized correctly within the snapshot. We are
+	// modifying the editor's instance of the actor here, but in theory those fields should be inferred or transient anyway, so it shouldn't be a problem.
+	Actor->CallPreReplication(NetDriver);
+
 	FRepChangeState InitialRepChanges = Channel->CreateInitialRepChangeState(Actor);
 	FHandoverChangeState InitialHandoverChanges = Channel->CreateInitialHandoverChangeState(Info);
 


### PR DESCRIPTION
#### Description
Call `CallPreReplication` before saving out actor's in the snapshot.
Also driveby in SpatialReceiver.

#### Tests
Tested a startup actor with simulate physics.

#### Primary reviewers
@davedolben @Vatyx 