### PR TITLE
Bugfix/unr 1705 crash on dynamic component re-add

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -161,7 +161,7 @@ bool USpatialActorChannel::CleanUp(const bool bForDestroy, EChannelCloseReason C
 	}
 #endif
 
-	// Must call cleanup actor and subobjects before UActorChannel::Cleanup as it will clear CreateSubObjects
+	// Must cleanup actor and subobjects before UActorChannel::Cleanup as it will clear CreateSubObjects
 	Receiver->CleanupDeletedEntity(EntityId);
 
 #if ENGINE_MINOR_VERSION <= 20

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -161,6 +161,9 @@ bool USpatialActorChannel::CleanUp(const bool bForDestroy, EChannelCloseReason C
 	}
 #endif
 
+	// Must call cleanup actor and subobjects before UActorChannel::Cleanup as it will clear CreateSubObjects
+	Receiver->CleanupDeletedEntity(EntityId);
+
 #if ENGINE_MINOR_VERSION <= 20
 	return UActorChannel::CleanUp(bForDestroy);
 #else

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -432,6 +432,21 @@ void FSpatialNetGUIDCache::RemoveEntityNetGUID(Worker_EntityId EntityId)
 		}
 	}
 
+	// Remove dynamically attached subobjects
+	USpatialActorChannel* Channel = SpatialNetDriver->GetActorChannelByEntityId(EntityId);
+	for (UObject* DynamicSubobject : Channel->CreateSubObjects)
+	{
+		if (FNetworkGUID* SubobjectNetGUID = NetGUIDLookup.Find(DynamicSubobject))
+		{
+			if (FUnrealObjectRef* SubobjectRef = NetGUIDToUnrealObjectRef.Find(*SubobjectNetGUID))
+			{
+				UnrealObjectRefToNetGUID.Remove(*SubobjectRef);
+			}
+
+			NetGUIDToUnrealObjectRef.Remove(*SubobjectNetGUID);
+		}
+	}
+
 	// Remove actor.
 	FNetworkGUID EntityNetGUID = GetNetGUIDFromEntityId(EntityId);
 	// TODO: Figure out why NetGUIDToUnrealObjectRef might not have this GUID. UNR-989

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -441,9 +441,8 @@ void FSpatialNetGUIDCache::RemoveEntityNetGUID(Worker_EntityId EntityId)
 			if (FUnrealObjectRef* SubobjectRef = NetGUIDToUnrealObjectRef.Find(*SubobjectNetGUID))
 			{
 				UnrealObjectRefToNetGUID.Remove(*SubobjectRef);
+				NetGUIDToUnrealObjectRef.Remove(*SubobjectNetGUID);
 			}
-
-			NetGUIDToUnrealObjectRef.Remove(*SubobjectNetGUID);
 		}
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -626,7 +626,6 @@ void USpatialReceiver::RemoveActor(Worker_EntityId EntityId)
 #else
 			ActorChannel->ConditionalCleanUp(false, EChannelCloseReason::Destroyed);
 #endif
-			CleanupDeletedEntity(EntityId);
 		}
 		return;
 	}
@@ -641,7 +640,6 @@ void USpatialReceiver::RemoveActor(Worker_EntityId EntityId)
 #else
 			ActorChannel->ConditionalCleanUp(false, EChannelCloseReason::TearOff);
 #endif
-			CleanupDeletedEntity(EntityId);
 		}
 		return;
 	}
@@ -760,7 +758,7 @@ void USpatialReceiver::DestroyActor(AActor* Actor, Worker_EntityId EntityId)
 	}
 	NetDriver->StopIgnoringAuthoritativeDestruction();
 
-	CleanupDeletedEntity(EntityId);
+	check(PackageMap->GetObjectFromEntityId(EntityId) == nullptr);
 }
 
 void USpatialReceiver::CleanupDeletedEntity(Worker_EntityId EntityId)


### PR DESCRIPTION
#### Description
Dynamic subobjects now get removed correctly from the package map.

#### Primary reviewers
@Vatyx @improbable-valentyn 