### PR TITLE
Check for duplicate RPCs and field names in schema

### DIFF
--- a/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/SchemaGenerator.cpp
+++ b/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/SchemaGenerator.cpp
@@ -386,12 +386,12 @@ int GenerateActorSchema(int ComponentId, UClass* Class, TSharedPtr<FUnrealType> 
 				}
 
 				Writer.Printf("event UnrealRPCCommandRequest {0};",
-					*SchemaRPCName(Class, RPC->Function));
+					*SchemaRPCName(RPC->Function));
 			}
 			else
 			{
 				Writer.Printf("command UnrealRPCCommandResponse {0}(UnrealRPCCommandRequest);",
-					*SchemaRPCName(Class, RPC->Function));
+					*SchemaRPCName(RPC->Function));
 			}
 		}
 		Writer.Outdent().Print("}");
@@ -478,12 +478,12 @@ FSubobjectSchemaData GenerateSubobjectSpecificSchema(FCodeWriter& Writer, FCompo
 			if (Group == ERPCType::RPC_NetMulticast)
 			{
 				Writer.Printf("event UnrealRPCCommandRequest {0};",
-					*SchemaRPCName(Cast<UClass>(ComponentClass), RPC->Function));
+					*SchemaRPCName(RPC->Function));
 			}
 			else
 			{
 				Writer.Printf("command UnrealRPCCommandResponse {0}(UnrealRPCCommandRequest);",
-					*SchemaRPCName(Cast<UClass>(ComponentClass), RPC->Function));
+					*SchemaRPCName(RPC->Function));
 			}
 		}
 		Writer.Outdent().Print("}");

--- a/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/Utils/DataTypeUtilities.cpp
+++ b/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/Utils/DataTypeUtilities.cpp
@@ -71,7 +71,7 @@ FString SchemaRPCComponentName(ERPCType RpcType, UStruct* Type, bool bPrependNam
 	return FString::Printf(TEXT("%s%s%sRPCs"), bPrependNamespace ? *GetNamespace(Type) : TEXT(""), *UnrealNameToSchemaComponentName(Type->GetName()), *GetRPCTypeName(RpcType));
 }
 
-FString SchemaRPCName(UClass* Class, UFunction* Function)
+FString SchemaRPCName(UFunction* Function)
 {
 	return UnrealNameToSchemaTypeName(Function->GetName().ToLower());
 }

--- a/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/Utils/DataTypeUtilities.h
+++ b/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/Utils/DataTypeUtilities.h
@@ -28,7 +28,7 @@ FString SchemaHandoverDataName(UStruct* Type, bool bPrependNamespace = false);
 FString SchemaRPCComponentName(ERPCType RpcType, UStruct* Type, bool bPrependNamespace = false);
 
 // Given a UFunction, generates the schema command name. Currently just returns the function name in lowercase.
-FString SchemaRPCName(UClass* Class, UFunction* Function);
+FString SchemaRPCName(UFunction* Function);
 
 // Given a property node, generates the schema field name.
 FString SchemaFieldName(const TSharedPtr<FUnrealProperty> Property);


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Recently we started checking for non-alphanumeric characters in RPCs and variable names and then removing them from the translated schema name. This allows for potential name collisions within schema.
This PR checks that there will be no naming collisions after removing non-alphanumeric characters before generating schema.

#### Tests

![schema not generated rep data](https://user-images.githubusercontent.com/31517089/49085525-1d6d3c80-f24a-11e8-832f-6d838c6c9b4d.PNG)
![schema not generated rpc](https://user-images.githubusercontent.com/31517089/49085531-1fcf9680-f24a-11e8-8b3c-b2f5a7c1e2bf.PNG)


#### Primary reviewers
@m-samiec @improbable-valentyn 