### PR TITLE
Docs - Explain local workflow better 

### DIFF
--- a/SpatialGDK/Documentation/content/cloud-deployment-workflow.md
+++ b/SpatialGDK/Documentation/content/cloud-deployment-workflow.md
@@ -6,7 +6,7 @@ If you haven't already, please follow the [GDK Starter Template guide]({{urlRoot
 
 <!-- This is a live embed of a google drawing -->
 
-<img src="https://docs.google.com/drawings/d/e/2PACX-1vQVcAihbYTNe7TjNsIvkfqIR34Vgw5RESKxboxbvgY5VcgxiI-SZT_M2kuGE8RYMU6sAYWqdkoCjMWt/pub?w=505&h=775">
+ <%(Lightbox image="https://docs.google.com/drawings/d/e/2PACX-1vQVcAihbYTNe7TjNsIvkfqIR34Vgw5RESKxboxbvgY5VcgxiI-SZT_M2kuGE8RYMU6sAYWqdkoCjMWt/pub?w=758&h=1162")%>
 
 You may find the following command-line snippets useful as reference:
 

--- a/SpatialGDK/Documentation/content/get-started/example-project/exampleproject-local-deployment.md
+++ b/SpatialGDK/Documentation/content/get-started/example-project/exampleproject-local-deployment.md
@@ -15,13 +15,11 @@ Use local deployments for small-scale tests, to quickly test and iterate on chan
 ### Step 1: Generate schema and a snapshot
 
 Before you launch a deployment (local or cloud) you must generate [schema]({{urlRoot}}/content/spatialos-concepts/schema-and-snapshots#schema) and a [snapshot]({{urlRoot}}/content/spatialos-concepts/schema-and-snapshots#snapshots). 
-1. In the Editor, on the [GDK Toolbar]({{urlRoot}}/content/toolbars), open the **Schema** drop-down menu and select **Schema (Full Scan)**. <br/>
-   ![Schema]({{assetRoot}}assets/screen-grabs/toolbar/schema-button-full-scan.png)<br/>
-   _Image: On the GDK toolbar in the Editor, select **Schema (Full Scan)**_
+1. In the Editor, on the [GDK Toolbar]({{urlRoot}}/content/toolbars), open the **Schema** drop-down menu and select **Schema (Full Scan)**. <br/><br/>
+   ![Schema]({{assetRoot}}assets/screen-grabs/toolbar/schema-button-full-scan.png)
    </br>
-2. Select **Snapshot** to generate a snapshot.<br/>
+2. Select **Snapshot** to generate a snapshot.<br/><br/>
    ![Toolbar]({{assetRoot}}assets/screen-grabs/toolbar/snapshot-button.png)<br/>
-   _Image: On the GDK toolbar in the Unreal Editor, select **Snapshot**_<br/>
 
 <%(#Expandable title="What is Schema?")%>
 
@@ -50,31 +48,53 @@ This section shows you how to  start one SpatialOS server-worker instance and tw
 
 1. On the Editor toolbar, open the **Play** drop-down menu.
 2. Under **Multiplayer Options**, set the number of players to **2** and ensure that checkboxes next to **Run Dedicated Server** and **Spatial Networking** are checked. Checking **Spatial Networking** makes deployments run using SpatialOS networking as opposed to native Unreal networking. If a checkbox is unchecked, select the checkbox to enable it.<br/></br>
-   ![Multiplayer Options]({{assetRoot}}assets/set-up-template/template-multiplayer-options.png))<br/>
-   _Image: The Unreal Engine **Play** drop-down menu, with **Multiplayer Options** and **New Editor Window (PIE)** highlighted_</br></br>
+   ![Multiplayer Options]({{assetRoot}}assets/set-up-template/template-multiplayer-options.png))<br/></br>
 3. Under **Modes**, select **New Editor Window (PIE)** to run the game. This starts one SpatialOS server-worker instance and two SpatialOS client-worker instances locally, in your Unreal Editor.
    The server-worker instance is acting as an Unreal server and the two client-worker instances are acting as two Unreal game clients (as would be used by two game players).
    You can switch between the two Editor windows to see and interact with each game client. 
 4. If the game does not run automatically after selecting **New Editor Window (PIE)**, on the Editor toolbar, select **Play** to start a local deployment and play the game.
 
