### PR TITLE
UNR-1814 - Fixing event fields to clear deserialization

### DIFF
--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/CodeGenerator/Unreal/SourceGenerator.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/CodeGenerator/Unreal/SourceGenerator.cs
@@ -297,7 +297,7 @@ for (const {Types.GetTypeDisplayName(_event.Type)}& Element : _{Text.SnakeCaseTo
 
             builder.AppendLine(Text.Indent(1, $@"
 uint32_t FieldCount = Schema_GetComponentUpdateClearedFieldCount(ComponentUpdate);
-auto FieldsToClear = new Schema_FieldId[FieldCount];
+Schema_FieldId* FieldsToClear = new Schema_FieldId[FieldCount];
 Schema_GetComponentUpdateClearedFieldList({componentUpdateObjectName}, FieldsToClear);
 std::set<Schema_FieldId> FieldsToClearSet(FieldsToClear, FieldsToClear + FieldCount * sizeof(Schema_FieldId));
 

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/CodeGenerator/Unreal/SourceGenerator.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/CodeGenerator/Unreal/SourceGenerator.cs
@@ -295,9 +295,11 @@ for (const {Types.GetTypeDisplayName(_event.Type)}& Element : _{Text.SnakeCaseTo
                 builder.AppendLine(Text.Indent(1, $"Schema_Object* {eventsObjectName} = Schema_GetComponentUpdateEvents({componentUpdateObjectName});"));
             }
 
-            builder.AppendLine(Text.Indent(1, $@"auto FieldsToClear = new Schema_FieldId[Schema_GetComponentUpdateClearedFieldCount({componentUpdateObjectName})];
+            builder.AppendLine(Text.Indent(1, $@"
+uint32_t FieldCount = Schema_GetComponentUpdateClearedFieldCount(ComponentUpdate);
+auto FieldsToClear = new Schema_FieldId[FieldCount];
 Schema_GetComponentUpdateClearedFieldList({componentUpdateObjectName}, FieldsToClear);
-std::set<Schema_FieldId> FieldsToClearSet(FieldsToClear, FieldsToClear + sizeof(FieldsToClear) / sizeof(Schema_FieldId));
+std::set<Schema_FieldId> FieldsToClearSet(FieldsToClear, FieldsToClear + FieldCount * sizeof(Schema_FieldId));
 
 {name}::Update {deserializingTargetObjectName};
 "));

--- a/SpatialGDK/Build/Scripts/ExternalSchemaCodegen.bat
+++ b/SpatialGDK/Build/Scripts/ExternalSchemaCodegen.bat
@@ -45,7 +45,7 @@ if not exist "%SCHEMA_STD_COPY_DIR%" (
 call :MarkStartOfBlock "Collecting external schema files"
 set EXTERNAL_SCHEMA_FILES=
 setlocal enabledelayedexpansion
-FOR /F %%i in ('dir /s/b %GAME_FOLDER%\%1\*.schema') do ( set "EXTERNAL_SCHEMA_FILES=!EXTERNAL_SCHEMA_FILES! %%i" )
+FOR /F %%i in ('dir /s/b "%GAME_FOLDER%\%1\*.schema"') do ( set "EXTERNAL_SCHEMA_FILES=!EXTERNAL_SCHEMA_FILES! %%i" )
 setlocal disabledelayedexpansion
 call :MarkEndOfBlock "Collecting external schema files"
 


### PR DESCRIPTION
### Description
Fix in generated code for non-Unreal workers so fields to clear are correctly deserialized

#### Release note
REQUIRED: Add a release note to the `##Unreleased` section of CHANGELOG.md. You can find guidance for writing useful release notes [here](../SpatialGDK/Extras/internal-documentation/how-to-write-good-release-notes.md). Documentation changes are exempt from this requirement.

#### Tests
David tested the dbsync work when deserialize events, and Ally tested his original test project which deserializes component updates.

STRONGLY SUGGESTED: How can this be verified by QA?

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.