### PR TITLE
Update the error in BuildWorker.bat to say the correct setup script name

### DIFF
--- a/SpatialGDK/Build/Scripts/BuildWorker.bat
+++ b/SpatialGDK/Build/Scripts/BuildWorker.bat
@@ -11,7 +11,7 @@ pushd "%~dp0..\..\..\..\..\"
 set BUILD_EXE_PATH="Plugins\UnrealGDK\SpatialGDK\Binaries\ThirdParty\Improbable\Programs\Build.exe"
 
 if not exist %BUILD_EXE_PATH% (
-	echo Error: Build executable not found! Please run BuildGDK.bat in your SpatialGDK directory to generate it.
+	echo Error: Build executable not found! Please run Setup.bat in your UnrealGDK root to generate it.
 	exit /b 1
 )
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
`BuildGDK.bat` was renamed to `Setup.bat` and we forgot to update `BuildWorker.bat` with the new name.
#### Primary reviewers
@danielimprobable @m-samiec 