### PR TITLE
UNR-1718 Only send client and multicast RPCs on entity creation

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -751,19 +751,18 @@ bool USpatialSender::SendRPC(const FPendingRPCParams& Params)
 
 	if (Channel->bCreatingNewEntity)
 	{
-		if (Function->HasAnyFunctionFlags(FUNC_NetMulticast))
+		if (Function->HasAnyFunctionFlags(FUNC_NetClient | FUNC_NetMulticast))
 		{
-			// TODO: UNR-1437 - Add Support for Multicast RPCs on Entity Creation
-			UE_LOG(LogSpatialSender, Warning, TEXT("NetMulticast RPC %s triggered on Object %s too close to initial creation."), *Function->GetName(), *TargetObject->GetName());
-		}
-		check(NetDriver->IsServer());
-		check(Function->HasAnyFunctionFlags(FUNC_NetClient | FUNC_NetMulticast));
-		check(PackageMap->GetUnrealObjectRefFromObject(TargetObject) != FUnrealObjectRef::UNRESOLVED_OBJECT_REF);
+			if (Function->HasAnyFunctionFlags(FUNC_NetMulticast))
+			{
+				// TODO: UNR-1437 - Add Support for Multicast RPCs on Entity Creation
+				UE_LOG(LogSpatialSender, Warning, TEXT("NetMulticast RPC %s triggered on Object %s too close to initial creation."), *Function->GetName(), *TargetObject->GetName());
+			}
+			check(NetDriver->IsServer());
 
-		// This is where we'll serialize this RPC and queue it to be added on entity creation
-		TSet<TWeakObjectPtr<const UObject>> UnresolvedObjects;
-		OutgoingOnCreateEntityRPCs.FindOrAdd(TargetObject).RPCs.Add(Params.Payload);
-		return true;
+			OutgoingOnCreateEntityRPCs.FindOrAdd(TargetObject).RPCs.Add(Params.Payload);
+			return true;
+		}
 	}
 
 	const FRPCInfo& RPCInfo= ClassInfoManager->GetRPCInfo(TargetObject, Function);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -765,7 +765,7 @@ bool USpatialSender::SendRPC(const FPendingRPCParams& Params)
 		}
 	}
 
-	const FRPCInfo& RPCInfo= ClassInfoManager->GetRPCInfo(TargetObject, Function);
+	const FRPCInfo& RPCInfo = ClassInfoManager->GetRPCInfo(TargetObject, Function);
 	Worker_EntityId EntityId = SpatialConstants::INVALID_ENTITY_ID;
 
 	switch (RPCInfo.Type)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -763,6 +763,10 @@ bool USpatialSender::SendRPC(const FPendingRPCParams& Params)
 			OutgoingOnCreateEntityRPCs.FindOrAdd(TargetObject).RPCs.Add(Params.Payload);
 			return true;
 		}
+		else
+		{
+			UE_LOG(LogSpatialSender, Warning, TEXT("CrossServer RPC %s triggered on Object %s too close to initial creation."), *Function->GetName(), *TargetObject->GetName());
+		}
 	}
 
 	const FRPCInfo& RPCInfo = ClassInfoManager->GetRPCInfo(TargetObject, Function);


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
There might be cases when RPCs other than client and multicast are sent on entity creation. This PR fixes it.

#### Release note
Fix for issue that wasn't in known issues.

#### Tests
Tested that it works as expected.

#### Documentation
No doc update,

#### Primary reviewers
@improbable-valentyn @m-samiec 