### PR TITLE
UNR-1350: Only load & generate schema for map dependencies in GenerateSchemaAndSnapshots Commandlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bugfix: BeginPlay is not called with authority when checking out entities from Spatial.
 - Bugfix: Launching SpatialOS would fail if there was a space in the full directory path.
 - Bugfix: Running Schema (Full Scan) now clears generated schema files first.
+- Bugfix: Fixed an issue with schema name collisions.
 
 ### External contributors:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fixes:
 - Bugfix: BeginPlay is not called with authority when checking out entities from Spatial.
 - Bugfix: Launching SpatialOS would fail if there was a space in the full directory path.
+- Bugfix: Running Schema (Full Scan) now clears generated schema files first.
 
 ### External contributors:
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SchemaDatabase.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SchemaDatabase.h
@@ -28,6 +28,9 @@ struct FSchemaData
 	GENERATED_USTRUCT_BODY()
 
 	UPROPERTY(VisibleAnywhere)
+	FString GeneratedSchemaName;
+
+	UPROPERTY(VisibleAnywhere)
 	uint32 SchemaComponents[SCHEMA_Count] = {};
 
 	UPROPERTY(VisibleAnywhere)

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SchemaGenerator.cpp
@@ -303,12 +303,12 @@ void GenerateSubobjectSchema(UClass* Class, TSharedPtr<FUnrealType> TypeInfo, FS
 		Writer.Outdent().Print("}");
 	}
 
-	Writer.WriteToFile(FString::Printf(TEXT("%s%s.schema"), *SchemaPath, *ClassToSchemaName[Class]));
+	Writer.WriteToFile(FString::Printf(TEXT("%s%s.schema"), *SchemaPath, *ClassToSchemaName[Class->GetPathName()]));
 }
 
 void GenerateActorSchema(FComponentIdGenerator& IdGenerator, UClass* Class, TSharedPtr<FUnrealType> TypeInfo, FString SchemaPath)
 {
-	const FSchemaData* const SchemaData = ClassPathToSchema.Find(*Class->GetPathName());
+	const FSchemaData* const SchemaData = ClassPathToSchema.Find(Class->GetPathName());
 
 	FCodeWriter Writer;
 
@@ -316,13 +316,14 @@ void GenerateActorSchema(FComponentIdGenerator& IdGenerator, UClass* Class, TSha
 		// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 		// Note that this file has been generated automatically
 		package unreal.generated.{0};)""",
-		*ClassToSchemaName[Class].ToLower());
+		*ClassToSchemaName[Class->GetPathName()].ToLower());
 
 	// Will always be included since AActor has replicated pointers to other actors
 	Writer.PrintNewLine();
 	Writer.Printf("import \"unreal/gdk/core_types.schema\";");
 
 	FSchemaData ActorSchemaData;
+	ActorSchemaData.GeneratedSchemaName = ClassToSchemaName[Class->GetPathName()];
 
 	FUnrealFlatRepData RepData = GetFlatRepData(TypeInfo);
 
@@ -401,12 +402,12 @@ void GenerateActorSchema(FComponentIdGenerator& IdGenerator, UClass* Class, TSha
 
 	ClassPathToSchema.Add(Class->GetPathName(), ActorSchemaData);
 
-	Writer.WriteToFile(FString::Printf(TEXT("%s%s.schema"), *SchemaPath, *ClassToSchemaName[Class]));
+	Writer.WriteToFile(FString::Printf(TEXT("%s%s.schema"), *SchemaPath, *ClassToSchemaName[Class->GetPathName()]));
 }
 
 FSubobjectSchemaData GenerateSubobjectSpecificSchema(FCodeWriter& Writer, FComponentIdGenerator& IdGenerator, FString PropertyName, TSharedPtr<FUnrealType>& TypeInfo, UClass* ComponentClass, UClass* ActorClass, int MapIndex)
 {
-	const FSchemaData* const SchemaData = ClassPathToSchema.Find(*ActorClass->GetPathName());
+	const FSchemaData* const SchemaData = ClassPathToSchema.Find(ActorClass->GetPathName());
 	const FSubobjectSchemaData* const SubobjectSchemaData = SchemaData ? SchemaData->SubobjectData.Find(MapIndex) : nullptr;
 	
 	FUnrealFlatRepData RepData = GetFlatRepData(TypeInfo);
@@ -479,7 +480,7 @@ void GenerateSubobjectSchemaForActor(FComponentIdGenerator& IdGenerator, UClass*
 		// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 		// Note that this file has been generated automatically
 		package unreal.generated.{0}.subobjects;)""",
-		*ClassToSchemaName[ActorClass].ToLower());
+		*ClassToSchemaName[ActorClass->GetPathName()].ToLower());
 
 	Writer.PrintNewLine();
 
