### PR TITLE
Bugfix/unr 1806 fix subobject schema name clash

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SchemaDatabase.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SchemaDatabase.h
@@ -45,9 +45,6 @@ struct FDynamicSubobjectSchemaData
 {
 	GENERATED_USTRUCT_BODY()
 
-	//UPROPERTY(Category = "SpatialGDK", VisibleAnywhere)
-	//FString GeneratedSchemaName;
-
 	UPROPERTY(Category = "SpatialGDK", VisibleAnywhere)
 	uint32 SchemaComponents[SCHEMA_Count] = {};
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SchemaDatabase.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SchemaDatabase.h
@@ -45,6 +45,9 @@ struct FDynamicSubobjectSchemaData
 {
 	GENERATED_USTRUCT_BODY()
 
+	//UPROPERTY(Category = "SpatialGDK", VisibleAnywhere)
+	//FString GeneratedSchemaName;
+
 	UPROPERTY(Category = "SpatialGDK", VisibleAnywhere)
 	uint32 SchemaComponents[SCHEMA_Count] = {};
 };
@@ -54,6 +57,9 @@ USTRUCT()
 struct FSubobjectSchemaData
 {
 	GENERATED_USTRUCT_BODY()
+
+	UPROPERTY(Category = "SpatialGDK", VisibleAnywhere)
+	FString GeneratedSchemaName;
 
 	UPROPERTY(Category = "SpatialGDK", VisibleAnywhere)
 	TArray<FDynamicSubobjectSchemaData> DynamicSubobjectComponents;

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SchemaGenerator.cpp
@@ -301,6 +301,9 @@ void GenerateSubobjectSchema(FComponentIdGenerator& IdGenerator, UClass* Class, 
 
 	// Use previously generated component IDs when possible.
 	const FSubobjectSchemaData* const ExistingSchemaData = SubobjectClassPathToSchema.Find(Class->GetPathName());
+	checkf(ExistingSchemaData == nullptr || ExistingSchemaData->GeneratedSchemaName == ClassPathToSchemaName[Class->GetPathName()],
+		TEXT("Existing schema generated name does not match in memory version for schema %s : %s"),
+		*ExistingSchemaData->GeneratedSchemaName, *ClassPathToSchemaName[Class->GetPathName()]);
 
 	for (uint32 i = 1; i <= DynamicComponentsPerClass; i++)
 	{
@@ -368,7 +371,7 @@ void GenerateSubobjectSchema(FComponentIdGenerator& IdGenerator, UClass* Class, 
 	}
 
 	Writer.WriteToFile(FString::Printf(TEXT("%s%s.schema"), *SchemaPath, *ClassPathToSchemaName[Class->GetPathName()]));
-
+	SubobjectSchemaData.GeneratedSchemaName = ClassPathToSchemaName[Class->GetPathName()];
 	SubobjectClassPathToSchema.Add(Class->GetPathName(), SubobjectSchemaData);
 }
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SchemaGenerator.cpp
@@ -306,6 +306,7 @@ void GenerateSubobjectSchema(FComponentIdGenerator& IdGenerator, UClass* Class, 
 	{
 		UE_LOG(LogSchemaGenerator, Error, TEXT("Saved generated schema name does not match in-memory version for class %s - schema %s : %s"),
 			*Class->GetPathName(), *ExistingSchemaData->GeneratedSchemaName, *ClassPathToSchemaName[Class->GetPathName()]);
+		UE_LOG(LogSchemaGenerator, Error, TEXT("Schema generation may have resulted in component name clash, recommend you perform a full schema generation"));
 	}
 
 	for (uint32 i = 1; i <= DynamicComponentsPerClass; i++)

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SchemaGenerator.cpp
@@ -301,9 +301,12 @@ void GenerateSubobjectSchema(FComponentIdGenerator& IdGenerator, UClass* Class, 
 
 	// Use previously generated component IDs when possible.
 	const FSubobjectSchemaData* const ExistingSchemaData = SubobjectClassPathToSchema.Find(Class->GetPathName());
-	checkf(ExistingSchemaData == nullptr || ExistingSchemaData->GeneratedSchemaName == ClassPathToSchemaName[Class->GetPathName()],
-		TEXT("Existing schema generated name does not match in memory version for schema %s : %s"),
-		*ExistingSchemaData->GeneratedSchemaName, *ClassPathToSchemaName[Class->GetPathName()]);
+	if ( ExistingSchemaData != nullptr && !ExistingSchemaData->GeneratedSchemaName.IsEmpty()
+		&& ExistingSchemaData->GeneratedSchemaName != ClassPathToSchemaName[Class->GetPathName()])
+	{
+		UE_LOG(LogSchemaGenerator, Error, TEXT("Saved generated schema name does not match in-memory version for class %s - schema %s : %s"),
+			*Class->GetPathName(), *ExistingSchemaData->GeneratedSchemaName, *ClassPathToSchemaName[Class->GetPathName()]);
+	}
 
 	for (uint32 i = 1; i <= DynamicComponentsPerClass; i++)
 	{

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -77,6 +77,10 @@ void GenerateCompleteSchemaFromClass(FString SchemaPath, FComponentIdGenerator& 
 	}
 	else
 	{
+		if (Class->GetName().Contains(TEXT("MyComponent")))
+		{
+			__debugbreak();
+		}
 		GenerateSubobjectSchema(IdGenerator, Class, TypeInfo, SchemaPath + TEXT("Subobjects/"));
 	}
 }
@@ -216,6 +220,11 @@ bool ValidateIdentifierNames(TArray<TSharedPtr<FUnrealType>>& TypeInfos)
 		const FString& ClassName = Class->GetName();
 		const FString& ClassPath = Class->GetPathName();
 		FString SchemaName = UnrealNameToSchemaName(ClassName);
+
+		if (ClassName.Contains(TEXT("MyComponent")))
+		{
+			__debugbreak();
+		}
 
 		if (!CheckSchemaNameValidity(SchemaName, ClassPath, TEXT("Class")))
 		{
@@ -616,6 +625,24 @@ void ResetUsedNames()
 		}
 		AddPotentialNameCollision(Entry.Value.GeneratedSchemaName, Entry.Key, Entry.Value.GeneratedSchemaName);
 	}
+
+ 	for (const TPair< FString, FSubobjectSchemaData>& Entry : SubobjectClassPathToSchema)
+ 	{
+		if (Entry.Value.GeneratedSchemaName.IsEmpty())
+		{
+			continue;
+		}
+		ClassPathToSchemaName.Add(Entry.Key, Entry.Value.GeneratedSchemaName);
+		SchemaNameToClassPath.Add(Entry.Value.GeneratedSchemaName, Entry.Key);
+		FSoftObjectPath ObjPath = FSoftObjectPath(Entry.Key);
+		FString DesiredSchemaName = UnrealNameToSchemaName(ObjPath.GetAssetName());
+
+		if (DesiredSchemaName != Entry.Value.GeneratedSchemaName)
+		{
+			AddPotentialNameCollision(DesiredSchemaName, Entry.Key, Entry.Value.GeneratedSchemaName);
+		}
+		AddPotentialNameCollision(Entry.Value.GeneratedSchemaName, Entry.Key, Entry.Value.GeneratedSchemaName);
+ 	}
 }
 
 void RunSchemaCompiler()


### PR DESCRIPTION
#### Description
UNR-1806
Dynamic subobject schema now respect their previously generated schema names.

#### Tests
Create two ActorComponents with the same name in different folders.
Do a full schema gen.
Restart the editor
Manually load only one of the ActorComponents and do an iterative schema gen
Restart the editor
Manually load the other ActorComponent and do an iterative schema gen
Ensure the ActorComponents schema contents didn't change after each iterative schema gen

#### Primary reviewers
@mattyoung-improbable @Vatyx 