### PR TITLE
Feature/use snapshot file named like current level

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -47,6 +47,10 @@ private:
 	UPROPERTY(EditAnywhere, config, Category = "Snapshots", meta = (ConfigRestartRequired = false, DisplayName = "Snapshot path"))
 	FDirectoryPath SpatialOSSnapshotPath;
 
+	/** Name snapshot file like current level. */
+	UPROPERTY(EditAnywhere, config, Category = "Snapshots", meta = (ConfigRestartRequired = false, DisplayName = "Name Snapshots like levels"))
+	bool bSnapshotUseCurrentLevelName = true;
+
 	/** Name of your SpatialOS snapshot file. */
 	UPROPERTY(EditAnywhere, config, Category = "Snapshots", meta = (ConfigRestartRequired = false, DisplayName = "Snapshot file name"))
 	FString SpatialOSSnapshotFile;
@@ -73,6 +77,11 @@ public:
 		return SpatialOSLaunchConfig.FilePath.IsEmpty()
 			? FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectDir(), TEXT("/../spatial/default_launch.json")))
 			: SpatialOSLaunchConfig.FilePath;
+	}
+
+	FORCEINLINE bool IsSnapshotUsingCurrentLevelName() const
+	{
+		return bSnapshotUseCurrentLevelName;
 	}
 
 	FORCEINLINE FString GetSpatialOSSnapshotFile() const

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -48,8 +48,8 @@ private:
 	FDirectoryPath SpatialOSSnapshotPath;
 
 	/** Name snapshot file like current level. */
-	UPROPERTY(EditAnywhere, config, Category = "Snapshots", meta = (ConfigRestartRequired = false, DisplayName = "Name Snapshots like levels"))
-	bool bSnapshotUseCurrentLevelName = true;
+	UPROPERTY(EditAnywhere, config, Category = "Snapshots", meta = (ConfigRestartRequired = false, DisplayName = "Name Snapshots like current level instead of default.snapshot"))
+	bool bSnapshotUseCurrentLevelName = false;
 
 	/** Name of your SpatialOS snapshot file. */
 	UPROPERTY(EditAnywhere, config, Category = "Snapshots", meta = (ConfigRestartRequired = false, DisplayName = "Snapshot file name"))

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -23,6 +23,7 @@
 
 #include "AssetRegistryModule.h"
 #include "GeneralProjectSettings.h"
+#include "Kismet/GameplayStatics.h"
 #include "LevelEditor.h"
 #include "Misc/FileHelper.h"
 #include "Serialization/JsonWriter.h"
@@ -207,8 +208,18 @@ void FSpatialGDKEditorToolbarModule::CreateSnapshotButtonClicked()
 
 	const USpatialGDKEditorSettings* Settings = GetDefault<USpatialGDKEditorSettings>();
 
+	FString SnapshotFilename;
+	if (Settings->IsSnapshotUsingCurrentLevelName())
+	{
+		const FString CurrentLevelName = UGameplayStatics::GetCurrentLevelName(GEditor->GetEditorWorldContext().World());
+		SnapshotFilename = CurrentLevelName + TEXT(".snapshot");
+	}
+	else
+	{
+		SnapshotFilename = Settings->GetSpatialOSSnapshotFile();
+	}
 	SpatialGDKEditorInstance->GenerateSnapshot(
-		GEditor->GetEditorWorldContext().World(), Settings->GetSpatialOSSnapshotFile(),
+		GEditor->GetEditorWorldContext().World(), SnapshotFilename,
 		FSimpleDelegate::CreateLambda([this]() { ShowSuccessNotification("Snapshot successfully generated!"); }),
 		FSimpleDelegate::CreateLambda([this]() { ShowFailedNotification("Snapshot generation failed!"); }),
 		FSpatialGDKEditorErrorHandler::CreateLambda([](FString ErrorText) { FMessageDialog::Debugf(FText::FromString(ErrorText)); }));
@@ -302,9 +313,21 @@ void FSpatialGDKEditorToolbarModule::StartSpatialOSButtonClicked()
 
 	const FString ExecuteAbsolutePath = SpatialGDKSettings->GetSpatialOSDirectory();
 	const FString CmdExecutable = TEXT("cmd.exe");
+	// Launch with the snapshot named like the current level
+	FString SnapshotFilename;
+	if (SpatialGDKSettings->IsSnapshotUsingCurrentLevelName())
+	{
+		const FString CurrentLevelName = UGameplayStatics::GetCurrentLevelName(GEditor->GetEditorWorldContext().World());
+		SnapshotFilename = CurrentLevelName + TEXT(".snapshot");
+	}
+	else
+	{
+		SnapshotFilename = SpatialGDKSettings->GetSpatialOSSnapshotFile();
+	}
+	const FString SnapshotFilePath = FPaths::Combine(SpatialGDKSettings->GetSpatialOSSnapshotFolderPath(), SnapshotFilename);
 
 	const FString SpatialCmdArgument = FString::Printf(
-		TEXT("/c cmd.exe /c spatial.exe worker build build-config ^& spatial.exe local launch %s ^& pause"), *LaunchConfig);
+		TEXT("/c cmd.exe /c spatial.exe worker build build-config ^& spatial.exe local launch %s --snapshot=%s ^& pause"), *LaunchConfig, *SnapshotFilePath);
 
 	UE_LOG(LogSpatialGDKEditorToolbar, Log, TEXT("Starting cmd.exe with `%s` arguments."), *SpatialCmdArgument);
 	// Temporary workaround: To get spatial.exe to properly show a window we have to call cmd.exe to


### PR DESCRIPTION
#### Description
Editor: generate & launch snapshot file named like current level instead of "default.snapshot"

This is driven by a new USpatialGDKEditorSettings::bSnapshotUseCurrentLevelName settings flag (false by default).

This is what we used to have with the GDK, it is convenient for testing deployments from multiple maps.
It is also more coherent with the behavior of Commandlet. 

Note: keeping old behavior by default to disrupt less other customers, and work best with LauchXxx.bat scripts in templates.

#### Release note
Bugfix: generate & launch snapshot file named like current level

#### Tests
We have been using this for the last 10 days at the office.

#### Documentation
Proper tooltip in the settings