### PR TITLE
[UNR-670] Report write access failures when generating snapshot or schema

### DIFF
--- a/SpatialGDKEditorToolbar/Source/Private/SpatialGDKEditorGenerateSnapshot.cpp
+++ b/SpatialGDKEditorToolbar/Source/Private/SpatialGDKEditorGenerateSnapshot.cpp
@@ -457,28 +457,38 @@ bool SpatialGDKGenerateSnapshot(UWorld* World)
 	Worker_SnapshotParameters Parameters{};
 	Parameters.default_component_vtable = &DefaultVtable;
 	Worker_SnapshotOutputStream* OutputStream = Worker_SnapshotOutputStream_Create(TCHAR_TO_UTF8(*SavePath), &Parameters);
+	if (const char* SchemaError = Worker_SnapshotOutputStream_GetError(OutputStream))
+	{
+		UE_LOG(LogSpatialGDKSnapshot, Error, TEXT("Error creating SnapshotOutputStream: %s"), UTF8_TO_TCHAR(SchemaError));
+		Worker_SnapshotOutputStream_Destroy(OutputStream);
+		return false;
+	}
 
 	if (!CreateSpawnerEntity(OutputStream))
 	{
 		UE_LOG(LogSpatialGDKSnapshot, Error, TEXT("Error generating Spawner in snapshot: %s"), UTF8_TO_TCHAR(Worker_SnapshotOutputStream_GetError(OutputStream)));
+		Worker_SnapshotOutputStream_Destroy(OutputStream);
 		return false;
 	}
 
 	if (!CreateGlobalStateManager(OutputStream))
 	{
 		UE_LOG(LogSpatialGDKSnapshot, Error, TEXT("Error generating GlobalStateManager in snapshot: %s"), UTF8_TO_TCHAR(Worker_SnapshotOutputStream_GetError(OutputStream)));
+		Worker_SnapshotOutputStream_Destroy(OutputStream);
 		return false;
 	}
 
 	if (!CreatePlaceholders(OutputStream))
 	{
 		UE_LOG(LogSpatialGDKSnapshot, Error, TEXT("Error generating Placeholders in snapshot: %s"), UTF8_TO_TCHAR(Worker_SnapshotOutputStream_GetError(OutputStream)));
+		Worker_SnapshotOutputStream_Destroy(OutputStream);
 		return false;
 	}
 
 	if (!CreateStartupActors(OutputStream, World))
 	{
 		UE_LOG(LogSpatialGDKSnapshot, Error, TEXT("Error generating Startup Actors in snapshot: %s"), UTF8_TO_TCHAR(Worker_SnapshotOutputStream_GetError(OutputStream)));
+		Worker_SnapshotOutputStream_Destroy(OutputStream);
 		return false;
 	}
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
When generating schema, generally two things can go wrong: deleting the generated schema folder, and rewriting the schema database.
When generating snapshot, we were already reporting the errors, but we leaked the SnapshotOutputStream if any errors happened. Also, we only started checking for errors after trying to write the Spawned entity instead of checking right after creating the SnapshotOutputStream, which is when the write access error is reported.

[JIRA ticket](https://improbableio.atlassian.net/browse/UNR-670)
#### Tests
Set files read-only. Run the schema generator. Run the snapshot generator.
#### Primary reviewers
@joshuahuburn @danielimprobable 