### PR TITLE
Bug fix - clean up the entity and actor channel when torn off.

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -454,7 +454,11 @@ void USpatialReceiver::RemoveActor(Worker_EntityId EntityId)
 	// If entity is to be deleted after having been torn off, clean up the entity, but don't destroy the actor.
 	if (Actor->GetTearOff())
 	{
-		CleanupDeletedEntity(EntityId);
+		if (USpatialActorChannel* ActorChannel = NetDriver->GetActorChannelByEntityId(EntityId))
+		{
+			ActorChannel->ConditionalCleanUp();
+			CleanupDeletedEntity(EntityId);
+		}
 		return;
 	}
 


### PR DESCRIPTION
#### Description
The ragdolls (actors) were not being cleaned up because their role was not set to ROLE_AUTHORITY (which is done when the actor channel is closed/cleaned up). Calling ConditionalCleanUp on the channel when the entity is removed fixes this.

#### Tests
Works on the UnrealGDKShooterGame. (visually is cleaned up)

#### Primary reviewers
@m-samiec @improbable-valentyn 