### PR TITLE
Fix 'Access is denied' when Setup.bat is run from git hook

### DIFF
--- a/RequireSetup
+++ b/RequireSetup
@@ -1,4 +1,4 @@
 Increment the below number whenever it is required to run Setup.bat as part of a new commit.
 Our git hooks will detect this file has been updated and automatically run Setup.bat on pull.
 
-2
+3

--- a/Setup.bat
+++ b/Setup.bat
@@ -17,10 +17,10 @@ call :MarkStartOfBlock "Setup the git hooks"
     if exist .git\hooks\post-merge del .git\hooks\post-merge
 
     rem Add git hook to run Setup.bat when RequireSetup file has been updated.
-    echo #!/usr/bin/env bash>>.git\hooks\post-merge
+    echo #!/usr/bin/env bash>.git\hooks\post-merge
     echo changed_files="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)">>.git\hooks\post-merge
     echo check_run() {>>.git\hooks\post-merge
-	echo echo "$changed_files" ^| grep --quiet "$1" ^&^& eval "$2" >>.git\hooks\post-merge
+	echo echo "$changed_files" ^| grep --quiet "$1" ^&^& exec $2>>.git\hooks\post-merge
     echo }>>.git\hooks\post-merge
     echo check_run RequireSetup "cmd.exe /c Setup.bat">>.git\hooks\post-merge
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
When `Setup.bat` runs inside `eval` inside `bash`, it doesn't have permissions to write a new git hook. Replacing `eval` with `exec` fixes the problem.
#### Tests
- Reset to a previous git commit
- Do a `git pull`
- Setup.bat does not generate error messages
The above flow works for both `bash` and `cmd`
#### Primary reviewers
@joshuahuburn @danielimprobable 