### PR TITLE
Fix crash when resolving subobject class in ClassInfoManager

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
@@ -41,7 +41,7 @@ FORCEINLINE UClass* ResolveClass(FString& ClassPath)
 	if (Class == nullptr)
 	{
 		UE_LOG(LogSpatialClassInfoManager, Warning, TEXT("Failed to find class at path %s! Attempting to load it."), *ClassPath);
-		Class = SoftClassPath.TryLoadClass<UClass>();
+		Class = SoftClassPath.TryLoadClass<UObject>();
 	}
 	return Class;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
@@ -38,7 +38,11 @@ FORCEINLINE UClass* ResolveClass(FString& ClassPath)
 {
 	FSoftClassPath SoftClassPath(ClassPath);
 	UClass* Class = SoftClassPath.ResolveClass();
-	checkf(Class, TEXT("Failed to load class at path %s"), *ClassPath);
+	if (Class == nullptr)
+	{
+		UE_LOG(LogSpatialClassInfoManager, Warning, TEXT("Failed to find class at path %s! Attempting to load it."), *ClassPath);
+		Class = SoftClassPath.TryLoadClass<UClass>();
+	}
 	return Class;
 }
 
@@ -173,6 +177,11 @@ void USpatialClassInfoManager::CreateClassInfoForClass(UClass* Class)
 		FSubobjectSchemaData SubobjectSchemaData = SubobjectClassDataPair.Value;
 
 		UClass* SubobjectClass = ResolveClass(SubobjectSchemaData.ClassPath);
+		if (SubobjectClass == nullptr)
+		{
+			UE_LOG(LogSpatialClassInfoManager, Error, TEXT("Failed to resolve the class for subobject %s (class path: %s) on actor class %s! This subobject will not be able to replicate in Spatial!"), *SubobjectSchemaData.Name.ToString(), *SubobjectSchemaData.ClassPath, *Class->GetPathName());
+			continue;
+		}
 
 		const FClassInfo& SubobjectInfo = GetOrCreateClassInfoByClass(SubobjectClass);
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Don't crash if a subobject class can't be resolved when creating ClassInfo. This could potentially happen if the actor's blueprint isn't fully loaded, though the crash has not been reproduced on our side.

#### Primary reviewers
@m-samiec