### PR TITLE
Add pragma once directive to header

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialWorkerFlags.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialWorkerFlags.h
@@ -1,5 +1,7 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
+#pragma once
+
 #include "Kismet/BlueprintFunctionLibrary.h"
 #include "SpatialWorkerFlags.generated.h"
 


### PR DESCRIPTION
#### Description
Fix header file

#### Release note
Bugfix: Add pragma once directive to header file.

#### Tests
Can `#include "Interop/SpatialWorkerFlags.h"` in two different places and compile

#### Documentation
release note

#### Primary reviewers
@Vatyx 