### PR TITLE
Search for actor in existing singletons

### DIFF
--- a/SpatialGDK/Source/Private/Interop/GlobalStateManager.cpp
+++ b/SpatialGDK/Source/Private/Interop/GlobalStateManager.cpp
@@ -117,6 +117,7 @@ void UGlobalStateManager::LinkExistingSingletonActors()
 		// Singleton wasn't found or channel is already set up
 		if (Channel == nullptr || Channel->Actor != nullptr)
 		{
+			check(Channel->Actor == SingletonActor);
 			continue;
 		}
 
@@ -155,9 +156,10 @@ void UGlobalStateManager::ExecuteInitialSingletonActorReplication()
 		USpatialActorChannel* Channel = nullptr;
 		GetSingletonActorAndChannel(Pair.Key, SingletonActor, Channel);
 
-		// Class couldn't be found
-		if (Channel == nullptr)
+		// Class couldn't be found or channel already exists
+		if (Channel == nullptr || Channel->Actor != nullptr)
 		{
+			check(Channel->Actor == SingletonActor);
 			continue;
 		}
 
@@ -231,6 +233,16 @@ void UGlobalStateManager::GetSingletonActorAndChannel(FString ClassName, AActor*
 	}
 
 	OutActor = SingletonActorList[0];
+
+	// Check if actor is already processed
+	for (auto ClassChannelPair : NetDriver->SingletonActorChannels)
+	{
+		if (ClassChannelPair.Value.Key == OutActor)
+		{
+			OutChannel = ClassChannelPair.Value.Value;
+			return;
+		}
+	}
 
 	USpatialNetConnection* Connection = Cast<USpatialNetConnection>(NetDriver->ClientConnections[0]);
 


### PR DESCRIPTION
#### Description
Inherited singletons was causing multiple actor channels to be created for the same actor. It now searches existing singleton actor/channel pairs when setting up singletons. This will all be refactored in the inherited spatialtype feature.

#### Primary reviewers
@Vatyx @improbable-valentyn 