### PR TITLE
Bugfix: [UNR-1693] Do not Pack RPCs that are destined for a different worker type

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1168,10 +1168,13 @@ void USpatialReceiver::HandleRPC(const Worker_ComponentUpdateOp& Op)
 		}
 	}
 
-	ProcessRPCEventField(EntityId, Op, RPCEndpointComponentId, false);
+	// Always process unpacked RPCs since some cannot be packed.
+	ProcessRPCEventField(EntityId, Op, RPCEndpointComponentId, /* bPacked */ false);
+
 	if (GetDefault<USpatialGDKSettings>()->bPackRPCs)
 	{
-		ProcessRPCEventField(EntityId, Op, RPCEndpointComponentId, true);
+		// Only process packed RPCs if packing is enabled
+		ProcessRPCEventField(EntityId, Op, RPCEndpointComponentId, /* bPacked */ true);
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1178,7 +1178,7 @@ void USpatialReceiver::HandleRPC(const Worker_ComponentUpdateOp& Op)
 	}
 }
 
-void USpatialReceiver::ProcessRPCEventField(Worker_EntityId EntityId, const Worker_ComponentUpdateOp &Op, const Worker_ComponentId RPCEndpointComponentId, bool bPacked)
+void USpatialReceiver::ProcessRPCEventField(Worker_EntityId EntityId, const Worker_ComponentUpdateOp& Op, Worker_ComponentId RPCEndpointComponentId, bool bPacked)
 {
 	Schema_Object* EventsObject = Schema_GetComponentUpdateEvents(Op.update.schema_type);
 	const Schema_FieldId EventId = bPacked ? SpatialConstants::UNREAL_RPC_ENDPOINT_PACKED_EVENT_ID : SpatialConstants::UNREAL_RPC_ENDPOINT_EVENT_ID;

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -849,8 +849,8 @@ bool USpatialSender::SendRPC(const FPendingRPCParams& Params)
 						{
 							UE_LOG(LogSpatialSender, Verbose, TEXT("RPC %s Cannot be packed as TargetActor (%s) and Connection Owner (%s) are on different worker types."),
 								*Function->GetName(),
-								*TargetActor->GetFName().ToString(),
-								*ConnectionOwner->GetFName().ToString()
+								*TargetActor->GetName(),
+								*ConnectionOwner->GetName()
 							)
 							bCanPackRPC = false;
 						}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -23,6 +23,7 @@
 #include "Schema/StandardLibrary.h"
 #include "Schema/UnrealMetadata.h"
 #include "SpatialConstants.h"
+#include "Utils/ActorGroupManager.h"
 #include "Utils/ComponentFactory.h"
 #include "Utils/InterestFactory.h"
 #include "Utils/RepLayoutUtils.h"
@@ -64,6 +65,7 @@ void USpatialSender::Init(USpatialNetDriver* InNetDriver, FTimerManager* InTimer
 	Receiver = InNetDriver->Receiver;
 	PackageMap = InNetDriver->PackageMap;
 	ClassInfoManager = InNetDriver->ClassInfoManager;
+	ActorGroupManager = InNetDriver->ActorGroupManager;
 	TimerManager = InTimerManager;
 }
 
@@ -843,11 +845,12 @@ bool USpatialSender::SendRPC(const FPendingRPCParams& Params)
 				{
 					if (const AActor* ConnectionOwner = OwningConnection->OwningActor)
 					{
-						if (!NetDriver->ActorGroupManager->IsSameWorkerType(TargetActor, ConnectionOwner))
+						if (!ActorGroupManager->IsSameWorkerType(TargetActor, ConnectionOwner))
 						{
-							UE_LOG(LogTemp, Display, TEXT("%s and %s not on same worker type, so cannot be packed."),
-								*GetPathNameSafe(TargetActor),
-								*GetPathNameSafe(ConnectionOwner)
+							UE_LOG(LogSpatialSender, Verbose, TEXT("RPC %s Cannot be packed as TargetActor (%s) and Connection Owner (%s) are on different worker types."),
+								*Function->GetName(),
+								*TargetActor->GetFName().ToString(),
+								*ConnectionOwner->GetFName().ToString()
 							)
 							bCanPackRPC = false;
 						}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -831,13 +831,13 @@ bool USpatialSender::SendRPC(const FPendingRPCParams& Params)
 
 		Worker_ComponentId ComponentId = SchemaComponentTypeToWorkerComponentId(RPCInfo.Type);
 
-		bool bCanPackRPC = true;
-		if (RPCInfo.Type == SCHEMA_NetMulticastRPC)
+		bool bCanPackRPC = GetDefault<USpatialGDKSettings>()->bPackRPCs;
+		if (bCanPackRPC && RPCInfo.Type == SCHEMA_NetMulticastRPC)
 		{
 			bCanPackRPC = false;
 		}
 
-		if (GetDefault<USpatialGDKSettings>()->bEnableOffloading)
+		if (bCanPackRPC && GetDefault<USpatialGDKSettings>()->bEnableOffloading)
 		{
 			if (const AActor* TargetActor = Cast<AActor>(PackageMap->GetObjectFromEntityId(TargetObjectRef.Entity).Get()))
 			{
@@ -859,7 +859,7 @@ bool USpatialSender::SendRPC(const FPendingRPCParams& Params)
 			}
 		}
 
-		if (GetDefault<USpatialGDKSettings>()->bPackRPCs && bCanPackRPC)
+		if (bCanPackRPC)
 		{
 			const UObject* UnresolvedObject = nullptr;
 			if (AddPendingUnreliableRPC(TargetObject, Params, ComponentId, RPCInfo.Index, UnresolvedObject))

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ActorGroupManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ActorGroupManager.cpp
@@ -75,6 +75,11 @@ FName UActorGroupManager::GetWorkerTypeForActorGroup(const FName& ActorGroup) co
 
 bool UActorGroupManager::IsSameWorkerType(const AActor* ActorA, const AActor* ActorB)
 {
+	if (ActorA == nullptr || ActorB == nullptr)
+	{
+		return false;
+	}
+
 	const FName& WorkerTypeA = GetWorkerTypeForClass(ActorA->GetClass());
 	const FName& WorkerTypeB = GetWorkerTypeForClass(ActorB->GetClass());
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ActorGroupManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ActorGroupManager.cpp
@@ -72,3 +72,11 @@ FName UActorGroupManager::GetWorkerTypeForActorGroup(const FName& ActorGroup) co
 
 	return DefaultWorkerType;
 }
+
+bool UActorGroupManager::IsSameWorkerType(const AActor* ActorA, const AActor* ActorB)
+{
+	const FName& WorkerTypeA = GetWorkerTypeForClass(ActorA->GetClass());
+	const FName& WorkerTypeB = GetWorkerTypeForClass(ActorB->GetClass());
+
+	return (WorkerTypeA == WorkerTypeB);
+}

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -127,7 +127,7 @@ public:
 	void OnComponentUpdate(const Worker_ComponentUpdateOp& Op);
 	void HandleRPC(const Worker_ComponentUpdateOp& Op);
 
-	void ProcessRPCEventField(bool bPacked, Worker_EntityId EntityId, const Worker_ComponentUpdateOp &Op, const Worker_ComponentId RPCEndpointComponentId);
+	void ProcessRPCEventField(Worker_EntityId EntityId, const Worker_ComponentUpdateOp &Op, const Worker_ComponentId RPCEndpointComponentId, bool bPacked);
 
 	void OnCommandRequest(const Worker_CommandRequestOp& Op);
 	void OnCommandResponse(const Worker_CommandResponseOp& Op);

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -126,6 +126,9 @@ public:
 
 	void OnComponentUpdate(const Worker_ComponentUpdateOp& Op);
 	void HandleRPC(const Worker_ComponentUpdateOp& Op);
+
+	void ProcessRPCEventField(bool bPacked, Worker_EntityId EntityId, const Worker_ComponentUpdateOp &Op, const Worker_ComponentId RPCEndpointComponentId);
+
 	void OnCommandRequest(const Worker_CommandRequestOp& Op);
 	void OnCommandResponse(const Worker_CommandResponseOp& Op);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -27,6 +27,7 @@ class USpatialPackageMapClient;
 class USpatialReceiver;
 class USpatialStaticComponentView;
 class USpatialClassInfoManager;
+class UActorGroupManager;
 class USpatialWorkerConnection;
 
 struct FReliableRPCForRetry
@@ -155,6 +156,9 @@ private:
 
 	UPROPERTY()
 	USpatialClassInfoManager* ClassInfoManager;
+
+	UPROPERTY()
+	UActorGroupManager* ActorGroupManager;
 
 	FTimerManager* TimerManager;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/ActorGroupManager.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/ActorGroupManager.h
@@ -71,4 +71,8 @@ public:
 
 	// Returns the Server worker type that is authoritative over this ActorGroup.
 	FName GetWorkerTypeForActorGroup(const FName& ActorGroup) const;
+
+	// Returns true if ActorA and ActorB are contained in ActorGroups that are
+	// on the same Server worker type.
+	bool IsSameWorkerType(const AActor* ActorA, const AActor* ActorB);
 };


### PR DESCRIPTION
#### Description
New Client<->Server RPC packing breaks RPCs that should be sent to a different worker from the one that has authority on the PlayerController when offloading is enabled. This fix checks that the Channel Owner and the Target Actor are on the same worker type before packing.

Also adds a new UActorGroup::IsSameWorkerType method for checking 2 actors are owned by the same worker type.

#### Tests
Testing Locally with Client + Server RPCs with Offloading on/off
STRONGLY SUGGESTED: How can this be verified by QA?
1. Enable offloading and create a 2nd worker type and an actor group owned by that worker type.
2. Define a new actor class called 'Proxy' and set it to replicate. Add a client + server RPC to it.
3. Add the actor class to the actor group owned by the 2nd worker type.
4. In player controller OnAuthorityGained (which will be called on 1st worker type), spawn an instance of the Proxy actor and set a reference to it in a replicated property. Make sure to set the 'Owner' to the Player Controller (self).
5. In a keypress event, check the reference is valid and call the Client->Server RPC on the Proxy.
6. Verify that the RPC is called on the 2nd worker type.

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.