### PR TITLE
Fix player movement when on zoned servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed issue where an Actor's Spatial position was not updated if it had an owner that was not replicated.
 - BeginPlay is only called once with authority per deployment for startup actors
 - Fixed null pointer dereference crash when trying to initiate a Spatial connection without an existing one.
+- Fixed an issue that could cause multiple Channels to be created for an Actor.
 
 ## [`0.5.0-preview`](https://github.com/spatialos/UnrealGDK/releases/tag/0.5.0-preview) - 2019-06-25
 - Prevented `Spatial GDK Content` from appearing under Content Browser in the editor, as the GDK plugin does not contain any game content.

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -98,7 +98,6 @@ public:
 
 	USpatialActorChannel* GetOrCreateSpatialActorChannel(UObject* TargetObject);
 	USpatialActorChannel* GetActorChannelByEntityId(Worker_EntityId EntityId) const;
-	USpatialActorChannel* CreateSpatialActorChannel(AActor* Actor, USpatialNetConnection* InConnection);
 
 	DECLARE_DELEGATE(PostWorldWipeDelegate);
 
@@ -192,6 +191,7 @@ private:
 	void CreateAndInitializeCoreClasses();
 
 	void CreateServerSpatialOSNetConnection();
+	USpatialActorChannel* CreateSpatialActorChannel(AActor* Actor);
 
 	void QueryGSMToLoadMap();
 


### PR DESCRIPTION
#### Description
Fix player movement on zoned servers (UNR-1820).

The symptom fixed by this PR was that, on a zoned deployment, one or more players would occasionally not have control of their player after joining a session. This was because the player movement component was not initialized, which is further caused by the client not processing the ClientRestart RPC.

The root cause is that the sending worker had two channels for the Actor for the RPC, and was checking the incorrect channel to determine if the channel is ready to receive RPCs.

Also made some changes to validate preconditions for private functions and avoid creation without first checking for existence of a channel.

#### Release note
In CHANGELOG.md

#### Tests
Run a deployment with multiple server workers and clients.
