### PR TITLE
Fix post-command purge script invocation

### DIFF
--- a/ci/purge.ps1
+++ b/ci/purge.ps1
@@ -9,8 +9,6 @@
 # The expected usage is as follows:
 #   powershell -NoProfile -NonInteractive scripts/purge.ps1 -projectRoot <project root>
 
-cd $projectRoot
-
 function Kill-Dangling-Processes {
 	param( [string]$ProcessName )
 


### PR DESCRIPTION
#### Description
I noticed in [this CI run](https://buildkite.com/improbable/unrealengine-premerge/builds/825#2b26d651-58d7-4f93-84b9-0b934baa093c/3385-3387) that the purge script was failing to run when it tried to execute because the `path` it tried to cd to was unset.  Since hooks are run from the repo root anyway, this doesn't need to cd anywhere, so I just removed that call.

Once this passes and is mergeable here, I'll make the same fix on the UnrealEngine repo.  It's just easier to prove that it works here with the shorter per-build execution time.

#### Tests
The post-command hook ran successfully on [this build](https://buildkite.com/improbable/unrealgdk-premerge/builds/2635#d663020e-ed10-41fa-9c90-e05ddbd6fd0e/556-557).

#### Documentation
Internal CI detail, does not require docs.
