### PR TITLE
UNR-996 Handcrafted Component ids start at 9999 and decrease. dynamic start at 10000

### DIFF
--- a/RequireSetup
+++ b/RequireSetup
@@ -1,4 +1,4 @@
 Increment the below number whenever it is required to run Setup.bat as part of a new commit.
 Our git hooks will detect this file has been updated and automatically run Setup.bat on pull.
 
-7
+8

--- a/SpatialGDK/Extras/schema/global_state_manager.schema
+++ b/SpatialGDK/Extras/schema/global_state_manager.schema
@@ -8,22 +8,22 @@ type ShutdownMultiProcessResponse {
 }
 
 component SingletonManager {
-    id = 100005;
+    id = 9995;
     map<string, EntityId> singleton_name_to_entity_id = 1;
 }
 
 component DeploymentMap {
-    id = 100006;
+    id = 9994;
     string map_url = 1;
     bool accepting_players = 2;
 }
 
 component StartupActorManager {
-    id = 100007;
+    id = 9993;
     bool can_begin_play = 1;
 }
 
 component GSMShutdown {
-    id = 100008;
+    id = 9992;
     command ShutdownMultiProcessResponse begin_shutdown_multiprocess(ShutdownMultiProcessRequest);
 }

--- a/SpatialGDK/Extras/schema/heartbeat.schema
+++ b/SpatialGDK/Extras/schema/heartbeat.schema
@@ -5,6 +5,6 @@ type HeartbeatEvent {
 }
 
 component Heartbeat {
-    id = 100009;
+    id = 9991;
     event HeartbeatEvent heartbeat;
 }

--- a/SpatialGDK/Extras/schema/singleton.schema
+++ b/SpatialGDK/Extras/schema/singleton.schema
@@ -2,5 +2,5 @@
 package unreal;
 
 component Singleton {
-    id = 100003;
+    id = 9997;
 }

--- a/SpatialGDK/Extras/schema/spawndata.schema
+++ b/SpatialGDK/Extras/schema/spawndata.schema
@@ -13,7 +13,7 @@ component SpawnData {
     // When Unreal replicates actors for the first time, it serializes their location, rotation,
     // scale, and velocity, regardless of whether the actor replicates movement. In our case,
     // location is represented by Spatial position, and this component contains the rest.
-    id = 100001;
+    id = 9999;
     improbable.Vector3f location = 1;
     Rotator rotation = 2;
     improbable.Vector3f scale = 3;

--- a/SpatialGDK/Extras/schema/spawner.schema
+++ b/SpatialGDK/Extras/schema/spawner.schema
@@ -14,6 +14,6 @@ type SpawnPlayerResponse {
 }
 
 component PlayerSpawner {
-    id = 100002;
+    id = 9998;
     command SpawnPlayerResponse spawn_player(SpawnPlayerRequest);
 }

--- a/SpatialGDK/Extras/schema/unreal_metadata.schema
+++ b/SpatialGDK/Extras/schema/unreal_metadata.schema
@@ -4,7 +4,7 @@ package unreal;
 import "unreal/gdk/core_types.schema";
 
 component UnrealMetadata {
-    id = 100004;
+    id = 9996;
     option<UnrealObjectRef> stably_named_ref = 1; // Exists when entity represents a stably named Actor
     option<string> owner_worker_attribute = 2;
     string class_path = 3;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -104,7 +104,7 @@ namespace SpatialConstants
 	const Worker_ComponentId UNREAL_METADATA_COMPONENT_ID					= 9996;
 	const Worker_ComponentId SINGLETON_MANAGER_COMPONENT_ID					= 9995;
 	const Worker_ComponentId DEPLOYMENT_MAP_COMPONENT_ID					= 9994;
-    const Worker_ComponentId STARTUP_ACTOR_MANAGER_COMPONENT_ID			    = 9993;
+	const Worker_ComponentId STARTUP_ACTOR_MANAGER_COMPONENT_ID			    = 9993;
 	const Worker_ComponentId GSM_SHUTDOWN_COMPONENT_ID						= 9992;
 	const Worker_ComponentId HEARTBEAT_COMPONENT_ID							= 9991;
 	const Worker_ComponentId STARTING_GENERATED_COMPONENT_ID				= 10000;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -98,16 +98,16 @@ namespace SpatialConstants
 	const Worker_ComponentId PERSISTENCE_COMPONENT_ID						= 55;
 	const Worker_ComponentId INTEREST_COMPONENT_ID							= 58;
 
-	const Worker_ComponentId SPAWN_DATA_COMPONENT_ID						= 100001;
-	const Worker_ComponentId PLAYER_SPAWNER_COMPONENT_ID					= 100002;
-	const Worker_ComponentId SINGLETON_COMPONENT_ID							= 100003;
-	const Worker_ComponentId UNREAL_METADATA_COMPONENT_ID					= 100004;
-	const Worker_ComponentId SINGLETON_MANAGER_COMPONENT_ID					= 100005;
-	const Worker_ComponentId DEPLOYMENT_MAP_COMPONENT_ID					= 100006;
-    const Worker_ComponentId STARTUP_ACTOR_MANAGER_COMPONENT_ID			    = 100007;
-	const Worker_ComponentId GSM_SHUTDOWN_COMPONENT_ID						= 100008;
-	const Worker_ComponentId HEARTBEAT_COMPONENT_ID							= 100009;
-	const Worker_ComponentId STARTING_GENERATED_COMPONENT_ID				= 100010;
+	const Worker_ComponentId SPAWN_DATA_COMPONENT_ID						= 9999;
+	const Worker_ComponentId PLAYER_SPAWNER_COMPONENT_ID					= 9998;
+	const Worker_ComponentId SINGLETON_COMPONENT_ID							= 9997;
+	const Worker_ComponentId UNREAL_METADATA_COMPONENT_ID					= 9996;
+	const Worker_ComponentId SINGLETON_MANAGER_COMPONENT_ID					= 9995;
+	const Worker_ComponentId DEPLOYMENT_MAP_COMPONENT_ID					= 9994;
+    const Worker_ComponentId STARTUP_ACTOR_MANAGER_COMPONENT_ID			    = 9993;
+	const Worker_ComponentId GSM_SHUTDOWN_COMPONENT_ID						= 9992;
+	const Worker_ComponentId HEARTBEAT_COMPONENT_ID							= 9991;
+	const Worker_ComponentId STARTING_GENERATED_COMPONENT_ID				= 10000;
 
 	const Schema_FieldId SINGLETON_MANAGER_SINGLETON_NAME_TO_ENTITY_ID		= 1;
 


### PR DESCRIPTION
#### Description
In order to avoid pain in the future, make handcrafted component ids decrease from 9999, avoiding any future clash with dynamic components

#### Release note
Feature: Dynamic Component Ids now start from 10000, Gdk Components will now use 9999 - 0 to avoid future clashes