### PR TITLE
Add region codes to the deployments

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCloudLauncher.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCloudLauncher.cpp
@@ -12,21 +12,23 @@ bool SpatialGDKCloudLaunch()
 	const FString CmdExecutable = TEXT("cmd.exe");
 
 	FString LauncherCmdArguments = FString::Printf(
-		TEXT("/c DeploymentLauncher.exe create %s %s %s %s %s "),
+		TEXT("/c DeploymentLauncher.exe create %s %s %s %s %s %s"),
 		*SpatialGDKCloudLauncherSettings->GetProjectName(),
 		*SpatialGDKCloudLauncherSettings->GetAssemblyName(),
 		*SpatialGDKCloudLauncherSettings->GetPrimaryDeploymentName(),
 		*SpatialGDKCloudLauncherSettings->GetPrimaryLanchConfigPath(),
-		*SpatialGDKCloudLauncherSettings->GetSnapshotPath()
+		*SpatialGDKCloudLauncherSettings->GetSnapshotPath(),
+		*SpatialGDKCloudLauncherSettings->GetPrimaryRegionCode().ToString()
 	);
 
 	if (SpatialGDKCloudLauncherSettings->IsSimulatedPlayersEnabled())
 	{
 		LauncherCmdArguments = FString::Printf(
-			TEXT("%s %s %s %s"),
+			TEXT("%s %s %s %s %s"),
 			*LauncherCmdArguments,
 			*SpatialGDKCloudLauncherSettings->GetSimulatedPlayerDeploymentName(),
 			*SpatialGDKCloudLauncherSettings->GetSimulatedPlayerLaunchConfigPath(),
+			*SpatialGDKCloudLauncherSettings->GetSimulatedPlayerRegionCode().ToString(),
 			*FString::FromInt(SpatialGDKCloudLauncherSettings->GetNumberOfSimulatedPlayer())
 		);
 	}

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCloudLauncherSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCloudLauncherSettings.cpp
@@ -65,7 +65,7 @@ bool USpatialGDKEditorCloudLauncherSettings::IsDeploymentNameValid(const FString
 	return RegMatcher.FindNext();
 }
 
