### PR TITLE
Bug fix - COND_InitialOnly not doing anything

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -256,7 +256,8 @@ int64 USpatialActorChannel::ReplicateActor()
 	if (bCreatingNewEntity)
 	{
 		RepFlags.bNetInitial = true;
-		// Include changes to Bunch, despite us not using it, since these are passed to the virtual OnSerializeNewActor, whose implementations could use them.
+		// Include changes to Bunch (duplicating existing logic in DataChannel), despite us not using it,
+		// since these are passed to the virtual OnSerializeNewActor, whose implementations could use them.
 		Bunch.bClose = Actor->bNetTemporary;
 		Bunch.bReliable = true; // Net temporary sends need to be reliable as well to force them to retry
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -260,6 +260,9 @@ int64 USpatialActorChannel::ReplicateActor()
 		Bunch.bReliable = true; // Net temporary sends need to be reliable as well to force them to retry
 	}
 
+	// Use spatial's bCreatingNewEntity to inform the replication flags.
+	RepFlags.bNetInitial = bCreatingNewEntity;
+
 	// Here, Unreal would have determined if this connection belongs to this actor's Outer.
 	// We don't have this concept when it comes to connections, our ownership-based logic is in the interop layer.
 	// Setting this to true, but should not matter in the end.

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -253,15 +253,13 @@ int64 USpatialActorChannel::ReplicateActor()
 	FReplicationFlags RepFlags;
 
 	// Send initial stuff.
-	if (OpenPacketId.First == INDEX_NONE)
+	if (bCreatingNewEntity)
 	{
 		RepFlags.bNetInitial = true;
+		// Include changes to Bunch, despite us not using it, since these are passed to the virtual OnSerializeNewActor, whose implementations could use them.
 		Bunch.bClose = Actor->bNetTemporary;
 		Bunch.bReliable = true; // Net temporary sends need to be reliable as well to force them to retry
 	}
-
-	// Use spatial's bCreatingNewEntity to inform the replication flags.
-	RepFlags.bNetInitial = bCreatingNewEntity;
 
 	// Here, Unreal would have determined if this connection belongs to this actor's Outer.
 	// We don't have this concept when it comes to connections, our ownership-based logic is in the interop layer.


### PR DESCRIPTION
#### Description
The bug was that there was some native Unreal code that would check an OpenPacketId, and use this to mark the repflag as being the initial update. However, since OpenPacketId is not used in spatial, this is simply always true, so initial only updates are sent every time. This PR overrides the native check with spatial's CreatingNewEntity.

To note - there is some legacy native code that could be removed (regarding a FOutBunch). This could be relevant to look into with this bug fix, but maybe it's better to ignore for now.

#### Release note
Bugfix - COND_InitialOnly are only replicated once at the start.

#### Tests
Fixes the bug reported in UT

#### Primary reviewers
@m-samiec @improbable-valentyn 