### PR TITLE
UNR-982: Actor not destroyed when entity removed

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -495,7 +495,7 @@ void USpatialReceiver::RemoveActor(Worker_EntityId EntityId)
 
 	// Actor is a startup actor that is a part of the level. We need to do an entity query to see
 	// if the entity was actually deleted or only removed from our view
-	if (Actor->bNetLoadOnClient)
+	if (Actor->IsFullNameStableForNetworking())
 	{
 		QueryForStartupActor(Actor, EntityId);
 		return;


### PR DESCRIPTION
#### Description
Fixed an issue in https://github.com/spatialos/UnrealGDK/pull/623 which caused character controllers to be treated as startup actors when it comes to removing the actor.

#### Release note
Bugfix: Fixed an issue which caused a character controller to not be destroyed when leaving the view of an observing client.

#### Tests
Tested locally in Starter project.
QA: Adjust client checkout radius to something small, connect two clients, move one of them outside the view of the other (use inspector to make sure it's out), ensure that the pawn is no longer visible. Move the client back into view, ensure that the pawn is visible again. 

#### Documentation
Release note

#### Primary reviewers
@Vatyx