### PR TITLE
Bugfix/fix snapshot reloading crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Running Schema (Full Scan) now clears generated schema files first.
 - Singletons authority and state resumes correct when reconnecting servers to snapshot.
 - Fixed a crash when retrying reliable RPCs with UObject arguments that got destroyed before the RPC was retried.
+- Fixed assert/crash in SpatialMetricsDisplay that occurred when reloading a snapshot.
 
 ### External contributors:
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetricsDisplay.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetricsDisplay.h
@@ -57,5 +57,6 @@ private:
 	UFUNCTION(CrossServer, Unreliable, WithValidation)
 	virtual void ServerUpdateWorkerStats(const float Time, const FWorkerStats& OneWorkerStats);
 
+	bool ShouldRemoveStats(const float CurrentTime, const FWorkerStats& OneWorkerStats) const;
 	void DrawDebug(class UCanvas* Canvas, APlayerController* Controller);
 };


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
This change fixes an assert/crash that fires inside SpatialMetricsDisplay due to an assumption that a worker name will be present in an internal data structure.  This assumption is incorrect in the case of a snapshot reload.  Longer term we will stop saving this structure into the snapshots, but the functionality to do that doesn't currently exist.

#### Release note
Added to CHANGELOG.md

#### Tests
Verified with my small test level in PIE with the following steps:

1. Launch Local SpatialOS deployment with managed worker (don't connect client)
2. After deployment loads, kill managed worker via inspector
3. Observe that when the worker reloads, it doesn't crash

STRONGLY SUGGESTED: It can be verified as above.

#### Documentation
This fix is documented in CHANGELOG.md

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.