-![]({{assetRoot}}assets/example-project/first-client-launch.png)<br/>_Image: New editor window with the game playing._<br/>
+![]({{assetRoot}}assets/example-project/first-client-launch.png)<br/>
 
 ### Step 3: Inspecting and stopping play
 
-When your game is running, select **Inspector** to open [the Inspector](https://docs.improbable.io/reference/latest/shared/operate/inspector#the-inspector) in your default web browser. The Inspector is a web-based tool that you use to explore the internal state of a SpatialOS world. It gives you a real-time view of what’s happening in a local or cloud deployment. 
+When your game is running, select **Inspector** to open the [Inspector](https://docs.improbable.io/unreal/alpha//content/glossary#inspector) in your default web browser. The Inspector is a web-based tool that you use to explore the internal state of a SpatialOS world. It gives you a real-time view of what’s happening in a local or cloud deployment. <br/><br/>
+![]({{assetRoot}}assets/screen-grabs/toolbar/inspector-button.png)<br/>
 
-![]({{assetRoot}}assets/screen-grabs/toolbar/inspector-button.png)<br/>_Image: On GDK toolbar, select Inspector_<br/>
+This will open the Inspector in your browser:
+
+![]({{assetRoot}}assets/set-up-template/template-two-client-inspector.png)<br/>
 
 When you’re done, select Unreal Engine's native **Stop** button to stop the client. 
 
-![]({{assetRoot}}assets/toolbar/stop-button-native.png)<br/>_Image: On the native Unreal Engine toolbar, select Stop_<br/>
+![]({{assetRoot}}assets/toolbar/stop-button-native.png)<br/>
 
-This stops the running clients but keeps your deployment running. As you iterate on your game, the GDK can (in most cases) automatically reload your client and server workers, so you can iterate on your game without having to restart your deployment. For more information and a reference diagram, see the [Local deployment workflow page]({{urlRoot}}/content/local-deployment-workflow).
+This stops the running client and server workers but keeps your deployment running. 
 
-To fully stop your SpatialOS deployment, select **Stop** in the GDK toolbar to stop your SpatialOS deployment.<br/></br>
-   ![Stop]({{assetRoot}}assets/screen-grabs/toolbar/stop-button.png)<br/>
-   _Image: On the GDK toolbar in the Editor select **Stop**_
+### Step 4: Iterating on your game
 
+As you iterate on your game (i.e modifying classes or blueprints), **making changes to replicated components will require incremental schema regeneration**. To do this, select the **Schema** button in the GDK toolbar.
+
+![Stop]({{assetRoot}}assets/screen-grabs/toolbar/schema-button.png)<br/>
+
+Once you've regenerated schema, the GDK will restart the running deployment with the new schema.
+
+If you haven't modified anything related to replication, you don't need to regenerate schema and the previously running deployment will continue to be used.
+
+To test your changes, hit play again which will start your client and server workers.
+
+<%(#Expandable title="Workflow reference diagram")%>
+
+ <%(Lightbox image="https://docs.google.com/drawings/d/e/2PACX-1vQCTOucXKMkDJ3-Vpg17_tpUS7IxOXD6Mps-FzWe2tQl3vw5alQPngCnw339cFy3u2NvrcBxhYASKsS/pub?w=710&h=1033")%>
+
+For more details, see the [Local deployment workflow page]({{urlRoot}}/content/local-deployment-workflow).
+
+<%(/Expandable)%>
+
+### Step 4: Stop your deployment
+
+To fully stop your SpatialOS deployment, select **Stop** in the GDK toolbar.<br/></br>
+![Stop]({{assetRoot}}assets/screen-grabs/toolbar/stop-button.png)<br/>
 </br>
 </br>
 **> Next:** [3: Launch a cloud deployment]({{urlRoot}}/content/get-started/example-project/exampleproject-cloud-deployment) 

--- a/SpatialGDK/Documentation/content/get-started/starter-template/get-started-template-local.md
+++ b/SpatialGDK/Documentation/content/get-started/starter-template/get-started-template-local.md
@@ -8,7 +8,7 @@ When you want to try out your game, you need to run a deployment.
 There are two types of deployment: local and cloud.
 
 - A [local deployment]({{urlRoot}}/content/glossary#deployment) launches your game with its own instance of SpatialOS, running on your development machine. 
-- [Cloud deployments]({{urlRoot}}/content/glossary#deployment) run in the cloud on [nodes]({{urlRoot}}/content/glossary#node). A node refers to a single machine used by a cloud deployment. When you have deployed your game, you can share it with other people and run your game at a scale not possible on a single machine. Once a cloud deployment is running, you can connect clients to it using the [Launcher]({{urlRoot}}/content/glossary#launcher).
+- A [cloud deployment]({{urlRoot}}/content/glossary#deployment) runs in the cloud on [nodes]({{urlRoot}}/content/glossary#node). A node refers to a single machine used by a cloud deployment. When you have deployed your game, you can share it with other people and run your game at a scale not possible on a single machine. Once a cloud deployment is running, you can connect clients to it using the [Launcher]({{urlRoot}}/content/glossary#launcher).
 
 Use local deployments for small-scale tests, to quickly test and iterate on changes to your project. For large-scale tests with several players, use a cloud deployment. 
 
@@ -18,11 +18,8 @@ Before you launch a deployment (local or cloud) you must generate [schema]({{url
 
 1. In the Editor, on the [GDK Toolbar]({{urlRoot}}/content/toolbars), open the **Schema** drop-down menu and select **Schema (Full Scan)**. <br/><br/>
    ![Schema]({{assetRoot}}assets/screen-grabs/toolbar/schema-button-full-scan.png)<br/>
-   _Image: On the GDK toolbar in the Editor, select **Schema (Full Scan)**_
-   </br>
-1. Select **Snapshot** to generate a snapshot.<br/>
-   ![Toolbar]({{assetRoot}}assets/screen-grabs/toolbar/snapshot-button.png)<br/><br/>
-   _Image: On the GDK toolbar in the Unreal Editor, select **Snapshot**_<br/>
+1. Select **Snapshot** to generate a snapshot.<br/><br/>
+   ![Toolbar]({{assetRoot}}assets/screen-grabs/toolbar/snapshot-button.png)<br/>
 
 <%(#Expandable title="What is Schema?")%>
 
@@ -51,35 +48,56 @@ This section shows you how to  start one SpatialOS server-worker instance and tw
 1. On the Unreal Editor toolbar, open the **Play** drop-down menu.
 1. Under **Multiplayer Options**, set the number of players to **2** and ensure that the check box next to **Run Dedicated Server** is selected.<br/><br/>
    ![]({{assetRoot}}assets/set-up-template/template-multiplayer-options.png)<br/>
-   _Image: The Unreal Engine **Play** drop-down menu, with **Multiplayer Options** and **New Editor Window (PIE)** highlighted_<br/><br/>
 1. Under **Modes**, select **New Editor Window (PIE)** to run the game.  You should see two clients start. You can switch between two Editor windows to see and interact with each game client.
 If the game does not run automatically after selecting **New Editor Window (PIE)**, on the Editor toolbar, select **Play** to run the game.
 
    ![]({{assetRoot}}assets/set-up-template/template-two-clients.png)<br/>
-   _Image: Two clients running in the Editor, with player Actors replicated by SpatialOS and the GDK_<br/>
 
 ### Step 3: Inspecting and stopping play
 
 When your game is running, select **Inspector** to open the [Inspector](https://docs.improbable.io/unreal/alpha//content/glossary#inspector) in your default web browser. The Inspector is a web-based tool that you use to explore the internal state of a SpatialOS world. It gives you a real-time view of what’s happening in a local or cloud deployment. <br/><br/>
-![]({{assetRoot}}assets/screen-grabs/toolbar/inspector-button.png)<br/>_Image: On the Unreal Engine toolbar, select Inspector_<br/><br/>
+![]({{assetRoot}}assets/screen-grabs/toolbar/inspector-button.png)<br/>
+
+This will open the Inspector in your browser:
+
 ![]({{assetRoot}}assets/set-up-template/template-two-client-inspector.png)<br/>
-_Image: The Inspector showing the state of your local deployment_<br/>
 
 When you’re done, select Unreal Engine's native **Stop** button to stop the client. 
 
-![]({{assetRoot}}assets/toolbar/stop-button-native.png)<br/>_Image: On the native Unreal Engine toolbar, select Stop_<br/>
+![]({{assetRoot}}assets/toolbar/stop-button-native.png)<br/>
 
-This stops the running clients but keeps your deployment running. As you iterate on your game, the GDK can (in most cases) automatically reload your client and server workers, so you can iterate on your game without having to restart your deployment. For more information and a reference diagram, see the [Local deployment workflow page]({{urlRoot}}/content/local-deployment-workflow).
+This stops the running client and server workers but keeps your deployment running. 
 
-To fully stop your SpatialOS deployment, select **Stop** in the GDK toolbar to stop your SpatialOS deployment.<br/></br>
+### Step 4: Iterating on your game
+
+As you iterate on your game (i.e modifying classes or blueprints), **making changes to replicated components will require incremental schema regeneration**. To do this, select the **Schema** button in the GDK toolbar.
+
+![Stop]({{assetRoot}}assets/screen-grabs/toolbar/schema-button.png)<br/>
+
+Once you've regenerated schema, the GDK will restart the running deployment with the new schema.
+
+If you haven't modified anything related to replication, you don't need to regenerate schema and the previously running deployment will continue to be used.
+
+To test your changes, hit play again which will start your client and server workers.
+
+<%(#Expandable title="Workflow reference diagram")%>
+
+ <%(Lightbox image="https://docs.google.com/drawings/d/e/2PACX-1vQCTOucXKMkDJ3-Vpg17_tpUS7IxOXD6Mps-FzWe2tQl3vw5alQPngCnw339cFy3u2NvrcBxhYASKsS/pub?w=710&h=1033")%>
+
+For more details, see the [Local deployment workflow page]({{urlRoot}}/content/local-deployment-workflow).
+
+<%(/Expandable)%>
+
+### Step 4: Stop your deployment
+
+To fully stop your SpatialOS deployment, select **Stop** in the GDK toolbar.<br/></br>
 ![Stop]({{assetRoot}}assets/screen-grabs/toolbar/stop-button.png)<br/>
-_Image: On the GDK toolbar in the Editor select **Stop**_
 
 **> Next:** [3: Launch a cloud deployment]({{urlRoot}}/content/get-started/starter-template/get-started-template-cloud)
 
 <br/>
 
 <br/>------------<br/>
-_2019-07-22 Page updated with limited editorial review._<br/>
+_2019-07-24 Page updated with limited editorial review._<br/>
 
 [//]: # (TODO: https://improbableio.atlassian.net/browse/DOC-1241)

--- a/SpatialGDK/Documentation/content/local-deployment-workflow.md
+++ b/SpatialGDK/Documentation/content/local-deployment-workflow.md
@@ -6,8 +6,7 @@ If you haven't already, please follow the [GDK Starter Template guide]({{urlRoot
 
 <!-- This is a live embed of a google drawing -->
 
-<img src="https://docs.google.com/drawings/d/e/2PACX-1vQCTOucXKMkDJ3-Vpg17_tpUS7IxOXD6Mps-FzWe2tQl3vw5alQPngCnw339cFy3u2NvrcBxhYASKsS/pub?w=474&h=689">
-
+ <%(Lightbox image="https://docs.google.com/drawings/d/e/2PACX-1vQCTOucXKMkDJ3-Vpg17_tpUS7IxOXD6Mps-FzWe2tQl3vw5alQPngCnw339cFy3u2NvrcBxhYASKsS/pub?w=710&h=1033")%>
 
 <br/>------<br/>
 _2019-07-20 Page updated: deployment now restarts automatically game modifications._


### PR DESCRIPTION
Explains the local workflow in the getting started guides. Provides an in context workflow diagram. Remove captions which duplicate a lot of text and don't add much.

Tested with improbadoc