### PR TITLE
Fix FBitReader::SetOverflowed being called due to using the number of bytes instead of bits

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialPlayerSpawner.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialPlayerSpawner.cpp
@@ -36,7 +36,7 @@ void USpatialPlayerSpawner::ReceivePlayerSpawnRequest(Schema_Object* Payload, co
 
 	FUniqueNetIdRepl UniqueId;
 	TArray<uint8> UniqueIdBytes = GetBytesFromSchema(Payload, 2);
-	FNetBitReader UniqueIdReader(nullptr, UniqueIdBytes.GetData(), UniqueIdBytes.Num());
+	FNetBitReader UniqueIdReader(nullptr, UniqueIdBytes.GetData(), UniqueIdBytes.Num() * 8);
 	UniqueIdReader << UniqueId;
 
 	FName OnlinePlatformName = FName(*GetStringFromSchema(Payload, 3));


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Bits, bytes.
If we wanted to be more correct, we could send the exact number of bits that was used to serialize the UniqueId, but that would mean adding bandwidth that isn't necessarily useful.
Bytes * 8 >= (Bits actually used)
#### Tests
Ran ShooterGame against this, and the `FBitReader::SetOverflowed` errors go away.
#### Primary reviewers
@m-samiec