### PR TITLE
Feature: Create default spatialos.WorkerType.worker.json files.

### DIFF
--- a/SpatialGDK/Extras/templates/WorkerJsonTemplate.json
+++ b/SpatialGDK/Extras/templates/WorkerJsonTemplate.json
@@ -1,0 +1,100 @@
+{
+  "build": {
+    "tasks": [
+      {
+        "name": "codegen",
+        "description": "required by spatial worker build build-config.",
+        "steps": [{"name": "No-op", "command": "echo", "arguments": ["No-op."]}]
+      },
+      {
+        "name": "build",
+        "description": "required by spatial worker build build-config.",
+        "steps": [{"name": "No-op", "command": "echo", "arguments": ["No-op."]}]
+      },
+      {
+        "name": "clean",
+        "description": "required by spatial worker build build-config.",
+        "steps": [{"name": "No-op", "command": "echo", "arguments": ["No-op."]}]
+      }
+    ]
+  },
+  "bridge": {
+    "worker_attribute_set": {
+      "attributes": [
+        "{{WorkerTypeName}}"
+      ]
+    },
+    "entity_interest": {
+      "range_entity_interest": {
+        "radius": 50
+      }
+    },
+    "streaming_query": [
+      {
+        "global_component_streaming_query": {
+          "component_name": "unreal.SingletonManager"
+        }
+      },
+      {
+        "global_component_streaming_query": {
+          "component_name": "unreal.Singleton"
+        }
+      }
+    ],
+    "component_delivery": {
+      "default": "RELIABLE_ORDERED",
+      "checkout_all_initially": true
+    }
+  },
+  "managed": {
+    "windows": {
+      "artifact_name": "UnrealEditor@Windows.zip",
+      "command": "StartEditor.bat",
+      "arguments": [
+        "-server",
+        "-stdout",
+        "-nowrite",
+        "-unattended",
+        "-nologtimes",
+        "-nopause",
+        "-messaging",
+        "-SaveToUserDir",
+        "+appName",
+        "${IMPROBABLE_PROJECT_NAME}",
+        "+receptionistHost",
+        "${IMPROBABLE_RECEPTIONIST_HOST}",
+        "+receptionistPort",
+        "${IMPROBABLE_RECEPTIONIST_PORT}",
+        "+workerType",
+        "${IMPROBABLE_WORKER_NAME}",
+        "+workerId",
+        "${IMPROBABLE_WORKER_ID}",
+        "+linkProtocol",
+        "Tcp",
+        "-abslog=${IMPROBABLE_LOG_FILE}",
+        "-NoVerifyGC"
+      ]
+    },
+    "linux": {
+      "artifact_name": "UnrealWorker@Linux.zip",
+      "command": "StartWorker.sh",
+      "arguments": [
+        "${IMPROBABLE_WORKER_ID}",
+        "${IMPROBABLE_LOG_FILE}",
+        "+appName",
+        "${IMPROBABLE_PROJECT_NAME}",
+        "+receptionistHost",
+        "${IMPROBABLE_RECEPTIONIST_HOST}",
+        "+receptionistPort",
+        "${IMPROBABLE_RECEPTIONIST_PORT}",
+        "+workerType",
+        "${IMPROBABLE_WORKER_NAME}",
+        "+workerId",
+        "${IMPROBABLE_WORKER_ID}",
+        "+linkProtocol",
+        "Tcp",
+        "-NoVerifyGC"
+      ]
+    }
+  }
+}

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -720,18 +720,18 @@ bool FSpatialGDKEditorToolbarModule::GenerateDefaultWorkerJson()
 {
 	if (const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>())
 	{
-		const FString WorkerJsonPath = FSpatialGDKServicesModule::GetSpatialOSDirectory(TEXT("workers/unreal"));
-		const FString WorkerJsonTemplatePath = FSpatialGDKServicesModule::GetSpatialGDKPluginDirectory(TEXT("SpatialGDK/Extras/templates/WorkerJsonTemplate.json"));
+		const FString WorkerJsonDir = FSpatialGDKServicesModule::GetSpatialOSDirectory(TEXT("workers/unreal"));
+		const FString TemplateWorkerJsonPath = FSpatialGDKServicesModule::GetSpatialGDKPluginDirectory(TEXT("SpatialGDK/Extras/templates/WorkerJsonTemplate.json"));
 
 		const FSpatialLaunchConfigDescription& LaunchConfigDescription = SpatialGDKEditorSettings->LaunchConfigDesc;
 		for (const FWorkerTypeLaunchSection& Worker : LaunchConfigDescription.ServerWorkers)
 		{
-			FString JsonPath = FPaths::Combine(WorkerJsonPath, FString::Printf(TEXT("spatialos.%s.worker.json"), *Worker.WorkerTypeName.ToString()));
+			FString JsonPath = FPaths::Combine(WorkerJsonDir, FString::Printf(TEXT("spatialos.%s.worker.json"), *Worker.WorkerTypeName.ToString()));
 			if (!FPaths::FileExists(JsonPath))
 			{
 				UE_LOG(LogSpatialGDKEditorToolbar, Verbose, TEXT("Could not worker json at %s"), *JsonPath);
 				FString Contents;
-				if (FFileHelper::LoadFileToString(Contents, *WorkerJsonTemplatePath))
+				if (FFileHelper::LoadFileToString(Contents, *TemplateWorkerJsonPath))
 				{
 					Contents.ReplaceInline(TEXT("{{WorkerTypeName}}"), *Worker.WorkerTypeName.ToString());
 					if (FFileHelper::SaveStringToFile(Contents, *JsonPath))
@@ -746,7 +746,7 @@ bool FSpatialGDKEditorToolbarModule::GenerateDefaultWorkerJson()
 				}
 				else
 				{
-					UE_LOG(LogSpatialGDKEditorToolbar, Error, TEXT("Failed to read default worker json at %s"), *WorkerJsonTemplatePath)
+					UE_LOG(LogSpatialGDKEditorToolbar, Error, TEXT("Failed to read default worker json at %s"), *TemplateWorkerJsonPath)
 				}
 			}
 			else

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -729,7 +729,7 @@ bool FSpatialGDKEditorToolbarModule::GenerateDefaultWorkerJson()
 			FString JsonPath = FPaths::Combine(WorkerJsonDir, FString::Printf(TEXT("spatialos.%s.worker.json"), *Worker.WorkerTypeName.ToString()));
 			if (!FPaths::FileExists(JsonPath))
 			{
-				UE_LOG(LogSpatialGDKEditorToolbar, Verbose, TEXT("Could not worker json at %s"), *JsonPath);
+				UE_LOG(LogSpatialGDKEditorToolbar, Verbose, TEXT("Could not find worker json at %s"), *JsonPath);
 				FString Contents;
 				if (FFileHelper::LoadFileToString(Contents, *TemplateWorkerJsonPath))
 				{
@@ -746,12 +746,12 @@ bool FSpatialGDKEditorToolbarModule::GenerateDefaultWorkerJson()
 				}
 				else
 				{
-					UE_LOG(LogSpatialGDKEditorToolbar, Error, TEXT("Failed to read default worker json at %s"), *TemplateWorkerJsonPath)
+					UE_LOG(LogSpatialGDKEditorToolbar, Error, TEXT("Failed to read default worker json template at %s"), *TemplateWorkerJsonPath)
 				}
 			}
 			else
 			{
-				UE_LOG(LogSpatialGDKEditorToolbar, Verbose, TEXT("Found worker json %s"), *JsonPath)
+				UE_LOG(LogSpatialGDKEditorToolbar, Verbose, TEXT("Found worker json at %s"), *JsonPath)
 			}
 		}
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -490,6 +490,11 @@ void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment()
 			return;
 		}
 
+		if (!GenerateDefaultWorkerJson())
+		{
+			return;
+		}
+
 		LaunchConfig = FPaths::Combine(FPaths::ConvertRelativePathToFull(FPaths::ProjectIntermediateDir()), TEXT("Improbable/DefaultLaunchConfig.json"));
 		GenerateDefaultLaunchConfig(LaunchConfig);
 	}
