### PR TITLE
Feature/UNR-1002 Generate Schema for sublevels of active level in editor

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -552,9 +552,9 @@ bool SpatialGDKGenerateSchema()
 
 	for (const auto& Class : SchemaGeneratedClasses)
 	{
-		// Parent and static array index start at 0 for checksum calculations.
 		if (!Class || !Class->IsValidLowLevel()) continue;
 
+		// Parent and static array index start at 0 for checksum calculations.
 		TypeInfos.Add(CreateUnrealTypeInfo(Class, 0, 0, false));
 	}
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -553,6 +553,8 @@ bool SpatialGDKGenerateSchema()
 	for (const auto& Class : SchemaGeneratedClasses)
 	{
 		// Parent and static array index start at 0 for checksum calculations.
+		if (!Class || !Class->IsValidLowLevel()) continue;
+
 		TypeInfos.Add(CreateUnrealTypeInfo(Class, 0, 0, false));
 	}
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
@@ -7,6 +7,7 @@
 
 #include "SpatialGDKEditorSchemaGenerator.h"
 #include "SpatialGDKEditorSnapshotGenerator.h"
+#include "SpatialGDKEditorSettings.h"
 
 #include "Editor.h"
 
@@ -38,7 +39,11 @@ void FSpatialGDKEditor::GenerateSchema(FSimpleDelegate SuccessCallback, FSimpleD
 
 	TryLoadExistingSchemaDatabase();
 
-	LoadAllStreamingLevels(GWorld);
+	const USpatialGDKEditorSettings* SpatialGDKSettings = GetDefault<USpatialGDKEditorSettings>();
+	if (SpatialGDKSettings->bLoadStreamingLevelsWhenGeneratingSchema)
+	{
+		LoadAllStreamingLevels(GWorld);
+	}
 
 	PreProcessSchemaMap();
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
@@ -50,6 +50,8 @@ void FSpatialGDKEditor::GenerateSchema(FSimpleDelegate SuccessCallback, FSimpleD
 		LoadedLevels = LoadAllStreamingLevels(GWorld);
 	}
 
+	PreProcessSchemaMap();
+
 	// Compile all dirty blueprints
 	TArray<UBlueprint*> ErroredBlueprints;
 	bool bPromptForCompilation = false;
@@ -61,6 +63,11 @@ void FSpatialGDKEditor::GenerateSchema(FSimpleDelegate SuccessCallback, FSimpleD
 		[this, LoadedLevels]() {
 
 		UE_LOG(LogSpatialGDKSchemaGenerator, Display, TEXT("Begin Schema Gen for %d Levels"), LoadedLevels.Num());
+
+		if (LoadedLevels.Num() == 0)
+		{
+			return SpatialGDKGenerateSchema();
+		}
 
 		for (ULevelStreaming* Level : LoadedLevels)
 		{

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -8,6 +8,7 @@ USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& O
 	, bGenerateDefaultLaunchConfig(true)
 	, bStopSpatialOnExit(false)
 	, bGeneratePlaceholderEntitiesInSnapshot(true)
+	, bLoadStreamingLevelsWhenGeneratingSchema(true)
 {
 	SpatialOSDirectory.Path = GetSpatialOSDirectory();
 	SpatialOSLaunchConfig.FilePath = GetSpatialOSLaunchConfig();
@@ -55,6 +56,7 @@ FString USpatialGDKEditorSettings::ToString()
 	Args.Add(SpatialOSSnapshotPath.Path);
 	Args.Add(SpatialOSSnapshotFile);
 	Args.Add(GeneratedSchemaOutputFolder.Path);
+	Args.Add(bLoadStreamingLevelsWhenGeneratingSchema);
 	Args.Add(bGeneratePlaceholderEntitiesInSnapshot);
 
 	return FString::Format(TEXT(
@@ -66,7 +68,8 @@ FString USpatialGDKEditorSettings::ToString()
 		"SpatialOSSnapshotPath={5}, "
 		"SpatialOSSnapshotFile={6}, "
 		"GeneratedSchemaOutputFolder={7}, "
-		"bGeneratePlaceholderEntitiesInSnapshot={8}")
+		"bLoadStreamingLevelsWhenGeneratingSchema={8}, "
+		"bGeneratePlaceholderEntitiesInSnapshot={9}")
 		, Args);
 }
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditor.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditor.h
@@ -19,7 +19,8 @@ public:
 
 	bool IsSchemaGeneratorRunning() { return bSchemaGeneratorRunning; }
 
-	void LoadAllStreamingLevels(UWorld* World);
+	TArray<ULevelStreaming*> LoadAllStreamingLevels(UWorld* World);
+	void UnloadLevels(TArray<ULevelStreaming*> LoadedLevels);
 
 private:
 	bool bSchemaGeneratorRunning;

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditor.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditor.h
@@ -23,6 +23,10 @@ public:
 	void UnloadLevels(TArray<ULevelStreaming*> LoadedLevels);
 
 private:
+
+	FDelegateHandle OnAssetLoadedHandle;
+	void OnAssetLoaded(UObject* Asset);
+
 	bool bSchemaGeneratorRunning;
 	TFuture<bool> SchemaGeneratorResult;
 };

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditor.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditor.h
@@ -19,6 +19,8 @@ public:
 
 	bool IsSchemaGeneratorRunning() { return bSchemaGeneratorRunning; }
 
+	void LoadAllStreamingLevels(UWorld* World);
+
 private:
 	bool bSchemaGeneratorRunning;
 	TFuture<bool> SchemaGeneratorResult;

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -42,6 +42,10 @@ public:
 	UPROPERTY(EditAnywhere, config, Category = "Launch", meta = (ConfigRestartRequired = false, DisplayName = "Stop on exit"))
 	bool bStopSpatialOnExit;
 
+	/** if checked, the GDK will load all streaming levels and World Composition tiles before generating schema. */
+	UPROPERTY(EditAnywhere, config, Category = "Schema", meta = (ConfigRestartRequired = false, DisplayName = "Load streaming levels when generating schema"))
+	bool bLoadStreamingLevelsWhenGeneratingSchema;
+
 private:
 	/** Path to your SpatialOS snapshot. */
 	UPROPERTY(EditAnywhere, config, Category = "Snapshots", meta = (ConfigRestartRequired = false, DisplayName = "Snapshot path"))
@@ -95,6 +99,6 @@ public:
 			? FPaths::ConvertRelativePathToFull(FPaths::Combine(GetSpatialOSDirectory(), FString(TEXT("schema/unreal/generated/"))))
 			: GeneratedSchemaOutputFolder.Path;
 	}
-	
+
 	virtual FString ToString();
 };

