### PR TITLE
UNR-1010 Fix Spatial connection destroy on PIE and allow map name as first argument.

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -320,6 +320,7 @@ void USpatialNetDriver::OnAcceptingPlayersChanged(bool bAcceptingPlayers)
 			RedirectURL.Host = WorldContext->LastURL.Host;
 			RedirectURL.Port = WorldContext->LastURL.Port;
 			RedirectURL.Op.Append(WorldContext->LastURL.Op);
+			RedirectURL.AddOption(*SpatialConstants::ClientsStayConnectedURLOption);
 
 			WorldContext->TravelURL = RedirectURL.ToString();
 		}

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
@@ -5,9 +5,12 @@
 #include "Containers/UnrealString.h"
 #include "Misc/CommandLine.h"
 #include "Misc/Parse.h"
+#include "Regex.h"
 #include "SpatialConstants.h"
 
 #include <WorkerSDK/improbable/c_worker.h>
+
+const FRegexPattern Ipv4RegexPattern(TEXT("^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$"));
 
 struct FConnectionConfig
 {
@@ -68,15 +71,16 @@ struct FReceptionistConfig : public FConnectionConfig
 		// Parse the commandline for receptionistHost, if it exists then use this as the host IP.
 		if (!FParse::Value(CommandLine, TEXT("receptionistHost"), ReceptionistHost))
 		{
-			// If receptionistHost is not specified then parse for a traditional IP. Parsing is done the same as Unreal in PlayLevel.cpp.
-			// Unreal uses the first commandline argument as a host to decide whether to create a NetDriver and connect.
-			// Here we are checking that the first commandline argument is not prefixed with '-' indicating a flag or '/' indicating a map name.
-			if (!FParse::Token(CommandLine, ReceptionistHost, 0) || ReceptionistHost[0] == '-' || ReceptionistHost[0] == '/')
+			// If a receptionistHost is not specified then parse for an IP address as the first argument and use this instead.
+			// This is how native Unreal handles connecting to other IP's, a map name can also be specified, in this case we use the default IP.
+			FParse::Token(CommandLine, ReceptionistHost, 0);
+
+			FRegexMatcher IpV4RegexMatcher(Ipv4RegexPattern, *ReceptionistHost);
+			if (!IpV4RegexMatcher.FindNext())
 			{
 				// If an IP is not specified then use default.
 				ReceptionistHost = SpatialConstants::LOCAL_HOST;
 			}
-			
 		}
 
 		FParse::Value(CommandLine, TEXT("receptionistPort"), ReceptionistPort);

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
@@ -3,9 +3,9 @@
 #pragma once
 
 #include "Containers/UnrealString.h"
+#include "Internationalization/Regex.h"
 #include "Misc/CommandLine.h"
 #include "Misc/Parse.h"
-#include "Internationalization/Regex.h"
 #include "SpatialConstants.h"
 
 #include <WorkerSDK/improbable/c_worker.h>

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
@@ -72,7 +72,7 @@ struct FReceptionistConfig : public FConnectionConfig
 		if (!FParse::Value(CommandLine, TEXT("receptionistHost"), ReceptionistHost))
 		{
 			// If a receptionistHost is not specified then parse for an IP address as the first argument and use this instead.
-			// This is how native Unreal handles connecting to other IP's, a map name can also be specified, in this case we use the default IP.
+			// This is how native Unreal handles connecting to other IPs, a map name can also be specified, in this case we use the default IP.
 			FParse::Token(CommandLine, ReceptionistHost, 0);
 
 			FRegexMatcher IpV4RegexMatcher(Ipv4RegexPattern, *ReceptionistHost);

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
@@ -5,7 +5,7 @@
 #include "Containers/UnrealString.h"
 #include "Misc/CommandLine.h"
 #include "Misc/Parse.h"
-#include "Regex.h"
+#include "Internationalization/Regex.h"
 #include "SpatialConstants.h"
 
 #include <WorkerSDK/improbable/c_worker.h>


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Fix Spatial connection destroy on PIE and allow map name as first argument.

#### Release note
Bugfix: Fix spatial connection being destroyed and recreated when connecting with PIE.

#### Tests
Tested standalone and PIE connections.

STRONGLY SUGGESTED: Launch PIE and standalone clients to different IPs.

#### Primary reviewers
@Vatyx @m-samiec 