### PR TITLE
Fix Visual Studio 2017 download link

### DIFF
--- a/SpatialGDK/Documentation/content/get-started/dependencies.md
+++ b/SpatialGDK/Documentation/content/get-started/dependencies.md
@@ -42,7 +42,7 @@ To build the GDK for Unreal you need the following software installed on your ma
 
   - The Windows SDK 8.1 provides libraries, headers, metadata and tools required for building Windows 10 applications. 
 
-- **Visual Studio** <a href="https://visualstudio.microsoft.com/vs/older-downloads/" data-track-link="Clicked VS 2015|product=Docs|platform=Win|label=Win" target="_blank">2015</a> or <a href="https://visualstudio.microsoft.com/downloads/2017" data-track-link="Clicked VS 2017|product=Docs|platform=Win|label=Win">2017</a> (we recommend 2017). During the installation, select the following items in the Workloads tab:
+- **Visual Studio** <a href="https://visualstudio.microsoft.com/vs/older-downloads/" data-track-link="Clicked VS 2015|product=Docs|platform=Win|label=Win" target="_blank">2015</a> or <a href="https://visualstudio.microsoft.com/vs/older-downloads/" data-track-link="Clicked VS 2017|product=Docs|platform=Win|label=Win">2017</a> (we recommend 2017). During the installation, select the following items in the Workloads tab:
     - Universal Windows Platform development<br>
     - Desktop development with C++<br>
     - Game development with C++


### PR DESCRIPTION
#### Description
Microsoft launched Visual Studio 2019 on April 2 and in the process they broke the Visual Studio 2017 link we provide in [/get-started/dependencies](https://docs.improbable.io/unreal/alpha/content/get-started/dependencies#step-3-software).

I've replaced this link with https://visualstudio.microsoft.com/vs/older-downloads/

#### Tests
Rendered and linted in `improbadoc`

#### Documentation
This is documentation.