### PR TITLE
UNR-1294: Removes unnecessary dependency: Unreal Engine Installer

### DIFF
--- a/SpatialGDK/Documentation/content/get-started/dependencies.md
+++ b/SpatialGDK/Documentation/content/get-started/dependencies.md
@@ -47,7 +47,7 @@ To build the GDK for Unreal you need the following software installed on your ma
     - **Universal Windows Platform development**<br>
     - **.NET desktop development**<br>
     - **Desktop development with C++**<br>
-    - **Game development with C++**, including the optional **Unreal Engine installer** component.
+    - **Game development with C++**
 
 </br>
 </br>


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
This PR removes all references to the Visual Studio component **Unreal Engine Installer**. Epic list this as a dependency for installing UE4 from source but it is actually superfluous (it’s used by Epic to manage engine and plugin versions, which are not used in the GDK).

#### Tests
I successfully local launched and cloud deployed the example project without the "Unreal Engine Installer" VS component installed.

#### Documentation
This is documentation bro.

#### Primary reviewers
@m-samiec 