### PR TITLE
UNR-1747: fix build script for local launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - BeginPlay is only called once with authority per deployment for startup actors
 - Fixed null pointer dereference crash when trying to initiate a Spatial connection without an existing one.
 - URL options are now properly sent through to the server when doing a ClientTravel.
+- Fixed an issue with `StartEditor.bat` not being generated correctly when building the server worker for local deployments outside of editor.
 
 ## [`0.5.0-preview`](https://github.com/spatialos/UnrealGDK/releases/tag/0.5.0-preview) - 2019-06-25
 - Prevented `Spatial GDK Content` from appearing under Content Browser in the editor, as the GDK plugin does not contain any game content.

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Build/Build.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Build/Build.cs
@@ -127,14 +127,17 @@ namespace Improbable
                     Directory.CreateDirectory(windowsEditorPath);
                 }
 
-                var RunEditorScript = $@"setlocal ENABLEDELAYEDEXPANSION 
-                {Path.Combine(unrealEngine, @"Engine\Binaries\Win64\UE4Editor.exe")} ""{0}"" %*
-                exit /b !ERRORLEVEL!
-                ";
+                var RunEditorScript =
+@"setlocal ENABLEDELAYEDEXPANSION
+{0} {1} %*
+exit /b !ERRORLEVEL!";
+
+                var PathToUnrealEditor = Path.Combine(unrealEngine, "Engine\\Binaries\\Win64\\UE4Editor.exe");
+                var StartEditorScript = string.Format(RunEditorScript, PathToUnrealEditor, projectFile);
 
                 // Write a simple batch file to launch the Editor as a managed worker.
                 File.WriteAllText(Path.Combine(windowsEditorPath, "StartEditor.bat"),
-                    string.Format(RunEditorScript, projectFile), new UTF8Encoding(false));
+                    StartEditorScript, new UTF8Encoding(false));
 
                 // The runtime currently requires all workers to be in zip files. Zip the batch file.
                 Common.RunRedirected(runUATBat, new[]

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Build/Build.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Build/Build.cs
@@ -127,13 +127,12 @@ namespace Improbable
                     Directory.CreateDirectory(windowsEditorPath);
                 }
 
-                var RunEditorScript =
-@"setlocal ENABLEDELAYEDEXPANSION
-{0} {1} %*
-exit /b !ERRORLEVEL!";
-
                 var PathToUnrealEditor = Path.Combine(unrealEngine, "Engine\\Binaries\\Win64\\UE4Editor.exe");
-                var StartEditorScript = string.Format(RunEditorScript, PathToUnrealEditor, projectFile);
+
+                var StartEditorScript =
+$@"setlocal ENABLEDELAYEDEXPANSION
+{PathToUnrealEditor} {projectFile} %*
+exit /b !ERRORLEVEL!";
 
                 // Write a simple batch file to launch the Editor as a managed worker.
                 File.WriteAllText(Path.Combine(windowsEditorPath, "StartEditor.bat"),


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
The script generated for local launch did not have the path to game interpreted correctly, so the local launch flow for launching server outside of Editor did not work correctly. This PR fixes it by making sure that the script has the game path output to it.

#### Tests
Build out a server worker for local deployments (`Game\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat <YourGame>Editor Win64 Development <YourGame>.uproject`) and check that `StartEditor.bat` script in `spatial/build/assembly/worker/UnrealEditor@Windows.zip` contains the right path to your game.

#### Primary reviewers
@joshuahuburn 