### PR TITLE
Skip over non-supported subobjects when generating schema for subobjects.

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SchemaGenerator.cpp
@@ -565,7 +565,7 @@ void GenerateSubobjectSchemaForActor(FComponentIdGenerator& IdGenerator, UClass*
 		}
 		else
 		{
-			SubobjectData.ClassPath = SubobjectClass->GetPathName();
+			continue;
 		}
 
 		SubobjectData.Name = SubobjectTypeInfo->Name;

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -438,12 +438,6 @@ TArray<UClass*> GetAllSupportedClasses()
 
 	for (TObjectIterator<UClass> ClassIt; ClassIt; ++ClassIt)
 	{
-		// User told us to ignore this class
-		if (ClassIt->HasAnySpatialClassFlags(SPATIALCLASS_NotSpatialType))
-		{
-			continue;
-		}
-
 		UClass* SupportedClass = *ClassIt;
 
 		// Ensure we don't process transient generated classes for BP

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -438,6 +438,12 @@ TArray<UClass*> GetAllSupportedClasses()
 
 	for (TObjectIterator<UClass> ClassIt; ClassIt; ++ClassIt)
 	{
+		// User told us to ignore this class	
+		if (ClassIt->HasAnySpatialClassFlags(SPATIALCLASS_NotSpatialType))
+		{
+			continue;
+		}
+
 		UClass* SupportedClass = *ClassIt;
 
 		// Ensure we don't process transient generated classes for BP

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -438,7 +438,7 @@ TArray<UClass*> GetAllSupportedClasses()
 
 	for (TObjectIterator<UClass> ClassIt; ClassIt; ++ClassIt)
 	{
-		// User told us to ignore this class	
+		// User told us to ignore this class
 		if (ClassIt->HasAnySpatialClassFlags(SPATIALCLASS_NotSpatialType))
 		{
 			continue;


### PR DESCRIPTION
We skip over subobjects that aren't supported for schema