@@ -642,12 +647,12 @@ void FSpatialGDKEditorToolbarModule::OnPropertyChanged(UObject* ObjectBeingModif
 
 bool FSpatialGDKEditorToolbarModule::GenerateDefaultLaunchConfig(const FString& LaunchConfigPath) const
 {
-	if (const USpatialGDKEditorSettings* SpatialGDKSettings = GetDefault<USpatialGDKEditorSettings>())
+	if (const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>())
 	{
 		FString Text;
 		TSharedRef< TJsonWriter<> > Writer = TJsonWriterFactory<>::Create(&Text);
 
-		const FSpatialLaunchConfigDescription& LaunchConfigDescription = SpatialGDKSettings->LaunchConfigDesc;
+		const FSpatialLaunchConfigDescription& LaunchConfigDescription = SpatialGDKEditorSettings->LaunchConfigDesc;
 
 		// Populate json file for launch config
 		Writer->WriteObjectStart(); // Start of json
@@ -703,6 +708,51 @@ bool FSpatialGDKEditorToolbarModule::GenerateDefaultLaunchConfig(const FString& 
 		{
 			UE_LOG(LogSpatialGDKEditorToolbar, Log, TEXT("Failed to write output file '%s'. It might be that the file is read-only."), *LaunchConfigPath);
 			return false;
+		}
+
+		return true;
+	}
+
+	return false;
+}
+
+bool FSpatialGDKEditorToolbarModule::GenerateDefaultWorkerJson()
+{
+	if (const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>())
+	{
+		const FString WorkerJsonPath = FSpatialGDKServicesModule::GetSpatialOSDirectory(TEXT("workers/unreal"));
+		const FString WorkerJsonTemplatePath = FSpatialGDKServicesModule::GetSpatialGDKPluginDirectory(TEXT("SpatialGDK/Extras/templates/WorkerJsonTemplate.json"));
+
+		const FSpatialLaunchConfigDescription& LaunchConfigDescription = SpatialGDKEditorSettings->LaunchConfigDesc;
+		for (const FWorkerTypeLaunchSection& Worker : LaunchConfigDescription.ServerWorkers)
+		{
+			FString JsonPath = FPaths::Combine(WorkerJsonPath, FString::Printf(TEXT("spatialos.%s.worker.json"), *Worker.WorkerTypeName.ToString()));
+			if (!FPaths::FileExists(JsonPath))
+			{
+				UE_LOG(LogSpatialGDKEditorToolbar, Verbose, TEXT("Could not worker json at %s"), *JsonPath);
+				FString Contents;
+				if (FFileHelper::LoadFileToString(Contents, *WorkerJsonTemplatePath))
+				{
+					Contents.ReplaceInline(TEXT("{{WorkerTypeName}}"), *Worker.WorkerTypeName.ToString());
+					if (FFileHelper::SaveStringToFile(Contents, *JsonPath))
+					{
+						bRedeployRequired = true;
+						UE_LOG(LogSpatialGDKEditorToolbar, Verbose, TEXT("Wrote default worker json to %s"), *JsonPath)
+					}
+					else
+					{
+						UE_LOG(LogSpatialGDKEditorToolbar, Error, TEXT("Failed to write default worker json to %s"), *JsonPath)
+					}
+				}
+				else
+				{
+					UE_LOG(LogSpatialGDKEditorToolbar, Error, TEXT("Failed to read default worker json at %s"), *WorkerJsonTemplatePath)
+				}
+			}
+			else
+			{
+				UE_LOG(LogSpatialGDKEditorToolbar, Verbose, TEXT("Found worker json %s"), *JsonPath)
+			}
 		}
 
 		return true;

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -86,6 +86,7 @@ private:
 
 	bool ValidateGeneratedLaunchConfig() const;
 	bool GenerateDefaultLaunchConfig(const FString& LaunchConfigPath) const;
+	bool GenerateDefaultWorkerJson();
 
 	void GenerateSchema(bool bFullScan);
 

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -112,7 +112,7 @@ void FLocalDeploymentManager::WorkerBuildConfigAsync()
 		int32 ExitCode;
 		ExecuteAndReadOutput(SpatialExe, BuildConfigArgs, FSpatialGDKServicesModule::GetSpatialOSDirectory(), WorkerBuildConfigResult, ExitCode);
 
-		if (ExitCode != ExitCodeSuccess)
+		if (ExitCode == ExitCodeSuccess)
 		{
 			UE_LOG(LogSpatialDeploymentManager, Display, TEXT("Building worker configurations succeeded!"));
 		}

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -64,9 +64,7 @@ void FLocalDeploymentManager::StartUpWorkerConfigDirectoryWatcher()
 		if (FPaths::DirectoryExists(WorkerConfigDirectory))
 		{
 			WorkerConfigDirectoryChangedDelegate = IDirectoryWatcher::FDirectoryChanged::CreateRaw(this, &FLocalDeploymentManager::OnWorkerConfigDirectoryChanged);
-			DirectoryWatcher->RegisterDirectoryChangedCallback_Handle(
-				WorkerConfigDirectory, WorkerConfigDirectoryChangedDelegate, WorkerConfigDirectoryChangedDelegateHandle,
-				IDirectoryWatcher::IncludeDirectoryChanges);
+			DirectoryWatcher->RegisterDirectoryChangedCallback_Handle(WorkerConfigDirectory, WorkerConfigDirectoryChangedDelegate, WorkerConfigDirectoryChangedDelegateHandle);
 		}
 		else
 		{

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -62,7 +62,7 @@ void FLocalDeploymentManager::StartUpWorkerConfigDirectoryWatcher()
 		FString WorkerConfigDirectory = FPaths::Combine(SpatialDirectory, TEXT("workers"));
 
 		if (FPaths::DirectoryExists(WorkerConfigDirectory))
-		{		
+		{
 			WorkerConfigDirectoryChangedDelegate = IDirectoryWatcher::FDirectoryChanged::CreateRaw(this, &FLocalDeploymentManager::OnWorkerConfigDirectoryChanged);
 			DirectoryWatcher->RegisterDirectoryChangedCallback_Handle(
 				WorkerConfigDirectory, WorkerConfigDirectoryChangedDelegate, WorkerConfigDirectoryChangedDelegateHandle,

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialGDKServicesModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialGDKServicesModule.cpp
@@ -23,9 +23,23 @@ FLocalDeploymentManager* FSpatialGDKServicesModule::GetLocalDeploymentManager()
 	return &LocalDeploymentManager;
 }
 
-FString FSpatialGDKServicesModule::GetSpatialOSDirectory()
+FString FSpatialGDKServicesModule::GetSpatialOSDirectory(FString RelativePath)
 {
-	return FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectDir(), TEXT("/../spatial/")));
+	return FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectDir(), TEXT("/../spatial/"), RelativePath));
+}
+
+FString FSpatialGDKServicesModule::GetSpatialGDKPluginDirectory(FString RelativePath)
+{
+	FString PluginDir = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectPluginsDir(), TEXT("UnrealGDK")));
+
+	if (!FPaths::DirectoryExists(PluginDir))
+	{
+		// If the Project Plugin doesn't exist then use the Engine Plugin.
+		PluginDir = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EnginePluginsDir(), TEXT("UnrealGDK")));
+		ensure(FPaths::DirectoryExists(PluginDir));
+	}
+
+	return FPaths::ConvertRelativePathToFull(FPaths::Combine(PluginDir, RelativePath));
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialGDKServicesModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialGDKServicesModule.cpp
@@ -23,12 +23,12 @@ FLocalDeploymentManager* FSpatialGDKServicesModule::GetLocalDeploymentManager()
 	return &LocalDeploymentManager;
 }
 
