### PR TITLE
Fix player movement when on zoned servers

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -978,7 +978,7 @@ void USpatialNetDriver::ServerReplicateActors_ProcessPrioritizedActors(UNetConne
 						continue;
 					}
 
-					Channel = CreateSpatialActorChannel(Actor, Cast<USpatialNetConnection>(InConnection));
+					Channel = GetOrCreateSpatialActorChannel(Actor);
 					if ((Channel == nullptr) && (Actor->NetUpdateFrequency < 1.0f))
 					{
 						UE_LOG(LogNetTraffic, Log, TEXT("Unable to replicate %s"), *Actor->GetName());
@@ -1686,6 +1686,10 @@ USpatialActorChannel* USpatialNetDriver::GetActorChannelByEntityId(Worker_Entity
 
 USpatialActorChannel* USpatialNetDriver::CreateSpatialActorChannel(AActor* Actor, USpatialNetConnection* InConnection)
 {
+	//
+	// This function should ONLY be used from GetOrCreateSpatialActorChannel.
+	//
+
 	if (InConnection == nullptr)
 	{
 		return nullptr;

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -98,7 +98,6 @@ public:
 
 	USpatialActorChannel* GetOrCreateSpatialActorChannel(UObject* TargetObject);
 	USpatialActorChannel* GetActorChannelByEntityId(Worker_EntityId EntityId) const;
-	USpatialActorChannel* CreateSpatialActorChannel(AActor* Actor, USpatialNetConnection* InConnection);
 
 	DECLARE_DELEGATE(PostWorldWipeDelegate);
 
@@ -187,6 +186,8 @@ private:
 	FString SnapshotToLoad;
 
 	void InitiateConnectionToSpatialOS(const FURL& URL);
+
+	USpatialActorChannel* CreateSpatialActorChannel(AActor* Actor, USpatialNetConnection* InConnection);
 
 	void InitializeSpatialOutputDevice();
 	void CreateAndInitializeCoreClasses();


### PR DESCRIPTION
#### Description
Fix player movement on zoned servers.

The symptom fixed by this PR was that, on a zoned deployment, one or more players would occasionally not have control of their player after joining a session. This was because the player movement component was not initialized, which is a consequence of the client receiving the ClientRestart RPC.

The root cause is that the sending worker had two channels for the Actor for the RPC, and was checking the incorrect channel to determine if the channel is ready to receive RPCs.

There's a slightly better version of this fix for master in #1235 

@m-samiec @cmsmithio 