### PR TITLE
Added error when replicating with no schema.

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -568,6 +568,8 @@ void USpatialActorChannel::SetChannelActor(AActor* InActor)
 
 	if (NetDriver->TypebindingManager->FindClassInfoByClass(InActor->GetClass()) == nullptr)
 	{
+		UE_LOG(LogSpatialActorChannel, Error, TEXT("No schema was generated for class %s! This class was not loaded during schema generation most likely due to soft references."
+			"Either manually load the class before schema generation or have a hard reference from a class that is already loaded."), *InActor->GetClass()->GetName())
 		return;
 	}
 


### PR DESCRIPTION
#### Description
Soft references to blueprints can cause referenced actors to not be loaded, leading to no schema generated for them which in turn means we can't replicate them. This will potentially help with finding what classes aren't being replicated.