### PR TITLE
Fix numbering and styling in setup docs.

### DIFF
--- a/SpatialGDK/Documentation/content/get-started/build-unreal-fork.md
+++ b/SpatialGDK/Documentation/content/get-started/build-unreal-fork.md
@@ -42,23 +42,21 @@ You need to add two [environment variables](https://docs.microsoft.com/en-us/win
 
 1. Open **File Explorer** and navigate to the directory you cloned the Unreal Engine fork into.
 
-2. Double-click **`Setup.bat`**.
+1. Double-click **`Setup.bat`**.
+This installs prerequisites for building Unreal Engine 4.<br>
+This process can take a long time to complete.
 
-This installs prerequisites for building Unreal Engine 4. This process can take a long time to complete.
+	> While running the Setup file, you should see `Checking dependencies (excluding Mac, Android)...`. If it also says `excluding Linux`, make sure that you set the environment variable `LINUX_MULTIARCH_ROOT` correctly, and run the Setup file again.
 
-> While running the Setup file, you should see `Checking dependencies (excluding Mac, Android)...`. If it also says `excluding Linux`, make sure that you set the environment variable `LINUX_MULTIARCH_ROOT` correctly, and run the Setup file again.
+1. In the same directory, double-click **`GenerateProjectFiles.bat`**. This file automatically sets up the project files you require to build Unreal Engine 4.
+	
+	> If you encounter an `error MSB4036: The "GetReferenceNearestTargetFrameworkTask" task was not found` when building with Visual Studio 2017, check that you have NuGet Package Manager installed via the Visual Studio installer.
 
-1. In the same directory, double-click **`GenerateProjectFiles.bat`**.
+1. In the same directory, open **UE4.sln** in Visual Studio.
 
-This file automatically sets up the project files you require to build Unreal Engine 4.
+1. In Visual Studio, on the toolbar, go to **Build** > **Configuration Manager** and set your active solution configuration to **Development Editor** and your active solution platform to **Win64**.
 
-> If you encounter an `error MSB4036: The "GetReferenceNearestTargetFrameworkTask" task was not found` when building with Visual Studio 2017, check that you have NuGet Package Manager installed via the Visual Studio installer.
-
-2. In the same directory, open **UE4.sln** in Visual Studio.
-
-3. In Visual Studio, on the toolbar, go to **Build** > **Configuration Manager** and set your active solution configuration to **Development Editor** and your active solution platform to **Win64**.
-
-4. In the Solution Explorer window, right-click on the **UE4** project and select **Build** (you may be prompted to install some dependencies first). <br>
+1. In the Solution Explorer window, right-click on the **UE4** project and select **Build** (you may be prompted to install some dependencies first). <br>
 
 Visual Studio then builds Unreal Engine, which can take up to a couple of hours.
 

--- a/SpatialGDK/Documentation/content/get-started/gdk-template.md
+++ b/SpatialGDK/Documentation/content/get-started/gdk-template.md
@@ -16,7 +16,7 @@ If you are ready to start developing your own game with the GDK, follow the step
 
 ### Create a new project using the Starter Template
 
-After [building the Unreal Engine fork]({{urlRoot}}/content/get-started/build-unreal-fork), in **File Explorer**, navigate to `UnrealEngine\Engine\Binaries\Win64`and double-click UE4Editor.exe to open the Unreal Editor. 
+After [building the Unreal Engine fork]({{urlRoot}}/content/get-started/build-unreal-fork), in **File Explorer**, navigate to `UnrealEngine\Engine\Binaries\Win64`and double-click `UE4Editor.exe` to open the Unreal Editor.
 
 1. In the [Project Browser](https://docs.unrealengine.com/en-us/Engine/Basics/Projects/Browser) window, select the **New Project** tab and then the **C++ tab**. 
 2. In this tab, select **SpatialOS GDK Starter**. 

--- a/SpatialGDK/Documentation/content/get-started/gdk-template.md
+++ b/SpatialGDK/Documentation/content/get-started/gdk-template.md
@@ -24,7 +24,7 @@ After [building the Unreal Engine fork]({{urlRoot}}/content/get-started/build-un
 4. In the **Name** field, enter a project name of your choice.
 5. Select **Create Project**.
 
-**Note:** When you create a project, the Unreal Engine automatically creates a directory named after the project name you entered. This page uses `YourProject` as an example project name.
+**Note:** When you create a project, the Unreal Engine automatically creates a directory named after the project name you entered. This page uses `<YourProject>` as an example project name.
 
 ![The Unreal Engine Project Browser]({{assetRoot}}assets/set-up-template/template-project-browser.png)
 
@@ -108,11 +108,11 @@ The name should look something like `beta_randomword_anotherword_randomnumber`. 
 
 An assembly is what’s created when you run `BuildWorker.bat`. Assemblies are `.zip` files that contain all the files that your game uses when running in the cloud.
 
-**Note:** In the following commands, you must replace **`YourProject`** with the name of your project.
+**Note:** In the following commands, you must replace **`<YourProject>`** with the name of your project.
  
 1. In a terminal window, navigate to your `<ProjectRoot>` directory.
-1. Build a server-worker assembly by running the following command: `Game\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat YourProjectServer Linux Development YourProject.uproject`
-1. Build a client-worker assembly by running the following command: `Game\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat YourProject Win64 Development YourProject.uproject`
+1. Build a server-worker assembly by running the following command: `Game\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat <YourProject>Server Linux Development <YourProject>.uproject`
+1. Build a client-worker assembly by running the following command: `Game\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat <YourProject> Win64 Development <YourProject>.uproject`
 
 ### Upload your game
 


### PR DESCRIPTION
#### Description
* Correctly use `<YourProject>` in docs.
* Correctly stylise `UE4Editor.exe`
* Fix the rendering of numbered steps in `/get-started/build-unreal-fork#step-4-build-unreal-engine`
#### Tests
Linted and rendered in `improbadoc`
#### Documentation
This is documentation.