### PR TITLE
Added a local state record for which players have been spawned

### DIFF
--- a/SpatialGDK/Extras/schema/spawner.schema
+++ b/SpatialGDK/Extras/schema/spawner.schema
@@ -7,11 +7,7 @@ type SpawnPlayerRequest {
     string online_platform_name = 3;
 }
 
-type SpawnPlayerResponse {
-    bool success = 1;
-    string error_message = 2;
-    EntityId created_entity_id = 3;
-}
+type SpawnPlayerResponse { }
 
 component PlayerSpawner {
     id = 9998;

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
@@ -372,7 +372,12 @@ Worker_RequestId USpatialWorkerConnection::SendCommandRequest(Worker_EntityId En
 
 void USpatialWorkerConnection::SendCommandResponse(Worker_RequestId RequestId, const Worker_CommandResponse* Response)
 {
-	return Worker_Connection_SendCommandResponse(WorkerConnection, RequestId, Response);
+	Worker_Connection_SendCommandResponse(WorkerConnection, RequestId, Response);
+}
+
+void USpatialWorkerConnection::SendCommandFailure(Worker_RequestId RequestId, const char* Message)
+{
+	Worker_Connection_SendCommandFailure(WorkerConnection, RequestId, Message);
 }
 
 void USpatialWorkerConnection::SendLogMessage(const uint8_t Level, const char* LoggerName, const char* Message)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialPlayerSpawner.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialPlayerSpawner.cpp
@@ -44,7 +44,7 @@ void USpatialPlayerSpawner::ReceivePlayerSpawnRequest(Schema_Object* Payload, co
 
 	// Accept the player if we have not already accepted a player from this worker.
 	bool bAlreadyHasPlayer;
-	WorkersWithPlayersSpawned.Emplace(FString{ CallerAttribute }, &bAlreadyHasPlayer);
+	WorkersWithPlayersSpawned.Emplace(UTF8_TO_TCHAR(CallerAttribute), &bAlreadyHasPlayer);
 
 	if (!bAlreadyHasPlayer)
 	{

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialWorkerConnection.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialWorkerConnection.h
@@ -41,6 +41,7 @@ public:
 	void SendComponentUpdate(Worker_EntityId EntityId, const Worker_ComponentUpdate* ComponentUpdate);
 	Worker_RequestId SendCommandRequest(Worker_EntityId EntityId, const Worker_CommandRequest* Request, uint32_t CommandId);
 	void SendCommandResponse(Worker_RequestId RequestId, const Worker_CommandResponse* Response);
+	void SendCommandFailure(Worker_RequestId RequestId, const char* Message = "");
 	void SendLogMessage(const uint8_t Level, const char* LoggerName, const char* Message);
 	void SendComponentInterest(Worker_EntityId EntityId, const TArray<Worker_InterestOverride>& ComponentInterest);
 	Worker_RequestId SendEntityQueryRequest(const Worker_EntityQuery* EntityQuery);

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialPlayerSpawner.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialPlayerSpawner.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "CoreMinimal.h"
 #include "GameFramework/OnlineReplStructs.h"
 #include "UObject/NoExportTypes.h"
 
@@ -30,7 +29,7 @@ public:
 
 	// Client
 	void SendPlayerSpawnRequest();
-	void ReceivePlayerSpawnResponse(Worker_CommandResponseOp& Op);
+	void ReceivePlayerSpawnResponse(const Worker_CommandResponseOp& Op);
 
 private:
 	void ObtainPlayerParams(struct FURL& LoginURL, FUniqueNetIdRepl& OutUniqueId, FName& OutOnlinePlatformName);
@@ -40,4 +39,6 @@ private:
 
 	FTimerManager* TimerManager;
 	int NumberOfAttempts;
+
+	TSet<FString> WorkersWithPlayersSpawned;
 };


### PR DESCRIPTION
#### Description
Temporary local state work around to stop multiple players being spawned.
Also added the ability to send command failures to the USpatialWorkerConnection.
Removed unused and unnecessary state from the player spawner response.

#### Release note
Bugfix: Fixed an issue where clients could crash after being assigned multiple players.


#### Tests
Tested locally by sending multiple spawn requests at a time, then sending a new one on each response.
Reproduced the multiple client crash by sending concurrent requests without this fix.

#### Documentation
release note

#### Primary reviewers
@improbable-valentyn @Vatyx 