### PR TITLE
Fix delete dynamic entities check

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -493,7 +493,7 @@ void USpatialReceiver::ReceiveActor(Worker_EntityId EntityId)
 		}
 
 		// Taken from PostNetInit
-		if (!EntityActor->HasActorBegunPlay())
+		if (NetDriver->GetWorld()->HasBegunPlay() && !EntityActor->HasActorBegunPlay())
 		{
 			EntityActor->DispatchBeginPlay();
 		}


### PR DESCRIPTION
#### Description
Ensure DeleteDynamicEntities is queried correctly.
Also ensure BeginPlay is only called on received actors if the world has dispatched the call.

#### Release note
Bugfix: Fix DeleteDynamicEntities not getting used correctly in shutdown
Bugfix: Only call BeginPlay() on Actors if the World has begun play

#### Tests
Ran locally with multiple clients.

#### Primary reviewers
@improbable-valentyn @BenNaccarato 