### PR TITLE
Fix the fix for the multiserver PIE shutdown

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -305,13 +305,12 @@ void FSpatialNetGUIDCache::RemoveEntityNetGUID(Worker_EntityId EntityId)
 
 	// Remove actor.
 	FNetworkGUID EntityNetGUID = GetNetGUIDFromEntityId(EntityId);
-	NetGUIDToUnrealObjectRef.Remove(EntityNetGUID);
 	// TODO: Figure out why NetGUIDToUnrealObjectRef might not have this GUID. UNR-989
 	if (FUnrealObjectRef* ActorRef = NetGUIDToUnrealObjectRef.Find(EntityNetGUID))
 	{
 		UnrealObjectRefToNetGUID.Remove(*ActorRef);
 	}
-
+	NetGUIDToUnrealObjectRef.Remove(EntityNetGUID);
 	if (StablyNamedRefOption.IsSet())
 	{
 		UnrealObjectRefToNetGUID.Remove(StablyNamedRefOption.GetValue());


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
This fixes my error in https://github.com/spatialos/UnrealGDK/pull/656.
The real reason for the crash observed in multiserver PIE shutdown is still unidentified, tracked in UNR-989.

#### Primary reviewers
@Vatyx 