### PR TITLE
Update docs to clarify DAT secret should be used instead of the ID

### DIFF
--- a/SpatialGDK/Documentation/content/tutorials/deployment-manager/tutorial-deploymentmgr-authentication.md
+++ b/SpatialGDK/Documentation/content/tutorials/deployment-manager/tutorial-deploymentmgr-authentication.md
@@ -25,14 +25,14 @@ To generate a development authentication token:
 
 This creates a temporary authentication token that lasts for 30 days. For information about updating and refreshing development authentication tokens, refer to the [development authentication token](https://docs.improbable.io/reference/Latest/shared/auth/development-authentication) documentation. 
 
-In the terminal window, copy the string displayed after `tokenSecret` and make a note of it, you will use this token ID in the next step. This token is always 100 characters long and ends in an equals (=) sign.
+In the terminal window, copy the string displayed after `tokenSecret` and make a note of it, you will use this token secret in the next step. This token is always 100 characters long and ends in an equals (=) sign.
 
 ### Step 2: Add the token to your project
 
 Next, you must add your development authentication token to the Example Project code.
 
 1. In File Explorer, navigate to UnrealGDKExampleProject\Game\Source\GDKShooter\Private\Deployments and double click `DeploymentsPlayerController.cpp` to open it in Visual Studio.
-1. In Visual studio with the  `DeploymentsPlayerController.cpp` file open, search for `PITParams->development_authentication_token_id` and replace `“REPLACE ME"` with the `tokenSecret` string you copied in step 3. <br/>
+1. In Visual studio with the  `DeploymentsPlayerController.cpp` file open, search for `PITParams->development_authentication_token` and replace `“REPLACE ME"` with the `tokenSecret` string you copied in step 3. <br/>
 ![img]({{assetRoot}}assets/deployment-manager/deploymentmgr-token.png)<br/>
 _Image: The development authentication token id code as shown in Visual Studio_ <br/>
 1. Save your changes and launch a debug build of your project by pressing F5 on your keyboard or by selecting **Local Windows Debugger** on the Visual Studio toolbar. 


### PR DESCRIPTION
#### Description

Updated the deployment manager tutorial docs to make it clear that the DAT Secret should be used and *not* the ID.

Unfortunately the screenshot still says `development_authentication_token_id` but I'm not in a position where I can make a new one.

