### PR TITLE
Add auto spawn option to spatial metrics display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features:
 - Added SpatialMetricsDisplay class, which allows you to view UnrealWorker stats as an overlay on the client.
-- Added runtime option to disable property handover when running in non-zoned deployments.
+- Added runtime option to disable property handover when running in non-zoned deployments - bEnableHandover.
+- Added runtime option to auto spawn the ASpatialMetricsDisplay for remote debugging of server metrics - bEnableMetricsDisplay.
 - Added runtime option to batch spatial position updates to runtime.
 
 ### Bug fixes:

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -250,11 +250,13 @@ void USpatialNetDriver::CreateAndInitializeCoreClasses()
 	SnapshotManager = NewObject<USnapshotManager>();
 	SpatialMetrics = NewObject<USpatialMetrics>();
 
+#if !UE_BUILD_SHIPPING
 	// If metrics display is enabled, spawn a singleton actor to replicate the information to each client
 	if (IsServer() && GetDefault<USpatialGDKSettings>()->bEnableMetricsDisplay)
 	{
 		SpatialMetricsDisplay = GetWorld()->SpawnActor<ASpatialMetricsDisplay>();
 	}
+#endif
 
 	PackageMap = Cast<USpatialPackageMapClient>(GetSpatialOSNetConnection()->PackageMap);
 	PackageMap->Init(this);

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -33,6 +33,7 @@
 #include "Utils/EngineVersionCheck.h"
 #include "Utils/EntityPool.h"
 #include "Utils/SpatialMetrics.h"
+#include "Utils/SpatialMetricsDisplay.h"
 
 DEFINE_LOG_CATEGORY(LogSpatialOSNetDriver);
 
@@ -271,6 +272,12 @@ void USpatialNetDriver::CreateServerSpatialOSNetConnection()
 	check(!bConnectAsClient);
 
 	EntityPool = NewObject<UEntityPool>();
+
+	// If metrics display is enabled, spawn a singleton actor to replicate the information to each client
+	if (GetDefault<USpatialGDKSettings>()->bEnableMetricsDisplay)
+	{
+		SpatialMetricsDisplay = GetWorld()->SpawnActor<ASpatialMetricsDisplay>();
+	}
 
 	USpatialNetConnection* NetConnection = NewObject<USpatialNetConnection>(GetTransientPackage(), NetConnectionClass);
 	check(NetConnection);

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -250,6 +250,12 @@ void USpatialNetDriver::CreateAndInitializeCoreClasses()
 	SnapshotManager = NewObject<USnapshotManager>();
 	SpatialMetrics = NewObject<USpatialMetrics>();
 
+	// If metrics display is enabled, spawn a singleton actor to replicate the information to each client
+	if (IsServer() && GetDefault<USpatialGDKSettings>()->bEnableMetricsDisplay)
+	{
+		SpatialMetricsDisplay = GetWorld()->SpawnActor<ASpatialMetricsDisplay>();
+	}
+
 	PackageMap = Cast<USpatialPackageMapClient>(GetSpatialOSNetConnection()->PackageMap);
 	PackageMap->Init(this);
 	Dispatcher->Init(this);
@@ -272,12 +278,6 @@ void USpatialNetDriver::CreateServerSpatialOSNetConnection()
 	check(!bConnectAsClient);
 
 	EntityPool = NewObject<UEntityPool>();
-
-	// If metrics display is enabled, spawn a singleton actor to replicate the information to each client
-	if (GetDefault<USpatialGDKSettings>()->bEnableMetricsDisplay)
-	{
-		SpatialMetricsDisplay = GetWorld()->SpawnActor<ASpatialMetricsDisplay>();
-	}
 
 	USpatialNetConnection* NetConnection = NewObject<USpatialNetConnection>(GetTransientPackage(), NetConnectionClass);
 	check(NetConnection);

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -24,6 +24,7 @@ USpatialGDKSettings::USpatialGDKSettings(const FObjectInitializer& ObjectInitial
 	, PositionUpdateFrequency(1.0f)
 	, PositionDistanceThreshold(100.0f) // 1m (100cm)
 	, bEnableMetrics(true)
+	, bEnableMetricsDisplay(false)
 	, MetricsReportRate(2.0f)
 	, bUseFrameTimeAsLoad(false)
 	, bCheckRPCOrder(false)

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetricsDisplay.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetricsDisplay.cpp
@@ -40,6 +40,11 @@ void ASpatialMetricsDisplay::BeginPlay()
 
 	WorkerStats.Reserve(PreallocatedWorkerCount);
 	WorkerStatsLastUpdateTime.Reserve(PreallocatedWorkerCount);
+
+	if (!GetWorld()->IsServer() && GetDefault<USpatialGDKSettings>()->bEnableMetricsDisplay)
+	{
+		ToggleStatDisplay();
+	}
 }
 
 void ASpatialMetricsDisplay::Destroyed()

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -32,6 +32,7 @@ class USpatialPlayerSpawner;
 class USpatialStaticComponentView;
 class USnapshotManager;
 class USpatialMetrics;
+class ASpatialMetricsDisplay;
 
 class UEntityPool;
 
@@ -125,6 +126,8 @@ public:
 	UEntityPool* EntityPool;
 	UPROPERTY()
 	USpatialMetrics* SpatialMetrics;
+	UPROPERTY()
+	ASpatialMetricsDisplay* SpatialMetricsDisplay;
 
 	TMap<UClass*, TPair<AActor*, USpatialActorChannel*>> SingletonActorChannels;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -79,6 +79,10 @@ public:
 	UPROPERTY(EditAnywhere, config, Category = "Metrics", meta = (ConfigRestartRequired = false))
 	bool bEnableMetrics;
 
+	/** Display server metrics on clients.*/
+	UPROPERTY(EditAnywhere, config, Category = "Metrics", meta = (ConfigRestartRequired = false))
+	bool bEnableMetricsDisplay;
+
 	/** Frequency that metrics are reported to SpatialOS.*/
 	UPROPERTY(EditAnywhere, config, Category = "Metrics", meta = (ConfigRestartRequired = false), DisplayName = "Metrics Report Rate (seconds)")
 	float MetricsReportRate;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetricsDisplay.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetricsDisplay.h
@@ -26,7 +26,7 @@ struct FWorkerStats
 	}
 };
 
-UCLASS()
+UCLASS(SpatialType=Singleton)
 class SPATIALGDK_API ASpatialMetricsDisplay :
 	public AInfo
 {


### PR DESCRIPTION
#### Description
Added option to auto spawn spatial metrics display

#### Release note
Added runtime option to auto spawn the ASpatialMetricsDisplay for remote debugging of server metrics - bEnableMetricsDisplay.

#### Primary reviewers
@joshuahuburn @cmsmithio 