### PR TITLE
Hide Unreal GDK from content browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format of this Changelog is based on [Keep a Changelog](https://keepachangel
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased-`0.5.0`] - 2019-xx-xx
-- Changing configurations to prevent `Spatial GDK Content` from appearing under Content Browser in the editor.
+- Prevent `Spatial GDK Content` from appearing under Content Browser in the editor, as the GDK plugin does not contain any game content.
 
 ### New Known Issues:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format of this Changelog is based on [Keep a Changelog](https://keepachangel
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased-`0.5.0`] - 2019-xx-xx
-- Prevent `Spatial GDK Content` from appearing under Content Browser in the editor, as the GDK plugin does not contain any game content.
+- Prevented `Spatial GDK Content` from appearing under Content Browser in the editor, as the GDK plugin does not contain any game content.
 
 ### New Known Issues:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format of this Changelog is based on [Keep a Changelog](https://keepachangel
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased-`0.5.0`] - 2019-xx-xx
+- Changing configurations to prevent `Spatial GDK Content` from appearing under Content Browser in the editor.
 
 ### New Known Issues:
 

--- a/SpatialGDK/SpatialGDK.uplugin
+++ b/SpatialGDK/SpatialGDK.uplugin
@@ -11,7 +11,7 @@
   "MarketplaceURL": "",
   "SupportURL": "https://forums.improbable.io/",
   "EnabledByDefault": true,
-  "CanContainContent": true,
+  "CanContainContent": false,
   "IsBetaVersion": false,
   "Installed": true,
   "Modules": [


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
[UNR-1327](https://improbableio.atlassian.net/browse/UNR-1327): a tiny change to remove `Unreal GDK Content` from Unreal Editor Content Browser, as Unreal GDK plugin does not contain any game content.

#### Tests
After launching the editor, navigate to the content browser and mark plugin content to be shown (under _View Options_ in the bottom right hand side). Then navigate to `Content` directory and display the source panel by clicking on the button left of `Filters` option. This will display all the game and plugin content. Notice that `SpatialGDK Content` is not listed there anymore, while previously it was. See the screenshots below:

Before the change:
![image](https://user-images.githubusercontent.com/33751053/58649526-38f1f680-8304-11e9-8fce-47dfcdb92aa7.png)

After the change:
![image](https://user-images.githubusercontent.com/33751053/58649545-47d8a900-8304-11e9-9f12-d30826b2b89f.png)
