### PR TITLE
Prevent delegates from causing runtime check failures

### DIFF
--- a/SpatialGDK/Source/Private/Utils/ComponentFactory.cpp
+++ b/SpatialGDK/Source/Private/Utils/ComponentFactory.cpp
@@ -257,6 +257,10 @@ void ComponentFactory::AddProperty(Schema_Object* Object, Schema_FieldId FieldId
 			AddProperty(Object, FieldId, EnumProperty->GetUnderlyingProperty(), Data, UnresolvedObjects, ClearedIds);
 		}
 	}
+	else if (Property->IsA<UDelegateProperty>() || Property->IsA<UMulticastDelegateProperty>())
+	{
+		// Delegates can be set to replicate, but won't serialize across the network.
+	}
 	else
 	{
 		checkf(false, TEXT("Tried to add unknown property in field %d"), FieldId);

--- a/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/TypeStructure.cpp
+++ b/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/TypeStructure.cpp
@@ -415,6 +415,12 @@ TSharedPtr<FUnrealType> CreateUnrealTypeInfo(UStruct* Type, uint32 ParentChecksu
 			continue;
 		}
 
+		// Jump over invalid replicated property types
+		if (Cmd.Property->IsA<UDelegateProperty>() || Cmd.Property->IsA<UMulticastDelegateProperty>())
+		{
+			continue;
+		}
+
 		FRepParentCmd& Parent = RepLayout.Parents[Cmd.ParentIndex];
 
 		// In a FRepLayout, all the root level replicated properties in a class are stored in the Parents array.


### PR DESCRIPTION
#### Description
Delegates can be marked as replicated, but Unreal doesn't support any type of network replication. Only added it to the component factory, as the component reader will never have it written to in fabric to read from.

#### Primary reviewers
@joshuahuburn @Vatyx