### PR TITLE
fixed misspelling of EntityQuery in SpatialWorkerConnection

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
@@ -312,9 +312,9 @@ const TArray<FString>& USpatialWorkerConnection::GetWorkerAttributes() const
 	return CachedWorkerAttributes;
 }
 
-Worker_RequestId USpatialWorkerConnection::SendEntityQueryRequest(const Worker_EntityQuery* EntiyQuery)
+Worker_RequestId USpatialWorkerConnection::SendEntityQueryRequest(const Worker_EntityQuery* EntityQuery)
 {
-	return Worker_Connection_SendEntityQueryRequest(WorkerConnection, EntiyQuery, 0);
+	return Worker_Connection_SendEntityQueryRequest(WorkerConnection, EntityQuery, 0);
 }
 
 void USpatialWorkerConnection::CacheWorkerAttributes()

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialWorkerConnection.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialWorkerConnection.h
@@ -40,7 +40,7 @@ public:
 	void SendComponentInterest(Worker_EntityId EntityId, const TArray<Worker_InterestOverride>& ComponentInterest);
 	FString GetWorkerId() const;
 	const TArray<FString>& GetWorkerAttributes() const;
-	Worker_RequestId SendEntityQueryRequest(const Worker_EntityQuery* EntiyQuery);
+	Worker_RequestId SendEntityQueryRequest(const Worker_EntityQuery* EntityQuery);
 
 	FOnConnectedDelegate OnConnected;
 	FOnConnectFailedDelegate OnConnectFailed;


### PR DESCRIPTION
#### Description
Fixed misspelling of "EntityQuery" in SpatialWorkerConnection, was "EntiyQuery"
#### Tests
Rebuilt my project after the change to make sure nothing was broken by fixing this spelling.
#### Documentation
None
#### Primary reviewers
@girayimprobable 