### PR TITLE
Fix boot segfault with packaged clients.

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
@@ -10,8 +10,6 @@
 
 #include <WorkerSDK/improbable/c_worker.h>
 
-const FRegexPattern Ipv4RegexPattern(TEXT("^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$"));
-
 struct FConnectionConfig
 {
 	FConnectionConfig()
@@ -74,6 +72,8 @@ struct FReceptionistConfig : public FConnectionConfig
 			// If a receptionistHost is not specified then parse for an IP address as the first argument and use this instead.
 			// This is how native Unreal handles connecting to other IPs, a map name can also be specified, in this case we use the default IP.
 			FParse::Token(CommandLine, ReceptionistHost, 0);
+
+			FRegexPattern Ipv4RegexPattern(TEXT("^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$"));
 
 			FRegexMatcher IpV4RegexMatcher(Ipv4RegexPattern, *ReceptionistHost);
 			if (!IpV4RegexMatcher.FindNext())


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Memory allocation issues with the `Ipv4RegexPattern` was causing segfaults. Changing it's initialisation resolves this issue.

#### Release note
Bugfix: Fixed regex segfault.

#### Tests
Tested locally and on the cloud

STRONGLY SUGGESTED: Client does not segfault when booting.

#### Primary reviewers
@girayimprobable @m-samiec 