### PR TITLE
Allow static subobjects to be deleted in constructors

### DIFF
--- a/SpatialGDK/Source/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -187,6 +187,12 @@ FNetworkGUID FSpatialNetGUIDCache::AssignNewEntityActorNetGUID(AActor* Actor, co
 FNetworkGUID FSpatialNetGUIDCache::AssignNewStablyNamedObjectNetGUID(UObject* Object)
 {
 	FNetworkGUID NetGUID = GetOrAssignNetGUID_SpatialGDK(Object);
+	FUnrealObjectRef ExistingObjRef = GetUnrealObjectRefFromNetGUID(NetGUID);
+	if (ExistingObjRef != SpatialConstants::UNRESOLVED_OBJECT_REF)
+	{
+		return NetGUID;
+	}
+
 	FNetworkGUID OuterGUID;
 	UObject* OuterObject = Object->GetOuter();
 

--- a/SpatialGDK/Source/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialReceiver.cpp
@@ -874,12 +874,12 @@ void USpatialReceiver::OnEntityQueryResponse(Worker_EntityQueryResponseOp& Op)
 		auto RequestDelegate = EntityQueryDelegates.Find(Op.request_id);
 		if (RequestDelegate)
 		{
-			UE_LOG(LogSpatialReceiver, Log, TEXT("Executing EntityQueryResponse with delegate, request id: %d, number of entities: %lld, message: %s"), Op.request_id, Op.result_count, UTF8_TO_TCHAR(Op.message));
+			UE_LOG(LogSpatialReceiver, Log, TEXT("Executing EntityQueryResponse with delegate, request id: %d, number of entities: %d, message: %s"), Op.request_id, Op.result_count, UTF8_TO_TCHAR(Op.message));
 			RequestDelegate->ExecuteIfBound(Op);
 		}
 		else
 		{
-			UE_LOG(LogSpatialReceiver, Warning, TEXT("Recieved EntityQueryResponse but with no delegate set, request id: %d, number of entities: %lld, message: %s"), Op.request_id, Op.result_count, UTF8_TO_TCHAR(Op.message));
+			UE_LOG(LogSpatialReceiver, Warning, TEXT("Recieved EntityQueryResponse but with no delegate set, request id: %d, number of entities: %d, message: %s"), Op.request_id, Op.result_count, UTF8_TO_TCHAR(Op.message));
 		}
 	}
 	else

--- a/SpatialGDK/Source/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialSender.cpp
@@ -179,7 +179,7 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 		FClassInfo* SubobjectInfo = SubobjectInfoPair.Value.Get();
 
 		UObject* Subobject = PackageMap->GetObjectFromUnrealObjectRef(FUnrealObjectRef(Channel->GetEntityId(), SubobjectInfoPair.Key));
-		if (Subobject == false)
+		if (Subobject == nullptr)
 		{
 			continue;
 		}

--- a/SpatialGDK/Source/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialSender.cpp
@@ -115,7 +115,7 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 
 		// Static subobjects aren't guaranteed to exist on actor instances, check they are present before adding write acls
 		UObject* Subobject = PackageMap->GetObjectFromUnrealObjectRef(FUnrealObjectRef(Channel->GetEntityId(), SubobjectInfoPair.Key));
-		if (Subobject == false)
+		if (Subobject == nullptr)
 		{
 			continue;
 		}

--- a/SpatialGDK/Source/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialSender.cpp
@@ -113,6 +113,13 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 	{
 		const FClassInfo& SubobjectInfo = *SubobjectInfoPair.Value;
 
+		// Static subobjects aren't guaranteed to exist on actor instances, check they are present before adding write acls
+		UObject* Subobject = PackageMap->GetObjectFromUnrealObjectRef(FUnrealObjectRef(Channel->GetEntityId(), SubobjectInfoPair.Key));
+		if (Subobject == false)
+		{
+			continue;
+		}
+
 		ForAllSchemaComponentTypes([&](ESchemaComponentType Type)
 		{
 			Worker_ComponentId ComponentId = SubobjectInfo.SchemaComponents[Type];
@@ -172,6 +179,10 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 		FClassInfo* SubobjectInfo = SubobjectInfoPair.Value.Get();
 
 		UObject* Subobject = PackageMap->GetObjectFromUnrealObjectRef(FUnrealObjectRef(Channel->GetEntityId(), SubobjectInfoPair.Key));
+		if (Subobject == false)
+		{
+			continue;
+		}
 
 		FRepChangeState SubobjectRepChanges = Channel->CreateInitialRepChangeState(Subobject);
 		FHandoverChangeState SubobjectHandoverChanges = Channel->CreateInitialHandoverChangeState(SubobjectInfo);

--- a/SpatialGDK/Source/Public/Schema/UnrealMetadata.h
+++ b/SpatialGDK/Source/Public/Schema/UnrealMetadata.h
@@ -77,9 +77,10 @@ FORCEINLINE SubobjectToOffsetMap CreateOffsetMapFromActor(AActor* Actor, FClassI
 		UObject* Subobject = Actor->GetDefaultSubobjectByName(SubobjectInfoPair.Value->SubobjectName);
 		uint32 Offset = SubobjectInfoPair.Key;
 
-		check(Subobject);
-
-		SubobjectNameToOffset.Add(Subobject, Offset);
+		if (Subobject && Subobject->IsPendingKill() == false)
+		{
+			SubobjectNameToOffset.Add(Subobject, Offset);
+		}
 	}
 
 	return SubobjectNameToOffset;

--- a/SpatialGDK/Source/Public/Schema/UnrealMetadata.h
+++ b/SpatialGDK/Source/Public/Schema/UnrealMetadata.h
@@ -77,7 +77,7 @@ FORCEINLINE SubobjectToOffsetMap CreateOffsetMapFromActor(AActor* Actor, FClassI
 		UObject* Subobject = Actor->GetDefaultSubobjectByName(SubobjectInfoPair.Value->SubobjectName);
 		uint32 Offset = SubobjectInfoPair.Key;
 
-		if (Subobject && Subobject->IsPendingKill() == false)
+		if (Subobject != nullptr && Subobject->IsPendingKill() == false)
 		{
 			SubobjectNameToOffset.Add(Subobject, Offset);
 		}

--- a/SpatialGDKEditorToolbar/Source/Private/SpatialGDKEditorGenerateSnapshot.cpp
+++ b/SpatialGDKEditorToolbar/Source/Private/SpatialGDKEditorGenerateSnapshot.cpp
@@ -273,20 +273,21 @@ TArray<Worker_ComponentData> CreateStartupActorData(USpatialActorChannel* Channe
 		uint32 Offset = SubobjectInfoPair.Key;
 		FClassInfo* SubobjectInfo = SubobjectInfoPair.Value.Get();
 
-		UObject* Subobject = NetDriver->PackageMap->GetObjectFromUnrealObjectRef(FUnrealObjectRef(Channel->GetEntityId(), Offset));
-
-		FRepChangeState SubobjectRepChanges = Channel->CreateInitialRepChangeState(Subobject);
-		FHandoverChangeState SubobjectHandoverChanges = Channel->CreateInitialHandoverChangeState(SubobjectInfo);
-
-		// Create component data for initial state of subobject
-		ComponentData.Append(DataFactory.CreateComponentDatas(Subobject, SubobjectInfo, SubobjectRepChanges, SubobjectHandoverChanges));
-
-		// Add subobject RPCs to entity
-		for (int32 RPCType = SCHEMA_FirstRPC; RPCType <= SCHEMA_LastRPC; RPCType++)
+		if (UObject* Subobject = NetDriver->PackageMap->GetObjectFromUnrealObjectRef(FUnrealObjectRef(Channel->GetEntityId(), Offset)))
 		{
-			if (SubobjectInfo->SchemaComponents[RPCType] != 0)
+			FRepChangeState SubobjectRepChanges = Channel->CreateInitialRepChangeState(Subobject);
+			FHandoverChangeState SubobjectHandoverChanges = Channel->CreateInitialHandoverChangeState(SubobjectInfo);
+
+			// Create component data for initial state of subobject
+			ComponentData.Append(DataFactory.CreateComponentDatas(Subobject, SubobjectInfo, SubobjectRepChanges, SubobjectHandoverChanges));
+
+			// Add subobject RPCs to entity
+			for (int32 RPCType = SCHEMA_FirstRPC; RPCType <= SCHEMA_LastRPC; RPCType++)
 			{
-				ComponentData.Add(ComponentFactory::CreateEmptyComponentData(SubobjectInfo->SchemaComponents[RPCType]));
+				if (SubobjectInfo->SchemaComponents[RPCType] != 0)
+				{
+					ComponentData.Add(ComponentFactory::CreateEmptyComponentData(SubobjectInfo->SchemaComponents[RPCType]));
+				}
 			}
 		}
 	}


### PR DESCRIPTION
#### Description
Scavengers have a static subobjects that can get deleted in the construct script dependent on other variables. This prevents them from being written to the startup actors component data.

#### Primary reviewers
@Vatyx @improbable-valentyn 