### PR TITLE
Bugfix: Fixed build issues related to new setup flow

### DIFF
--- a/RequireSetup
+++ b/RequireSetup
@@ -1,4 +1,4 @@
 Increment the below number whenever it is required to run Setup.bat as part of a new commit.
 Our git hooks will detect this file has been updated and automatically run Setup.bat on pull.
 
-17
+18

--- a/Setup.bat
+++ b/Setup.bat
@@ -1,6 +1,6 @@
 @echo off
 
-setlocal
+setlocal EnableDelayedExpansion
 
 pushd "%~dp0"
 
@@ -12,7 +12,10 @@ if defined ProjectDirectory (
     echo Project directory for installation is: %ProjectDirectory%
 ) else (
     rem If no argument for the project is provided, assume this script is being run as a plugin within a game project.
-    set ProjectDirectory="%~dp0..\..\.."
+    pushd "%~dp0..\..\.."
+    set ProjectDirectory="!cd!"
+    popd
+    echo Setup running as project plugin. Project directory is: !ProjectDirectory!
 )
 
 if not exist %ProjectDirectory% (
@@ -72,16 +75,14 @@ call :MarkStartOfBlock "Check dependencies"
 
     rem If there was no engine association then we need to climb the directory path of the project to find the Engine.
     if %UNREAL_ENGINE%=="" (
-        pushd "%~dp0"
-        cd /d  %ProjectDirectory%
+        pushd %ProjectDirectory%
 
         :climb_parent_directory
-        cd ..
+        echo Checking for Engine in directory: !cd!
         if exist Engine (
             rem Check for the Build.version file to be sure we have found a correct Engine folder.
             if exist "Engine\Build\Build.version" (
-                echo Found Engine at: "%cd%"
-                set UNREAL_ENGINE="%cd%"
+                set UNREAL_ENGINE="!cd!"
             )
         ) else (
             rem This checks if we are in a root directory. If so we cannot check any higher and so should error out.
@@ -90,11 +91,11 @@ call :MarkStartOfBlock "Check dependencies"
                 pause
                 exit /b 1
             )
+            cd ..
             goto :climb_parent_directory
         )
 
         popd
-        pushd "%~dp0"
     )
 
     if %UNREAL_ENGINE%=="" (

--- a/Setup.bat
+++ b/Setup.bat
@@ -44,12 +44,13 @@ call :MarkEndOfBlock "Setup the git hooks"
 call :MarkStartOfBlock "Check dependencies"
     rem Find the Unreal Engine used to build this project.
     set UNREAL_ENGINE=""
+    set UPROJECT=""
 
     rem Get the Unreal Engine used by this project by querying the registry for the engine association found in the .uproject.
-    for /f "delims=" %%A in (' powershell -Command "Get-Childitem -Path %ProjectDirectory% -Recurse -Depth 1 -Include *.uproject -File | %% {$_.FullName}" ') do set UPROJECT="%%A"
+    for /f "delims=" %%A in (' powershell -Command "Get-ChildItem %ProjectDirectory% -Depth 1 -Filter *.uproject -File | %% {$_.FullName}" ') do set UPROJECT="%%A"
     
     rem If the regex failed then it will return a string containing only a space.
-    if %UPROJECT%==" " (
+    if %UPROJECT%=="" (
         echo Error: Could not find uproject. Please make sure you have passed in the project directory correctly.
         pause
         exit /b 1


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Fixed a few issues with setup automation and related build issues.
- Fixed `-depth` not working correctly in `Get-ChildItem` when looking for games `.uproject`. `-Include` was overwriting this flag.
- Fixed finding the UnrealEngine when GDK is installed as a project plugin but with no engine association (so game is nested in UnrealEngine folder). Was caused by no delayed expansion.
- Fixed using the wrong UnrealEngine folder in the `Build.cs` when engine association is set. Caused by a bad refactor.

#### Release note
Issue not present in last release, no note required.

#### Tests
Tested with GDK installed as project plugin with no project association.
Tested with GDK installed as engine plugin with no project association.
Tested with GDK installed as project plugin with engine association set.
Tested with GDK installed as engine plugin with engine association set.

How can this be verified by QA?: Test the above configurations and ensure install and build succeeds.

#### Primary reviewers
@m-samiec 