### PR TITLE
Refactor utility functions

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCloudLauncher.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCloudLauncher.cpp
@@ -3,8 +3,8 @@
 #include "SpatialGDKEditorCloudLauncher.h"
 
 #include "Interfaces/IPluginManager.h"
-#include "SpatialGDKServicesModule.h"
 #include "SpatialGDKEditorSettings.h"
+#include "SpatialGDKServicesModule.h"
 
 bool SpatialGDKCloudLaunch()
 {

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCloudLauncher.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCloudLauncher.cpp
@@ -3,6 +3,7 @@
 #include "SpatialGDKEditorCloudLauncher.h"
 
 #include "Interfaces/IPluginManager.h"
+#include "SpatialGDKServicesModule.h"
 #include "SpatialGDKEditorSettings.h"
 
 bool SpatialGDKCloudLaunch()
@@ -13,7 +14,7 @@ bool SpatialGDKCloudLaunch()
 
 	FString LauncherCmdArguments = FString::Printf(
 		TEXT("/c cmd.exe /c DeploymentLauncher.exe create %s %s %s \"%s\" \"%s\" %s"),
-		*SpatialGDKSettings->GetProjectName(),
+		*FSpatialGDKServicesModule::GetProjectName(),
 		*SpatialGDKSettings->GetAssemblyName(),
 		*SpatialGDKSettings->GetPrimaryDeploymentName(),
 		*SpatialGDKSettings->GetPrimaryLanchConfigPath(),

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -2,14 +2,10 @@
 
 #include "SpatialGDKEditorSettings.h"
 
-#include "Dom/JsonObject.h"
 #include "Internationalization/Regex.h"
 #include "ISettingsModule.h"
-#include "Misc/FileHelper.h"
 #include "Misc/MessageDialog.h"
 #include "Modules/ModuleManager.h"
-#include "Serialization/JsonReader.h"
-#include "Serialization/JsonSerializer.h"
 #include "Settings/LevelEditorPlaySettings.h"
 #include "Templates/SharedPointer.h"
 #include "SpatialConstants.h"

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -30,7 +30,6 @@ USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& O
 {
 	SpatialOSLaunchConfig.FilePath = GetSpatialOSLaunchConfig();
 	SpatialOSSnapshotFile = GetSpatialOSSnapshotFile();
-	ProjectName = GetProjectNameFromSpatial();
 }
 
 void USpatialGDKEditorSettings::PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent)
@@ -101,27 +100,6 @@ void USpatialGDKEditorSettings::SetLevelEditorPlaySettingsWorkerTypes()
 	}
 }
 
