### PR TITLE
[UNR-1350] Bugfix: GenerateSchemaAndSnapshots: Run full schema gen once, then generate snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fixes:
 - Bugfix: BeginPlay is not called with authority when checking out entities from Spatial.
 - Bugfix: Launching SpatialOS would fail if there was a space in the full directory path.
+- Bugfix: GenerateSchemaAndSnapshots commandlet no longer runs a full schema generation for each map.
 
 ### External contributors:
 

--- a/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/GenerateSchemaAndSnapshotsCommandlet.h
+++ b/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/GenerateSchemaAndSnapshotsCommandlet.h
@@ -26,9 +26,9 @@ private:
 	TArray<FString> GeneratedMapPaths;
 
 private:
-	bool GenerateSchemaAndSnapshotForPath(FSpatialGDKEditor& InSpatialGDKEditor, const FString& InPath);
-	bool GenerateSchemaAndSnapshotForMap(FSpatialGDKEditor& InSpatialGDKEditor, const FString& InMapName);
+	bool GenerateSnapshotForPath(FSpatialGDKEditor& InSpatialGDKEditor, const FString& InPath);
+	bool GenerateSnapshotForMap(FSpatialGDKEditor& InSpatialGDKEditor, const FString& InMapName);
 
-	bool GenerateSchemaForLoadedMap(FSpatialGDKEditor& InSpatialGDKEditor);
+	bool GenerateSchema(FSpatialGDKEditor& InSpatialGDKEditor);
 	bool GenerateSnapshotForLoadedMap(FSpatialGDKEditor& InSpatialGDKEditor, const FString& InMapName);
 };


### PR DESCRIPTION
#### Description
Now that schema generation does a full scan, only run it once before generating snapshots.

#### Tests
Tested locally using sample project.

STRONGLY SUGGESTED: How can this be verified by QA?
Run commandlet and verify it takes less time than before:
`%UNREAL_HOME%/Engine/Binaries/Win64/UE4Editor.exe %PATH_TO_UPROJECT% -run=GenerateSchemaAndSnapshots -MapPath=Path/To/MapOne\;Path/To/Other/Map`