### PR TITLE
Add more info to the 'invalid sub-object' error log

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -190,7 +190,7 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 		TWeakObjectPtr<UObject> Subobject = PackageMap->GetObjectFromUnrealObjectRef(FUnrealObjectRef(Channel->GetEntityId(), SubobjectInfoPair.Key));
 		if (!Subobject.IsValid())
 		{
-			UE_LOG(LogSpatialSender, Error, TEXT("Tried to generate initial replication state for an invalid sub-object. Object may have been deleted or is PendingKill."));
+			UE_LOG(LogSpatialSender, Error, TEXT("Tried to generate initial replication state for an invalid sub-object (class %s, sub-object %s, actor %s). Object may have been deleted or is PendingKill."), *SubobjectInfo->Class->GetName(), *SubobjectInfo->SubobjectName.ToString(), *Actor->GetName());
 			continue;
 		}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -190,7 +190,7 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 		TWeakObjectPtr<UObject> Subobject = PackageMap->GetObjectFromUnrealObjectRef(FUnrealObjectRef(Channel->GetEntityId(), SubobjectInfoPair.Key));
 		if (!Subobject.IsValid())
 		{
-			UE_LOG(LogSpatialSender, Error, TEXT("Tried to generate initial replication state for an invalid sub-object (class %s, sub-object %s, actor %s). Object may have been deleted or is PendingKill."), *SubobjectInfo->Class->GetName(), *SubobjectInfo->SubobjectName.ToString(), *Actor->GetName());
+			UE_LOG(LogSpatialSender, Warning, TEXT("Tried to generate initial replication state for an invalid sub-object (class %s, sub-object %s, actor %s). Object may have been deleted or is PendingKill."), *SubobjectInfo->Class->GetName(), *SubobjectInfo->SubobjectName.ToString(), *Actor->GetName());
 			continue;
 		}
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Makes it easier to tell if something is wrong or if the error is benign.
In the case of ShooterGame, this gets triggered with the level scripts actors' DefaultSceneRoot objects, which are present for schema generation, but removed at runtime.
Also, make this a warning instead of error (this will trigger consistently for LevelScriptActor's DefaultSceneRoot).
#### Primary reviewers
@m-samiec 