### PR TITLE
Prevent loading levels when resolving UnrealObjectRefs

### DIFF
--- a/RequireSetup
+++ b/RequireSetup
@@ -1,4 +1,4 @@
 Increment the below number whenever it is required to run Setup.bat as part of a new commit.
 Our git hooks will detect this file has been updated and automatically run Setup.bat on pull.
 
-9
+10

--- a/SpatialGDK/Extras/schema/core_types.schema
+++ b/SpatialGDK/Extras/schema/core_types.schema
@@ -1,14 +1,12 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 package unreal;
 
-type LoadInfo {
-    string path = 1;
-    bool no_load = 2;
-}
-
 type UnrealObjectRef {
     EntityId entity = 1;
     uint32 offset = 2;
-    option<LoadInfo> load_info = 3;
-    option<UnrealObjectRef> outer = 4;
+    option<string> path = 3;
+    // Not all objects should be loaded on clients as a result of resolving
+    // a reference, e.g. anything inside streaming levels should not be loaded.
+    option<bool> no_load_on_client = 4;
+    option<UnrealObjectRef> outer = 5;
 }

--- a/SpatialGDK/Extras/schema/core_types.schema
+++ b/SpatialGDK/Extras/schema/core_types.schema
@@ -1,9 +1,14 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 package unreal;
 
