### PR TITLE
Early out when trying to call RPC on NotSpatial type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fixes:
 - Disconnected players no longer remain on the server until they time out if the client was shut down manually.
 - Fixed support for relative paths as the engine association in your games .uproject file.
+- `NotSpatial` types no longer get replicated when an RPC is called on them.
 
 ## [`0.5.0-preview`](https://github.com/spatialos/UnrealGDK/releases/tag/0.5.0-preview) - 2019-06-25
 - Prevented `Spatial GDK Content` from appearing under Content Browser in the editor, as the GDK plugin does not contain any game content.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fixes:
 - Disconnected players no longer remain on the server until they time out if the client was shut down manually.
 - Fixed support for relative paths as the engine association in your games .uproject file.
+- RPCs on `NotSpatial` types are no longer queued forever and are now dropped instead.
 
 ## [`0.5.0-preview`](https://github.com/spatialos/UnrealGDK/releases/tag/0.5.0-preview) - 2019-06-25
 - Prevented `Spatial GDK Content` from appearing under Content Browser in the editor, as the GDK plugin does not contain any game content.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fixes:
 - Disconnected players no longer remain on the server until they time out if the client was shut down manually.
 - Fixed support for relative paths as the engine association in your games .uproject file.
-- `NotSpatial` types no longer get replicated when an RPC is called on them.
 
 ## [`0.5.0-preview`](https://github.com/spatialos/UnrealGDK/releases/tag/0.5.0-preview) - 2019-06-25
 - Prevented `Spatial GDK Content` from appearing under Content Browser in the editor, as the GDK plugin does not contain any game content.

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1184,7 +1184,7 @@ void USpatialNetDriver::ProcessRemoteFunction(
 
 	if (CallingObject->GetClass()->HasAnySpatialClassFlags(SPATIALCLASS_NotSpatialType))
 	{
-		// Trying to call an RPC on an object that isn't supported by Spatial (i.e. marked NotSpatial)
+		UE_LOG(LogSpatialOSNetDriver, Verbose, TEXT("Trying to call RPC %s on object %s (class %s) that isn't supported by Spatial. This RPC will be dropped."), *Function->GetName(), *CallingObject->GetName(), *CallingObject->GetClass()->GetName());
 		return;
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1179,6 +1179,15 @@ void USpatialNetDriver::ProcessRemoteFunction(
 		return;
 	}
 
+	// The RPC might have been called by an actor directly, or by a subobject on that actor
+	UObject* CallingObject = SubObject ? SubObject : Actor;
+
+	if (CallingObject->GetClass()->HasAnySpatialClassFlags(SPATIALCLASS_NotSpatialType))
+	{
+		// Trying to call an RPC on an object that isn't supported by Spatial (i.e. marked NotSpatial)
+		return;
+	}
+
 	// Copied from UNetDriver::ProcessRemoteFunctionForChannel to copy pass-by-ref
 	// parameters from OutParms into Parameters's memory.
 	if (Stack == nullptr)
@@ -1211,9 +1220,6 @@ void USpatialNetDriver::ProcessRemoteFunction(
 			}
 		}
 	}
-
-	// The RPC might have been called by an actor directly, or by a subobject on that actor
-	UObject* CallingObject = SubObject ? SubObject : Actor;
 
 	if (Function->FunctionFlags & FUNC_Net)
 	{


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
If the class is marked `NotSpatial`, it still ended up replicated if e.g. a multicast RPC was called. Now we explicitly check for that and early out if the calling object is `NotSpatial`.

#### Documentation
Release note

#### Primary reviewers
@m-samiec