### PR TITLE
Moves workflow reference docs to Reference section

### DIFF
--- a/SpatialGDK/Documentation/toc.md
+++ b/SpatialGDK/Documentation/toc.md
@@ -61,15 +61,15 @@
     - [Snapshots]({{urlRoot}}/content/how-to-use-snapshots) 
     - [Gameplay Ability System]({{urlRoot}}/content/ability-system)
     - [Map travel]({{urlRoot}}/content/map-travel)
+    - [Command line arguments]({{urlRoot}}/content/command-line-arguments)
+    - [Helper scripts]({{urlRoot}}/content/helper-scripts)
+    - [Directory structure]({{urlRoot}}/content/directory-structure)
 - <h3>Workflows</h3>
     - [Troubleshooting]({{urlRoot}}/content/troubleshooting)
     - [Keeping your GDK up to date]({{urlRoot}}/content/upgrading)
     - Deployment workflows
         - [Local deployment workflow]({{urlRoot}}/content/local-deployment-workflow)
         - [Cloud deployment workflow]({{urlRoot}}/content/cloud-deployment-workflow)
-    - [Command line arguments]({{urlRoot}}/content/command-line-arguments)
-    - [Helper scripts]({{urlRoot}}/content/helper-scripts)
-    - [Directory structure]({{urlRoot}}/content/directory-structure)
 - <h3>Pricing and support</h3>
     - [Pricing]({{urlRoot}}/content/pricing-and-support/pricing)
     - [Support]({{urlRoot}}/content/pricing-and-support/support)


### PR DESCRIPTION
These three pages are actually reference materials which are better suited in the Reference section than workflows, which is more about "workflow for achieving something":
* Command line arguments
* Helper scripts
* Directory structure

Tested with Improbadoc:

![2019-06-18 11_54_27-Improbadoc](https://user-images.githubusercontent.com/2433131/59676683-ff543300-91bf-11e9-9fe0-2f4423260b66.png)

@ElleEss for review
cc @Vatyx following discussion
