### PR TITLE
Switch default to network protocol to TCP

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
@@ -15,7 +15,7 @@ struct FConnectionConfig
 	FConnectionConfig()
 		: UseExternalIp(false)
 		, EnableProtocolLoggingAtStartup(false)
-		, LinkProtocol(WORKER_NETWORK_CONNECTION_TYPE_RAKNET)
+		, LinkProtocol(WORKER_NETWORK_CONNECTION_TYPE_TCP)
 	{
 		const TCHAR* CommandLine = FCommandLine::Get();
 


### PR DESCRIPTION
#### Description
Switching the default connection protocol to TCP. Will make changes to the worker configs for each project.

#### Release note
Feature: The default connection protocol is now TCP.