-FString USpatialGDKEditorSettings::GetProjectNameFromSpatial() const
-{
-	FString FileContents;
-	const FString SpatialOSFile = FSpatialGDKServicesModule::GetSpatialOSDirectory().Append(TEXT("/spatialos.json"));
-
-	if (!FFileHelper::LoadFileToString(FileContents, *SpatialOSFile))
-	{
-		return TEXT("");
-	}
-
-	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(FileContents);
-	TSharedPtr<FJsonObject> JsonObject;
-
-	if (FJsonSerializer::Deserialize(Reader, JsonObject))
-	{
-		return JsonObject->GetStringField("name");
-	}
-
-	return FString();
-}
-
 bool USpatialGDKEditorSettings::IsAssemblyNameValid(const FString& Name)
 {
 	const FRegexPattern AssemblyPatternRegex(SpatialConstants::AssemblyPattern);
@@ -162,12 +140,6 @@ void USpatialGDKEditorSettings::SetPrimaryDeploymentName(const FString& Name)
 void USpatialGDKEditorSettings::SetAssemblyName(const FString& Name)
 {
 	AssemblyName = Name;
-	SaveConfig();
-}
-
-void USpatialGDKEditorSettings::SetProjectName(const FString& Name)
-{
-	ProjectName = Name;
 	SaveConfig();
 }
 
@@ -215,7 +187,6 @@ bool USpatialGDKEditorSettings::IsDeploymentConfigurationValid() const
 {
 	bool result = IsAssemblyNameValid(AssemblyName) &&
 		IsDeploymentNameValid(PrimaryDeploymentName) &&
-		IsProjectNameValid(ProjectName) &&
 		!SnapshotPath.FilePath.IsEmpty() &&
 		!PrimaryLaunchConfigPath.FilePath.IsEmpty() &&
 		IsRegionCodeValid(PrimaryDeploymentRegionCode);

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -266,9 +266,6 @@ private:
 	TArray<FString> SpatialOSCommandLineLaunchFlags;
 
 private:
-	UPROPERTY(EditAnywhere, config, Category = "Cloud", meta = (ConfigRestartRequired = false, DisplayName = "SpatialOS project"))
-		FString ProjectName;
-
 	UPROPERTY(EditAnywhere, config, Category = "Cloud", meta = (ConfigRestartRequired = false, DisplayName = "Assembly name"))
 		FString AssemblyName;
 
@@ -371,12 +368,6 @@ public:
 	FORCEINLINE FString GetAssemblyName() const
 	{
 		return AssemblyName;
-	}
-
-	void SetProjectName(const FString& Name);
-	FORCEINLINE FString GetProjectName() const
-	{
-		return ProjectName;
 	}
 
 	void SetPrimaryLaunchConfigPath(const FString& Path);

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -91,22 +91,21 @@ void SSpatialGDKSimulatedPlayerDeployment::Construct(const FArguments& InArgs)
 							.AutoHeight()
 							.Padding(2.0f)
 							[
-									SNew(SHorizontalBox)
-									+ SHorizontalBox::Slot()
-									.FillWidth(1.0f)
-									[
-											SNew(STextBlock)
-											.Text(FText::FromString(FString(TEXT("Project Name"))))
-											.ToolTipText(FText::FromString(FString(TEXT("The name of the SpatialOS project."))))
-									]
-									+ SHorizontalBox::Slot()
-									.FillWidth(1.0f)
-									[
-											SNew(SEditableTextBox)
-											.Text(FText::FromString(ProjectName))
-											.ToolTipText(FText::FromString(FString(TEXT("The name of the SpatialOS project."))))
-											.IsEnabled(false)
-									]
+								SNew(SHorizontalBox)
+								+ SHorizontalBox::Slot()
+								.FillWidth(1.0f)
+								[
+									SNew(STextBlock)
+									.Text(FText::FromString(FString(TEXT("Project Name"))))
+									.ToolTipText(FText::FromString(FString(TEXT("The name of the SpatialOS project."))))
+								]
+								+ SHorizontalBox::Slot()
+								.FillWidth(1.0f)
+								[											SNew(SEditableTextBox)
+									.Text(FText::FromString(ProjectName))
+									.ToolTipText(FText::FromString(FString(TEXT("The name of the SpatialOS project."))))
+									.IsEnabled(false)
+								]
 							]
 							// Assembly Name 
 							+ SVerticalBox::Slot()

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -10,6 +10,7 @@
 #include "Framework/Notifications/NotificationManager.h"
 #include "Templates/SharedPointer.h"
 #include "SpatialGDKEditorSettings.h"
+#include "SpatialGDKServicesModule.h"
 #include "Textures/SlateIcon.h"
 #include "Widgets/Input/SButton.h"
 #include "Widgets/Input/SComboButton.h"
@@ -28,7 +29,8 @@
 void SSpatialGDKSimulatedPlayerDeployment::Construct(const FArguments& InArgs)
 {
 	const USpatialGDKEditorSettings* SpatialGDKSettings = GetDefault<USpatialGDKEditorSettings>();
-	
+	FString ProjectName = FSpatialGDKServicesModule::GetProjectName();
+
 	ParentWindowPtr = InArgs._ParentWindow;
 	SpatialGDKEditorPtr = InArgs._SpatialGDKEditor;
 
@@ -89,23 +91,22 @@ void SSpatialGDKSimulatedPlayerDeployment::Construct(const FArguments& InArgs)
 							.AutoHeight()
 							.Padding(2.0f)
 							[
-								SNew(SHorizontalBox)
-								+ SHorizontalBox::Slot()
-								.FillWidth(1.0f)
-								[
-									SNew(STextBlock)
-									.Text(FText::FromString(FString(TEXT("Project Name"))))
-									.ToolTipText(FText::FromString(FString(TEXT("The name of the SpatialOS project."))))
-								]
-								+ SHorizontalBox::Slot()
-								.FillWidth(1.0f)
-								[
-									SNew(SEditableTextBox)
-									.Text(FText::FromString(SpatialGDKSettings->GetProjectName()))
-									.ToolTipText(FText::FromString(FString(TEXT("The name of the SpatialOS project."))))
-									.OnTextCommitted(this, &SSpatialGDKSimulatedPlayerDeployment::OnProjectNameCommited)
-									.OnTextChanged(this, &SSpatialGDKSimulatedPlayerDeployment::OnProjectNameCommited, ETextCommit::Default)
-								]
+									SNew(SHorizontalBox)
+									+ SHorizontalBox::Slot()
+									.FillWidth(1.0f)
+									[
+											SNew(STextBlock)
+											.Text(FText::FromString(FString(TEXT("Project Name"))))
+											.ToolTipText(FText::FromString(FString(TEXT("The name of the SpatialOS project."))))
+									]
+									+ SHorizontalBox::Slot()
+									.FillWidth(1.0f)
+									[
+											SNew(SEditableTextBox)
+											.Text(FText::FromString(ProjectName))
+											.ToolTipText(FText::FromString(FString(TEXT("The name of the SpatialOS project."))))
+											.IsEnabled(false)
+									]
 							]
 							// Assembly Name 
 							+ SVerticalBox::Slot()
@@ -395,12 +396,6 @@ void SSpatialGDKSimulatedPlayerDeployment::OnDeploymentAssemblyCommited(const FT
 {
 	USpatialGDKEditorSettings* SpatialGDKSettings = GetMutableDefault<USpatialGDKEditorSettings>();
 	SpatialGDKSettings->SetAssemblyName(InText.ToString());
-}
-
-void SSpatialGDKSimulatedPlayerDeployment::OnProjectNameCommited(const FText& InText, ETextCommit::Type InCommitType)
-{
-	USpatialGDKEditorSettings* SpatialGDKSettings = GetMutableDefault<USpatialGDKEditorSettings>();
-	SpatialGDKSettings->SetProjectName(InText.ToString());
 }
 
 void SSpatialGDKSimulatedPlayerDeployment::OnPrimaryDeploymentNameCommited(const FText& InText, ETextCommit::Type InCommitType)

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -101,7 +101,8 @@ void SSpatialGDKSimulatedPlayerDeployment::Construct(const FArguments& InArgs)
 								]
 								+ SHorizontalBox::Slot()
 								.FillWidth(1.0f)
-								[											SNew(SEditableTextBox)
+								[
+									SNew(SEditableTextBox)
 									.Text(FText::FromString(ProjectName))
 									.ToolTipText(FText::FromString(FString(TEXT("The name of the SpatialOS project."))))
 									.IsEnabled(false)

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKSimulatedPlayerDeployment.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKSimulatedPlayerDeployment.h
@@ -43,9 +43,6 @@ private:
 	/** Delegate to commit assembly name */
 	void OnDeploymentAssemblyCommited(const FText& InText, ETextCommit::Type InCommitType);
 
-	/** Delegate to commit project name */
-	void OnProjectNameCommited(const FText& InText, ETextCommit::Type InCommitType);
-
 	/** Delegate to commit primary deployment name */
 	void OnPrimaryDeploymentNameCommited(const FText& InText, ETextCommit::Type InCommitType);
 

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -369,14 +369,14 @@ bool FLocalDeploymentManager::GetLocalDeploymentStatus()
 	}
 
 	TSharedPtr<FJsonObject> SpotJsonResult;
-	bool bPasingSuccess = FSpatialGDKServicesModule::ParseJson(SpotListResult, SpotJsonResult);
-	if (!bPasingSuccess)
+	bool bParsingSuccess = FSpatialGDKServicesModule::ParseJson(SpotListResult, SpotJsonResult);
+	if (!bParsingSuccess)
 	{
 		UE_LOG(LogSpatialDeploymentManager, Error, TEXT("Json parsing of spot list result failed. Result: %s"), *SpotListResult);
 	}
 
 	const TSharedPtr<FJsonObject>* SpotJsonContent = nullptr;
-	if (bPasingSuccess && SpotJsonResult->TryGetObjectField(TEXT("content"), SpotJsonContent))
+	if (bParsingSuccess && SpotJsonResult->TryGetObjectField(TEXT("content"), SpotJsonContent))
 	{
 		const TArray<TSharedPtr<FJsonValue>>* JsonDeployments;
 		if (!SpotJsonContent->Get()->TryGetArrayField(TEXT("deployments"), JsonDeployments))

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -8,13 +8,8 @@
 #include "Editor.h"
 #include "FileCache.h"
 #include "GeneralProjectSettings.h"
-#include "HAL/FileManager.h"
-#include "HAL/PlatformFilemanager.h"
 #include "Interop/Connection/EditorWorkerController.h"
-#include "Misc/FileHelper.h"
-#include "Serialization/JsonReader.h"
-#include "Serialization/JsonSerializer.h"
-#include "Serialization/JsonWriter.h"
+#include "Json/Public/Dom/JsonObject.h"
 #include "SpatialGDKServicesModule.h"
 
 DEFINE_LOG_CATEGORY(LogSpatialDeploymentManager);

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialGDKServicesModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialGDKServicesModule.cpp
@@ -2,6 +2,9 @@
 
 #include "SpatialGDKServicesModule.h"
 
+#include "Misc/FileHelper.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
 #include "SpatialGDKServicesPrivate.h"
 
 #define LOCTEXT_NAMESPACE "FSpatialGDKServicesModule"
@@ -10,6 +13,7 @@ DEFINE_LOG_CATEGORY(LogSpatialGDKServices);
 
 IMPLEMENT_MODULE(FSpatialGDKServicesModule, SpatialGDKServices);
 
+
 void FSpatialGDKServicesModule::StartupModule()
 {
 }
@@ -17,6 +21,8 @@ void FSpatialGDKServicesModule::StartupModule()
 void FSpatialGDKServicesModule::ShutdownModule()
 {
 }
+
+FString FSpatialGDKServicesModule::ProjectName = FSpatialGDKServicesModule::ParseProjectName();
 
 FLocalDeploymentManager* FSpatialGDKServicesModule::GetLocalDeploymentManager()
 {
@@ -40,6 +46,75 @@ FString FSpatialGDKServicesModule::GetSpatialGDKPluginDirectory(const FString& A
 	}
 
 	return FPaths::ConvertRelativePathToFull(FPaths::Combine(PluginDir, AppendPath));
+}
+
+bool FSpatialGDKServicesModule::ParseJson(const FString& RawJsonString, TSharedPtr<FJsonObject>& JsonParsed)
+{
+	TSharedRef<TJsonReader<TCHAR>> JsonReader = TJsonReaderFactory<TCHAR>::Create(RawJsonString);
+	return FJsonSerializer::Deserialize(JsonReader, JsonParsed);
+}
+
+// ExecuteAndReadOutput exists so that a spatial command window does not spawn when using 'spatial.exe'. It does not however allow reading from StdErr.
+// For other processes which do not spawn cmd windows, use ExecProcess instead.
+void FSpatialGDKServicesModule::ExecuteAndReadOutput(const FString& Executable, const FString& Arguments, const FString& DirectoryToRun, FString& OutResult, int32& ExitCode)
+{
+	UE_LOG(LogSpatialDeploymentManager, Verbose, TEXT("Executing '%s' with arguments '%s' in directory '%s'"), *Executable, *Arguments, *DirectoryToRun);
+
+	void* ReadPipe = nullptr;
+	void* WritePipe = nullptr;
+	ensure(FPlatformProcess::CreatePipe(ReadPipe, WritePipe));
+
+	FProcHandle ProcHandle = FPlatformProcess::CreateProc(*Executable, *Arguments, false, true, true, nullptr, 1 /*PriorityModifer*/, *DirectoryToRun, WritePipe);
+
+	if (ProcHandle.IsValid())
+	{
+		for (bool bProcessFinished = false; !bProcessFinished; )
+		{
+			bProcessFinished = FPlatformProcess::GetProcReturnCode(ProcHandle, &ExitCode);
+
+			OutResult = OutResult.Append(FPlatformProcess::ReadPipe(ReadPipe));
+			FPlatformProcess::Sleep(0.01f);
+		}
+
+		FPlatformProcess::CloseProc(ProcHandle);
+	}
+	else
+	{
+		UE_LOG(LogSpatialDeploymentManager, Error, TEXT("Execution failed. '%s' with arguments '%s' in directory '%s' "), *Executable, *Arguments, *DirectoryToRun);
+	}
+
+	FPlatformProcess::ClosePipe(0, ReadPipe);
+	FPlatformProcess::ClosePipe(0, WritePipe);
+}
+
+FString FSpatialGDKServicesModule::ParseProjectName()
+{
+	FString ProjectNameParsed;
+	const FString SpatialDirectory = FSpatialGDKServicesModule::GetSpatialOSDirectory();
+
+	FString SpatialFileName = TEXT("spatialos.json");
+	FString SpatialFileResult;
+	FFileHelper::LoadFileToString(SpatialFileResult, *FPaths::Combine(SpatialDirectory, SpatialFileName));
+
+	TSharedPtr<FJsonObject> JsonParsedSpatialFile;
+	if (ParseJson(SpatialFileResult, JsonParsedSpatialFile))
+	{
+		if (JsonParsedSpatialFile->TryGetStringField(TEXT("name"), ProjectNameParsed))
+		{
+			return ProjectNameParsed;
+		}
+		else
+		{
+			UE_LOG(LogSpatialDeploymentManager, Error, TEXT("'name' does not exist in spatialos.json. Can't read project name."));
+		}
+	}
+	else
+	{
+		UE_LOG(LogSpatialDeploymentManager, Error, TEXT("Json parsing of spatialos.json failed. Can't get project name."));
+	}
+
+	ProjectNameParsed.Empty();
+	return ProjectNameParsed;
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialGDKServicesModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialGDKServicesModule.cpp
@@ -58,7 +58,7 @@ bool FSpatialGDKServicesModule::ParseJson(const FString& RawJsonString, TSharedP
 // For other processes which do not spawn cmd windows, use ExecProcess instead.
 void FSpatialGDKServicesModule::ExecuteAndReadOutput(const FString& Executable, const FString& Arguments, const FString& DirectoryToRun, FString& OutResult, int32& ExitCode)
 {
-	UE_LOG(LogSpatialDeploymentManager, Verbose, TEXT("Executing '%s' with arguments '%s' in directory '%s'"), *Executable, *Arguments, *DirectoryToRun);
+	UE_LOG(LogSpatialGDKServices, Verbose, TEXT("Executing '%s' with arguments '%s' in directory '%s'"), *Executable, *Arguments, *DirectoryToRun);
 
 	void* ReadPipe = nullptr;
 	void* WritePipe = nullptr;
@@ -80,7 +80,7 @@ void FSpatialGDKServicesModule::ExecuteAndReadOutput(const FString& Executable, 
 	}
 	else
 	{
-		UE_LOG(LogSpatialDeploymentManager, Error, TEXT("Execution failed. '%s' with arguments '%s' in directory '%s' "), *Executable, *Arguments, *DirectoryToRun);
+		UE_LOG(LogSpatialGDKServices, Error, TEXT("Execution failed. '%s' with arguments '%s' in directory '%s' "), *Executable, *Arguments, *DirectoryToRun);
 	}
 
 	FPlatformProcess::ClosePipe(0, ReadPipe);
@@ -105,12 +105,12 @@ FString FSpatialGDKServicesModule::ParseProjectName()
 		}
 		else
 		{
-			UE_LOG(LogSpatialDeploymentManager, Error, TEXT("'name' does not exist in spatialos.json. Can't read project name."));
+			UE_LOG(LogSpatialGDKServices, Error, TEXT("'name' does not exist in spatialos.json. Can't read project name."));
 		}
 	}
 	else
 	{
-		UE_LOG(LogSpatialDeploymentManager, Error, TEXT("Json parsing of spatialos.json failed. Can't get project name."));
+		UE_LOG(LogSpatialGDKServices, Error, TEXT("Json parsing of spatialos.json failed. Can't get project name."));
 	}
 
 	ProjectNameParsed.Empty();

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalDeploymentManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalDeploymentManager.h
@@ -75,7 +75,6 @@ private:
 	bool bStoppingSpatialService;
 
 	FString LocalRunningDeploymentID;
-	FString ProjectName;
 
 	bool bRedeployRequired = false;
 	bool bAutoDeploy = false;

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalDeploymentManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalDeploymentManager.h
@@ -45,11 +45,7 @@ public:
 
 	void SPATIALGDKSERVICES_API SetAutoDeploy(bool bAutoDeploy);
 
-	// TODO: Refactor these into Utils
-	FString GetProjectName();
 	void WorkerBuildConfigAsync();
-	bool ParseJson(const FString& RawJsonString, TSharedPtr<FJsonObject>& JsonParsed);
-	void ExecuteAndReadOutput(const FString& Executable, const FString& Arguments, const FString& DirectoryToRun, FString& OutResult, int32& ExitCode);
 	const FString GetSpotExe();
 
 	FSimpleMulticastDelegate OnSpatialShutdown;

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesModule.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesModule.h
@@ -8,6 +8,8 @@
 class SPATIALGDKSERVICES_API FSpatialGDKServicesModule : public IModuleInterface
 {
 public:
+	static FString ProjectName;
+
 	virtual void StartupModule() override;
 	virtual void ShutdownModule() override;
 
@@ -21,6 +23,15 @@ public:
 	static FString GetSpatialOSDirectory(const FString& AppendPath = TEXT(""));
 	static FString GetSpatialGDKPluginDirectory(const FString& AppendPath = TEXT(""));
 
+	FORCEINLINE static FString GetProjectName()
+	{
+		return ProjectName;
+	}
+
+	static bool ParseJson(const FString& RawJsonString, TSharedPtr<FJsonObject>& JsonParsed);
+	static void ExecuteAndReadOutput(const FString& Executable, const FString& Arguments, const FString& DirectoryToRun, FString& OutResult, int32& ExitCode);
+
 private:
 	FLocalDeploymentManager LocalDeploymentManager;
+	static FString ParseProjectName();
 };


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
This PR refactors some existing logic that retrieves the SpatialOS project from the spatial.json file and other utility functions from the `FLocalDeploymentManager` to the `FSpatialGDKServicesModule` and making them static. It also removes duplicated code from the Cloud settings that retrieves the SpatialOS project name.

#### Primary reviewers
@joshuahuburn 