### PR TITLE
Use custom FindMSBuild.bat which suits our needs

### DIFF
--- a/Setup.bat
+++ b/Setup.bat
@@ -81,7 +81,6 @@ call :MarkStartOfBlock "Retrieve dependencies"
     spatial package retrieve worker_sdk      c-dynamic-x86-msvc_md-win32            %PINNED_CORE_SDK_VERSION%       "%CORE_SDK_DIR%\worker_sdk\c-dynamic-x86-msvc_md-win32.zip"
     spatial package retrieve worker_sdk      c-dynamic-x86_64-msvc_md-win32         %PINNED_CORE_SDK_VERSION%       "%CORE_SDK_DIR%\worker_sdk\c-dynamic-x86_64-msvc_md-win32.zip"
     spatial package retrieve worker_sdk      c-dynamic-x86_64-gcc_libstdcpp-linux   %PINNED_CORE_SDK_VERSION%       "%CORE_SDK_DIR%\worker_sdk\c-dynamic-x86_64-gcc_libstdcpp-linux.zip"
-    spatial package retrieve spot            spot-win64                             20190610.120455.850841e422      "%BINARIES_DIR%\Programs\spot.exe"
 call :MarkEndOfBlock "Retrieve dependencies"
 
 call :MarkStartOfBlock "Unpack dependencies"

--- a/Setup.bat
+++ b/Setup.bat
@@ -6,24 +6,6 @@ pushd "%~dp0"
 
 call :MarkStartOfBlock "%~0"
 
-set ProjectDirectory=%1
-
-if defined ProjectDirectory (
-    echo Project directory for installation is: %ProjectDirectory%
-) else (
-    rem If no argument for the project is provided, assume this script is being run as a plugin within a game project.
-    pushd "%~dp0..\..\.."
-    set ProjectDirectory="!cd!"
-    popd
-    echo Setup running as project plugin. Project directory is: !ProjectDirectory!
-)
-
-if not exist %ProjectDirectory% (
-    echo Error: Project directory does not exist. Please make sure you have passed in the project directory correctly.
-    pause
-    exit /b 1
-)
-
 call :MarkStartOfBlock "Setup the git hooks"
     if not exist .git\hooks goto SkipGitHooks
 
@@ -45,69 +27,8 @@ call :MarkStartOfBlock "Setup the git hooks"
 call :MarkEndOfBlock "Setup the git hooks"
 
 call :MarkStartOfBlock "Check dependencies"
-    rem Find the Unreal Engine used to build this project.
-    set UNREAL_ENGINE=""
-    set UPROJECT=""
 
