### PR TITLE
Fix spawn location and rotation

### DIFF
--- a/RequireSetup
+++ b/RequireSetup
@@ -1,4 +1,4 @@
 Increment the below number whenever it is required to run Setup.bat as part of a new commit.
 Our git hooks will detect this file has been updated and automatically run Setup.bat on pull.
 
-1
+2

--- a/SpatialGDK/Extras/schema/spawndata.schema
+++ b/SpatialGDK/Extras/schema/spawndata.schema
@@ -14,7 +14,8 @@ component SpawnData {
     // scale, and velocity, regardless of whether the actor replicates movement. In our case,
     // location is represented by Spatial position, and this component contains the rest.
     id = 100001;
-    Rotator rotation = 1;
-    improbable.Vector3f scale = 2;
-    improbable.Vector3f velocity = 3;
+    improbable.Vector3f location = 1;
+    Rotator rotation = 2;
+    improbable.Vector3f scale = 3;
+    improbable.Vector3f velocity = 4;
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -134,7 +134,9 @@ private:
 
 	void ReceiveActor(Worker_EntityId EntityId);
 	void RemoveActor(Worker_EntityId EntityId);
-	AActor* CreateActor(improbable::Position* Position, improbable::SpawnData* SpawnData, UClass* ActorClass, bool bDeferred);
+	AActor* CreateActor(improbable::SpawnData* SpawnData, UClass* ActorClass, bool bDeferred);
+
+	static FTransform GetRelativeSpawnTransform(UClass* ActorClass, FTransform SpawnTransform);
 
 	void HandleActorAuthority(Worker_AuthorityChangeOp& Op);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/SpawnData.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/SpawnData.h
@@ -22,6 +22,7 @@ struct SpawnData : Component
 	{
 		const USceneComponent* RootComponent = Actor->GetRootComponent();
 
+		Location = RootComponent ? FRepMovement::RebaseOntoZeroOrigin(Actor->GetActorLocation(), Actor) : FVector::ZeroVector;
 		Rotation = RootComponent ? Actor->GetActorRotation() : FRotator::ZeroRotator;
 		Scale = RootComponent ? Actor->GetActorScale() : FVector::OneVector;
 		Velocity = RootComponent ? Actor->GetVelocity() : FVector::ZeroVector;
@@ -31,9 +32,10 @@ struct SpawnData : Component
 	{
 		Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
 
-		Rotation = GetRotatorFromSchema(ComponentObject, 1);
-		Scale = GetVectorFromSchema(ComponentObject, 2);
-		Velocity = GetVectorFromSchema(ComponentObject, 3);
+		Location = GetVectorFromSchema(ComponentObject, 1);
+		Rotation = GetRotatorFromSchema(ComponentObject, 2);
+		Scale = GetVectorFromSchema(ComponentObject, 3);
+		Velocity = GetVectorFromSchema(ComponentObject, 4);
 	}
 
 	Worker_ComponentData CreateSpawnDataData()
@@ -43,13 +45,15 @@ struct SpawnData : Component
 		Data.schema_type = Schema_CreateComponentData(ComponentId);
 		Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
 
-		AddRotatorToSchema(ComponentObject, 1, Rotation);
-		AddVectorToSchema(ComponentObject, 2, Scale);
-		AddVectorToSchema(ComponentObject, 3, Velocity);
+		AddVectorToSchema(ComponentObject, 1, Location);
+		AddRotatorToSchema(ComponentObject, 2, Rotation);
+		AddVectorToSchema(ComponentObject, 3, Scale);
+		AddVectorToSchema(ComponentObject, 4, Velocity);
 
 		return Data;
 	}
 
+	FVector Location;
 	FRotator Rotation;
 	FVector Scale;
 	FVector Velocity;


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
TL;DR: Location was broken for actors with an owner, rotation was broken if the template actor has rotation.

For actors with an owner, we assign the spatial position to the position of the owner. However, when spawning the actor, we then use that spatial position as the spawn location, so it used the wrong location for actors with an owner. Now, the spawn location is written into SpawnData, and spatial position will not be actually read from by workers (only by Spatial itself to decide authority).
This has a caveat that was already there for rotation, scale, and velocity, which is: if a client checks out an actor some time after it spawned, and the actor doesn't replicate movement but still moved on the server, the client will see it at the original spawn location and not at the new location (as it would in native Unreal due to it sending location, rotation, scale, and velocity to each client with the new actor data, regardless of replicated movement). However, I still think this is acceptable, because in the GDK we don't send new actors individually for each client so we can't imitate Unreal native behavior exactly, and we shouldn't update SpawnData because that's extra bandwidth that the developer didn't ask for. We can always re-evaluate this if it becomes a problem.

For rotation, the problem occurred because `FinishSpawning` actually takes a transform and applies it on top of the template transform, and we were passing it the absolute transform, so it ended up applying the rotation twice.
#### Tests
The location and rotation problems in the Shooter Game were fixed. No visible new problems introduced.
#### Documentation
[JIRA](https://improbableio.atlassian.net/browse/UNR-764)
#### Primary reviewers
@joshuahuburn @m-samiec 