### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased-`0.5.0`] - 2019-xx-xx
 - Prevented `Spatial GDK Content` from appearing under Content Browser in the editor, as the GDK plugin does not contain any game content.
 
+### Breaking Changes:
+- If you are using Unreal Engine 4.22, the AutomationTool and UnrealBuildTool now require [.NET 4.6.2](https://dotnet.microsoft.com/download/dotnet-framework/net462).
+
 ### New Known Issues:
 
 ### Features:
+- Unreal Engine 4.22 is now supported. You can find the 4.22 verson of our engine fork [here](https://github.com/improbableio/UnrealEngine/tree/4.22-SpatialOSUnrealGDK-release).
 - Setup.bat can now take a project path as an argument. This allows the UnrealGDK to be installed as an Engine Plugin, pass the project path as the first variable if you are running Setup.bat from UnrealEngine/Engine/Plugins.
 - Removed the need for setting the `UNREAL_HOME` environment variable. The build and setup scripts will now use your project's engine association to find the Unreal Engine directory. If an association is not set they will search parent directories looking for the 'Engine' folder.
 - Added SpatialMetricsDisplay class, which allows you to view UnrealWorker stats as an overlay on the client.


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
* Add a release note for 4.22 support.
* Add a breaking change not for the fact that 4.22 requires .NET 4.6.2.

Please note, the link to https://github.com/improbableio/UnrealEngine/tree/4.22-SpatialOSUnrealGDK-staging is currently non-functional. This will change once the `4.22-SpatialOSUnrealGDK-staging` branch is cut as part of the `0.5.0` staging release process.

#### Tests
Rendered markdown,