### PR TITLE
[UNR-874] Heartbeats, player disconnection

### DIFF
--- a/RequireSetup
+++ b/RequireSetup
@@ -1,4 +1,4 @@
 Increment the below number whenever it is required to run Setup.bat as part of a new commit.
 Our git hooks will detect this file has been updated and automatically run Setup.bat on pull.
 
-5
+7

--- a/SpatialGDK/Extras/schema/heartbeat.schema
+++ b/SpatialGDK/Extras/schema/heartbeat.schema
@@ -5,6 +5,6 @@ type HeartbeatEvent {
 }
 
 component Heartbeat {
-    id = 100007;
+    id = 100009;
     event HeartbeatEvent heartbeat;
 }

--- a/SpatialGDK/Extras/schema/heartbeat.schema
+++ b/SpatialGDK/Extras/schema/heartbeat.schema
@@ -1,0 +1,10 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+package unreal;
+
+type HeartbeatEvent {
+}
+
+component Heartbeat {
+    id = 100008;
+    event HeartbeatEvent heartbeat;
+}

--- a/SpatialGDK/Extras/schema/heartbeat.schema
+++ b/SpatialGDK/Extras/schema/heartbeat.schema
@@ -5,6 +5,6 @@ type HeartbeatEvent {
 }
 
 component Heartbeat {
-    id = 100008;
+    id = 100007;
     event HeartbeatEvent heartbeat;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
@@ -99,7 +99,7 @@ void USpatialNetConnection::InitHeartbeat(FTimerManager* InTimerManager, Worker_
 				{
 					if (EventCount > 1)
 					{
-						UE_LOG(LogTemp, Warning, TEXT("Received multiple heartbeat events in a single component update, entity %lld."), ConnectionPtr->PlayerControllerEntity);
+						UE_LOG(LogTemp, Log, TEXT("Received multiple heartbeat events in a single component update, entity %lld."), ConnectionPtr->PlayerControllerEntity);
 					}
 
 					ConnectionPtr->OnHeartbeat();

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
@@ -2,12 +2,27 @@
 
 #include "EngineClasses/SpatialNetConnection.h"
 
+#include "TimerManager.h"
+
 #include "EngineClasses/SpatialNetDriver.h"
 #include "EngineClasses/SpatialPackageMapClient.h"
+#include "Interop/SpatialReceiver.h"
+#include "SpatialConstants.h"
 
-USpatialNetConnection::USpatialNetConnection(const FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer)
+#include <WorkerSDK/improbable/c_schema.h>
+
+USpatialNetConnection::USpatialNetConnection(const FObjectInitializer& ObjectInitializer)
+	: Super(ObjectInitializer)
+	, PlayerControllerEntity(SpatialConstants::INVALID_ENTITY_ID)
 {
 	InternalAck = 1;
+}
+
+void USpatialNetConnection::BeginDestroy()
+{
+	DisableHeartbeat();
+
+	Super::BeginDestroy();
 }
 
 void USpatialNetConnection::InitBase(UNetDriver* InDriver, class FSocket* InSocket, const FURL& InURL, EConnectionState InState, int32 InMaxPacket /*= 0*/, int32 InPacketOverhead /*= 0*/)
@@ -28,26 +43,15 @@ void USpatialNetConnection::InitBase(UNetDriver* InDriver, class FSocket* InSock
 	}
 }
 
-void USpatialNetConnection::InitLocalConnection(UNetDriver* InDriver, class FSocket* InSocket, const FURL& InURL, EConnectionState InState, int32 InMaxPacket, int32 InPacketOverhead)
+void USpatialNetConnection::LowLevelSend(void * Data, int32 CountBytes, int32 CountBits)
 {
-	Super::InitLocalConnection(InDriver, InSocket, InURL, InState, InMaxPacket, InPacketOverhead);
-}
-
-void USpatialNetConnection::InitRemoteConnection(UNetDriver* InDriver, class FSocket* InSocket, const FURL& InURL, const class FInternetAddr& InRemoteAddr, EConnectionState InState, int32 InMaxPacket, int32 InPacketOverhead)
-{
-	Super::InitRemoteConnection(InDriver, InSocket, InURL, InRemoteAddr, InState, InMaxPacket, InPacketOverhead);
-
+	//Intentionally does not call Super::
 }
 
 bool USpatialNetConnection::ClientHasInitializedLevelFor(const AActor* TestActor) const
 {
 	check(Driver->IsServer());
 	return true;
-	//Intentionally does not call Super::
-}
-
-void USpatialNetConnection::LowLevelSend(void * Data, int32 CountBytes, int32 CountBits)
-{
 	//Intentionally does not call Super::
 }
 
@@ -69,4 +73,81 @@ int32 USpatialNetConnection::IsNetReady(bool Saturate)
 	// TODO: UNR-664 - Currently we do not report the number of bits sent when replicating, this means channel saturation cannot be checked properly.
 	// This will always return true until we solve this.
 	return true;
+}
+
+void USpatialNetConnection::InitHeartbeat(FTimerManager* InTimerManager, Worker_EntityId InPlayerControllerEntity)
+{
+	checkf(PlayerControllerEntity == SpatialConstants::INVALID_ENTITY_ID, TEXT("InitHeartbeat: PlayerControllerEntity already set: %lld. New entity: %lld"), PlayerControllerEntity, InPlayerControllerEntity);
+	PlayerControllerEntity = InPlayerControllerEntity;
+	TimerManager = InTimerManager;
+
+	bIsServer = Driver->IsServer();
+
+	if (Driver->IsServer())
+	{
+		SetHeartbeatTimeoutTimer();
+
+		// Set up heartbeat event callback
+		TWeakObjectPtr<USpatialNetConnection> ConnectionPtr = this;
+		Cast<USpatialNetDriver>(Driver)->Receiver->AddHeartbeatDelegate(PlayerControllerEntity, HeartbeatDelegate::CreateLambda([ConnectionPtr](Worker_ComponentUpdateOp& Op)
+		{
+			if (ConnectionPtr.IsValid())
+			{
+				Schema_Object* EventsObject = Schema_GetComponentUpdateEvents(Op.update.schema_type);
+				uint32 EventCount = Schema_GetObjectCount(EventsObject, SpatialConstants::HEARTBEAT_EVENT_ID);
+				if (EventCount > 0)
+				{
+					if (EventCount > 1)
+					{
+						UE_LOG(LogTemp, Warning, TEXT("Received multiple heartbeat events in a single component update, entity %lld."), ConnectionPtr->PlayerControllerEntity);
+					}
+
+					ConnectionPtr->OnHeartbeat();
+				}
+			}
+		}));
+	}
+	else
+	{
+		SetHeartbeatEventTimer();
+	}
+}
+
+void USpatialNetConnection::SetHeartbeatTimeoutTimer()
+{
+	TimerManager->SetTimer(HeartbeatTimer, [this]()
+	{
+		// This client timed out. Disconnect it and trigger OnDisconnected logic.
+		CleanUp();
+	}, SpatialConstants::HEARTBEAT_TIMEOUT_SECONDS, false);
+}
+
+void USpatialNetConnection::SetHeartbeatEventTimer()
+{
+	TimerManager->SetTimer(HeartbeatTimer, [this]()
+	{
+		Worker_ComponentUpdate ComponentUpdate = {};
+
+		ComponentUpdate.component_id = SpatialConstants::HEARTBEAT_COMPONENT_ID;
+		ComponentUpdate.schema_type = Schema_CreateComponentUpdate(SpatialConstants::HEARTBEAT_COMPONENT_ID);
+		Schema_Object* EventsObject = Schema_GetComponentUpdateEvents(ComponentUpdate.schema_type);
+		Schema_AddObject(EventsObject, SpatialConstants::HEARTBEAT_EVENT_ID);
+
+		Cast<USpatialNetDriver>(Driver)->Connection->SendComponentUpdate(PlayerControllerEntity, &ComponentUpdate);
+	}, SpatialConstants::HEARTBEAT_INTERVAL_SECONDS, true, 0.0f);
+}
+
+void USpatialNetConnection::DisableHeartbeat()
+{
+	// Remove the heartbeat callback
+	if (TimerManager != nullptr && HeartbeatTimer.IsValid())
+	{
+		TimerManager->ClearTimer(HeartbeatTimer);
+	}
+	PlayerControllerEntity = SpatialConstants::INVALID_ENTITY_ID;
+}
+
+void USpatialNetConnection::OnHeartbeat()
+{
+	SetHeartbeatTimeoutTimer();
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
@@ -11,6 +11,8 @@
 
 #include <WorkerSDK/improbable/c_schema.h>
 
+DEFINE_LOG_CATEGORY(LogSpatialNetConnection);
+
 USpatialNetConnection::USpatialNetConnection(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 	, PlayerControllerEntity(SpatialConstants::INVALID_ENTITY_ID)
@@ -81,8 +83,6 @@ void USpatialNetConnection::InitHeartbeat(FTimerManager* InTimerManager, Worker_
 	PlayerControllerEntity = InPlayerControllerEntity;
 	TimerManager = InTimerManager;
 
-	bIsServer = Driver->IsServer();
-
 	if (Driver->IsServer())
 	{
 		SetHeartbeatTimeoutTimer();
@@ -99,7 +99,7 @@ void USpatialNetConnection::InitHeartbeat(FTimerManager* InTimerManager, Worker_
 				{
 					if (EventCount > 1)
 					{
-						UE_LOG(LogTemp, Log, TEXT("Received multiple heartbeat events in a single component update, entity %lld."), ConnectionPtr->PlayerControllerEntity);
+						UE_LOG(LogSpatialNetConnection, Log, TEXT("Received multiple heartbeat events in a single component update, entity %lld."), ConnectionPtr->PlayerControllerEntity);
 					}
 
 					ConnectionPtr->OnHeartbeat();

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -666,7 +666,6 @@ int32 USpatialNetDriver::ServerReplicateActors_ProcessPrioritizedActors(UNetConn
 	for (int32 j = 0; j < FinalSortedCount; j++)
 	{
 		// Deletion entry
-		// Does this ever happen? Seems to be intended for destroyed startup actors, since we don't populate DestroyedStartupOrDormantActors after that because of the overridden NotifyActorDestroyed.
 		if (PriorityActors[j]->ActorInfo == NULL && PriorityActors[j]->DestructionInfo)
 		{
 			// Make sure client has streaming level loaded
@@ -892,18 +891,18 @@ int32 USpatialNetDriver::ServerReplicateActors(float DeltaSeconds)
 	// The fake spatial connection will borrow the player controllers from other connections.
 	for (int j = 1; j < ClientConnections.Num(); j++)
 	{
-		USpatialNetConnection* OtherSpatialConnection = Cast<USpatialNetConnection>(ClientConnections[j]);
-		check(OtherSpatialConnection);
+		USpatialNetConnection* ClientConnection = Cast<USpatialNetConnection>(ClientConnections[j]);
+		check(ClientConnection);
 
-		if (OtherSpatialConnection->ViewTarget)
+		if (ClientConnection->ViewTarget != nullptr)
 		{
-			new(ConnectionViewers)FNetViewer(OtherSpatialConnection, DeltaSeconds);
+			new(ConnectionViewers)FNetViewer(ClientConnection, DeltaSeconds);
 
-			for (int32 ViewerIndex = 0; ViewerIndex < OtherSpatialConnection->Children.Num(); ViewerIndex++)
+			for (UChildConnection* ChildConnection : ClientConnection->Children)
 			{
-				if (OtherSpatialConnection->Children[ViewerIndex]->ViewTarget != NULL)
+				if (ChildConnection->ViewTarget != nullptr)
 				{
-					new(ConnectionViewers)FNetViewer(OtherSpatialConnection->Children[ViewerIndex], DeltaSeconds);
+					new(ConnectionViewers)FNetViewer(ChildConnection, DeltaSeconds);
 				}
 			}
 		}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -598,26 +598,7 @@ int32 USpatialNetDriver::ServerReplicateActors_PrioritizeActors(UNetConnection* 
 				Channel->StartBecomingDormant();
 			}
 
-			// SpatialGDK: This actor should only be replicated if GetNetworkConnection() matches this connection. However, if this actor doesn't have a connection
-			// (which implies that it's owned by the server rather than a client), then it should fall back to the "catch all" SpatialOS connection which is
-			// ClientConnections[0]. The below condition means that each actor should only be replicated once, unless "ClientConnections" contain duplicates,
-			// which should never happen.
-			UNetConnection* ActorConnection = Actor->GetNetConnection();
-			if (ActorConnection != InConnection)
-			{
-				if (ActorConnection == nullptr && InConnection == ClientConnections[0])
-				{
-					UE_LOG(LogSpatialOSNetDriver, Verbose, TEXT("Actor %s will be replicated on the catch-all connection"), *Actor->GetName());
-				}
-				else
-				{
-					continue;
-				}
-			}
-			else
-			{
-				UE_LOG(LogSpatialOSNetDriver, Verbose, TEXT("Actor %s will be replicated on the connection %s"), *Actor->GetName(), *InConnection->GetName());
-			}
+			UE_LOG(LogSpatialOSNetDriver, Verbose, TEXT("Actor %s will be replicated on the catch-all connection"), *Actor->GetName());
 
 			// SpatialGDK: Here, Unreal does initial relevancy checking and level load checking.
 			// We have removed the level load check because it doesn't apply.
@@ -685,6 +666,7 @@ int32 USpatialNetDriver::ServerReplicateActors_ProcessPrioritizedActors(UNetConn
 	for (int32 j = 0; j < FinalSortedCount; j++)
 	{
 		// Deletion entry
+		// Does this ever happen? Seems to be intended for destroyed startup actors, since we don't populate DestroyedStartupOrDormantActors after that because of the overridden NotifyActorDestroyed.
 		if (PriorityActors[j]->ActorInfo == NULL && PriorityActors[j]->DestructionInfo)
 		{
 			// Make sure client has streaming level loaded
@@ -718,25 +700,10 @@ int32 USpatialNetDriver::ServerReplicateActors_ProcessPrioritizedActors(UNetConn
 		// Normal actor replication
 		USpatialActorChannel* Channel = Cast<USpatialActorChannel>(PriorityActors[j]->Channel);
 		UE_LOG(LogNetTraffic, Log, TEXT(" Maybe Replicate %s"), *PriorityActors[j]->ActorInfo->Actor->GetName());
-		if (Channel == nullptr || Channel->Actor) // Make sure didn't just close this channel.
+		if (Channel == nullptr || Channel->Actor != nullptr) // Make sure didn't just close this channel.
 		{
 			AActor* Actor = PriorityActors[j]->ActorInfo->Actor;
 			bool bIsRelevant = false;
-
-			// Workaround: If the actor channel can't be found in the current connection (e.g. if the actor was detached from the controller),
-			// then search through all the connections to find the actor's channel.
-			// Task to improve this: https://improbableio.atlassian.net/browse/UNR-842
-			if (Channel == nullptr)
-			{
-				for (auto& ClientConnection : ClientConnections)
-				{
-					Channel = Cast<USpatialActorChannel>(ClientConnection->ActorChannelMap().FindRef(Actor));
-					if (Channel != nullptr)
-					{
-						break;
-					}
-				}
-			}
 
 			// SpatialGDK: Here, Unreal would check (again) whether an actor is relevant. Removed such checks.
 			// only check visibility on already visible actors every 1.0 + 0.5R seconds
@@ -913,112 +880,79 @@ int32 USpatialNetDriver::ServerReplicateActors(float DeltaSeconds)
 
 	FMemMark Mark(FMemStack::Get());
 
-	for (int32 i = 0; i < ClientConnections.Num(); i++)
+	// Only process the fake spatial connection. It will be responsible for replicating all actors, regardless of whether they're owned by a client.
+	USpatialNetConnection* SpatialConnection = Cast<USpatialNetConnection>(ClientConnections[0]);
+	check(SpatialConnection && SpatialConnection->bReliableSpatialConnection);
+
+	// Make a list of viewers this connection should consider (this connection and children of this connection)
+	TArray<FNetViewer>& ConnectionViewers = WorldSettings->ReplicationViewers;
+
+	ConnectionViewers.Reset();
+
+	// The fake spatial connection will borrow the player controllers from other connections.
+	for (int j = 1; j < ClientConnections.Num(); j++)
 	{
-		USpatialNetConnection* SpatialConnection = Cast<USpatialNetConnection>(ClientConnections[i]);
-		check(SpatialConnection);
+		USpatialNetConnection* OtherSpatialConnection = Cast<USpatialNetConnection>(ClientConnections[j]);
+		check(OtherSpatialConnection);
 
-		if (SpatialConnection->bReliableSpatialConnection || SpatialConnection->ViewTarget)
+		if (OtherSpatialConnection->ViewTarget)
 		{
-			// Make a list of viewers this connection should consider (this connection and children of this connection)
-			TArray<FNetViewer>& ConnectionViewers = WorldSettings->ReplicationViewers;
+			new(ConnectionViewers)FNetViewer(OtherSpatialConnection, DeltaSeconds);
 
-			if (SpatialConnection->ViewTarget)
+			for (int32 ViewerIndex = 0; ViewerIndex < OtherSpatialConnection->Children.Num(); ViewerIndex++)
 			{
-				ConnectionViewers.Reset();
-				new(ConnectionViewers)FNetViewer(SpatialConnection, DeltaSeconds);
-				for (int32 ViewerIndex = 0; ViewerIndex < SpatialConnection->Children.Num(); ViewerIndex++)
+				if (OtherSpatialConnection->Children[ViewerIndex]->ViewTarget != NULL)
 				{
-					if (SpatialConnection->Children[ViewerIndex]->ViewTarget != NULL)
-					{
-						new(ConnectionViewers)FNetViewer(SpatialConnection->Children[ViewerIndex], DeltaSeconds);
-					}
+					new(ConnectionViewers)FNetViewer(OtherSpatialConnection->Children[ViewerIndex], DeltaSeconds);
 				}
 			}
-			else
-			{
-				ConnectionViewers.Reset();
-
-				// Not having a ViewTarget implies this must be the fake spatial connection and thus borrow the player controllers from other connections.
-				for (int j = 0; j < ClientConnections.Num(); j++)
-				{
-					USpatialNetConnection* OtherSpatialConnection = Cast<USpatialNetConnection>(ClientConnections[j]);
-					check(OtherSpatialConnection);
-
-					if (OtherSpatialConnection->ViewTarget)
-					{
-						new(ConnectionViewers)FNetViewer(OtherSpatialConnection, DeltaSeconds);
-
-						for (int32 ViewerIndex = 0; ViewerIndex < OtherSpatialConnection->Children.Num(); ViewerIndex++)
-						{
-							if (OtherSpatialConnection->Children[ViewerIndex]->ViewTarget != NULL)
-							{
-								new(ConnectionViewers)FNetViewer(OtherSpatialConnection->Children[ViewerIndex], DeltaSeconds);
-							}
-						}
-					}
-				}
-			}
-
-			FMemMark RelevantActorMark(FMemStack::Get());
-
-			FActorPriority* PriorityList = NULL;
-			FActorPriority** PriorityActors = NULL;
-
-			// Get a sorted list of actors for this connection
-			const int32 FinalSortedCount = ServerReplicateActors_PrioritizeActors(SpatialConnection, ConnectionViewers, ConsiderList, bCPUSaturated, PriorityList, PriorityActors);
-
-			// Process the sorted list of actors for this connection
-			const int32 LastProcessedActor = ServerReplicateActors_ProcessPrioritizedActors(SpatialConnection, ConnectionViewers, PriorityActors, FinalSortedCount, Updated);
-
-			// relevant actors that could not be processed this frame are marked to be considered for next frame
-			for (int32 k = LastProcessedActor; k < FinalSortedCount; k++)
-			{
-				if (!PriorityActors[k]->ActorInfo)
-				{
-					// A deletion entry, skip it because we dont have anywhere to store a 'better give higher priority next time'
-					continue;
-				}
-
-				AActor* Actor = PriorityActors[k]->ActorInfo->Actor;
-
-				UActorChannel* Channel = PriorityActors[k]->Channel;
-
-				UE_LOG(LogNetTraffic, Verbose, TEXT("Saturated. %s"), *Actor->GetName());
-				if (Channel != NULL && Time - Channel->RelevantTime <= 1.f)
-				{
-					UE_LOG(LogNetTraffic, Log, TEXT(" Saturated. Mark %s NetUpdateTime to be checked for next tick"), *Actor->GetName());
-					PriorityActors[k]->ActorInfo->bPendingNetUpdate = true;
-				}
-				else if (IsActorRelevantToConnection(Actor, ConnectionViewers))
-				{
-					// If this actor was relevant but didn't get processed, force another update for next frame
-					UE_LOG(LogNetTraffic, Log, TEXT(" Saturated. Mark %s NetUpdateTime to be checked for next tick"), *Actor->GetName());
-					PriorityActors[k]->ActorInfo->bPendingNetUpdate = true;
-					if (Channel != NULL)
-					{
-						Channel->RelevantTime = Time + 0.5f * FMath::SRand();
-					}
-				}
-			}
-			RelevantActorMark.Pop();
-			ConnectionViewers.Reset();
 		}
 	}
 
-	// shuffle the list of connections if not all connections were ticked
-	if (NumClientsToTick < ClientConnections.Num())
+	FMemMark RelevantActorMark(FMemStack::Get());
+
+	FActorPriority* PriorityList = NULL;
+	FActorPriority** PriorityActors = NULL;
+
+	// Get a sorted list of actors for this connection
+	const int32 FinalSortedCount = ServerReplicateActors_PrioritizeActors(SpatialConnection, ConnectionViewers, ConsiderList, bCPUSaturated, PriorityList, PriorityActors);
+
+	// Process the sorted list of actors for this connection
+	const int32 LastProcessedActor = ServerReplicateActors_ProcessPrioritizedActors(SpatialConnection, ConnectionViewers, PriorityActors, FinalSortedCount, Updated);
+
+	// relevant actors that could not be processed this frame are marked to be considered for next frame
+	for (int32 k = LastProcessedActor; k < FinalSortedCount; k++)
 	{
-		int32 NumConnectionsToMove = NumClientsToTick;
-		while (NumConnectionsToMove > 0)
+		if (!PriorityActors[k]->ActorInfo)
 		{
-			// move all the ticked connections to the end of the list so that the other connections are considered first for the next frame
-			UNetConnection *ClientConnection = ClientConnections[0];
-			ClientConnections.RemoveAt(0, 1);
-			ClientConnections.Add(ClientConnection);
-			NumConnectionsToMove--;
+			// A deletion entry, skip it because we don't have anywhere to store a 'better give higher priority next time'
+			continue;
+		}
+
+		AActor* Actor = PriorityActors[k]->ActorInfo->Actor;
+
+		UActorChannel* Channel = PriorityActors[k]->Channel;
+
+		UE_LOG(LogNetTraffic, Verbose, TEXT("Saturated. %s"), *Actor->GetName());
+		if (Channel != NULL && Time - Channel->RelevantTime <= 1.f)
+		{
+			UE_LOG(LogNetTraffic, Log, TEXT(" Saturated. Mark %s NetUpdateTime to be checked for next tick"), *Actor->GetName());
+			PriorityActors[k]->ActorInfo->bPendingNetUpdate = true;
+		}
+		else if (IsActorRelevantToConnection(Actor, ConnectionViewers))
+		{
+			// If this actor was relevant but didn't get processed, force another update for next frame
+			UE_LOG(LogNetTraffic, Log, TEXT(" Saturated. Mark %s NetUpdateTime to be checked for next tick"), *Actor->GetName());
+			PriorityActors[k]->ActorInfo->bPendingNetUpdate = true;
+			if (Channel != NULL)
+			{
+				Channel->RelevantTime = Time + 0.5f * FMath::SRand();
+			}
 		}
 	}
+	RelevantActorMark.Pop();
+	ConnectionViewers.Reset();
+
 	Mark.Pop();
 
 	if (DebugRelevantActors)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -13,6 +13,7 @@
 #include "Interop/Connection/SpatialWorkerConnection.h"
 #include "Interop/SpatialReceiver.h"
 #include "Interop/SpatialDispatcher.h"
+#include "Schema/Heartbeat.h"
 #include "Schema/Interest.h"
 #include "Schema/Singleton.h"
 #include "Schema/SpawnData.h"
@@ -103,6 +104,10 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 	ComponentWriteAcl.Add(SpatialConstants::INTEREST_COMPONENT_ID, ServersOnly);
 	ComponentWriteAcl.Add(SpatialConstants::SPAWN_DATA_COMPONENT_ID, ServersOnly);
 	ComponentWriteAcl.Add(SpatialConstants::ENTITY_ACL_COMPONENT_ID, ServersOnly);
+	if (Actor->IsA<APlayerController>())
+	{
+		ComponentWriteAcl.Add(SpatialConstants::HEARTBEAT_COMPONENT_ID, OwningClientOnly);
+	}
 
 	ForAllSchemaComponentTypes([&](ESchemaComponentType Type)
 	{
@@ -148,6 +153,10 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 	ComponentDatas.Add(improbable::SpawnData(Actor).CreateSpawnDataData());
 	ComponentDatas.Add(improbable::UnrealMetadata({}, ClientWorkerAttribute, Class->GetPathName()).CreateUnrealMetadataData());
 	ComponentDatas.Add(improbable::Interest().CreateInterestData());
+	if (Actor->IsA<APlayerController>())
+	{
+		ComponentDatas.Add(improbable::Heartbeat().CreateHeartbeatData());
+	}
 
 	if (Class->HasAnySpatialClassFlags(SPATIALCLASS_Singleton))
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStaticComponentView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStaticComponentView.cpp
@@ -3,6 +3,7 @@
 #include "Interop/SpatialStaticComponentView.h"
 
 #include "Schema/Component.h"
+#include "Schema/Heartbeat.h"
 #include "Schema/Interest.h"
 #include "Schema/Singleton.h"
 #include "Schema/SpawnData.h"
@@ -54,6 +55,9 @@ void USpatialStaticComponentView::OnAddComponent(const Worker_AddComponentOp& Op
 		break;
 	case SpatialConstants::INTEREST_COMPONENT_ID:
 		Data = MakeUnique<improbable::ComponentStorage<improbable::Interest>>(Op.data);
+		break;
+	case SpatialConstants::HEARTBEAT_COMPONENT_ID:
+		Data = MakeUnique<improbable::ComponentStorage<improbable::Heartbeat>>(Op.data);
 		break;
 	default:
 		return;

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetConnection.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetConnection.h
@@ -5,6 +5,8 @@
 #include "CoreMinimal.h"
 #include "IpConnection.h"
 
+#include <WorkerSDK/improbable/c_worker.h>
+
 #include "SpatialNetConnection.generated.h"
 
 UCLASS(transient)
@@ -14,9 +16,9 @@ class SPATIALGDK_API USpatialNetConnection : public UIpConnection
 public:
 	USpatialNetConnection(const FObjectInitializer& ObjectInitializer);
 
+	virtual void BeginDestroy() override;
+
 	virtual void InitBase(UNetDriver* InDriver, class FSocket* InSocket, const FURL& InURL, EConnectionState InState, int32 InMaxPacket = 0, int32 InPacketOverhead = 0) override;
-	virtual void InitRemoteConnection(UNetDriver* InDriver, class FSocket* InSocket, const FURL& InURL, const class FInternetAddr& InRemoteAddr, EConnectionState InState, int32 InMaxPacket = 0, int32 InPacketOverhead = 0) override;
-	virtual void InitLocalConnection(UNetDriver* InDriver, class FSocket* InSocket, const FURL& InURL, EConnectionState InState, int32 InMaxPacket = 0, int32 InPacketOverhead = 0) override;
 	virtual void LowLevelSend(void* Data, int32 CountBytes, int32 CountBits) override;
 	virtual bool ClientHasInitializedLevelFor(const AActor* TestActor) const override;
 	virtual void Tick() override;
@@ -28,9 +30,25 @@ public:
 	virtual FString RemoteAddressToString() override { return TEXT(""); }
 	///////
 
+	void InitHeartbeat(class FTimerManager* InTimerManager, Worker_EntityId InPlayerControllerEntity);
+	void SetHeartbeatTimeoutTimer();
+	void SetHeartbeatEventTimer();
+
+	void DisableHeartbeat();
+
+	void OnHeartbeat();
+
 	UPROPERTY()
 	bool bReliableSpatialConnection;
 
 	UPROPERTY()
 	FString WorkerAttribute;
+
+	class FTimerManager* TimerManager;
+
+	// Player lifecycle
+	Worker_EntityId PlayerControllerEntity;
+	FTimerHandle HeartbeatTimer;
+
+	bool bIsServer;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetConnection.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetConnection.h
@@ -9,6 +9,8 @@
 
 #include "SpatialNetConnection.generated.h"
 
+DECLARE_LOG_CATEGORY_EXTERN(LogSpatialNetConnection, Log, All);
+
 UCLASS(transient)
 class SPATIALGDK_API USpatialNetConnection : public UIpConnection
 {
@@ -49,6 +51,4 @@ public:
 	// Player lifecycle
 	Worker_EntityId PlayerControllerEntity;
 	FTimerHandle HeartbeatTimer;
-
-	bool bIsServer;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -91,6 +91,7 @@ using FIncomingRPCArray = TArray<TSharedPtr<FPendingIncomingRPC>>;
 
 DECLARE_DELEGATE_OneParam(EntityQueryDelegate, Worker_EntityQueryResponseOp&);
 DECLARE_DELEGATE_OneParam(ReserveEntityIDsDelegate, Worker_ReserveEntityIdsResponseOp&);
+DECLARE_DELEGATE_OneParam(HeartbeatDelegate, Worker_ComponentUpdateOp&);
 
 UCLASS()
 class USpatialReceiver : public UObject
@@ -120,6 +121,8 @@ public:
 
 	void AddEntityQueryDelegate(Worker_RequestId RequestId, EntityQueryDelegate Delegate);
 	void AddReserveEntityIdsDelegate(Worker_RequestId RequestId, ReserveEntityIDsDelegate Delegate);
+
+	void AddHeartbeatDelegate(Worker_EntityId EntityId, HeartbeatDelegate Delegate);
 
 	void OnEntityQueryResponse(Worker_EntityQueryResponseOp& Op);
 
@@ -203,4 +206,6 @@ private:
 
 	TMap<Worker_RequestId, EntityQueryDelegate> EntityQueryDelegates;
 	TMap<Worker_RequestId, ReserveEntityIDsDelegate> ReserveEntityIDsDelegates;
+
+	TMap<Worker_EntityId_Key, HeartbeatDelegate> HeartbeatDelegates;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -144,6 +144,7 @@ private:
 
 	void QueryForStartupActor(AActor* Actor, Worker_EntityId EntityId);
 
+	void HandlePlayerLifecycleAuthority(Worker_AuthorityChangeOp& Op, class APlayerController* PlayerController);
 	void HandleActorAuthority(Worker_AuthorityChangeOp& Op);
 
 	void ApplyComponentData(Worker_EntityId EntityId, Worker_ComponentData& Data, USpatialActorChannel* Channel);

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/Heartbeat.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/Heartbeat.h
@@ -1,0 +1,34 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "Schema/Component.h"
+#include "SpatialConstants.h"
+#include "Utils/SchemaUtils.h"
+
+#include <WorkerSDK/improbable/c_schema.h>
+#include <WorkerSDK/improbable/c_worker.h>
+
+namespace improbable
+{
+
+struct Heartbeat : Component
+{
+	static const Worker_ComponentId ComponentId = SpatialConstants::HEARTBEAT_COMPONENT_ID;
+
+	Heartbeat() = default;
+	Heartbeat(const Worker_ComponentData& Data)
+	{
+	}
+
+	FORCEINLINE Worker_ComponentData CreateHeartbeatData()
+	{
+		Worker_ComponentData Data = {};
+		Data.component_id = ComponentId;
+		Data.schema_type = Schema_CreateComponentData(ComponentId);
+
+		return Data;
+	}
+};
+
+}

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -104,7 +104,7 @@ namespace SpatialConstants
 	const Worker_ComponentId UNREAL_METADATA_COMPONENT_ID					= 100004;
 	const Worker_ComponentId SINGLETON_MANAGER_COMPONENT_ID					= 100005;
 	const Worker_ComponentId DEPLOYMENT_MAP_COMPONENT_ID					= 100006;
-	const Worker_ComponentId HEARTBEAT_COMPONENT_ID							= 100007;
+	const Worker_ComponentId HEARTBEAT_COMPONENT_ID							= 100009;
 	const Worker_ComponentId STARTING_GENERATED_COMPONENT_ID				= 100010;
 
 	const Schema_FieldId GLOBAL_STATE_MANAGER_MAP_URL_ID			= 1;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -105,10 +105,16 @@ namespace SpatialConstants
 	const Worker_ComponentId SINGLETON_MANAGER_COMPONENT_ID					= 100005;
 	const Worker_ComponentId DEPLOYMENT_MAP_COMPONENT_ID					= 100006;
 	const Worker_ComponentId SERVER_ONLY_SINGLETON_COMPONENT_ID				= 100007;
+	const Worker_ComponentId HEARTBEAT_COMPONENT_ID							= 100008;
 	const Worker_ComponentId STARTING_GENERATED_COMPONENT_ID				= 100010;
 
 	const Schema_FieldId GLOBAL_STATE_MANAGER_MAP_URL_ID			= 1;
 	const Schema_FieldId GLOBAL_STATE_MANAGER_ACCEPTING_PLAYERS_ID	= 2;
+
+	const Schema_FieldId HEARTBEAT_EVENT_ID = 1;
+
+	const float HEARTBEAT_INTERVAL_SECONDS = 2.0f;
+	const float HEARTBEAT_TIMEOUT_SECONDS = 10.0f;
 
 	const float FIRST_COMMAND_RETRY_WAIT_SECONDS = 0.2f;
 	const float REPLICATED_STABLY_NAMED_ACTORS_DELETION_TIMEOUT_SECONDS = 5.0f;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -104,8 +104,7 @@ namespace SpatialConstants
 	const Worker_ComponentId UNREAL_METADATA_COMPONENT_ID					= 100004;
 	const Worker_ComponentId SINGLETON_MANAGER_COMPONENT_ID					= 100005;
 	const Worker_ComponentId DEPLOYMENT_MAP_COMPONENT_ID					= 100006;
-	const Worker_ComponentId SERVER_ONLY_SINGLETON_COMPONENT_ID				= 100007;
-	const Worker_ComponentId HEARTBEAT_COMPONENT_ID							= 100008;
+	const Worker_ComponentId HEARTBEAT_COMPONENT_ID							= 100007;
 	const Worker_ComponentId STARTING_GENERATED_COMPONENT_ID				= 100010;
 
 	const Schema_FieldId GLOBAL_STATE_MANAGER_MAP_URL_ID			= 1;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -119,6 +119,7 @@ namespace SpatialConstants
 
 	const Schema_FieldId HEARTBEAT_EVENT_ID = 1;
 
+	// TODO: Make these easily configurable: UNR-984
 	const float HEARTBEAT_INTERVAL_SECONDS = 2.0f;
 	const float HEARTBEAT_TIMEOUT_SECONDS = 10.0f;
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Allow the server to tell when a client disconnects from the deployment.
This is implemented using heartbeats using events. Client is authoritative over the heartbeat component and sends heartbeat events at regular intervals. The server will reset the timeout each time it receives a heartbeat event.

#### Release note
Feature: Server will identify clients that have been disconnected from Spatial and trigger the cleanup on their NetConnection.

#### Tests
Tested with ThirdPersonShooter and ShooterGame by running a PIE server + client and connecting an external client, then closing the external client and observing the character get destroyed.
Also, tested by running an external server with two clients and closing one of the clients.

How can this be verified by QA?
Player character is destroyed some time after a player disconnects (10 seconds).

#### Primary reviewers
@m-samiec @Vatyx 