### PR TITLE
[UNR 1415] Bugfix: Readonly Schema Database crashes editor during generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GenerateSchemaAndSnapshots commandlet no longer runs a full schema generation for each map.
 - Launching SpatialOS would fail if there was a space in the full directory path.
 - Fixed an issue with schema name collisions.
-- Fixed an issue where schema generation was not respecting "Directories to never cook"
+- Fixed an issue where schema generation was not respecting "Directories to never cook".
+- Fixed an issue causing the editor to crash during schema generation if the database is readonly.
 
 ## [`0.4.1`](https://github.com/spatialos/UnrealGDK/releases/tag/0.4.1) - 2019-05-01
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -498,7 +498,7 @@ bool TryLoadExistingSchemaDatabase()
 
 	IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
 
-		FFileStatData StatData = PlatformFile.GetStatData(*SchemaDatabaseFileName);
+	FFileStatData StatData = PlatformFile.GetStatData(*SchemaDatabaseFileName);
 
 	if (StatData.bIsValid)
 	{

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -502,7 +502,7 @@ bool TryLoadExistingSchemaDatabase()
 	{
 		if (StatData.bIsReadOnly)
 		{
-			UE_LOG(LogSpatialGDKSchemaGenerator, Error, TEXT("Schema Generation failed: Schema Database at %s%s is read only. Make writable before generating schema"), *SchemaDatabasePackagePath, *FPackageName::GetAssetPackageExtension());
+			UE_LOG(LogSpatialGDKSchemaGenerator, Error, TEXT("Schema Generation failed: Schema Database at %s%s is read only. Make it writable before generating schema"), *SchemaDatabasePackagePath, *FPackageName::GetAssetPackageExtension());
 			return false;
 		}
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -496,15 +496,13 @@ bool TryLoadExistingSchemaDatabase()
 	const FString SchemaDatabaseAssetPath = FString::Printf(TEXT("%s.SchemaDatabase"), *SchemaDatabasePackagePath);
 	const FString SchemaDatabaseFileName = FPackageName::LongPackageNameToFilename(SchemaDatabasePackagePath, FPackageName::GetAssetPackageExtension());
 
-	IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
-
-	FFileStatData StatData = PlatformFile.GetStatData(*SchemaDatabaseFileName);
+	FFileStatData StatData = FPlatformFileManager::Get().GetPlatformFile().GetStatData(*SchemaDatabaseFileName);
 
 	if (StatData.bIsValid)
 	{
 		if (StatData.bIsReadOnly)
 		{
-			UE_LOG(LogSpatialGDKSchemaGenerator, Error, TEXT("Schema Database at %s%s is not writable."), *SchemaDatabasePackagePath, *FPackageName::GetAssetPackageExtension());
+			UE_LOG(LogSpatialGDKSchemaGenerator, Error, TEXT("Schema Generation failed: Schema Database at %s%s is read only. Make writable before generating schema"), *SchemaDatabasePackagePath, *FPackageName::GetAssetPackageExtension());
 			return false;
 		}
 
@@ -512,7 +510,7 @@ bool TryLoadExistingSchemaDatabase()
 
 		if (SchemaDatabase == nullptr)
 		{
-			UE_LOG(LogSpatialGDKSchemaGenerator, Error, TEXT("Failed to load existing schema database."));
+			UE_LOG(LogSpatialGDKSchemaGenerator, Error, TEXT("Schema Generation failed: Failed to load existing schema database."));
 			return false;
 		}
 
@@ -531,7 +529,7 @@ bool TryLoadExistingSchemaDatabase()
 	}
 	else
 	{
-		UE_LOG(LogSpatialGDKSchemaGenerator, Log, TEXT("SchemaDatabase not found so the generated schema directory will be cleared out if it exists."));
+		UE_LOG(LogSpatialGDKSchemaGenerator, Display, TEXT("SchemaDatabase not found so the generated schema directory will be cleared out if it exists."));
 		ClearGeneratedSchema();
 	}
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
@@ -56,6 +56,12 @@ bool FSpatialGDKEditor::GenerateSchema(bool bFullScan)
 
 	RemoveEditorAssetLoadedCallback();
 
+	if (!TryLoadExistingSchemaDatabase())
+	{
+		bSchemaGeneratorRunning = false;
+		return false;
+	}
+
 	TArray<TStrongObjectPtr<UObject>> LoadedAssets;
 	if (bFullScan)
 	{
@@ -76,8 +82,6 @@ bool FSpatialGDKEditor::GenerateSchema(bool bFullScan)
 		const bool bPromptForCompilation = false;
 		UEditorEngine::ResolveDirtyBlueprints(bPromptForCompilation, ErroredBlueprints);
 	}
-
-	TryLoadExistingSchemaDatabase();
 
 	Progress.EnterProgressFrame(bFullScan ? 10.f : 100.f);
 	bool bResult = SpatialGDKGenerateSchema();

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSchemaGenerator.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSchemaGenerator.h
@@ -10,4 +10,4 @@ SPATIALGDKEDITOR_API bool SpatialGDKGenerateSchema();
 
 SPATIALGDKEDITOR_API void ClearGeneratedSchema();
 
-SPATIALGDKEDITOR_API void TryLoadExistingSchemaDatabase();
+SPATIALGDKEDITOR_API bool TryLoadExistingSchemaDatabase();


### PR DESCRIPTION
#### Description
https://improbableio.atlassian.net/browse/UNR-1410

Schema generation crashes if schema database asset is readonly. This PR adds a check before doing any schema generation and fails early if the asset is not writable, printing an informative error message.

#### Release note
- Fixed an issue causing the editor to crash during schema generation if the database is readonly.

#### Tests
Tested in editor with database set to readonly via explorer.