### PR TITLE
Fix variable names missed when changing WorkerId -> WorkerAttribute

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -36,18 +36,18 @@ DECLARE_LOG_CATEGORY_EXTERN(LogSpatialOSNetDriver, Log, All);
 class FSpatialWorkerUniqueNetId : public FUniqueNetId
 {
 public:
-	FSpatialWorkerUniqueNetId(const FString& WorkerId) : WorkerId{WorkerId} {}
+	FSpatialWorkerUniqueNetId(const FString& WorkerAttribute) : WorkerAttribute{WorkerAttribute} {}
 	~FSpatialWorkerUniqueNetId() override = default;
 
-	const uint8* GetBytes() const override { return reinterpret_cast<const uint8*>(*WorkerId); }
-	int32 GetSize() const override { return WorkerId.Len() * sizeof(TCHAR); }
+	const uint8* GetBytes() const override { return reinterpret_cast<const uint8*>(*WorkerAttribute); }
+	int32 GetSize() const override { return WorkerAttribute.Len() * sizeof(TCHAR); }
 	bool IsValid() const override { return true; }
-	FString ToString() const override { return WorkerId; }
-	FString ToDebugString() const override { return TEXT("workerId:") + WorkerId; }
+	FString ToString() const override { return WorkerAttribute; }
+	FString ToDebugString() const override { return WorkerAttribute; }
 	virtual FName GetType() const override { return NULL_SUBSYSTEM; };
 
 private:
-	FString WorkerId;
+	FString WorkerAttribute;
 };
 
 UCLASS()

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -36,7 +36,7 @@ DECLARE_LOG_CATEGORY_EXTERN(LogSpatialOSNetDriver, Log, All);
 class FSpatialWorkerUniqueNetId : public FUniqueNetId
 {
 public:
-	FSpatialWorkerUniqueNetId(const FString& WorkerAttribute) : WorkerAttribute{WorkerAttribute} {}
+	FSpatialWorkerUniqueNetId(const FString& InWorkerAttribute) : WorkerAttribute{InWorkerAttribute} {}
 	~FSpatialWorkerUniqueNetId() override = default;
 
 	const uint8* GetBytes() const override { return reinterpret_cast<const uint8*>(*WorkerAttribute); }

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealMetadata.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealMetadata.h
@@ -24,8 +24,8 @@ struct UnrealMetadata : Component
 
 	UnrealMetadata() = default;
 
-	UnrealMetadata(const FString& InStaticPath, const FString& InOwnerWorkerId, const FString& InClassPath)
-		: StaticPath(InStaticPath), OwnerWorkerAttribute(InOwnerWorkerId), ClassPath(InClassPath) {}
+	UnrealMetadata(const FString& InStaticPath, const FString& InOwnerWorkerAttribute, const FString& InClassPath)
+		: StaticPath(InStaticPath), OwnerWorkerAttribute(InOwnerWorkerAttribute), ClassPath(InClassPath) {}
 
 	UnrealMetadata(const Worker_ComponentData& Data)
 	{


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
After the changes to the spawn flow (https://github.com/spatialos/UnrealGDK/pull/391) WorkerAttribute is used instead of WorkerId to represent the owning client. Some variables weren't updated to reflect this.
#### Primary reviewers
@m-samiec @danielimprobable 