### PR TITLE
Fix missing SchemaDatabase

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
-#pragma optimize("", off)
+
 #include "Interop/SpatialClassInfoManager.h"
 
 #include "AssetRegistryModule.h"

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
-
+#pragma optimize("", off)
 #include "Interop/SpatialClassInfoManager.h"
 
 #include "AssetRegistryModule.h"
@@ -25,10 +25,9 @@ DEFINE_LOG_CATEGORY(LogSpatialClassInfoManager);
 void USpatialClassInfoManager::Init(USpatialNetDriver* InNetDriver)
 {
 	NetDriver = InNetDriver;
-	
-	TSoftObjectPtr<USchemaDatabase> SchemaDatabasePtr(FSoftObjectPath(TEXT("/Game/Spatial/SchemaDatabase.SchemaDatabase")));
-	SchemaDatabasePtr.LoadSynchronous();
-	SchemaDatabase = SchemaDatabasePtr.Get();
+
+	FSoftObjectPath SchemaDatabasePath = FSoftObjectPath(TEXT("/Game/Spatial/SchemaDatabase.SchemaDatabase"));
+	SchemaDatabase = Cast<USchemaDatabase>(SchemaDatabasePath.TryLoad());
 
 	if (SchemaDatabase == nullptr)
 	{


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
UNR-1231 "SchemaDatabase not found!"

Seems that `TSoftObjectPtr.LoadSynchronous();` would not guarantee we load the asset.
Switched to `FSoftObjectPath.TryLoad();` and now the SchemaDatabase is no longer missing during initialisation.

#### Release note
Bugfix: Fixed potential loading issue when attempting to load the SchemaDatabase asset. 

#### Tests
Tested with high repro case Editor build where SchemaDatabase was consistently missing at initialisation.
After switching to TryLoad I no longer encountered the issue after many tests.

QA: Attempt to load a server (outside of the editor) using a large map with many sub-levels. If the game does not crash then the SchemaDatabase is loaded.

#### Primary reviewers
@davedolben @mattyoung-improbable 