### PR TITLE
Use the EntityToChannel map the netdriver already has in the dispatcher

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1454,6 +1454,11 @@ void USpatialNetDriver::RemoveActorChannel(Worker_EntityId EntityId)
 	EntityToActorChannel.FindAndRemoveChecked(EntityId);
 }
 
+TMap<Worker_EntityId, USpatialActorChannel*>& USpatialNetDriver::GetEntityToActorChannelMap()
+{
+	return EntityToActorChannel;
+}
+
 USpatialActorChannel* USpatialNetDriver::GetActorChannelByEntityId(Worker_EntityId EntityId) const
 {
 	return EntityToActorChannel.FindRef(EntityId);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialDispatcher.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialDispatcher.cpp
@@ -124,13 +124,9 @@ void USpatialDispatcher::ProcessOps(Worker_OpList* OpList)
 	Receiver->FlushRetryRPCs();
 
 	// Check every channel for net ownership changes (determines ACL and component interest)
-	const FActorChannelMap& ChannelMap = NetDriver->GetSpatialOSNetConnection()->ActorChannelMap();
-	for (auto& Pair : ChannelMap)
+	for (auto& EntityChannelPair : NetDriver->GetEntityToActorChannelMap())
 	{
-		if (USpatialActorChannel* Channel = Cast<USpatialActorChannel>(Pair.Value))
-		{
-			Channel->SpatialViewTick();
-		}
+		EntityChannelPair.Value->SpatialViewTick();
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -87,6 +87,7 @@ public:
 
 	void AddActorChannel(Worker_EntityId EntityId, USpatialActorChannel* Channel);
 	void RemoveActorChannel(Worker_EntityId EntityId);
+	TMap<Worker_EntityId, USpatialActorChannel*>& GetEntityToActorChannelMap();
 
 	USpatialActorChannel* GetActorChannelByEntityId(Worker_EntityId EntityId) const;
 


### PR DESCRIPTION
#### Description
Use the EntityToChannel map in the netdriver to stop crashing

#### Release note
Bugfix - fix crashing on SpatialDispatcher::ProcessOps