### PR TITLE
[bugfix] Add UPROPERTY Category to ActorGroupManager properties

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/ActorGroupManager.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/ActorGroupManager.h
@@ -11,7 +11,7 @@ struct FWorkerType
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "SpatialGDK")
 	FName WorkerTypeName;
 
 	FWorkerType() : WorkerTypeName(NAME_None)
@@ -28,12 +28,12 @@ struct FActorGroupInfo
 	FName Name;
 
 	/** The server worker type that has authority of all classes in this actor group. */
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "SpatialGDK")
 	FWorkerType OwningWorkerType;
 
 	// Using TSoftClassPtr here to prevent eagerly loading all classes.
 	/** The Actor classes contained within this group. Children of these classes will also be included. */	
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "SpatialGDK")
 	TSet<TSoftClassPtr<AActor>> ActorClasses;
 	
 	FActorGroupInfo() : Name(NAME_None), OwningWorkerType()


### PR DESCRIPTION
#### Description
When running the GDK as an Engine Plugin, all UPROPERTYs exposed to Blueprint / Editor must have a Category specified.