### PR TITLE
[UNR-1688] - Update broken link for the building workers

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -567,7 +567,7 @@ FReply SSpatialGDKSimulatedPlayerDeployment::OnStopClicked()
 void SSpatialGDKSimulatedPlayerDeployment::OnCloudDocumentationClicked()
 {
 	FString WebError;
-	FPlatformProcess::LaunchURL(TEXT("https://docs.improbable.io/unreal/alpha/content/get-started/gdk-template#step-3-upload-your-workers"), TEXT(""), &WebError);
+	FPlatformProcess::LaunchURL(TEXT("https://docs.improbable.io/unreal/latest/content/get-started/gdk-template#step-2-build-your-workers"), TEXT(""), &WebError);
 	if (!WebError.IsEmpty())
 	{
 		FNotificationInfo Info(FText::FromString(WebError));


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Fixes broken link within the cloud launcher popup, which redirects the user to build their workers: https://docs.improbable.io/unreal/alpha/content/get-started/gdk-template#step-2-build-your-workers

#### Primary reviewers
@girayimprobable 