### PR TITLE
Fix crash when loading SchemaDatabase with async loading suspended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed being unable to launch SpatialOS if project path had spaces in it.
 - Editor no longer crashes when setting LogSpatialSender to Verbose.
 - Server-workers quickly restarted in the editor will connect to runtime correctly.
+- Game no longer crashes when connecting to Spatial with async loading thread suspended.
 
 ## [`0.3.0`](https://github.com/spatialos/UnrealGDK/releases/tag/0.3.0) - 2019-04-04
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -74,6 +74,14 @@ bool USpatialNetDriver::InitBase(bool bInitAsClient, FNetworkNotify* InNotify, c
 		bPersistSpatialConnection = true;
 	}
 
+	// Initialize ClassInfoManager here because it needs to load SchemaDatabase.
+	// We shouldn't do that in CreateAndInitializeCoreClasses because it is called
+	// from OnConnectedToSpatialOS callback which could be executed with the async
+	// loading thread suspended (e.g. when resuming rendering thread), in which
+	// case we'll crash upon trying to load SchemaDatabase.
+	ClassInfoManager = NewObject<USpatialClassInfoManager>();
+	ClassInfoManager->Init(this);
+
 	InitiateConnectionToSpatialOS(URL);
 
 	return true;
@@ -211,12 +219,10 @@ void USpatialNetDriver::CreateAndInitializeCoreClasses()
 	PlayerSpawner = NewObject<USpatialPlayerSpawner>();
 	StaticComponentView = NewObject<USpatialStaticComponentView>();
 	SnapshotManager = NewObject<USnapshotManager>();
-	ClassInfoManager = NewObject<USpatialClassInfoManager>();
 	SpatialMetrics = NewObject<USpatialMetrics>();
 
 	PackageMap = Cast<USpatialPackageMapClient>(GetSpatialOSNetConnection()->PackageMap);
 	PackageMap->Init(this);
-	ClassInfoManager->Init(this);
 	Dispatcher->Init(this);
 	Sender->Init(this);
 	Receiver->Init(this, &TimerManager);


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Fix a crash caused by loading SchemaDatabase when async loading is suspended, for example when resuming the rendering thread which flushes the tasks on the GameThread, triggering `OnConnectedToSpatial` which would eventually try to load the SchemaDatabase.

#### Documentation
Release note.

#### Primary reviewers
@m-samiec @oblm 