### PR TITLE
UNR-1757 Skip actor itself when iterating ReplicationMap when creating entity

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -262,6 +262,12 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 		if (UObject* Subobject = RepSubobject.Value()->GetWeakObjectPtr().Get())
 #endif
 		{
+			if (Subobject == Actor)
+			{
+				// Actor's replicator is also contained in ReplicationMap.
+				continue;
+			}
+
 			// If this object is not in the PackageMap, it has been dynamically created.
 			if (!PackageMap->GetUnrealObjectRefFromObject(Subobject).IsValid())
 			{


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Actor's replicator is also contained in `ReplicationMap`. We weren't explicitly checking for it, and that caused the unresolved objects to be added twice, which shouldn't happen.
On a side note, the only reason we had an unresolved object was because of a torn off actor which was referenced by the actor whose entity was being created.

#### Primary reviewers
@m-samiec 