### PR TITLE
Fixes for various netguid resolution issues

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -154,6 +154,8 @@ void USpatialPackageMapClient::RemoveEntityActor(Worker_EntityId EntityId)
 	{
 		SpatialGuidCache->RemoveEntityNetGUID(EntityId);
 	}
+
+	check(!SpatialGuidCache->GetNetGUIDFromEntityId(EntityId).IsValid());
 }
 
 void USpatialPackageMapClient::RemoveSubobject(const FUnrealObjectRef& ObjectRef)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialDispatcher.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialDispatcher.cpp
@@ -53,6 +53,7 @@ void USpatialDispatcher::ProcessOps(Worker_OpList* OpList)
 		case WORKER_OP_TYPE_REMOVE_ENTITY:
 			Receiver->OnRemoveEntity(Op->remove_entity);
 			StaticComponentView->OnRemoveEntity(Op->remove_entity.entity_id);
+			Receiver->RemoveComponentOpsForEntity(Op->remove_entity.entity_id);
 			break;
 
 		// Components

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -122,6 +122,7 @@ public:
 	void OnRemoveEntity(const Worker_RemoveEntityOp& Op);
 	void OnRemoveComponent(const Worker_RemoveComponentOp& Op);
 	void FlushRemoveComponentOps();
+	void RemoveComponentOpsForEntity(Worker_EntityId EntityId);
 	void OnAuthorityChange(const Worker_AuthorityChangeOp& Op);
 
 	void OnComponentUpdate(const Worker_ComponentUpdateOp& Op);


### PR DESCRIPTION
#### Description
Two fixes.
1. Startup actors are cleanup correctly when leaving view, so they don't error when getting readded.
2. Don't incorrectly process remove component ops when both add and remove entity ops are received in the same ops tick.

#### Tests
Ran on the offloaded ai project which was erroring regularly previously

#### Primary reviewers
@Vatyx @samiwh 