-bool USpatialGDKEditorCloudLauncherSettings::IsRegionCodeValid(const ERegionCode::Type RegionCode)
+bool USpatialGDKEditorCloudLauncherSettings::IsRegionCodeValid(const ERegionCode::Type RegionCode) const
 {
 	UEnum* pEnum = FindObject<UEnum>(ANY_PACKAGE, TEXT("ERegionCode"), true);
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCloudLauncherSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCloudLauncherSettings.cpp
@@ -65,6 +65,13 @@ bool USpatialGDKEditorCloudLauncherSettings::IsDeploymentNameValid(const FString
 	return RegMatcher.FindNext();
 }
 
+bool USpatialGDKEditorCloudLauncherSettings::IsRegionCodeValid(const ERegionCode::Type RegionCode)
+{
+	UEnum* pEnum = FindObject<UEnum>(ANY_PACKAGE, TEXT("ERegionCode"), true);
+
+	return pEnum && pEnum->IsValidEnumValue(RegionCode);
+}
+
 void USpatialGDKEditorCloudLauncherSettings::SetPrimaryDeploymentName(const FString& Name)
 {
 	PrimaryDeploymentName = Name;
@@ -95,6 +102,16 @@ void USpatialGDKEditorCloudLauncherSettings::SetSnapshotPath(const FString& Path
 	SaveConfig();
 }
 
+void USpatialGDKEditorCloudLauncherSettings::SetPrimaryRegionCode(const ERegionCode::Type RegionCode)
+{
+	PrimaryDeploymentRegionCode = RegionCode;
+}
+
+void USpatialGDKEditorCloudLauncherSettings::SetSimulatedPlayerRegionCode(const ERegionCode::Type RegionCode)
+{
+	SimulatedPlayerDeploymentRegionCode = RegionCode;
+}
+
 void USpatialGDKEditorCloudLauncherSettings::SetSimulatedPlayersEnabledState(bool IsEnabled)
 {
 	bSimulatedPlayersIsEnabled = IsEnabled;
@@ -115,9 +132,20 @@ void USpatialGDKEditorCloudLauncherSettings::SetNumberOfSimulatedPlayers(uint32 
 
 bool USpatialGDKEditorCloudLauncherSettings::IsDeploymentConfigurationValid() const
 {
-	return IsAssemblyNameValid(AssemblyName) &&
+	bool result = IsAssemblyNameValid(AssemblyName) &&
 		IsDeploymentNameValid(PrimaryDeploymentName) &&
 		IsProjectNameValid(ProjectName) &&
 		!SnapshotPath.FilePath.IsEmpty() &&
-		!PrimaryLaunchConfigPath.FilePath.IsEmpty();
+		!PrimaryLaunchConfigPath.FilePath.IsEmpty() &&
+		IsRegionCodeValid(PrimaryDeploymentRegionCode);
+
+	if (IsSimulatedPlayersEnabled())
+	{
+		result = result &&
+			IsDeploymentNameValid(SimulatedPlayerDeploymentName) &&
+			!SimulatedPlayerLaunchConfigPath.IsEmpty() &&
+			IsRegionCodeValid(SimulatedPlayerDeploymentRegionCode);
+	}
+
+	return result;
 }

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCloudLauncherSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCloudLauncherSettings.cpp
@@ -65,7 +65,7 @@ bool USpatialGDKEditorCloudLauncherSettings::IsDeploymentNameValid(const FString
 	return RegMatcher.FindNext();
 }
 
-bool USpatialGDKEditorCloudLauncherSettings::IsRegionCodeValid(const ERegionCode::Type RegionCode) const
+bool USpatialGDKEditorCloudLauncherSettings::IsRegionCodeValid(const ERegionCode::Type RegionCode)
 {
 	UEnum* pEnum = FindObject<UEnum>(ANY_PACKAGE, TEXT("ERegionCode"), true);
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCloudLauncherSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCloudLauncherSettings.cpp
@@ -69,7 +69,7 @@ bool USpatialGDKEditorCloudLauncherSettings::IsRegionCodeValid(const ERegionCode
 {
 	UEnum* pEnum = FindObject<UEnum>(ANY_PACKAGE, TEXT("ERegionCode"), true);
 
-	return pEnum && pEnum->IsValidEnumValue(RegionCode);
+	return pEnum != nullptr && pEnum->IsValidEnumValue(RegionCode);
 }
 
 void USpatialGDKEditorCloudLauncherSettings::SetPrimaryDeploymentName(const FString& Name)

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCloudLauncher.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCloudLauncher.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "Misc/Paths.h"
 #include "Logging/LogMacros.h"
 
 DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKCloudLauncher, Log, All);

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCloudLauncherSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCloudLauncherSettings.h
@@ -127,7 +127,7 @@ public:
 	{
 		UEnum* pEnum = FindObject<UEnum>(ANY_PACKAGE, TEXT("ERegionCode"), true);
 
-		if (!pEnum || !IsRegionCodeValid(SimulatedPlayerDeploymentRegionCode))
+		if (pEnum == nullptr || !IsRegionCodeValid(SimulatedPlayerDeploymentRegionCode))
 		{
 			return FText::FromString(TEXT("Invalid"));
 		}

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCloudLauncherSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCloudLauncherSettings.h
@@ -34,7 +34,6 @@ public:
 	USpatialGDKEditorCloudLauncherSettings(const FObjectInitializer& ObjectInitializer);
 
 private:
-
 	UPROPERTY(EditAnywhere, config, Category = "General", meta = (ConfigRestartRequired = false, DisplayName = "SpatialOS project"))
 	FString ProjectName;
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCloudLauncherSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCloudLauncherSettings.h
@@ -119,7 +119,7 @@ public:
 			return FText::FromString(TEXT("Invalid"));
 		}
 
-		return pEnum->GetEnumTextByValue(static_cast<int64>(PrimaryDeploymentRegionCode.GetValue()));
+		return pEnum->GetDisplayNameTextByValue(static_cast<int64>(PrimaryDeploymentRegionCode.GetValue()));
 	}
 
 	void SetSimulatedPlayerRegionCode(const ERegionCode::Type RegionCode);
@@ -132,7 +132,7 @@ public:
 			return FText::FromString(TEXT("Invalid"));
 		}
 
-		return pEnum->GetEnumTextByValue(static_cast<int64>(SimulatedPlayerDeploymentRegionCode.GetValue()));
+		return pEnum->GetDisplayNameTextByValue(static_cast<int64>(SimulatedPlayerDeploymentRegionCode.GetValue()));
 	}
 
 	void SetSimulatedPlayersEnabledState(bool IsEnabled);

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCloudLauncherSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCloudLauncherSettings.h
@@ -114,7 +114,7 @@ public:
 	{
 		UEnum* pEnum = FindObject<UEnum>(ANY_PACKAGE, TEXT("ERegionCode"), true);
 
-		if (!pEnum || !IsRegionCodeValid(PrimaryDeploymentRegionCode))
+		if (pEnum == nullptr || !IsRegionCodeValid(PrimaryDeploymentRegionCode))
 		{
 			return FText::FromString(TEXT("Invalid"));
 		}

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCloudLauncherSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCloudLauncherSettings.h
@@ -5,7 +5,6 @@
 #include "Engine/EngineTypes.h"
 #include "Misc/Paths.h"
 #include "SpatialGDKEditorSettings.h"
-#include "UObject/Class.h"
 #include "UObject/Package.h"
 
 #include "SpatialGDKEditorCloudLauncherSettings.generated.h"

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCloudLauncherSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCloudLauncherSettings.h
@@ -5,8 +5,25 @@
 #include "Engine/EngineTypes.h"
 #include "Misc/Paths.h"
 #include "SpatialGDKEditorSettings.h"
+#include "UObject/Class.h"
+#include "UObject/Package.h"
 
 #include "SpatialGDKEditorCloudLauncherSettings.generated.h"
+
+
+/**
+* Enumerates available Region Codes
+*/
+UENUM()
+namespace ERegionCode
+{
+	enum Type
+	{
+		US = 1,
+		EU,
+		AP,
+	};
+}
 
 UCLASS(config = SpatialGDKEditorCloudLauncherSettings, defaultconfig)
 class SPATIALGDKEDITOR_API USpatialGDKEditorCloudLauncherSettings : public UObject
@@ -17,6 +34,7 @@ public:
 	USpatialGDKEditorCloudLauncherSettings(const FObjectInitializer& ObjectInitializer);
 
 private:
+
 	UPROPERTY(EditAnywhere, config, Category = "General", meta = (ConfigRestartRequired = false, DisplayName = "SpatialOS project"))
 	FString ProjectName;
 
@@ -32,6 +50,9 @@ private:
 	UPROPERTY(EditAnywhere, config, Category = "General", meta = (ConfigRestartRequired = false, DisplayName = "Snapshot path"))
 	FFilePath SnapshotPath;
 
+	UPROPERTY(EditAnywhere, config, Category = "General", meta = (ConfigRestartRequired = false, DisplayName = "Region"))
+	TEnumAsByte<ERegionCode::Type> PrimaryDeploymentRegionCode;
+
 	UPROPERTY(EditAnywhere, config, Category = "Simulated Players", meta = (ConfigRestartRequired = false, DisplayName = "Include simulated players"))
 	bool bSimulatedPlayersIsEnabled;
 
@@ -43,9 +64,13 @@ private:
 	UPROPERTY(EditAnywhere, config, Category = "Simulated Players", meta = (EditCondition = "bSimulatedPlayersIsEnabled", ConfigRestartRequired = false, DisplayName = "Number of simulated players"))
 	uint32 NumberOfSimulatedPlayers;
 
+	UPROPERTY(EditAnywhere, config, Category = "Simulated Players", meta = (EditCondition = "bSimulatedPlayersIsEnabled", ConfigRestartRequired = false, DisplayName = "Region"))
+	TEnumAsByte<ERegionCode::Type> SimulatedPlayerDeploymentRegionCode;
+
 	static bool IsAssemblyNameValid(const FString& Name);
 	static bool IsProjectNameValid(const FString& Name);
 	static bool IsDeploymentNameValid(const FString& Name);
+	static bool IsRegionCodeValid(const ERegionCode::Type RegionCode);
 
 public:
 	FString GetProjectNameFromSpatial() const;
@@ -84,6 +109,32 @@ public:
 		return SnapshotPath.FilePath.IsEmpty()
 			? FPaths::Combine(SpatialEditorSettings->GetSpatialOSSnapshotFolderPath(), SpatialEditorSettings->GetSpatialOSSnapshotFile())
 			: SnapshotPath.FilePath;
+	}
+
+	void SetPrimaryRegionCode(const ERegionCode::Type RegionCode);
+	FORCEINLINE FText GetPrimaryRegionCode() const
+	{
+		UEnum* pEnum = FindObject<UEnum>(ANY_PACKAGE, TEXT("ERegionCode"), true);
+
+		if (!pEnum || !IsRegionCodeValid(PrimaryDeploymentRegionCode))
+		{
+			return FText::FromString(TEXT("Invalid"));
+		}
+
+		return pEnum->GetEnumTextByValue((int64) PrimaryDeploymentRegionCode.GetValue());
+	}
+
+	void SetSimulatedPlayerRegionCode(const ERegionCode::Type RegionCode);
+	FORCEINLINE FText GetSimulatedPlayerRegionCode() const
+	{
+		UEnum* pEnum = FindObject<UEnum>(ANY_PACKAGE, TEXT("ERegionCode"), true);
+
+		if (!pEnum || !IsRegionCodeValid(SimulatedPlayerDeploymentRegionCode))
+		{
+			return FText::FromString(TEXT("Invalid"));
+		}
+
+		return pEnum->GetEnumTextByValue((int64) SimulatedPlayerDeploymentRegionCode.GetValue());
 	}
 
 	void SetSimulatedPlayersEnabledState(bool IsEnabled);

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCloudLauncherSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCloudLauncherSettings.h
@@ -114,7 +114,7 @@ public:
 	{
 		UEnum* pEnum = FindObject<UEnum>(ANY_PACKAGE, TEXT("ERegionCode"), true);
 
-		if (pEnum == nullptr || !IsRegionCodeValid(PrimaryDeploymentRegionCode))
+		if (!IsRegionCodeValid(PrimaryDeploymentRegionCode))
 		{
 			return FText::FromString(TEXT("Invalid"));
 		}
@@ -127,7 +127,7 @@ public:
 	{
 		UEnum* pEnum = FindObject<UEnum>(ANY_PACKAGE, TEXT("ERegionCode"), true);
 
-		if (pEnum == nullptr || !IsRegionCodeValid(SimulatedPlayerDeploymentRegionCode))
+		if (!IsRegionCodeValid(SimulatedPlayerDeploymentRegionCode))
 		{
 			return FText::FromString(TEXT("Invalid"));
 		}

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCloudLauncherSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCloudLauncherSettings.h
@@ -120,7 +120,7 @@ public:
 			return FText::FromString(TEXT("Invalid"));
 		}
 
-		return pEnum->GetEnumTextByValue((int64) PrimaryDeploymentRegionCode.GetValue());
+		return pEnum->GetEnumTextByValue(static_cast<int64>(PrimaryDeploymentRegionCode.GetValue()));
 	}
 
 	void SetSimulatedPlayerRegionCode(const ERegionCode::Type RegionCode);

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCloudLauncherSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCloudLauncherSettings.h
@@ -132,7 +132,7 @@ public:
 			return FText::FromString(TEXT("Invalid"));
 		}
 
-		return pEnum->GetEnumTextByValue((int64) SimulatedPlayerDeploymentRegionCode.GetValue());
+		return pEnum->GetEnumTextByValue(static_cast<int64>(SimulatedPlayerDeploymentRegionCode.GetValue()));
 	}
 
 	void SetSimulatedPlayersEnabledState(bool IsEnabled);

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -4,11 +4,14 @@
 #include "EditorDirectories.h"
 #include "EditorStyleSet.h"
 #include "Framework/Application/SlateApplication.h"