--- a/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/GenerateSchemaAndSnapshotsCommandlet.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/GenerateSchemaAndSnapshotsCommandlet.cpp
@@ -140,25 +140,7 @@ void UGenerateSchemaAndSnapshotsCommandlet::GenerateSchemaAndSnapshotForMap(FSpa
 	}
 
 	// Ensure all sub-levels are also loaded
-	const TArray<ULevelStreaming*> StreamingLevels = GWorld->GetStreamingLevels();
-	UE_LOG(LogSpatialGDKEditorCommandlet, Display, TEXT("Loading %d Streaming SubLevels"), StreamingLevels.Num());
-	for (ULevelStreaming* StreamingLevel : StreamingLevels)
-	{
-		FLatentActionInfo LatentInfo;
-		UGameplayStatics::LoadStreamLevel(GWorld, StreamingLevel->GetWorldAssetPackageFName(), false, true, LatentInfo);
-	}
-
-	// Ensure all world composition tiles are also loaded
-	if (GWorld->WorldComposition != nullptr)
-	{
-		TArray<ULevelStreaming*> StreamingTiles = GWorld->WorldComposition->TilesStreaming;
-		UE_LOG(LogSpatialGDKEditorCommandlet, Display, TEXT("Loading %d World Composition Tiles"), StreamingTiles.Num());
-		for (ULevelStreaming* StreamingTile : StreamingTiles)
-		{
-			FLatentActionInfo LatentInfo;
-			UGameplayStatics::LoadStreamLevel(GWorld, StreamingTile->GetWorldAssetPackageFName(), false, true, LatentInfo);
-		}
-	}
+	InSpatialGDKEditor.LoadAllStreamingLevels(GWorld);
 
 	// Generate Schema Iteration
 	GenerateSchemaForLoadedMap(InSpatialGDKEditor);


### PR DESCRIPTION
#### Description
Load sublevels into memory before generating schema. Added option in settings to disable the feature.

#### Release note
Feature: Generate schema for all sublevels in current map (including World Composition). Can be disabled in Settings.

#### Tests
Tested with simple world composition setup. Verified schema generated for replicated actors only present in sublevels. Verified that disabling via settings does indeed stop schema generation of actors only present in sublevels.