### PR TITLE
WIP: Level actor initialisation for multiple worker types

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialWorker.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialWorker.cpp
@@ -1,0 +1,25 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "SpatialWorker.h"
+
+#include "SpatialConstants.h"
+
+#include "Engine/World.h"
+
+
+bool USpatialWorker::CanHaveAuthority(const AActor* Actor)
+{
+	if (Actor == nullptr)
+	{
+		return false;
+	}
+
+	if (UWorld* World = Actor->GetWorld())
+	{
+		FString WorkerType = World->GetGameInstance()->GetSpatialWorkerType();
+		bool bUsesDefaultAuthority = Actor->GetClass()->WorkerAssociation.IsEmpty() && WorkerType.Equals(SpatialConstants::ServerWorkerType);
+		bool bMatchesWorkerAssociation = Actor->GetClass()->WorkerAssociation.Equals(WorkerType);
+		return bUsesDefaultAuthority || bMatchesWorkerAssociation;
+	}
+	return false;
+}

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialWorker.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialWorker.h
@@ -1,0 +1,23 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "SpatialWorker.generated.h"
+
+/**
+ * SpatialOS worker abstraction
+ */
+UCLASS()
+class SPATIALGDK_API USpatialWorker : public UBlueprintFunctionLibrary
+{
+	GENERATED_BODY()
+	
+public:
+	/** Check whether the SpatialOS worker responsible for simulating the UWorld of the given actor can have authority over the actor.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "SpatialOS")
+	static bool CanHaveAuthority(const AActor* Actor);
+	
+};


### PR DESCRIPTION
#### Description
This branch is not meant to be merged. It's just an example of some workarounds we had to do while working on a spike that uses multiple worker types. See commit message for details. I imagine an acceptable implementation could generate a startup actor manager SpatialOS component for each worker type which is updated as the existing one and non-authoritative workers wait for all startup actor manager components to be updated before they TriggerBeginPlay.

#### Tests
Local deployment in the AI playground I built on top of TPS.