### PR TITLE
Fix bug in Rotation::ApplyComponentUpdate

### DIFF
--- a/SpatialGDK/Source/Public/Schema/Rotation.h
+++ b/SpatialGDK/Source/Public/Schema/Rotation.h
@@ -69,9 +69,18 @@ struct Rotation : Component
 	void ApplyComponentUpdate(const Worker_ComponentUpdate& Update)
 	{
 		Schema_Object* ComponentObject = Schema_GetComponentUpdateFields(Update.schema_type);
-		Pitch = Schema_GetDouble(ComponentObject, 1);
-		Yaw = Schema_GetDouble(ComponentObject, 2);
-		Roll = Schema_GetDouble(ComponentObject, 3);
+		if (Schema_GetFloatCount(ComponentObject, 1) > 0)
+		{
+			Pitch = Schema_GetFloat(ComponentObject, 1);
+		}
+		if (Schema_GetFloatCount(ComponentObject, 2) > 0)
+		{
+			Yaw = Schema_GetFloat(ComponentObject, 2);
+		}
+		if (Schema_GetFloatCount(ComponentObject, 3) > 0)
+		{
+			Roll = Schema_GetFloat(ComponentObject, 3);
+		}
 	}
 
 	float Pitch;


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Change `improbable::Rotation::ApplyComponentUpdate` to only update fields present in the update, and also to read Floats instead of Doubles.

#### Tests
Tested locally with starter project on snapshot entities.

#### Documentation
n/a

#### Primary reviewers
@Vatyx @m-samiec 