### PR TITLE
If updating the spatial position of a controller, use its Pawn's position

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -737,7 +737,7 @@ FVector USpatialActorChannel::GetActorSpatialPosition(AActor* InActor)
 	// Otherwise if the Actor has a well defined location then use that
 	// Otherwise use the origin
 	AController* Controller = Cast<AController>(InActor);
-	if (Controller && Controller->GetPawn())
+	if (Controller != nullptr && Controller->GetPawn() != nullptr)
 	{
 		return GetActorSpatialPosition(Controller->GetPawn());
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -741,7 +741,7 @@ FVector USpatialActorChannel::GetActorSpatialPosition(AActor* InActor)
 	{
 		return GetActorSpatialPosition(Controller->GetPawn());
 	}
-	else if (InActor->GetOwner())
+	else if (InActor->GetOwner() != nullptr)
 	{
 		return GetActorSpatialPosition(InActor->GetOwner());
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -732,10 +732,16 @@ FVector USpatialActorChannel::GetActorSpatialPosition(AActor* InActor)
 {
 	FVector Location = FVector::ZeroVector;
 
-	// If the Actor has an Owner, use its position.
+	// If the Actor is a Controller, use its Pawn's position,
+	// Otherwise if the Actor has an Owner, use its position.
 	// Otherwise if the Actor has a well defined location then use that
 	// Otherwise use the origin
-	if (InActor->GetOwner())
+	AController* Controller = Cast<AController>(InActor);
+	if (Controller && Controller->GetPawn())
+	{
+		return GetActorSpatialPosition(Controller->GetPawn());
+	}
+	else if (InActor->GetOwner())
 	{
 		return GetActorSpatialPosition(InActor->GetOwner());
 	}


### PR DESCRIPTION


**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------
UNR 762
#### Description
Adding a special case when updating Spatial Position. If the entity is an AController, we instead use it's Pawn's position. This is to prevent players checking out areas of the world they do not require due to their controller being spatially separate from their pawn.

This is an alternative fix to the previous engine change, so that we can revert the engine change.
For reference: 
    https://github.com/improbableio/UnrealEngine/pull/61
    https://github.com/improbableio/UnrealEngine/pull/64
#### Tests
Connect a player to a deployment, without moving, check in the inspector that all 5 player entities are in the same place.
#### Documentation
Updated comment within the method to match new functionality
#### Primary reviewers
@m-samiec @girayimprobable 