### PR TITLE
Allow bad characters in events and variables

### DIFF
--- a/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/SchemaGenerator.cpp
+++ b/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/SchemaGenerator.cpp
@@ -281,7 +281,7 @@ void GenerateSubobjectSchema(UClass* Class, TSharedPtr<FUnrealType> TypeInfo, FS
 		Writer.Outdent().Print("}");
 	}
 
-	Writer.WriteToFile(FString::Printf(TEXT("%s%s.schema"), *SchemaPath, *UnrealNameToSchemaName(Class->GetName())));
+	Writer.WriteToFile(FString::Printf(TEXT("%s%s.schema"), *SchemaPath, *UnrealClassNameToSchemaName(Class->GetName())));
 }
 
 
@@ -295,7 +295,7 @@ int GenerateActorSchema(int ComponentId, UClass* Class, TSharedPtr<FUnrealType> 
 		// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 		// Note that this file has been generated automatically
 		package unreal.generated.{0};)""",
-		*UnrealNameToSchemaName(Class->GetName().ToLower()));
+		*UnrealClassNameToSchemaName(Class->GetName().ToLower()));
 
 	// Will always be included since AActor has replicated pointers to other actors
 	Writer.PrintNewLine();
@@ -412,7 +412,7 @@ int GenerateActorSchema(int ComponentId, UClass* Class, TSharedPtr<FUnrealType> 
 
 	ClassPathToSchema.Add(Class->GetPathName(), ActorSchemaData);
 
-	Writer.WriteToFile(FString::Printf(TEXT("%s%s.schema"), *SchemaPath, *UnrealNameToSchemaName(Class->GetName())));
+	Writer.WriteToFile(FString::Printf(TEXT("%s%s.schema"), *SchemaPath, *UnrealClassNameToSchemaName(Class->GetName())));
 
 	return IdGenerator.GetNumUsedIds();
 }
@@ -502,7 +502,7 @@ void GenerateSubobjectSchemaForActor(FComponentIdGenerator& IdGenerator, UClass*
 		// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 		// Note that this file has been generated automatically
 		package unreal.generated.{0}.subobjects;)""",
-		*UnrealNameToSchemaName(TypeInfo->Type->GetName().ToLower()));
+		*UnrealClassNameToSchemaName(TypeInfo->Type->GetName().ToLower()));
 
 	Writer.PrintNewLine();
 
@@ -553,7 +553,7 @@ void GenerateSubobjectSchemaForActor(FComponentIdGenerator& IdGenerator, UClass*
 
 	if (bHasComponents)
 	{
-		Writer.WriteToFile(FString::Printf(TEXT("%s%sComponents.schema"), *SchemaPath, *UnrealNameToSchemaName(ActorClass->GetName())));
+		Writer.WriteToFile(FString::Printf(TEXT("%s%sComponents.schema"), *SchemaPath, *UnrealClassNameToSchemaName(ActorClass->GetName())));
 	}
 }
 
@@ -582,7 +582,7 @@ void GenerateActorIncludes(FCodeWriter& Writer, TSharedPtr<FUnrealType>& TypeInf
 				UClass* Class = Value->GetClass();
 				if (!AlreadyImported.Contains(Class) && SchemaGeneratedClasses.Contains(Class))
 				{
-					Writer.Printf("import \"unreal/generated/Subobjects/{0}.schema\";", *UnrealNameToSchemaName(Class->GetName()));
+					Writer.Printf("import \"unreal/generated/Subobjects/{0}.schema\";", *UnrealClassNameToSchemaName(Class->GetName()));
 					AlreadyImported.Add(Class);
 				}
 			}

