### PR TITLE
WorkerType stored in GameInstance

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -152,11 +152,7 @@ void USpatialNetDriver::OnMapLoaded(UWorld* LoadedWorld)
 		Connection->LegacyLocatorConfig.DeploymentName = LoadedWorld->URL.GetOption(TEXT("deployment="), TEXT(""));
 		Connection->LegacyLocatorConfig.LoginToken = LoadedWorld->URL.GetOption(TEXT("token="), TEXT(""));
 		Connection->LegacyLocatorConfig.UseExternalIp = true;
-
-		if (!GameInstance->GetSpatialWorkerType().IsEmpty())
-		{
-			Connection->LegacyLocatorConfig.WorkerType = GameInstance->GetSpatialWorkerType();
-		}
+		Connection->LegacyLocatorConfig.WorkerType = GameInstance->GetSpatialWorkerType();
 	}
 	else if (LoadedWorld->URL.HasOption(TEXT("locator")))
 	{
@@ -164,11 +160,7 @@ void USpatialNetDriver::OnMapLoaded(UWorld* LoadedWorld)
 		Connection->LocatorConfig.PlayerIdentityToken = LoadedWorld->URL.GetOption(TEXT("playeridentity="), TEXT(""));
 		Connection->LocatorConfig.LoginToken = LoadedWorld->URL.GetOption(TEXT("login="), TEXT(""));
 		Connection->LocatorConfig.UseExternalIp = true;
-
-		if (!GameInstance->GetSpatialWorkerType().IsEmpty())
-		{
-			Connection->LocatorConfig.WorkerType = GameInstance->GetSpatialWorkerType();
-		}
+		Connection->LocatorConfig.WorkerType = GameInstance->GetSpatialWorkerType();
 	}
 	else
 	{
@@ -178,10 +170,7 @@ void USpatialNetDriver::OnMapLoaded(UWorld* LoadedWorld)
 			Connection->ReceptionistConfig.ReceptionistHost = LoadedWorld->URL.Host;
 		}
 
-		if (!GameInstance->GetSpatialWorkerType().IsEmpty())
-		{
-			Connection->ReceptionistConfig.WorkerType = GameInstance->GetSpatialWorkerType();
-		}
+		Connection->ReceptionistConfig.WorkerType = GameInstance->GetSpatialWorkerType();
 
 		bool bHasUseExternalIpOption = LoadedWorld->URL.HasOption(TEXT("useExternalIpForBridge"));
 		if (bHasUseExternalIpOption)

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -152,6 +152,11 @@ void USpatialNetDriver::OnMapLoaded(UWorld* LoadedWorld)
 		Connection->LegacyLocatorConfig.DeploymentName = LoadedWorld->URL.GetOption(TEXT("deployment="), TEXT(""));
 		Connection->LegacyLocatorConfig.LoginToken = LoadedWorld->URL.GetOption(TEXT("token="), TEXT(""));
 		Connection->LegacyLocatorConfig.UseExternalIp = true;
