### PR TITLE
Bugfix - get subobject if not default

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealMetadata.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealMetadata.h
@@ -99,7 +99,18 @@ FORCEINLINE SubobjectToOffsetMap CreateOffsetMapFromActor(AActor* Actor, const F
 
 	for (auto& SubobjectInfoPair : Info.SubobjectInfo)
 	{
-		UObject* Subobject = Actor->GetDefaultSubobjectByName(SubobjectInfoPair.Value->SubobjectName);
+		UObject* Subobject = nullptr;
+
+		// Override the GetDefaultSubobjectByName method from Obj.cpp, to not care whether the object is the default subobject, if it is safe to do so (not garbage collecting).
+		if (!GIsSavingPackage && !IsGarbageCollecting())
+		{
+			Subobject = StaticFindObjectFast(UObject::StaticClass(), Actor, SubobjectInfoPair.Value->SubobjectName);
+		}
+		else
+		{
+			Subobject = Actor->GetDefaultSubobjectByName(SubobjectInfoPair.Value->SubobjectName);
+		}
+
 		uint32 Offset = SubobjectInfoPair.Key;
 
 		if (Subobject != nullptr && Subobject->IsPendingKill() == false && Subobject->IsSupportedForNetworking())

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealMetadata.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealMetadata.h
@@ -100,7 +100,6 @@ FORCEINLINE SubobjectToOffsetMap CreateOffsetMapFromActor(AActor* Actor, const F
 	for (auto& SubobjectInfoPair : Info.SubobjectInfo)
 	{
 		UObject* Subobject = StaticFindObjectFast(UObject::StaticClass(), Actor, SubobjectInfoPair.Value->SubobjectName);
-
 		uint32 Offset = SubobjectInfoPair.Key;
 
 		if (Subobject != nullptr && Subobject->IsPendingKill() == false && Subobject->IsSupportedForNetworking())

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealMetadata.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealMetadata.h
@@ -99,17 +99,7 @@ FORCEINLINE SubobjectToOffsetMap CreateOffsetMapFromActor(AActor* Actor, const F
 
 	for (auto& SubobjectInfoPair : Info.SubobjectInfo)
 	{
-		UObject* Subobject = nullptr;
-
-		// Override the GetDefaultSubobjectByName method from Obj.cpp, to not care whether the object is the default subobject, if it is safe to do so (not garbage collecting).
-		if (!GIsSavingPackage && !IsGarbageCollecting())
-		{
-			Subobject = StaticFindObjectFast(UObject::StaticClass(), Actor, SubobjectInfoPair.Value->SubobjectName);
-		}
-		else
-		{
-			Subobject = Actor->GetDefaultSubobjectByName(SubobjectInfoPair.Value->SubobjectName);
-		}
+		UObject* Subobject = StaticFindObjectFast(UObject::StaticClass(), Actor, SubobjectInfoPair.Value->SubobjectName);
 
 		uint32 Offset = SubobjectInfoPair.Key;
 


### PR DESCRIPTION
#### Description
Bug fix for https://improbableio.atlassian.net/browse/UNR-1181
Bug reported by (and fixed working from the suggestion of) GitHub user Antialiased

The issue was due to when resolving an actor, when attempting to create the offset map, we previously used the `GetDefaultSubobjectByName` method. The method looks as follows:
```UObject* UObject::GetDefaultSubobjectByName(FName ToFind)
{
	UObject* Object = nullptr;
	// If it is safe use the faster StaticFindObjectFast rather than searching all the subobjects
	if (!GIsSavingPackage && !IsGarbageCollecting())
	{
		Object = StaticFindObjectFast(UObject::StaticClass(), this, ToFind);
		if (Object && !Object->IsDefaultSubobject())
		{
			Object = nullptr;
		}
	}
	else
	{
		TArray<UObject*> SubObjects;
		GetDefaultSubobjects(SubObjects);
		for (UObject* SubObject : SubObjects)
		{
			if (SubObject->GetFName() == ToFind)
			{
				Object = SubObject;
				break;
			}
		}
	}
	return Object;
}
```

When considering a subobject using this method, it is effectively discarded if it is not the 'default subobject' (which fails if e.g. its outer doesn't have the `ClassDefaultObject` flag). We can safely ignore the `!GIsSavingPackage && !IsGarbageCollecting()` check, since we would only be calling this from the game thread, meaning we can just replace the method call with `StaticFindObjectFast`

#### Release note
Bugfix: Ensure that components added in blueprints are replicated.

#### Tests
Ran through test case provided in the task. SpatialOS behaves same as native.
This could be replicated by QA if they ran though the same test case (Ask for the Zip that causes this error)

#### Documentation
Documentation not needed.

#### Primary reviewers
@Vatyx @improbable-valentyn 