### PR TITLE
COMP-2137 - Docs workaround for Workernanny bug

### DIFF
--- a/SpatialGDK/Documentation/content/get-started/example-project/exampleproject-cloud-deployment.md
+++ b/SpatialGDK/Documentation/content/get-started/example-project/exampleproject-cloud-deployment.md
@@ -51,6 +51,17 @@ You can find out more about the Console in the [Glossary]({{urlRoot}}/content/gl
 
 <%(Callout type="warn" message="Note: you must close the Unreal Editor before building your workers. If the Editor is open when you try to build your workers the command will fail.")%>
 
+<%(#Expandable title="If you do not intend to use the Simulated player functionality when starting the deployment you must follow these steps first")%>
+
+1. Navigate to `UnrealGDKExampleProject\spatial\spatial\workers`
+2. Delete the `improbable` folder and the `spatialos.SimulatedPlayerCoordinator.worker.json` file inside it
+3. Navigate to `UnrealGDKExampleProject\spatial\build\assembly`
+4. If there is a folder named `SimulatedPlayerCoordinator`, delete it and the files contained inside it
+5. Re-run `spatial build build-config` from the `UnrealGDKExampleProject\spatial` directory 
+6. Ensure the folder `SimulatedPlayerCoordinator` is not regenerated in the directory `UnrealGDKExampleProject\spatial\build\assembly`
+
+<%(/Expandable)%>
+
 There are two ways to build your worker assemblies (known as “building workers”):  
 
 #### **Option 1**: Build your workers using `BuildProject.bat`

--- a/SpatialGDK/Documentation/content/get-started/starter-template/get-started-template-cloud.md
+++ b/SpatialGDK/Documentation/content/get-started/starter-template/get-started-template-cloud.md
@@ -29,12 +29,12 @@ You can find out more about the Console in the [Glossary]({{urlRoot}}/content/gl
 
 <%(#Expandable title="If you do not intend to use the Simulated player functionality when starting the deployment you must follow these steps first")%>
 
-1. Navigate to `myprojectname\spatial\spatial\workers`
+1. Navigate to `<YourProject>\spatial\spatial\workers`
 2. Delete the `improbable` folder and the `spatialos.SimulatedPlayerCoordinator.worker.json` file inside it
-3. Navigate to `myprojectname\spatial\build\assembly`
+3. Navigate to `<YourProject>\spatial\build\assembly`
 4. If there is a folder named `SimulatedPlayerCoordinator`, delete it and the files contained inside it
-5. Re-run `spatial build build-config` from the `myprojectname\spatial` directory 
-6. Ensure the folder `SimulatedPlayerCoordinator` is not regenerated in the directory `myprojectname\spatial\build\assembly`
+5. Re-run `spatial build build-config` from the `<YourProject>\spatial` directory 
+6. Ensure the folder `SimulatedPlayerCoordinator` is not regenerated in the directory `<YourProject>\spatial\build\assembly`
 
 <%(/Expandable)%>
 

--- a/SpatialGDK/Documentation/content/get-started/starter-template/get-started-template-cloud.md
+++ b/SpatialGDK/Documentation/content/get-started/starter-template/get-started-template-cloud.md
@@ -27,6 +27,17 @@ You can find out more about the Console in the [Glossary]({{urlRoot}}/content/gl
 
 **Note:** You must close the Unreal Editor before building your workers. If the Editor is open when you try to build your workers the command will fail.
 
+<%(#Expandable title="If you do not intend to use the Simulated player functionality when starting the deployment you must follow these steps first")%>
+
+1. Navigate to `myprojectname\spatial\spatial\workers`
+2. Delete the `improbable` folder and the `spatialos.SimulatedPlayerCoordinator.worker.json` file inside it
+3. Navigate to `myprojectname\spatial\build\assembly`
+4. If there is a folder named `SimulatedPlayerCoordinator`, delete it and the files contained inside it
+5. Re-run `spatial build build-config` from the `myprojectname\spatial` directory 
+6. Ensure the folder `SimulatedPlayerCoordinator` is not regenerated in the directory `myprojectname\spatial\build\assembly`
+
+<%(/Expandable)%>
+
 There are two ways to build your worker assemblies (known as “building workers”):
 
 - Build your workers automatically using the `BuildProject.bat` script. </br>

--- a/SpatialGDK/Documentation/content/tutorials/porting-guide/tutorial-portingguide-setup.md
+++ b/SpatialGDK/Documentation/content/tutorials/porting-guide/tutorial-portingguide-setup.md
@@ -63,6 +63,15 @@ To do this:
 
 **Note**: The helper scripts `LaunchClient.bat` and `LaunchServer.bat` will not work if you do not follow this step correctly. 
 
+<%(Callout type="warn" message="If you do not intend to use the Simulated player functionality when starting the deployment you must follow these steps first")%>
+
+1. Navigate to `<ProjectRoot>\spatial\spatial\workers`  
+1. Delete the `improbable` folder and the `spatialos.SimulatedPlayerCoordinator.worker.json` file inside it  
+1. Navigate to `<ProjectRoot>\spatial\build\assembly`  
+1. If there is a folder named `SimulatedPlayerCoordinator`, delete it and the files contained inside it  
+1. Re-run `spatial build build-config` from the `<ProjectRoot>\spatial` directory  
+1. Ensure the folder `SimulatedPlayerCoordinator` is not regenerated in the directory `<ProjectRoot>\spatial\build\assembly`  
+
 ### **> Next:** [2. Modify and build your project]({{urlRoot}}/content/tutorials/porting-guide/tutorial-portingguide-build)
 
 <br/>


### PR DESCRIPTION
#### Description
Docs workaround for WorkerNanny issue COMP-2137. 

This change updates the following pages
Example project
https://docs.improbable.io/unreal/alpha/content/get-started/example-project/exampleproject-cloud-deployment#step-4-launch-your-cloud-deployment

Unreal GDK Starter Template
https://docs.improbable.io/unreal/alpha/content/get-started/starter-template/get-started-template-cloud#step-4-launch-your-cloud-deployment

This is NOT a fix and this issue and still needs to be fixed in - COMP-2137

#### Tests
Tested locally with improbadoc 