### PR TITLE
Change deployment launcher to launch both deployments at the same time

### DIFF
--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/DeploymentLauncher/DeploymentLauncher.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/DeploymentLauncher/DeploymentLauncher.cs
@@ -455,23 +455,11 @@ namespace Improbable
             {
                 if (e.Status.StatusCode == Grpc.Core.StatusCode.Unauthenticated)
                 {
-                    Console.WriteLine("<error:unauthenticated>");
+                    Console.WriteLine("Error: unauthenticated. Please run `spatial auth login`");
                 }
                 else
                 {
                     Console.Error.WriteLine($"Encountered an unknown gRPC error. Exception = {e.ToString()}");
-                }
-            }
-            catch (ArgumentNullException e)
-            {
-                // This is here to work around WF-464, present as of Platform SDK version 13.5.0.
-                if (e.ParamName == "path")
-                {
-                    Console.WriteLine("<error:authentication>");
-                }
-                else
-                {
-                    throw;
                 }
             }
 

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/DeploymentLauncher/DeploymentLauncher.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/DeploymentLauncher/DeploymentLauncher.cs
@@ -112,7 +112,13 @@ namespace Improbable
                 {
                     // Don't launch a simulated player deployment. Wait for main deployment to be created and then return.
                     Console.WriteLine("Waiting for deployment to be ready...");
-                    createMainDeploymentOp.PollUntilCompleted();
+                    var result = createMainDeploymentOp.PollUntilCompleted().GetResultOrNull();
+                    if (result == null)
+                    {
+                        Console.WriteLine("Failed to create the main deployment");
+                        return 1;
+                    }
+
                     Console.WriteLine("Successfully created the main deployment");
                     return 0;
                 }
@@ -121,13 +127,18 @@ namespace Improbable
 
                 // Wait for both deployments to be created.
                 Console.WriteLine("Waiting for deployments to be ready...");
-                createMainDeploymentOp.PollUntilCompleted();
-                Console.WriteLine("Successfully created the main deployment");
+                var mainDeploymentResult = createMainDeploymentOp.PollUntilCompleted().GetResultOrNull();
+                if (mainDeploymentResult == null)
+                {
+                    Console.WriteLine("Failed to create the main deployment");
+                    return 1;
+                }
 
+                Console.WriteLine("Successfully created the main deployment");
                 var simPlayerDeployment = createSimDeploymentOp.PollUntilCompleted().GetResultOrNull();
                 if (simPlayerDeployment == null)
                 {
-                    Console.WriteLine("Failed to launch the simulated player deployment");
+                    Console.WriteLine("Failed to create the simulated player deployment");
                     return 1;
                 }
 

--- a/SpatialGDK/Build/Scripts/DeploymentLauncher.bat
+++ b/SpatialGDK/Build/Scripts/DeploymentLauncher.bat
@@ -13,4 +13,6 @@ if not exist %DEPLOYMENT_LAUNCHER_EXE_PATH% (
 
 popd
 
+pause
+
 exit /b %ERRORLEVEL%

--- a/SpatialGDK/Build/Scripts/DeploymentLauncher.bat
+++ b/SpatialGDK/Build/Scripts/DeploymentLauncher.bat
@@ -1,0 +1,16 @@
+@echo off
+
+pushd "%~dp0..\..\..\..\..\"
+
+set DEPLOYMENT_LAUNCHER_EXE_PATH="Plugins\UnrealGDK\SpatialGDK\Binaries\ThirdParty\Improbable\Programs\DeploymentLauncher\DeploymentLauncher.exe"
+
+if not exist %DEPLOYMENT_LAUNCHER_EXE_PATH% (
+	echo Error: Deployment launcher executable not found! Please run Setup.bat in your UnrealGDK root to generate it.
+	exit /b 1
+)
+
+%DEPLOYMENT_LAUNCHER_EXE_PATH% %*
+
+popd
+
+exit /b %ERRORLEVEL%

--- a/SpatialGDK/Build/Scripts/DeploymentLauncher.bat
+++ b/SpatialGDK/Build/Scripts/DeploymentLauncher.bat
@@ -1,8 +1,6 @@
 @echo off
 
-pushd "%~dp0..\..\..\..\..\"
-
-set DEPLOYMENT_LAUNCHER_EXE_PATH="Plugins\UnrealGDK\SpatialGDK\Binaries\ThirdParty\Improbable\Programs\DeploymentLauncher\DeploymentLauncher.exe"
+set DEPLOYMENT_LAUNCHER_EXE_PATH="%~dp0..\..\..\..\..\Plugins\UnrealGDK\SpatialGDK\Binaries\ThirdParty\Improbable\Programs\DeploymentLauncher\DeploymentLauncher.exe"
 
 if not exist %DEPLOYMENT_LAUNCHER_EXE_PATH% (
 	echo Error: Deployment launcher executable not found! Please run Setup.bat in your UnrealGDK root to generate it.
@@ -10,8 +8,6 @@ if not exist %DEPLOYMENT_LAUNCHER_EXE_PATH% (
 )
 
 %DEPLOYMENT_LAUNCHER_EXE_PATH% %*
-
-popd
 
 pause
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
To reduce the time it takes to launch a scale test, the deployment launcher will launch both the game and simplayer deployments at the same time. To make sure simulated clients aren't connected too early, a worker flag is set for the coordinator worker once both deployments are ready. Only once this flag is set, the coordinator starts connecting clients.
