### PR TITLE
Update build script to use SimulatedPlayer instead of FakeClient

### DIFF
--- a/RequireSetup
+++ b/RequireSetup
@@ -1,4 +1,4 @@
 Increment the below number whenever it is required to run Setup.bat as part of a new commit.
 Our git hooks will detect this file has been updated and automatically run Setup.bat on pull.
 
-11
+12

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Build/Build.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Build/Build.cs
@@ -184,8 +184,7 @@ exit /b !ERRORLEVEL!
                 var isUsingFakeClient = gameName == baseGameName + "FakeClient";
                 if (isUsingFakeClient)
                 {
-                    Console.Error.WriteLine("'FakeClient' GameName is deprecated and renamed to 'SimulatedPlayer'. Please run 'BuildWorker.bat <ProjectName>SimulatedPlayer ...' instead.");
-                    Console.Error.WriteLine("Warning: using `SimulatedPlayer` will output an assembly with a different name: UnrealSimulatedPlayer@Linux.zip. Make sure you change any reference to the old UnrealFakeClient@Linux.zip to this new assembly in your config files.");
+                    Common.WriteWarning("[Deprecated] 'FakeClient' is deprecated, please use 'SimulatedPlayer' instead. This will create the same assembly under a different name: UnrealSimulatedPlayer@Linux.zip.");
                 }
 
                 Common.WriteHeading(" > Building simulated player.");

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Build/Build.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Build/Build.cs
@@ -179,14 +179,12 @@ exit /b !ERRORLEVEL!
                     "-archive=" + Quote(Path.Combine(outputDir, "UnrealClient@Windows.zip")),
                 });
             }