+#include "Framework/MultiBox/MultiBoxBuilder.h"
 #include "Framework/Notifications/NotificationManager.h"
 #include "SharedPointer.h"
 #include "SpatialGDKEditorCloudLauncherSettings.h"
 #include "SpatialGDKEditorSettings.h"
+#include "Textures/SlateIcon.h"
 #include "Widgets/Input/SButton.h"
+#include "Widgets/Input/SComboButton.h"
 #include "Widgets/Input/SFilePathPicker.h"
 #include "Widgets/Input/SHyperlink.h"
 #include "Widgets/Input/SSpinBox.h"
@@ -25,7 +28,7 @@ void SSpatialGDKSimulatedPlayerDeployment::Construct(const FArguments& InArgs)
 {
 	const USpatialGDKEditorSettings* SpatialGDKSettings = GetDefault<USpatialGDKEditorSettings>();
 	const USpatialGDKEditorCloudLauncherSettings* SpatialGDKCloudLauncherSettings = GetMutableDefault<USpatialGDKEditorCloudLauncherSettings>();
-	
+
 	ParentWindowPtr = InArgs._ParentWindow;
 	SpatialGDKEditorPtr = InArgs._SpatialGDKEditor;
 
@@ -204,6 +207,32 @@ void SSpatialGDKSimulatedPlayerDeployment::Construct(const FArguments& InArgs)
 									.OnPathPicked(this, &SSpatialGDKSimulatedPlayerDeployment::OnPrimaryLaunchConfigPathPicked)
 								]
 							]
