### PR TITLE
[UNR-1010] Fix crash when retrying reliable RPCs with destroyed argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue with schema name collisions.
 - Running Schema (Full Scan) now clears generated schema files first.
 - Singletons authority and state resumes correct when reconnecting servers to snapshot.
+- Fixed a crash when retrying reliable RPCs with UObject arguments that got destroyed before the RPC was retried.
 
 ### External contributors:
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1051,14 +1051,14 @@ void USpatialReceiver::FlushRetryRPCs()
 
 void USpatialReceiver::ReceiveCommandResponse(Worker_CommandResponseOp& Op)
 {
-	TSharedRef<FPendingRPCParams>* ReliableRPCPtr = PendingReliableRPCs.Find(Op.request_id);
+	TSharedRef<FReliableRPCForRetry>* ReliableRPCPtr = PendingReliableRPCs.Find(Op.request_id);
 	if (ReliableRPCPtr == nullptr)
 	{
-		// We received a response for an unreliable RPC, ignore.
+		// We received a response for some other command, ignore.
 		return;
 	}
 
-	TSharedRef<FPendingRPCParams> ReliableRPC = *ReliableRPCPtr;
+	TSharedRef<FReliableRPCForRetry> ReliableRPC = *ReliableRPCPtr;
 	PendingReliableRPCs.Remove(Op.request_id);
 	if (Op.status_code != WORKER_STATUS_CODE_SUCCESS)
 	{
@@ -1243,9 +1243,9 @@ void USpatialReceiver::AddPendingActorRequest(Worker_RequestId RequestId, USpati
 	PendingActorRequests.Add(RequestId, Channel);
 }
 
-void USpatialReceiver::AddPendingReliableRPC(Worker_RequestId RequestId, TSharedRef<FPendingRPCParams> Params)
+void USpatialReceiver::AddPendingReliableRPC(Worker_RequestId RequestId, TSharedRef<FReliableRPCForRetry> ReliableRPC)
 {
-	PendingReliableRPCs.Add(RequestId, Params);
+	PendingReliableRPCs.Add(RequestId, ReliableRPC);
 }
 
 void USpatialReceiver::AddEntityQueryDelegate(Worker_RequestId RequestId, EntityQueryDelegate Delegate)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -524,7 +524,7 @@ void USpatialSender::SendRPC(TSharedRef<FPendingRPCParams> Params)
 		if (!UnresolvedObject)
 		{
 			check(EntityId != SpatialConstants::INVALID_ENTITY_ID);
-			Worker_RequestId RequestId = Connection->SendCommandRequest(EntityId, &CommandRequest, RPCInfo->Index + 1);
+			Worker_RequestId RequestId = Connection->SendCommandRequest(EntityId, &CommandRequest, SpatialConstants::UNREAL_RPC_ENDPOINT_COMMAND_ID);
 
 			if (Params->Function->HasAnyFunctionFlags(FUNC_NetReliable))
 			{
@@ -618,7 +618,7 @@ void USpatialSender::RetryReliableRPC(TSharedRef<FReliableRPCForRetry> RetryRPC)
 	}
 
 	Worker_CommandRequest CommandRequest = CreateRetryRPCCommandRequest(*RetryRPC, TargetObjectRef.Offset);
-	Worker_RequestId RequestId = Connection->SendCommandRequest(TargetObjectRef.Entity, &CommandRequest, RetryRPC->RPCIndex + 1);
+	Worker_RequestId RequestId = Connection->SendCommandRequest(TargetObjectRef.Entity, &CommandRequest, SpatialConstants::UNREAL_RPC_ENDPOINT_COMMAND_ID);
 
 	// The number of attempts is used to determine the delay in case the command times out and we need to resend it.
 	RetryRPC->Attempts++;

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -37,7 +37,6 @@ DECLARE_CYCLE_STAT(TEXT("QueueOutgoingUpdate"), STAT_SpatialSenderQueueOutgoingU
 FPendingRPCParams::FPendingRPCParams(UObject* InTargetObject, UFunction* InFunction, void* InParameters, int InRetryIndex)
 	: TargetObject(InTargetObject)
 	, Function(InFunction)
-	, Attempts(0)
 	, RetryIndex(InRetryIndex)
 	, ReliableRPCIndex(0)
 {
@@ -56,6 +55,17 @@ FPendingRPCParams::~FPendingRPCParams()
 	{
 		It->DestroyValue_InContainer(Parameters.GetData());
 	}
+}
+
+FReliableRPCForRetry::FReliableRPCForRetry(UObject* InTargetObject, UFunction* InFunction, Worker_ComponentId InComponentId, Schema_FieldId InRPCIndex, TArray<uint8>&& InPayload, int InRetryIndex)
+	: TargetObject(InTargetObject)
+	, Function(InFunction)
+	, ComponentId(InComponentId)
+	, RPCIndex(InRPCIndex)
+	, Payload(MoveTemp(InPayload))
+	, Attempts(1)
+	, RetryIndex(InRetryIndex)
+{
 }
 
 void USpatialSender::Init(USpatialNetDriver* InNetDriver)
@@ -508,7 +518,8 @@ void USpatialSender::SendRPC(TSharedRef<FPendingRPCParams> Params)
 	{
 		Worker_ComponentId ComponentId = RPCInfo->Type == SCHEMA_ClientReliableRPC ? SpatialConstants::CLIENT_RPC_ENDPOINT_COMPONENT_ID : SpatialConstants::SERVER_RPC_ENDPOINT_COMPONENT_ID;
 
-		Worker_CommandRequest CommandRequest = CreateRPCCommandRequest(TargetObject, Params->Function, Params->Parameters.GetData(), ComponentId, RPCInfo->Index, EntityId, UnresolvedObject, Params->ReliableRPCIndex);
+		TArray<uint8> Payload;
+		Worker_CommandRequest CommandRequest = CreateRPCCommandRequest(TargetObject, Params->Function, Params->Parameters.GetData(), ComponentId, RPCInfo->Index, EntityId, UnresolvedObject, Payload, Params->ReliableRPCIndex);
 
 		if (!UnresolvedObject)
 		{
@@ -518,10 +529,8 @@ void USpatialSender::SendRPC(TSharedRef<FPendingRPCParams> Params)
 			if (Params->Function->HasAnyFunctionFlags(FUNC_NetReliable))
 			{
 				UE_LOG(LogSpatialSender, Verbose, TEXT("Sending reliable command request (entity: %lld, component: %d, function: %s, attempt: %d)"),
-					EntityId, CommandRequest.component_id, *Params->Function->GetName(), Params->Attempts + 1);
-				// The number of attempts is used to determine the delay in case the command times out and we need to resend it.
-				Params->Attempts++;
-				Receiver->AddPendingReliableRPC(RequestId, Params);
+					EntityId, CommandRequest.component_id, *Params->Function->GetName(), 1);
+				Receiver->AddPendingReliableRPC(RequestId, MakeShared<FReliableRPCForRetry>(TargetObject, Params->Function, ComponentId, RPCInfo->Index, MoveTemp(Payload), Params->RetryIndex));
 			}
 			else
 			{
@@ -576,20 +585,46 @@ void USpatialSender::SendRPC(TSharedRef<FPendingRPCParams> Params)
 	}
 }
 
-void USpatialSender::EnqueueRetryRPC(TSharedRef<FPendingRPCParams> Params)
+void USpatialSender::EnqueueRetryRPC(TSharedRef<FReliableRPCForRetry> RetryRPC)
 {
-	RetryRPCs.Add(Params);
+	RetryRPCs.Add(RetryRPC);
 }
 
 void USpatialSender::FlushRetryRPCs()
 {
 	// Retried RPCs are sorted by their index.
-	RetryRPCs.Sort([](const TSharedPtr<FPendingRPCParams>& A, const TSharedPtr<FPendingRPCParams>& B) { return A->RetryIndex < B->RetryIndex; });
+	RetryRPCs.Sort([](const TSharedRef<FReliableRPCForRetry>& A, const TSharedRef<FReliableRPCForRetry>& B) { return A->RetryIndex < B->RetryIndex; });
 	for (auto& RetryRPC : RetryRPCs)
 	{
-		SendRPC(RetryRPC);
+		RetryReliableRPC(RetryRPC);
 	}
 	RetryRPCs.Empty();
+}
+
+void USpatialSender::RetryReliableRPC(TSharedRef<FReliableRPCForRetry> RetryRPC)
+{
+	if (!RetryRPC->TargetObject.IsValid())
+	{
+		// Target object was destroyed before the RPC could be (re)sent
+		return;
+	}
+
+	UObject* TargetObject = RetryRPC->TargetObject.Get();
+	FUnrealObjectRef TargetObjectRef = PackageMap->GetUnrealObjectRefFromObject(TargetObject);
+	if (TargetObjectRef == FUnrealObjectRef::UNRESOLVED_OBJECT_REF)
+	{
+		UE_LOG(LogSpatialSender, Warning, TEXT("Actor %s got unresolved (?) before RPC %s could be retried. This RPC will not be sent."), *TargetObject->GetName(), *RetryRPC->Function->GetName());
+		return;
+	}
+
+	Worker_CommandRequest CommandRequest = CreateRetryRPCCommandRequest(*RetryRPC, TargetObjectRef.Offset);
+	Worker_RequestId RequestId = Connection->SendCommandRequest(TargetObjectRef.Entity, &CommandRequest, RetryRPC->RPCIndex + 1);
+
+	// The number of attempts is used to determine the delay in case the command times out and we need to resend it.
+	RetryRPC->Attempts++;
+	UE_LOG(LogSpatialSender, Verbose, TEXT("Sending reliable command request (entity: %lld, component: %d, function: %s, attempt: %d)"),
+		TargetObjectRef.Entity, RetryRPC->ComponentId, *RetryRPC->Function->GetName(), RetryRPC->Attempts);
+	Receiver->AddPendingReliableRPC(RequestId, RetryRPC);
 }
 
 void USpatialSender::SendCreateEntityRequest(USpatialActorChannel* Channel)
@@ -741,7 +776,7 @@ FSpatialNetBitWriter USpatialSender::PackRPCDataToSpatialNetBitWriter(UFunction*
 	return PayloadWriter;
 }
 
-Worker_CommandRequest USpatialSender::CreateRPCCommandRequest(UObject* TargetObject, UFunction* Function, void* Parameters, Worker_ComponentId ComponentId, Schema_FieldId CommandIndex, Worker_EntityId& OutEntityId, const UObject*& OutUnresolvedObject, int ReliableRPCId)
+Worker_CommandRequest USpatialSender::CreateRPCCommandRequest(UObject* TargetObject, UFunction* Function, void* Parameters, Worker_ComponentId ComponentId, Schema_FieldId CommandIndex, Worker_EntityId& OutEntityId, const UObject*& OutUnresolvedObject, TArray<uint8>& OutPayload, int ReliableRPCId)
 {
 	Worker_CommandRequest CommandRequest = {};
 	CommandRequest.component_id = ComponentId;
@@ -773,6 +808,21 @@ Worker_CommandRequest USpatialSender::CreateRPCCommandRequest(UObject* TargetObj
 	}
 
 	RPCPayload::WriteToSchemaObject(RequestObject, TargetObjectRef.Offset, CommandIndex, PayloadWriter.GetData(), PayloadWriter.GetNumBytes());
+	// Save payload in case we need to retry later.
+	OutPayload = TArray<uint8>(PayloadWriter.GetData(), PayloadWriter.GetNumBytes());
+
+	return CommandRequest;
+}
+
+Worker_CommandRequest USpatialSender::CreateRetryRPCCommandRequest(const FReliableRPCForRetry& RPC, uint32 TargetObjectOffset)
+{
+	Worker_CommandRequest CommandRequest = {};
+	CommandRequest.component_id = RPC.ComponentId;
+	CommandRequest.schema_type = Schema_CreateCommandRequest(RPC.ComponentId, SpatialConstants::UNREAL_RPC_ENDPOINT_COMMAND_ID);
+	Schema_Object* RequestObject = Schema_GetCommandRequestObject(CommandRequest.schema_type);
+
+	RPCPayload::WriteToSchemaObject(RequestObject, TargetObjectOffset, RPC.RPCIndex, RPC.Payload.GetData(), RPC.Payload.Num());
+
 	return CommandRequest;
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -528,8 +528,8 @@ void USpatialSender::SendRPC(TSharedRef<FPendingRPCParams> Params)
 
 			if (Params->Function->HasAnyFunctionFlags(FUNC_NetReliable))
 			{
-				UE_LOG(LogSpatialSender, Verbose, TEXT("Sending reliable command request (entity: %lld, component: %d, function: %s, attempt: %d)"),
-					EntityId, CommandRequest.component_id, *Params->Function->GetName(), 1);
+				UE_LOG(LogSpatialSender, Verbose, TEXT("Sending reliable command request (entity: %lld, component: %d, function: %s, attempt: 1)"),
+					EntityId, CommandRequest.component_id, *Params->Function->GetName());
 				Receiver->AddPendingReliableRPC(RequestId, MakeShared<FReliableRPCForRetry>(TargetObject, Params->Function, ComponentId, RPCInfo->Index, MoveTemp(Payload), Params->RetryIndex));
 			}
 			else

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -120,7 +120,7 @@ public:
 	void OnCreateEntityResponse(Worker_CreateEntityResponseOp& Op);
 
 	void AddPendingActorRequest(Worker_RequestId RequestId, USpatialActorChannel* Channel);
-	void AddPendingReliableRPC(Worker_RequestId RequestId, TSharedRef<struct FPendingRPCParams> Params);
+	void AddPendingReliableRPC(Worker_RequestId RequestId, TSharedRef<struct FReliableRPCForRetry> ReliableRPC);
 
 	void AddEntityQueryDelegate(Worker_RequestId RequestId, EntityQueryDelegate Delegate);
 	void AddReserveEntityIdsDelegate(Worker_RequestId RequestId, ReserveEntityIDsDelegate Delegate);

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -27,6 +27,9 @@ class USpatialStaticComponentView;
 class USpatialClassInfoManager;
 class USpatialWorkerConnection;
 
+// This is currently only really used for queuing outgoing RPCs in case they have unresolved target object
+// or arguments. This is only possible for singletons in a multi-worker scenario.
+// TODO: remove this logic when singletons can be referenced without entity IDs (UNR-1456).
 struct FPendingRPCParams
 {
 	FPendingRPCParams(UObject* InTargetObject, UFunction* InFunction, void* InParameters, int InRetryIndex);

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialCommonTypes.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialCommonTypes.h
@@ -18,4 +18,4 @@ using WriteAclMap = TMap<Worker_ComponentId, WorkerRequirementSet>;
 using FChannelObjectPair = TPair<TWeakObjectPtr<class USpatialActorChannel>, TWeakObjectPtr<UObject>>;
 struct FObjectReferences;
 using FObjectReferencesMap = TMap<int32, FObjectReferences>;
-using FReliableRPCMap = TMap<Worker_RequestId, TSharedRef<struct FPendingRPCParams>>;
+using FReliableRPCMap = TMap<Worker_RequestId, TSharedRef<struct FReliableRPCForRetry>>;


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Fixed a crash when retrying reliable RPCs with UObject arguments that got destroyed before the RPC was retried.

#### Tests
I set up a test in ThirdPersonShooter where I would spawn a box, shoot at it, and destroy the box.
In one case, I made 20% of commands timeout by doing a random early return in `SpatialReceiver::OnCommandRequest` that would not send a command response (effectively making Runtime think the command timed out). The commands were then retried and applied correctly.
In the other case, I made all `ServerDidHit` RPCs timeout by doing an early return for this particular RPC. This let me reproduce the crash on master, and then confirm that the crash no longer happens on my branch.

#### Documentation
Release note

#### Primary reviewers
@m-samiec @aleximprobable 