### PR TITLE
Revert the revert of #493 and fix the crash due to not loading classes

### DIFF
--- a/SpatialGDK/Source/Private/Interop/SpatialTypebindingManager.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialTypebindingManager.cpp
@@ -40,11 +40,7 @@ void USpatialTypebindingManager::FindSupportedClasses()
 	for (auto& ClassPath : SupportedClassPaths)
 	{
 		FSoftClassPath SoftClassPath(ClassPath);
-		UClass* Class = SoftClassPath.ResolveClass();
-		if (Class == nullptr)
-		{
-			Class = SoftClassPath.TryLoadClass<UObject>();
-		}
+		UClass* Class = SoftClassPath.TryLoadClass<UObject>();
 
 		if (Class != nullptr)
 		{
@@ -150,11 +146,7 @@ void USpatialTypebindingManager::CreateTypebindings()
 			FClassInfo* ActorInfo = FindClassInfoByClass(Class);
 
 			FSoftClassPath SubobjectClassPath(SubobjectSchemaData.ClassPath);
-			UClass* SubobjectClass = SubobjectClassPath.ResolveClass();
-			if (SubobjectClass == nullptr)
-			{
-				SubobjectClass = SubobjectClassPath.TryLoadClass<UObject>();
-			}
+			UClass* SubobjectClass = SubobjectClassPath.TryLoadClass<UObject>();
 			if (SubobjectClass == nullptr)
 			{
 				continue;

--- a/SpatialGDK/Source/Public/Utils/SchemaDatabase.h
+++ b/SpatialGDK/Source/Public/Utils/SchemaDatabase.h
@@ -11,13 +11,13 @@ struct FSubobjectSchemaData
 {
 	GENERATED_USTRUCT_BODY()
 
-	UPROPERTY()
-	UClass* Class = nullptr;
+	UPROPERTY(VisibleAnywhere)
+	FString ClassPath;
 
-	UPROPERTY()
+	UPROPERTY(VisibleAnywhere)
 	FName Name;
 
-	UPROPERTY()
+	UPROPERTY(VisibleAnywhere)
 	uint32 SchemaComponents[SCHEMA_Count] = {};
 };
 
@@ -26,10 +26,10 @@ struct FSchemaData
 {
 	GENERATED_USTRUCT_BODY()
 
-	UPROPERTY()
+	UPROPERTY(VisibleAnywhere)
 	uint32 SchemaComponents[SCHEMA_Count] = {};
 
-	UPROPERTY()
+	UPROPERTY(VisibleAnywhere)
 	TMap<uint32, FSubobjectSchemaData> SubobjectData;
 };
 
@@ -39,6 +39,6 @@ class SPATIALGDK_API USchemaDatabase : public UDataAsset
 	GENERATED_BODY()
 
 public:
-	UPROPERTY()
-	TMap<UClass*, FSchemaData> ClassToSchema;
+	UPROPERTY(VisibleAnywhere)
+	TMap<FString, FSchemaData> ClassPathToSchema;
 };

--- a/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/SchemaGenerator.cpp
+++ b/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/SchemaGenerator.cpp
@@ -410,7 +410,7 @@ int GenerateActorSchema(int ComponentId, UClass* Class, TSharedPtr<FUnrealType> 
 		UE_LOG(LogTemp, Warning, TEXT("Unreal GDK currently does not support Reliable Multicast RPCs. These RPC will be treated as unreliable:\n%s"), *AllReliableMulticasts);
 	}
 
-	ClassToSchema.Add(Class, ActorSchemaData);
+	ClassPathToSchema.Add(Class->GetPathName(), ActorSchemaData);
 
 	Writer.WriteToFile(FString::Printf(TEXT("%s%s.schema"), *SchemaPath, *UnrealNameToSchemaTypeName(Class->GetName())));
 
@@ -422,7 +422,7 @@ FSubobjectSchemaData GenerateSubobjectSpecificSchema(FCodeWriter& Writer, FCompo
 	FUnrealFlatRepData RepData = GetFlatRepData(TypeInfo);
 
 	FSubobjectSchemaData SubobjectData;
-	SubobjectData.Class = ComponentClass;
+	SubobjectData.ClassPath = ComponentClass->GetPathName();
 
 	for (EReplicatedPropertyGroup Group : GetAllReplicatedPropertyGroups())
 	{
@@ -538,12 +538,12 @@ void GenerateSubobjectSchemaForActor(FComponentIdGenerator& IdGenerator, UClass*
 					}
 					else
 					{
-						SubobjectData.Class = Value->GetClass();
+						SubobjectData.ClassPath = Value->GetClass()->GetPathName();
 					}
 
 					SubobjectData.Name = PropertyTypeInfo->Name;
 					ActorSchemaData.SubobjectData.Add(CurrentOffset, SubobjectData);
-					ClassToSchema.Add(Value->GetClass(), FSchemaData());
+					ClassPathToSchema.Add(Value->GetClass()->GetPathName(), FSchemaData());
 				}
 
 				CurrentOffset++;

--- a/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/SchemaGenerator.h
+++ b/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/SchemaGenerator.h
@@ -9,7 +9,7 @@ class FCodeWriter;
 struct FComponentIdGenerator;
 
 extern TArray<UClass*> SchemaGeneratedClasses;
-extern TMap<UClass*, FSchemaData> ClassToSchema;
+extern TMap<FString, FSchemaData> ClassPathToSchema;
 
 // Generates a schema file, given an output code writer, component ID, Unreal type and type info.
 int GenerateActorSchema(int ComponentId, UClass* Class, TSharedPtr<FUnrealType> TypeInfo, FString SchemaPath);

--- a/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -24,7 +24,7 @@
 DEFINE_LOG_CATEGORY(LogSpatialGDKSchemaGenerator);
 
 TArray<UClass*> SchemaGeneratedClasses;
-TMap<UClass*, FSchemaData> ClassToSchema;
+TMap<FString, FSchemaData> ClassPathToSchema;
 
 namespace
 {
@@ -115,7 +115,7 @@ void SaveSchemaDatabase()
 		UPackage *Package = CreatePackage(nullptr, *PackagePath);
 
 		USchemaDatabase* SchemaDatabase = NewObject<USchemaDatabase>(Package, USchemaDatabase::StaticClass(), FName("SchemaDatabase"), EObjectFlags::RF_Public | EObjectFlags::RF_Standalone);
-		SchemaDatabase->ClassToSchema = ClassToSchema;
+		SchemaDatabase->ClassPathToSchema = ClassPathToSchema;
 
 		FAssetRegistryModule::AssetCreated(SchemaDatabase);
 		SchemaDatabase->MarkPackageDirty();
@@ -173,9 +173,6 @@ TArray<UClass*> GetAllSupportedClasses()
 		// No replicated/handover properties found
 		if (SupportedClass == nullptr) continue;
 
-		// Doesn't let us save the schema database
-		if (SupportedClass->IsChildOf<ALevelScriptActor>()) continue;
-
 		if (SupportedClass->IsChildOf<USceneComponent>()) continue;
 
 		// Ensure we don't process skeleton or reinitialized classes
@@ -193,7 +190,7 @@ TArray<UClass*> GetAllSupportedClasses()
 
 bool SpatialGDKGenerateSchema()
 {
-	ClassToSchema.Empty();
+	ClassPathToSchema.Empty();
 
 	const USpatialGDKEditorToolbarSettings* SpatialGDKToolbarSettings = GetDefault<USpatialGDKEditorToolbarSettings>();
 

--- a/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -173,6 +173,9 @@ TArray<UClass*> GetAllSupportedClasses()
 		// No replicated/handover properties found
 		if (SupportedClass == nullptr) continue;
 
+		// Doesn't let us save the schema database
+		if (SupportedClass->IsChildOf<ALevelScriptActor>()) continue;
+
 		if (SupportedClass->IsChildOf<USceneComponent>()) continue;
 
 		// Ensure we don't process skeleton or reinitialized classes


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
`ResolveClass` doesn't do anything if the class isn't loaded, so the client ends up without the classes it needs.
#### Tests
Run a local deployment with external workers, see no crash.
#### Primary reviewers
@Vatyx @girayimprobable 