### PR TITLE
Startup actor level streaming fix

### DIFF
--- a/SpatialGDK/Source/Private/EngineClasses/SpatialNetBitReader.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialNetBitReader.cpp
@@ -61,7 +61,7 @@ FArchive& FSpatialNetBitReader::operator<<(UObject*& Value)
 				// it's part of a streaming level that hasn't been streamed in. In either case, there's nothing we can do.
 				FString FullPath;
 				improbable::GetFullPathFromUnrealObjectReference(ObjectRef, FullPath);
-				UE_LOG(LogSpatialNetBitReader, Warning, TEXT("Object ref did not map to valid object, will be set to nullptr: %s %s"),
+				UE_LOG(LogSpatialNetBitReader, Verbose, TEXT("Object ref did not map to valid object. Streaming level not loaded or actor deleted. Will be set to nullptr: %s %s"),
 					*ObjectRef.ToString(), FullPath.IsEmpty() ? TEXT("[NO PATH]") : *FullPath);
 			}
 		}

--- a/SpatialGDK/Source/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -308,6 +308,8 @@ FNetworkGUID FSpatialNetGUIDCache::RegisterNetGUIDFromPath(const FString& PathNa
 	FNetGuidCacheObject CacheObject;
 	CacheObject.PathName = FName(*PathName);
 	CacheObject.OuterGUID = OuterGUID;
+	CacheObject.bNoLoad = true;
+	CacheObject.bIgnoreWhenMissing = true;
 	FNetworkGUID NetGUID = GenerateNewNetGUID(0);
 	RegisterNetGUID_Internal(NetGUID, CacheObject);
 	return NetGUID;


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Changed how we build CacheObjets so we don't break them.
#### Tests
Client travelled to a level with streamed sub-levels which would error spam and warning spam being unable to resolve the CacheObject from it's NetGuid. After the fix no spam and object loads correctly (had a BeginPlay attached to the object which worked correctly after the fix).

#### Primary reviewers
@m-samiec @davedolben 