-    rem Get the Unreal Engine used by this project by querying the registry for the engine association found in the .uproject.
-    for /f "delims=" %%A in (' powershell -Command "Get-ChildItem %ProjectDirectory% -Depth 1 -Filter *.uproject -File | %% {$_.FullName}" ') do set UPROJECT="%%A"
-    
-    rem If the regex failed then it will return a string containing only a space.
-    if %UPROJECT%=="" (
-        echo Error: Could not find uproject. Please make sure you have passed in the project directory correctly.
-        pause
-        exit /b 1
-    )
-
-    echo Using uproject: %UPROJECT%
-
-    rem Get the Engine association from the uproject.
-    for /f "delims=" %%A in (' powershell -Command "Select-String -Pattern '..{8}-.{4}-.{4}-.{4}-.{12}.' %UPROJECT% -AllMatches | %% { $_.Matches } | %% { $_.Value }" ') do set ENGINE_ASSOCIATION="%%A"
-    
-    echo Engine association for uproject is: "%ENGINE_ASSOCIATION%"
-
-    if not "%ENGINE_ASSOCIATION%"=="" (
-        rem Query the registry for the path to the Unreal Engine using the engine associtation.
-        for /f "usebackq tokens=3*" %%A in (`reg query "HKCU\Software\Epic Games\Unreal Engine\Builds" /v %ENGINE_ASSOCIATION%`) do (
-            set UNREAL_ENGINE="%%A"
-        )
-    )
-
-    rem If there was no engine association then we need to climb the directory path of the project to find the Engine.
-    if %UNREAL_ENGINE%=="" (
-        pushd %ProjectDirectory%
-
-        :climb_parent_directory
-        echo Checking for Engine in directory: !cd!
-        if exist Engine (
-            rem Check for the Build.version file to be sure we have found a correct Engine folder.
-            if exist "Engine\Build\Build.version" (
-                set UNREAL_ENGINE="!cd!"
-            )
-        ) else (
-            rem This checks if we are in a root directory. If so we cannot check any higher and so should error out.
-            if "%cd:~3,1%"=="" (
-                echo Error: Could not find Unreal Engine folder. Please set a project association or ensure your game project is within an Unreal Engine folder.
-                pause
-                exit /b 1
-            )
-            cd ..
-            goto :climb_parent_directory
-        )
-
-        popd
-    )
-
-    if %UNREAL_ENGINE%=="" (
-        echo Error: Could not find the Unreal Engine. Please associate your '.uproject' with an engine version or ensure this game project is nested within an engine build.
-        pause
-        exit /b 1
-    )
-
-    echo Using Unreal Engine at: %UNREAL_ENGINE%
-
-    rem Use Unreal Engine's script to get the path to MSBuild. This turns off echo so turn it back on for TeamCity.
-    call "%UNREAL_ENGINE%\Engine\Build\BatchFiles\GetMSBuildPath.bat"
+    call "%~dp0SpatialGDK\Build\Scripts\FindMSBuild.bat"
 
     if not defined MSBUILD_EXE (
         echo Error: Could not find the MSBuild executable. Please make sure you have Microsoft Visual Studio or Microsoft Build Tools installed.
@@ -160,6 +81,7 @@ call :MarkStartOfBlock "Retrieve dependencies"
     spatial package retrieve worker_sdk      c-dynamic-x86-msvc_md-win32            %PINNED_CORE_SDK_VERSION%       "%CORE_SDK_DIR%\worker_sdk\c-dynamic-x86-msvc_md-win32.zip"
     spatial package retrieve worker_sdk      c-dynamic-x86_64-msvc_md-win32         %PINNED_CORE_SDK_VERSION%       "%CORE_SDK_DIR%\worker_sdk\c-dynamic-x86_64-msvc_md-win32.zip"
     spatial package retrieve worker_sdk      c-dynamic-x86_64-gcc_libstdcpp-linux   %PINNED_CORE_SDK_VERSION%       "%CORE_SDK_DIR%\worker_sdk\c-dynamic-x86_64-gcc_libstdcpp-linux.zip"
+    spatial package retrieve spot            spot-win64                             20190610.120455.850841e422      "%BINARIES_DIR%\Programs\spot.exe"
 call :MarkEndOfBlock "Retrieve dependencies"
 
 call :MarkStartOfBlock "Unpack dependencies"

--- a/SpatialGDK/Build/Scripts/FindMSBuild.bat
+++ b/SpatialGDK/Build/Scripts/FindMSBuild.bat
@@ -1,0 +1,25 @@
+rem Convenient code to find MSBuild.exe from https://github.com/microsoft/vswhere 
+rem We only support VS2017 so only look for MS_Build 15.0 
+
+@echo off
+
+set MSBUILD_EXE=
+
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" (
+	for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere" -prerelease -latest -requires Microsoft.Component.MSBuild -property installationPath`) do (
+		if exist "%%i\MSBuild\15.0\Bin\MSBuild.exe" (
+			set MSBUILD_EXE="%%i\MSBuild\15.0\Bin\MSBuild.exe"
+			exit /b 0
+		)
+	)
+)
+
+rem As a backup, if we couldn't find MSBuild via vswhere then ask the registry.
+for /f "usebackq tokens=2,*" %%A in (`reg query "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\SxS\VS7" /v 15.0`) do (
+	if exist "%%BMSBuild\15.0\Bin\MSBuild.exe" (
+		set MSBUILD_EXE="%%BMSBuild\15.0\Bin\MSBuild.exe"
+		exit /b 0
+	)
+)
+
+exit /b 1


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Setup.bat had some huge code that was used to find the engine which in turn was only used to find the MSBuild install. Made a custom script to find it for our supported version and this simplifies the code.

#### Release note
Not needed: Customers shouldn't notice a change.

#### Tests
Ran Setup.bat and worlds

How can this be verified by QA?: Run Setup.bat from the UnrealGDK and any project using it should work.

#### Primary reviewers
@mattyoung-improbable @m-samiec 