### PR TITLE
Remove mention of 13.2

### DIFF
--- a/SpatialGDK/Documentation/content/get-started/dependencies.md
+++ b/SpatialGDK/Documentation/content/get-started/dependencies.md
@@ -35,7 +35,7 @@ To build the GDK for Unreal you need the following software installed on your ma
 
   - You need to download and install Git for windows to clone the GDK and Unreal Engine GitHub repositories. 
 
-- <a href="https://console.improbable.io/installer/download/stable/latest/win" data-track-link="Clicked Download SpatialOS|product=Docs|platform=Win|label=Win" target="_blank">**SpatialOS version 13.2**</a>
+- <a href="https://console.improbable.io/installer/download/stable/latest/win" data-track-link="Clicked Download SpatialOS|product=Docs|platform=Win|label=Win" target="_blank">**SpatialOS**</a>
     - This installs the [SpatialOS CLI]({{urlRoot}}/content/glossary#spatial-command-line-tool-cli), the [SpatialOS Launcher]({{urlRoot}}/content/glossary#launcher), and 32-bit and 64-bit Visual C++ Redistributables.
 
 - The <a href="https://developer.microsoft.com/en-us/windows/downloads/sdk-archive" data-track-link="Clicked Windows SDK 8.1|product=Docs|platform=Win|label=Win" target="_blank">**Windows SDK 8.1**</a>


### PR DESCRIPTION
Following a comment from David A in Slack - removed the mention of "13.2" from the instruction to download SpatialOS (the link goes to the latest SpatialOS version, I believe).