### PR TITLE
NoLogToSpatial Param to stop logging to Spatial

### DIFF
--- a/SpatialGDK/Source/Private/Interop/SpatialOutputDevice.cpp
+++ b/SpatialGDK/Source/Private/Interop/SpatialOutputDevice.cpp
@@ -10,6 +10,9 @@ FSpatialOutputDevice::FSpatialOutputDevice(USpatialWorkerConnection* InConnectio
 	Name = LoggerName;
 	FilterLevel = ELogVerbosity::Warning;
 
+	const TCHAR* CommandLine = FCommandLine::Get();
+	bLogToSpatial = !FParse::Param(CommandLine, TEXT("NoLogToSpatial"));
+
 	FOutputDeviceRedirector::Get()->AddOutputDevice(this);
 }
 
@@ -25,7 +28,7 @@ void FSpatialOutputDevice::Serialize(const TCHAR* InData, ELogVerbosity::Type Ve
 		return;
 	}
 
-	if (Connection->IsConnected())
+	if (bLogToSpatial && Connection->IsConnected())
 	{
 		Connection->SendLogMessage(ConvertLogLevelToSpatial(Verbosity), TCHAR_TO_UTF8(*Name), TCHAR_TO_UTF8(InData));
 	}

--- a/SpatialGDK/Source/Public/Interop/SpatialOutputDevice.h
+++ b/SpatialGDK/Source/Public/Interop/SpatialOutputDevice.h
@@ -27,4 +27,6 @@ protected:
 	TSet<FName> CategoriesToRedirect;
 	USpatialWorkerConnection* Connection;
 	FString Name;
+
+	bool bLogToSpatial;
 };


### PR DESCRIPTION
#### Description
Adding this command will stop logging to Spatial. Important to do if there are a lot of logs since it can affect performance.