### PR TITLE
Bugfix/maintain order of command retries

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialDispatcher.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialDispatcher.cpp
@@ -105,6 +105,8 @@ void USpatialDispatcher::ProcessOps(Worker_OpList* OpList)
 		Receiver->OnComponentUpdate(Op->component_update);
 	}
 
+	Receiver->FlushQueuedRPCs();
+
 	// Check every channel for net ownership changes (determines ACL and component interest)
 	const FActorChannelMap& ChannelMap = NetDriver->GetSpatialOSNetConnection()->ActorChannelMap();
 	for (auto& Pair : ChannelMap)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -738,6 +738,11 @@ void USpatialReceiver::OnCommandResponse(Worker_CommandResponseOp& Op)
 	ReceiveCommandResponse(Op);
 }
 
+void USpatialReceiver::FlushQueuedRPCs()
+{
+	Sender->FlushQueuedRPCs();
+}
+
 void USpatialReceiver::ReceiveCommandResponse(Worker_CommandResponseOp& Op)
 {
 	TSharedRef<FPendingRPCParams>* ReliableRPCPtr = PendingReliableRPCs.Find(Op.request_id);
@@ -768,7 +773,7 @@ void USpatialReceiver::ReceiveCommandResponse(Worker_CommandResponseOp& Op)
 			FTimerHandle RetryTimer;
 			TimerManager->SetTimer(RetryTimer, [this, ReliableRPC]()
 			{
-				Sender->SendRPC(ReliableRPC);
+				Sender->EnqueueRPC(ReliableRPC);
 			}, WaitTime, false);
 		}
 		else

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -438,6 +438,8 @@ void USpatialSender::EnqueueRPC(TSharedRef<FPendingRPCParams> Params)
 
 void USpatialSender::FlushQueuedRPCs()
 {
+	// Retried RPCs are popped from a stack to reverse their order.
+	// This is doe to undo the reversal of ordering caused by the TimerManager class.
 	while (QueuedRPCs.Num() > 0)
 	{
 		SendRPC(QueuedRPCs.Pop());

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -431,6 +431,19 @@ void USpatialSender::SendRPC(TSharedRef<FPendingRPCParams> Params)
 	}
 }
 
+void USpatialSender::EnqueueRPC(TSharedRef<FPendingRPCParams> Params)
+{
+	QueuedRPCs.Push(Params);
+}
+
+void USpatialSender::FlushQueuedRPCs()
+{
+	while (QueuedRPCs.Num() > 0)
+	{
+		SendRPC(QueuedRPCs.Pop());
+	}
+}
+
 void USpatialSender::SendReserveEntityIdRequest(USpatialActorChannel* Channel)
 {
 	UE_LOG(LogSpatialSender, Log, TEXT("Sending reserve entity Id request for %s"), *Channel->Actor->GetName());

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -128,6 +128,7 @@ public:
 	void CleanupDeletedEntity(Worker_EntityId EntityId);
 
 	void ResolvePendingOperations(UObject* Object, const FUnrealObjectRef& ObjectRef);
+	void FlushQueuedRPCs();
 
 private:
 	void EnterCriticalSection();

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -55,6 +55,8 @@ public:
 	void SendComponentUpdates(UObject* Object, FClassInfo* Info, USpatialActorChannel* Channel, const FRepChangeState* RepChanges, const FHandoverChangeState* HandoverChanges);
 	void SendComponentInterest(AActor* Actor, Worker_EntityId EntityId);
 	void SendPositionUpdate(Worker_EntityId EntityId, const FVector& Location);
+	void EnqueueRPC(TSharedRef<FPendingRPCParams> Params);
+	void FlushQueuedRPCs();
 	void SendRPC(TSharedRef<FPendingRPCParams> Params);
 	void SendCommandResponse(Worker_RequestId request_id, Worker_CommandResponse& Response);
 
@@ -110,4 +112,6 @@ private:
 	FOutgoingRPCMap OutgoingRPCs;
 
 	TMap<Worker_RequestId, USpatialActorChannel*> PendingActorRequests;
+
+	TArray<TSharedRef<FPendingRPCParams>> QueuedRPCs;
 };


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------
UNR-760

#### Description
Problem: Retried ReliableRPCs were being retried in the reverse order.

Symptom: HUD was not being displayed.

Explanation:  On startup UPlayerController sends the following RPCs in the following order:

ClientSetHUD
ClientVoiceHandshakeComplete
ClientEnableNetworkVoice
ClientUpdateMultipleLevelsStreamingStatus
ClientFlushLevelStreaming
ClientCapBandwidth
ClientSetSpectatorCamera
ClientSetCameraMode
ClientSetRotation
ClientGameStarted

If Spatial fails these commands for whatever reason, they were being returned, queued up in FTimerManager to be replayed.
FTimerManager was then executing them in the reverse order, resulting in ClientGameStarted being executed before ClientSetHUD, meaning the HUD never got told that the game had started, and thus never displayed itself.

The fix included here, is to push all RPCs to be replayed per frame into a stack, thus reversing the order when they are popped and sent, thus restoring the original ordering of RPCs.
#### Tests
Connecting Shooter game very shortly after starting shooter game is the most reliable way of causing the initial ReliableRPCs sent to UPlayerController to fail. When this happened, and they were replayed in  reverse order, the match was started before the HUD was created, resulting in the HUD not being shown.
With this change, the same startup method is deployed, examining logs to confirm the RPCs still failed, but they get replayed in the correct order, and the HUD displays correctly.
#### Documentation
In-code documentation explaining the reasoning
#### Primary reviewers
@danielimprobable  @m-samiec 