### PR TITLE
[DOC-1086] - add "Server" to Linux server worker build

### DIFF
--- a/SpatialGDK/Documentation/content/get-started/gdk-template.md
+++ b/SpatialGDK/Documentation/content/get-started/gdk-template.md
@@ -142,7 +142,7 @@ You can find out more about the [Console]({{urlRoot}}/content/glossary#console) 
 1. In a terminal window, navigate to your `<ProjectRoot>` directory.
 2. Build a server-worker assembly by running the following command: 
 ```
-Game\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat YourProject Linux Development YourProject.uproject
+Game\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat YourProjectServer Linux Development YourProject.uproject
 ```
 3. Build a client-worker assembly by running the following command: 
 ```


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
[DOC-1086] - add "Server" to Linux server worker build

This fixes a defect where users are instructed to build a useless standalone Linux client.

#### Tests
With this fix this command works and I was able to cloud deploy. Without it I received a fatal error (cannot find UnrealWorker@Linux.zip)

#### Documentation
This is documentation lads.