### PR TITLE
Use correct class to create type structure

### DIFF
--- a/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/TypeStructure.cpp
+++ b/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/TypeStructure.cpp
@@ -282,7 +282,7 @@ TSharedPtr<FUnrealType> CreateUnrealTypeInfo(UStruct* Type, uint32 ParentChecksu
 				UE_LOG(LogSpatialGDKSchemaGenerator, Verbose, TEXT("Property Class: %s Instance Class: %s"), *ObjectProperty->PropertyClass->GetName(), *Value->GetClass()->GetName());
 
 				// This property is definitely a strong reference, recurse into it.
-				PropertyNode->Type = CreateUnrealTypeInfo(ObjectProperty->PropertyClass, ParentChecksum, 0, bIsRPC);
+				PropertyNode->Type = CreateUnrealTypeInfo(Value->GetClass(), ParentChecksum, 0, bIsRPC);
 				PropertyNode->Type->ParentProperty = PropertyNode;
 				PropertyNode->Type->Object = Value;
 				PropertyNode->Type->Name = Value->GetFName();

--- a/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/TypeStructure.cpp
+++ b/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/TypeStructure.cpp
@@ -295,7 +295,7 @@ TSharedPtr<FUnrealType> CreateUnrealTypeInfo(UStruct* Type, uint32 ParentChecksu
 						TSharedPtr<FUnrealProperty> StaticObjectArrayPropertyNode = CreateUnrealProperty(TypeNode, Property, ParentChecksum, i);
 
 						// Note: The parent checksum of static arrays of strong object references will be the parent checksum of this class.
-						StaticObjectArrayPropertyNode->Type = CreateUnrealTypeInfo(ObjectProperty->PropertyClass, ParentChecksum, 0, bIsRPC);
+						StaticObjectArrayPropertyNode->Type = CreateUnrealTypeInfo(Value->GetClass(), ParentChecksum, 0, bIsRPC);
 						StaticObjectArrayPropertyNode->Type->ParentProperty = StaticObjectArrayPropertyNode;
 					}
 				}


### PR DESCRIPTION
#### Description
We were using the property's class rather than the object's class to create the type structure for a subobject. It should be the subobject's class since a subobject can be a derived class of the property's class.

#### Primary reviewers
@improbable-valentyn @m-samiec 