### PR TITLE
Wrap with null check to avoid crash bug on quit for deployments

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
@@ -191,7 +191,10 @@ void USpatialGameInstance::Shutdown()
 	UWorld* World = GetWorld();
 	if (World != nullptr && SpatialConnection != nullptr && SpatialConnection->IsConnected())
 	{
-		Cast<USpatialNetDriver>(World->GetNetDriver())->HandleOnDisconnected(TEXT("Client shutdown"));
+		if (World->GetNetDriver() != nullptr)
+		{
+			Cast<USpatialNetDriver>(World->GetNetDriver())->HandleOnDisconnected(TEXT("Client shutdown"));
+		}
 	}
 
 	Super::Shutdown();


### PR DESCRIPTION
#### Description
There was a crash bug due to having a null netdriver when attempting to quit from a built out client. Adding a null check before the call stops this crash arising.

#### Tests
Tested on shooter game, in editor, and in playtest (13/02/19 - will wait until QA confirm it doesn't occur when using this fix before merging it.)

#### Primary reviewers
@m-samiec @joshuahuburn 