### PR TITLE
UNR-1710 Fixed a crash that may happen if rpcs are sent to tornoff actor

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1072,7 +1072,7 @@ void USpatialNetDriver::ProcessRPC(AActor* Actor, UObject* SubObject, UFunction*
 
 	if (Actor->bTearOff)
 	{
-		UE_LOG(LogSpatialOSNetDriver, Verbose, TEXT("The object %s is being torn off; RPC %s will be dropped."), *Actor->GetName(), *Function->GetName());
+		UE_LOG(LogSpatialOSNetDriver, Verbose, TEXT("The object %s is torn off; RPC %s will be dropped."), *Actor->GetName(), *Function->GetName());
 		return;
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1070,6 +1070,12 @@ void USpatialNetDriver::ProcessRPC(AActor* Actor, UObject* SubObject, UFunction*
 		}
 	}
 
+	if (Actor->bTearOff)
+	{
+		UE_LOG(LogSpatialOSNetDriver, Verbose, TEXT("The object %s is being torn off; RPC %s will be dropped."), *Actor->GetName(), *Function->GetName());
+		return;
+	}
+
 	TSet<TWeakObjectPtr<const UObject>> UnresolvedObjects;
 	RPCPayload Payload = Sender->CreateRPCPayloadFromParams(CallingObject, Function, ReliableRPCIndex, Parameters, UnresolvedObjects);
 
@@ -1672,6 +1678,10 @@ USpatialActorChannel* USpatialNetDriver::GetOrCreateSpatialActorChannel(UObject*
 			TargetActor = Cast<AActor>(TargetObject->GetOuter());
 		}
 		check(TargetActor);
+		if (TargetActor->bTearOff)
+		{
+			return nullptr;
+		}
 		Channel = CreateSpatialActorChannel(TargetActor, GetSpatialOSNetConnection());
 	}
 	return Channel;


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
In some cases RPCs might be sent to AActor that's been tornoff. This PR eliminates such cases.

#### Release note
Fix for an issue that didn't get to known issues yet.

#### Tests
This was experienced when a ragdoll was caught in an explosion.

#### Documentation
No doc update.

#### Primary reviewers
@mattyoung-improbable @improbable-valentyn