### PR TITLE
Docs/tutorial small fixes

### DIFF
--- a/SpatialGDK/Documentation/content/get-started/introduction.md
+++ b/SpatialGDK/Documentation/content/get-started/introduction.md
@@ -3,7 +3,7 @@
 
 Get started with the SpatialOS GDK for Unreal by building the SpatialOS Unreal Engine Fork and setting up the GDK Starter Template which you can use as a base for your own project running on SpatialOS.
 
-After this, you can follow the Multiserver tutorial which shows you how to deploy a project to the cloud and demos a simple shooter game running across two servers or, if you have an existing Unreal multiplayer project, you can follow the porting guide to get it onto the GDK and running on SpatialOS.
+After this, you can follow the Multiserver Shooter Tutorial which shows you how to deploy a project to the cloud and demos a simple shooter game running across two servers or, if you have an existing Unreal multiplayer project, you can follow the porting guide to get it onto the GDK and running on SpatialOS.
 
 ## Your feedback and ideas
 

--- a/SpatialGDK/Documentation/content/get-started/introduction.md
+++ b/SpatialGDK/Documentation/content/get-started/introduction.md
@@ -3,7 +3,9 @@
 
 Get started with the SpatialOS GDK for Unreal by building the SpatialOS Unreal Engine Fork and setting up the GDK Starter Template which you can use as a base for your own project running on SpatialOS.
 
-After this, you can follow the Multiserver Shooter Tutorial which shows you how to deploy a project to the cloud and demos a simple shooter game running across two servers or, if you have an existing Unreal multiplayer project, you can follow the porting guide to get it onto the GDK and running on SpatialOS.
+After this you can either:<br>
+* Follow the Multiserver Shooter Tutorial, which shows you how to deploy a project to the cloud and demonstrates a simple shooter game running across two servers.
+* Or, if you have an existing Unreal multiplayer project, you can follow the porting guide to get your game running on  the SpatialOS GDK.
 
 ## Your feedback and ideas
 

--- a/SpatialGDK/Documentation/content/get-started/introduction.md
+++ b/SpatialGDK/Documentation/content/get-started/introduction.md
@@ -1,9 +1,9 @@
 <%(TOC)%>
 # Get started: Introduction
 
-Get started with the SpatialOS GDK for Unreal by building the SpatialOS Unreal Engine Fork and following the Multiserver Shooter Tutorial. The tutorial shows you how to deploy a project to the cloud and lets you experience a simple shooter game running across two servers. 
+Get started with the SpatialOS GDK for Unreal by building the SpatialOS Unreal Engine Fork and setting up the GDK Starter Template which you can use as a base for your own project running on SpatialOS.
 
-Once you have completed the tutorial, you are then ready to set up and deploy the Starter Template, which you can use as a base for your own Unreal project running on SpatialOS or, if you have an existing Unreal multiplayer project, you can follow our detailed porting guide to get it onto the GDK and running on SpatialOS.
+After this, you can follow the Multiserver tutorial which shows you how to deploy a project to the cloud and demos a simple shooter game running across two servers or, if you have an existing Unreal multiplayer project, you can follow the porting guide to get it onto the GDK and running on SpatialOS.
 
 ## Your feedback and ideas
 
