### PR TITLE
Bug fix Handle bad NetSerialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed path naming issues in setup.sh
 - Fixed assert/crash in SpatialMetricsDisplay that occurred when reloading a snapshot.
 - Added Singleton and SingletonManager to QBI constraints to fix issue preventing Test configuration builds from functioning correctly.
+- Fixed a crash when failing to NetSerialize a struct in spatial. Now print a warning instead which matches native Unreal behavior.
 
 ### External contributors:
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialFastArrayNetSerialize.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialFastArrayNetSerialize.cpp
@@ -64,7 +64,7 @@ void SpatialFastArrayNetSerializeCB::NetSerializeStruct(UScriptStruct* Struct, F
 		// Check the success of the serialization and print a warning if it failed. This is how native handles failed serialization.
 		if (!bSuccess)
 		{
-			UE_LOG(LogRep, Warning, TEXT("SpatialFastArrayNetSerialize: NetSerialize %s failed."), *Struct->GetFullName());
+			UE_LOG(LogSpatialNetSerialize, Warning, TEXT("SpatialFastArrayNetSerialize: NetSerialize %s failed."), *Struct->GetFullName());
 		}
 	}
 	else

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialFastArrayNetSerialize.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialFastArrayNetSerialize.cpp
@@ -60,7 +60,12 @@ void SpatialFastArrayNetSerializeCB::NetSerializeStruct(UScriptStruct* Struct, F
 		{
 			bHasUnmapped = true;
 		}
-		checkf(bSuccess, TEXT("NetSerialize on %s failed."), *Struct->GetStructCPPName());
+
+		// Check the success of the serialization and print a warning if it failed. This is how native handles failed serialization.
+		if (!bSuccess)
+		{
+			UE_LOG(LogRep, Warning, TEXT("SpatialFastArrayNetSerialize: NetSerialize %s failed."), *Struct->GetFullName());
+		}
 	}
 	else
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitWriter.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitWriter.cpp
@@ -10,6 +10,8 @@
 #include "SpatialConstants.h"
 #include "Utils/EntityPool.h"
 
+DEFINE_LOG_CATEGORY(LogSpatialNetSerialize);
+
 FSpatialNetBitWriter::FSpatialNetBitWriter(USpatialPackageMapClient* InPackageMap, TSet<TWeakObjectPtr<const UObject>>& InUnresolvedObjects)
 	: FNetBitWriter(InPackageMap, 0)
 	, UnresolvedObjects(InUnresolvedObjects)

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
@@ -152,7 +152,13 @@ void ComponentFactory::AddProperty(Schema_Object* Object, Schema_FieldId FieldId
 			{
 				bHasUnmapped = true;
 			}
-			checkf(bSuccess, TEXT("NetSerialize on %s failed."), *Struct->GetStructCPPName());
+
+			// Check the success of the serialization and print a warning if it failed. This is how native handles failed serialization.
+			if (!bSuccess)
+			{
+				UE_LOG(LogRep, Warning, TEXT("AddProperty: NetSerialize %s failed."), *Struct->GetFullName());
+				return;
+			}
 		}
 		else
 		{

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
@@ -156,7 +156,7 @@ void ComponentFactory::AddProperty(Schema_Object* Object, Schema_FieldId FieldId
 			// Check the success of the serialization and print a warning if it failed. This is how native handles failed serialization.
 			if (!bSuccess)
 			{
-				UE_LOG(LogRep, Warning, TEXT("AddProperty: NetSerialize %s failed."), *Struct->GetFullName());
+				UE_LOG(LogSpatialNetSerialize, Warning, TEXT("AddProperty: NetSerialize %s failed."), *Struct->GetFullName());
 				return;
 			}
 		}

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetBitWriter.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetBitWriter.h
@@ -6,6 +6,8 @@
 #include "UObject/CoreNet.h"
 #include "Schema/UnrealObjectRef.h"
 
+DECLARE_LOG_CATEGORY_EXTERN(LogSpatialNetSerialize, All, All);
+
 class USpatialPackageMapClient;
 
 class SPATIALGDK_API FSpatialNetBitWriter : public FNetBitWriter

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/RepLayoutUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/RepLayoutUtils.h
@@ -6,6 +6,7 @@
 #include "Net/RepLayout.h"
 
 #include "EngineClasses/SpatialNetBitReader.h"
+#include "EngineClasses/SpatialNetBitWriter.h"
 #include "EngineClasses/SpatialNetDriver.h"
 #include "EngineClasses/SpatialPackageMapClient.h"
 
@@ -145,7 +146,7 @@ inline void ReadStructProperty(FSpatialNetBitReader& Reader, UStructProperty* Pr
 		// Check the success of the serialization and print a warning if it failed. This is how native handles failed serialization.
 		if (!bSuccess)
 		{
-			UE_LOG(LogRep, Warning, TEXT("ReadStructProperty: NetSerialize %s failed."), *Struct->GetFullName());
+			UE_LOG(LogSpatialNetSerialize, Warning, TEXT("ReadStructProperty: NetSerialize %s failed."), *Struct->GetFullName());
 		}
 	}
 	else

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/RepLayoutUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/RepLayoutUtils.h
@@ -141,7 +141,12 @@ inline void ReadStructProperty(FSpatialNetBitReader& Reader, UStructProperty* Pr
 		{
 			bOutHasUnmapped = true;
 		}
-		checkf(bSuccess, TEXT("NetSerialize on %s failed."), *Struct->GetStructCPPName());
+
+		// Check the success of the serialization and print a warning if it failed. This is how native handles failed serialization.
+		if (!bSuccess)
+		{
+			UE_LOG(LogRep, Warning, TEXT("ReadStructProperty: NetSerialize %s failed."), *Struct->GetFullName());
+		}
 	}
 	else
 	{


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
If we failed to `NetSerialize` a struct in Spatial we would crash on a `checkf`, in native they simply print a warning. Matched this behaviour.

#### Release note
Bugfix: - Fixed a crash when failing to NetSerialize a struct in spatial. Now print a warning instead which matches native Unreal behavior.

#### Tests
Ran with bad serialization and doesn't crash.

How can this be verified by QA?: Game does not crash with NaN data in component updates.

#### Primary reviewers
@m-samiec @padhansell 