### PR TITLE
Docs - Adds Local and Cloud dev workflows docs, create Workflow section of TOC

### DIFF
--- a/SpatialGDK/Documentation/content/cloud-dev-workflow.md
+++ b/SpatialGDK/Documentation/content/cloud-dev-workflow.md
@@ -4,7 +4,7 @@
 
 <img src="https://docs.google.com/drawings/d/e/2PACX-1vQRmK7TxLji8pT7erPl54hqMMMDsdosZY1OZ2wuPYLQ23dWIrx86qCHggEeq-XasTCsqRe40fCKQvKN/pub?w=758&amp;h=1162">
 
-You may find the below snippets useful as reference:
+You may find the following snippets useful as reference:
 
 ### Build server-worker assembly
 

--- a/SpatialGDK/Documentation/content/cloud-dev-workflow.md
+++ b/SpatialGDK/Documentation/content/cloud-dev-workflow.md
@@ -1,4 +1,4 @@
-# Cloud Development Workflow
+# Cloud development workflow
 
 <!-- This is a live embed of a google drawing -->
 

--- a/SpatialGDK/Documentation/content/cloud-dev-workflow.md
+++ b/SpatialGDK/Documentation/content/cloud-dev-workflow.md
@@ -20,7 +20,7 @@ Replacing **`<YourProject>`** with the name of your Unreal project.
 Game\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat <YourProject> Win64 Development <YourProject>.uproject
 ```
 
-Replacing **`<YourProject>`** with the name of your Unreal project.
+Replacing `<YourProject>` with the name of your Unreal project.
 
 ### Upload assembly
 

--- a/SpatialGDK/Documentation/content/cloud-dev-workflow.md
+++ b/SpatialGDK/Documentation/content/cloud-dev-workflow.md
@@ -16,7 +16,7 @@ You may find the following command-line snippets useful as reference:
 Game\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat <YourProject>Server Linux Development <YourProject>.uproject
 ```
 
-Replacing **`<YourProject>`** with the name of your Unreal project.
+Replacing `<YourProject>` with the name of your Unreal project.
 
 ### Build client-worker assembly
 
@@ -29,22 +29,22 @@ Replacing `<YourProject>` with the name of your Unreal project.
 ### Upload assembly
 
 ```
-spatial cloud upload myassembly
+spatial cloud upload <myassembly>
 ```
 
-Replacing `myassembly` with the name you choose to give your assembly.
+Replacing `<myassembly>` with the name you choose to give your assembly.
 
-### Launch Cloud Deployment
+### Launch cloud deployment
 
 ```
-spatial cloud launch --snapshot=snapshots/default.snapshot <assembly_name> launch_config.json <deployment_name>
+spatial cloud launch --snapshot=snapshots/default.snapshot <myassembly> <launch_config>.json <deployment_name>
 ```
 
-Providing:
+Replacing:
 
