### PR TITLE
Call OnConnectedToSpatialOS directly rather than binding to a delegate

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -165,7 +165,6 @@ void USpatialNetDriver::InitiateConnectionToSpatialOS(const FURL& URL)
 		}
 	}
 
-	GameInstance->OnConnected.AddUObject(this, &USpatialNetDriver::OnConnectedToSpatialOS);
 	Connection->Connect(bConnectAsClient);
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
@@ -377,6 +377,7 @@ void USpatialWorkerConnection::OnConnectionSuccess()
 		InitializeOpsProcessingThread();
 	}
 
+	GetSpatialNetDriverChecked()->OnConnectedToSpatialOS();
 	GameInstance->HandleOnConnected();
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -66,6 +66,8 @@ public:
 
 	virtual void OnOwnerUpdated(AActor* Actor);
 
+	void OnConnectedToSpatialOS();
+
 #if !UE_BUILD_SHIPPING
 	bool HandleNetDumpCrossServerRPCCommand(const TCHAR* Cmd, FOutputDevice& Ar);
 #endif
@@ -161,8 +163,6 @@ private:
 
 	void InitiateConnectionToSpatialOS(const FURL& URL);
 
-	UFUNCTION()
-	void OnConnectedToSpatialOS();
 
 	void InitializeSpatialOutputDevice();
 	void CreateAndInitializeCoreClasses();


### PR DESCRIPTION
#### Description
We were crashing on a client travel since we were calling the OnConnectedDelegate on an old SpatialNetDriver. We now directly call OnConnectedToSpatialOS on the current NetDriver directly rather than binding to a delegate.

#### Primary reviewers
@improbable-valentyn @aleximprobable 