### PR TITLE
UNR-1724: Only count actors that are actually replicated against frame rep budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - BeginPlay is only called once with authority per deployment for startup actors
 - Fixed null pointer dereference crash when trying to initiate a Spatial connection without an existing one.
 - URL options are now properly sent through to the server when doing a ClientTravel.
+- Fix bug where actors that haven't changed are still counted against actor-per-frame count replication limit.
 
 ## [`0.5.0-preview`](https://github.com/spatialos/UnrealGDK/releases/tag/0.5.0-preview) - 2019-06-25
 - Prevented `Spatial GDK Content` from appearing under Content Browser in the editor, as the GDK plugin does not contain any game content.

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -950,7 +950,6 @@ void USpatialNetDriver::ServerReplicateActors_ProcessPrioritizedActors(UNetConne
 			else if ((FinalReplicatedCount < MaxActorsToReplicate && !Actor->GetTearOff()) || (Actor->GetTearOff() && Channel != nullptr))
 			{
 				bIsRelevant = true;
-				FinalReplicatedCount++;
 			}
 
 			// If the actor is now relevant or was recently relevant.
@@ -1003,6 +1002,9 @@ void USpatialNetDriver::ServerReplicateActors_ProcessPrioritizedActors(UNetConne
 
 						if (Channel->ReplicateActor())
 						{
+							// Only count actors we've actually replicated against the throttling count.
+							FinalReplicatedCount++;
+
 							ActorUpdatesThisConnectionSent++;
 							if (DebugRelevantActors)
 							{


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Fix a bug where actors that haven't changed, and thus aren't actually replicated, are still counted against a frame's actor replication count budget.

#### Release note
REQUIRED: Add a release note to the `##Unreleased` section of CHANGELOG.md. You can find guidance for writing useful release notes [here](../SpatialGDK/Extras/internal-documentation/how-to-write-good-release-notes.md). Documentation changes are exempt from this requirement.

#### Tests
How did you test these changes prior to submitting this pull request?
* Tested manually in a local deployment on my BigGym sandbox project by dumping out `net.DumpRelevantActors` on the server with and without the fix.

What automated tests are included in this PR?
* n/a

STRONGLY SUGGESTED: How can this be verified by QA?
* Set the actor replication limit and dump out `net.DumpRelevantActors` on the server, and ensure that, with lots of replicated (and changing) actors on the server, it is always replicating exactly the limit of actors and not fewer.

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?
* CHANGELOG

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@m-samiec @joshuahuburn 