### PR TITLE
Fixed a AActor::bTearOff compilation warning

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1071,7 +1071,7 @@ void USpatialNetDriver::ProcessRPC(AActor* Actor, UObject* SubObject, UFunction*
 		}
 	}
 
-	if (Actor->bTearOff)
+	if (Actor->GetTearOff())
 	{
 		UE_LOG(LogSpatialOSNetDriver, Verbose, TEXT("The object %s is torn off; RPC %s will be dropped."), *Actor->GetName(), *Function->GetName());
 		return;
@@ -1679,7 +1679,7 @@ USpatialActorChannel* USpatialNetDriver::GetOrCreateSpatialActorChannel(UObject*
 			TargetActor = Cast<AActor>(TargetObject->GetOuter());
 		}
 		check(TargetActor);
-		if (TargetActor->bTearOff)
+		if (TargetActor->GetTearOff())
 		{
 			return nullptr;
 		}


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Fixing a UE4 deprecation warning, when AActor::bTearOff is used directly.

#### Release note
Not in known issues yet.

#### Tests
When compiling a UE4 project, there should be no "warning C4996: 'AActor::bTearOff': Use GetTearOff() or TearOff() functions. This property will become private. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile."

#### Documentation
No documentation update

#### Primary reviewers
@mattyoung-improbable @peterimprobable 