### PR TITLE
[UNR-911] Pass player name and login options in the login URL

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialPlayerSpawner.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialPlayerSpawner.cpp
@@ -85,18 +85,18 @@ void USpatialPlayerSpawner::SendPlayerSpawnRequest()
 			checkf(Op.result_count == 1, TEXT("There should never be more than one SpatialSpawner entity."));
 
 			// Construct and send the player spawn request.
-			FURL DummyURL;
+			FURL LoginURL;
+			FUniqueNetIdRepl UniqueId;
+			FName OnlinePlatformName;
+			ObtainPlayerId(LoginURL, UniqueId, OnlinePlatformName);
+
 			Worker_CommandRequest CommandRequest = {};
 			CommandRequest.component_id = SpatialConstants::PLAYER_SPAWNER_COMPONENT_ID;
 			CommandRequest.schema_type = Schema_CreateCommandRequest(SpatialConstants::PLAYER_SPAWNER_COMPONENT_ID, 1);
 			Schema_Object* RequestObject = Schema_GetCommandRequestObject(CommandRequest.schema_type);
-			AddStringToSchema(RequestObject, 1, DummyURL.ToString(true));
+			AddStringToSchema(RequestObject, 1, LoginURL.ToString(true));
 
 			// Write player identity information.
-			FUniqueNetIdRepl UniqueId;
-			FName OnlinePlatformName;
-			ObtainPlayerId(UniqueId, OnlinePlatformName);
-
 			FNetBitWriter UniqueIdWriter(0);
 			UniqueIdWriter << UniqueId;
 			AddBytesToSchema(RequestObject, 2, UniqueIdWriter);
@@ -136,7 +136,7 @@ void USpatialPlayerSpawner::ReceivePlayerSpawnResponse(Worker_CommandResponseOp&
 	}
 }
 
-void USpatialPlayerSpawner::ObtainPlayerId(FUniqueNetIdRepl& OutUniqueId, FName& OutOnlinePlatformName)
+void USpatialPlayerSpawner::ObtainPlayerId(FURL& LoginURL, FUniqueNetIdRepl& OutUniqueId, FName& OutOnlinePlatformName)
 {
 	const FWorldContext* const WorldContext = GEngine->GetWorldContextFromWorld(NetDriver->GetWorld());
 	check(WorldContext->OwningGameInstance);
@@ -144,7 +144,19 @@ void USpatialPlayerSpawner::ObtainPlayerId(FUniqueNetIdRepl& OutUniqueId, FName&
 	// This code is adapted from PendingNetGame.cpp:242
 	if (ULocalPlayer* LocalPlayer = WorldContext->OwningGameInstance->GetFirstGamePlayer())
 	{
-		// TODO: Send nickname and game login options as a part of the URL. UNR-911
+		// Send the player nickname if available
+		FString OverrideName = LocalPlayer->GetNickname();
+		if (OverrideName.Len() > 0)
+		{
+			LoginURL.AddOption(*FString::Printf(TEXT("Name=%s"), *OverrideName));
+		}
+
+		// Send any game-specific url options for this player
+		FString GameUrlOptions = LocalPlayer->GetGameLoginOptions();
+		if (GameUrlOptions.Len() > 0)
+		{
+			LoginURL.AddOption(*FString::Printf(TEXT("%s"), *GameUrlOptions));
+		}
 
 		// Send the player unique Id at login
 		OutUniqueId = LocalPlayer->GetPreferredUniqueNetId();

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialPlayerSpawner.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialPlayerSpawner.h
@@ -33,7 +33,7 @@ public:
 	void ReceivePlayerSpawnResponse(Worker_CommandResponseOp& Op);
 
 private:
-	void ObtainPlayerId(FURL& LoginURL, FUniqueNetIdRepl& OutUniqueId, FName& OutOnlinePlatformName);
+	void ObtainPlayerId(struct FURL& LoginURL, FUniqueNetIdRepl& OutUniqueId, FName& OutOnlinePlatformName);
 
 	UPROPERTY()
 	USpatialNetDriver* NetDriver;

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialPlayerSpawner.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialPlayerSpawner.h
@@ -33,7 +33,7 @@ public:
 	void ReceivePlayerSpawnResponse(Worker_CommandResponseOp& Op);
 
 private:
-	void ObtainPlayerId(FUniqueNetIdRepl& OutUniqueId, FName& OutOnlinePlatformName);
+	void ObtainPlayerId(FURL& LoginURL, FUniqueNetIdRepl& OutUniqueId, FName& OutOnlinePlatformName);
 
 	UPROPERTY()
 	USpatialNetDriver* NetDriver;


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Imitate the native Unreal login logic from `PendingNetGame.cpp` and pass the player's nickname and login options with the URL.

#### Release note
Feature: Pass player name and login options in the login URL.
(Documentation changes are exempt)

#### Tests
In native Unreal in ShooterGame, the players are given names based on the name of their machine, and that shows on the leaderboard. With this PR, that functionality is also present in Spatial.

#### Primary reviewers
@m-samiec @BenNaccarato 