### PR TITLE
Still generate schema even if some blueprints haven't compiled

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
@@ -48,6 +48,7 @@ void FSpatialGDKEditor::GenerateSchema(FSimpleDelegate SuccessCallback, FSimpleD
 	SchemaGeneratorResult = Async<bool>(EAsyncExecution::Thread, SpatialGDKGenerateSchema,
 		[this, bCachedSpatialNetworking, ErroredBlueprints, SuccessCallback, FailureCallback]()
 	{
+		// We delay printing this error until after the schema spam to make it have a higher chance of being noticed.
 		if (ErroredBlueprints.Num() > 0)
 		{
 			UE_LOG(LogSpatialGDKEditor, Error, TEXT("Errors compiling blueprints during schema generation! The following blueprints did not have schema generated for them:"));

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
@@ -51,7 +51,7 @@ void FSpatialGDKEditor::GenerateSchema(FSimpleDelegate SuccessCallback, FSimpleD
 		if (ErroredBlueprints.Num() > 0)
 		{
 			UE_LOG(LogSpatialGDKEditor, Error, TEXT("Errors compiling blueprints during schema generation! The following blueprints did not have schema generated for them:"));
-			for (auto const& Blueprint : ErroredBlueprints)
+			for (const auto& Blueprint : ErroredBlueprints)
 			{
 				UE_LOG(LogSpatialGDKEditor, Error, TEXT("%s"), *GetPathNameSafe(Blueprint));
 			}


### PR DESCRIPTION
#### Description
We should still generate schema if we have blueprints that haven't compiled. We report what blueprints haven't compiled after generating schema.

#### Release note
Bugfix: Still generate schema even if some blueprints have failed to compile.

#### Tests
Made a blueprint that didn't compile and then generated schema.

#### Primary reviewers
@m-samiec @BenNaccarato 