--- a/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -37,7 +37,7 @@ void OnStatusOutput(FString Message)
 int GenerateCompleteSchemaFromClass(FString SchemaPath, int ComponentId, TSharedPtr<FUnrealType> TypeInfo)
 {
 	UClass* Class = Cast<UClass>(TypeInfo->Type);
-	FString SchemaFilename = UnrealNameToSchemaName(Class->GetName());
+	FString SchemaFilename = UnrealClassNameToSchemaName(Class->GetName());
 
 	int NumComponents = 0;
 	if (Class->IsChildOf<AActor>())
@@ -120,12 +120,12 @@ bool ValidateIdentifierNames(TArray<TSharedPtr<FUnrealType>>& TypeInfos)
 	for (int i = 0; i < TypeInfos.Num() - 1; ++i)
 	{
 		const FString& ClassA = TypeInfos[i]->Type->GetName();
-		const FString SchemaTypeA = UnrealNameToSchemaName(ClassA);
+		const FString SchemaTypeA = UnrealClassNameToSchemaName(ClassA);
 
 		for (int j = i + 1; j < TypeInfos.Num(); ++j)
 		{
 			const FString& ClassB = TypeInfos[j]->Type->GetName();
-			const FString SchemaTypeB = UnrealNameToSchemaName(ClassB);
+			const FString SchemaTypeB = UnrealClassNameToSchemaName(ClassB);
 
 			if (SchemaTypeA.Equals(SchemaTypeB))
 			{

--- a/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/Utils/DataTypeUtilities.cpp
+++ b/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/Utils/DataTypeUtilities.cpp
@@ -34,6 +34,104 @@ FString UnrealNameToSchemaName(const FString& UnrealName)
 	return AlphanumericSanitization(UnrealName);
 }
 
+FString ASCIICharacterConverter(const FString& InString)
+{
+	FRegexMatcher AlphanumericPatternMatcher(AlphanumericPattern, InString);
+
+	FString ConvertedString;
+
+	const int AsciiZero = int('0');
+	const int AsciiNine = int('9');
+
+	const int AsciiUpperA = int('A');
+	const int AsciiUpperZ = int('Z');
+
+	const int AsciiLowerA = int('A');
+	const int AsciiLowerZ = int('Z');
+
+	for (auto& Char : InString)
+	{
+		int CharAscii = int(Char);
+
+		// If we have an alphanumeric character then use it.
+		if((CharAscii >= AsciiZero && CharAscii <= AsciiNine)
+			|| (CharAscii >= AsciiUpperA && CharAscii <= AsciiUpperZ)
+			|| (CharAscii >= AsciiLowerA && CharAscii <= AsciiLowerZ))
+		{
+			ConvertedString += Char;
+		}
+		else
+		{
+			// If this is a non-alphanumeric character then use the string converted ASCII code.
+			ConvertedString += ConvertASCIICodeToFString(CharAscii);
+		}
+	}
+
+
+
+
+	for (int CurrentCharacter = 0; CurrentCharacter < InString.Len(); CurrentCharacter++)
+	{
+		// Find the next alphanumeric character in this string.
+		if(AlphanumericPatternMatcher.FindNext())
+		{
+			int32 NextAlphanumericCharacter = AlphanumericPatternMatcher.GetMatchBeginning();
+
+			// If the current character is the next alphanumeric character we have matched so we can safely add this character.
+			if (NextAlphanumericCharacter == CurrentCharacter)
+			{
+				ConvertedString += InString[CurrentCharacter];
+			}
+			else
+			{
+				// Convert all the next non-alphanumeric characters.
+				for (int NextNonAlphanumericChar = NextAlphanumericCharacter - CurrentCharacter; NextNonAlphanumericChar < NextAlphanumericCharacter; NextNonAlphanumericChar++)
+				{
+					// If we did not match, the current character is non-alphanumeric so convert it
+					ConvertedString.Append(ConvertASCIICodeToFString(int(InString[NextNonAlphanumericChar])));
+				}
+
+				// The outer for loop will increment.
+				CurrentCharacter = NextAlphanumericCharacter - 1;
+			}
+		}
+		else
+		{
+			// If we didn't match then all the next characters are non-alphanumeric
+			//..
+		}
+	}
+
+
+
+	//
+	for (int CurrentCharacter = 0; CurrentCharacter < InString.Len(); CurrentCharacter++)
+	{
+		int32 NextAlphanumericCharacter = AlphanumericPatternMatcher.GetMatchBeginning();
+
+		// If the current character is alphanumeric then add it.
+		if (CurrentCharacter == NextAlphanumericCharacter)
+		{
+			ConvertedString += InString[CurrentCharacter];
+		}
+		else
+		{
+			for (;CurrentCharacter < NextAlphanumericCharacter - 1; CurrentCharacter++)
+			{
+				// If the current character is non-alphanumeric then convert it to an ascii code.
+				ConvertedString.Append(ConvertASCIICodeToFString(int(InString[CurrentCharacter])));
+			}
+		}
+	}
+
+
+}
+
+FString ConvertASCIICodeToFString(int ASCIICode)
+{
+	return FString::Printf(TEXT("0x%s"), *FString::FromInt(ASCIICode));
+}
+
 FString AlphanumericSanitization(const FString& InString)
 {
 	FRegexMatcher AlphanumericPatternMatcher(AlphanumericPattern, InString);

--- a/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/Utils/DataTypeUtilities.cpp
+++ b/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/Utils/DataTypeUtilities.cpp
@@ -9,7 +9,7 @@ const FRegexPattern AlphanumericPattern(TEXT("[A-Z,a-z,0-9]"));
 
 FString GetNamespace(UStruct* Struct)
 {
-	return FString::Printf(TEXT("improbable::unreal::generated::%s::"), *UnrealFunctionNameToSchemaName(Struct->GetName().ToLower()));
+	return FString::Printf(TEXT("improbable::unreal::generated::%s::"), *UnrealNameToSchemaName(Struct->GetName().ToLower()));
 }
 
 FString GetEnumDataType(const UEnumProperty* EnumProperty)
@@ -29,7 +29,7 @@ FString GetEnumDataType(const UEnumProperty* EnumProperty)
 	return DataType;
 }
 
-FString UnrealFunctionNameToSchemaName(const FString& UnrealName)
+FString UnrealNameToSchemaName(const FString& UnrealName)
 {
 	return NonAlphanumericAsciiCharacterConverter(UnrealName);
 }
@@ -120,7 +120,7 @@ FString SchemaRPCComponentName(ERPCType RpcType, UStruct* Type, bool bPrependNam
 
 FString SchemaRPCName(UFunction* Function)
 {
-	return UnrealFunctionNameToSchemaName(Function->GetName().ToLower());
+	return UnrealNameToSchemaName(Function->GetName().ToLower());
 }
 
 FString SchemaFieldName(const TSharedPtr<FUnrealProperty> Property)
@@ -134,7 +134,7 @@ FString SchemaFieldName(const TSharedPtr<FUnrealProperty> Property)
 		{
 			PropName.Append(FString::FromInt(Property->StaticArrayIndex));
 		}
-		return UnrealFunctionNameToSchemaName(PropName);
+		return UnrealNameToSchemaName(PropName);
 	});
 
 	// Prefix is required to disambiguate between properties in the generated code and UActorComponent/UObject properties

--- a/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/Utils/DataTypeUtilities.cpp
+++ b/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/Utils/DataTypeUtilities.cpp
@@ -39,7 +39,7 @@ FString UnrealClassNameToSchemaName(const FString& UnrealName)
 	// Class names cannot have underscores so remove them.
 	// This is a limitation from schema where component names do not support underscores. We use the class name as part of the components name.
 	FString SchemaClassName = UnrealName.Replace(TEXT("_"), TEXT("")).Replace(TEXT(" "), TEXT(""));
-	return NonAlphanumericAsciiCharacterConverter(SchemaClassName);
+	return UnrealNameToSchemaName(SchemaClassName);
 }
 
 FString NonAlphanumericAsciiCharacterConverter(const FString& InString)

--- a/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/Utils/DataTypeUtilities.h
+++ b/SpatialGDKEditorToolbar/Source/Private/SchemaGenerator/Utils/DataTypeUtilities.h
@@ -9,10 +9,16 @@
 // Return the string representation of the underlying data type of an enum property
 FString GetEnumDataType(const UEnumProperty* EnumProperty);
 
-// Given a class or function name, generates the name used for naming schema components and types. Removes all non-alphanumeric characters.
-FString UnrealNameToSchemaName(const FString& UnrealName);
+// Given a function name, generates the name used for naming schema commands.
+// Converts all non-alphanumeric characters to hex code strings.
+FString UnrealFunctionNameToSchemaName(const FString& UnrealName);
 
-// Given an object name, generates the name used for naming schema components. Removes all non-alphanumeric characters and capitalizes the first letter.
+// Given a class name, generates the name used for naming schema classes.
+// Removes all underscores. Any other non-alphanumeric characters are converted to hex code strings.
+FString UnrealClassNameToSchemaName(const FString& UnrealName);
+
+// Given an object name, generates the name used for naming schema components.
+// Removes all underscores. Any other non-alphanumeric characters are converted to hex code strings and capitalizes the first letter.
 FString UnrealNameToSchemaComponentName(const FString& UnrealName);
 
 // Given a replicated property group and Unreal type, generates the name of the corresponding schema component.
@@ -33,4 +39,11 @@ FString SchemaRPCName(UFunction* Function);
 // Given a property node, generates the schema field name.
 FString SchemaFieldName(const TSharedPtr<FUnrealProperty> Property);
 
+// Converts all non-alphanumeric characters in the InString to hex code strings.
+FString NonAlphanumericAsciiCharacterConverter(const FString& InString);
+
+// Takes an ASCII character code and returns a hex code string.
+FString ConvertAsciiCodeToHexString(int ASCIICode);
+
+// Returns a string with all non-alphanumeric characters removed from the InString.
 FString AlphanumericSanitization(const FString& InString);


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Instead of removing non-alphanumeric characters from UnrealNames so they conform to schema, convert these characters to hex code strings.

e.g. `MyFunc!` becomes `myfunc0x21`

This prevents name collisions when developers use non-alphanumeric characters in their naming conventions.

![got it](https://user-images.githubusercontent.com/31517089/49596774-04b00580-f973-11e8-8018-1d3251bb2e46.PNG)

It is still possible to have name collisions so the collision code is staying, but now we support more naming conventions.

Schema file names and component names cannot have underscores in them still, so we manually remove those when using Unreal class names for anything schema (since in Unreal you can have class names with underscores i.e. blueprints).

#### Tests
Created events and variables with non-alphanumeric characters and had no collisions and they worked.

#### Documentation
Gonna make a docs PR to update our naming guidelines.
#### Primary reviewers
@danielimprobable 	@m-samiec 