+							// Primary Deployment Region Picker
+							+ SVerticalBox::Slot()
+							.AutoHeight()
+							.Padding(2.0f)
+							[
+								SNew(SHorizontalBox)
+								+ SHorizontalBox::Slot()
+								.FillWidth(1.0f)
+								[
+									SNew(STextBlock)
+									.Text(FText::FromString(FString(TEXT("Region"))))
+									.ToolTipText(FText::FromString(FString(TEXT("The region in which the deployment will be deployed."))))
+								]
+								+ SHorizontalBox::Slot()
+								.FillWidth(1.0f)
+								[
+									SNew(SComboButton)
+									.OnGetMenuContent(this, &SSpatialGDKSimulatedPlayerDeployment::OnGetPrimaryDeploymentRegionCode)
+									.ContentPadding(FMargin(2.0f, 2.0f))
+									.ButtonContent()
+									[
+										SNew(STextBlock)
+										.Text_UObject(SpatialGDKCloudLauncherSettings, &USpatialGDKEditorCloudLauncherSettings::GetPrimaryRegionCode)
+									]
+								]
+							]
 							// Separator
 							+ SVerticalBox::Slot()
 							.AutoHeight()
@@ -284,6 +313,33 @@ void SSpatialGDKSimulatedPlayerDeployment::Construct(const FArguments& InArgs)
 									.IsEnabled_UObject(SpatialGDKCloudLauncherSettings, &USpatialGDKEditorCloudLauncherSettings::IsSimulatedPlayersEnabled)
 								]
 							]
