### PR TITLE
Check against unresolved objects before sending rpcs

### DIFF
--- a/SpatialGDK/Source/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialSender.cpp
@@ -352,6 +352,12 @@ void USpatialSender::SendRPC(TSharedRef<FPendingRPCParams> Params)
 	}
 
 	UObject* TargetObject = Params->TargetObject.Get();
+	if (PackageMap->GetUnrealObjectRefFromObject(TargetObject) == SpatialConstants::UNRESOLVED_OBJECT_REF)
+	{
+		UE_LOG(LogSpatialSender, Warning, TEXT("Trying to send RPC %s on unresolved Actor %s."), *Params->Function->GetName(), *TargetObject->GetName());
+		QueueOutgoingRPC(TargetObject, Params);
+		return;
+	}
 
 	FClassInfo* Info = TypebindingManager->FindClassInfoByObject(TargetObject);
 

--- a/SpatialGDK/Source/Private/Interop/SpatialTypebindingManager.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialTypebindingManager.cpp
@@ -223,7 +223,7 @@ FClassInfo* USpatialTypebindingManager::FindClassInfoByObject(UObject* Object)
 
 		FUnrealObjectRef ObjectRef = NetDriver->PackageMap->GetUnrealObjectRefFromObject(Object);
 
-		if (ObjectRef != SpatialConstants::NULL_OBJECT_REF)
+		if (ObjectRef != SpatialConstants::NULL_OBJECT_REF && ObjectRef != SpatialConstants::UNRESOLVED_OBJECT_REF)
 		{
 			return FindClassInfoByActorClassAndOffset(Object->GetOuter()->GetClass(), ObjectRef.Offset);
 		}


### PR DESCRIPTION
#### Description
Ensure the target object is resolved before sending RPCs on it.

#### Primary reviewers
@improbable-valentyn @joshuahuburn @Vatyx