-FString FSpatialGDKServicesModule::GetSpatialOSDirectory(FString RelativePath)
+FString FSpatialGDKServicesModule::GetSpatialOSDirectory(const FString& RelativePath)
 {
 	return FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectDir(), TEXT("/../spatial/"), RelativePath));
 }
 
-FString FSpatialGDKServicesModule::GetSpatialGDKPluginDirectory(FString RelativePath)
+FString FSpatialGDKServicesModule::GetSpatialGDKPluginDirectory(const FString& RelativePath)
 {
 	FString PluginDir = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectPluginsDir(), TEXT("UnrealGDK")));
 

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialGDKServicesModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialGDKServicesModule.cpp
@@ -23,12 +23,12 @@ FLocalDeploymentManager* FSpatialGDKServicesModule::GetLocalDeploymentManager()
 	return &LocalDeploymentManager;
 }
 
-FString FSpatialGDKServicesModule::GetSpatialOSDirectory(const FString& RelativePath)
+FString FSpatialGDKServicesModule::GetSpatialOSDirectory(const FString& AppendPath)
 {
-	return FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectDir(), TEXT("/../spatial/"), RelativePath));
+	return FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectDir(), TEXT("/../spatial/"), AppendPath));
 }
 
-FString FSpatialGDKServicesModule::GetSpatialGDKPluginDirectory(const FString& RelativePath)
+FString FSpatialGDKServicesModule::GetSpatialGDKPluginDirectory(const FString& AppendPath)
 {
 	FString PluginDir = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectPluginsDir(), TEXT("UnrealGDK")));
 