+							// Simulated Players Deployment Region Picker
+							+ SVerticalBox::Slot()
+							.AutoHeight()
+							.Padding(2.0f)
+							[
+								SNew(SHorizontalBox)
+								+ SHorizontalBox::Slot()
+								.FillWidth(1.0f)
+								[
+									SNew(STextBlock)
+									.Text(FText::FromString(FString(TEXT("Region"))))
+									.ToolTipText(FText::FromString(FString(TEXT("The region in which the simulated player deployment will be deployed."))))
+								]
+								+ SHorizontalBox::Slot()
+								.FillWidth(1.0f)
+								[
+									SNew(SComboButton)
+									.OnGetMenuContent(this, &SSpatialGDKSimulatedPlayerDeployment::OnGetSimulatedPlayerDeploymentRegionCode)
+									.ContentPadding(FMargin(2.0f, 2.0f))
+									.IsEnabled_UObject(SpatialGDKCloudLauncherSettings, &USpatialGDKEditorCloudLauncherSettings::IsSimulatedPlayersEnabled)
+									.ButtonContent()
+									[
+										SNew(STextBlock)
+										.Text_UObject(SpatialGDKCloudLauncherSettings, &USpatialGDKEditorCloudLauncherSettings::GetSimulatedPlayerRegionCode)
+									]
+								]
+							]
 							// Buttons
 							+ SVerticalBox::Slot()
 							.FillHeight(1.0f)
