### PR TITLE
[UNR-442] Don't send log messages to Spatial if PIE index doesn't match

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -191,7 +191,19 @@ void USpatialNetDriver::OnConnectedToSpatialOS()
 
 void USpatialNetDriver::CreateAndInitializeCoreClasses()
 {
-	SpatialOutputDevice = MakeUnique<FSpatialOutputDevice>(Connection, TEXT("Unreal"));
+	int PIEIndex = -1; // -1 is Unreal's default index when not using PIE
+#if WITH_EDITOR
+	if (IsServer())
+	{
+		PIEIndex = GEngine->GetWorldContextFromWorldChecked(GetWorld()).PIEInstance;
+	}
+	else
+	{
+		PIEIndex = GEngine->GetWorldContextFromPendingNetGameNetDriverChecked(this).PIEInstance;
+	}
+#endif //WITH_EDITOR
+	SpatialOutputDevice = MakeUnique<FSpatialOutputDevice>(Connection, TEXT("Unreal"), PIEIndex);
+
 	Dispatcher = NewObject<USpatialDispatcher>();
 	Sender = NewObject<USpatialSender>();
 	Receiver = NewObject<USpatialReceiver>();

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -191,7 +191,7 @@ void USpatialNetDriver::OnConnectedToSpatialOS()
 
 void USpatialNetDriver::CreateAndInitializeCoreClasses()
 {
-	int PIEIndex = -1; // -1 is Unreal's default index when not using PIE
+	int32 PIEIndex = -1; // -1 is Unreal's default index when not using PIE
 #if WITH_EDITOR
 	if (IsServer())
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -189,7 +189,7 @@ void USpatialNetDriver::OnConnectedToSpatialOS()
 	}
 }
 
-void USpatialNetDriver::CreateAndInitializeCoreClasses()
+void USpatialNetDriver::InitializeSpatialOutputDevice()
 {
 	int32 PIEIndex = -1; // -1 is Unreal's default index when not using PIE
 #if WITH_EDITOR
@@ -203,6 +203,11 @@ void USpatialNetDriver::CreateAndInitializeCoreClasses()
 	}
 #endif //WITH_EDITOR
 	SpatialOutputDevice = MakeUnique<FSpatialOutputDevice>(Connection, TEXT("Unreal"), PIEIndex);
+}
+
+void USpatialNetDriver::CreateAndInitializeCoreClasses()
+{
+	InitializeSpatialOutputDevice();
 
 	Dispatcher = NewObject<USpatialDispatcher>();
 	Sender = NewObject<USpatialSender>();

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialOutputDevice.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialOutputDevice.cpp
@@ -4,7 +4,7 @@
 
 #include "Interop/Connection/SpatialWorkerConnection.h"
 
-FSpatialOutputDevice::FSpatialOutputDevice(USpatialWorkerConnection* InConnection, FString LoggerName, int InPIEIndex)
+FSpatialOutputDevice::FSpatialOutputDevice(USpatialWorkerConnection* InConnection, FString LoggerName, int32 InPIEIndex)
 	: FilterLevel(ELogVerbosity::Warning)
 	, Connection(InConnection)
 	, Name(LoggerName)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialOutputDevice.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialOutputDevice.cpp
@@ -4,12 +4,12 @@
 
 #include "Interop/Connection/SpatialWorkerConnection.h"
 
-FSpatialOutputDevice::FSpatialOutputDevice(USpatialWorkerConnection* InConnection, FString LoggerName)
+FSpatialOutputDevice::FSpatialOutputDevice(USpatialWorkerConnection* InConnection, FString LoggerName, int InPIEIndex)
+	: FilterLevel(ELogVerbosity::Warning)
+	, Connection(InConnection)
+	, Name(LoggerName)
+	, PIEIndex(InPIEIndex)
 {
-	Connection = InConnection;
-	Name = LoggerName;
-	FilterLevel = ELogVerbosity::Warning;
-
 	const TCHAR* CommandLine = FCommandLine::Get();
 	bLogToSpatial = !FParse::Param(CommandLine, TEXT("NoLogToSpatial"));
 
@@ -30,6 +30,12 @@ void FSpatialOutputDevice::Serialize(const TCHAR* InData, ELogVerbosity::Type Ve
 
 	if (bLogToSpatial && Connection->IsConnected())
 	{
+#if WITH_EDITOR
+		if (GPlayInEditorID != PIEIndex)
+		{
+			return;
+		}
+#endif //WITH_EDITOR
 		Connection->SendLogMessage(ConvertLogLevelToSpatial(Verbosity), TCHAR_TO_UTF8(*Name), TCHAR_TO_UTF8(InData));
 	}
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -172,6 +172,7 @@ private:
 	UFUNCTION()
 	void OnConnectedToSpatialOS();
 
+	void InitializeSpatialOutputDevice();
 	void CreateAndInitializeCoreClasses();
 
 	void CreateServerSpatialOSNetConnection();

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialOutputDevice.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialOutputDevice.h
@@ -12,7 +12,7 @@ class USpatialWorkerConnection;
 class SPATIALGDK_API FSpatialOutputDevice : public FOutputDevice
 {
 public:
-	FSpatialOutputDevice(USpatialWorkerConnection* InConnection, FString LoggerName, int InPIEIndex);
+	FSpatialOutputDevice(USpatialWorkerConnection* InConnection, FString LoggerName, int32 InPIEIndex);
 	~FSpatialOutputDevice();
 
 	void AddRedirectCategory(const FName& Category);
@@ -28,6 +28,6 @@ protected:
 	USpatialWorkerConnection* Connection;
 	FString Name;
 
-	int PIEIndex;
+	int32 PIEIndex;
 	bool bLogToSpatial;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialOutputDevice.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialOutputDevice.h
@@ -12,7 +12,7 @@ class USpatialWorkerConnection;
 class SPATIALGDK_API FSpatialOutputDevice : public FOutputDevice
 {
 public:
-	FSpatialOutputDevice(USpatialWorkerConnection* InConnection, FString LoggerName);
+	FSpatialOutputDevice(USpatialWorkerConnection* InConnection, FString LoggerName, int InPIEIndex);
 	~FSpatialOutputDevice();
 
 	void AddRedirectCategory(const FName& Category);
@@ -28,5 +28,6 @@ protected:
 	USpatialWorkerConnection* Connection;
 	FString Name;
 
+	int PIEIndex;
 	bool bLogToSpatial;
 };


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Use `GPlayInEditorID` to filter logs that are sent to Spatial when running in PIE.

#### Release note
Bugfix: Fix duplicated log messages in Spatial when running in PIE.

#### Tests
Log a unique warning on client and server (e.g. in PlayerController's BeginPlay, print its memory address), run in PIE with 2 clients and 2 servers.
Observe the logs only reported in Spatial once for each worker.

#### Documentation
Release note

#### Primary reviewers
@joshuahuburn @m-samiec 