-* `<assembly_name>`, which identifies the worker assemblies to use (as chosen in the `spatial cloud upload` command).
-* `launch_config.json`, which declares the world and load balancing configuration.
-* `<deployment name>`, labels the deployment for SpatialOS to reference in the [Console]({{urlroot}}/content/glossary#console).
+* `<myassembly>` - identifies the worker assemblies to use (as chosen in the `spatial cloud upload` command).
+* `<launch_config>.json` - declares the world and load balancing configuration.
+* `<deployment_name>` - labels the deployment for SpatialOS to reference in the [Console]({{urlroot}}/content/glossary#console).
 
 ----
 

--- a/SpatialGDK/Documentation/content/cloud-dev-workflow.md
+++ b/SpatialGDK/Documentation/content/cloud-dev-workflow.md
@@ -22,7 +22,7 @@ Game\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat <YourProject> Wi
 
 Replacing **`<YourProject>`** with the name of your Unreal project.
 
-### Upload Assembly
+### Upload assembly
 
 ```
 spatial cloud upload myassembly

--- a/SpatialGDK/Documentation/content/cloud-dev-workflow.md
+++ b/SpatialGDK/Documentation/content/cloud-dev-workflow.md
@@ -1,10 +1,14 @@
 # Cloud development workflow
 
+The following flowchart provides a reference of the cloud development workflow on the GDK.
+ 
+If you haven't already, please follow the [GDK Starter Template guide]({{urlRoot}}/content/get-started/gdk-template) which provides a detailed explanation of the different steps. 
+
 <!-- This is a live embed of a google drawing -->
 
 <img src="https://docs.google.com/drawings/d/e/2PACX-1vQRmK7TxLji8pT7erPl54hqMMMDsdosZY1OZ2wuPYLQ23dWIrx86qCHggEeq-XasTCsqRe40fCKQvKN/pub?w=758&amp;h=1162">
 
-You may find the following snippets useful as reference:
+You may find the following command-line snippets useful as reference:
 
 ### Build server-worker assembly
 
@@ -40,8 +44,8 @@ Providing:
 
 * `<assembly_name>`, which identifies the worker assemblies to use (as chosen in the `spatial cloud upload` command).
 * `launch_config.json`, which declares the world and load balancing configuration.
-* `<deployment name>`, which labels the deployment in the [Console](https://console.improbable.io).
+* `<deployment name>`, labels the deployment for SpatialOS to reference in the [Console]({{urlroot}}/content/glossary#console).
 
 ----
 
-Last updated: April 2019
+_2019-04-15 Page added with editorial review_

--- a/SpatialGDK/Documentation/content/cloud-dev-workflow.md
+++ b/SpatialGDK/Documentation/content/cloud-dev-workflow.md
@@ -1,0 +1,47 @@
+# Cloud Development Workflow
+
+<!-- This is a live embed of a google drawing -->
+
+<img src="https://docs.google.com/drawings/d/e/2PACX-1vQRmK7TxLji8pT7erPl54hqMMMDsdosZY1OZ2wuPYLQ23dWIrx86qCHggEeq-XasTCsqRe40fCKQvKN/pub?w=758&amp;h=1162">
+
+You may find the below snippets useful as reference:
+
+### Build server-worker assembly
+
+```
+Game\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat <YourProject>Server Linux Development <YourProject>.uproject
+```
+
+Replacing **`<YourProject>`** with the name of your Unreal project.
+
+### Build client-worker assembly
+
+```
+Game\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat <YourProject> Win64 Development <YourProject>.uproject
+```
+
+Replacing **`<YourProject>`** with the name of your Unreal project.
+
+### Upload Assembly
+
+```
+spatial cloud upload myassembly
+```
+
+Replacing `myassembly` with the name you choose to give your assembly.
+
+### Launch Cloud Deployment
+
+```
+spatial cloud launch --snapshot=snapshots/default.snapshot <assembly_name> launch_config.json <deployment_name>
+```
+
+Providing:
+
+* `<assembly_name>`, which identifies the worker assemblies to use (as chosen in the `spatial cloud upload` command).
+* `launch_config.json`, which declares the world and load balancing configuration.
+* `<deployment name>`, which labels the deployment in the [Console](https://console.improbable.io).
+
+----
+
+Last updated: April 2019

--- a/SpatialGDK/Documentation/content/local-dev-workflow.md
+++ b/SpatialGDK/Documentation/content/local-dev-workflow.md
@@ -1,0 +1,9 @@
+# Local Development Workflow
+
+<!-- This is a live embed of a google drawing -->
+
+<img src="https://docs.google.com/drawings/d/e/2PACX-1vSCfvXabpgHPgNyb_9nr1rjcaHomevciDajOG1YNXol1a_qfa5Bll8swtncY_zcEiH1ZVMLH3v07PS8/pub?w=708&amp;h=1117">
+
+----
+
+Last updated: April 2019

--- a/SpatialGDK/Documentation/content/local-dev-workflow.md
+++ b/SpatialGDK/Documentation/content/local-dev-workflow.md
@@ -1,4 +1,8 @@
-# Local Development Workflow
+# Local development workflow
+
+The following flowchart provides a reference of the local development workflow on the GDK.
+ 
+If you haven't already, please follow the [GDK Starter Template guide]({{urlRoot}}/content/get-started/gdk-template) which provides a detailed explanation of the different steps. 
 
 <!-- This is a live embed of a google drawing -->
 
@@ -6,4 +10,4 @@
 
 ----
 
-Last updated: April 2019
+_2019-04-15 Page added with editorial review_

--- a/SpatialGDK/Documentation/toc.md
+++ b/SpatialGDK/Documentation/toc.md
@@ -29,7 +29,7 @@
     - [Gameplay Ability System]({{urlRoot}}/content/ability-system)
     - [Non-Unreal server-worker types]({{urlRoot}}/content/non-unreal-server-worker-types)
 - <h3>Workflows</h3>
-    - [Local deployment workflow]({{urlRoot}}/content/local-dev-workflow)
+    - [Local development workflow]({{urlRoot}}/content/local-dev-workflow)
     - [Cloud development workflow]({{urlRoot}}/content/cloud-dev-workflow)
     - [Troubleshooting]({{urlRoot}}/content/troubleshooting)
     - [Known issues]({{urlRoot}}/known-issues)

--- a/SpatialGDK/Documentation/toc.md
+++ b/SpatialGDK/Documentation/toc.md
@@ -29,7 +29,7 @@
     - [Gameplay Ability System]({{urlRoot}}/content/ability-system)
     - [Non-Unreal server-worker types]({{urlRoot}}/content/non-unreal-server-worker-types)
 - <h3>Workflow</h3>
-    - [Local Development Workflow]({{urlRoot}}/content/local-dev-workflow)
+    - [Local deployment workflow]({{urlRoot}}/content/local-dev-workflow)
     - [Cloud Development Workflow]({{urlRoot}}/content/cloud-dev-workflow)
     - [Troubleshooting]({{urlRoot}}/content/troubleshooting)
     - [Known issues]({{urlRoot}}/known-issues)

--- a/SpatialGDK/Documentation/toc.md
+++ b/SpatialGDK/Documentation/toc.md
@@ -28,7 +28,9 @@
     - [Directory structure]({{urlRoot}}/content/directory-structure)
     - [Gameplay Ability System]({{urlRoot}}/content/ability-system)
     - [Non-Unreal server-worker types]({{urlRoot}}/content/non-unreal-server-worker-types)
-- <h3>Troubleshooting</h3>
+- <h3>Workflow</h3>
+    - [Local Development Workflow]({{urlRoot}}/content/local-dev-workflow)
+    - [Cloud Development Workflow]({{urlRoot}}/content/cloud-dev-workflow)
     - [Troubleshooting]({{urlRoot}}/content/troubleshooting)
     - [Known issues]({{urlRoot}}/known-issues)
 - <h3>Get involved</h3>

--- a/SpatialGDK/Documentation/toc.md
+++ b/SpatialGDK/Documentation/toc.md
@@ -30,7 +30,7 @@
     - [Non-Unreal server-worker types]({{urlRoot}}/content/non-unreal-server-worker-types)
 - <h3>Workflows</h3>
     - [Local deployment workflow]({{urlRoot}}/content/local-dev-workflow)
-    - [Cloud Development Workflow]({{urlRoot}}/content/cloud-dev-workflow)
+    - [Cloud development workflow]({{urlRoot}}/content/cloud-dev-workflow)
     - [Troubleshooting]({{urlRoot}}/content/troubleshooting)
     - [Known issues]({{urlRoot}}/known-issues)
 - <h3>Get involved</h3>

--- a/SpatialGDK/Documentation/toc.md
+++ b/SpatialGDK/Documentation/toc.md
@@ -28,7 +28,7 @@
     - [Directory structure]({{urlRoot}}/content/directory-structure)
     - [Gameplay Ability System]({{urlRoot}}/content/ability-system)
     - [Non-Unreal server-worker types]({{urlRoot}}/content/non-unreal-server-worker-types)
-- <h3>Workflow</h3>
+- <h3>Workflows</h3>
     - [Local deployment workflow]({{urlRoot}}/content/local-dev-workflow)
     - [Cloud Development Workflow]({{urlRoot}}/content/cloud-dev-workflow)
     - [Troubleshooting]({{urlRoot}}/content/troubleshooting)


### PR DESCRIPTION
Adds two new workflow docs
* Local Dev workflow - google diagram [here](https://docs.google.com/drawings/d/1g7NNbHiTYKNAeu7X_BvwnpPgDBx5Op7MigwEpBP7T8s/edit) - paired on it with @m-samiec 
* Cloud Dev workflow - google diagram [here](https://docs.google.com/drawings/d/1JnpViwBGxIJa5S8bEN3nspaBKGNqmebZkLmgNdn2A_c/edit) - paired on it with @Vatyx 

The Google diagrams areembedded in improbadoc - this means they update live from the diagrams

![2019-04-12 16_58_40-Window](https://user-images.githubusercontent.com/2433131/56050624-4b0fd980-5d44-11e9-8ad7-bff6d9ee49ed.png)

![2019-04-12 16_58_31-Window](https://user-images.githubusercontent.com/2433131/56050625-4b0fd980-5d44-11e9-9f64-7659781f4db1.png)

Additionally renamed the Troubleshooting section of the docs to Workflow:

![2019-04-12 16_58_48-Window](https://user-images.githubusercontent.com/2433131/56050636-52cf7e00-5d44-11e9-956e-296805039658.png)



