### PR TITLE
UNR-1772 - Bugfix: Log errored blueprints before running GC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - URL options are now properly sent through to the server when doing a ClientTravel.
 - Fixed an issue that stopped the correct error message from being shown when the SchemaDatabase is missing.
 - Fixed an issue with `StartEditor.bat` not being generated correctly when building the server worker for local deployments outside of editor.
+- Fixed an issue with logging errored blueprints after garbage collection which caused an invalid pointer crash.
 
 ## [`0.5.0-preview`](https://github.com/spatialos/UnrealGDK/releases/tag/0.5.0-preview) - 2019-06-25
 - Prevented `Spatial GDK Content` from appearing under Content Browser in the editor, as the GDK plugin does not contain any game content.

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
@@ -95,13 +95,6 @@ bool FSpatialGDKEditor::GenerateSchema(bool bFullScan)
 
 	Progress.EnterProgressFrame(bFullScan ? 10.f : 100.f);
 	bool bResult = SpatialGDKGenerateSchema();
-
-	if (bFullScan)
-	{
-		Progress.EnterProgressFrame(10.f);
-		LoadedAssets.Empty();
-		CollectGarbage(RF_NoFlags, true);
-	}
 	
 	// We delay printing this error until after the schema spam to make it have a higher chance of being noticed.
 	if (ErroredBlueprints.Num() > 0)
@@ -111,6 +104,13 @@ bool FSpatialGDKEditor::GenerateSchema(bool bFullScan)
 		{
 			UE_LOG(LogSpatialGDKEditor, Error, TEXT("%s"), *GetPathNameSafe(Blueprint));
 		}
+	}
+
+	if (bFullScan)
+	{
+		Progress.EnterProgressFrame(10.f);
+		LoadedAssets.Empty();
+		CollectGarbage(RF_NoFlags, true);
 	}
 
 	GetMutableDefault<UGeneralProjectSettings>()->bSpatialNetworking = bCachedSpatialNetworking;


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Moved the block emptying LoadedAssets and running garbage collection after the logging of errored blueprints to prevent the pointers from being invalid when getting their path.

#### Release note
Fixed an issue with logging errored blueprints after garbage collection which caused an invalid pointer crash.

#### Tests
Running full schema generation from the Editor with blueprints that fail to compile.

#### Primary reviewers
@mattyoung-improbable 