### PR TITLE
Make 'Delete dynamic actors' work with servers as a separate process

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -123,17 +123,19 @@ bool USpatialActorChannel::IsSingletonEntity()
 bool USpatialActorChannel::CleanUp(const bool bForDestroy)
 {
 #if WITH_EDITOR
-	if (NetDriver != nullptr && NetDriver->GetWorld() != nullptr)
+	if (NetDriver != nullptr)
 	{
 		const bool bDeleteDynamicEntities = GetDefault<ULevelEditorPlaySettings>()->GetDeleteDynamicEntities();
 
+		UWorld* World = NetDriver->GetWorld();
+		const bool bPIEShutdown = World != nullptr && World->WorldType == EWorldType::PIE && World->bIsTearingDown;
+
 		if (bDeleteDynamicEntities &&
 			NetDriver->IsServer() &&
-			NetDriver->GetWorld()->WorldType == EWorldType::PIE &&
-			NetDriver->GetWorld()->bIsTearingDown &&
-			NetDriver->GetEntityRegistry()->GetActorFromEntityId(EntityId))
+			(bPIEShutdown || GIsRequestingExit) &&
+			NetDriver->GetEntityRegistry()->GetActorFromEntityId(EntityId) != nullptr)
 		{
-			// If we're running in PIE, as a server worker, and the entity hasn't already been cleaned up, delete it on shutdown.
+			// If we're a server worker, and the entity hasn't already been cleaned up, delete it on shutdown.
 			DeleteEntityIfAuthoritative();
 		}
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -653,7 +653,7 @@ void USpatialReceiver::DestroyActor(AActor* Actor, Worker_EntityId EntityId)
 
 void USpatialReceiver::CleanupDeletedEntity(Worker_EntityId EntityId)
 {
-	Cast<USpatialPackageMapClient>(NetDriver->GetSpatialOSNetConnection()->PackageMap)->RemoveEntityActor(EntityId);
+	PackageMap->RemoveEntityActor(EntityId);
 	NetDriver->GetEntityRegistry()->RemoveFromRegistry(EntityId);
 	NetDriver->RemoveActorChannel(EntityId);
 }


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
With `Use Single Process` unchecked, the server would ignore `Delete dynamic entities` setting because the `World` pointer is set to null before the actor channels are cleaned up. Instead, we can check `GIsRequestingExit` which is true when the server is shutting down.
This has a side effect of triggering with external servers that are built with editor, e.g. in the standard local deployment flow, which may or may not be a useful feature. If necessary, we can modify this to only trigger on non-PIE servers if they're terminated from `ReceiveShutdownMultiProcessRequest`.

#### Release note
Feature: "Delete dynamic entities" functionality now works with multiple processes.

#### Tests
Run game with `Use Single Process` disabled, observe entities spawn in the inspector.
Shut down the game, observe entities deleted in the inspector.
Start the game again without restarting the deployment, observe the game state is reset to the starting state.

#### Primary reviewers
@m-samiec @Vatyx 