### PR TITLE
UNR-1147 Fix external client connections.

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -113,7 +113,7 @@ void USpatialNetDriver::InitiateConnectionToSpatialOS(const FURL& URL)
 	// Set the timer manager.
 	TimerManager = &GameInstance->GetTimerManager();
 
-	if (!bPersistSpatialConnection)
+	if (!bPersistSpatialConnection && GetWorld()) // GetWorld check as we do not want to destroy on our first time connecting.
 	{
 		// Destroy the old connection
 		GameInstance->GetSpatialWorkerConnection()->DestroyConnection();


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
It appears that we were destroying the worker connection unless bPersistSpatialConnection was true even when we are connecting to Spatial for the first time. This would mean the SpatialWorkerConnection would become garbage collected and then the lambdas that used GC'd worker connection would try using it. This would cause a fatal. 

I've added an additional check to make sure we don't try and delete the worker connection on first connection. Additionally there should be follow up work to prevent connection race conditions in the lambdas in SpatialWorkerConnection, this will be in a new ticket.

#### Release note
Bugfix: Fixed spatial worker connection from being destroyed at client startup

#### Tests
Tested with external clients in ShooterGame, clients no longer fatal.

STRONGLY SUGGESTED: Start ShooterGame with external server and clients, if connection succeeds then we're good.


#### Primary reviewers
@improbable-valentyn 