### PR TITLE
Fixed using incorrect component ID and Linux builds.

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -858,13 +858,11 @@ bool USpatialSender::UpdateEntityACLs(AActor* Actor, Worker_EntityId EntityId)
 		return false;
 	}
 
-	const FClassInfo& Info = ClassInfoManager->GetOrCreateClassInfoByClass(Actor->GetClass());
-
 	FString OwnerWorkerAttribute = GetOwnerWorkerAttribute(Actor);
 	WorkerAttributeSet OwningClientAttribute = { OwnerWorkerAttribute };
 	WorkerRequirementSet OwningClientOnly = { OwningClientAttribute };
 
-	EntityACL->ComponentWriteAcl.Add(Info.SchemaComponents[SCHEMA_ClientReliableRPC], OwningClientOnly);
+	EntityACL->ComponentWriteAcl.Add(SpatialConstants::CLIENT_RPC_ENDPOINT_COMPONENT_ID, OwningClientOnly);
 	Worker_ComponentUpdate Update = EntityACL->CreateEntityAclUpdate();
 
 	Connection->SendComponentUpdate(EntityId, &Update);

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -57,9 +57,7 @@ public:
 			return false;
 		}
 
-		const FClassInfo& Info = NetDriver->ClassInfoManager->GetOrCreateClassInfoByClass(Actor->GetClass());
-
-		return NetDriver->StaticComponentView->HasAuthority(EntityId, Info.SchemaComponents[SCHEMA_ClientReliableRPC]);
+		return NetDriver->StaticComponentView->HasAuthority(EntityId, SpatialConstants::CLIENT_RPC_ENDPOINT_COMPONENT_ID);
 	}
 
 	FORCEINLINE bool IsOwnedByWorker() const


### PR DESCRIPTION
#### Description
We were incorrectly using the FClassInfo to find out what component to use when it should be the client endpoint component. This was breaking Linux builds.

#### Release note
This should not be included in release notes. This was an oversight.

#### Primary reviewers
@mattyoung-improbable @m-samiec 