### PR TITLE
UNR-1735

### DIFF
--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/CodeGenerator/Unreal/HeaderGenerator.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/CodeGenerator/Unreal/HeaderGenerator.cs
@@ -235,7 +235,8 @@ struct Response
 Response({string.Join($", ", types.Find(t => t.QualifiedName == command.ResponseType).Fields.Select(f => $"{Types.GetConstAccessorTypeModification(f, bundle, type)} {Text.SnakeCaseToPascalCase(f.Name)}"))})
 : Data({string.Join($", ", types.Find(t => t.QualifiedName == command.ResponseType).Fields.Select(f => $"{Text.SnakeCaseToPascalCase(f.Name)}"))}) {{}}
 Response(Type Data) : Data{{ Data }} {{}}
-Type Data;")}
+{(types.Find(t => t.QualifiedName == command.ResponseType).Fields.Count() > 0 ? $@"Response() : Data() {{}}
+Type Data;" : "Type Data;")}")}
 }};
 using RequestOp = ::improbable::CommandRequestOp<Request>;
 using ResponseOp = ::improbable::CommandResponseOp<Response>;")} 

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/CodeGenerator/Unreal/InterfaceGenerator.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/CodeGenerator/Unreal/InterfaceGenerator.cs
@@ -190,7 +190,9 @@ USpatialDispatcher::FCallbackId {ClassName}::OnCommandResponse(const TFunction<v
 {{
 {Text.Indent(1, $@"if (Op.command_id == {command.CommandIndex})
 {{
-{Text.Indent(1, $@"auto Response = Op.status_code == Worker_StatusCode::WORKER_STATUS_CODE_SUCCESS  ? {Types.GetTypeDisplayName(component.QualifiedName)}::Commands::{Text.SnakeCaseToPascalCase(command.Name)}::Response({Types.GetTypeDisplayName(component.QualifiedName)}::Commands::{ Text.SnakeCaseToPascalCase(command.Name)}::Response::Type::Deserialize(Schema_GetCommandResponseObject(Op.response.schema_type))) : {Types.GetTypeDisplayName(component.QualifiedName)}::Commands::{Text.SnakeCaseToPascalCase(command.Name)}::Response();
+{Text.Indent(1, $@"auto Response = Op.status_code == Worker_StatusCode::WORKER_STATUS_CODE_SUCCESS  ?
+{Text.Indent(1, $@"{Types.GetTypeDisplayName(component.QualifiedName)}::Commands::{Text.SnakeCaseToPascalCase(command.Name)}::Response({Types.GetTypeDisplayName(component.QualifiedName)}::Commands::{ Text.SnakeCaseToPascalCase(command.Name)}::Response::Type::Deserialize(Schema_GetCommandResponseObject(Op.response.schema_type))) :
+{Types.GetTypeDisplayName(component.QualifiedName)}::Commands::{Text.SnakeCaseToPascalCase(command.Name)}::Response();")}
 Callback({Types.GetTypeDisplayName(component.QualifiedName)}::Commands::{Text.SnakeCaseToPascalCase(command.Name)}::ResponseOp(Op.entity_id, Op.request_id, Op.status_code, Op.message, Op.command_id, Response));")}
 }}")}
 }});")}

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/CodeGenerator/Unreal/InterfaceGenerator.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/CodeGenerator/Unreal/InterfaceGenerator.cs
@@ -188,8 +188,11 @@ USpatialDispatcher::FCallbackId {ClassName}::OnCommandResponse(const TFunction<v
 {{
 {Text.Indent(1, $@"return SpatialDispatcher->OnCommandResponse({component.ComponentId}, [Callback](const Worker_CommandResponseOp& Op)
 {{
-{Text.Indent(1, $@"auto Response = {Types.GetTypeDisplayName(component.QualifiedName)}::Commands::{Text.SnakeCaseToPascalCase(command.Name)}::Response({Types.GetTypeDisplayName(component.QualifiedName)}::Commands::{ Text.SnakeCaseToPascalCase(command.Name)}::Response::Type::Deserialize(Schema_GetCommandResponseObject(Op.response.schema_type)));
+{Text.Indent(1, $@"if (Op.command_id == {command.CommandIndex})
+{{
+{Text.Indent(1, $@"auto Response = Op.status_code == Worker_StatusCode::WORKER_STATUS_CODE_SUCCESS  ? {Types.GetTypeDisplayName(component.QualifiedName)}::Commands::{Text.SnakeCaseToPascalCase(command.Name)}::Response({Types.GetTypeDisplayName(component.QualifiedName)}::Commands::{ Text.SnakeCaseToPascalCase(command.Name)}::Response::Type::Deserialize(Schema_GetCommandResponseObject(Op.response.schema_type))) : {Types.GetTypeDisplayName(component.QualifiedName)}::Commands::{Text.SnakeCaseToPascalCase(command.Name)}::Response();
 Callback({Types.GetTypeDisplayName(component.QualifiedName)}::Commands::{Text.SnakeCaseToPascalCase(command.Name)}::ResponseOp(Op.entity_id, Op.request_id, Op.status_code, Op.message, Op.command_id, Response));")}
+}}")}
 }});")}
 }}
 "))}"))}";


### PR DESCRIPTION
Fix for generated code from external schema to call the right callbacks.
-------

#### Description
Added control flow to prevent callbacks for all commands in a component to be called when a single one should.

#### Release note
External schema codegen tool is a new feature and this is a fix to that feature so there is no need for release note changes.

#### Tests
How did you test these changes prior to submitting this pull request?
Before the fix, getting a response to one command of a component would trigger the callback for all commands in that component. With the fix, this no longer happens and only the right callback is being called.

What automated tests are included in this PR?
None.

STRONGLY SUGGESTED: How can this be verified by QA?
Using a project that includes external schema with one component that has several commands and registering to several callbacks and seeing that only the right one is being called (This bug was discovered and tested in the upcoming DBSync Worker UnrealGDK tutorial).

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

Bugfix, no documentation needed.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.