### PR TITLE
Feature/switch metrics to frame time

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetricsDisplay.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetricsDisplay.cpp
@@ -72,7 +72,7 @@ void ASpatialMetricsDisplay::DrawDebug(class UCanvas* Canvas, APlayerController*
 	enum StatColumns
 	{
 		StatColumn_Worker,
-		StatColumn_AverageFPS,
+		StatColumn_AverageFrameTime,
 		StatColumn_WorkerLoad,
 		StatColumn_Last
 	};
@@ -80,7 +80,7 @@ void ASpatialMetricsDisplay::DrawDebug(class UCanvas* Canvas, APlayerController*
 	const uint32 StatDisplayStartX = 25;
 	const uint32 StatDisplayStartY = 80;
 
-	const FString StatColumnTitles[StatColumn_Last] = { TEXT("Worker"), TEXT("FPS"), TEXT("Load") };
+	const FString StatColumnTitles[StatColumn_Last] = { TEXT("Worker"), TEXT("Frame"), TEXT("Load") };
 	const uint32 StatColumnOffsets[StatColumn_Last] = { 0, 160, 80 };
 	const uint32 StatRowOffset = 20;
 
@@ -116,8 +116,8 @@ void ASpatialMetricsDisplay::DrawDebug(class UCanvas* Canvas, APlayerController*
 		DrawX = StatDisplayStartX + StatColumnOffsets[StatColumn_Worker];
 		Canvas->DrawText(RenderFont, FString::Printf(TEXT("%s"), *OneWorkerStats.WorkerName), DrawX, DrawY, 1.0f, 1.0f, FontRenderInfo);
 
-		DrawX += StatColumnOffsets[StatColumn_AverageFPS];
-		Canvas->DrawText(RenderFont, FString::Printf(TEXT("%.2f"), OneWorkerStats.AverageFPS), DrawX, DrawY, 1.0f, 1.0f, FontRenderInfo);
+		DrawX += StatColumnOffsets[StatColumn_AverageFrameTime];
+		Canvas->DrawText(RenderFont, FString::Printf(TEXT("%.2f ms"), 1000.f / OneWorkerStats.AverageFPS), DrawX, DrawY, 1.0f, 1.0f, FontRenderInfo);
 
 		DrawX += StatColumnOffsets[StatColumn_WorkerLoad];
 		Canvas->DrawText(RenderFont, FString::Printf(TEXT("%.2f"), OneWorkerStats.WorkerLoad), DrawX, DrawY, 1.0f, 1.0f, FontRenderInfo);

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetricsDisplay.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetricsDisplay.cpp
@@ -143,7 +143,7 @@ void ASpatialMetricsDisplay::Tick(float DeltaSeconds)
 {
 	Super::Tick(DeltaSeconds);
 
-	if (!GetWorld()->IsServer())
+	if (!GetWorld()->IsServer() || !HasActorBegunPlay())
 	{
 		return;
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetricsDisplay.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetricsDisplay.cpp
@@ -85,7 +85,6 @@ void ASpatialMetricsDisplay::DrawDebug(class UCanvas* Canvas, APlayerController*
 	{
 		StatColumn_Worker,
 		StatColumn_AverageFrameTime,
-		StatColumn_WorkerLoad,
 		StatColumn_MovementCorrections,
 		StatColumn_Last
 	};
@@ -93,8 +92,8 @@ void ASpatialMetricsDisplay::DrawDebug(class UCanvas* Canvas, APlayerController*
 	const uint32 StatDisplayStartX = 25;
 	const uint32 StatDisplayStartY = 80;
 
-	const FString StatColumnTitles[StatColumn_Last] = { TEXT("Worker"), TEXT("Frame"), TEXT("Load"), TEXT("Movement Corrections") };
-	const uint32 StatColumnOffsets[StatColumn_Last] = { 0, 160, 80, 50 };
+	const FString StatColumnTitles[StatColumn_Last] = { TEXT("Worker"), TEXT("Frame"), TEXT("Movement Corrections") };
+	const uint32 StatColumnOffsets[StatColumn_Last] = { 0, 160, 80 };
 	const uint32 StatRowOffset = 20;
 
 	const FString StatSectionTitle = TEXT("Spatial Metrics Display");
@@ -131,9 +130,6 @@ void ASpatialMetricsDisplay::DrawDebug(class UCanvas* Canvas, APlayerController*
 
 		DrawX += StatColumnOffsets[StatColumn_AverageFrameTime];
 		Canvas->DrawText(RenderFont, FString::Printf(TEXT("%.2f ms"), 1000.f / OneWorkerStats.AverageFPS), DrawX, DrawY, 1.0f, 1.0f, FontRenderInfo);
-
-		DrawX += StatColumnOffsets[StatColumn_WorkerLoad];
-		Canvas->DrawText(RenderFont, FString::Printf(TEXT("%.2f"), OneWorkerStats.WorkerLoad), DrawX, DrawY, 1.0f, 1.0f, FontRenderInfo);
 
 		DrawX += StatColumnOffsets[StatColumn_MovementCorrections];
 		Canvas->DrawText(RenderFont, FString::Printf(TEXT("%.4f"), OneWorkerStats.ServerMovementCorrections), DrawX, DrawY, 1.0f, 1.0f, FontRenderInfo);
@@ -200,7 +196,6 @@ void ASpatialMetricsDisplay::Tick(float DeltaSeconds)
 	FWorkerStats Stats{};
 	Stats.WorkerName = SpatialNetDriver->Connection->GetWorkerId().Left(WorkerNameMaxLength).ToLower();
 	Stats.AverageFPS = Metrics.GetAverageFPS();
-	Stats.WorkerLoad = Metrics.GetWorkerLoad();
 
 #if USE_SERVER_PERF_COUNTERS
 	float MovementCorrectionsPerSecond = 0.f;
@@ -210,8 +205,8 @@ void ASpatialMetricsDisplay::Tick(float DeltaSeconds)
 	MovementCorrectionRecord OldestRecord;
 	if (MovementCorrectionRecords.Peek(OldestRecord))
 	{
-		float WorldTimeDelta = WorldTime - OldestRecord.Time;
-		int32 CorrectionsDelta = NumServerMoveCorrections - OldestRecord.MovementCorrections;
+		const float WorldTimeDelta = WorldTime - OldestRecord.Time;
+		const int32 CorrectionsDelta = NumServerMoveCorrections - OldestRecord.MovementCorrections;
 		if (WorldTimeDelta > 0.f && CorrectionsDelta > 0)
 		{
 			MovementCorrectionsPerSecond = CorrectionsDelta / WorldTimeDelta;

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetricsDisplay.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetricsDisplay.cpp
@@ -8,8 +8,11 @@
 #include "EngineClasses/SpatialNetDriver.h"
 #include "Interop/Connection/SpatialWorkerConnection.h"
 #include "Net/UnrealNetwork.h"
-#include "Net/PerfCountersHelpers.h"
 #include "Utils/SpatialMetrics.h"
+
+#if USE_SERVER_PERF_COUNTERS
+#include "Net/PerfCountersHelpers.h"
+#endif
 
 ASpatialMetricsDisplay::ASpatialMetricsDisplay(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
@@ -207,8 +210,8 @@ void ASpatialMetricsDisplay::Tick(float DeltaSeconds)
 	MovementCorrectionRecord OldestRecord;
 	if (MovementCorrectionRecords.Peek(OldestRecord))
 	{
-		float WorldTimeDelta = OldestRecord.Time - WorldTime;
-		int32 CorrectionsDelta = OldestRecord.MovementCorrections - NumServerMoveCorrections;
+		float WorldTimeDelta = WorldTime - OldestRecord.Time;
+		int32 CorrectionsDelta = NumServerMoveCorrections - OldestRecord.MovementCorrections;
 		if (WorldTimeDelta > 0.f && CorrectionsDelta > 0)
 		{
 			MovementCorrectionsPerSecond = CorrectionsDelta / WorldTimeDelta;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetricsDisplay.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetricsDisplay.h
@@ -17,6 +17,8 @@ struct FWorkerStats
 	float AverageFPS;
 	UPROPERTY()
 	float WorkerLoad;
+	UPROPERTY()
+	int32 ServerMovementCorrections;
 
 	bool operator==(const FWorkerStats& other) const
 	{

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetricsDisplay.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetricsDisplay.h
@@ -18,8 +18,6 @@ struct FWorkerStats
 	UPROPERTY()
 	float AverageFPS;
 	UPROPERTY()
-	float WorkerLoad;
-	UPROPERTY()
 	float ServerMovementCorrections; // per second
 
 	bool operator==(const FWorkerStats& other) const

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetricsDisplay.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetricsDisplay.h
@@ -18,7 +18,7 @@ struct FWorkerStats
 	UPROPERTY()
 	float WorkerLoad;
 	UPROPERTY()
-	int32 ServerMovementCorrections;
+	float ServerMovementCorrections; // per second
 
 	bool operator==(const FWorkerStats& other) const
 	{
@@ -60,4 +60,11 @@ private:
 	virtual void ServerUpdateWorkerStats(const float Time, const FWorkerStats& OneWorkerStats);
 
 	void DrawDebug(class UCanvas* Canvas, APlayerController* Controller);
+
+	struct MovementCorrectionRecord
+	{
+		int32 MovementCorrections;
+		float Time;
+	};
+	TQueue<MovementCorrectionRecord> MovementCorrectionRecords;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetricsDisplay.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetricsDisplay.h
@@ -3,7 +3,9 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Containers/Queue.h"
 #include "GameFramework/Info.h"
+
 #include "SpatialMetricsDisplay.generated.h"
 
 USTRUCT()

--- a/SpatialGDK/Source/SpatialGDK/SpatialGDK.Build.cs
+++ b/SpatialGDK/Source/SpatialGDK/SpatialGDK.Build.cs
@@ -36,6 +36,11 @@ public class SpatialGDK : ModuleRules
 			PublicDependencyModuleNames.Add("SpatialGDKEditorToolbar");
 		}
 
+        if (Target.bWithPerfCounters)
+        {
+            PublicDependencyModuleNames.Add("PerfCounters");
+        }
+
         var WorkerLibraryDir = Path.GetFullPath(Path.Combine(ModuleDirectory, "..", "..", "Binaries", "ThirdParty", "Improbable", Target.Platform.ToString()));
 
         string LibPrefix = "";


### PR DESCRIPTION
#### Description
Add server movement corrections to spatial metrics display
Switched FPS to Frametime
Fixed issue where metrics could be updated before begin play was called.

#### Tests
Ran this in AIGym to see metrics.

#### Primary reviewers
@cmsmithio @girayimprobable 