### PR TITLE
[UNR-927] Better error reporting during schema generation

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SchemaGenerator.cpp
@@ -541,47 +541,31 @@ void GenerateSubobjectSchemaForActor(FComponentIdGenerator& IdGenerator, UClass*
 
 	GenerateActorIncludes(Writer, TypeInfo);
 
+	FSubobjectMap Subobjects = GetAllSubobjects(TypeInfo);
+
 	bool bHasComponents = false;
-	TSet<UObject*> SeenComponents;
-	int32 CurrentOffset = 1;
 
-	for (auto& PropertyPair : TypeInfo->Properties)
+	for (auto& It : Subobjects)
 	{
-		UProperty* Property = PropertyPair.Key;
-		UObjectProperty* ObjectProperty = Cast<UObjectProperty>(Property);
+		uint32 Offset = It.Key;
+		TSharedPtr<FUnrealType>& SubobjectTypeInfo = It.Value;
+		UClass* SubobjectClass = Cast<UClass>(SubobjectTypeInfo->Type);
 
-		TSharedPtr<FUnrealType>& PropertyTypeInfo = PropertyPair.Value->Type;
+		FSubobjectSchemaData SubobjectData;
 
-		if (ObjectProperty && PropertyTypeInfo.IsValid())
+		if (IsReplicatedSubobject(SubobjectTypeInfo) && SchemaGeneratedClasses.Contains(SubobjectClass))
 		{
-			UObject* Value = PropertyTypeInfo->Object;
-
-			if (Value != nullptr && !Value->IsEditorOnly())
-			{
-				if (!SeenComponents.Contains(Value))
-				{
-					SeenComponents.Add(Value);
-
-					FSubobjectSchemaData SubobjectData;
-
-					if (IsReplicatedSubobject(PropertyTypeInfo) && SchemaGeneratedClasses.Contains(Value->GetClass()))
-					{
-						bHasComponents = true;
-						SubobjectData = GenerateSubobjectSpecificSchema(Writer, IdGenerator, UnrealNameToSchemaComponentName(PropertyTypeInfo->Name.ToString()), PropertyTypeInfo, Value->GetClass(), ActorClass, CurrentOffset);
-					}
-					else
-					{
-						SubobjectData.ClassPath = Value->GetClass()->GetPathName();
-					}
-
-					SubobjectData.Name = PropertyTypeInfo->Name;
-					ActorSchemaData.SubobjectData.Add(CurrentOffset, SubobjectData);
-					ClassPathToSchema.Add(Value->GetClass()->GetPathName(), FSchemaData());
-				}
-
-				CurrentOffset++;
-			}
+			bHasComponents = true;
+			SubobjectData = GenerateSubobjectSpecificSchema(Writer, IdGenerator, UnrealNameToSchemaComponentName(SubobjectTypeInfo->Name.ToString()), SubobjectTypeInfo, SubobjectClass, ActorClass, Offset);
 		}
+		else
+		{
+			SubobjectData.ClassPath = SubobjectClass->GetPathName();
+		}
+
+		SubobjectData.Name = SubobjectTypeInfo->Name;
+		ActorSchemaData.SubobjectData.Add(Offset, SubobjectData);
+		ClassPathToSchema.Add(SubobjectClass->GetPathName(), FSchemaData());
 	}
 
 	if (bHasComponents)

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -188,13 +188,20 @@ void CheckIdentifierNameValidity(TSharedPtr<FUnrealType> TypeInfo, bool& bOutSuc
 
 bool ValidateIdentifierNames(TArray<TSharedPtr<FUnrealType>>& TypeInfos)
 {
-	// Remove all underscores from the class names, check for duplicates.
+	bool bSuccess = true;
+
+	// Remove all underscores from the class names, check for duplicates or invalid schema names.
 	for (const auto& TypeInfo : TypeInfos)
 	{
 		UClass* Class = Cast<UClass>(TypeInfo->Type);
 		check(Class);
 		const FString& ClassName = Class->GetName();
 		FString SchemaName = UnrealNameToSchemaName(ClassName);
+
+		if (!CheckSchemaName(SchemaName, Class->GetPathName(), TEXT("Class")))
+		{
+			bSuccess = false;
+		}
 
 		int Suffix = 0;
 		while (UsedSchemaNames.Contains(SchemaName))
@@ -210,7 +217,6 @@ bool ValidateIdentifierNames(TArray<TSharedPtr<FUnrealType>>& TypeInfos)
 	}
 
 	// Check for invalid/duplicate names in the generated type info.
-	bool bSuccess = true;
 	for (auto& TypeInfo : TypeInfos)
 	{
 		CheckIdentifierNameValidity(TypeInfo, bSuccess);

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -63,7 +63,7 @@ int GenerateCompleteSchemaFromClass(FString SchemaPath, int ComponentId, TShared
 	return NumComponents;
 }
 
-bool CheckSchemaName(FString Name, FString Identifier, FString Category)
+bool CheckSchemaNameValidity(FString Name, FString Identifier, FString Category)
 {
 	if (Name.IsEmpty())
 	{
@@ -91,7 +91,7 @@ void CheckIdentifierNameValidity(TSharedPtr<FUnrealType> TypeInfo, bool& bOutSuc
 		{
 			FString NextSchemaReplicatedDataName = SchemaFieldName(RepProp.Value);
 
-			if (!CheckSchemaName(NextSchemaReplicatedDataName, RepProp.Value->Property->GetPathName(), TEXT("Replicated property")))
+			if (!CheckSchemaNameValidity(NextSchemaReplicatedDataName, RepProp.Value->Property->GetPathName(), TEXT("Replicated property")))
 			{
 				bOutSuccess = false;
 			}
@@ -116,7 +116,7 @@ void CheckIdentifierNameValidity(TSharedPtr<FUnrealType> TypeInfo, bool& bOutSuc
 	{
 		FString NextSchemaHandoverDataName = SchemaFieldName(Prop.Value);
 
-		if (!CheckSchemaName(NextSchemaHandoverDataName, Prop.Value->Property->GetPathName(), TEXT("Handover property")))
+		if (!CheckSchemaNameValidity(NextSchemaHandoverDataName, Prop.Value->Property->GetPathName(), TEXT("Handover property")))
 		{
 			bOutSuccess = false;
 		}
@@ -142,7 +142,7 @@ void CheckIdentifierNameValidity(TSharedPtr<FUnrealType> TypeInfo, bool& bOutSuc
 		{
 			FString NextSchemaRPCName = SchemaRPCName(RPC->Function);
 
-			if (!CheckSchemaName(NextSchemaRPCName, RPC->Function->GetPathName(), TEXT("RPC")))
+			if (!CheckSchemaNameValidity(NextSchemaRPCName, RPC->Function->GetPathName(), TEXT("RPC")))
 			{
 				bOutSuccess = false;
 			}
@@ -168,7 +168,7 @@ void CheckIdentifierNameValidity(TSharedPtr<FUnrealType> TypeInfo, bool& bOutSuc
 		TSharedPtr<FUnrealType>& SubobjectTypeInfo = It.Value;
 		FString NextSchemaSubobjectName = UnrealNameToSchemaComponentName(SubobjectTypeInfo->Name.ToString());
 
-		if (!CheckSchemaName(NextSchemaSubobjectName, SubobjectTypeInfo->Object->GetPathName(), TEXT("Subobject")))
+		if (!CheckSchemaNameValidity(NextSchemaSubobjectName, SubobjectTypeInfo->Object->GetPathName(), TEXT("Subobject")))
 		{
 			bOutSuccess = false;
 		}
@@ -198,7 +198,7 @@ bool ValidateIdentifierNames(TArray<TSharedPtr<FUnrealType>>& TypeInfos)
 		const FString& ClassName = Class->GetName();
 		FString SchemaName = UnrealNameToSchemaName(ClassName);
 
-		if (!CheckSchemaName(SchemaName, Class->GetPathName(), TEXT("Class")))
+		if (!CheckSchemaNameValidity(SchemaName, Class->GetPathName(), TEXT("Class")))
 		{
 			bSuccess = false;
 		}

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -63,7 +63,24 @@ int GenerateCompleteSchemaFromClass(FString SchemaPath, int ComponentId, TShared
 	return NumComponents;
 }
 
-bool CheckIdentifierNameValidity(TSharedPtr<FUnrealType> TypeInfo)
+bool CheckSchemaName(FString Name, FString Identifier, FString Category)
+{
+	if (Name.IsEmpty())
+	{
+		UE_LOG(LogSpatialGDKSchemaGenerator, Error, TEXT("%s %s is empty after removing non-alphanumeric characters, schema not generated."), *Category, *Identifier);
+		return false;
+	}
+
+	if (FChar::IsDigit(Name[0]))
+	{
+		UE_LOG(LogSpatialGDKSchemaGenerator, Error, TEXT("%s names should not start with digits. %s %s (%s) has leading digits (potentially after removing non-alphanumeric characters), schema not generated."), *Category, *Category, *Name, *Identifier);
+		return false;
+	}
+
+	return true;
+}
+
+void CheckIdentifierNameValidity(TSharedPtr<FUnrealType> TypeInfo, bool& bOutSuccess)
 {
 	// Check Replicated data.
 	FUnrealFlatRepData RepData = GetFlatRepData(TypeInfo);
@@ -73,16 +90,22 @@ bool CheckIdentifierNameValidity(TSharedPtr<FUnrealType> TypeInfo)
 		for (auto& RepProp : RepData[Group])
 		{
 			FString NextSchemaReplicatedDataName = SchemaFieldName(RepProp.Value);
-			TSharedPtr<FUnrealProperty>* ExistingReplicatedProperty = SchemaReplicatedDataNames.Find(NextSchemaReplicatedDataName);
 
-			if (ExistingReplicatedProperty != nullptr)
+			if (!CheckSchemaName(NextSchemaReplicatedDataName, RepProp.Value->Property->GetPathName(), TEXT("Replicated property")))
+			{
+				bOutSuccess = false;
+			}
+
+			if (TSharedPtr<FUnrealProperty>* ExistingReplicatedProperty = SchemaReplicatedDataNames.Find(NextSchemaReplicatedDataName))
 			{
 				UE_LOG(LogSpatialGDKSchemaGenerator, Error, TEXT("Replicated property name collision after removing non-alphanumeric characters, schema not generated. Name '%s' collides for '%s' and '%s'"),
 					*NextSchemaReplicatedDataName, *ExistingReplicatedProperty->Get()->Property->GetPathName(), *RepProp.Value->Property->GetPathName());
-				return false;
+				bOutSuccess = false;
 			}
-
-			SchemaReplicatedDataNames.Add(NextSchemaReplicatedDataName, RepProp.Value);
+			else
+			{
+				SchemaReplicatedDataNames.Add(NextSchemaReplicatedDataName, RepProp.Value);
+			}
 		}
 	}
 
@@ -92,16 +115,22 @@ bool CheckIdentifierNameValidity(TSharedPtr<FUnrealType> TypeInfo)
 	for (auto& Prop : HandoverData)
 	{
 		FString NextSchemaHandoverDataName = SchemaFieldName(Prop.Value);
-		TSharedPtr<FUnrealProperty>* ExistingHandoverData = SchemaHandoverDataNames.Find(NextSchemaHandoverDataName);
 
-		if (ExistingHandoverData != nullptr)
+		if (!CheckSchemaName(NextSchemaHandoverDataName, Prop.Value->Property->GetPathName(), TEXT("Handover property")))
+		{
+			bOutSuccess = false;
+		}
+
+		if (TSharedPtr<FUnrealProperty>* ExistingHandoverData = SchemaHandoverDataNames.Find(NextSchemaHandoverDataName))
 		{
 			UE_LOG(LogSpatialGDKSchemaGenerator, Error, TEXT("Handover data name collision after removing non-alphanumeric characters, schema not generated. Name '%s' collides for '%s' and '%s'"),
 				*NextSchemaHandoverDataName, *ExistingHandoverData->Get()->Property->GetPathName(), *Prop.Value->Property->GetPathName());
-			return false;
+			bOutSuccess = false;
 		}
-
-		SchemaHandoverDataNames.Add(NextSchemaHandoverDataName, Prop.Value);
+		else
+		{
+			SchemaHandoverDataNames.Add(NextSchemaHandoverDataName, Prop.Value);
+		}
 	}
 
 	// Check RPC name validity.
@@ -112,20 +141,49 @@ bool CheckIdentifierNameValidity(TSharedPtr<FUnrealType> TypeInfo)
 		for (auto& RPC : RPCsByType[Group])
 		{
 			FString NextSchemaRPCName = SchemaRPCName(RPC->Function);
-			TSharedPtr<FUnrealRPC>* ExistingRPC = SchemaRPCNames.Find(NextSchemaRPCName);
 
-			if (ExistingRPC != nullptr)
+			if (!CheckSchemaName(NextSchemaRPCName, RPC->Function->GetPathName(), TEXT("RPC")))
+			{
+				bOutSuccess = false;
+			}
+
+			if (TSharedPtr<FUnrealRPC>* ExistingRPC = SchemaRPCNames.Find(NextSchemaRPCName))
 			{
 				UE_LOG(LogSpatialGDKSchemaGenerator, Error, TEXT("RPC name collision after removing non-alphanumeric characters, schema not generated. Name '%s' collides for '%s' and '%s'"),
 					*NextSchemaRPCName, *ExistingRPC->Get()->Function->GetPathName(), *RPC->Function->GetPathName());
-				return false;
+				bOutSuccess = false;
 			}
-
-			SchemaRPCNames.Add(NextSchemaRPCName, RPC);
+			else
+			{
+				SchemaRPCNames.Add(NextSchemaRPCName, RPC);
+			}
 		}
 	}
 
-	return true;
+	// Check subobject name validity.
+	FSubobjectMap Subobjects = GetAllSubobjects(TypeInfo);
+	TMap<FString, TSharedPtr<FUnrealType>> SchemaSubobjectNames;
+	for (auto& It : Subobjects)
+	{
+		TSharedPtr<FUnrealType>& SubobjectTypeInfo = It.Value;
+		FString NextSchemaSubobjectName = UnrealNameToSchemaComponentName(SubobjectTypeInfo->Name.ToString());
+
+		if (!CheckSchemaName(NextSchemaSubobjectName, SubobjectTypeInfo->Object->GetPathName(), TEXT("Subobject")))
+		{
+			bOutSuccess = false;
+		}
+
+		if (TSharedPtr<FUnrealType>* ExistingSubobject = SchemaSubobjectNames.Find(NextSchemaSubobjectName))
+		{
+			UE_LOG(LogSpatialGDKSchemaGenerator, Error, TEXT("Subobject name collision after removing non-alphanumeric characters, schema not generated. Name '%s' collides for '%s' and '%s'"),
+				*NextSchemaSubobjectName, *ExistingSubobject->Get()->Object->GetPathName(), *SubobjectTypeInfo->Object->GetPathName());
+			bOutSuccess = false;
+		}
+		else
+		{
+			SchemaSubobjectNames.Add(NextSchemaSubobjectName, SubobjectTypeInfo);
+		}
+	}
 }
 
 bool ValidateIdentifierNames(TArray<TSharedPtr<FUnrealType>>& TypeInfos)
@@ -151,16 +209,14 @@ bool ValidateIdentifierNames(TArray<TSharedPtr<FUnrealType>>& TypeInfos)
 		UsedSchemaNames.Add(SchemaName, Class);
 	}
 
-	// Check for duplicate names in the generated type info.
+	// Check for invalid/duplicate names in the generated type info.
+	bool bSuccess = true;
 	for (auto& TypeInfo : TypeInfos)
 	{
-		if (!CheckIdentifierNameValidity(TypeInfo))
-		{
-			return false;
-		}
+		CheckIdentifierNameValidity(TypeInfo, bSuccess);
 	}
 
-	return true;
+	return bSuccess;
 }
 }// ::
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/TypeStructure.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/TypeStructure.cpp
@@ -630,3 +630,35 @@ TArray<TSharedPtr<FUnrealProperty>> GetPropertyChain(TSharedPtr<FUnrealProperty>
 	Algo::Reverse(OutputChain);
 	return OutputChain;
 }
+
+FSubobjectMap GetAllSubobjects(TSharedPtr<FUnrealType> TypeInfo)
+{
+	FSubobjectMap Subobjects;
+
+	TSet<UObject*> SeenComponents;
+	uint32 CurrentOffset = 1;
+
+	for (auto& PropertyPair : TypeInfo->Properties)
+	{
+		UProperty* Property = PropertyPair.Key;
+		TSharedPtr<FUnrealType>& PropertyTypeInfo = PropertyPair.Value->Type;
+
+		if (Property->IsA<UObjectProperty>() && PropertyTypeInfo.IsValid())
+		{
+			UObject* Value = PropertyTypeInfo->Object;
+
+			if (Value != nullptr && !Value->IsEditorOnly())
+			{
+				if (!SeenComponents.Contains(Value))
+				{
+					SeenComponents.Add(Value);
+					Subobjects.Add(CurrentOffset, PropertyTypeInfo);
+				}
+
+				CurrentOffset++;
+			}
+		}
+	}
+
+	return Subobjects;
+}

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/TypeStructure.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/TypeStructure.h
@@ -156,6 +156,7 @@ struct FUnrealHandoverData
 using FUnrealFlatRepData = TMap<EReplicatedPropertyGroup, TMap<uint16, TSharedPtr<FUnrealProperty>>>;
 using FUnrealRPCsByType = TMap<ERPCType, TArray<TSharedPtr<FUnrealRPC>>>;
 using FCmdHandlePropertyMap = TMap<uint16, TSharedPtr<FUnrealProperty>>;
+using FSubobjectMap = TMap<uint32, TSharedPtr<FUnrealType>>;
 
 // Given a UClass, returns either "AFoo" or "UFoo" depending on whether Foo is a subclass of actor.
 FString GetFullCPPName(UClass* Class);
@@ -223,3 +224,6 @@ FUnrealRPCsByType GetAllRPCsByType(TSharedPtr<FUnrealType> TypeInfo);
 // Given a property, traverse up to the root property and create a list of properties needed to reach the leaf property.
 // For example: foo->bar->baz becomes {"foo", "bar", "baz"}.
 TArray<TSharedPtr<FUnrealProperty>> GetPropertyChain(TSharedPtr<FUnrealProperty> LeafProperty);
+
+// Get all default subobjects for an actor.
+FSubobjectMap GetAllSubobjects(TSharedPtr<FUnrealType> TypeInfo);

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/Utils/DataTypeUtilities.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/Utils/DataTypeUtilities.cpp
@@ -53,7 +53,10 @@ FString AlphanumericSanitization(const FString& InString)
 FString UnrealNameToSchemaComponentName(const FString& UnrealName)
 {
 	FString SchemaTypeName = UnrealNameToSchemaName(UnrealName);
-	SchemaTypeName[0] = FChar::ToUpper(SchemaTypeName[0]);
+	if (!SchemaTypeName.IsEmpty())
+	{
+		SchemaTypeName[0] = FChar::ToUpper(SchemaTypeName[0]);
+	}
 	return SchemaTypeName;
 }
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Fail schema generation if there are replicated/handover properties, RPCs, or subobjects that contain only non-alphanumeric characters, or leading digits, since they will produce invalid schema names.
Also, report all the errors that are found across all supported classes rather than early outing on the first error.

#### Release note
Bugfix: Report invalid name errors during schema generation instead of when launching a deployment.

#### Tests
Create replicated/handover properties, RPCs, or subobjects with invalid names:
- names only consisting of non-alphanumeric characters
- leading digits after removing non-alphanumeric characters
- clashing identifier names after removing non-alphanumeric characters

![image](https://user-images.githubusercontent.com/32096431/52790348-3a9df400-305e-11e9-9851-01cc577ca606.png)
![image](https://user-images.githubusercontent.com/32096431/52790370-4984a680-305e-11e9-8892-b0d8c192596d.png)


#### Documentation
Need to figure out where and how to document our additional restrictions on variable names.
@NotRobSheridan 

#### Primary reviewers
@Vatyx @joshuahuburn 