### PR TITLE
Remove iterate from worker build

### DIFF
--- a/RequireSetup
+++ b/RequireSetup
@@ -1,4 +1,4 @@
 Increment the below number whenever it is required to run Setup.bat as part of a new commit.
 Our git hooks will detect this file has been updated and automatically run Setup.bat on pull.
 
-16
+17

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Build/Build.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Build/Build.cs
@@ -141,7 +141,6 @@ exit /b !ERRORLEVEL!
                     "-serverconfig=" + configuration,
                     "-utf8output",
                     "-cook",
-                    "-iterate",
                     "-stage",
                     "-package",
                     "-unversioned",
@@ -164,6 +163,10 @@ exit /b !ERRORLEVEL!
                 // TO-DO: Remove this once LAUNCH-341 has been completed, and the _ is no longer necessary.
                 var oldExe = Path.Combine(windowsNoEditorPath, $"{gameName}.exe");
                 var renamedExe = Path.Combine(windowsNoEditorPath, $"_{gameName}.exe");
+                if (File.Exists(renamedExe))
+                {
+                    File.Delete(renamedExe);
+                }
                 if (File.Exists(oldExe))
                 {
                     File.Move(oldExe, renamedExe);
@@ -198,7 +201,6 @@ exit /b !ERRORLEVEL!
                     "-utf8output",
                     "-compile",
                     "-cook",
-                    "-iterate",
                     "-stage",
                     "-package",
                     "-unversioned",
@@ -256,7 +258,6 @@ exit /b !ERRORLEVEL!
                     "-serverconfig=" + configuration,
                     "-utf8output",
                     "-cook",
-                    "-iterate",
                     "-stage",
                     "-package",
                     "-unversioned",


### PR DESCRIPTION
#### Description
If you use BuildWorker.bat to build an UnrealClient twice for a project, it'll fail. This removes the implicit iterate from a build script (it can still be passed as an optional parameter), and explicitly deletes the old exe if it still exists.

#### Tests
Ran client builds multiple times.

#### Primary reviewers
@joshuahuburn @Vatyx 