@@ -514,7 +515,7 @@ void GenerateSubobjectSchemaForActor(FComponentIdGenerator& IdGenerator, UClass*
 
 	if (bHasComponents)
 	{
-		Writer.WriteToFile(FString::Printf(TEXT("%s%sComponents.schema"), *SchemaPath, *ClassToSchemaName[ActorClass]));
+		Writer.WriteToFile(FString::Printf(TEXT("%s%sComponents.schema"), *SchemaPath, *ClassToSchemaName[ActorClass->GetPathName()]));
 	}
 }
 
@@ -543,7 +544,7 @@ void GenerateActorIncludes(FCodeWriter& Writer, TSharedPtr<FUnrealType>& TypeInf
 				UClass* Class = Value->GetClass();
 				if (!AlreadyImported.Contains(Class) && SchemaGeneratedClasses.Contains(Class))
 				{
-					Writer.Printf("import \"unreal/generated/Subobjects/{0}.schema\";", *ClassToSchemaName[Class]);
+					Writer.Printf("import \"unreal/generated/Subobjects/{0}.schema\";", *ClassToSchemaName[Class->GetPathName()]);
 					AlreadyImported.Add(Class);
 				}
 			}

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/Utils/DataTypeUtilities.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/Utils/DataTypeUtilities.cpp
@@ -57,12 +57,12 @@ FString UnrealNameToSchemaComponentName(const FString& UnrealName)
 
 FString SchemaReplicatedDataName(EReplicatedPropertyGroup Group, UClass* Class)
 {
-	return FString::Printf(TEXT("%s%s"), *UnrealNameToSchemaComponentName(ClassToSchemaName[Class]), *GetReplicatedPropertyGroupName(Group));
+	return FString::Printf(TEXT("%s%s"), *UnrealNameToSchemaComponentName(ClassToSchemaName[Class->GetPathName()]), *GetReplicatedPropertyGroupName(Group));
 }
 
 FString SchemaHandoverDataName(UClass* Class)
 {
-	return FString::Printf(TEXT("%sHandover"), *UnrealNameToSchemaComponentName(ClassToSchemaName[Class]));
+	return FString::Printf(TEXT("%sHandover"), *UnrealNameToSchemaComponentName(ClassToSchemaName[Class->GetPathName()]));
 }
 
 FString SchemaRPCName(UFunction* Function)

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/Utils/DataTypeUtilities.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/Utils/DataTypeUtilities.h
@@ -6,7 +6,7 @@
 
 #include "SchemaGenerator/TypeStructure.h"
 
-extern TMap<UClass*, FString> ClassToSchemaName;
+extern TMap<FString, FString> ClassToSchemaName;
 
 // Return the string representation of the underlying data type of an enum property
 FString GetEnumDataType(const UEnumProperty* EnumProperty);

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
@@ -78,6 +78,11 @@ bool FSpatialGDKEditor::GenerateSchema(bool bFullScan)
 
 	TryLoadExistingSchemaDatabase();
 
+	if (bFullScan)
+	{
+		DeleteGeneratedSchemaFiles();
+	}
+
 	Progress.EnterProgressFrame(bFullScan ? 10.f : 100.f);
 	bool bResult = SpatialGDKGenerateSchema();
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditor.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditor.h
@@ -18,15 +18,18 @@ public:
 	}
 
 	bool GenerateSchema(bool bFullScan);
