### PR TITLE
Buildkite: Upgrade taskkill plugin to v4.2

### DIFF
--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -19,7 +19,7 @@ common: &common
   plugins:
     - git-clean#v0.0.1:
         flags: "-ffdx --exclude=UnrealEngine-Cache"
-    - ca-johnson/taskkill#v4.1: ~
+    - ca-johnson/taskkill#v4.2: ~
 
 # NOTE: step labels turn into commit-status names like {org}/{repo}/{pipeline}/{step-label}, lower-case and hyphenated.
 # These are then relied on to have stable names by other things, so once named, please beware renaming has consequences.


### PR DESCRIPTION
* Lists process tree
* Uses wmic to kill processes instead of taskkill

This should help debug and/or fix an issue where taskkill fails to kill a process