### PR TITLE
Bug fix - removing from a set whilst iterating over it.

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -511,6 +511,7 @@ void USpatialSender::ResetOutgoingUpdate(USpatialActorChannel* DependentChannel,
 	UE_LOG(LogSpatialSender, Log, TEXT("Resetting pending outgoing array depending on channel: %s, object: %s, handle: %d."),
 		*DependentChannel->GetName(), *ReplicatedObject->GetName(), Handle);
 
+	TArray<TWeakObjectPtr<const UObject>> InvalidObjects;
 	for (TWeakObjectPtr<const UObject>& UnresolvedObject : *Unresolved)
 	{
 		if (UnresolvedObject.IsValid())
@@ -531,9 +532,15 @@ void USpatialSender::ResetOutgoingUpdate(USpatialActorChannel* DependentChannel,
 		else
 		{
 			// If the object is no longer valid (may have been deleted or IsPendingKill) then remove it from the UnresolvedObjects.
-			Unresolved->Remove(UnresolvedObject);
+			// (Only remove after iterating over the set)
+			InvalidObjects.Add(UnresolvedObject);
 			// TODO: UNR-814 Also remove it from other maps which reference the object by handle etc.
 		}
+	}
+
+	for (TWeakObjectPtr<const UObject>& InvalidObject : InvalidObjects)
+	{
+		Unresolved->Remove(InvalidObject);
 	}
 
 	HandleToUnresolved->Remove(Handle);
@@ -580,9 +587,8 @@ void USpatialSender::QueueOutgoingUpdate(USpatialActorChannel* DependentChannel,
 		}
 		else
 		{
-			// If the object is no longer valid (may have been deleted or IsPendingKill) then remove it from the UnresolvedObjects.
-			Unresolved->Remove(UnresolvedObject);
-			// TODO: UNR-814 Also remove it from other maps which reference the object by handle etc.
+			// It is expected that this will never be reached. If it is, we should consider whether to clean up the invalid objects here.
+			UE_LOG(LogSpatialSender, Error, TEXT("Invalid UnresolvedObject passed in to USpatialSender::QueueOutgoingUpdate"));
 		}
 	}
 }
@@ -633,12 +639,6 @@ Worker_CommandRequest USpatialSender::CreateRPCCommandRequest(UObject* TargetObj
 			Schema_DestroyCommandRequest(CommandRequest.schema_type);
 			return CommandRequest;
 		}
-		else
-		{
-			// If the object is no longer valid (may have been deleted or IsPendingKill) then remove it from the UnresolvedObjects.
-			UnresolvedObjects.Remove(Object);
-			// TODO: UNR-814 Also remove it from other maps which reference the object by handle etc.
-		}
 	}
 
 	AddPayloadToSchema(RequestObject, 1, PayloadWriter);
@@ -679,12 +679,6 @@ Worker_ComponentUpdate USpatialSender::CreateMulticastUpdate(UObject* TargetObje
 			OutUnresolvedObject = Object.Get();
 			Schema_DestroyComponentUpdate(ComponentUpdate.schema_type);
 			return ComponentUpdate;
-		}
-		else
-		{
-			// If the object is no longer valid (may have been deleted or IsPendingKill) then remove it from the UnresolvedObjects.
-			UnresolvedObjects.Remove(Object);
-			// TODO: UNR-814 Also remove it from other maps which reference the object by handle etc.
 		}
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -511,6 +511,8 @@ void USpatialSender::ResetOutgoingUpdate(USpatialActorChannel* DependentChannel,
 	UE_LOG(LogSpatialSender, Log, TEXT("Resetting pending outgoing array depending on channel: %s, object: %s, handle: %d."),
 		*DependentChannel->GetName(), *ReplicatedObject->GetName(), Handle);
 
+	// Remove any references to the unresolved objects. Since these are not dereferenced before removing,
+	// it is safe to not check whether the unresolved object is still valid.
 	for (TWeakObjectPtr<const UObject>& UnresolvedObject : *Unresolved)
 	{
 		FChannelToHandleToUnresolved& ChannelToUnresolved = ObjectToUnresolved.FindChecked(UnresolvedObject);


### PR DESCRIPTION
#### Description
(See https://improbableio.atlassian.net/browse/UNR-881 for context)

For `ResetOutgoingUpdate`. make a list of invalid objects, to remove after iterating on the set.

For `CreateRPCCommandRequest` and `CreateMulticastRequest`, `UnresolvedObjects.Remove(Object);` is useless here because the set is only used to get the first element then return.

For `QueueOutgoingUpdate`, it is not expected to ever have invalid subobjects, so the remove has been removed, but if it is ever found to be reached, we should deal with it properly.

#### Tests
Running for a while in UnrealTournament, attempting to trigger the use case that caused the issue. It is no longer reached, and the QueueOutgoingUpdate log was not reached.

#### Primary reviewers
@improbable-valentyn @joshuahuburn 