### PR TITLE
[UNR-1239] - Fix String Deserialization from Schema

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SchemaUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SchemaUtils.h
@@ -18,17 +18,19 @@ namespace improbable
 
 inline void AddStringToSchema(Schema_Object* Object, Schema_FieldId Id, const FString& Value)
 {
-	FTCHARToUTF8 CStrConvertion(*Value);
-	uint32 StringLength = CStrConvertion.Length();
+	FTCHARToUTF8 CStrConversion(*Value);
+	uint32 StringLength = CStrConversion.Length();
 	uint8* StringBuffer = Schema_AllocateBuffer(Object, sizeof(char) * StringLength);
-	FMemory::Memcpy(StringBuffer, CStrConvertion.Get(), sizeof(char) * StringLength);
+	FMemory::Memcpy(StringBuffer, CStrConversion.Get(), sizeof(char) * StringLength);
 	Schema_AddBytes(Object, Id, StringBuffer, sizeof(char) * StringLength);
 }
 
 inline FString IndexStringFromSchema(const Schema_Object* Object, Schema_FieldId Id, uint32 Index)
 {
 	int32 StringLength = (int32)Schema_IndexBytesLength(Object, Id, Index);
-	return FString(StringLength, UTF8_TO_TCHAR(Schema_IndexBytes(Object, Id, Index)));
+	const uint8_t* Bytes = Schema_IndexBytes(Object, Id, Index);
+	FUTF8ToTCHAR FStringConversion(reinterpret_cast<const ANSICHAR*>(Bytes), StringLength);
+	return FString(FStringConversion.Length(), FStringConversion.Get());
 }
 
 inline FString GetStringFromSchema(const Schema_Object* Object, Schema_FieldId Id)


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
When deserializing strings containing Chinese characters in component updates, extra unreadable characters were present at the end of the final string. This was due to runtime not providing null-terminated strings in the byte stream, when calling `Schema_IndexBytes` we would read past the end of the desired string and into garbage until a null character was reached. The bytes (including the garbage) would then be converted to `TCHAR*`, and the final `FString` would be created using `Schema_IndexBytesLength` as the length which was also incorrect.

New implementation uses `FUTF8ToTCHAR` to convert the bytes and also passes the bytes length to tell the converter that our string is not null-terminated and we want to read the specified amount of bytes (avoiding reading extra garbage). An FString is then created using the TCHAR and the string length from the conversion to avoid the FString from overflowing.

#### Release note
Bugfix: Fixed deserialization of strings from schema

#### Primary reviewers
@joshuahuburn @BenNaccarato 