### PR TITLE
Fix USpatialGameInstance::StartPlayInEditorGameInstance() to properly call OnStart() if on Client

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
@@ -139,6 +139,12 @@ FGameInstancePIEResult USpatialGameInstance::StartPlayInEditorGameInstance(ULoca
 	{
 		return Super::StartPlayInEditorGameInstance(LocalPlayer, Params);
 	}
+	// CORVUS_BEGIN
+	else
+	{
+		OnStart();
+	}
+	// CORVUS_END
 
 	FString Error;
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
@@ -139,12 +139,10 @@ FGameInstancePIEResult USpatialGameInstance::StartPlayInEditorGameInstance(ULoca
 	{
 		return Super::StartPlayInEditorGameInstance(LocalPlayer, Params);
 	}
-	// CORVUS_BEGIN
 	else
 	{
 		OnStart();
 	}
-	// CORVUS_END
 
 	FString Error;
 


### PR DESCRIPTION
#### Description
USpatialGameInstance::StartPlayInEditorGameInstance() was not calling OnStart() on every path it can takes, that is, when not calling Super::StartPlayInEditorGameInstance() that call it for us.

#### Release note
Bugfix: StartPlayInEditorGameInstance() now correctly call OnStart() on PIE_Client

#### Tests
void UCorvusGameInstance::OnStart() derived class was not called on PIE_Client if running on Spatial Networking, while it was called when playing in raw unreal engine networking

Now our logs (and features) are showing that it work.