### PR TITLE
If schema database is manually deleted, reset internal state for schema generator

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -268,7 +268,7 @@ void DeleteGeneratedSchemaFiles()
 	PlatformFile.CreateDirectory(*SchemaOutputPath);
 }
 
-void InitClassPathToSchemaMap()
+void TryLoadExistingSchemaDatabase()
 {
 	TSoftObjectPtr<USchemaDatabase> SchemaDatabasePtr(FSoftObjectPath(TEXT("/Game/Spatial/SchemaDatabase.SchemaDatabase")));
 	SchemaDatabasePtr.LoadSynchronous();
@@ -290,7 +290,10 @@ void InitClassPathToSchemaMap()
 	else
 	{
 		UE_LOG(LogSpatialGDKSchemaGenerator, Log, TEXT("SchemaDatabase not found on Engine startup so the generated schema directory will be cleared out if it exists."));
+
+		ClassPathToSchema.Empty();
 		NextAvailableComponentId = SpatialConstants::STARTING_GENERATED_COMPONENT_ID;
+
 		// As a safety precaution, if the SchemaDatabase.uasset doesn't exist then make sure the schema generated folder is cleared as well. 
 		DeleteGeneratedSchemaFiles();
 	}
@@ -333,6 +336,8 @@ bool SpatialGDKGenerateSchema()
 {
 	ClassToSchemaName.Empty();
 	UsedSchemaNames.Empty();
+
+	TryLoadExistingSchemaDatabase();
 
 	// gets the classes currently loaded into memory
 	SchemaGeneratedClasses = GetAllSupportedClasses();

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
@@ -16,7 +16,7 @@ DEFINE_LOG_CATEGORY(LogSpatialGDKEditor);
 FSpatialGDKEditor::FSpatialGDKEditor()
 	: bSchemaGeneratorRunning(false)
 {
-	InitClassPathToSchemaMap();
+	TryLoadExistingSchemaDatabase();
 }
 
 void FSpatialGDKEditor::GenerateSchema(FSimpleDelegate SuccessCallback, FSimpleDelegate FailureCallback, FSpatialGDKEditorErrorHandler ErrorCallback)

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSchemaGenerator.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSchemaGenerator.h
@@ -8,6 +8,6 @@ DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKSchemaGenerator, Log, All);
 
 SPATIALGDKEDITOR_API bool SpatialGDKGenerateSchema();
 
-SPATIALGDKEDITOR_API void InitClassPathToSchemaMap();
+SPATIALGDKEDITOR_API void TryLoadExistingSchemaDatabase();
 
 SPATIALGDKEDITOR_API void PreProcessSchemaMap();


### PR DESCRIPTION
#### Description
If the SchemaDatabase doesn't exist on generation of schema, ClassPathToSchema is emptied to reset what classes are supported.

#### Release note
Bugfix - Deleting the schema database reset the starting component ID

#### Primary reviewers
@m-samiec @BenNaccarato 