### PR TITLE
When searching for startup ops, we cannot rely on receiving the autho…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - URL options are now properly sent through to the server when doing a ClientTravel.
 - Fixed an issue that stopped the correct error message from being shown when the SchemaDatabase is missing.
 - Fixed an issue with `StartEditor.bat` not being generated correctly when building the server worker for local deployments outside of editor.
+- Replicated startup actors with NetLoadOnClient=false will no longer fail to load occasionally at startup
 
 ## [`0.5.0-preview`](https://github.com/spatialos/UnrealGDK/releases/tag/0.5.0-preview) - 2019-06-25
 - Prevented `Spatial GDK Content` from appearing under Content Browser in the editor, as the GDK plugin does not contain any game content.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - URL options are now properly sent through to the server when doing a ClientTravel.
 - Fixed an issue that stopped the correct error message from being shown when the SchemaDatabase is missing.
 - Fixed an issue with `StartEditor.bat` not being generated correctly when building the server worker for local deployments outside of editor.
-- Replicated startup actors with NetLoadOnClient=false will no longer fail to load occasionally at startup
 
 ## [`0.5.0-preview`](https://github.com/spatialos/UnrealGDK/releases/tag/0.5.0-preview) - 2019-06-25
 - Prevented `Spatial GDK Content` from appearing under Content Browser in the editor, as the GDK plugin does not contain any game content.

--- a/RequireSetup
+++ b/RequireSetup
@@ -1,4 +1,4 @@
 Increment the below number whenever it is required to run Setup.bat as part of a new commit.
 Our git hooks will detect this file has been updated and automatically run Setup.bat on pull.
 
-27
+28

