### PR TITLE
Bugfix/external client missing class

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealMetadata.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealMetadata.h
@@ -66,6 +66,13 @@ struct UnrealMetadata : Component
 				return Class;
 			}
 		}
+		if (UClass* Class = LoadObject<UClass>(nullptr, *ClassPath))
+		{
+			if (Class->IsChildOf<AActor>())
+			{
+				return Class;
+			}
+		}
 
 		return nullptr;
 	}

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealMetadata.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealMetadata.h
@@ -59,13 +59,6 @@ struct UnrealMetadata : Component
 
 	FORCEINLINE UClass* GetNativeEntityClass()
 	{
-		if (UClass* Class = FindObject<UClass>(ANY_PACKAGE, *ClassPath))
-		{
-			if (Class->IsChildOf<AActor>())
-			{
-				return Class;
-			}
-		}
 		if (UClass* Class = LoadObject<UClass>(nullptr, *ClassPath))
 		{
 			if (Class->IsChildOf<AActor>())


### PR DESCRIPTION
#### Description
The main bugfix to get launching external clients to work. Looks like class required for an actor required by the player wasn't being loaded, so the the entire creating/assigning player to controller logic fell down. Fixing this one thing meant clients could connect again.

To discuss: To avoid crashes, the outer had to be changed to nullptr, from ANY_PACKAGE. I'm not entirely sure on the implications of this (the intended outer gets lost?) So it'd be good to get confirmation this isn't a terrible idea.

#### Release note
Bugfix: missing classes when connecting via a non-editor client.

#### Tests
Tested on recent port. Haven't tested with ShooterGame yet, so probably should before this goes in.

#### Primary reviewers
@Vatyx @m-samiec 