### PR TITLE
[UNR-1083] Handle unreliable RPCs only if worker has authority

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -874,6 +874,16 @@ void USpatialReceiver::OnComponentUpdate(Worker_ComponentUpdateOp& Op)
 void USpatialReceiver::HandleUnreliableRPC(Worker_ComponentUpdateOp& Op)
 {
 	Worker_EntityId EntityId = Op.entity_id;
+
+	// If the update is to the client rpc endpoint, then the handler should have authority over the server rpc endpoint component and vice versa
+	// Ideally these events are never delivered to workers which are not able to handle them with clever interest management
+	Worker_ComponentId RPCEndpointComponentId = Op.update.component_id == SpatialConstants::CLIENT_RPC_ENDPOINT_COMPONENT_ID ? SpatialConstants::SERVER_RPC_ENDPOINT_COMPONENT_ID : SpatialConstants::CLIENT_RPC_ENDPOINT_COMPONENT_ID;
+	if (StaticComponentView->GetAuthority(Op.entity_id, RPCEndpointComponentId) != WORKER_AUTHORITY_AUTHORITATIVE)
+	{
+		UE_LOG(LogSpatialReceiver, Verbose, TEXT("Entity: %d Component: %d - Skipping unreliable RPC handler because worker has no authority"), Op.entity_id, Op.update.component_id);
+		return;
+	}
+
 	Schema_Object* EventsObject = Schema_GetComponentUpdateEvents(Op.update.schema_type);
 
 	uint32 EventCount = Schema_GetObjectCount(EventsObject, SpatialConstants::UNREAL_RPC_ENDPOINT_EVENT_ID);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -877,10 +877,11 @@ void USpatialReceiver::HandleUnreliableRPC(Worker_ComponentUpdateOp& Op)
 
 	// If the update is to the client rpc endpoint, then the handler should have authority over the server rpc endpoint component and vice versa
 	// Ideally these events are never delivered to workers which are not able to handle them with clever interest management
-	Worker_ComponentId RPCEndpointComponentId = Op.update.component_id == SpatialConstants::CLIENT_RPC_ENDPOINT_COMPONENT_ID ? SpatialConstants::SERVER_RPC_ENDPOINT_COMPONENT_ID : SpatialConstants::CLIENT_RPC_ENDPOINT_COMPONENT_ID;
+	const Worker_ComponentId RPCEndpointComponentId = Op.update.component_id == SpatialConstants::CLIENT_RPC_ENDPOINT_COMPONENT_ID
+		? SpatialConstants::SERVER_RPC_ENDPOINT_COMPONENT_ID : SpatialConstants::CLIENT_RPC_ENDPOINT_COMPONENT_ID;
+
 	if (StaticComponentView->GetAuthority(Op.entity_id, RPCEndpointComponentId) != WORKER_AUTHORITY_AUTHORITATIVE)
 	{
-		UE_LOG(LogSpatialReceiver, Verbose, TEXT("Entity: %d Component: %d - Skipping unreliable RPC handler because worker has no authority"), Op.entity_id, Op.update.component_id);
 		return;
 	}
 


### PR DESCRIPTION
#### Description

JIRA: https://improbableio.atlassian.net/browse/UNR-1083

With https://github.com/spatialos/UnrealGDK/pull/682 a non-authoritative server also tries to handle unreliable RPCs because it receives events. This causes an assertion to fail in the character movement controller which expects to have the authority network role. I assume many other RPCs will also fail.

Also brings latest master into hydra.

#### Release note
Bugfix: Handle unreliable RPC only on worker with authority

#### Tests
launched starter project with a two-server config
raised the added log to a warning to see how often it fires (too often to be anything other than verbose)

#### Documentation
release note

#### Primary reviewers
@danielimprobable 