@@ -342,6 +398,49 @@ void SSpatialGDKSimulatedPlayerDeployment::OnPrimaryLaunchConfigPathPicked(const
 {
 	USpatialGDKEditorCloudLauncherSettings* SpatialGDKCloudLauncherSettings = GetMutableDefault<USpatialGDKEditorCloudLauncherSettings>();
 	SpatialGDKCloudLauncherSettings->SetPrimaryLaunchConfigPath(PickedPath);
+}
+
+TSharedRef<SWidget> SSpatialGDKSimulatedPlayerDeployment::OnGetPrimaryDeploymentRegionCode()
+{
+	FMenuBuilder MenuBuilder(true, NULL);
+	UEnum* pEnum = FindObject<UEnum>(ANY_PACKAGE, TEXT("ERegionCode"), true);
+
+	for (int32 i = 0; i < pEnum->NumEnums() - 1; i++)
+	{
+		int64 CurrentEnumValue = pEnum->GetValueByIndex(i);
+		FUIAction ItemAction(FExecuteAction::CreateSP(this, &SSpatialGDKSimulatedPlayerDeployment::OnPrimaryDeploymentRegionCodePicked, CurrentEnumValue));
+		MenuBuilder.AddMenuEntry(pEnum->GetEnumTextByValue(CurrentEnumValue), TAttribute<FText>(), FSlateIcon(), ItemAction);
+	}
+
+	return MenuBuilder.MakeWidget();
+}
+
+TSharedRef<SWidget> SSpatialGDKSimulatedPlayerDeployment::OnGetSimulatedPlayerDeploymentRegionCode()
+{
+	FMenuBuilder MenuBuilder(true, NULL);
+	UEnum* pEnum = FindObject<UEnum>(ANY_PACKAGE, TEXT("ERegionCode"), true);
+
+	for (int32 i = 0; i < pEnum->NumEnums() - 1; i++)
+	{
+		int64 CurrentEnumValue = pEnum->GetValueByIndex(i);
+		FUIAction ItemAction(FExecuteAction::CreateSP(this, &SSpatialGDKSimulatedPlayerDeployment::OnSimulatedPlayerDeploymentRegionCodePicked, CurrentEnumValue));
+		MenuBuilder.AddMenuEntry(pEnum->GetEnumTextByValue(CurrentEnumValue), TAttribute<FText>(), FSlateIcon(), ItemAction);
+	}
+
+	return MenuBuilder.MakeWidget();
+}
+
+void SSpatialGDKSimulatedPlayerDeployment::OnPrimaryDeploymentRegionCodePicked(const int64 RegionCodeEnumValue)
+{
+	USpatialGDKEditorCloudLauncherSettings* SpatialGDKCloudLauncherSettings = GetMutableDefault<USpatialGDKEditorCloudLauncherSettings>();
+	SpatialGDKCloudLauncherSettings->SetPrimaryRegionCode((ERegionCode::Type) RegionCodeEnumValue);
+
+}
+
+void SSpatialGDKSimulatedPlayerDeployment::OnSimulatedPlayerDeploymentRegionCodePicked(const int64 RegionCodeEnumValue)
+{
+	USpatialGDKEditorCloudLauncherSettings* SpatialGDKCloudLauncherSettings = GetMutableDefault<USpatialGDKEditorCloudLauncherSettings>();
+	SpatialGDKCloudLauncherSettings->SetSimulatedPlayerRegionCode((ERegionCode::Type) RegionCodeEnumValue);
 }
 
 void SSpatialGDKSimulatedPlayerDeployment::OnSimulatedPlayerDeploymentNameCommited(const FText& InText, ETextCommit::Type InCommitType)

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -405,11 +405,14 @@ TSharedRef<SWidget> SSpatialGDKSimulatedPlayerDeployment::OnGetPrimaryDeployment
 	FMenuBuilder MenuBuilder(true, NULL);
 	UEnum* pEnum = FindObject<UEnum>(ANY_PACKAGE, TEXT("ERegionCode"), true);
 
-	for (int32 i = 0; i < pEnum->NumEnums() - 1; i++)
+	if (pEnum != nullptr)
 	{
-		int64 CurrentEnumValue = pEnum->GetValueByIndex(i);
-		FUIAction ItemAction(FExecuteAction::CreateSP(this, &SSpatialGDKSimulatedPlayerDeployment::OnPrimaryDeploymentRegionCodePicked, CurrentEnumValue));
-		MenuBuilder.AddMenuEntry(pEnum->GetEnumTextByValue(CurrentEnumValue), TAttribute<FText>(), FSlateIcon(), ItemAction);
+		for (int32 i = 0; i < pEnum->NumEnums() - 1; i++)
+		{
+			int64 CurrentEnumValue = pEnum->GetValueByIndex(i);
+			FUIAction ItemAction(FExecuteAction::CreateSP(this, &SSpatialGDKSimulatedPlayerDeployment::OnPrimaryDeploymentRegionCodePicked, CurrentEnumValue));
+			MenuBuilder.AddMenuEntry(pEnum->GetEnumTextByValue(CurrentEnumValue), TAttribute<FText>(), FSlateIcon(), ItemAction);
+		}
 	}
 
 	return MenuBuilder.MakeWidget();
@@ -420,13 +423,16 @@ TSharedRef<SWidget> SSpatialGDKSimulatedPlayerDeployment::OnGetSimulatedPlayerDe
 	FMenuBuilder MenuBuilder(true, NULL);
 	UEnum* pEnum = FindObject<UEnum>(ANY_PACKAGE, TEXT("ERegionCode"), true);
 
-	for (int32 i = 0; i < pEnum->NumEnums() - 1; i++)
+	if (pEnum != nullptr)
 	{
-		int64 CurrentEnumValue = pEnum->GetValueByIndex(i);
-		FUIAction ItemAction(FExecuteAction::CreateSP(this, &SSpatialGDKSimulatedPlayerDeployment::OnSimulatedPlayerDeploymentRegionCodePicked, CurrentEnumValue));
-		MenuBuilder.AddMenuEntry(pEnum->GetEnumTextByValue(CurrentEnumValue), TAttribute<FText>(), FSlateIcon(), ItemAction);
+		for (int32 i = 0; i < pEnum->NumEnums() - 1; i++)
+		{
+			int64 CurrentEnumValue = pEnum->GetValueByIndex(i);
+			FUIAction ItemAction(FExecuteAction::CreateSP(this, &SSpatialGDKSimulatedPlayerDeployment::OnSimulatedPlayerDeploymentRegionCodePicked, CurrentEnumValue));
+			MenuBuilder.AddMenuEntry(pEnum->GetEnumTextByValue(CurrentEnumValue), TAttribute<FText>(), FSlateIcon(), ItemAction);
+		}
 	}
-
+	
 	return MenuBuilder.MakeWidget();
 }
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -6,7 +6,7 @@
 #include "Framework/Application/SlateApplication.h"
 #include "Framework/MultiBox/MultiBoxBuilder.h"
 #include "Framework/Notifications/NotificationManager.h"
