### PR TITLE
Bugfix/unr 1798 prevent loading stale classes

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -418,21 +418,28 @@ void FSpatialNetGUIDCache::RemoveEntityNetGUID(Worker_EntityId EntityId)
 		return;
 	}
 
-	const FClassInfo& Info = SpatialNetDriver->ClassInfoManager->GetOrCreateClassInfoByClass(UnrealMetadata->GetNativeEntityClass());
-
-	SpatialGDK::TSchemaOption<FUnrealObjectRef>& StablyNamedRefOption = UnrealMetadata->StablyNamedRef;
-
-	for (auto& SubobjectInfoPair : Info.SubobjectInfo)
+	if (UnrealMetadata->NativeClass.IsStale())
 	{
-		FUnrealObjectRef SubobjectRef(EntityId, SubobjectInfoPair.Key);
-		if (FNetworkGUID* SubobjectNetGUID = UnrealObjectRefToNetGUID.Find(SubobjectRef))
-		{
-			NetGUIDToUnrealObjectRef.Remove(*SubobjectNetGUID);
-			UnrealObjectRefToNetGUID.Remove(SubobjectRef);
+		UE_LOG(LogTemp, Error, TEXT("MCS: metadata error - FSpatialNetGUIDCache::RemoveEntityNetGUID - %s"), *UnrealMetadata->ClassPath);
+	}
+	else
+	{
+		const FClassInfo& Info = SpatialNetDriver->ClassInfoManager->GetOrCreateClassInfoByClass(UnrealMetadata->GetNativeEntityClass());
 
-			if (StablyNamedRefOption.IsSet())
+		SpatialGDK::TSchemaOption<FUnrealObjectRef>& StablyNamedRefOption = UnrealMetadata->StablyNamedRef;
+
+		for (auto& SubobjectInfoPair : Info.SubobjectInfo)
+		{
+			FUnrealObjectRef SubobjectRef(EntityId, SubobjectInfoPair.Key);
+			if (FNetworkGUID* SubobjectNetGUID = UnrealObjectRefToNetGUID.Find(SubobjectRef))
 			{
-				UnrealObjectRefToNetGUID.Remove(FUnrealObjectRef(0, 0, SubobjectInfoPair.Value->SubobjectName.ToString(), StablyNamedRefOption.GetValue()));
+				NetGUIDToUnrealObjectRef.Remove(*SubobjectNetGUID);
+				UnrealObjectRefToNetGUID.Remove(SubobjectRef);
+
+				if (StablyNamedRefOption.IsSet())
+				{
+					UnrealObjectRefToNetGUID.Remove(FUnrealObjectRef(0, 0, SubobjectInfoPair.Value->SubobjectName.ToString(), StablyNamedRefOption.GetValue()));
+				}
 			}
 		}
 	}
@@ -490,16 +497,23 @@ void FSpatialNetGUIDCache::RemoveSubobjectNetGUID(const FUnrealObjectRef& Subobj
 		return;
 	}
 
-	const FClassInfo& Info = SpatialNetDriver->ClassInfoManager->GetOrCreateClassInfoByClass(UnrealMetadata->GetNativeEntityClass());
-
-	// Part of the CDO
-	if (const TSharedRef<const FClassInfo>* SubobjectInfoPtr = Info.SubobjectInfo.Find(SubobjectRef.Offset))
+	if (UnrealMetadata->NativeClass.IsStale())
 	{
-		SpatialGDK::TSchemaOption<FUnrealObjectRef>& StablyNamedRefOption = UnrealMetadata->StablyNamedRef;
+		UE_LOG(LogTemp, Error, TEXT("MCS: metadata error - FSpatialNetGUIDCache::RemoveSubobjectNetGUID - %s"), *UnrealMetadata->ClassPath);
+	}
+	else
+	{
+		const FClassInfo& Info = SpatialNetDriver->ClassInfoManager->GetOrCreateClassInfoByClass(UnrealMetadata->GetNativeEntityClass());
 
-		if (StablyNamedRefOption.IsSet())
+		// Part of the CDO
+		if (const TSharedRef<const FClassInfo>* SubobjectInfoPtr = Info.SubobjectInfo.Find(SubobjectRef.Offset))
 		{
-			UnrealObjectRefToNetGUID.Remove(FUnrealObjectRef(0, 0, SubobjectInfoPtr->Get().SubobjectName.ToString(), StablyNamedRefOption.GetValue()));
+			SpatialGDK::TSchemaOption<FUnrealObjectRef>& StablyNamedRefOption = UnrealMetadata->StablyNamedRef;
+
+			if (StablyNamedRefOption.IsSet())
+			{
+				UnrealObjectRefToNetGUID.Remove(FUnrealObjectRef(0, 0, SubobjectInfoPtr->Get().SubobjectName.ToString(), StablyNamedRefOption.GetValue()));
+			}
 		}
 	}
 	FNetworkGUID SubobjectNetGUID = UnrealObjectRefToNetGUID[SubobjectRef];

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -422,7 +422,7 @@ void FSpatialNetGUIDCache::RemoveEntityNetGUID(Worker_EntityId EntityId)
 
 	if (UnrealMetadata->NativeClass.IsStale())
 	{
-		UE_LOG(LogTemp, Error, TEXT("MCS: metadata error - FSpatialNetGUIDCache::RemoveEntityNetGUID - %s"), *UnrealMetadata->ClassPath);
+		UE_LOG(LogSpatialPackageMap, Warning, TEXT("Attempting to remove stale object from package map - %s"), *UnrealMetadata->ClassPath);
 	}
 	else
 	{
@@ -499,7 +499,7 @@ void FSpatialNetGUIDCache::RemoveSubobjectNetGUID(const FUnrealObjectRef& Subobj
 
 	if (UnrealMetadata->NativeClass.IsStale())
 	{
-		UE_LOG(LogTemp, Error, TEXT("MCS: metadata error - FSpatialNetGUIDCache::RemoveSubobjectNetGUID - %s"), *UnrealMetadata->ClassPath);
+		UE_LOG(LogSpatialPackageMap, Warning, TEXT("Attempting to remove stale subobject from package map - %s"), *UnrealMetadata->ClassPath);
 	}
 	else
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -418,6 +418,8 @@ void FSpatialNetGUIDCache::RemoveEntityNetGUID(Worker_EntityId EntityId)
 		return;
 	}
 
+	SpatialGDK::TSchemaOption<FUnrealObjectRef>& StablyNamedRefOption = UnrealMetadata->StablyNamedRef;
+
 	if (UnrealMetadata->NativeClass.IsStale())
 	{
 		UE_LOG(LogTemp, Error, TEXT("MCS: metadata error - FSpatialNetGUIDCache::RemoveEntityNetGUID - %s"), *UnrealMetadata->ClassPath);
@@ -425,8 +427,6 @@ void FSpatialNetGUIDCache::RemoveEntityNetGUID(Worker_EntityId EntityId)
 	else
 	{
 		const FClassInfo& Info = SpatialNetDriver->ClassInfoManager->GetOrCreateClassInfoByClass(UnrealMetadata->GetNativeEntityClass());
-
-		SpatialGDK::TSchemaOption<FUnrealObjectRef>& StablyNamedRefOption = UnrealMetadata->StablyNamedRef;
 
 		for (auto& SubobjectInfoPair : Info.SubobjectInfo)
 		{

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -488,7 +488,8 @@ void USpatialReceiver::ReceiveActor(Worker_EntityId EntityId)
 		UClass* Class = UnrealMetadataComp->GetNativeEntityClass();
 		if (Class == nullptr)
 		{
-			UE_LOG(LogSpatialReceiver, Warning, TEXT("The received actor with entity id %lld couldn't be loaded. The actor will not be spawned."), EntityId);
+			UE_LOG(LogSpatialReceiver, Warning, TEXT("The received actor with entity id %lld couldn't be loaded. The actor (%s) will not be spawned."),
+				EntityId, *UnrealMetadataComp->ClassPath);
 			return;
 		}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -485,6 +485,12 @@ void USpatialReceiver::ReceiveActor(Worker_EntityId EntityId)
 	}
 	else
 	{
+		if (UnrealMetadataComp->NativeClass.IsStale())
+		{
+			UE_LOG(LogTemp, Error, TEXT("MCS: metadata error - USpatialReceiver::ReceiveActor - %s"), *UnrealMetadataComp->ClassPath);
+			return;
+		}
+
 		// Make sure ClassInfo exists
 		ClassInfoManager->GetOrCreateClassInfoByClass(UnrealMetadataComp->GetNativeEntityClass());
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -485,12 +485,6 @@ void USpatialReceiver::ReceiveActor(Worker_EntityId EntityId)
 	}
 	else
 	{
-		if (UnrealMetadataComp->NativeClass.IsStale())
-		{
-			UE_LOG(LogTemp, Error, TEXT("MCS: metadata error - USpatialReceiver::ReceiveActor - %s"), *UnrealMetadataComp->ClassPath);
-			return;
-		}
-
 		// Make sure ClassInfo exists
 		ClassInfoManager->GetOrCreateClassInfoByClass(UnrealMetadataComp->GetNativeEntityClass());
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -485,8 +485,15 @@ void USpatialReceiver::ReceiveActor(Worker_EntityId EntityId)
 	}
 	else
 	{
+		UClass* Class = UnrealMetadataComp->GetNativeEntityClass();
+		if (Class == nullptr)
+		{
+			UE_LOG(LogSpatialReceiver, Warning, TEXT("The received actor with entity id %lld couldn't be loaded. The actor will not be spawned."), EntityId);
+			return;
+		}
+
 		// Make sure ClassInfo exists
-		ClassInfoManager->GetOrCreateClassInfoByClass(UnrealMetadataComp->GetNativeEntityClass());
+		ClassInfoManager->GetOrCreateClassInfoByClass(Class);
 
 		// If the received actor is torn off, don't bother spawning it.
 		// (This is only needed due to the delay between tearoff and deleting the entity. See https://improbableio.atlassian.net/browse/UNR-841)

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealMetadata.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealMetadata.h
@@ -79,14 +79,21 @@ struct UnrealMetadata : Component
 			UE_LOG(LogSpatialClassInfoManager, Warning, TEXT("UnrealMetadata native class %s unloaded whilst entity in view."), *ClassPath);
 		}
 #endif
+		UClass* Class = nullptr;
 
-		if (UClass* Class = LoadObject<UClass>(nullptr, *ClassPath))
+		if (StablyNamedRef.IsSet())
 		{
-			if (Class->IsChildOf<AActor>())
-			{
-				NativeClass = Class;
-				return Class;
-			}
+			Class = FindObject<UClass>(nullptr, *ClassPath, false);
+		}
+		else
+		{
+			Class = LoadObject<UClass>(nullptr, *ClassPath);
+		}
+
+		if (Class->IsChildOf<AActor>())
+		{
+			NativeClass = Class;
+			return Class;
 		}
 
 		return nullptr;

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealMetadata.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealMetadata.h
@@ -90,7 +90,7 @@ struct UnrealMetadata : Component
 			Class = LoadObject<UClass>(nullptr, *ClassPath);
 		}
 
-		if (Class->IsChildOf<AActor>())
+		if (Class != nullptr && Class->IsChildOf<AActor>())
 		{
 			NativeClass = Class;
 			return Class;


### PR DESCRIPTION
#### Description
Don't allow stably named object references to trigger object load. If it's stably named it should already be in memory, and reloading it can have fatal consequences.

#### Primary reviewers
@Vatyx @mattyoung-improbable 