### PR TITLE
Removed PIE prefixes from map checking when connecting to a server.

### DIFF
--- a/SpatialGDK/Source/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialNetDriver.cpp
@@ -227,7 +227,7 @@ void USpatialNetDriver::OnMapLoadedAndConnected()
 	if (ServerConnection)
 	{
 		// If we know the GSM is already accepting players, simply spawn.
-		if (GlobalStateManager->bAcceptingPlayers && GlobalStateManager->DeploymentMapURL == GetWorld()->URL.Map)
+		if (GlobalStateManager->bAcceptingPlayers && GetWorld()->RemovePIEPrefix(GlobalStateManager->DeploymentMapURL) == GetWorld()->RemovePIEPrefix(GetWorld()->URL.Map))
 		{
 			PlayerSpawner->SendPlayerSpawnRequest();
 		}
@@ -263,7 +263,7 @@ void USpatialNetDriver::OnAcceptingPlayersChanged(bool bAcceptingPlayers)
 	if (bWaitingForAcceptingPlayersToSpawn && bAcceptingPlayers)
 	{
 		// If we have the correct map loaded then ask to spawn.
-		if (GlobalStateManager->DeploymentMapURL == GetWorld()->URL.Map)
+		if (GetWorld()->RemovePIEPrefix(GlobalStateManager->DeploymentMapURL) == GetWorld()->RemovePIEPrefix(GetWorld()->URL.Map))
 		{
 			PlayerSpawner->SendPlayerSpawnRequest();
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
When checking the correct map is loaded on connection to a server we need to make sure the map names aren't affected by PIE prefixes. 
The PIE prefix is different for every client / server in a PIE instance and so was causing uneeded client travel and warnings to be printed.
#### Tests
Tested starting up in PIE, no client travel or warnings happened unnecessarily.
What automated tests are included in this PR?
#### Primary reviewers
@jacqueslebrun @Vatyx 