### PR TITLE
[UNR-1371] Bugfix: Do not generate schema for assets in 'Directories to Never Cook'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GenerateSchemaAndSnapshots commandlet no longer runs a full schema generation for each map.
 - Launching SpatialOS would fail if there was a space in the full directory path.
 - Fixed an issue with schema name collisions.
+- Fixed an issues where schema generation was not respecting "Directories to never cook"
 
 ## [`0.4.1`](https://github.com/spatialos/UnrealGDK/releases/tag/0.4.1) - 2019-05-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GenerateSchemaAndSnapshots commandlet no longer runs a full schema generation for each map.
 - Launching SpatialOS would fail if there was a space in the full directory path.
 - Fixed an issue with schema name collisions.
-- Fixed an issues where schema generation was not respecting "Directories to never cook"
+- Fixed an issue where schema generation was not respecting "Directories to never cook"
 
 ## [`0.4.1`](https://github.com/spatialos/UnrealGDK/releases/tag/0.4.1) - 2019-05-01
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -454,7 +454,7 @@ TArray<UClass*> GetAllSupportedClasses()
 		if (DirectoriesToNeverCook.FindByPredicate([&ClassPath](const FDirectoryPath& Directory)
 		{
 			return ClassPath.StartsWith(Directory.Path);
-		}))
+		}) != nullptr)
 		{
 			continue;
 		}

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -394,7 +394,7 @@ void SaveSchemaDatabase()
 TArray<UClass*> GetAllSupportedClasses()
 {
 	TSet<UClass*> Classes;
-	TArray<FDirectoryPath> DirectoriesToNeverCook = GetMutableDefault<UProjectPackagingSettings>()->DirectoriesToNeverCook;
+	const TArray<FDirectoryPath>& DirectoriesToNeverCook = GetDefault<UProjectPackagingSettings>()->DirectoriesToNeverCook;
 
 	for (TObjectIterator<UClass> ClassIt; ClassIt; ++ClassIt)
 	{
@@ -450,12 +450,13 @@ TArray<UClass*> GetAllSupportedClasses()
 		}
 
 		// Avoid processing classes contained in Directories to Never Cook
-		bool bNeverCook = false;
-		if (FDirectoryPath* ContainingDirectory = DirectoriesToNeverCook.FindByPredicate([SupportedClass](FDirectoryPath Directory) {
-			return SupportedClass->GetPathName().StartsWith(Directory.Path);
+		const FString& ClassPath = SupportedClass->GetPathName();
+		if (DirectoriesToNeverCook.FindByPredicate([&ClassPath](const FDirectoryPath& Directory)
+		{
+			return ClassPath.StartsWith(Directory.Path);
 		}))
 		{
-				continue;
+			continue;
 		}
 		
 		Classes.Add(SupportedClass);

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -451,10 +451,10 @@ TArray<UClass*> GetAllSupportedClasses()
 
 		// Avoid processing classes contained in Directories to Never Cook
 		const FString& ClassPath = SupportedClass->GetPathName();
-		if (DirectoriesToNeverCook.FindByPredicate([&ClassPath](const FDirectoryPath& Directory)
+		if (DirectoriesToNeverCook.ContainsByPredicate([&ClassPath](const FDirectoryPath& Directory)
 		{
 			return ClassPath.StartsWith(Directory.Path);
-		}) != nullptr)
+		}))
 		{
 			continue;
 		}

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -32,6 +32,7 @@
 #include "Engine/WorldComposition.h"
 #include "Misc/ScopedSlowTask.h"
 #include "UObject/StrongObjectPtr.h"
+#include "Settings/ProjectPackagingSettings.h"
 
 DEFINE_LOG_CATEGORY(LogSpatialGDKSchemaGenerator);
 #define LOCTEXT_NAMESPACE "SpatialGDKSchemaGenerator"
@@ -393,6 +394,7 @@ void SaveSchemaDatabase()
 TArray<UClass*> GetAllSupportedClasses()
 {
 	TSet<UClass*> Classes;
+	TArray<FDirectoryPath> DirectoriesToNeverCook = GetMutableDefault<UProjectPackagingSettings>()->DirectoriesToNeverCook;
 
 	for (TObjectIterator<UClass> ClassIt; ClassIt; ++ClassIt)
 	{
@@ -432,7 +434,10 @@ TArray<UClass*> GetAllSupportedClasses()
 		}
 
 		// No replicated/handover properties found
-		if (SupportedClass == nullptr) continue;
+		if (SupportedClass == nullptr)
+		{
+			continue;
+		}
 
 		// Ensure we don't process skeleton, reinitialized or classes that have since been hot reloaded
 		if (SupportedClass->GetName().StartsWith(TEXT("SKEL_"), ESearchCase::CaseSensitive)
@@ -444,6 +449,15 @@ TArray<UClass*> GetAllSupportedClasses()
 			continue;
 		}
 
+		// Avoid processing classes contained in Directories to Never Cook
+		bool bNeverCook = false;
+		if (FDirectoryPath* ContainingDirectory = DirectoriesToNeverCook.FindByPredicate([SupportedClass](FDirectoryPath Directory) {
+			return SupportedClass->GetPathName().StartsWith(Directory.Path);
+		}))
+		{
+				continue;
+		}
+		
 		Classes.Add(SupportedClass);
 	}
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
@@ -201,10 +201,11 @@ bool FSpatialGDKEditor::LoadPotentialAssets(TArray<TStrongObjectPtr<UObject>>& O
 	TArray<FAssetData> FoundAssets;
 	AssetRegistryModule.Get().GetAllAssets(FoundAssets, true);
 
-	TArray<FDirectoryPath> DirectoriesToNeverCook = GetMutableDefault<UProjectPackagingSettings>()->DirectoriesToNeverCook;
+	const TArray<FDirectoryPath>& DirectoriesToNeverCook = GetDefault<UProjectPackagingSettings>()->DirectoriesToNeverCook;
 
 	// Filter assets to game blueprint classes that are not loaded and not inside DirectoriesToNeverCook.
-	FoundAssets = FoundAssets.FilterByPredicate([DirectoriesToNeverCook](FAssetData Data) {
+	FoundAssets = FoundAssets.FilterByPredicate([&DirectoriesToNeverCook](const FAssetData& Data)
+	{
 		if (Data.IsAssetLoaded())
 		{
 			return false;

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
@@ -13,6 +13,7 @@
 #include "GeneralProjectSettings.h"
 #include "Misc/ScopedSlowTask.h"
 #include "UObject/StrongObjectPtr.h"
+#include "Settings/ProjectPackagingSettings.h"
 
 DEFINE_LOG_CATEGORY(LogSpatialGDKEditor);
 
@@ -200,9 +201,31 @@ bool FSpatialGDKEditor::LoadPotentialAssets(TArray<TStrongObjectPtr<UObject>>& O
 	TArray<FAssetData> FoundAssets;
 	AssetRegistryModule.Get().GetAllAssets(FoundAssets, true);
 
-	// Filter assets to game blueprint classes that are not loaded.
-	FoundAssets = FoundAssets.FilterByPredicate([](FAssetData Data) {
-		return (!Data.IsAssetLoaded() && Data.TagsAndValues.Contains("GeneratedClass") && Data.PackagePath.ToString().StartsWith("/Game"));
+	TArray<FDirectoryPath> DirectoriesToNeverCook = GetMutableDefault<UProjectPackagingSettings>()->DirectoriesToNeverCook;
+
+	// Filter assets to game blueprint classes that are not loaded and not inside DirectoriesToNeverCook.
+	FoundAssets = FoundAssets.FilterByPredicate([DirectoriesToNeverCook](FAssetData Data) {
+		if (Data.IsAssetLoaded())
+		{
+			return false;
+		}
+		if (!Data.TagsAndValues.Contains("GeneratedClass"))
+		{
+			return false;
+		}
+		const FString PackagePath = Data.PackagePath.ToString();
+		if (!PackagePath.StartsWith("/Game"))
+		{
+			return false;
+		}
+		for (const auto& Directory : DirectoriesToNeverCook)
+		{
+			if (PackagePath.StartsWith(Directory.Path))
+			{
+				return false;
+			}
+		}
+		return true;
 	});
 
 	FScopedSlowTask Progress(static_cast<float>(FoundAssets.Num()), FText::FromString(FString::Printf(TEXT("Loading %d Assets before generating schema"), FoundAssets.Num())));


### PR DESCRIPTION
#### Description
During schema generation, avoid loading assets & selecting classes that are inside packages marked as 'Never Cook' in packaging settings.

#### Release note

### Bug fixes:
- Fixed an issues where schema generation was not respecting "Directories to never cook"

#### Tests
Tested Full & in-memory schema generation in editor & tested via commandlet.

STRONGLY SUGGESTED: How can this be verified by QA?
1. Add a new folder to a project
2. Add a replicated actor to the new folder
3. Add the new folder to Project Settings -> Project - Packaging -> Directories to never cook
4. Run schema generation (full or incremental)
5. Verify that no .schema file was generated for the new actor & that it has not been added to the schema database.

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.