### PR TITLE
Added checks for actor channel validity when creating entities

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -439,6 +439,7 @@ void USpatialNetDriver::NotifyActorDestroyed(AActor* ThisActor, bool IsSeamlessT
 			{
 				check(Channel->OpenedLocally);
 				Channel->bClearRecentActorRefs = false;
+				// TODO: UNR-952 - Add code here for cleaning up actor channels from our maps.
 				Channel->Close();
 			}
 
@@ -846,6 +847,7 @@ int32 USpatialNetDriver::ServerReplicateActors_ProcessPrioritizedActors(UNetConn
 				if (!Actor->IsNetStartupActor())
 				{
 					UE_LOG(LogNetTraffic, Log, TEXT("- Closing channel for no longer relevant actor %s"), *Actor->GetName());
+					// TODO: UNR-952 - Add code here for cleaning up actor channels from our maps.
 					Channel->Close();
 				}
 			}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -968,7 +968,7 @@ void USpatialReceiver::OnCreateEntityResponse(Worker_CreateEntityResponseOp& Op)
 	}
 	else
 	{
-		UE_LOG(LogSpatialReceiver, Warning, TEXT("Recieved CreateEntityResponse for actor which no longer has an actor channel: request id: %d, entity id: %lld"), Op.request_id, Op.entity_id);
+		UE_LOG(LogSpatialReceiver, Warning, TEXT("Received CreateEntityResponse for actor which no longer has an actor channel: request id: %d, entity id: %lld"), Op.request_id, Op.entity_id);
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -918,7 +918,7 @@ void USpatialReceiver::OnReserveEntityIdResponse(Worker_ReserveEntityIdResponseO
 	TWeakObjectPtr<USpatialActorChannel> Channel = PopPendingActorRequest(Op.request_id);
 
 	// It's possible for the ActorChannel to have been closed by the time we receive a response. Actor validity is checked within the channel.
-	if (Channel != nullptr && !Channel->IsPendingKill())
+	if (Channel.IsValid())
 	{
 		Channel->OnReserveEntityIdResponse(Op);
 	}
@@ -962,7 +962,7 @@ void USpatialReceiver::OnCreateEntityResponse(Worker_CreateEntityResponseOp& Op)
 	TWeakObjectPtr<USpatialActorChannel> Channel = PopPendingActorRequest(Op.request_id);
 
 	// It's possible for the ActorChannel to have been closed by the time we receive a response. Actor validity is checked within the channel.
-	if (Channel != nullptr && !Channel->IsPendingKill())
+	if (Channel.IsValid())
 	{
 		Channel->OnCreateEntityResponse(Op);
 	}

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -159,7 +159,7 @@ private:
 
 	void ProcessQueuedResolvedObjects();
 	void UpdateShadowData(Worker_EntityId EntityId);
-	USpatialActorChannel* PopPendingActorRequest(Worker_RequestId RequestId);
+	TWeakObjectPtr<USpatialActorChannel> PopPendingActorRequest(Worker_RequestId RequestId);
 
 private:
 	template <typename T>
@@ -198,7 +198,7 @@ private:
 	TArray<PendingAddComponentWrapper> PendingAddComponents;
 	TArray<Worker_EntityId> PendingRemoveEntities;
 
-	TMap<Worker_RequestId, USpatialActorChannel*> PendingActorRequests;
+	TMap<Worker_RequestId, TWeakObjectPtr<USpatialActorChannel>> PendingActorRequests;
 	FReliableRPCMap PendingReliableRPCs;
 
 	TMap<Worker_RequestId, EntityQueryDelegate> EntityQueryDelegates;


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
It's possible for actor channels to be closed when receiving reserve ID or create entity responses. This PR checks actor channel validity before using them to prevent crashing.
Also converted PendingActorRequests to use TWeakPtrs since the channels can be closed and GC'd.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.