### PR TITLE
Hide frequency from being exposed in the editor

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialInterestConstraints.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialInterestConstraints.h
@@ -53,7 +53,7 @@ public:
 	 * If multiple queries match the same Entity-Component then the highest of
 	 * all frequencies is used.
 	 */
-	UPROPERTY(BlueprintReadOnly, EditDefaultsOnly, Meta=(ClampMin=0.0), Category = "SpatialGDK")
+	UPROPERTY()
 	float Frequency;
 };
 


### PR DESCRIPTION
In order to match the schema Interest component on the SpatialOS side, we're going to hide the frequency field until it's supported.