### PR TITLE
UNR-1677 : Preserve URL options on ClientTravel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed issue where an Actor's Spatial position was not updated if it had an owner that was not replicated.
 - BeginPlay is only called once with authority per deployment for startup actors
 - Fixed null pointer dereference crash when trying to initiate a Spatial connection without an existing one.
+- URL options are now properly sent through to the server when doing a ClientTravel.
 
 ## [`0.5.0-preview`](https://github.com/spatialos/UnrealGDK/releases/tag/0.5.0-preview) - 2019-06-25
 - Prevented `Spatial GDK Content` from appearing under Content Browser in the editor, as the GDK plugin does not contain any game content.

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -448,11 +448,12 @@ void USpatialNetDriver::OnAcceptingPlayersChanged(bool bAcceptingPlayers)
 
 			// Extract map name and options
 			FWorldContext& WorldContext = GEngine->GetWorldContextFromPendingNetGameNetDriverChecked(this);
+			FURL LastURL = WorldContext.PendingNetGame->URL;
 
-			FURL RedirectURL = FURL(&WorldContext.LastURL, *GlobalStateManager->DeploymentMapURL, (ETravelType)WorldContext.TravelType);
-			RedirectURL.Host = WorldContext.LastURL.Host;
-			RedirectURL.Port = WorldContext.LastURL.Port;
-			RedirectURL.Op.Append(WorldContext.LastURL.Op);
+			FURL RedirectURL = FURL(&LastURL, *GlobalStateManager->DeploymentMapURL, (ETravelType)WorldContext.TravelType);
+			RedirectURL.Host = LastURL.Host;
+			RedirectURL.Port = LastURL.Port;
+			RedirectURL.Op.Append(LastURL.Op);
 			RedirectURL.AddOption(*SpatialConstants::ClientsStayConnectedURLOption);
 
 			WorldContext.PendingNetGame->bSuccessfullyConnected = true;

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialPlayerSpawner.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialPlayerSpawner.cpp
@@ -171,9 +171,10 @@ void USpatialPlayerSpawner::ObtainPlayerParams(FURL& LoginURL, FUniqueNetIdRepl&
 
 		// Send any game-specific url options for this player
 		FString GameUrlOptions = LocalPlayer->GetGameLoginOptions();
-		if (GameUrlOptions.Len() > 0)
+		auto LastURLOptions = WorldContext->LastURL.Op;
+		for (const FString& Op : LastURLOptions)
 		{
-			LoginURL.AddOption(*FString::Printf(TEXT("%s"), *GameUrlOptions));
+			LoginURL.AddOption(*Op);
 		}
 
 		// Send the player unique Id at login

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialPlayerSpawner.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialPlayerSpawner.cpp
@@ -176,7 +176,7 @@ void USpatialPlayerSpawner::ObtainPlayerParams(FURL& LoginURL, FUniqueNetIdRepl&
 			LoginURL.AddOption(*FString::Printf(TEXT("%s"), *GameUrlOptions));
 		}
 		// Pull in options from the current world URL (to preserve options added to a travel URL)
-		auto LastURLOptions = WorldContext->LastURL.Op;
+		const TArray<FString>& LastURLOptions = WorldContext->LastURL.Op;
 		for (const FString& Op : LastURLOptions)
 		{
 			LoginURL.AddOption(*Op);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialPlayerSpawner.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialPlayerSpawner.cpp
@@ -171,6 +171,11 @@ void USpatialPlayerSpawner::ObtainPlayerParams(FURL& LoginURL, FUniqueNetIdRepl&
 
 		// Send any game-specific url options for this player
 		FString GameUrlOptions = LocalPlayer->GetGameLoginOptions();
+		if (GameUrlOptions.Len() > 0)
+		{
+			LoginURL.AddOption(*FString::Printf(TEXT("%s"), *GameUrlOptions));
+		}
+		// Pull in options from the current world URL (to preserve options added to a travel URL)
 		auto LastURLOptions = WorldContext->LastURL.Op;
 		for (const FString& Op : LastURLOptions)
 		{


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Preserve URL options when sending the URL to the server through a ClientTravel. They were being replaced.

#### Release note
REQUIRED: Add a release note to the `##Unreleased` section of CHANGELOG.md. You can find guidance for writing useful release notes [here](../SpatialGDK/Extras/internal-documentation/how-to-write-good-release-notes.md). Documentation changes are exempt from this requirement.

#### Tests
How did you test these changes prior to submitting this pull request?
Manually tested theoretically exhaustive list of possible ClientTravel scenarios to validate that URL options are propagated through. See UNR-1677 for full test matrix.
What automated tests are included in this PR?
n/a

STRONGLY SUGGESTED: How can this be verified by QA?
See UNR-1677 and replicate a subset of the scenarios tested there. Note that this may require a little bit of coding for validation.

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?
Release Note.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@joshuahuburn @m-samiec 