### PR TITLE
Remove legacy flag in generated default config to fix warning when launching SpatialOS

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -448,10 +448,6 @@ bool FSpatialGDKEditorToolbarModule::GenerateDefaultLaunchConfig(const FString& 
 					Writer->WriteValue(TEXT("name"), TEXT("bridge_soft_handover_enabled"));
 					Writer->WriteValue(TEXT("value"), TEXT("false"));
 				Writer->WriteObjectEnd();
-				Writer->WriteObjectStart();
-					Writer->WriteValue(TEXT("name"), TEXT("qos_max_unacked_pings_rate"));
-					Writer->WriteValue(TEXT("value"), TEXT("10"));
-				Writer->WriteObjectEnd();
 			Writer->WriteArrayEnd();
 			Writer->WriteObjectStart(TEXT("snapshots"));
 				Writer->WriteValue(TEXT("snapshot_write_period_seconds"), 0);


### PR DESCRIPTION
#### Description
Remove legacy flag "qos_max_unacked_pings_rate" in auto-generated default config to fix the following warning that appears when launching SpatialOS:

[improbable.core.config.flagz.FlagzFieldRegistryUpdater] Failed to set deployment flag 'qos_max_unacked_pings_rate' to '10'. If you configured this flag in the legacy flags section of your launch configuration, make sure you spelled its value correctly.

#### Release note
Bugfix: Remove legacy flag "qos_max_unacked_pings_rate" in generated default config

#### Tests
Upgrade spatial command line tools, and generate & launch to see the warning poping in the spatial window.
Apply the fix to see that it is not generated anymore afterward.