+type LoadInfo {
+    string path = 1;
+    bool no_load = 2;
+}
+
 type UnrealObjectRef {
     EntityId entity = 1;
     uint32 offset = 2;
-    option<string> path = 3;
+    option<LoadInfo> load_info = 3;
     option<UnrealObjectRef> outer = 4;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -252,7 +252,15 @@ FNetworkGUID FSpatialNetGUIDCache::AssignNewStablyNamedObjectNetGUID(UObject* Ob
 		UE_LOG(LogSpatialPackageMap, Fatal, TEXT("Found object called PersistentLevel which isn't a Level! This is not allowed when using the GDK"));
 	}
 
-	FUnrealObjectRef StablyNamedObjRef(0, 0, Object->GetFName().ToString(), (OuterGUID.IsValid() && !OuterGUID.IsDefault()) ? GetUnrealObjectRefFromNetGUID(OuterGUID) : FUnrealObjectRef());
+	bool bNoLoad = false;
+	if (IsNetGUIDAuthority())
+	{
+		// If the server is replicating references to things inside levels, it needs to indicate
+		// that the client should not load these. Once the level is streamed in, the client will
+		// resolve the references.
+		bNoLoad = !CanClientLoadObject(Object, NetGUID);
+	}
+	FUnrealObjectRef StablyNamedObjRef(0, 0, Object->GetFName().ToString(), (OuterGUID.IsValid() && !OuterGUID.IsDefault()) ? GetUnrealObjectRefFromNetGUID(OuterGUID) : FUnrealObjectRef(), bNoLoad);
 	RegisterObjectRef(NetGUID, StablyNamedObjRef);
 
 	return NetGUID;
@@ -328,7 +336,7 @@ FNetworkGUID FSpatialNetGUIDCache::GetNetGUIDFromUnrealObjectRefInternal(const F
 		{
 			OuterGUID = GetNetGUIDFromUnrealObjectRef(ObjectRef.Outer.GetValue());
 		}
-		NetGUID = RegisterNetGUIDFromPathForStaticObject(ObjectRef.Path.GetValue(), OuterGUID);
+		NetGUID = RegisterNetGUIDFromPathForStaticObject(ObjectRef.Path.GetValue(), OuterGUID, ObjectRef.bNoLoad);
 		RegisterObjectRef(NetGUID, ObjectRef);
 	}
 	return NetGUID;
@@ -372,7 +380,7 @@ FNetworkGUID FSpatialNetGUIDCache::GetNetGUIDFromEntityId(Worker_EntityId Entity
 	return (NetGUID == nullptr ? FNetworkGUID(0) : *NetGUID);
 }
 
-FNetworkGUID FSpatialNetGUIDCache::RegisterNetGUIDFromPathForStaticObject(const FString& PathName, const FNetworkGUID& OuterGUID)
+FNetworkGUID FSpatialNetGUIDCache::RegisterNetGUIDFromPathForStaticObject(const FString& PathName, const FNetworkGUID& OuterGUID, bool bNoLoad)
 {
 	// Put the PIE prefix back (if applicable) so that the correct object can be found.
 	FString TempPath = PathName;
@@ -382,7 +390,7 @@ FNetworkGUID FSpatialNetGUIDCache::RegisterNetGUIDFromPathForStaticObject(const 
 	FNetGuidCacheObject CacheObject;
 	CacheObject.PathName = FName(*TempPath);
 	CacheObject.OuterGUID = OuterGUID;
-	CacheObject.bNoLoad = false;				// allow worker to attempt to load object
+	CacheObject.bNoLoad = bNoLoad;				// server decides whether the client should load objects (e.g. don't load levels)
 	CacheObject.bIgnoreWhenMissing = true;		// ensure we give workers time to load non-loaded assets
 	FNetworkGUID NetGUID = GenerateNewNetGUID(0);
 	RegisterNetGUID_Internal(NetGUID, CacheObject);

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -390,8 +390,8 @@ FNetworkGUID FSpatialNetGUIDCache::RegisterNetGUIDFromPathForStaticObject(const 
 	FNetGuidCacheObject CacheObject;
 	CacheObject.PathName = FName(*TempPath);
 	CacheObject.OuterGUID = OuterGUID;
-	CacheObject.bNoLoad = bNoLoadOnClient;		// server decides whether the client should load objects (e.g. don't load levels)
-	CacheObject.bIgnoreWhenMissing = true;		// ensure we give workers time to load non-loaded assets
+	CacheObject.bNoLoad = bNoLoadOnClient;				// server decides whether the client should load objects (e.g. don't load levels)
+	CacheObject.bIgnoreWhenMissing = bNoLoadOnClient;
 	FNetworkGUID NetGUID = GenerateNewNetGUID(0);
 	RegisterNetGUID_Internal(NetGUID, CacheObject);
 	return NetGUID;

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialPackageMapClient.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialPackageMapClient.h
@@ -63,7 +63,7 @@ private:
 	FNetworkGUID GetOrAssignNetGUID_SpatialGDK(UObject* Object);
 	void RegisterObjectRef(FNetworkGUID NetGUID, const FUnrealObjectRef& ObjectRef);
 	
-	FNetworkGUID RegisterNetGUIDFromPathForStaticObject(const FString& PathName, const FNetworkGUID& OuterGUID);
+	FNetworkGUID RegisterNetGUIDFromPathForStaticObject(const FString& PathName, const FNetworkGUID& OuterGUID, bool bNoLoad);
 	FNetworkGUID GenerateNewNetGUID(const int32 IsStatic);
 
 	TMap<FNetworkGUID, FUnrealObjectRef> NetGUIDToUnrealObjectRef;

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialPackageMapClient.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialPackageMapClient.h
@@ -63,7 +63,7 @@ private:
 	FNetworkGUID GetOrAssignNetGUID_SpatialGDK(UObject* Object);
 	void RegisterObjectRef(FNetworkGUID NetGUID, const FUnrealObjectRef& ObjectRef);
 	
-	FNetworkGUID RegisterNetGUIDFromPathForStaticObject(const FString& PathName, const FNetworkGUID& OuterGUID, bool bNoLoad);
+	FNetworkGUID RegisterNetGUIDFromPathForStaticObject(const FString& PathName, const FNetworkGUID& OuterGUID, bool bNoLoadOnClient);
 	FNetworkGUID GenerateNewNetGUID(const int32 IsStatic);
 
 	TMap<FNetworkGUID, FUnrealObjectRef> NetGUIDToUnrealObjectRef;

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.h
@@ -15,15 +15,15 @@ struct FUnrealObjectRef
 	FUnrealObjectRef(Worker_EntityId Entity, uint32 Offset)
 		: Entity(Entity)
 		, Offset(Offset)
-		, bNoLoad(false)
+		, bNoLoadOnClient(false)
 	{}
 
-	FUnrealObjectRef(Worker_EntityId Entity, uint32 Offset, FString Path, FUnrealObjectRef Outer, bool bNoLoad = false)
+	FUnrealObjectRef(Worker_EntityId Entity, uint32 Offset, FString Path, FUnrealObjectRef Outer, bool bNoLoadOnClient = false)
 		: Entity(Entity)
 		, Offset(Offset)
 		, Path(Path)
 		, Outer(Outer)
-		, bNoLoad(bNoLoad)
+		, bNoLoadOnClient(bNoLoadOnClient)
 	{}
 
 	FUnrealObjectRef(const FUnrealObjectRef& In)
@@ -31,7 +31,7 @@ struct FUnrealObjectRef
 		, Offset(In.Offset)
 		, Path(In.Path)
 		, Outer(In.Outer)
-		, bNoLoad(In.bNoLoad)
+		, bNoLoadOnClient(In.bNoLoadOnClient)
 	{}
 
 	FORCEINLINE FUnrealObjectRef& operator=(const FUnrealObjectRef& In)
@@ -40,7 +40,7 @@ struct FUnrealObjectRef
 		Offset = In.Offset;
 		Path = In.Path;
 		Outer = In.Outer;
-		bNoLoad = In.bNoLoad;
+		bNoLoadOnClient = In.bNoLoadOnClient;
 		return *this;
 	}
 
@@ -72,7 +72,7 @@ struct FUnrealObjectRef
 			Offset == Other.Offset &&
 			((!Path && !Other.Path) || (Path && Other.Path && Path->Equals(*Other.Path))) &&
 			((!Outer && !Other.Outer) || (Outer && Other.Outer && *Outer == *Other.Outer));
-		// Intentionally don't compare bNoLoad since it does not affect equality.
+		// Intentionally don't compare bNoLoadOnClient since it does not affect equality.
 	}
 
 	FORCEINLINE bool operator!=(const FUnrealObjectRef& Other) const
@@ -92,7 +92,7 @@ struct FUnrealObjectRef
 	uint32 Offset;
 	improbable::TSchemaOption<FString> Path;
 	improbable::TSchemaOption<FUnrealObjectRef> Outer;
-	bool bNoLoad;
+	bool bNoLoadOnClient;
 };
 
 inline uint32 GetTypeHash(const FUnrealObjectRef& ObjectRef)
@@ -102,6 +102,6 @@ inline uint32 GetTypeHash(const FUnrealObjectRef& ObjectRef)
 	Result = (Result * 977u) + GetTypeHash(ObjectRef.Offset);
 	Result = (Result * 977u) + GetTypeHash(ObjectRef.Path);
 	Result = (Result * 977u) + GetTypeHash(ObjectRef.Outer);
-	// Intentionally don't hash bNoLoad.
+	// Intentionally don't hash bNoLoadOnClient.
 	return Result;
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.h
@@ -15,13 +15,15 @@ struct FUnrealObjectRef
 	FUnrealObjectRef(Worker_EntityId Entity, uint32 Offset)
 		: Entity(Entity)
 		, Offset(Offset)
+		, bNoLoad(false)
 	{}
 
-	FUnrealObjectRef(Worker_EntityId Entity, uint32 Offset, FString Path, FUnrealObjectRef Outer)
+	FUnrealObjectRef(Worker_EntityId Entity, uint32 Offset, FString Path, FUnrealObjectRef Outer, bool bNoLoad = false)
 		: Entity(Entity)
 		, Offset(Offset)
 		, Path(Path)
 		, Outer(Outer)
+		, bNoLoad(bNoLoad)
 	{}
 
 	FUnrealObjectRef(const FUnrealObjectRef& In)
@@ -29,6 +31,7 @@ struct FUnrealObjectRef
 		, Offset(In.Offset)
 		, Path(In.Path)
 		, Outer(In.Outer)
+		, bNoLoad(In.bNoLoad)
 	{}
 
 	FORCEINLINE FUnrealObjectRef& operator=(const FUnrealObjectRef& In)
@@ -37,6 +40,7 @@ struct FUnrealObjectRef
 		Offset = In.Offset;
 		Path = In.Path;
 		Outer = In.Outer;
+		bNoLoad = In.bNoLoad;
 		return *this;
 	}
 
