### PR TITLE
[Bugfix] Add defaults to ServerWorkerTypes & DefaultWorkerType

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
 #include "SpatialGDKSettings.h"
+#include "Improbable/SpatialEngineConstants.h"
 #include "Misc/MessageDialog.h"
 #include "Misc/CommandLine.h"
 
@@ -31,6 +32,9 @@ USpatialGDKSettings::USpatialGDKSettings(const FObjectInitializer& ObjectInitial
 	, bEnableServerQBI(bUsingQBI)
 	, bPackUnreliableRPCs(true)
 	, bUseDevelopmentAuthenticationFlow(false)
+	, DefaultWorkerType(FWorkerType(SpatialConstants::DefaultServerWorkerType))
+	, bEnableOffloading(false)
+	, ServerWorkerTypes({ SpatialConstants::DefaultServerWorkerType })
 {
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/ActorGroupManager.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/ActorGroupManager.h
@@ -17,6 +17,10 @@ struct FWorkerType
 	FWorkerType() : WorkerTypeName(NAME_None)
 	{
 	}
+
+	FWorkerType(FName InWorkerTypeName) : WorkerTypeName(InWorkerTypeName)
+	{
+	}
 };
 
 USTRUCT()


### PR DESCRIPTION
#### Description
Which workers to start is now determined by SpatialGDKSettings::DefaultWorkerType, which defaulted to None.