### PR TITLE
[UNR-878] - Override GameNetDriver with SpatialNetDriver

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
@@ -28,6 +28,18 @@ bool USpatialGameInstance::HasSpatialNetDriver() const
 
 		if (NetDriver == nullptr)
 		{
+			// If Spatial networking is enabled, override the GameNetDriver with the SpatialNetDriver
+			if (GetDefault<UGeneralProjectSettings>()->bSpatialNetworking)
+			{
+				if (FNetDriverDefinition* DriverDefinition = GEngine->NetDriverDefinitions.FindByPredicate([](const FNetDriverDefinition& CurDef)
+				{
+					return CurDef.DefName == NAME_GameNetDriver;
+				}))
+				{
+					DriverDefinition->DriverClassName = DriverDefinition->DriverClassNameFallback = TEXT("/Script/SpatialGDK.SpatialNetDriver");
+				}
+			}
+
 			bShouldDestroyNetDriver = GEngine->CreateNamedNetDriver(World, NAME_PendingNetDriver, NAME_GameNetDriver);
 			NetDriver = GEngine->FindNamedNetDriver(World, NAME_PendingNetDriver);
 		}


### PR DESCRIPTION
#### Description
If spatial networking is enabled, override the GameNetDriver with the SpatialNetDriver to save doing this in config ini files

#### Tests
Tested with StarterProject in editor and externally, NetDriver was overridden successfully when spatial networking was enabled

#### Primary reviewers
@Vatyx @m-samiec 