### PR TITLE
Don't try to replicate actors not supported by Spatial

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -736,6 +736,12 @@ int32 USpatialNetDriver::ServerReplicateActors_ProcessPrioritizedActors(UNetConn
 				// or it's an editor placed actor and the client hasn't initialized the level it's in
 				if (Channel == nullptr && GuidCache->SupportsObject(Actor->GetClass()) && GuidCache->SupportsObject(Actor->IsNetStartupActor() ? Actor : Actor->GetArchetype()))
 				{
+					if (!ClassInfoManager->IsSupportedClass(Actor->GetClass()))
+					{
+						// Trying to replicate an actor that isn't supported by Spatial (e.g. marked NotSpatial)
+						continue;
+					}
+
 					if (!Actor->HasAuthority())
 					{
 						// Trying to replicate Actor which we don't have authority over.


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
If you mark an actor as `NotSpatial`, we should not try to replicate it.
Right now, attempting to replicate an unsupported actor results in a failed `checkf` in `SpatialClassInfoManager`.

#### Release note
Bugfix: Fix crash when trying to replicate an actor marked "NotSpatial".

#### Tests
Mark something as `NotSpatial`. Run the game. Don't crash.

#### Primary reviewers
@m-samiec @Vatyx 