### PR TITLE
Spatial Type doc: remove mention of Advanced section

### DIFF
--- a/SpatialGDK/Documentation/content/get-started/gdk-template.md
+++ b/SpatialGDK/Documentation/content/get-started/gdk-template.md
@@ -110,7 +110,7 @@ To launch a local deployment:
 _Image: On the GDK toolbar in the Unreal Editor select **Start**_<br/>
 1. On the Unreal Editor toolbar, open the **Play** drop-down menu.
 1. Under **Modes**, select **New Editor Window (PIE)**.<br/>
-1. Under **Multiplayer Options**, set the number of players to **2** and ensure that the check box next to **Run Dedicated Server** is checked. (If it is unchecked, select the checkbox to enable it.)<br/>
+1. Under **Multiplayer Options**, set the number of players to **2** and ensure that the checkbox next to **Run Dedicated Server** is checked. (If it is unchecked, select the checkbox to enable it.)<br/>
 ![]({{assetRoot}}assets/set-up-template/template-multiplayer-options.png)<br/>
 _Image: The Unreal Engine **Play** drop-down menu, with **Multiplayer Options** and **New Editor Window (PIE)** highlighted_<br/>
 1. On the Unreal Engine toolbar, select **Play** to run the game, and you should see two clients start.<br/><br/>

--- a/SpatialGDK/Documentation/content/spatial-type.md
+++ b/SpatialGDK/Documentation/content/spatial-type.md
@@ -52,7 +52,7 @@ class AMySingleton : public AActor
 You can also tag your Blueprint classes with the `SpatialType` tag and descriptors. To do this,
 
 1. Open the class in the Blueprint Editor and, from the menu, select **Class Settings**. 
-1. Select **Class Options** and check the `Spatial Type` checkbox. 
-1. Add any descriptors to the `Spatial Description` textbox, like so:
+1. Ensure that the `Spatial Type` check box is selected. 
+1. Add any descriptors to the `Spatial Description` text box, like so:
 
 ![blueprint-singleton]({{assetRoot}}assets/screen-grabs/blueprint-singleton.png)

--- a/SpatialGDK/Documentation/content/spatial-type.md
+++ b/SpatialGDK/Documentation/content/spatial-type.md
@@ -52,7 +52,7 @@ class AMySingleton : public AActor
 You can also tag your Blueprint classes with the `SpatialType` tag and descriptors. To do this,
 
 1. Open the class in the Blueprint Editor and, from the menu, select **Class Settings**. 
-1. Ensure that the `Spatial Type` check box is selected. 
-1. Add any descriptors to the `Spatial Description` text box, like so:
+1. Ensure that the `Spatial Type` checkbox is selected. 
+1. Add any descriptors to the `Spatial Description` textbox, like so:
 
 ![blueprint-singleton]({{assetRoot}}assets/screen-grabs/blueprint-singleton.png)

--- a/SpatialGDK/Documentation/content/spatial-type.md
+++ b/SpatialGDK/Documentation/content/spatial-type.md
@@ -52,7 +52,7 @@ class AMySingleton : public AActor
 You can also tag your Blueprint classes with the `SpatialType` tag and descriptors. To do this,
 
 1. Open the class in the Blueprint Editor and, from the menu, select **Class Settings**. 
-1. Select **Class Options** and under **Advanced**, check the `Spatial Type` checkbox. 
+1. Select **Class Options** and check the `Spatial Type` checkbox. 
 1. Add any descriptors to the `Spatial Description` textbox, like so:
 
 ![blueprint-singleton]({{assetRoot}}assets/screen-grabs/blueprint-singleton.png)


### PR DESCRIPTION
Minor update to reflect the UI: the "Spatial Type" checkbox is no longer under "Advanced".

(This is also mentioned in the Singleton Actors doc, but there are bigger changes in progress for that one, so I haven't touched it for now.)