### PR TITLE
docs/Remove Visual Studio 2015 link

### DIFF
--- a/SpatialGDK/Documentation/content/get-started/dependencies.md
+++ b/SpatialGDK/Documentation/content/get-started/dependencies.md
@@ -43,7 +43,7 @@ To build the GDK for Unreal you need the following software installed on your ma
 
   - You need the DirectX End-User Runtime to run Unreal Engine 4 clients.
 
-- **Visual Studio** <a href="https://visualstudio.microsoft.com/vs/older-downloads/" data-track-link="Clicked VS 2015|product=Docs|platform=Win|label=Win" target="_blank">2015</a> or <a href="https://visualstudio.microsoft.com/vs/older-downloads/" data-track-link="Clicked VS 2017|product=Docs|platform=Win|label=Win">2017</a> (we recommend 2017). During the installation, select the following items in the Workloads tab:
+- <a href="https://visualstudio.microsoft.com/vs/older-downloads/" data-track-link="Clicked VS 2017|product=Docs|platform=Win|label=Win">**Visual Studio**  2017</a> . During the installation, select the following items in the Workloads tab:
     - **Universal Windows Platform development**<br>
     - **.NET desktop development**<br>
     - **Desktop development with C++**<br>

--- a/SpatialGDK/Documentation/content/get-started/dependencies.md
+++ b/SpatialGDK/Documentation/content/get-started/dependencies.md
@@ -43,7 +43,7 @@ To build the GDK for Unreal you need the following software installed on your ma
 
   - You need the DirectX End-User Runtime to run Unreal Engine 4 clients.
 
-- <a href="https://visualstudio.microsoft.com/vs/older-downloads/" data-track-link="Clicked VS 2017|product=Docs|platform=Win|label=Win">**Visual Studio**  2017</a> . During the installation, select the following items in the Workloads tab:
+- <a href="https://visualstudio.microsoft.com/vs/older-downloads/" data-track-link="Clicked VS 2017|product=Docs|platform=Win|label=Win">**Visual Studio  2017**</a> . During the installation, select the following items in the Workloads tab:
     - **Universal Windows Platform development**<br>
     - **.NET desktop development**<br>
     - **Desktop development with C++**<br>

--- a/SpatialGDK/Documentation/content/get-started/dependencies.md
+++ b/SpatialGDK/Documentation/content/get-started/dependencies.md
@@ -43,7 +43,7 @@ To build the GDK for Unreal you need the following software installed on your ma
 
   - You need the DirectX End-User Runtime to run Unreal Engine 4 clients.
 
-- <a href="https://visualstudio.microsoft.com/vs/older-downloads/" data-track-link="Clicked VS 2017|product=Docs|platform=Win|label=Win">**Visual Studio  2017**</a> . During the installation, select the following items in the Workloads tab:
+- <a href="https://visualstudio.microsoft.com/vs/older-downloads/" data-track-link="Clicked VS 2017|product=Docs|platform=Win|label=Win">**Visual Studio 2017**</a> . During the installation, select the following items in the Workloads tab:
     - **Universal Windows Platform development**<br>
     - **.NET desktop development**<br>
     - **Desktop development with C++**<br>


### PR DESCRIPTION
Removed mention of Visual Studio 2015 from https://docs.improbable.io/unreal/alpha/content/get-started/dependencies.