@@ -68,6 +72,7 @@ struct FUnrealObjectRef
 			Offset == Other.Offset &&
 			((!Path && !Other.Path) || (Path && Other.Path && Path->Equals(*Other.Path))) &&
 			((!Outer && !Other.Outer) || (Outer && Other.Outer && *Outer == *Other.Outer));
+		// Intentionally don't compare bNoLoad since it does not affect equality.
 	}
 
 	FORCEINLINE bool operator!=(const FUnrealObjectRef& Other) const
@@ -87,6 +92,7 @@ struct FUnrealObjectRef
 	uint32 Offset;
 	improbable::TSchemaOption<FString> Path;
 	improbable::TSchemaOption<FUnrealObjectRef> Outer;
+	bool bNoLoad;
 };
 
 inline uint32 GetTypeHash(const FUnrealObjectRef& ObjectRef)
@@ -96,5 +102,6 @@ inline uint32 GetTypeHash(const FUnrealObjectRef& ObjectRef)
 	Result = (Result * 977u) + GetTypeHash(ObjectRef.Offset);
 	Result = (Result * 977u) + GetTypeHash(ObjectRef.Path);
 	Result = (Result * 977u) + GetTypeHash(ObjectRef.Outer);
+	// Intentionally don't hash bNoLoad.
 	return Result;
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SchemaUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SchemaUtils.h
@@ -111,13 +111,12 @@ inline void AddObjectRefToSchema(Schema_Object* Object, Schema_FieldId Id, const
 	Schema_AddUint32(ObjectRefObject, 2, ObjectRef.Offset);
 	if (ObjectRef.Path)
 	{
-		Schema_Object* LoadInfoObject = Schema_AddObject(ObjectRefObject, 3);
-		AddStringToSchema(LoadInfoObject, 1, *ObjectRef.Path);
-		Schema_AddBool(LoadInfoObject, 2, ObjectRef.bNoLoad);
+		AddStringToSchema(ObjectRefObject, 3, *ObjectRef.Path);
+		Schema_AddBool(ObjectRefObject, 4, ObjectRef.bNoLoadOnClient);
 	}
 	if (ObjectRef.Outer)
 	{
-		AddObjectRefToSchema(ObjectRefObject, 4, *ObjectRef.Outer);
+		AddObjectRefToSchema(ObjectRefObject, 5, *ObjectRef.Outer);
 	}
 }
 
