### PR TITLE
Fix GCS-1288 & 1298 schema generator load default game mode + generate schema for one map

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
@@ -75,6 +75,10 @@ bool FSpatialGDKEditor::GenerateSchema(bool bFullScan)
 			return false;
 		}
 	}
+	else
+	{
+		LoadDefaultGameModes();
+	}
 
 	// If running from an open editor then compile all dirty blueprints
 	TArray<UBlueprint*> ErroredBlueprints;

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSchemaGenerator.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSchemaGenerator.h
@@ -13,3 +13,5 @@ SPATIALGDKEDITOR_API void ClearGeneratedSchema();
 SPATIALGDKEDITOR_API void DeleteGeneratedSchemaFiles();
 
 SPATIALGDKEDITOR_API bool TryLoadExistingSchemaDatabase();
+
+SPATIALGDKEDITOR_API void LoadDefaultGameModes();

--- a/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/GenerateSchemaCommandlet.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/GenerateSchemaCommandlet.cpp
@@ -4,10 +4,15 @@
 #include "SpatialGDKEditorCommandletPrivate.h"
 #include "SpatialGDKEditor.h"
 
+#include "Engine/ObjectLibrary.h"
+#include "Engine/World.h"
+#include "FileHelpers.h"
+#include "Misc/Paths.h"
+
 UGenerateSchemaCommandlet::UGenerateSchemaCommandlet()
 {
 	IsClient = false;
-	IsEditor = false;
+	IsEditor = true;
 	IsServer = false;
 	LogToConsole = true;
 }
@@ -16,16 +21,36 @@ int32 UGenerateSchemaCommandlet::Main(const FString& Args)
 {
 	UE_LOG(LogSpatialGDKEditorCommandlet, Display, TEXT("Schema Generation Commandlet Started"));
 
-	//NOTE: For future use, if schema generation configuration at the command line is desired
-	//TArray<FString> Tokens;
-	//TArray<FString> Switches;
-	//TMap<FString, FString> Params;
-	//ParseCommandLine(*Args, Tokens, Switches, Params);
+	TArray<FString> Tokens;
+	TArray<FString> Switches;
+	TMap<FString, FString> Params;
+	ParseCommandLine(*Args, Tokens, Switches, Params);
+
+	const FString* MapName = Params.Find(TEXT("Map"));
+	if (MapName)
+	{
+		const FString MapDir = TEXT("/Game");
+		const TArray<FString> MapFilePaths = GetAllMapPaths(MapDir);
+		for (FString MapFilePath : MapFilePaths)
+		{
+			if (MapFilePath.EndsWith(*MapName))
+			{
+				// Load the World
+				UE_LOG(LogSpatialGDKEditorCommandlet, Display, TEXT("LoadMap %s"), *MapFilePath);
+				if (!FEditorFileUtils::LoadMap(MapFilePath))
+				{
+					UE_LOG(LogSpatialGDKEditorCommandlet, Display, TEXT("Failed to load map %s"), *MapFilePath);
+				}
+				break;
+			}
+		}
+	}
+	const bool bFullScan = (MapName == nullptr);
 
 	//Generate Schema!
 	bool bSchemaGenSuccess;
 	FSpatialGDKEditor SpatialGDKEditor;
-	if (SpatialGDKEditor.GenerateSchema(true))
+	if (SpatialGDKEditor.GenerateSchema(bFullScan))
 	{
 		UE_LOG(LogSpatialGDKEditorCommandlet, Display, TEXT("Schema Generation Completed!"));
 		bSchemaGenSuccess = true;
@@ -39,4 +64,23 @@ int32 UGenerateSchemaCommandlet::Main(const FString& Args)
 	UE_LOG(LogSpatialGDKEditorCommandlet, Display, TEXT("Schema Generation Commandlet Complete"));
 
 	return bSchemaGenSuccess ? 0 : 1;
+}
+
+TArray<FString> UGenerateSchemaCommandlet::GetAllMapPaths(FString InMapsPath)
+{
+	UObjectLibrary* ObjectLibrary = UObjectLibrary::CreateLibrary(UWorld::StaticClass(), false, true);
+	ObjectLibrary->LoadAssetDataFromPath(InMapsPath);
+	TArray<FAssetData> AssetDatas;
+	ObjectLibrary->GetAssetDataList(AssetDatas);
+	UE_LOG(LogSpatialGDKEditorCommandlet, Display, TEXT("Found %d maps:"), AssetDatas.Num());
+
+	TArray<FString> Paths = TArray<FString>();
+	for (FAssetData& AssetData : AssetDatas)
+	{
+		FString Path = AssetData.PackageName.ToString();
+		Paths.Add(Path);
+		UE_LOG(LogSpatialGDKEditorCommandlet, Log, TEXT("\t%s"), *Path);
+	}
+
+	return Paths;
 }

--- a/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/GenerateSchemaCommandlet.h
+++ b/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/GenerateSchemaCommandlet.h
@@ -16,4 +16,7 @@ public:
 
 public:
 	virtual int32 Main(const FString& Params) override;
+
+private:
+	TArray<FString> GetAllMapPaths(FString InMapsPath);
 };


### PR DESCRIPTION
#### Description
Restore GDK 0.3+ feature to explicitly load the default game mode before generating schemas

This is needed to be able to generate proper schemas when doing a non-fullscan schema generation (so this is linked to GCS-1289 "GenerateSchemaAndSnapshot" commandlet is now generating schemas for ALL classes in the project)

Fix GCS-1288 GDK no longer loading the BP Game mode taken from the Project Settings

#### Release note
Explicitly load the default game mode before generating schemas when not doing a full-scan.

#### Tests
Used in our project and especially on the build machine