### PR TITLE
Add IsReplayConnection func

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
@@ -69,19 +69,6 @@ bool USpatialNetConnection::ClientHasInitializedLevelFor(const AActor* TestActor
 	//Intentionally does not call Super::
 }
 
-void USpatialNetConnection::Tick()
-{
-	// Since we're not receiving actual Unreal packets, Unreal may time out the connection. Timeouts are handled by SpatialOS, so we're setting these values here to keep Unreal happy.
-	// Note that in the case of InternalAck (UnrealWorker) the engine does this (and more) in Super.
-	if (!InternalAck)
-	{
-		LastReceiveTime = Driver->Time;
-		LastReceiveRealtime = FPlatformTime::Seconds();
-		LastGoodPacketRealtime = FPlatformTime::Seconds();
-	}
-	Super::Tick();
-}
-
 int32 USpatialNetConnection::IsNetReady(bool Saturate)
 {
 	// TODO: UNR-664 - Currently we do not report the number of bits sent when replicating, this means channel saturation cannot be checked properly.

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetConnection.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetConnection.h
@@ -21,6 +21,7 @@ class SPATIALGDK_API USpatialNetConnection : public UIpConnection
 public:
 	USpatialNetConnection(const FObjectInitializer& ObjectInitializer);
 
+	//~ Begin NetConnection Interface
 	virtual void BeginDestroy() override;
 
 	virtual void InitBase(UNetDriver* InDriver, class FSocket* InSocket, const FURL& InURL, EConnectionState InState, int32 InMaxPacket = 0, int32 InPacketOverhead = 0) override;
@@ -30,17 +31,19 @@ public:
 	virtual void LowLevelSend(void* Data, int32 CountBits, FOutPacketTraits& Traits) override;
 #endif
 	virtual bool ClientHasInitializedLevelFor(const AActor* TestActor) const override;
-	virtual void Tick() override;
 	virtual int32 IsNetReady(bool Saturate) override;
 
 	/** Called by PlayerController to tell connection about client level visibility change */
 	virtual void UpdateLevelVisibility(const FName& PackageName, bool bIsVisible) override;
+
+	virtual bool IsReplayConnection() const { return false; }
 
 	// These functions don't make a lot of sense in a SpatialOS implementation.
 	virtual FString LowLevelGetRemoteAddress(bool bAppendPort = false) override { return TEXT(""); }
 	virtual FString LowLevelDescribe() override { return TEXT(""); }
 	virtual FString RemoteAddressToString() override { return TEXT(""); }
 	///////
+	//~ End NetConnection Interface
 
 	void InitHeartbeat(class FTimerManager* InTimerManager, Worker_EntityId InPlayerControllerEntity);
 	void SetHeartbeatTimeoutTimer();

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetConnection.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetConnection.h
@@ -21,7 +21,7 @@ class SPATIALGDK_API USpatialNetConnection : public UIpConnection
 public:
 	USpatialNetConnection(const FObjectInitializer& ObjectInitializer);
 
-	//~ Begin NetConnection Interface
+	// Begin NetConnection Interface
 	virtual void BeginDestroy() override;
 
 	virtual void InitBase(UNetDriver* InDriver, class FSocket* InSocket, const FURL& InURL, EConnectionState InState, int32 InMaxPacket = 0, int32 InPacketOverhead = 0) override;
@@ -43,7 +43,7 @@ public:
 	virtual FString LowLevelDescribe() override { return TEXT(""); }
 	virtual FString RemoteAddressToString() override { return TEXT(""); }
 	///////
-	//~ End NetConnection Interface
+	// End NetConnection Interface
 
 	void InitHeartbeat(class FTimerManager* InTimerManager, Worker_EntityId InPlayerControllerEntity);
 	void SetHeartbeatTimeoutTimer();

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetConnection.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetConnection.h
@@ -36,7 +36,7 @@ public:
 	/** Called by PlayerController to tell connection about client level visibility change */
 	virtual void UpdateLevelVisibility(const FName& PackageName, bool bIsVisible) override;
 
-	virtual bool IsReplayConnection() const { return false; }
+	virtual bool IsReplayConnection() const override { return false; }
 
 	// These functions don't make a lot of sense in a SpatialOS implementation.
 	virtual FString LowLevelGetRemoteAddress(bool bAppendPort = false) override { return TEXT(""); }

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/EngineVersionCheck.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/EngineVersionCheck.h
@@ -7,7 +7,7 @@
 // GDK Version to be updated with SPATIAL_ENGINE_VERSION
 // when breaking changes are made to the engine that requires
 // changes to the GDK to remain compatible
-#define SPATIAL_GDK_VERSION 4
+#define SPATIAL_GDK_VERSION 5
 
 // Check if GDK is compatible with the current version of Unreal Engine
 // SPATIAL_ENGINE_VERSION is incremented in engine when breaking changes

--- a/ci/unreal-engine.version
+++ b/ci/unreal-engine.version
@@ -1,1 +1,1 @@
-UnrealEngine-b8834f416c4e1971de828123a467da993ab680b4
+UnrealEngine-73377b33c8a9ea2c3e09126e982d71da659a0eeb


### PR DESCRIPTION
#### Description
GameplayTagContainer used InternalAck as a soft check if we were in a replay connection. We use InternalAck for it's actual purpose, so created a new function - NetConnection::IsReplayConnection().

Engine PR - https://github.com/improbableio/UnrealEngine/pull/214

#### Primary reviewers
@girayozil @improbable-valentyn 