+	bool GenerateSchema(TSet<FAssetData> AssetsToLoad);
 	void GenerateSnapshot(UWorld* World, FString SnapshotFilename, FSimpleDelegate SuccessCallback, FSimpleDelegate FailureCallback, FSpatialGDKEditorErrorHandler ErrorCallback);
 
 	bool IsSchemaGeneratorRunning() { return bSchemaGeneratorRunning; }
+
+	void GetWorldDependencies(UWorld* World, TSet<FAssetData>& OutAssets);
 
 private:
 	bool bSchemaGeneratorRunning;
 	TFuture<bool> SchemaGeneratorResult;
 
-	bool LoadPotentialAssets(TArray<TStrongObjectPtr<UObject>>& OutAssets);
+	bool LoadPotentialAssets(TArray<TStrongObjectPtr<UObject>>& OutAssetsLoaded, TSet<FAssetData> AssetsToLoad);
 
 	FDelegateHandle OnAssetLoadedHandle;
 	void OnAssetLoaded(UObject* Asset);

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditor.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditor.h
@@ -23,7 +23,7 @@ public:
 
 	bool IsSchemaGeneratorRunning() { return bSchemaGeneratorRunning; }
 
-	void GetWorldDependencies(UWorld* World, TSet<FAssetData>& OutAssets);
+	void GetWorldDependencies(UWorld* World, TSet<FAssetData>& OutAssets, TSet<FAssetData>* AssetsToIgnore = nullptr);
 
 private:
 	bool bSchemaGeneratorRunning;

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSchemaGenerator.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSchemaGenerator.h
@@ -10,4 +10,6 @@ SPATIALGDKEDITOR_API bool SpatialGDKGenerateSchema();
 
 SPATIALGDKEDITOR_API void ClearGeneratedSchema();
 
+SPATIALGDKEDITOR_API void DeleteGeneratedSchemaFiles();
+
 SPATIALGDKEDITOR_API void TryLoadExistingSchemaDatabase();

--- a/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/GenerateSchemaAndSnapshotsCommandlet.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/GenerateSchemaAndSnapshotsCommandlet.cpp
@@ -71,6 +71,9 @@ int32 UGenerateSchemaAndSnapshotsCommandlet::Main(const FString& Args)
 		}
 	}
 
+	// Generate Schema, loading all assets found in all maps.
+	SpatialGDKEditor.GenerateSchema(AssetsToLoad);
+
 	UE_LOG(LogSpatialGDKEditorCommandlet, Display, TEXT("Schema & Snapshot Generation Commandlet Complete"));
 
 	return 0;
@@ -167,31 +170,28 @@ bool UGenerateSchemaAndSnapshotsCommandlet::GenerateSchemaAndSnapshotForMap(FSpa
 	}
 
 	// Ensure all sub-levels are also loaded
-	const TArray<ULevelStreaming*> StreamingLevels = GWorld->GetStreamingLevels();
-	UE_LOG(LogSpatialGDKEditorCommandlet, Display, TEXT("Loading %d Streaming SubLevels"), StreamingLevels.Num());
-	for (ULevelStreaming* StreamingLevel : StreamingLevels)
-	{
-		FLatentActionInfo LatentInfo;
-		UGameplayStatics::LoadStreamLevel(GWorld, StreamingLevel->GetWorldAssetPackageFName(), false, true, LatentInfo);
-	}
+	//const TArray<ULevelStreaming*> StreamingLevels = GWorld->GetStreamingLevels();
+	//UE_LOG(LogSpatialGDKEditorCommandlet, Display, TEXT("Loading %d Streaming SubLevels"), StreamingLevels.Num());
+	//for (ULevelStreaming* StreamingLevel : StreamingLevels)
+	//{
+	//	FLatentActionInfo LatentInfo;
+	//	UGameplayStatics::LoadStreamLevel(GWorld, StreamingLevel->GetWorldAssetPackageFName(), false, true, LatentInfo);
+	//}
 
