### PR TITLE
Bugfix/faster tearoff

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1014,13 +1014,10 @@ void USpatialReceiver::ApplyComponentUpdate(const Worker_ComponentUpdate& Compon
 	// If the update includes tearoff, close the channel and delete the entity.
 	if (TargetObject->IsA<AActor>() && ClassInfoManager->GetCategoryByComponentId(ComponentUpdate.component_id) == SCHEMA_Data)
 	{
-		TArray<uint32> UpdatedIds;
 		Schema_Object* ComponentObject = Schema_GetComponentUpdateFields(ComponentUpdate.schema_type);
-		UpdatedIds.SetNumUninitialized(Schema_GetUniqueFieldIdCount(ComponentObject));
-		Schema_GetUniqueFieldIds(ComponentObject, UpdatedIds.GetData());
 
 		// The third Id is btearoff on an actor.
-		if (UpdatedIds.Contains(SpatialConstants::ACTOR_TEAROFF_ID))
+		if (Schema_GetBool(ComponentObject, SpatialConstants::ACTOR_TEAROFF_ID))
 		{
 			Channel->ConditionalCleanUp();
 			CleanupDeletedEntity(Channel->GetEntityId());

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1011,7 +1011,7 @@ void USpatialReceiver::ApplyComponentUpdate(const Worker_ComponentUpdate& Compon
 	Reader.ApplyComponentUpdate(ComponentUpdate, TargetObject, Channel, bIsHandover);
 
 	// This is a temporary workaround, see UNR-841:
-	// If the update includes tearoff, close the channel and delete the entity.
+	// If the update includes tearoff, close the channel and clean up the entity.
 	if (TargetObject->IsA<AActor>() && ClassInfoManager->GetCategoryByComponentId(ComponentUpdate.component_id) == SCHEMA_Data)
 	{
 		Schema_Object* ComponentObject = Schema_GetComponentUpdateFields(ComponentUpdate.schema_type);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1014,13 +1014,13 @@ void USpatialReceiver::ApplyComponentUpdate(const Worker_ComponentUpdate& Compon
 	// If the update includes tearoff, close the channel.
 	if (TargetObject->IsA<AActor>() && ClassInfoManager->GetCategoryByComponentId(ComponentUpdate.component_id) == SCHEMA_Data)
 	{
-		Schema_Object* ComponentObject = Schema_GetComponentUpdateFields(ComponentUpdate.schema_type);
-
 		TArray<uint32> UpdatedIds;
+		Schema_Object* ComponentObject = Schema_GetComponentUpdateFields(ComponentUpdate.schema_type);
 		UpdatedIds.SetNumUninitialized(Schema_GetUniqueFieldIdCount(ComponentObject));
 		Schema_GetUniqueFieldIds(ComponentObject, UpdatedIds.GetData());
+
 		// The third Id is btearoff on an actor.
-		if (UpdatedIds.Contains(3))
+		if (UpdatedIds.Contains(SpatialConstants::ACTOR_TEAROFF_ID))
 		{
 			Channel->ConditionalCleanUp();
 		}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1016,7 +1016,7 @@ void USpatialReceiver::ApplyComponentUpdate(const Worker_ComponentUpdate& Compon
 	{
 		Schema_Object* ComponentObject = Schema_GetComponentUpdateFields(ComponentUpdate.schema_type);
 
-		// The third Id is btearoff on an actor.
+		// Check if bTearOff has been set to true
 		if (Schema_GetBool(ComponentObject, SpatialConstants::ACTOR_TEAROFF_ID))
 		{
 			Channel->ConditionalCleanUp();

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -530,7 +530,7 @@ void USpatialReceiver::RemoveActor(Worker_EntityId EntityId)
 		return;
 	}
 
-	// If entity is to be deleted after having been torn off, clean up the entity, but don't destroy the actor.
+	// If the entity is to be deleted after having been torn off, ignore the request (but clean up the channel if it has not been cleaned up already).
 	if (Actor->GetTearOff())
 	{
 		if (USpatialActorChannel* ActorChannel = NetDriver->GetActorChannelByEntityId(EntityId))
@@ -1011,7 +1011,7 @@ void USpatialReceiver::ApplyComponentUpdate(const Worker_ComponentUpdate& Compon
 	Reader.ApplyComponentUpdate(ComponentUpdate, TargetObject, Channel, bIsHandover);
 
 	// This is a temporary workaround, see UNR-841:
-	// If the update includes tearoff, close the channel.
+	// If the update includes tearoff, close the channel and delete the entity.
 	if (TargetObject->IsA<AActor>() && ClassInfoManager->GetCategoryByComponentId(ComponentUpdate.component_id) == SCHEMA_Data)
 	{
 		TArray<uint32> UpdatedIds;
@@ -1023,6 +1023,7 @@ void USpatialReceiver::ApplyComponentUpdate(const Worker_ComponentUpdate& Compon
 		if (UpdatedIds.Contains(SpatialConstants::ACTOR_TEAROFF_ID))
 		{
 			Channel->ConditionalCleanUp();
+			CleanupDeletedEntity(Channel->GetEntityId());
 		}
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -121,6 +121,7 @@ namespace SpatialConstants
 	const Schema_FieldId STARTUP_ACTOR_MANAGER_CAN_BEGIN_PLAY_ID			= 1;
 
 	const Schema_FieldId ACTOR_COMPONENT_REPLICATES_ID                      = 1;
+	const Schema_FieldId ACTOR_TEAROFF_ID									= 3;
 
 	const Schema_FieldId HEARTBEAT_EVENT_ID                                 = 1;
 


### PR DESCRIPTION
#### Description
Fix for https://improbableio.atlassian.net/browse/UNR-882
Instead of waiting for the RemoveActor call on remove-entity, if we receive a tearoff update, close and channel and clean up the channel and associated entity/entity mappings. (This assumes we start off not torn off, and that the update will therefore be to set tearoff to true.)
(This is a temporary workaround, due to having the second delay between the final update and the remove entity request. There is a task to update this once we have a better solution:  https://improbableio.atlassian.net/browse/UNR-841)

#### Release note
Bugfix: `AActor::TornOff`, and channel cleanup logic occurs at tearoff, rather than after a delay.

#### Tests
Verified in PIE, launching external client/server, and in a recent playtest.

#### Documentation
None necessary?

#### Primary reviewers
@Vatyx @m-samiec 