### PR TITLE
UNR-824: Quick fix for aggressive ROLE_AutonomousProxy assignment

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -194,11 +194,7 @@ void USpatialReceiver::HandleActorAuthority(Worker_AuthorityChangeOp& Op)
 				{
 					Actor->Role = ROLE_Authority;
 
-					if (Actor->GetNetConnection() != nullptr)
-					{
-						Actor->RemoteRole = ROLE_AutonomousProxy;
-					}
-					else if (Actor->IsA<APawn>())
+					if (Actor->IsA<APawn>() || Actor->IsA<APlayerController>())
 					{
 						Actor->RemoteRole = ROLE_AutonomousProxy;
 					}
@@ -232,7 +228,7 @@ void USpatialReceiver::HandleActorAuthority(Worker_AuthorityChangeOp& Op)
 			FClassInfo* Info = TypebindingManager->FindClassInfoByClass(Actor->GetClass());
 			check(Info);
 
-			if (Op.component_id == Info->SchemaComponents[SCHEMA_ClientRPC])
+			if ((Actor->IsA<APawn>() || Actor->IsA<APlayerController>()) && Op.component_id == Info->SchemaComponents[SCHEMA_ClientRPC])
 			{
 				Actor->Role = Op.authority == WORKER_AUTHORITY_AUTHORITATIVE ? ROLE_AutonomousProxy : ROLE_SimulatedProxy;
 			}


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Change USpatialReceiver::HandleActorAuthority to only assign ROLE_AutonomousProxy to APawn or APlayerController. This is a quick fix for UNR-824, which caused owned actors to be set as AutonomousProxy and broke movement replication. A larger re-work of USpatialReceiver::HandleActorAuthority is probably still required.

#### Tests
Tested manually against UnrealGDKStarterProject and UnrealGDKTestSuite locally.

#### Documentation
n/a

#### Primary reviewers
@girayimprobable @joshuahuburn 