### PR TITLE
Add Direct X to dependencies

### DIFF
--- a/SpatialGDK/Documentation/content/get-started/dependencies.md
+++ b/SpatialGDK/Documentation/content/get-started/dependencies.md
@@ -40,7 +40,11 @@ To build the GDK for Unreal you need the following software installed on your ma
 
 - The <a href="https://developer.microsoft.com/en-us/windows/downloads/sdk-archive" data-track-link="Clicked Windows SDK 8.1|product=Docs|platform=Win|label=Win" target="_blank">**Windows SDK 8.1**</a>
 
-  - The Windows SDK 8.1 provides libraries, headers, metadata and tools required for building Windows 10 applications. 
+  - The Windows SDK 8.1 provides libraries, headers, metadata and tools required for building Windows 10 applications.
+
+- The [**DirectX End-User Runtime**](https://www.microsoft.com/en-gb/download/details.aspx?id=35)
+
+  - The DirectX End-User Runtime is used to run built out Unreal Engine 4 clients on Windows.
 
 - **Visual Studio** <a href="https://visualstudio.microsoft.com/vs/older-downloads/" data-track-link="Clicked VS 2015|product=Docs|platform=Win|label=Win" target="_blank">2015</a> or <a href="https://visualstudio.microsoft.com/downloads/2017" data-track-link="Clicked VS 2017|product=Docs|platform=Win|label=Win">2017</a> (we recommend 2017). During the installation, select the following items in the Workloads tab:
     - Universal Windows Platform development<br>


### PR DESCRIPTION
#### Description
The DirectX runtime is a dependency for running built out clients that are downloaded when running a cloud deployment. I've added it to the dependencies list.
#### Tests
Rendered and linted in `improbadoc`
#### Documentation
This is documentation.