--- a/SpatialGDK/Extras/schema/global_state_manager.schema
+++ b/SpatialGDK/Extras/schema/global_state_manager.schema
@@ -23,7 +23,7 @@ component DeploymentMap {
 
 component StartupActorManager {
     id = 9993;
-    bool auth_begin_play_called = 1;
+    bool can_begin_play = 1;
 }
 
 component GSMShutdown {

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1893,8 +1893,8 @@ bool USpatialNetDriver::FindAndDispatchStartupOps(const TArray<Worker_OpList*>& 
 		Worker_Op* AuthorityChangedOp = nullptr;
 		FindFirstOpOfTypeForComponent(InOpLists, WORKER_OP_TYPE_AUTHORITY_CHANGE, SpatialConstants::STARTUP_ACTOR_MANAGER_COMPONENT_ID, &AuthorityChangedOp);
 
-		// If we are going to get both ops, we expect them in the same Worker_OpList
-		check(AddComponentOp != nullptr || (AuthorityChangedOp == nullptr));
+		Worker_Op* ComponentUpdateOp = nullptr;
+		FindFirstOpOfTypeForComponent(InOpLists, WORKER_OP_TYPE_COMPONENT_UPDATE, SpatialConstants::STARTUP_ACTOR_MANAGER_COMPONENT_ID, &ComponentUpdateOp);
 
 		if (AddComponentOp != nullptr)
 		{
@@ -1904,6 +1904,11 @@ bool USpatialNetDriver::FindAndDispatchStartupOps(const TArray<Worker_OpList*>& 
 		if (AuthorityChangedOp != nullptr)
 		{
 			FoundOps.Add(AuthorityChangedOp);
+		}
+
+		if (ComponentUpdateOp != nullptr)
+		{
+			FoundOps.Add(ComponentUpdateOp);
 		}
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
@@ -472,13 +472,14 @@ void UGlobalStateManager::AuthorityChanged(const Worker_AuthorityChangeOp& AuthO
 		}
 		case SpatialConstants::STARTUP_ACTOR_MANAGER_COMPONENT_ID:
 		{
-			if (bCanBeginPlay)
+			// We can reach this point with bCanBeginPlay==true if the server
+			// that was authoritative over the GSM restarts.
+			if (!bCanBeginPlay)
 			{
-				return;
+				BecomeAuthoritativeOverAllActors();
+				SetCanBeginPlay(true);
 			}
 
-			BecomeAuthoritativeOverAllActors();
-			SetCanBeginPlay(true);
 			break;
 		}
 		default:

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
@@ -55,8 +55,7 @@ void UGlobalStateManager::Init(USpatialNetDriver* InNetDriver, FTimerManager* In
 #endif // WITH_EDITOR
   
 	bAcceptingPlayers = false;
-	bAuthBeginPlayCalled = false;
-	bIsReadyToCallBeginPlay = false;
+	bCanBeginPlay = false;
 }
 
 void UGlobalStateManager::ApplySingletonManagerData(const Worker_ComponentData& Data)
@@ -81,8 +80,8 @@ void UGlobalStateManager::ApplyStartupActorManagerData(const Worker_ComponentDat
 {
 	Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
 
-	const bool bAuthBeginPlayCalledData = GetBoolFromSchema(ComponentObject, SpatialConstants::STARTUP_ACTOR_MANAGER_AUTH_BEGIN_PLAY_CALLED_ID);
-	ApplyAuthBeginPlayCalledUpdate(bAuthBeginPlayCalledData);
+	const bool bCanBeginPlayData = GetBoolFromSchema(ComponentObject, SpatialConstants::STARTUP_ACTOR_MANAGER_CAN_BEGIN_PLAY_ID);
+	ApplyCanBeginPlayUpdate(bCanBeginPlayData);
 }
 
 void UGlobalStateManager::ApplySingletonManagerUpdate(const Worker_ComponentUpdate& Update)
@@ -203,18 +202,16 @@ void UGlobalStateManager::ApplyStartupActorManagerUpdate(const Worker_ComponentU
 {
 	Schema_Object* ComponentObject = Schema_GetComponentUpdateFields(Update.schema_type);
 
-	if (Schema_GetBoolCount(ComponentObject, SpatialConstants::STARTUP_ACTOR_MANAGER_AUTH_BEGIN_PLAY_CALLED_ID) == 1)
+	if (Schema_GetBoolCount(ComponentObject, SpatialConstants::STARTUP_ACTOR_MANAGER_CAN_BEGIN_PLAY_ID) == 1)
 	{
-		const bool bAuthBeginPlayCalledUpdate = GetBoolFromSchema(ComponentObject, SpatialConstants::STARTUP_ACTOR_MANAGER_AUTH_BEGIN_PLAY_CALLED_ID);
-		ApplyAuthBeginPlayCalledUpdate(bAuthBeginPlayCalledUpdate);
+		const bool bCanBeginPlayUpdate = GetBoolFromSchema(ComponentObject, SpatialConstants::STARTUP_ACTOR_MANAGER_CAN_BEGIN_PLAY_ID);
+		ApplyCanBeginPlayUpdate(bCanBeginPlayUpdate);
 	}
 }
 
-void UGlobalStateManager::ApplyAuthBeginPlayCalledUpdate(const bool bAuthBeginPlayCalledUpdate)
+void UGlobalStateManager::ApplyCanBeginPlayUpdate(const bool bCanBeginPlayUpdate)
 {
-	bAuthBeginPlayCalled = bAuthBeginPlayCalledUpdate;
-
-	bIsReadyToCallBeginPlay = true;
+	bCanBeginPlay = bCanBeginPlayUpdate;
 }
 
 void UGlobalStateManager::LinkExistingSingletonActor(const UClass* SingletonActorClass)
@@ -435,7 +432,7 @@ void UGlobalStateManager::SetAcceptingPlayers(bool bInAcceptingPlayers)
 	NetDriver->Connection->SendComponentUpdate(GlobalStateManagerEntityId, &Update);
 }
 
-void UGlobalStateManager::SetAuthBeginPlayCalled(const bool bInAuthBeginPlayCalled)
+void UGlobalStateManager::SetCanBeginPlay(const bool bInCanBeginPlay)
 {
 	check(NetDriver->StaticComponentView->HasAuthority(GlobalStateManagerEntityId, SpatialConstants::STARTUP_ACTOR_MANAGER_COMPONENT_ID));
 
@@ -444,9 +441,9 @@ void UGlobalStateManager::SetAuthBeginPlayCalled(const bool bInAuthBeginPlayCall
 	Update.schema_type = Schema_CreateComponentUpdate(SpatialConstants::STARTUP_ACTOR_MANAGER_COMPONENT_ID);
 	Schema_Object* UpdateObject = Schema_GetComponentUpdateFields(Update.schema_type);
 
-	Schema_AddBool(UpdateObject, SpatialConstants::STARTUP_ACTOR_MANAGER_AUTH_BEGIN_PLAY_CALLED_ID, static_cast<uint8_t>(bInAuthBeginPlayCalled));
+	Schema_AddBool(UpdateObject, SpatialConstants::STARTUP_ACTOR_MANAGER_CAN_BEGIN_PLAY_ID, static_cast<uint8_t>(bInCanBeginPlay));
 
-	bAuthBeginPlayCalled = bInAuthBeginPlayCalled;
+	bCanBeginPlay = bInCanBeginPlay;
 	NetDriver->Connection->SendComponentUpdate(GlobalStateManagerEntityId, &Update);
 }
 
@@ -463,14 +460,31 @@ void UGlobalStateManager::AuthorityChanged(const Worker_AuthorityChangeOp& AuthO
 	switch (AuthOp.component_id)
 	{
 		case SpatialConstants::DEPLOYMENT_MAP_COMPONENT_ID:
+		{
 			GlobalStateManagerEntityId = AuthOp.entity_id;
 			SetAcceptingPlayers(true);
 			break;
+		}
 		case SpatialConstants::SINGLETON_MANAGER_COMPONENT_ID:
+		{
 			ExecuteInitialSingletonActorReplication();
 			break;
-		default:
+		}
+		case SpatialConstants::STARTUP_ACTOR_MANAGER_COMPONENT_ID:
+		{
+			if (bCanBeginPlay)
+			{
+				return;
+			}
+
+			BecomeAuthoritativeOverAllActors();
+			SetCanBeginPlay(true);
 			break;
+		}
+		default:
+		{
+			break;
+		}
 	}
 }
 
@@ -499,7 +513,7 @@ void UGlobalStateManager::BeginDestroy()
 		if (GetDefault<ULevelEditorPlaySettings>()->GetDeleteDynamicEntities())
 		{
 			// Reset the BeginPlay flag so Startup Actors are properly managed.
-			SetAuthBeginPlayCalled(false);
+			SetCanBeginPlay(false);
 
 			// Reset the Singleton map so Singletons are recreated.
 			Worker_ComponentUpdate Update = {};
@@ -537,13 +551,6 @@ void UGlobalStateManager::BecomeAuthoritativeOverAllActors()
 void UGlobalStateManager::TriggerBeginPlay()
 {
 	check(IsReadyToCallBeginPlay());
-
-	if (!bAuthBeginPlayCalled &&
-		NetDriver->StaticComponentView->HasAuthority(GlobalStateManagerEntityId, SpatialConstants::STARTUP_ACTOR_MANAGER_COMPONENT_ID))
-	{
-		BecomeAuthoritativeOverAllActors();
-		SetAuthBeginPlayCalled(true);
-	}
 
 	NetDriver->World->GetWorldSettings()->SetGSMReadyForPlay();
 	NetDriver->World->GetWorldSettings()->NotifyBeginPlay();

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/GlobalStateManager.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/GlobalStateManager.h
@@ -49,7 +49,7 @@ public:
 	void SetDeploymentMapURL(const FString& MapURL);
 
 	void SetAcceptingPlayers(bool bAcceptingPlayers);
-	void SetAuthBeginPlayCalled(const bool bInAuthBeginPlayCalled);
+	void SetCanBeginPlay(const bool bInCanBeginPlay);
 
 	void AuthorityChanged(const Worker_AuthorityChangeOp& AuthChangeOp);
 	bool HandlesComponent(const Worker_ComponentId ComponentId) const;
@@ -62,7 +62,7 @@ public:
 
 	FORCEINLINE bool IsReadyToCallBeginPlay() const
 	{
-		return bIsReadyToCallBeginPlay;
+		return bCanBeginPlay;
 	}
 
 	USpatialActorChannel* AddSingleton(AActor* SingletonActor);
@@ -78,7 +78,7 @@ public:
 	bool bAcceptingPlayers;
 
 	// Startup Actor Manager Component
-	bool bAuthBeginPlayCalled;
+	bool bCanBeginPlay;
 
 #if WITH_EDITOR
 	void OnPrePIEEnded(bool bValue);
@@ -90,7 +90,7 @@ public:
 private:
 	void LinkExistingSingletonActor(const UClass* SingletonClass);
 	void ApplyAcceptingPlayersUpdate(bool bAcceptingPlayersUpdate);
-	void ApplyAuthBeginPlayCalledUpdate(const bool bAuthBeginPlayCalledUpdate);
+	void ApplyCanBeginPlayUpdate(const bool bCanBeginPlayUpdate);
 
 	void BecomeAuthoritativeOverAllActors();
 
@@ -113,6 +113,4 @@ private:
 	USpatialReceiver* Receiver;
 
 	FTimerManager* TimerManager;
-
-	bool bIsReadyToCallBeginPlay;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -121,7 +121,7 @@ namespace SpatialConstants
 	const Schema_FieldId DEPLOYMENT_MAP_MAP_URL_ID							= 1;
 	const Schema_FieldId DEPLOYMENT_MAP_ACCEPTING_PLAYERS_ID				= 2;
 
-	const Schema_FieldId STARTUP_ACTOR_MANAGER_AUTH_BEGIN_PLAY_CALLED_ID	= 1;
+	const Schema_FieldId STARTUP_ACTOR_MANAGER_CAN_BEGIN_PLAY_ID			= 1;
 
 	const Schema_FieldId ACTOR_COMPONENT_REPLICATES_ID                      = 1;
 	const Schema_FieldId ACTOR_TEAROFF_ID									= 3;

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SnapshotGenerator/SpatialGDKEditorSnapshotGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SnapshotGenerator/SpatialGDKEditorSnapshotGenerator.cpp
@@ -106,7 +106,7 @@ Worker_ComponentData CreateStartupActorManagerData()
 	StartupActorManagerData.schema_type = Schema_CreateComponentData(SpatialConstants::STARTUP_ACTOR_MANAGER_COMPONENT_ID);
 	Schema_Object* StartupActorManagerObject = Schema_GetComponentDataFields(StartupActorManagerData.schema_type);
 
-	Schema_AddBool(StartupActorManagerObject, SpatialConstants::STARTUP_ACTOR_MANAGER_AUTH_BEGIN_PLAY_CALLED_ID, false);
+	Schema_AddBool(StartupActorManagerObject, SpatialConstants::STARTUP_ACTOR_MANAGER_CAN_BEGIN_PLAY_ID, false);
 
 	return StartupActorManagerData;
 }


### PR DESCRIPTION
…rity op in the same oplist as the add component op.  This means we must revert to the older approach of CanBeginPlay to notify non-auth servers when they can call BeginPlay.  This additionally means queueing for component updates for StartupActorManagerComponent in some cases.

**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
When searching for startup ops, we cannot rely on receiving the authority op in the same oplist as the add component op.  This means we must revert to the older approach of CanBeginPlay to notify non-auth servers when they can call BeginPlay.  This additionally means queueing for component updates for StartupActorManagerComponent in some cases.

#### Release note
CHANGELOG.md has been updated.

#### Tests
The failure case on UNR-1760 has been tested several times and is now working correctly.  In addition, I repeated the testing associated with the initial change to call BeginPlay() with authority only once on startup actors.

STRONGLY SUGGESTED: How can this be verified by QA?
To verify the bugfix for UNR-1760, follow these steps:

1. Make a small test level containing 2 cubes.  Set 1 cube to replicates with bNetLoadOnClient=true, set the other cube to replicates with bNetLoadOnClient false.

2. Start SpatialOS

3. Click 'Play', let the game start

4. Click 'Stop', then click 'Play' again within 1-2 seconds

5. Verify both cubes are present in the PIE session
