### PR TITLE
Fix post-merge hook

### DIFF
--- a/Setup.bat
+++ b/Setup.bat
@@ -1,6 +1,6 @@
 @echo off
 
-setlocal EnableDelayedExpansion
+setlocal
 
 pushd "%~dp0"
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
With `EnableDelayedExpansion`, you need to escape `!` with `^^!`. We only needed `EnableDelayedExpansion` for the complicated logic retrieving the engine association which is no longer needed, so it's easier to just remove it altogether.

#### Primary reviewers
@joshuahuburn @m-samiec 