@@ -39,7 +39,7 @@ FString FSpatialGDKServicesModule::GetSpatialGDKPluginDirectory(const FString& R
 		ensure(FPaths::DirectoryExists(PluginDir));
 	}
 
-	return FPaths::ConvertRelativePathToFull(FPaths::Combine(PluginDir, RelativePath));
+	return FPaths::ConvertRelativePathToFull(FPaths::Combine(PluginDir, AppendPath));
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesModule.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesModule.h
@@ -18,8 +18,8 @@ public:
 
 	FLocalDeploymentManager* GetLocalDeploymentManager();
 
-	static FString GetSpatialOSDirectory(FString RelativePath = TEXT(""));
-	static FString GetSpatialGDKPluginDirectory(FString RelativePath = TEXT(""));
+	static FString GetSpatialOSDirectory(const FString& AppendPath = TEXT(""));
+	static FString GetSpatialGDKPluginDirectory(const FString& AppendPath = TEXT(""));
 
 private:
 	FLocalDeploymentManager LocalDeploymentManager;

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesModule.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesModule.h
@@ -18,7 +18,8 @@ public:
 
 	FLocalDeploymentManager* GetLocalDeploymentManager();
 
-	static FString GetSpatialOSDirectory();
+	static FString GetSpatialOSDirectory(FString RelativePath = TEXT(""));
+	static FString GetSpatialGDKPluginDirectory(FString RelativePath = TEXT(""));
 
 private:
 	FLocalDeploymentManager LocalDeploymentManager;


### PR DESCRIPTION
#### Description
When launching, verify worker.json files exist for all server worker types defined in launch config, copy over default if no file exists.