### PR TITLE
Remove hardcoding of AIWorker

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -82,7 +82,7 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 	WorkerRequirementSet OwningClientOnlyRequirementSet = { OwningClientAttributeSet };
 
 	TArray<FString> ServerWorkerTypes = GetDefault<USpatialGDKSettings>()->ServerWorkerTypes;
-	for (FString ServerWorkerType : ServerWorkerTypes)
+	for (const FString& ServerWorkerType : ServerWorkerTypes)
 	{
 		WorkerAttributeSet ServerWorkerAttributeSet = { ServerWorkerType };
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -73,7 +73,7 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 
 	FString ClientWorkerAttribute = improbable::GetOwnerWorkerAttribute(Actor);
 
-		WorkerRequirementSet AnyServerRequirementSet;
+	WorkerRequirementSet AnyServerRequirementSet;
 	WorkerRequirementSet AnyServerOrClientRequirementSet = { SpatialConstants::UnrealClientAttributeSet };
 
 	WorkerAttributeSet OwningClientAttributeSet = { ClientWorkerAttribute };

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -73,9 +73,7 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 
 	FString ClientWorkerAttribute = improbable::GetOwnerWorkerAttribute(Actor);
 
-	TArray<FString> ServerWorkerTypes = GetDefault<USpatialGDKSettings>()->ServerWorkerTypes;
-
-	WorkerRequirementSet AnyServerRequirementSet;
+		WorkerRequirementSet AnyServerRequirementSet;
 	WorkerRequirementSet AnyServerOrClientRequirementSet = { SpatialConstants::UnrealClientAttributeSet };
 
 	WorkerAttributeSet OwningClientAttributeSet = { ClientWorkerAttribute };
@@ -83,7 +81,8 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 	WorkerRequirementSet AnyServerOrOwningClientRequirementSet = { OwningClientAttributeSet };
 	WorkerRequirementSet OwningClientOnlyRequirementSet = { OwningClientAttributeSet };
 
-	for (WorkerAttributeSet ServerWorkerType : ServerWorkerTypes)
+	TArray<FString> ServerWorkerTypes = GetDefault<USpatialGDKSettings>()->ServerWorkerTypes;
+	for (FString ServerWorkerType : ServerWorkerTypes)
 	{
 		WorkerAttributeSet ServerWorkerAttributeSet = { ServerWorkerType };
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -66,11 +66,6 @@ void USpatialSender::Init(USpatialNetDriver* InNetDriver)
 	ClassInfoManager = InNetDriver->ClassInfoManager;
 }
 
-const WorkerAttributeSet ServerWorkerAttributeSet = { SpatialConstants::ServerWorkerType };
-const WorkerAttributeSet ClientWorkerAttributeSet = { SpatialConstants::ClientWorkerType };
-
-const WorkerRequirementSet ServerWorkerOnlyRequirementSet = { ServerWorkerAttributeSet };
-
 Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 {
 	AActor* Actor = Channel->Actor;
@@ -81,7 +76,7 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 	TArray<FString> ServerWorkerTypes = GetDefault<USpatialGDKSettings>()->ServerWorkerTypes;
 
 	WorkerRequirementSet AllServerTypesRequirementSet;
-	WorkerRequirementSet AnyServerOrClientRequirementSet = { ClientWorkerAttributeSet };
+	WorkerRequirementSet AnyServerOrClientRequirementSet = { SpatialConstants::UnrealClientAttributeSet };
 
 	WorkerAttributeSet OwningClientAttributeSet = { ClientWorkerAttribute };
 
@@ -114,7 +109,7 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 
 	const FClassInfo& Info = ClassInfoManager->GetOrCreateClassInfoByClass(Class);
 
-	WorkerRequirementSet AuthoritativeWorkerType = ServerWorkerOnlyRequirementSet;
+	WorkerRequirementSet AuthoritativeWorkerType = SpatialConstants::UnrealServerPermission;
 	if (!Class->WorkerAssociation.IsEmpty())
 	{
 		const WorkerAttributeSet WorkerAttribute{ Class->WorkerAssociation };

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -81,7 +81,7 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 	WorkerRequirementSet AnyServerOrOwningClientRequirementSet = { OwningClientAttributeSet };
 	WorkerRequirementSet OwningClientOnlyRequirementSet = { OwningClientAttributeSet };
 
-	TArray<FString> ServerWorkerTypes = GetDefault<USpatialGDKSettings>()->ServerWorkerTypes;
+	const TArray<FString>& ServerWorkerTypes = GetDefault<USpatialGDKSettings>()->ServerWorkerTypes;
 	for (const FString& ServerWorkerType : ServerWorkerTypes)
 	{
 		WorkerAttributeSet ServerWorkerAttributeSet = { ServerWorkerType };

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -84,7 +84,7 @@ public:
 	bool bUseFrameTimeAsLoad;
 
 	/** Server Worker Type Names. Edit the launch configuration description to affect this property. */
-	UPROPERTY(VisibleAnywhere, config, Category = "Access Control", meta = (ConfigRestartRequired = false))
+	UPROPERTY(config, meta = (ConfigRestartRequired = false))
 	TArray<FString> ServerWorkerTypes;
 };
 

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -82,5 +82,9 @@ public:
 	/** Change 'Load' value in inspector to represent worker Frame Time instead of a fraction of target FPS.*/
 	UPROPERTY(EditAnywhere, config, Category = "Metrics", meta = (ConfigRestartRequired = false))
 	bool bUseFrameTimeAsLoad;
+
+	/** Server Worker Type Names. Edit the launch configuration description to affect this property. */
+	UPROPERTY(VisibleAnywhere, config, Category = "Access Control", meta = (ConfigRestartRequired = false))
+	TArray<FString> ServerWorkerTypes;
 };
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SnapshotGenerator/SpatialGDKEditorSnapshotGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SnapshotGenerator/SpatialGDKEditorSnapshotGenerator.cpp
@@ -161,6 +161,10 @@ bool CreatePlaceholders(Worker_SnapshotOutputStream* OutputStream)
 	checkf(PlaceholderCountAxis % 2 == 0, TEXT("The number of placeholders on each axis must be even."));
 	const float CHUNK_SIZE = 5.0f; // in SpatialOS coordinates.
 	int PlaceholderEntityIdCounter = SpatialConstants::PLACEHOLDER_ENTITY_ID_FIRST;
+
+	TArray<FString> ServerWorkerTypes = GetDefault<USpatialGDKSettings>()->ServerWorkerTypes;
+	const WorkerRequirementSet ServerWorkerRequirementSet{ {ServerWorkerTypes} };
+
 	for (int x = -PlaceholderCountAxis / 2; x < PlaceholderCountAxis / 2; x++)
 	{
 		for (int y = -PlaceholderCountAxis / 2; y < PlaceholderCountAxis / 2; y++)
@@ -181,7 +185,7 @@ bool CreatePlaceholders(Worker_SnapshotOutputStream* OutputStream)
 			Components.Add(improbable::Position(PlaceholderPosition).CreatePositionData());
 			Components.Add(improbable::Metadata(TEXT("Placeholder")).CreateMetadataData());
 			Components.Add(improbable::Persistence().CreatePersistenceData());
-			Components.Add(improbable::EntityAcl(SpatialConstants::UnrealServerPermission, ComponentWriteAcl).CreateEntityAclData());
+			Components.Add(improbable::EntityAcl(ServerWorkerRequirementSet, ComponentWriteAcl).CreateEntityAclData());
 
 			Placeholder.component_count = Components.Num();
 			Placeholder.components = Components.GetData();

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SnapshotGenerator/SpatialGDKEditorSnapshotGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SnapshotGenerator/SpatialGDKEditorSnapshotGenerator.cpp
@@ -162,7 +162,7 @@ bool CreatePlaceholders(Worker_SnapshotOutputStream* OutputStream)
 	const float CHUNK_SIZE = 5.0f; // in SpatialOS coordinates.
 	int PlaceholderEntityIdCounter = SpatialConstants::PLACEHOLDER_ENTITY_ID_FIRST;
 
-	TArray<FString> ServerWorkerTypes = GetDefault<USpatialGDKSettings>()->ServerWorkerTypes;
+	const TArray<FString>& ServerWorkerTypes = GetDefault<USpatialGDKSettings>()->ServerWorkerTypes;
 	const WorkerRequirementSet ServerWorkerRequirementSet{ {ServerWorkerTypes} };
 
 	for (int x = -PlaceholderCountAxis / 2; x < PlaceholderCountAxis / 2; x++)

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -21,7 +21,6 @@ void USpatialGDKEditorSettings::SynchronizeGDKWorkerNames()
 {
 	USpatialGDKSettings* SpatialGDKSettings = GetMutableDefault<USpatialGDKSettings>();
 	SpatialGDKSettings->ServerWorkerTypes = {};
-	
 
 	for (uint8 i = 0; i < LaunchConfigDesc.Workers.Num(); ++i)
 	{

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -20,7 +20,7 @@ USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& O
 void USpatialGDKEditorSettings::SynchronizeGDKWorkerNames()
 {
 	USpatialGDKSettings* SpatialGDKSettings = GetMutableDefault<USpatialGDKSettings>();
-	SpatialGDKSettings->ServerWorkerTypes = {};
+	SpatialGDKSettings->ServerWorkerTypes.Empty();
 
 	for (uint8 i = 0; i < LaunchConfigDesc.Workers.Num(); ++i)
 	{

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -22,9 +22,9 @@ void USpatialGDKEditorSettings::SynchronizeGDKWorkerNames()
 	USpatialGDKSettings* SpatialGDKSettings = GetMutableDefault<USpatialGDKSettings>();
 	SpatialGDKSettings->ServerWorkerTypes.Empty();
 
-	for (uint8 i = 0; i < LaunchConfigDesc.Workers.Num(); ++i)
+	for (const FWorkerTypeLaunchSection& WorkerLaunchDescription : LaunchConfigDesc.Workers)
 	{
-		SpatialGDKSettings->ServerWorkerTypes.Add(LaunchConfigDesc.Workers[i].WorkerTypeName);
+		SpatialGDKSettings->ServerWorkerTypes.Add(WorkerLaunchDescription.WorkerTypeName);
 	}
 
 	SpatialGDKSettings->PostEditChange();

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -21,14 +21,15 @@ void USpatialGDKEditorSettings::SynchronizeGDKWorkerNames()
 {
 	USpatialGDKSettings* SpatialGDKSettings = GetMutableDefault<USpatialGDKSettings>();
 	SpatialGDKSettings->ServerWorkerTypes = {};
+	
 
-	for(uint8 i = 0; i< LaunchConfigDesc.Workers.Num(); ++i)
+	for (uint8 i = 0; i < LaunchConfigDesc.Workers.Num(); ++i)
 	{
 		SpatialGDKSettings->ServerWorkerTypes.Add(LaunchConfigDesc.Workers[i].WorkerTypeName);
 	}
-		
+
 	SpatialGDKSettings->PostEditChange();
-	SpatialGDKSettings->SaveConfig();
+	SpatialGDKSettings->UpdateDefaultConfigFile();
 }
 
 void USpatialGDKEditorSettings::PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent)

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 #include "SpatialGDKEditorSettings.h"
 #include "Settings/LevelEditorPlaySettings.h"
+#include "SpatialGDKSettings.h"
 
 USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
@@ -14,6 +15,20 @@ USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& O
 	SpatialOSSnapshotPath.Path = GetSpatialOSSnapshotFolderPath();
 	SpatialOSSnapshotFile = GetSpatialOSSnapshotFile();
 	GeneratedSchemaOutputFolder.Path = GetGeneratedSchemaOutputFolder();
+}
+
+void USpatialGDKEditorSettings::SynchronizeGDKWorkerNames()
+{
+	USpatialGDKSettings* SpatialGDKSettings = GetMutableDefault<USpatialGDKSettings>();
+	SpatialGDKSettings->ServerWorkerTypes = {};
+
+	for(uint8 i = 0; i< LaunchConfigDesc.Workers.Num(); ++i)
+	{
+		SpatialGDKSettings->ServerWorkerTypes.Add(LaunchConfigDesc.Workers[i].WorkerTypeName);
+	}
+		
+	SpatialGDKSettings->PostEditChange();
+	SpatialGDKSettings->SaveConfig();
 }
 
 void USpatialGDKEditorSettings::PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent)
@@ -31,6 +46,11 @@ void USpatialGDKEditorSettings::PostEditChangeProperty(struct FPropertyChangedEv
 		PlayInSettings->PostEditChange();
 		PlayInSettings->SaveConfig();
 	}
+
+	if (Name == GET_MEMBER_NAME_CHECKED(USpatialGDKEditorSettings, LaunchConfigDesc))
+	{
+		SynchronizeGDKWorkerNames();
+	}
 }
 
 void USpatialGDKEditorSettings::PostInitProperties()
@@ -42,4 +62,6 @@ void USpatialGDKEditorSettings::PostInitProperties()
 
 	PlayInSettings->PostEditChange();
 	PlayInSettings->SaveConfig();
+
+	SynchronizeGDKWorkerNames();
 }

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -197,7 +197,6 @@ class SPATIALGDKEDITOR_API USpatialGDKEditorSettings : public UObject
 
 public:
 	USpatialGDKEditorSettings(const FObjectInitializer& ObjectInitializer);
-	void SynchronizeGDKWorkerNames();
 
 	virtual void PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent) override;
 	virtual void PostInitProperties() override;
@@ -299,4 +298,7 @@ public:
 
 		return CommandLineLaunchFlags;
 	}
+
+private:
+	void SynchronizeGDKWorkerNames();
 };

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -197,6 +197,7 @@ class SPATIALGDKEDITOR_API USpatialGDKEditorSettings : public UObject
 
 public:
 	USpatialGDKEditorSettings(const FObjectInitializer& ObjectInitializer);
+	void SynchronizeGDKWorkerNames();
 
 	virtual void PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent) override;
 	virtual void PostInitProperties() override;


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
This adds the auto-populated list property to SpatialGDKSettings

The list property gets reconstructed from the list of server worker names from the Launch Config Description property

#### Release note
Internal changes

#### Tests
Test: an offloaded SearchablesWorker still works - can read from entities and write to appropriate ones.

- [x] manually via editor runs
- [x] locally launched built workers
- [x] cloud run

#### Documentation
Internal changes