-	// Ensure all world composition tiles are also loaded
-	if (GWorld->WorldComposition != nullptr)
-	{
-		TArray<ULevelStreaming*> StreamingTiles = GWorld->WorldComposition->TilesStreaming;
-		UE_LOG(LogSpatialGDKEditorCommandlet, Display, TEXT("Loading %d World Composition Tiles"), StreamingTiles.Num());
-		for (ULevelStreaming* StreamingTile : StreamingTiles)
-		{
-			FLatentActionInfo LatentInfo;
-			UGameplayStatics::LoadStreamLevel(GWorld, StreamingTile->GetWorldAssetPackageFName(), false, true, LatentInfo);
-		}
-	}
+	//// Ensure all world composition tiles are also loaded
+	//if (GWorld->WorldComposition != nullptr)
+	//{
+	//	TArray<ULevelStreaming*> StreamingTiles = GWorld->WorldComposition->TilesStreaming;
+	//	UE_LOG(LogSpatialGDKEditorCommandlet, Display, TEXT("Loading %d World Composition Tiles"), StreamingTiles.Num());
+	//	for (ULevelStreaming* StreamingTile : StreamingTiles)
+	//	{
+	//		FLatentActionInfo LatentInfo;
+	//		UGameplayStatics::LoadStreamLevel(GWorld, StreamingTile->GetWorldAssetPackageFName(), false, true, LatentInfo);
+	//	}
+	//}
 
-	// Generate Schema Iteration
-	if (!GenerateSchemaForLoadedMap(InSpatialGDKEditor))
-	{
-		return false;
-	}
+	// Add Map Deps to Assets to load for
+	InSpatialGDKEditor.GetWorldDependencies(GWorld, AssetsToLoad);
 
 	// Generate Snapshot
 	if (!GenerateSnapshotForLoadedMap(InSpatialGDKEditor, FPaths::GetCleanFilename(InMapName)))

--- a/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/GenerateSchemaAndSnapshotsCommandlet.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/GenerateSchemaAndSnapshotsCommandlet.cpp
@@ -71,9 +71,6 @@ int32 UGenerateSchemaAndSnapshotsCommandlet::Main(const FString& Args)
 		}
 	}
 
-	// Generate Schema, loading all assets found in all maps.
-	SpatialGDKEditor.GenerateSchema(AssetsToLoad);
-
 	UE_LOG(LogSpatialGDKEditorCommandlet, Display, TEXT("Schema & Snapshot Generation Commandlet Complete"));
 
 	return 0;
@@ -169,29 +166,17 @@ bool UGenerateSchemaAndSnapshotsCommandlet::GenerateSchemaAndSnapshotForMap(FSpa
 		return false;
 	}
 
-	// Ensure all sub-levels are also loaded
-	//const TArray<ULevelStreaming*> StreamingLevels = GWorld->GetStreamingLevels();
-	//UE_LOG(LogSpatialGDKEditorCommandlet, Display, TEXT("Loading %d Streaming SubLevels"), StreamingLevels.Num());
-	//for (ULevelStreaming* StreamingLevel : StreamingLevels)
-	//{
-	//	FLatentActionInfo LatentInfo;
-	//	UGameplayStatics::LoadStreamLevel(GWorld, StreamingLevel->GetWorldAssetPackageFName(), false, true, LatentInfo);
-	//}
+	TSet<FAssetData> AssetsToLoad;
+	InSpatialGDKEditor.GetWorldDependencies(GWorld, AssetsToLoad, &AssetsAlreadyGenerated);
 
-	//// Ensure all world composition tiles are also loaded
-	//if (GWorld->WorldComposition != nullptr)
-	//{
-	//	TArray<ULevelStreaming*> StreamingTiles = GWorld->WorldComposition->TilesStreaming;
-	//	UE_LOG(LogSpatialGDKEditorCommandlet, Display, TEXT("Loading %d World Composition Tiles"), StreamingTiles.Num());
-	//	for (ULevelStreaming* StreamingTile : StreamingTiles)
-	//	{
-	//		FLatentActionInfo LatentInfo;
-	//		UGameplayStatics::LoadStreamLevel(GWorld, StreamingTile->GetWorldAssetPackageFName(), false, true, LatentInfo);
-	//	}
-	//}
+	// Generate Schema
+	if (!GenerateSchemaForLoadedMap(InSpatialGDKEditor, AssetsToLoad))
+	{
+		return false;
+	}
 
