### PR TITLE
0.4.1 rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - yyyy-mm-dd
 
+## [`0.4.1`](https://github.com/spatialos/UnrealGDK/releases/tag/0.4.1) - 2019-05-01
+
+### Bug fixes:
+- Fixed an issue where schema components were sometimes generated with incorrect component IDs.
+
 ## [`0.4.0`](https://github.com/spatialos/UnrealGDK/releases/tag/0.4.0) - 2019-04-30
 
 ### New Known Issues:

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SchemaGenerator.cpp
@@ -334,7 +334,15 @@ void GenerateActorSchema(FComponentIdGenerator& IdGenerator, UClass* Class, TSha
 			continue;
 		}
 
-		const Worker_ComponentId ComponentId = SchemaData ? SchemaData->SchemaComponents[PropertyGroupToSchemaComponentType(Group)] : IdGenerator.Next();
+		Worker_ComponentId ComponentId = 0;
+		if (SchemaData != nullptr && SchemaData->SchemaComponents[PropertyGroupToSchemaComponentType(Group)] != 0)
+		{
+			ComponentId = SchemaData->SchemaComponents[PropertyGroupToSchemaComponentType(Group)];
+		}
+		else
+		{
+			ComponentId = IdGenerator.Next();
+		}
 
 		Writer.PrintNewLine();
 
@@ -359,7 +367,15 @@ void GenerateActorSchema(FComponentIdGenerator& IdGenerator, UClass* Class, TSha
 	FCmdHandlePropertyMap HandoverData = GetFlatHandoverData(TypeInfo);
 	if (HandoverData.Num() > 0)
 	{
-		const Worker_ComponentId ComponentId = SchemaData ? SchemaData->SchemaComponents[ESchemaComponentType::SCHEMA_Handover] : IdGenerator.Next();
+		Worker_ComponentId ComponentId = 0;
+		if (SchemaData != nullptr && SchemaData->SchemaComponents[ESchemaComponentType::SCHEMA_Handover] != 0)
+		{
+			ComponentId = SchemaData->SchemaComponents[ESchemaComponentType::SCHEMA_Handover];
+		}
+		else
+		{
+			ComponentId = IdGenerator.Next();
+		}
 
 		Writer.PrintNewLine();
 
@@ -405,7 +421,15 @@ FSubobjectSchemaData GenerateSubobjectSpecificSchema(FCodeWriter& Writer, FCompo
 			continue;
 		}
 
-		const Worker_ComponentId ComponentId = SubobjectSchemaData ? SubobjectSchemaData->SchemaComponents[PropertyGroupToSchemaComponentType(Group)] : IdGenerator.Next();
+		Worker_ComponentId ComponentId = 0;
+		if (SubobjectSchemaData != nullptr && SubobjectSchemaData->SchemaComponents[PropertyGroupToSchemaComponentType(Group)] != 0)
+		{
+			ComponentId = SubobjectSchemaData->SchemaComponents[PropertyGroupToSchemaComponentType(Group)];
+		}
+		else
+		{
+			ComponentId = IdGenerator.Next();
+		}
 
 		Writer.PrintNewLine();
 
@@ -422,7 +446,15 @@ FSubobjectSchemaData GenerateSubobjectSpecificSchema(FCodeWriter& Writer, FCompo
 	FCmdHandlePropertyMap HandoverData = GetFlatHandoverData(TypeInfo);
 	if (HandoverData.Num() > 0)
 	{
-		const Worker_ComponentId ComponentId = SubobjectSchemaData ? SubobjectSchemaData->SchemaComponents[ESchemaComponentType::SCHEMA_Handover] : IdGenerator.Next();
+		Worker_ComponentId ComponentId = 0;
+		if (SubobjectSchemaData != nullptr && SubobjectSchemaData->SchemaComponents[ESchemaComponentType::SCHEMA_Handover] != 0)
+		{
+			ComponentId = SubobjectSchemaData->SchemaComponents[ESchemaComponentType::SCHEMA_Handover];
+		}
+		else
+		{
+			ComponentId = IdGenerator.Next();
+		}
 
 		Writer.PrintNewLine();
 


### PR DESCRIPTION
#### Description
Merges the `0.4.1` release branch into `release`.
This release candidate has successfully passed our release testing process.

#### Release note
[Unreal GDK version 0.4.1 is go!](https://github.com/spatialos/unrealgdk/releases/tag/0.4.1)<br>
Corresponding Engine version: https://github.com/improbableio/UnrealEngine/tree/4.20-SpatialOSUnrealGDK-0.4.1

Make sure to upgrade your GDK and Engine fork to the latest release. Either use the `0.4.1` tagged commits or switch your projects to the `release` branches and `git pull`.

Happy developing!<br>
GDK team

## Release Notes 0.4.1

### Bug fixes:
- Fixed an issue where schema components were sometimes generated with incorrect component IDs.