-            else if (gameName == baseGameName + "SimulatedPlayer" || gameName == baseGameName + "FakeClient") // This is for internal use only. We do not support Linux clients.
+            else if (gameName == baseGameName + "FakeClient")
             {
-                var isUsingFakeClient = gameName == baseGameName + "FakeClient";
-                if (isUsingFakeClient)
-                {
-                    Common.WriteWarning("[Deprecated] 'FakeClient' is deprecated, please use 'SimulatedPlayer' instead. This will create the same assembly under a different name: UnrealSimulatedPlayer@Linux.zip.");
-                }
-
+                Common.WriteWarning("'FakeClient' has been renamed to 'SimulatedPlayer', please use this instead. It will create the same assembly under a different name: UnrealSimulatedPlayer@Linux.zip.");
+            }
+            else if (gameName == baseGameName + "SimulatedPlayer") // This is for internal use only. We do not support Linux clients.
+            {
                 Common.WriteHeading(" > Building simulated player.");
                 Common.RunRedirected(@"%UNREAL_HOME%\Engine\Build\BatchFiles\RunUAT.bat", new[]
                 {
@@ -234,7 +232,7 @@ exit /b !ERRORLEVEL!
                     Console.WriteLine("worker coordinator path did not exist");
                 }
 
-                var archiveFileName = isUsingFakeClient ? "UnrealFakeClient@Linux.zip" : "UnrealSimulatedPlayer@Linux.zip";
+                var archiveFileName = "UnrealSimulatedPlayer@Linux.zip";
                 Common.RunRedirected(@"%UNREAL_HOME%\Engine\Build\BatchFiles\RunUAT.bat", new[]
                 {
                     "ZipUtils",

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Build/Build.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Build/Build.cs
@@ -37,7 +37,7 @@ gosu $NEW_USER ""${{SCRIPT}}"" ""$@""";
 
 
         // This is for internal use only. We do not support Linux clients.
-        private const string FakeClientWorkerShellScript =
+        private const string SimulatedPlayerWorkerShellScript =
 @"#!/bin/bash
 NEW_USER=unrealworker
 WORKER_ID=$1
@@ -179,9 +179,16 @@ exit /b !ERRORLEVEL!
                     "-archive=" + Quote(Path.Combine(outputDir, "UnrealClient@Windows.zip")),
                 });
             }
-            else if (gameName == baseGameName + "FakeClient") // This is for internal use only. We do not support Linux clients.
+            else if (gameName == baseGameName + "SimulatedPlayer" || gameName == baseGameName + "FakeClient") // This is for internal use only. We do not support Linux clients.
             {
-                Common.WriteHeading(" > Building fakeclient.");
+                var isUsingFakeClient = gameName == baseGameName + "FakeClient";
+                if (isUsingFakeClient)
+                {
+                    Console.Error.WriteLine("'FakeClient' GameName is deprecated and renamed to 'SimulatedPlayer'. Please run 'BuildWorker.bat <ProjectName>SimulatedPlayer ...' instead.");
+                    Console.Error.WriteLine("Warning: using `SimulatedPlayer` will output an assembly with a different name: UnrealSimulatedPlayer@Linux.zip. Make sure you change any reference to the old UnrealFakeClient@Linux.zip to this new assembly in your config files.");
+                }
+
+                Common.WriteHeading(" > Building simulated player.");
                 Common.RunRedirected(@"%UNREAL_HOME%\Engine\Build\BatchFiles\RunUAT.bat", new[]
                 {
                     "BuildCookRun",
@@ -210,8 +217,8 @@ exit /b !ERRORLEVEL!
                     additionalUATArgs
                 });
 
-                var linuxFakeClientPath = Path.Combine(stagingDir, "LinuxNoEditor");
-                File.WriteAllText(Path.Combine(linuxFakeClientPath, "StartWorker.sh"), FakeClientWorkerShellScript.Replace("\r\n", "\n"), new UTF8Encoding(false));
+                var linuxSimulatedPlayerPath = Path.Combine(stagingDir, "LinuxNoEditor");
+                File.WriteAllText(Path.Combine(linuxSimulatedPlayerPath, "StartWorker.sh"), SimulatedPlayerWorkerShellScript.Replace("\r\n", "\n"), new UTF8Encoding(false));
 
                 var workerCoordinatorPath = Path.GetFullPath(Path.Combine("../spatial", "build", "dependencies", "WorkerCoordinator"));
                 if (Directory.Exists(workerCoordinatorPath))
@@ -221,18 +228,19 @@ exit /b !ERRORLEVEL!
                         "/I",
                         "/Y",
                         workerCoordinatorPath,
-                        linuxFakeClientPath
+                        linuxSimulatedPlayerPath
                     });
                 } else
                 {
                     Console.WriteLine("worker coordinator path did not exist");
                 }
 
+                var archiveFileName = isUsingFakeClient ? "UnrealFakeClient@Linux.zip" : "UnrealSimulatedPlayer@Linux.zip";
                 Common.RunRedirected(@"%UNREAL_HOME%\Engine\Build\BatchFiles\RunUAT.bat", new[]
                 {
                     "ZipUtils",
-                    "-add=" + Quote(linuxFakeClientPath),
-                    "-archive=" + Quote(Path.Combine(outputDir, "UnrealFakeClient@Linux.zip")),
+                    "-add=" + Quote(linuxSimulatedPlayerPath),
+                    "-archive=" + Quote(Path.Combine(outputDir, archiveFileName)),
                 });
             }
             else if (gameName == baseGameName + "Server")

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Common/Common.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Common/Common.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -91,6 +91,13 @@ namespace Improbable
         public static void WriteHeading(string format, params object[] args)
         {
             Console.ForegroundColor = ConsoleColor.Cyan;
+            Console.WriteLine(format, args);
+            Console.ForegroundColor = ConsoleColor.Gray;
+        }
+
+        public static void WriteWarning(string format, params object[] args)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
             Console.WriteLine(format, args);
             Console.ForegroundColor = ConsoleColor.Gray;
         }


### PR DESCRIPTION
#### Description
We are renaming "fake client" to "simulated player" to align terminology across (upcoming) projects.

The build script has the option to build headless Linux (fake) clients. This PR renames the option to build these headless Linux clients from FakeClient to SimulatedPlayer.

For backwards compatibility the build script will still support FakeClient as a GameName (which results in `UnrealFakeClient@Linux.zip` as the created assembly), but will show a warning to use SimulatedPlayer instead. Using SimulatedPlayer as the GameName will result in the same assembly being created under a different name: `UnrealSimulatedPlayer@Linux.zip`. 

#### Release note
No release notes: the FakeClient/SimulatedPlayer option in the build script is currently for internal use only.

#### Tests
Tested this change by building both a FakeClient and SimulatedPlayer assembly for an existing project. Result when using FakeClient hasn't changed, except for now showing a warning message. Using SimulatedPlayer outputs the same assembly as FakeClient under a different name.