### PR TITLE
Extend BuildKite cleanup

### DIFF
--- a/ci/purge.ps1
+++ b/ci/purge.ps1
@@ -28,7 +28,7 @@ function Kill-Dangling-Processes {
 	}
 }
 
-$ProcessesToKill = @("AutomationToolLauncher")
+$ProcessesToKill = @("AutomationToolLauncher", "UnrealHeaderTool")
 
 ForEach ($Process in $ProcessesToKill)
 {


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Clean up `UnrealHeaderTool` if it's still running after the testing is finished. Otherwise this leads to locked files on the BK agent, which causes all later builds to fail.

#### Primary reviewers
@oblm 