### PR TITLE
UNR-1773 - Bugfix: Don't always wait for deployment 

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -137,7 +137,7 @@ bool USpatialNetDriver::InitBase(bool bInitAsClient, FNetworkNotify* InNotify, c
 		FLocalDeploymentManager* LocalDeploymentManager = GDKServices->GetLocalDeploymentManager();
 
 		// Wait for a running local deployment before connecting. If the deployment has already started then just connect.
-		if (!LocalDeploymentManager->IsLocalDeploymentRunning() || LocalDeploymentManager->IsDeploymentStopping() || LocalDeploymentManager->IsDeploymentStarting())
+		if (LocalDeploymentManager->ShouldWaitForDeployment())
 		{
 			UE_LOG(LogSpatialOSNetDriver, Display, TEXT("Waiting for local SpatialOS deployment to start before connecting..."));
 			SpatialDeploymentStartHandle = LocalDeploymentManager->OnDeploymentStart.AddLambda([WeakThis = TWeakObjectPtr<USpatialNetDriver>(this), URL]

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -72,6 +72,7 @@ void FSpatialGDKEditorToolbarModule::StartupModule()
 
 	FSpatialGDKServicesModule& GDKServices = FModuleManager::GetModuleChecked<FSpatialGDKServicesModule>("SpatialGDKServices");
 	LocalDeploymentManager = GDKServices.GetLocalDeploymentManager();
+	LocalDeploymentManager->SetAutoDeploy(GetDefault<USpatialGDKEditorSettings>()->bAutoStartLocalDeployment);
 
 	// Bind the play button delegate to starting a local spatial deployment.
 	if (!UEditorEngine::TryStartSpatialDeployment.IsBound() && GetDefault<USpatialGDKEditorSettings>()->bAutoStartLocalDeployment)
@@ -525,7 +526,7 @@ void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment()
 	// Don't try and start a local deployment if spatial networking is disabled.
 	if (!GetDefault<UGeneralProjectSettings>()->bSpatialNetworking)
 	{
-		UE_LOG(LogSpatialGDKEditorToolbar, Verbose, TEXT("Attempted to start a local deployment but spatial networking is disabled."));
+		UE_LOG(LogSpatialGDKEditorToolbar, Error, TEXT("Attempted to start a local deployment but spatial networking is disabled."));
 		return;
 	}
 
@@ -694,6 +695,9 @@ void FSpatialGDKEditorToolbarModule::OnPropertyChanged(UObject* ObjectBeingModif
 		}
 		else if (PropertyName.ToString() == TEXT("bAutoStartLocalDeployment"))
 		{
+			// TODO: UNR-1776 Workaround for SpatialNetDriver requiring editor settings.
+			LocalDeploymentManager->SetAutoDeploy(Settings->bAutoStartLocalDeployment);
+
 			if (Settings->bAutoStartLocalDeployment)
 			{
 				// Bind the TryStartSpatialDeployment delegate if autostart is enabled.

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -123,5 +123,4 @@ private:
 	TSharedPtr<SSpatialGDKSimulatedPlayerDeployment> SimulatedPlayerDeploymentConfigPtr;
 	
 	FLocalDeploymentManager* LocalDeploymentManager;
-	bool bRedeployRequired = false;
 };

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -582,7 +582,24 @@ bool FLocalDeploymentManager::IsRedeployRequired() const
 	return bRedeployRequired;
 }
 
-bool FLocalDeploymentManager::SetRedeployRequired()
+void FLocalDeploymentManager::SetRedeployRequired()
 {
 	bRedeployRequired = true;
+}
+
+bool FLocalDeploymentManager::ShouldWaitForDeployment() const
+{
+	if (bAutoDeploy)
+	{
+		return !IsLocalDeploymentRunning() || IsDeploymentStopping() || IsDeploymentStarting();
+	}
+	else
+	{
+		return false;
+	}
+}
+
+void FLocalDeploymentManager::SetAutoDeploy(bool bInAutoDeploy)
+{
+	bAutoDeploy = bInAutoDeploy;
 }

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -201,6 +201,8 @@ void FLocalDeploymentManager::RefreshServiceStatus()
 
 bool FLocalDeploymentManager::TryStartLocalDeployment(FString LaunchConfig, FString LaunchArgs)
 {
+	bRedeployRequired = false;
+
 	if (bStoppingDeployment)
 	{
 		UE_LOG(LogSpatialDeploymentManager, Verbose, TEXT("Local deployment is in the process of stopping. New deployment will start when previous one has stopped."));
@@ -573,4 +575,14 @@ bool FLocalDeploymentManager::IsServiceStarting() const
 bool FLocalDeploymentManager::IsServiceStopping() const
 {
 	return bStoppingSpatialService;
+}
+
+bool FLocalDeploymentManager::IsRedeployRequired() const
+{
+	return bRedeployRequired;
+}
+
+bool FLocalDeploymentManager::SetRedeployRequired()
+{
+	bRedeployRequired = true;
 }

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalDeploymentManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalDeploymentManager.h
@@ -38,7 +38,12 @@ public:
 	bool SPATIALGDKSERVICES_API IsServiceStopping() const;
 
 	bool SPATIALGDKSERVICES_API IsRedeployRequired() const;
-	bool SPATIALGDKSERVICES_API SetRedeployRequired();
+	void SPATIALGDKSERVICES_API SetRedeployRequired();
+
+	// Helper function to inform a client or server whether it should wait for a local deployment to become active.
+	bool SPATIALGDKSERVICES_API ShouldWaitForDeployment() const;
+
+	void SPATIALGDKSERVICES_API SetAutoDeploy(bool bAutoDeploy);
 
 	// TODO: Refactor these into Utils
 	FString GetProjectName();
@@ -77,4 +82,5 @@ private:
 	FString ProjectName;
 
 	bool bRedeployRequired = false;
+	bool bAutoDeploy = false;
 };

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalDeploymentManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalDeploymentManager.h
@@ -37,6 +37,9 @@ public:
 	bool SPATIALGDKSERVICES_API IsServiceStarting() const;
 	bool SPATIALGDKSERVICES_API IsServiceStopping() const;
 
+	bool SPATIALGDKSERVICES_API IsRedeployRequired() const;
+	bool SPATIALGDKSERVICES_API SetRedeployRequired();
+
 	// TODO: Refactor these into Utils
 	FString GetProjectName();
 	void WorkerBuildConfigAsync();
@@ -72,4 +75,6 @@ private:
 
 	FString LocalRunningDeploymentID;
 	FString ProjectName;
+
+	bool bRedeployRequired = false;
 };


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
We have a flag for disabling auto deployment launching but this would mean editor clients would always wait forever, this fixes that.

#### Release note
Already in changelog

How can this be verified by QA?: Enable Auto launch deployment in GDKEditorSettings and press Play, local deployment should start and you should connect. Disable the option and then click Play, no deployment should launch and you should fail to connect. 

#### Primary reviewers
@m-samiec 	@mattyoung-improbable 