@@ -22,3 +22,7 @@ Create an issue in [this repository](https://github.com/spatialos/UnrealGDK/issu
 #### Next: [Get the dependencies]({{urlRoot}}/content/get-started/dependencies.md)
 
 <%(Callout type="warn" message="This is an [alpha](https://docs.improbable.io/reference/latest/shared/release-policy#maturity-stages) release of the SpatialOS GDK for Unreal, pending stability, performance and documentation improvements. The API may change as we learn from feedback  - see the guidance on [Recommended use]({{urlRoot}}/recommended-use).")%>
+
+<br/>
+------
+_2019-03-20 Page updated with editorial review_

--- a/SpatialGDK/Documentation/content/get-started/tutorial.md
+++ b/SpatialGDK/Documentation/content/get-started/tutorial.md
@@ -1,15 +1,26 @@
 <%(TOC)%>
 # Follow the Multiserver Shooter tutorial
 
-### What will be covered?
-
-In this tutorial you’ll implement cross server remote procedure calls (RPCs) in a simple third person shooter. The end result will be a multiplayer, cloud-hosted Unreal game running across multiple [server-workers]({{urlRoot}}/content/glossary#inspector) that players can seamlessly move between and shoot across. It will look something like this:
+**What the tutorial covers**<br/>
+In this tutorial you’ll implement cross-server remote procedure calls (RPCs) in a simple third person shooter. The end result will be a multiplayer, cloud-hosted Unreal game running across multiple [server-workers]({{urlRoot}}/content/glossary#inspector) that players can seamlessly move between and shoot across. It will look something like this:
 
 ![]({{assetRoot}}assets/tutorial/cross-server.gif)
 
 The exercise demonstrates that the workflows and iteration speed you’re used to as an Unreal developer are almost entirely unaltered by the GDK: it’s just like regular Unreal!
+<br/>
+<br/>
+### Check you have the prerequistes
 
-Let’s get started.
+Before following the Multiserver Shooter tutorial, you need to have followed:
+
+* [Getting started: 1 - Dependencies]({{urlRoot}}/content/get-started/dependencies)
+* [Getting started: 2 - Get and build the SpatialOS Unreal Engine Fork]({{urlRoot}}/content/get-started/tutorial).
+
+Once you have done this, you are ready to get going with the Multiserver Shooter tutorial by following the steps below.
+<br/>
+<br/>
+**Let's get started!**<br/>
+<br/>
 
 ### Clone the Unreal GDK Third Person Shooter repository
 
@@ -23,6 +34,7 @@ This repository contains a version of Unreal’s Third Person template that has 
 
 > **Note:**  A completed version of this tutorial is available in the `tutorial-complete` branch.
 
+<br/>
 ### Clone the GDK into the `Plugins` directory
 
 1. Navigate to `UnrealGDKThirdPersonShooter\Game` and create a `Plugins` directory.
@@ -36,6 +48,7 @@ The GDK's [default branch (GitHub documentation)](https://help.github.com/en/art
 
 > **Note:**  You need to ensure that the root folder of the Unreal GDK repository is called `UnrealGDK` so its path is: `UnrealGDKThirdPersonShooter\Game\Plugins\UnrealGDK\`.
 
+<br/>
 ### Build Dependencies 
 
 In this step, you're going to build the Unreal GDK's dependencies.
@@ -53,20 +66,19 @@ _Image: On the GDK toolbar in the Unreal Editor select **Schema**_<br/>
 ![Toolbar]({{assetRoot}}assets/screen-grabs/toolbar/snapshot-button.png)<br/>
 _Image: On the GDK toolbar in the Unreal Editor select **Snapshot**_<br/>
 
+<br/>
 ### Deploy the project locally
 
 In this section you’ll run a [local deployment](https://docs.improbable.io/reference/latest/shared/glossary#local-deployment) of the project. As the name suggests, local deployments run on your development machine (you will [cloud deploy](https://docs.improbable.io/reference/latest/shared/glossary#cloud-deployment) later in this tutorial).
 
 1. In a text editor, open `UnrealGDKThirdPersonShooter\spatial\default_launch.json` and in the `layer_configurations` section set `rows` to `2`. This instructs SpatialOS that you will be launching two server-workers.
 1. In the Unreal Editor, in the Unreal toolbar, open the **Play** drop-down menu.<br/>
-2. Under **Multiplayer Options**, enter the number of players as **2**
-3. Enter the number of servers as **2**
-4. Ensure the box next to **Run Dedicated Server** is checked<br/>
+2. Under **Multiplayer Options**, enter the number of players as **2**.
+3. Enter the number of servers as **2**.
+4. Ensure the box next to **Run Dedicated Server** is checked.<br/>
 ![]({{assetRoot}}assets/set-up-template/template-multiplayer-options.png)<br/>
 _Image: The Unreal Engine **Play** drop-down menu, with **Multiplayer Options** and **New Editor Window (PIE)** highlighted_<br/>
-1. In the Unreal Editor, in the SpatialOS GDK toolbar, select **Start** (the green play icon). This opens a terminal window and runs the [`spatial local launch`](https://docs.improbable.io/reference/latest/shared/spatial-cli/spatial-local-launch#spatial-local-launch) command, which starts the [SpatialOS Runtime](https://docs.improbable.io/reference/latest/shared/glossary#the-runtime).<br/>
-![Toolbar]({{assetRoot}}assets/set-up-template/template-start.png)<br/>
-_Image: On the GDK toolbar in the Unreal Editor select **Start**_<br/>
+5. In the Unreal Editor, in the SpatialOS GDK toolbar, select **Start** (the green play icon). This opens a terminal window and runs the [`spatial local launch`](https://docs.improbable.io/reference/latest/shared/spatial-cli/spatial-local-launch#spatial-local-launch) command, which starts the [SpatialOS Runtime](https://docs.improbable.io/reference/latest/shared/glossary#the-runtime).
 6. It's ready when you see `SpatialOS ready. Access the inspector at http://localhost:21000/inspector`.
 7. From the Unreal Editor toolbar, select **Play** to run the game. This starts two SpatialOS server-worker instances and two SpatialOS client-worker instances locally, in your Unreal Editor.
 <br/>The two server-worker instances are acting as two Unreal servers and the two client-worker instances are acting as two Unreal game clients (as would be used by two game players).
@@ -74,6 +86,7 @@ _Image: On the GDK toolbar in the Unreal Editor select **Start**_<br/>
 
 Notice that when players shoot each other, their health does not go down. It's not much fun with no skin in the game is it? Let’s fix the health system.
 
+<br/>
 ### Replicate health changes
 
 In this ThirdPersonShooter project each `TPSCharacter` contains a variable called `CurrentHealth`, which keeps track of that character's health. On your servers, `CurrentHealth` is reduced whenever a character is shot, but this reduction is not replicated on the clients connected to the game. This is because the `CurrentHealth` variable is not setup for replication.
@@ -142,6 +155,7 @@ Because you’ve changed code in a function you now need to build your project, 
 
 Now let’s test our health replication in another local deployment.
 
+<br/>
 ### Deploy the project locally (again)
 
 1. In Unreal Editor, in the SpatialOS GDK toolbar, select **Start**. It's ready when you see `SpatialOS ready. Access the inspector at [http://localhost:21000/inspector]()`.
@@ -149,6 +163,7 @@ Now let’s test our health replication in another local deployment.
 
 Notice that health now decrements when you are shot.
 
+<br/>
 ### View your SpatialOS world in the Inspector
 
 ![]({{assetRoot}}assets/tutorial/inspector-two-workers.png)
@@ -164,6 +179,7 @@ This causes the Inspector to display the areas that each server-worker instance 
 1. Back in your two Unreal game clients, run around and shoot.
 1. Using the Inspector to track the location of your two players, notice that if you position them in the same area of authority then their shots damage each other, but if they are on different servers, they can’t damage each other. Let’s fix that.
 
+<br/>
 ### Enable cross server RPCs
 
 To damage a player on a different server, the actor shooting the bullet must send a cross-server RPC to the actor getting hit by the bullet. You will implement this by overriding the [TakeDamage (Unreal documentation)](https://api.unrealengine.com/INT/API/Runtime/Engine/GameFramework/APawn/TakeDamage/index.html) function in the TPSCharcter class.
@@ -234,6 +250,7 @@ Because you’ve changed code in a function you now need build **ThirdPersonShoo
 
 Now let’s test our new cross-server functionality in another local deployment.
 
+<br/>
 ### Deploy the project locally (last time)
 
 1. In Unreal Editor, in the SpatialOS GDK toolbar, select **Start**. It's ready when you see `SpatialOS ready. Access the inspector at [http://localhost:21000/inspector]()`.
@@ -247,6 +264,7 @@ Now that you're free of the single-server paradigm, have a think about the huge,
 
 Speaking of hosting, let’s upload your game.
 
+<br/>
 ### Build your assemblies
 
 An assembly is what’s created when you run `BuildWorker.bat`. They’re .zip files that contains all the files that your game uses when running in the cloud.
@@ -255,6 +273,7 @@ An assembly is what’s created when you run `BuildWorker.bat`. They’re .zip f
 1. Build a server-worker assembly by running: `Game\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat ThirdPersonShooterServer Linux Development ThirdPersonShooter.uproject`
 1. Build a client-worker assembly by running: `Game\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat ThirdPersonShooter Win64 Development ThirdPersonShooter.uproject`
 
+<br/>
 ### Upload your game
 
 1. In File Explorer, navigate to `UnrealGDKThirdPersonShooter\spatial` and open `spatialos.json` in a text editor.
@@ -268,6 +287,7 @@ spatial cloud upload myassembly
 
 > **Note:** Based on your network speed it may take a little while (1-10 minutes) to upload your assembly.
 
+<br/>
 ### Launch a cloud deployment
 
 The next step is to launch a cloud deployment using the assembly that you just uploaded. This can only be done through the SpatialOS command-line interface (also known as the [`spatial` CLI]({{urlRoot}}/content/glossary#spatial-command-line-tool-cli).
@@ -287,6 +307,7 @@ spatial cloud launch --snapshot=snapshots/default.snapshot myassembly two_worker
 
 > **Note:** This command defaults to deploying to clusters located in the US. If you’re in Europe, add the `--cluster_region=eu` flag for lower latency.
 
+<br/>
 ### Play your game
 
 ![]({{assetRoot}}assets/tutorial/console.png)
@@ -297,6 +318,7 @@ When your deployment has launched, SpatialOS automatically opens the [Console](h
 ![]({{assetRoot}}assets/tutorial/launch.png)
 1. Once the client has launched, enter the game and fire a few celebratory shots - you are now playing in your first SpatialOS cloud deployment!
 
+<br/>
 ### Invite your friends
 
 1. To invite other players to this game, head back to the Deployment Overview page in your [Console](https://console.improbable.io), and select the **Share button**.
@@ -304,10 +326,11 @@ When your deployment has launched, SpatialOS automatically opens the [Console](h
 
 When you’re done shooting your friends, you can click the **Stop** button in the [Console](https://console.improbable.io) to halt your deployment.
 
+<br/>
 ### Next steps
 We hope you've enjoyed this tutorial. If you want to build a new game using the SpatialOS GDK, you should build it on top of the [SpatialOS GDK Starter template]({{urlRoot}}/content/get-started/gdk-template). If you want to port your existing game to SpatialOS, follow the [porting guide]({{urlRoot}}/content/get-started/porting-unreal-project-to-gdk).
 
 <br/>
 <br/>
 -------------
-2019-03-15 Page updated with limited editorial review
+_2019-03-20 Page updated with limited editorial review_

--- a/SpatialGDK/Documentation/content/get-started/tutorial.md
+++ b/SpatialGDK/Documentation/content/get-started/tutorial.md
@@ -49,7 +49,7 @@ The GDK's [default branch (GitHub documentation)](https://help.github.com/en/art
 > **Note:**  You need to ensure that the root folder of the Unreal GDK repository is called `UnrealGDK` so its path is: `UnrealGDKThirdPersonShooter\Game\Plugins\UnrealGDK\`.
 
 <br/>
-### Build Dependencies 
+### Build dependencies 
 
 In this step, you're going to build the Unreal GDK's dependencies.
 


### PR DESCRIPTION
#### Description
Fixed docs to work with new get started order.
 - Intro was wrong way round
 - Multiserver tutorial didn't have the pre-requisites listed.
 - Teeny title change at the top explainer and added white space in the form of <br/>s  to make sections of multi-server tutorial easier to see (white space good for human brains)
 - Removed broken link to missing image


#### Tests
Improbadoc


#### Documentation
Is docs.

#### Primary reviewers
@anne-edwards (as second tech writer)
(FYI) @NotRobSheridan (sick so not primary)  @ernopp  @oblm 