-#include "SharedPointer.h"
+#include "Templates/SharedPointer.h"
 #include "SpatialGDKEditorCloudLauncherSettings.h"
 #include "SpatialGDKEditorSettings.h"
 #include "Textures/SlateIcon.h"

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -28,7 +28,7 @@ void SSpatialGDKSimulatedPlayerDeployment::Construct(const FArguments& InArgs)
 {
 	const USpatialGDKEditorSettings* SpatialGDKSettings = GetDefault<USpatialGDKEditorSettings>();
 	const USpatialGDKEditorCloudLauncherSettings* SpatialGDKCloudLauncherSettings = GetMutableDefault<USpatialGDKEditorCloudLauncherSettings>();
-
+	
 	ParentWindowPtr = InArgs._ParentWindow;
 	SpatialGDKEditorPtr = InArgs._SpatialGDKEditor;
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKSimulatedPlayerDeployment.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKSimulatedPlayerDeployment.h
@@ -53,6 +53,18 @@ private:
 	/** Delegate called when the user has picked a path for the primary launch configuration file */
 	void OnPrimaryLaunchConfigPathPicked(const FString& PickedPath);
 
+	/** Delegate called to populate the primary deployment region code dropdown */
+	TSharedRef<SWidget> OnGetPrimaryDeploymentRegionCode();
+
+	/** Delegate called to populate the simulated deployment region code dropdown */
+	TSharedRef<SWidget> OnGetSimulatedPlayerDeploymentRegionCode();
+
+	/** Delegate called when the user selects a region code from the dropdown for the primary deployment */
+	void OnPrimaryDeploymentRegionCodePicked(const int64 RegionCodeEnumValue);
+
+	/** Delegate called when the user selects a region code from the dropdown for the simulated player deployment */
+	void OnSimulatedPlayerDeploymentRegionCodePicked(const int64 RegionCodeEnumValue);
+
 	/** Delegate to commit simulated player deployment name */
 	void OnSimulatedPlayerDeploymentNameCommited(const FText& InText, ETextCommit::Type InCommitType);
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKSimulatedPlayerDeployment.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKSimulatedPlayerDeployment.h
@@ -53,10 +53,10 @@ private:
 	/** Delegate called when the user has picked a path for the primary launch configuration file */
 	void OnPrimaryLaunchConfigPathPicked(const FString& PickedPath);
 
-	/** Delegate called to populate the primary deployment region code dropdown */
+	/** Delegate called to populate the region codes for the primary deployment */
 	TSharedRef<SWidget> OnGetPrimaryDeploymentRegionCode();
 
-	/** Delegate called to populate the simulated deployment region code dropdown */
+	/** Delegate called to populate the region codes for the simulated player deployment */
 	TSharedRef<SWidget> OnGetSimulatedPlayerDeploymentRegionCode();
 
 	/** Delegate called when the user selects a region code from the dropdown for the primary deployment */


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Adds a dropdown to select the region of the deployment both for the primary deployment and the simulated player deployment. The region is also adjustable from the SpatialOS GDK Cloud Deployment Settings:

![image](https://user-images.githubusercontent.com/7618468/55328371-208c6980-5484-11e9-8602-fdbf0094e8b5.png)

![image](https://user-images.githubusercontent.com/7618468/55328480-592c4300-5484-11e9-80fa-e3a1289b7186.png)

 
#### Release note
Feature: Add Region configuration and dropdown

STRONGLY SUGGESTED: How can this be verified by QA?
**Scenario 1 (cloud launch only):**
- [ ] Fill-in the default cloud configuration (refer to other guides)
- [ ] Choose a specific region (e.g. US)
- [ ] Launch the cloud deployment and verify that it's in the correct region 

**Scenario 2 (cloud launch + simulated players):**
- [ ] Fill-in the default cloud configuration (refer to other guides)
- [ ] Choose a specific region (e.g. US) for the primary deployment 
- [ ] Choose a different region (e.g. EU) for the simulated players deployment 
- [ ] Launch the scale test and verify that both the deployments are in the correct regions

#### Documentation
In-code documentation