### PR TITLE
Build.cs also search for "UnrealEngine" to find the "Engine" directory

### DIFF
--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Build/Build.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Build/Build.cs
@@ -120,6 +120,11 @@ gosu $NEW_USER ""${SCRIPT}"" ""$@"" >> ""/improbable/logs/${WORKER_ID}.log"" 2>&
                 {
                     currentDir = currentDir.Parent;
                     unrealEngine = currentDir.GetDirectories().Where(d => d.Name == "Engine" && File.Exists(Path.Combine(d.FullName, @"Build\Build.version"))).Select(d => d.Parent.FullName).FirstOrDefault();
+                    // also look for the "UnrealEngine" root folder instead of the "Engine" sub-folder
+                    if (string.IsNullOrEmpty(unrealEngine))
+                    {
+                        unrealEngine = currentDir.GetDirectories().Where(d => d.Name == "UnrealEngine" && File.Exists(Path.Combine(d.FullName, @"Engine\Build\Build.version"))).Select(d => d.FullName).FirstOrDefault();
+                    }
                 }
             }
 


### PR DESCRIPTION
#### Description
Improve Build.cs to also search for a "UnrealEngine" directory to find the "Engine" sub-directory

In my experience, it's quite common to have a "GameProject" directory side by side with the "UnrealEngine" directory.

It might not be the best directory structure, but it's good to be able to support it by default.

branches build-exe-search-unreal-engine-directory, origin/build-exe-search-unreal-engine-directory

#### Release note
Improve Build.cs to also search for a "UnrealEngine" directory to find the "Engine" sub-directory

#### Tests
Tested locally on my computer, will be tested by our build machine today so I will report here if it breaks.