@@ -133,13 +132,15 @@ inline FUnrealObjectRef IndexObjectRefFromSchema(Schema_Object* Object, Schema_F
 	ObjectRef.Offset = Schema_GetUint32(ObjectRefObject, 2);
 	if (Schema_GetObjectCount(ObjectRefObject, 3) > 0)
 	{
-		Schema_Object* LoadInfoObject = Schema_GetObject(ObjectRefObject, 3);
-		ObjectRef.Path = GetStringFromSchema(LoadInfoObject, 1);
-		ObjectRef.bNoLoad = GetBoolFromSchema(LoadInfoObject, 2);
+		ObjectRef.Path = GetStringFromSchema(ObjectRefObject, 3);
 	}
-	if (Schema_GetObjectCount(ObjectRefObject, 4) > 0)
+	if (Schema_GetBoolCount(ObjectRefObject, 4) > 0)
 	{
-		ObjectRef.Outer = GetObjectRefFromSchema(ObjectRefObject, 4);
+		ObjectRef.bNoLoadOnClient = GetBoolFromSchema(ObjectRefObject, 4);
+	}
+	if (Schema_GetObjectCount(ObjectRefObject, 5) > 0)
+	{
+		ObjectRef.Outer = GetObjectRefFromSchema(ObjectRefObject, 5);
 	}
 
 	return ObjectRef;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SchemaUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SchemaUtils.h
@@ -111,7 +111,9 @@ inline void AddObjectRefToSchema(Schema_Object* Object, Schema_FieldId Id, const
 	Schema_AddUint32(ObjectRefObject, 2, ObjectRef.Offset);
 	if (ObjectRef.Path)
 	{
-		AddStringToSchema(ObjectRefObject, 3, *ObjectRef.Path);
+		Schema_Object* LoadInfoObject = Schema_AddObject(ObjectRefObject, 3);
+		AddStringToSchema(LoadInfoObject, 1, *ObjectRef.Path);
+		Schema_AddBool(LoadInfoObject, 2, ObjectRef.bNoLoad);
 	}
 	if (ObjectRef.Outer)
 	{
@@ -129,13 +131,15 @@ inline FUnrealObjectRef IndexObjectRefFromSchema(Schema_Object* Object, Schema_F
 
 	ObjectRef.Entity = Schema_GetEntityId(ObjectRefObject, 1);
 	ObjectRef.Offset = Schema_GetUint32(ObjectRefObject, 2);
-	if (Schema_GetBytesCount(ObjectRefObject, 3) > 0)
+	if (Schema_GetObjectCount(ObjectRefObject, 3) > 0)
 	{
-		ObjectRef.Path = GetStringFromSchema(ObjectRefObject, 3);
+		Schema_Object* LoadInfoObject = Schema_GetObject(ObjectRefObject, 3);
+		ObjectRef.Path = GetStringFromSchema(LoadInfoObject, 1);
+		ObjectRef.bNoLoad = GetBoolFromSchema(LoadInfoObject, 2);
 	}
 	if (Schema_GetObjectCount(ObjectRefObject, 4) > 0)
 	{
-		ObjectRef.Outer = FUnrealObjectRef(GetObjectRefFromSchema(ObjectRefObject, 4));
+		ObjectRef.Outer = GetObjectRefFromSchema(ObjectRefObject, 4);
 	}
 
 	return ObjectRef;


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Client is supposed to load streaming levels when the server tells it to. Instead, we could load them when resolving an UnrealObjectRef to an object inside a streaming level. This led to strange behavior and crashes when restarting the game.
Now, the server will include a flag inside UnrealObjectRef to indicate whether client should load any given objects. Since this only matters for objects loaded by path, I put the path and this flag together in an optional field inside UnrealObjectRef to reduce the bandwidth overhead.

#### Release note
Bugfix: Fixed an issue where a reference to an object inside a streaming level could cause strange behavior on the client if it is resolved before the level is streamed in.

#### Tests
Create a sublevel, put a box inside, change its scale on the placed instance, make a dynamic actor (e.g. player controller) reference that object.
If the dynamic actor is checked out on the client before the level is streamed in, the box should not appear. It should only appear after the level is streamed in, at what point the pointer to the box should get resolved.

#### Primary reviewers
@Vatyx @m-samiec 