+
+		if (!GameInstance->GetSpatialWorkerType().IsEmpty())
+		{
+			Connection->LegacyLocatorConfig.WorkerType = GameInstance->GetSpatialWorkerType();
+		}
 	}
 	else if (LoadedWorld->URL.HasOption(TEXT("locator")))
 	{
@@ -159,6 +164,11 @@ void USpatialNetDriver::OnMapLoaded(UWorld* LoadedWorld)
 		Connection->LocatorConfig.PlayerIdentityToken = LoadedWorld->URL.GetOption(TEXT("playeridentity="), TEXT(""));
 		Connection->LocatorConfig.LoginToken = LoadedWorld->URL.GetOption(TEXT("login="), TEXT(""));
 		Connection->LocatorConfig.UseExternalIp = true;
+
+		if (!GameInstance->GetSpatialWorkerType().IsEmpty())
+		{
+			Connection->LocatorConfig.WorkerType = GameInstance->GetSpatialWorkerType();
+		}
 	}
 	else
 	{
@@ -166,6 +176,11 @@ void USpatialNetDriver::OnMapLoaded(UWorld* LoadedWorld)
 		if (!LoadedWorld->URL.Host.IsEmpty())
 		{
 			Connection->ReceptionistConfig.ReceptionistHost = LoadedWorld->URL.Host;
+		}
+
+		if (!GameInstance->GetSpatialWorkerType().IsEmpty())
+		{
+			Connection->ReceptionistConfig.WorkerType = GameInstance->GetSpatialWorkerType();
 		}
 
 		bool bHasUseExternalIpOption = LoadedWorld->URL.HasOption(TEXT("useExternalIpForBridge"));

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
@@ -77,6 +77,7 @@ void USpatialWorkerConnection::ConnectToReceptionist(bool bConnectAsClient)
 	if (ReceptionistConfig.WorkerType.IsEmpty())
 	{
 		ReceptionistConfig.WorkerType = bConnectAsClient ? SpatialConstants::ClientWorkerType : SpatialConstants::ServerWorkerType;
+		UE_LOG(LogSpatialWorkerConnection, Warning, TEXT("No worker type specified through commandline, defaulting to %s"), *ReceptionistConfig.WorkerType);
 	}
 
 	if (ReceptionistConfig.WorkerId.IsEmpty())
@@ -144,6 +145,7 @@ void USpatialWorkerConnection::ConnectToLegacyLocator()
 	if (LegacyLocatorConfig.WorkerType.IsEmpty())
 	{
 		LegacyLocatorConfig.WorkerType = SpatialConstants::ClientWorkerType;
+		UE_LOG(LogSpatialWorkerConnection, Warning, TEXT("No worker type specified through commandline, defaulting to %s"), *LegacyLocatorConfig.WorkerType);
 	}
 
 	if (LegacyLocatorConfig.WorkerId.IsEmpty())
@@ -254,6 +256,7 @@ void USpatialWorkerConnection::ConnectToLocator()
 	if (LocatorConfig.WorkerType.IsEmpty())
 	{
 		LocatorConfig.WorkerType = SpatialConstants::ClientWorkerType;
+		UE_LOG(LogSpatialWorkerConnection, Warning, TEXT("No worker type specified through commandline, defaulting to %s"), *LocatorConfig.WorkerType);
 	}
 
 	if (LocatorConfig.WorkerId.IsEmpty())

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
@@ -19,7 +19,6 @@ struct FConnectionConfig
 	{
 		const TCHAR* CommandLine = FCommandLine::Get();
 
-		FParse::Value(CommandLine, TEXT("workerType"), WorkerType);
 		FParse::Value(CommandLine, TEXT("workerId"), WorkerId);
 		FParse::Bool(CommandLine, TEXT("useExternalIpForBridge"), UseExternalIp);
 		FParse::Bool(CommandLine, TEXT("enableProtocolLogging"), EnableProtocolLoggingAtStartup);

--- a/ci/unreal-engine.version
+++ b/ci/unreal-engine.version
@@ -1,1 +1,1 @@
-UnrealEngine-4606458f0ccb248184edcb695189d67d9017e3d1
+UnrealEngine-b8b65aaea9e6b998dff3bc5c3d002c2a94c17fe6

--- a/ci/unreal-engine.version
+++ b/ci/unreal-engine.version
@@ -1,1 +1,1 @@
-UnrealEngine-b8b65aaea9e6b998dff3bc5c3d002c2a94c17fe6
+UnrealEngine-b9f63385c9efcc64ac44c838c12a593730a24549

--- a/ci/unreal-engine.version
+++ b/ci/unreal-engine.version
@@ -1,1 +1,1 @@
-UnrealEngine-8d84b8ff3364d70f43c0efd9d9149c7f1fc26997
+UnrealEngine-4606458f0ccb248184edcb695189d67d9017e3d1


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
In order to open up for future support for offloading, this PR associates a game instance with a spatial worker type. 

Associated engine branch: https://github.com/improbableio/UnrealEngine/pull/99

#### Release note
Feature: It is now possible to access the worker type through the game instance.

#### Tests
Validated the normal connection flow.

#### How can this be verified by QA?

Do a local and a cloud deployment and validate that the workers spun up have the correct worker types.

#### Documentation
None required, non breaking change.

#### Primary reviewers
@m-samiec @Vatyx 