### PR TITLE
Check against bNetStartup to see if path should be in UnrealMetadata

### DIFF
--- a/SpatialGDK/Extras/schema/unreal_metadata.schema
+++ b/SpatialGDK/Extras/schema/unreal_metadata.schema
@@ -8,5 +8,5 @@ component UnrealMetadata {
     option<UnrealObjectRef> stably_named_ref = 1; // Exists when entity represents a stably named Actor (RF_WasLoaded)
     option<string> owner_worker_attribute = 2;
     string class_path = 3;
-    option<bool> net_load_on_client = 4; // Exists only when entity has a stably_named_ref
+    option<bool> net_startup = 4; // Exists only when entity has a stably_named_ref
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -596,7 +596,7 @@ AActor* USpatialReceiver::TryGetOrCreateActor(improbable::UnrealMetadata* Unreal
 {
 	if (UnrealMetadata->StablyNamedRef.IsSet())
 	{
-		if (NetDriver->IsServer() || UnrealMetadata->NetLoadOnClient.GetValue())
+		if (NetDriver->IsServer() || UnrealMetadata->bNetStartup.GetValue())
 		{
 			// This Actor already exists in the map, get it from the package map.
 			const FUnrealObjectRef& StablyNamedRef = UnrealMetadata->StablyNamedRef.GetValue();

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -150,8 +150,8 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 	// We use this to indicate if a new Actor should be created or to link a pre-existing Actor when receiving an AddEntityOp.
 	// Previously, IsFullNameStableForNetworking was used but this was only true if bNetLoadOnClient was true.
 	TSchemaOption<FUnrealObjectRef> StablyNamedObjectRef;
-	TSchemaOption<bool> NetLoadOnClient;
-	if (Actor->HasAnyFlags(RF_WasLoaded))
+	TSchemaOption<bool> bNetStartup;
+	if (Actor->HasAnyFlags(RF_WasLoaded) || Actor->bNetStartup)
 	{
 		// Since we've already received the EntityId for this Actor. It is guaranteed to be resolved
 		// with the package map by this point
@@ -167,7 +167,7 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 		GEngine->NetworkRemapPath(NetDriver, TempPath, false /*bIsReading*/);
 
 		StablyNamedObjectRef = FUnrealObjectRef(0, 0, TempPath, OuterObjectRef, true);
-		NetLoadOnClient = Actor->bNetLoadOnClient;
+		bNetStartup = Actor->bNetStartup;
 	}
 
 	TArray<Worker_ComponentData> ComponentDatas;
@@ -176,7 +176,7 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 	ComponentDatas.Add(improbable::EntityAcl(ReadAcl, ComponentWriteAcl).CreateEntityAclData());
 	ComponentDatas.Add(improbable::Persistence().CreatePersistenceData());
 	ComponentDatas.Add(improbable::SpawnData(Actor).CreateSpawnDataData());
-	ComponentDatas.Add(improbable::UnrealMetadata(StablyNamedObjectRef, ClientWorkerAttribute, Class->GetPathName(), NetLoadOnClient).CreateUnrealMetadataData());
+	ComponentDatas.Add(improbable::UnrealMetadata(StablyNamedObjectRef, ClientWorkerAttribute, Class->GetPathName(), bNetStartup).CreateUnrealMetadataData());
 
 	if (Class->HasAnySpatialClassFlags(SPATIALCLASS_Singleton))
 	{

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealMetadata.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealMetadata.h
@@ -25,8 +25,8 @@ struct UnrealMetadata : Component
 
 	UnrealMetadata() = default;
 
-	UnrealMetadata(const TSchemaOption<FUnrealObjectRef>& InStablyNamedRef, const FString& InOwnerWorkerAttribute, const FString& InClassPath, const TSchemaOption<bool>& InNetLoadOnClient)
-		: StablyNamedRef(InStablyNamedRef), OwnerWorkerAttribute(InOwnerWorkerAttribute), ClassPath(InClassPath), NetLoadOnClient(InNetLoadOnClient) {}
+	UnrealMetadata(const TSchemaOption<FUnrealObjectRef>& InStablyNamedRef, const FString& InOwnerWorkerAttribute, const FString& InClassPath, const TSchemaOption<bool>& InbNetStartup)
+		: StablyNamedRef(InStablyNamedRef), OwnerWorkerAttribute(InOwnerWorkerAttribute), ClassPath(InClassPath), bNetStartup(InbNetStartup) {}
 
 	UnrealMetadata(const Worker_ComponentData& Data)
 	{
@@ -41,7 +41,7 @@ struct UnrealMetadata : Component
 
 		if (Schema_GetBoolCount(ComponentObject, 4) == 1)
 		{
-			NetLoadOnClient = GetBoolFromSchema(ComponentObject, 4);
+			bNetStartup = GetBoolFromSchema(ComponentObject, 4);
 		}
 	}
 
@@ -58,9 +58,9 @@ struct UnrealMetadata : Component
 		}
 		AddStringToSchema(ComponentObject, 2, OwnerWorkerAttribute);
 		AddStringToSchema(ComponentObject, 3, ClassPath);
-		if (NetLoadOnClient.IsSet())
+		if (bNetStartup.IsSet())
 		{
-			Schema_AddBool(ComponentObject, 4, NetLoadOnClient.GetValue());
+			Schema_AddBool(ComponentObject, 4, bNetStartup.GetValue());
 		}
 
 		return Data;
@@ -88,7 +88,7 @@ struct UnrealMetadata : Component
 	TSchemaOption<FUnrealObjectRef> StablyNamedRef;
 	FString OwnerWorkerAttribute;
 	FString ClassPath;
-	TSchemaOption<bool> NetLoadOnClient;
+	TSchemaOption<bool> bNetStartup;
 
 	UClass* NativeClass = nullptr;
 };


### PR DESCRIPTION
#### Description
Actors that are placed into a level but aren't saved to disk, will not have the flag `RF_WasLoaded` set. This means we need to check against both the RF_WasLoaded flag (in the case of bNetLoadOnClient = false) and against bNetStartup to see if we need to put the path into the UnrealMetadata in the cases where the map isn't saved.

This will cause issues in the edge case of Actors with bNetLoadOnClient = false, and the map wasn't saved. No path will be in the UnrealMetadata so the server will not know to link up the entity when it connects. We can solve this edge case in the future.

Related Engine PR: https://github.com/improbableio/UnrealEngine/pull/108