### PR TITLE
changed type of key in TMap so linux build will not give errors

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -47,7 +47,7 @@ using FUnresolvedEntry = TSharedPtr<TSet<TWeakObjectPtr<const UObject>>>;
 using FHandleToUnresolved = TMap<uint16, FUnresolvedEntry>;
 using FChannelToHandleToUnresolved = TMap<FChannelObjectPair, FHandleToUnresolved>;
 using FOutgoingRepUpdates = TMap<TWeakObjectPtr<const UObject>, FChannelToHandleToUnresolved>;
-using FUpdatesQueuedUntilAuthority = TMap<int64, TArray<Worker_ComponentUpdate>>;
+using FUpdatesQueuedUntilAuthority = TMap<Worker_EntityId_Key, TArray<Worker_ComponentUpdate>>;
 
 UCLASS()
 class SPATIALGDK_API USpatialSender : public UObject

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -47,7 +47,7 @@ using FUnresolvedEntry = TSharedPtr<TSet<TWeakObjectPtr<const UObject>>>;
 using FHandleToUnresolved = TMap<uint16, FUnresolvedEntry>;
 using FChannelToHandleToUnresolved = TMap<FChannelObjectPair, FHandleToUnresolved>;
 using FOutgoingRepUpdates = TMap<TWeakObjectPtr<const UObject>, FChannelToHandleToUnresolved>;
-using FUpdatesQueuedUntilAuthority = TMap<Worker_EntityId, TArray<Worker_ComponentUpdate>>;
+using FUpdatesQueuedUntilAuthority = TMap<int64, TArray<Worker_ComponentUpdate>>;
 
 UCLASS()
 class SPATIALGDK_API USpatialSender : public UObject


### PR DESCRIPTION
#### Description
In SpatialSender.h changed type of the key of a TMap from Worker_EntityId to int64, as the former was causing clang to throw errors for linux builds.
#### Tests
I tried to build a server worker after the changes and the build succeeded (instead of failing as it did before). I also launched a deployment and it runs successfully.
What automated tests are included in this PR?
#### Documentation
none
#### Primary reviewers
@BenNaccarato @improbable-valentyn 