### PR TITLE
UNR-938 Critical with unresolved objects

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitWriter.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitWriter.cpp
@@ -37,7 +37,7 @@ void FSpatialNetBitWriter::SerializeObjectRef(FUnrealObjectRef& ObjectRef)
 FArchive& FSpatialNetBitWriter::operator<<(UObject*& Value)
 {
 	FUnrealObjectRef ObjectRef;
-	if (Value != nullptr)
+	if (Value != nullptr && !Value->IsPendingKill())
 	{
 		auto PackageMapClient = Cast<USpatialPackageMapClient>(PackageMap);
 		FNetworkGUID NetGUID = PackageMapClient->GetNetGUIDFromObject(Value);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -511,7 +511,7 @@ void USpatialSender::ResetOutgoingUpdate(USpatialActorChannel* DependentChannel,
 		*DependentChannel->GetName(), *ReplicatedObject->GetName(), Handle);
 
 	// Remove any references to the unresolved objects. Since these are not dereferenced before removing,
-	// it is safe to not check whether the unresolved object is still valid.
+	// It is safe to not check whether the unresolved object is still valid.
 	for (TWeakObjectPtr<const UObject>& UnresolvedObject : *Unresolved)
 	{
 		FChannelToHandleToUnresolved& ChannelToUnresolved = ObjectToUnresolved.FindChecked(UnresolvedObject);
@@ -561,20 +561,17 @@ void USpatialSender::QueueOutgoingUpdate(USpatialActorChannel* DependentChannel,
 
 	for (const TWeakObjectPtr<const UObject>& UnresolvedObject : UnresolvedObjects)
 	{
-		if (UnresolvedObject.IsValid())
-		{
-			FHandleToUnresolved& AnotherHandleToUnresolved = ObjectToUnresolved.FindOrAdd(UnresolvedObject).FindOrAdd(ChannelObjectPair);
-			check(!AnotherHandleToUnresolved.Find(Handle));
-			AnotherHandleToUnresolved.Add(Handle, Unresolved);
+		// It is expected that this will never be reached. We should never have added an invalid object as an unresolved reference.
+		// Check the ComponentFactory.cpp should this ever be triggered.
+		checkf(UnresolvedObject.IsValid(), TEXT("Invalid UnresolvedObject passed in to USpatialSender::QueueOutgoingUpdate"));
 
-			// Following up on the previous log: listing the unresolved objects
-			UE_LOG(LogSpatialSender, Log, TEXT("- %s"), *UnresolvedObject->GetName());
-		}
-		else
-		{
-			// It is expected that this will never be reached. If it is, we should consider whether to clean up the invalid objects here.
-			UE_LOG(LogSpatialSender, Error, TEXT("Invalid UnresolvedObject passed in to USpatialSender::QueueOutgoingUpdate"));
-		}
+		FHandleToUnresolved& AnotherHandleToUnresolved = ObjectToUnresolved.FindOrAdd(UnresolvedObject).FindOrAdd(ChannelObjectPair);
+		check(!AnotherHandleToUnresolved.Find(Handle));
+		AnotherHandleToUnresolved.Add(Handle, Unresolved);
+
+		// Following up on the previous log: listing the unresolved objects
+		UE_LOG(LogSpatialSender, Log, TEXT("- %s"), *UnresolvedObject->GetName());
+
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -510,8 +510,8 @@ void USpatialSender::ResetOutgoingUpdate(USpatialActorChannel* DependentChannel,
 	UE_LOG(LogSpatialSender, Log, TEXT("Resetting pending outgoing array depending on channel: %s, object: %s, handle: %d."),
 		*DependentChannel->GetName(), *ReplicatedObject->GetName(), Handle);
 
-	// Remove any references to the unresolved objects. Since these are not dereferenced before removing,
-	// It is safe to not check whether the unresolved object is still valid.
+	// Remove any references to the unresolved objects.
+	// Since these are not dereferenced before removing, it is safe to not check whether the unresolved object is still valid.
 	for (TWeakObjectPtr<const UObject>& UnresolvedObject : *Unresolved)
 	{
 		FChannelToHandleToUnresolved& ChannelToUnresolved = ObjectToUnresolved.FindChecked(UnresolvedObject);

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
@@ -188,7 +188,7 @@ void ComponentFactory::AddProperty(Schema_Object* Object, Schema_FieldId FieldId
 		FUnrealObjectRef ObjectRef = SpatialConstants::NULL_OBJECT_REF;
 
 		UObject* ObjectValue = ObjectProperty->GetObjectPropertyValue(Data);
-		if (ObjectValue != nullptr)
+		if (ObjectValue != nullptr && !ObjectValue->IsPendingKill())
 		{
 			FNetworkGUID NetGUID;
 			if (ObjectValue->IsFullNameStableForNetworking() || ObjectValue->IsSupportedForNetworking())


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
https://improbableio.atlassian.net/browse/UNR-938

When constructing component updates we would check for the object not being null but not whether the object is invalid (IsPendingKill()).

Then when adding UnresolvedObjects to our unresolved maps, we WOULD check for `IsPendingKill()` and never add that UnresolvedObject to our maps.

`LogSpatialSender: Error: Invalid UnresolvedObject passed in to USpatialSender::QueueOutgoingUpdate`

Then when running `USpatialSender::ResetOutgoingUpdate` we would look for the UnresolvedObject inside of the component update using `FChannelToHandleToUnresolved& ChannelToUnresolved = ObjectToUnresolved.FindChecked(UnresolvedObject);` 

Since the UnresolvedObject was never added to the map this would hit a `check(Pair != nullptr);` and crash the server.

To fix this we now have a `IsPendingKill()` check added in the ComponentFactory.cpp and SpatialNetBitWritter before constructing an update.

#### Primary reviewers
@m-samiec @improbable-valentyn 