-	// Add Map Deps to Assets to load for
-	InSpatialGDKEditor.GetWorldDependencies(GWorld, AssetsToLoad);
+	AssetsAlreadyGenerated.Append(AssetsToLoad);
+
 
 	// Generate Snapshot
 	if (!GenerateSnapshotForLoadedMap(InSpatialGDKEditor, FPaths::GetCleanFilename(InMapName)))
@@ -202,10 +187,10 @@ bool UGenerateSchemaAndSnapshotsCommandlet::GenerateSchemaAndSnapshotForMap(FSpa
 	return true;
 }
 
-bool UGenerateSchemaAndSnapshotsCommandlet::GenerateSchemaForLoadedMap(FSpatialGDKEditor& InSpatialGDKEditor)
+bool UGenerateSchemaAndSnapshotsCommandlet::GenerateSchemaForLoadedMap(FSpatialGDKEditor& InSpatialGDKEditor, TSet<FAssetData> AssetsToLoad)
 {
 	bool bSchemaGenSuccess;
-	if (InSpatialGDKEditor.GenerateSchema(true))
+	if (InSpatialGDKEditor.GenerateSchema(AssetsToLoad))
 	{
 		UE_LOG(LogSpatialGDKEditorCommandlet, Display, TEXT("Schema Generation Completed!"));
 		bSchemaGenSuccess = true;

--- a/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/GenerateSchemaAndSnapshotsCommandlet.h
+++ b/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/GenerateSchemaAndSnapshotsCommandlet.h
@@ -26,12 +26,12 @@ private:
 
 	TArray<FString> GeneratedMapPaths;
 
-	TSet<FAssetData> AssetsToLoad;
+	TSet<FAssetData> AssetsAlreadyGenerated;
 
 private:
 	bool GenerateSchemaAndSnapshotForPath(FSpatialGDKEditor& InSpatialGDKEditor, const FString& InPath);
 	bool GenerateSchemaAndSnapshotForMap(FSpatialGDKEditor& InSpatialGDKEditor, const FString& InMapName);
 
-	bool GenerateSchemaForLoadedMap(FSpatialGDKEditor& InSpatialGDKEditor);
+	bool GenerateSchemaForLoadedMap(FSpatialGDKEditor& InSpatialGDKEditor, TSet<FAssetData> AssetsToLoad);
 	bool GenerateSnapshotForLoadedMap(FSpatialGDKEditor& InSpatialGDKEditor, const FString& InMapName);
 };

--- a/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/GenerateSchemaAndSnapshotsCommandlet.h
+++ b/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/GenerateSchemaAndSnapshotsCommandlet.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "Commandlets/Commandlet.h"
+#include "AssetRegistryModule.h"
 
 #include "GenerateSchemaAndSnapshotsCommandlet.generated.h"
 
@@ -24,6 +25,8 @@ private:
 	const FString AssetPathGameDirName = TEXT("/Game");	// Root asset path directory name that maps will ultimately be found in
 
 	TArray<FString> GeneratedMapPaths;
+
+	TSet<FAssetData> AssetsToLoad;
 
 private:
 	bool GenerateSchemaAndSnapshotForPath(FSpatialGDKEditor& InSpatialGDKEditor, const FString& InPath);


### PR DESCRIPTION
#### Description
- Adds a new method to Schema Generator for finding all dependencies of a UWorld (including world composition deps).
- Add support for running schema generator to load a specific set of assets.
- Use the above changes to make GenerateSchemaAndSnapshot commandlet generate minimal schema for each map passed as an argument.

#### Release note
TODO

#### Tests
How did you test these changes prior to submitting this pull request?
What automated tests are included in this PR?

STRONGLY SUGGESTED: How can this be verified by QA?

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.