### PR TITLE
Fix order when ProcessQueuedResolvedObjects is called

### DIFF
--- a/SpatialGDK/Source/Private/Interop/SpatialDispatcher.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialDispatcher.cpp
@@ -102,8 +102,6 @@ void USpatialDispatcher::ProcessOps(Worker_OpList* OpList)
 		Receiver->OnComponentUpdate(Op->component_update);
 	}
 
-	Receiver->ProcessQueuedResolvedObjects();
-
 	// Check every channel for net ownership changes (determines ACL and component interest)
 	const FActorChannelMap& ChannelMap = NetDriver->GetSpatialOSNetConnection()->ActorChannelMap();
 	for (auto& Pair : ChannelMap)

--- a/SpatialGDK/Source/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialReceiver.cpp
@@ -96,6 +96,8 @@ void USpatialReceiver::LeaveCriticalSection()
 	PendingAddComponents.Empty();
 	PendingAuthorityChanges.Empty();
 	PendingRemoveEntities.Empty();
+
+	ProcessQueuedResolvedObjects();
 }
 
 void USpatialReceiver::OnAddEntity(Worker_AddEntityOp& Op)

--- a/SpatialGDK/Source/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/Public/Interop/SpatialReceiver.h
@@ -127,7 +127,6 @@ public:
 
 	void CleanupDeletedEntity(Worker_EntityId EntityId);
 
-	void ProcessQueuedResolvedObjects();
 	void ResolvePendingOperations(UObject* Object, const FUnrealObjectRef& ObjectRef);
 
 private:
@@ -156,6 +155,8 @@ private:
 	void ResolveIncomingOperations(UObject* Object, const FUnrealObjectRef& ObjectRef);
 	void ResolveIncomingRPCs(UObject* Object, const FUnrealObjectRef& ObjectRef);
 	void ResolveObjectReferences(FRepLayout& RepLayout, UObject* ReplicatedObject, FObjectReferencesMap& ObjectReferencesMap, uint8* RESTRICT StoredData, uint8* RESTRICT Data, int32 MaxAbsOffset, TArray<UProperty*>& RepNotifies, bool& bOutSomeObjectsWereMapped, bool& bOutStillHasUnresolved);
+
+	void ProcessQueuedResolvedObjects();
 
 	USpatialActorChannel* PopPendingActorRequest(Worker_RequestId RequestId);
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
If objects get resolved in a critical section, they get queued up and were meant to be resolved after we leave the critical section. Instead, they were resolved after we process all the ops, which causes problems if an entity gets added and removed in the same frame.
#### Primary reviewers
@Vatyx @m-samiec 