### PR TITLE
Removed the all map option from BuildWorker

### DIFF
--- a/RequireSetup
+++ b/RequireSetup
@@ -1,4 +1,4 @@
 Increment the below number whenever it is required to run Setup.bat as part of a new commit.
 Our git hooks will detect this file has been updated and automatically run Setup.bat on pull.
 
-5
+6

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Build/Build.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Build/Build.cs
@@ -151,7 +151,6 @@ exit /b !ERRORLEVEL!
                     "-SkipCookingEditorContent",
                     "-platform=" + platform,
                     "-targetplatform=" + platform,
-                    "-allmaps",
                 });
 
                 var windowsNoEditorPath = Path.Combine(stagingDir, "WindowsNoEditor");
@@ -189,7 +188,6 @@ exit /b !ERRORLEVEL!
                     "-SkipCookingEditorContent",
                     "-platform=" + platform,
                     "-targetplatform=" + platform,
-                    "-allmaps",
                     "-nullrhi",
                 });
 
@@ -243,7 +241,6 @@ exit /b !ERRORLEVEL!
                     "-unattended",
                     "-fileopenlog",
                     "-SkipCookingEditorContent",
-                    "-allmaps",
                     "-server",
                     "-serverplatform=" + platform,
                     "-noclient",


### PR DESCRIPTION
#### Description
Remove the -allmaps option from the build.cs script.
Users can specify the maps they want to build via `+MapsToCook` option in their Game config.

#### Tests
Built win64 development and verified the MapsToCook are present (as well as any default maps)

#### Primary reviewers
@Vatyx @chrisfields0 