### PR TITLE
Fix stack overflow from pawn's owner being its controller

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -763,7 +763,7 @@ FVector USpatialActorChannel::GetActorSpatialPosition(AActor* InActor)
 		USceneComponent* PawnRootComponent = Controller->GetPawn()->GetRootComponent();
 		Location = PawnRootComponent->GetComponentLocation();
 	}
-	else if (InActor->GetOwner() != nullptr)
+	else if (InActor->GetOwner() != nullptr && InActor->GetIsReplicated())
 	{
 		return GetActorSpatialPosition(InActor->GetOwner());
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -760,7 +760,8 @@ FVector USpatialActorChannel::GetActorSpatialPosition(AActor* InActor)
 	AController* Controller = Cast<AController>(InActor);
 	if (Controller != nullptr && Controller->GetPawn() != nullptr)
 	{
-		return GetActorSpatialPosition(Controller->GetPawn());
+		USceneComponent* PawnRootComponent = Controller->GetPawn()->GetRootComponent();
+		Location = PawnRootComponent->GetComponentLocation();
 	}
 	else if (InActor->GetOwner() != nullptr)
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -761,7 +761,7 @@ FVector USpatialActorChannel::GetActorSpatialPosition(AActor* InActor)
 	if (Controller != nullptr && Controller->GetPawn() != nullptr)
 	{
 		USceneComponent* PawnRootComponent = Controller->GetPawn()->GetRootComponent();
-		Location = PawnRootComponent->GetComponentLocation();
+		Location = PawnRootComponent ? PawnRootComponent->GetComponentLocation() : FVector::ZeroVector;
 	}
 	else if (InActor->GetOwner() != nullptr && InActor->GetIsReplicated())
 	{


### PR DESCRIPTION
#### Description
When attempting to port a different project, the game crashed on begin play, due to a stack overflow from a pawn calling GetActorSpatialPosition on its owner (the Controller), which in turn called it back on the pawn. The logic has been updated to explicitly get the position from the pawn, rather than calling the method on the pawn.

#### Tests
In editor mode for the ported game. The crash no longer happens