### PR TITLE
UNR-1456 Use class path to refer to singleton actors

### DIFF
--- a/SpatialGDK/Extras/schema/core_types.schema
+++ b/SpatialGDK/Extras/schema/core_types.schema
@@ -12,4 +12,8 @@ type UnrealObjectRef {
     // a reference, e.g. anything inside streaming levels should not be loaded.
     option<bool> no_load_on_client = 4;
     option<UnrealObjectRef> outer = 5;
+    // Singleton objects can be referred to by their class path in the case of an
+    // authoritative server that hasn't checked the singleton entity yet. This bool
+    // will differentiate that from their class pointer.
+    option<bool> singleton_ref = 6;
 }

--- a/SpatialGDK/Extras/schema/core_types.schema
+++ b/SpatialGDK/Extras/schema/core_types.schema
@@ -15,5 +15,5 @@ type UnrealObjectRef {
     // Singleton objects can be referred to by their class path in the case of an
     // authoritative server that hasn't checked the singleton entity yet. This bool
     // will differentiate that from their class pointer.
-    option<bool> singleton_ref = 6;
+    option<bool> use_singleton_class_path = 6;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitReader.cpp
@@ -37,6 +37,9 @@ void FSpatialNetBitReader::DeserializeObjectRef(FUnrealObjectRef& ObjectRef)
 		ObjectRef.Outer = FUnrealObjectRef();
 		DeserializeObjectRef(*ObjectRef.Outer);
 	}
+
+	SerializeBits(&ObjectRef.bNoLoadOnClient, 1);
+	SerializeBits(&ObjectRef.bSingletonRef, 1);
 }
 
 FArchive& FSpatialNetBitReader::operator<<(UObject*& Value)
@@ -44,35 +47,14 @@ FArchive& FSpatialNetBitReader::operator<<(UObject*& Value)
 	FUnrealObjectRef ObjectRef;
 
 	DeserializeObjectRef(ObjectRef);
-
 	check(ObjectRef != FUnrealObjectRef::UNRESOLVED_OBJECT_REF);
-	if (ObjectRef == FUnrealObjectRef::NULL_OBJECT_REF)
+
+	bool bUnresolved = false;
+	Value = ObjectRef.ToObjectPtr(Cast<USpatialPackageMapClient>(PackageMap), bUnresolved);
+
+	if (bUnresolved)
 	{
-		Value = nullptr;
-	}
-	else
-	{
-		auto PackageMapClient = Cast<USpatialPackageMapClient>(PackageMap);
-		FNetworkGUID NetGUID = PackageMapClient->GetNetGUIDFromUnrealObjectRef(ObjectRef);
-		if (NetGUID.IsValid())
-		{
-			Value = PackageMapClient->GetObjectFromNetGUID(NetGUID, true);
-			if (Value == nullptr)
-			{
-				// At this point, we're unable to resolve a stably-named actor by path. This likely means either the actor doesn't exist, or
-				// it's part of a streaming level that hasn't been streamed in. Native Unreal networking sets reference to nullptr and continues.
-				// So we do the same.
-				FString FullPath;
-				SpatialGDK::GetFullPathFromUnrealObjectReference(ObjectRef, FullPath);
-				UE_LOG(LogSpatialNetBitReader, Verbose, TEXT("Object ref did not map to valid object. Streaming level not loaded or actor deleted. Will be set to nullptr: %s %s"),
-					*ObjectRef.ToString(), FullPath.IsEmpty() ? TEXT("[NO PATH]") : *FullPath);
-			}
-		}
-		else
-		{
-			UnresolvedRefs.Add(ObjectRef);
-			Value = nullptr;
-		}
+		UnresolvedRefs.Add(ObjectRef);
 	}
 
 	return *this;

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitReader.cpp
@@ -50,7 +50,7 @@ FArchive& FSpatialNetBitReader::operator<<(UObject*& Value)
 	check(ObjectRef != FUnrealObjectRef::UNRESOLVED_OBJECT_REF);
 
 	bool bUnresolved = false;
-	Value = ObjectRef.ToObjectPtr(Cast<USpatialPackageMapClient>(PackageMap), bUnresolved);
+	Value = FUnrealObjectRef::ToObjectPtr(ObjectRef, Cast<USpatialPackageMapClient>(PackageMap), bUnresolved);
 
 	if (bUnresolved)
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitReader.cpp
@@ -39,7 +39,7 @@ void FSpatialNetBitReader::DeserializeObjectRef(FUnrealObjectRef& ObjectRef)
 	}
 
 	SerializeBits(&ObjectRef.bNoLoadOnClient, 1);
-	SerializeBits(&ObjectRef.bSingletonRef, 1);
+	SerializeBits(&ObjectRef.bUseSingletonClassPath, 1);
 }
 
 FArchive& FSpatialNetBitReader::operator<<(UObject*& Value)

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitWriter.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitWriter.cpp
@@ -12,9 +12,8 @@
 
 DEFINE_LOG_CATEGORY(LogSpatialNetSerialize);
 
-FSpatialNetBitWriter::FSpatialNetBitWriter(USpatialPackageMapClient* InPackageMap, TSet<TWeakObjectPtr<const UObject>>& InUnresolvedObjects)
+FSpatialNetBitWriter::FSpatialNetBitWriter(USpatialPackageMapClient* InPackageMap)
 	: FNetBitWriter(InPackageMap, 0)
-	, UnresolvedObjects(InUnresolvedObjects)
 {}
 
 void FSpatialNetBitWriter::SerializeObjectRef(FUnrealObjectRef& ObjectRef)
@@ -40,34 +39,7 @@ void FSpatialNetBitWriter::SerializeObjectRef(FUnrealObjectRef& ObjectRef)
 
 FArchive& FSpatialNetBitWriter::operator<<(UObject*& Value)
 {
-	FUnrealObjectRef ObjectRef;
-	if (Value != nullptr && !Value->IsPendingKill())
-	{
-		auto PackageMapClient = Cast<USpatialPackageMapClient>(PackageMap);
-		FNetworkGUID NetGUID = PackageMapClient->GetNetGUIDFromObject(Value);
-		if (!NetGUID.IsValid())
-		{
-			if (Value->IsFullNameStableForNetworking())
-			{
-				NetGUID = PackageMapClient->ResolveStablyNamedObject(Value);
-			}
-			else
-			{
-				NetGUID = PackageMapClient->TryResolveObjectAsEntity(Value);
-			}
-		}
-		ObjectRef = FUnrealObjectRef(PackageMapClient->GetUnrealObjectRefFromNetGUID(NetGUID));
-		if (ObjectRef == FUnrealObjectRef::UNRESOLVED_OBJECT_REF)
-		{
-			UnresolvedObjects.Add(Value);
-			ObjectRef = FUnrealObjectRef::NULL_OBJECT_REF;
-		}
-	}
-	else
-	{
-		ObjectRef = FUnrealObjectRef::NULL_OBJECT_REF;
-	}
-
+	FUnrealObjectRef ObjectRef = FUnrealObjectRef::FromObjectPtr(Value, Cast<USpatialPackageMapClient>(PackageMap));
 	SerializeObjectRef(ObjectRef);
 
 	return *this;

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitWriter.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitWriter.cpp
@@ -37,7 +37,7 @@ void FSpatialNetBitWriter::SerializeObjectRef(FUnrealObjectRef& ObjectRef)
 	}
 
 	SerializeBits(&ObjectRef.bNoLoadOnClient, 1);
-	SerializeBits(&ObjectRef.bSingletonRef, 1);
+	SerializeBits(&ObjectRef.bUseSingletonClassPath, 1);
 }
 
 FArchive& FSpatialNetBitWriter::operator<<(UObject*& Value)

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitWriter.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitWriter.cpp
@@ -35,6 +35,9 @@ void FSpatialNetBitWriter::SerializeObjectRef(FUnrealObjectRef& ObjectRef)
 	{
 		SerializeObjectRef(*ObjectRef.Outer);
 	}
+
+	SerializeBits(&ObjectRef.bNoLoadOnClient, 1);
+	SerializeBits(&ObjectRef.bSingletonRef, 1);
 }
 
 FArchive& FSpatialNetBitWriter::operator<<(UObject*& Value)

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1086,9 +1086,14 @@ void USpatialNetDriver::ProcessRPC(AActor* Actor, UObject* SubObject, UFunction*
 		}
 	}
 
-	RPCPayload Payload = Sender->CreateRPCPayloadFromParams(CallingObject, Function, ReliableRPCIndex, Parameters);
-
 	FUnrealObjectRef ObjectRef = PackageMap->GetUnrealObjectRefFromObject(CallingObject);
+	if (!ObjectRef.IsValid())
+	{
+		UE_LOG(LogSpatialOSNetDriver, Warning, TEXT("The target object %s is unresolved; RPC %s will be dropped."), *CallingObject->GetFullName(), *Function->GetName());
+		return;
+	}
+	RPCPayload Payload = Sender->CreateRPCPayloadFromParams(CallingObject, ObjectRef, Function, ReliableRPCIndex, Parameters);
+
 	FPendingRPCParamsPtr RPCParams = MakeUnique<FPendingRPCParams>(ObjectRef, MoveTemp(Payload), ReliableRPCIndex);
 	Sender->ProcessRPC(MoveTemp(RPCParams));
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1086,15 +1086,15 @@ void USpatialNetDriver::ProcessRPC(AActor* Actor, UObject* SubObject, UFunction*
 		}
 	}
 
-	FUnrealObjectRef ObjectRef = PackageMap->GetUnrealObjectRefFromObject(CallingObject);
-	if (!ObjectRef.IsValid())
+	FUnrealObjectRef CallingObjectRef = PackageMap->GetUnrealObjectRefFromObject(CallingObject);
+	if (!CallingObjectRef.IsValid())
 	{
 		UE_LOG(LogSpatialOSNetDriver, Warning, TEXT("The target object %s is unresolved; RPC %s will be dropped."), *CallingObject->GetFullName(), *Function->GetName());
 		return;
 	}
-	RPCPayload Payload = Sender->CreateRPCPayloadFromParams(CallingObject, ObjectRef, Function, ReliableRPCIndex, Parameters);
+	RPCPayload Payload = Sender->CreateRPCPayloadFromParams(CallingObject, CallingObjectRef, Function, ReliableRPCIndex, Parameters);
 
-	FPendingRPCParamsPtr RPCParams = MakeUnique<FPendingRPCParams>(ObjectRef, MoveTemp(Payload), ReliableRPCIndex);
+	FPendingRPCParamsPtr RPCParams = MakeUnique<FPendingRPCParams>(CallingObjectRef, MoveTemp(Payload), ReliableRPCIndex);
 	Sender->ProcessRPC(MoveTemp(RPCParams));
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1086,19 +1086,11 @@ void USpatialNetDriver::ProcessRPC(AActor* Actor, UObject* SubObject, UFunction*
 		}
 	}
 
-	TSet<TWeakObjectPtr<const UObject>> UnresolvedObjects;
-	RPCPayload Payload = Sender->CreateRPCPayloadFromParams(CallingObject, Function, ReliableRPCIndex, Parameters, UnresolvedObjects);
+	RPCPayload Payload = Sender->CreateRPCPayloadFromParams(CallingObject, Function, ReliableRPCIndex, Parameters);
 
-	if (UnresolvedObjects.Num() == 0)
-	{
-		FUnrealObjectRef ObjectRef = PackageMap->GetUnrealObjectRefFromObject(CallingObject);
-		FPendingRPCParamsPtr RPCParams = MakeUnique<FPendingRPCParams>(ObjectRef, MoveTemp(Payload), ReliableRPCIndex);
-		Sender->ProcessRPC(MoveTemp(RPCParams));
-	}
-	else
-	{
-		UE_LOG(LogSpatialOSNetDriver, Warning, TEXT("The object %s is unresolved because of failure to create a SpatialActorChannel; RPC %s will be dropped."), *UnresolvedObjects.CreateIterator()->Get()->GetName(), *Function->GetName());
-	}
+	FUnrealObjectRef ObjectRef = PackageMap->GetUnrealObjectRefFromObject(CallingObject);
+	FPendingRPCParamsPtr RPCParams = MakeUnique<FPendingRPCParams>(ObjectRef, MoveTemp(Payload), ReliableRPCIndex);
+	Sender->ProcessRPC(MoveTemp(RPCParams));
 }
 
 #endif

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -243,8 +243,7 @@ Worker_EntityId USpatialPackageMapClient::GetEntityIdFromObject(const UObject* O
 
 AActor* USpatialPackageMapClient::GetSingletonByClassRef(const FUnrealObjectRef& SingletonClassRef)
 {
-	UClass* SingletonClass = Cast<UClass>(GetObjectFromUnrealObjectRef(SingletonClassRef));
-	if (SingletonClass != nullptr)
+	if (UClass* SingletonClass = Cast<UClass>(GetObjectFromUnrealObjectRef(SingletonClassRef)))
 	{
 		TArray<AActor*> FoundActors;
 		UGameplayStatics::GetAllActorsOfClass(NetDriver->World, SingletonClass, FoundActors);

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -256,7 +256,7 @@ AActor* USpatialPackageMapClient::GetSingletonByClassRef(const FUnrealObjectRef&
 
 		FString FullPath;
 		SpatialGDK::GetFullPathFromUnrealObjectReference(SingletonClassRef, FullPath);
-		UE_LOG(LogSpatialPackageMap, Warning, TEXT("GetSingletonByClassRef: Found %d actors for singleton class: %s"), FoundActors.Num(), *FullPath);
+		UE_LOG(LogSpatialPackageMap, Verbose, TEXT("GetSingletonByClassRef: Found %d actors for singleton class: %s"), FoundActors.Num(), *FullPath);
 		return nullptr;
 	}
 	else

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -254,12 +254,16 @@ AActor* USpatialPackageMapClient::GetSingletonByClassRef(const FUnrealObjectRef&
 			return FoundActors[0];
 		}
 
-		UE_LOG(LogSpatialPackageMap, Warning, TEXT("GetSingletonByClassRef: Found %d actors for singleton class: %s"), FoundActors.Num(), *SingletonClassRef.ToString());
+		FString FullPath;
+		SpatialGDK::GetFullPathFromUnrealObjectReference(SingletonClassRef, FullPath);
+		UE_LOG(LogSpatialPackageMap, Warning, TEXT("GetSingletonByClassRef: Found %d actors for singleton class: %s"), FoundActors.Num(), *FullPath);
 		return nullptr;
 	}
 	else
 	{
-		UE_LOG(LogSpatialPackageMap, Warning, TEXT("GetSingletonByClassRef: Can't resolve singleton class: %s"), *SingletonClassRef.ToString());
+		FString FullPath;
+		SpatialGDK::GetFullPathFromUnrealObjectReference(SingletonClassRef, FullPath);
+		UE_LOG(LogSpatialPackageMap, Warning, TEXT("GetSingletonByClassRef: Can't resolve singleton class: %s"), *FullPath);
 		return nullptr;
 	}
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -84,12 +84,12 @@ FNetworkGUID USpatialPackageMapClient::TryResolveObjectAsEntity(UObject* Value)
 		return NetGUID;
 	}
 
-	if (!Value->IsA<AActor>() && !Value->GetOuter()->IsA<AActor>())
+	AActor* Actor = Value->IsA<AActor>() ? Cast<AActor>(Value) : Value->GetTypedOuter<AActor>();
+	if (Actor == nullptr)
 	{
 		return NetGUID;
 	}
 
-	AActor* Actor = Value->IsA<AActor>() ? Cast<AActor>(Value) : Cast<AActor>(Value->GetOuter());
 	if (!Actor->GetIsReplicated())
 	{
 		return NetGUID;

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1719,8 +1719,6 @@ void USpatialReceiver::ResolvePendingOperations_Internal(UObject* Object, const 
 {
 	UE_LOG(LogSpatialReceiver, Verbose, TEXT("Resolving pending object refs and RPCs which depend on object: %s %s."), *Object->GetName(), *ObjectRef.ToString());
 
-	Sender->ResolveOutgoingOperations(Object, /* bIsHandover */ false);
-	Sender->ResolveOutgoingOperations(Object, /* bIsHandover */ true);
 	ResolveIncomingOperations(Object, ObjectRef);
 	// TODO: UNR-1650 We're trying to resolve all queues, which introduces more overhead.
 	ResolveIncomingRPCs();

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -618,15 +618,9 @@ TArray<Worker_InterestOverride> USpatialSender::CreateComponentInterestForActor(
 	return ComponentInterest;
 }
 
-RPCPayload USpatialSender::CreateRPCPayloadFromParams(UObject* TargetObject, UFunction* Function, int ReliableRPCIndex, void* Params)
+RPCPayload USpatialSender::CreateRPCPayloadFromParams(UObject* TargetObject, const FUnrealObjectRef& TargetObjectRef, UFunction* Function, int ReliableRPCIndex, void* Params)
 {
 	const FRPCInfo& RPCInfo = ClassInfoManager->GetRPCInfo(TargetObject, Function);
-
-	FUnrealObjectRef TargetObjectRef(PackageMap->GetUnrealObjectRefFromNetGUID(PackageMap->GetNetGUIDFromObject(TargetObject)));
-	if (TargetObjectRef == FUnrealObjectRef::UNRESOLVED_OBJECT_REF)
-	{
-		UE_LOG(LogSpatialSender, Warning, TEXT("CreateRPCPayloadFromParams: TargetObject is unresolved! %s"), *TargetObject->GetName());
-	}
 
 	FSpatialNetBitWriter PayloadWriter = PackRPCDataToSpatialNetBitWriter(Function, Params, ReliableRPCIndex);
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -234,25 +234,13 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 		ComponentDatas.Add(Heartbeat().CreateHeartbeatData());
 	}
 
-	FUnresolvedObjectsMap UnresolvedObjectsMap;
-	FUnresolvedObjectsMap HandoverUnresolvedObjectsMap;
-	ComponentFactory DataFactory(UnresolvedObjectsMap, HandoverUnresolvedObjectsMap, false, NetDriver);
+	ComponentFactory DataFactory(false, NetDriver);
 
 	FRepChangeState InitialRepChanges = Channel->CreateInitialRepChangeState(Actor);
 	FHandoverChangeState InitialHandoverChanges = Channel->CreateInitialHandoverChangeState(Info);
 
 	TArray<Worker_ComponentData> DynamicComponentDatas = DataFactory.CreateComponentDatas(Actor, Info, InitialRepChanges, InitialHandoverChanges);
 	ComponentDatas.Append(DynamicComponentDatas);
-
-	for (auto& HandleUnresolvedObjectsPair : UnresolvedObjectsMap)
-	{
-		QueueOutgoingUpdate(Channel, Actor, HandleUnresolvedObjectsPair.Key, HandleUnresolvedObjectsPair.Value, /* bIsHandover */ false);
-	}
-
-	for (auto& HandleUnresolvedObjectsPair : HandoverUnresolvedObjectsMap)
-	{
-		QueueOutgoingUpdate(Channel, Actor, HandleUnresolvedObjectsPair.Key, HandleUnresolvedObjectsPair.Value, /* bIsHandover */ true);
-	}
 
 	InterestFactory InterestDataFactory(Actor, Info, NetDriver);
 	ComponentDatas.Add(InterestDataFactory.CreateInterestData());
@@ -301,22 +289,8 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 			FRepChangeState SubobjectRepChanges = Channel->CreateInitialRepChangeState(Subobject);
 			FHandoverChangeState SubobjectHandoverChanges = Channel->CreateInitialHandoverChangeState(SubobjectInfo);
 
-			// Reset unresolved objects so they can be filled again by DataFactory
-			UnresolvedObjectsMap.Empty();
-			HandoverUnresolvedObjectsMap.Empty();
-
 			TArray<Worker_ComponentData> ActorSubobjectDatas = DataFactory.CreateComponentDatas(Subobject, SubobjectInfo, SubobjectRepChanges, SubobjectHandoverChanges);
 			ComponentDatas.Append(ActorSubobjectDatas);
-
-			for (auto& HandleUnresolvedObjectsPair : UnresolvedObjectsMap)
-			{
-				QueueOutgoingUpdate(Channel, Subobject, HandleUnresolvedObjectsPair.Key, HandleUnresolvedObjectsPair.Value, /* bIsHandover */ false);
-			}
-
-			for (auto& HandleUnresolvedObjectsPair : HandoverUnresolvedObjectsMap)
-			{
-				QueueOutgoingUpdate(Channel, Subobject, HandleUnresolvedObjectsPair.Key, HandleUnresolvedObjectsPair.Value, /* bIsHandover */ true);
-			}
 		}
 	}
 
@@ -349,18 +323,10 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 
 		FHandoverChangeState SubobjectHandoverChanges = Channel->CreateInitialHandoverChangeState(SubobjectInfo);
 
-		// Reset unresolved objects so they can be filled again by DataFactory
-		HandoverUnresolvedObjectsMap.Empty();
-
 		Worker_ComponentData SubobjectHandoverData = DataFactory.CreateHandoverComponentData(SubobjectInfo.SchemaComponents[SCHEMA_Handover], Subobject, SubobjectInfo, SubobjectHandoverChanges);
 		ComponentDatas.Add(SubobjectHandoverData);
 
 		ComponentWriteAcl.Add(SubobjectInfo.SchemaComponents[SCHEMA_Handover], AuthoritativeWorkerRequirementSet);
-
-		for (auto& HandleUnresolvedObjectsPair : HandoverUnresolvedObjectsMap)
-		{
-			QueueOutgoingUpdate(Channel, Subobject, HandleUnresolvedObjectsPair.Key, HandleUnresolvedObjectsPair.Value, /* bIsHandover */ true);
-		}
 	}
 
 	ComponentDatas.Add(EntityAcl(ReadAcl, ComponentWriteAcl).CreateEntityAclData());
@@ -397,21 +363,9 @@ void USpatialSender::SendAddComponent(USpatialActorChannel* Channel, UObject* Su
 	FRepChangeState SubobjectRepChanges = Channel->CreateInitialRepChangeState(Subobject);
 	FHandoverChangeState SubobjectHandoverChanges = Channel->CreateInitialHandoverChangeState(SubobjectInfo);
 
-	FUnresolvedObjectsMap UnresolvedObjectsMap;
-	FUnresolvedObjectsMap HandoverUnresolvedObjectsMap;
-	ComponentFactory DataFactory(UnresolvedObjectsMap, HandoverUnresolvedObjectsMap, false, NetDriver);
+	ComponentFactory DataFactory(false, NetDriver);
 
 	TArray<Worker_ComponentData> SubobjectDatas = DataFactory.CreateComponentDatas(Subobject, SubobjectInfo, SubobjectRepChanges, SubobjectHandoverChanges);
-
-	for (auto& HandleUnresolvedObjectsPair : UnresolvedObjectsMap)
-	{
-		QueueOutgoingUpdate(Channel, Subobject, HandleUnresolvedObjectsPair.Key, HandleUnresolvedObjectsPair.Value, /* bIsHandover */ false);
-	}
-
-	for (auto& HandleUnresolvedObjectsPair : HandoverUnresolvedObjectsMap)
-	{
-		QueueOutgoingUpdate(Channel, Subobject, HandleUnresolvedObjectsPair.Key, HandleUnresolvedObjectsPair.Value, /* bIsHandover */ true);
-	}
 
 	for (Worker_ComponentData& ComponentData : SubobjectDatas)
 	{
@@ -550,40 +504,9 @@ void USpatialSender::SendComponentUpdates(UObject* Object, const FClassInfo& Inf
 
 	UE_LOG(LogSpatialSender, Verbose, TEXT("Sending component update (object: %s, entity: %lld)"), *Object->GetName(), EntityId);
 
-	FUnresolvedObjectsMap UnresolvedObjectsMap;
-	FUnresolvedObjectsMap HandoverUnresolvedObjectsMap;
-	ComponentFactory UpdateFactory(UnresolvedObjectsMap, HandoverUnresolvedObjectsMap, Channel->GetInterestDirty(), NetDriver);
+	ComponentFactory UpdateFactory(Channel->GetInterestDirty(), NetDriver);
 
 	TArray<Worker_ComponentUpdate> ComponentUpdates = UpdateFactory.CreateComponentUpdates(Object, Info, EntityId, RepChanges, HandoverChanges);
-
-	if (RepChanges)
-	{
-		for (uint16 Handle : RepChanges->RepChanged)
-		{
-			if (Handle > 0)
-			{
-				ResetOutgoingUpdate(Channel, Object, Handle, /* bIsHandover */ false);
-
-				if (TSet<TWeakObjectPtr<const UObject>>* UnresolvedObjects = UnresolvedObjectsMap.Find(Handle))
-				{
-					QueueOutgoingUpdate(Channel, Object, Handle, *UnresolvedObjects, /* bIsHandover */ false);
-				}
-			}
-		}
-	}
-
-	if (HandoverChanges)
-	{
-		for (uint16 Handle : *HandoverChanges)
-		{
-			ResetOutgoingUpdate(Channel, Object, Handle, /* bIsHandover */ true);
-
-			if (TSet<TWeakObjectPtr<const UObject>>* UnresolvedObjects = HandoverUnresolvedObjectsMap.Find(Handle))
-			{
-				QueueOutgoingUpdate(Channel, Object, Handle, *UnresolvedObjects, /* bIsHandover */ true);
-			}
-		}
-	}
 
 	for (Worker_ComponentUpdate& Update : ComponentUpdates)
 	{
@@ -695,21 +618,17 @@ TArray<Worker_InterestOverride> USpatialSender::CreateComponentInterestForActor(
 	return ComponentInterest;
 }
 
-RPCPayload USpatialSender::CreateRPCPayloadFromParams(UObject* TargetObject, UFunction* Function, int ReliableRPCIndex, void* Params, TSet<TWeakObjectPtr<const UObject>>& UnresolvedObjects)
+RPCPayload USpatialSender::CreateRPCPayloadFromParams(UObject* TargetObject, UFunction* Function, int ReliableRPCIndex, void* Params)
 {
 	const FRPCInfo& RPCInfo = ClassInfoManager->GetRPCInfo(TargetObject, Function);
 
 	FUnrealObjectRef TargetObjectRef(PackageMap->GetUnrealObjectRefFromNetGUID(PackageMap->GetNetGUIDFromObject(TargetObject)));
 	if (TargetObjectRef == FUnrealObjectRef::UNRESOLVED_OBJECT_REF)
 	{
-		UnresolvedObjects.Add(TargetObject);
+		UE_LOG(LogSpatialSender, Warning, TEXT("CreateRPCPayloadFromParams: TargetObject is unresolved! %s"), *TargetObject->GetName());
 	}
 
-	FSpatialNetBitWriter PayloadWriter = PackRPCDataToSpatialNetBitWriter(Function, Params, ReliableRPCIndex, UnresolvedObjects);
-	if (UnresolvedObjects.Num() > 0)
-	{
-		UE_LOG(LogSpatialSender, Warning, TEXT("Some RPC parameters for %s were not resolved."), *Function->GetName());
-	}
+	FSpatialNetBitWriter PayloadWriter = PackRPCDataToSpatialNetBitWriter(Function, Params, ReliableRPCIndex);
 
 	return RPCPayload(TargetObjectRef.Offset, RPCInfo.Index, TArray<uint8>(PayloadWriter.GetData(), PayloadWriter.GetNumBytes()));
 }
@@ -1025,102 +944,6 @@ void USpatialSender::SendServerEndpointReadyUpdate(Worker_EntityId EntityId)
 	NetDriver->Connection->SendComponentUpdate(EntityId, &Update);
 }
 
-void USpatialSender::ResetOutgoingUpdate(USpatialActorChannel* DependentChannel, UObject* ReplicatedObject, int16 Handle, bool bIsHandover)
-{
-	SCOPE_CYCLE_COUNTER(STAT_SpatialSenderResetOutgoingUpdate);
-
-	check(DependentChannel);
-	check(ReplicatedObject);
-	const FChannelObjectPair ChannelObjectPair(DependentChannel, ReplicatedObject);
-
-	// Choose the correct container based on whether it's handover or not
-	FChannelToHandleToUnresolved& PropertyToUnresolved = bIsHandover ? HandoverPropertyToUnresolved : RepPropertyToUnresolved;
-	FOutgoingRepUpdates& ObjectToUnresolved = bIsHandover ? HandoverObjectToUnresolved : RepObjectToUnresolved;
-
-	FHandleToUnresolved* HandleToUnresolved = PropertyToUnresolved.Find(ChannelObjectPair);
-	if (HandleToUnresolved == nullptr)
-	{
-		return;
-	}
-
-	FUnresolvedEntry* UnresolvedPtr = HandleToUnresolved->Find(Handle);
-	if (UnresolvedPtr == nullptr)
-	{
-		return;
-	}
-
-	FUnresolvedEntry& Unresolved = *UnresolvedPtr;
-
-	check(Unresolved.IsValid());
-
-	UE_LOG(LogSpatialSender, Log, TEXT("Resetting pending outgoing array depending on channel: %s, object: %s, handle: %d."),
-		*DependentChannel->GetName(), *ReplicatedObject->GetName(), Handle);
-
-	// Remove any references to the unresolved objects.
-	// Since these are not dereferenced before removing, it is safe to not check whether the unresolved object is still valid.
-	for (TWeakObjectPtr<const UObject>& UnresolvedObject : *Unresolved)
-	{
-		FChannelToHandleToUnresolved& ChannelToUnresolved = ObjectToUnresolved.FindChecked(UnresolvedObject);
-		FHandleToUnresolved& OtherHandleToUnresolved = ChannelToUnresolved.FindChecked(ChannelObjectPair);
-
-		OtherHandleToUnresolved.Remove(Handle);
-		if (OtherHandleToUnresolved.Num() == 0)
-		{
-			ChannelToUnresolved.Remove(ChannelObjectPair);
-			if (ChannelToUnresolved.Num() == 0)
-			{
-				ObjectToUnresolved.Remove(UnresolvedObject);
-			}
-		}
-	}
-
-	HandleToUnresolved->Remove(Handle);
-	if (HandleToUnresolved->Num() == 0)
-	{
-		PropertyToUnresolved.Remove(ChannelObjectPair);
-	}
-}
-
-void USpatialSender::QueueOutgoingUpdate(USpatialActorChannel* DependentChannel, UObject* ReplicatedObject, int16 Handle, const TSet<TWeakObjectPtr<const UObject>>& UnresolvedObjects, bool bIsHandover)
-{
-	SCOPE_CYCLE_COUNTER(STAT_SpatialSenderQueueOutgoingUpdate);
-	check(DependentChannel);
-	check(ReplicatedObject);
-	FChannelObjectPair ChannelObjectPair(DependentChannel, ReplicatedObject);
-
-	UE_LOG(LogSpatialSender, Log, TEXT("Added pending outgoing property: channel: %s, object: %s, handle: %d. Depending on objects:"),
-		*DependentChannel->GetName(), *ReplicatedObject->GetName(), Handle);
-
-	// Choose the correct container based on whether it's handover or not
-	FChannelToHandleToUnresolved& PropertyToUnresolved = bIsHandover ? HandoverPropertyToUnresolved : RepPropertyToUnresolved;
-	FOutgoingRepUpdates& ObjectToUnresolved = bIsHandover ? HandoverObjectToUnresolved : RepObjectToUnresolved;
-
-	FUnresolvedEntry Unresolved = MakeShared<TSet<TWeakObjectPtr<const UObject>>>();
-	*Unresolved = UnresolvedObjects;
-
-	FHandleToUnresolved& HandleToUnresolved = PropertyToUnresolved.FindOrAdd(ChannelObjectPair);
-	if (HandleToUnresolved.Find(Handle))
-	{
-		HandleToUnresolved.Remove(Handle);
-	}
-	HandleToUnresolved.Add(Handle, Unresolved);
-
-	for (const TWeakObjectPtr<const UObject>& UnresolvedObject : UnresolvedObjects)
-	{
-		// It is expected that this will never be reached. We should never have added an invalid object as an unresolved reference.
-		// Check the ComponentFactory.cpp should this ever be triggered.
-		checkf(UnresolvedObject.IsValid(), TEXT("Invalid UnresolvedObject passed in to USpatialSender::QueueOutgoingUpdate"));
-
-		FHandleToUnresolved& AnotherHandleToUnresolved = ObjectToUnresolved.FindOrAdd(UnresolvedObject).FindOrAdd(ChannelObjectPair);
-		check(!AnotherHandleToUnresolved.Find(Handle));
-		AnotherHandleToUnresolved.Add(Handle, Unresolved);
-
-		// Following up on the previous log: listing the unresolved objects
-		UE_LOG(LogSpatialSender, Log, TEXT("- %s"), *UnresolvedObject->GetName());
-
-	}
-}
-
 void USpatialSender::QueueOutgoingRPC(FPendingRPCParamsPtr Params)
 {
 	TWeakObjectPtr<UObject> TargetObjectWeakPtr = PackageMap->GetObjectFromUnrealObjectRef(Params->ObjectRef);
@@ -1140,9 +963,9 @@ void USpatialSender::QueueOutgoingRPC(FPendingRPCParamsPtr Params)
 	OutgoingRPCs.QueueRPC(MoveTemp(Params), RPCInfo.Type);
 }
 
-FSpatialNetBitWriter USpatialSender::PackRPCDataToSpatialNetBitWriter(UFunction* Function, void* Parameters, int ReliableRPCId, TSet<TWeakObjectPtr<const UObject>>& UnresolvedObjects) const
+FSpatialNetBitWriter USpatialSender::PackRPCDataToSpatialNetBitWriter(UFunction* Function, void* Parameters, int ReliableRPCId) const
 {
-	FSpatialNetBitWriter PayloadWriter(PackageMap, UnresolvedObjects);
+	FSpatialNetBitWriter PayloadWriter(PackageMap);
 
 	if (GetDefault<USpatialGDKSettings>()->bCheckRPCOrder)
 	{
@@ -1281,79 +1104,6 @@ void USpatialSender::SendEmptyCommandResponse(Worker_ComponentId ComponentId, Sc
 	Response.schema_type = Schema_CreateCommandResponse(ComponentId, CommandIndex);
 
 	Connection->SendCommandResponse(RequestId, &Response);
-}
-
-void USpatialSender::ResolveOutgoingOperations(UObject* Object, bool bIsHandover)
-{
-	// Choose the correct container based on whether it's handover or not
-	FChannelToHandleToUnresolved& PropertyToUnresolved = bIsHandover ? HandoverPropertyToUnresolved : RepPropertyToUnresolved;
-	FOutgoingRepUpdates& ObjectToUnresolved = bIsHandover ? HandoverObjectToUnresolved : RepObjectToUnresolved;
-
-	FChannelToHandleToUnresolved* ChannelToUnresolved = ObjectToUnresolved.Find(Object);
-	if (!ChannelToUnresolved)
-	{
-		return;
-	}
-
-	for (auto& ChannelProperties : *ChannelToUnresolved)
-	{
-		FChannelObjectPair& ChannelObjectPair = ChannelProperties.Key;
-		if (!ChannelObjectPair.Key.IsValid() || !ChannelObjectPair.Value.IsValid())
-		{
-			continue;
-		}
-
-		USpatialActorChannel* DependentChannel = ChannelObjectPair.Key.Get();
-		UObject* ReplicatingObject = ChannelObjectPair.Value.Get();
-		FHandleToUnresolved& HandleToUnresolved = ChannelProperties.Value;
-
-		const FClassInfo& Info = ClassInfoManager->GetOrCreateClassInfoByObject(ReplicatingObject);
-
-		TArray<uint16> PropertyHandles;
-
-		for (auto& HandleUnresolvedPair : HandleToUnresolved)
-		{
-			uint16 Handle = HandleUnresolvedPair.Key;
-			FUnresolvedEntry& Unresolved = HandleUnresolvedPair.Value;
-
-			Unresolved->Remove(Object);
-			if (Unresolved->Num() == 0)
-			{
-				PropertyHandles.Add(Handle);
-
-				// Hack to figure out if this property is an array to add extra handles
-				if (!bIsHandover && DependentChannel->IsDynamicArrayHandle(ReplicatingObject, Handle))
-				{
-					PropertyHandles.Add(0);
-					PropertyHandles.Add(0);
-				}
-
-				FHandleToUnresolved& AnotherHandleToUnresolved = PropertyToUnresolved.FindChecked(ChannelObjectPair);
-				AnotherHandleToUnresolved.Remove(Handle);
-				if (AnotherHandleToUnresolved.Num() == 0)
-				{
-					PropertyToUnresolved.Remove(ChannelObjectPair);
-				}
-			}
-		}
-
-		if (PropertyHandles.Num() > 0)
-		{
-			if (bIsHandover)
-			{
-				SendComponentUpdates(ReplicatingObject, Info, DependentChannel, nullptr, &PropertyHandles);
-			}
-			else
-			{
-				// End with zero to indicate the end of the list of handles.
-				PropertyHandles.Add(0);
-				FRepChangeState RepChangeState = { PropertyHandles, DependentChannel->GetObjectRepLayout(ReplicatingObject) };
-				SendComponentUpdates(ReplicatingObject, Info, DependentChannel, &RepChangeState, nullptr);
-			}
-		}
-	}
-
-	ObjectToUnresolved.Remove(Object);
 }
 
 void USpatialSender::SendOutgoingRPCs()

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
@@ -87,6 +87,8 @@ bool ComponentFactory::FillSchemaObject(Schema_Object* ComponentObject, UObject*
 
 bool ComponentFactory::FillHandoverSchemaObject(Schema_Object* ComponentObject, UObject* Object, const FClassInfo& Info, const FHandoverChangeState& Changes, bool bIsInitialData, TArray<Schema_FieldId>* ClearedIds /* = nullptr */)
 {
+	bool bWroteSomething = false;
+
 	for (uint16 ChangedHandle : Changes)
 	{
 		check(ChangedHandle > 0 && ChangedHandle - 1 < Info.HandoverProperties.Num());
@@ -95,9 +97,11 @@ bool ComponentFactory::FillHandoverSchemaObject(Schema_Object* ComponentObject, 
 		const uint8* Data = (uint8*)Object + PropertyInfo.Offset;
 
 		AddProperty(ComponentObject, ChangedHandle, PropertyInfo.Property, Data, ClearedIds);
+
+		bWroteSomething = true;
 	}
 
-	return Changes.Num() > 0;
+	return bWroteSomething;
 }
 
 void ComponentFactory::AddProperty(Schema_Object* Object, Schema_FieldId FieldId, UProperty* Property, const uint8* Data, TArray<Schema_FieldId>* ClearedIds)

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
@@ -19,12 +19,10 @@
 namespace SpatialGDK
 {
 
-ComponentFactory::ComponentFactory(FUnresolvedObjectsMap& RepUnresolvedObjectsMap, FUnresolvedObjectsMap& HandoverUnresolvedObjectsMap, bool bInterestDirty, USpatialNetDriver* InNetDriver)
+ComponentFactory::ComponentFactory(bool bInterestDirty, USpatialNetDriver* InNetDriver)
 	: NetDriver(InNetDriver)
 	, PackageMap(InNetDriver->PackageMap)
 	, ClassInfoManager(InNetDriver->ClassInfoManager)
-	, PendingRepUnresolvedObjectsMap(RepUnresolvedObjectsMap)
-	, PendingHandoverUnresolvedObjectsMap(HandoverUnresolvedObjectsMap)
 	, bInterestHasChanged(bInterestDirty)
 { }
 
@@ -45,7 +43,6 @@ bool ComponentFactory::FillSchemaObject(Schema_Object* ComponentObject, UObject*
 			if (GetGroupFromCondition(Parent.Condition) == PropertyGroup)
 			{
 				const uint8* Data = (uint8*)Object + Cmd.Offset;
-				TSet<TWeakObjectPtr<const UObject>> UnresolvedObjects;
 
 				bool bProcessedFastArrayProperty = false;
 
@@ -56,7 +53,7 @@ bool ComponentFactory::FillSchemaObject(Schema_Object* ComponentObject, UObject*
 					// Check if this is a FastArraySerializer array and if so, call our custom delta serialization
 					if (UScriptStruct* NetDeltaStruct = GetFastArraySerializerProperty(ArrayProperty))
 					{
-						FSpatialNetBitWriter ValueDataWriter(PackageMap, UnresolvedObjects);
+						FSpatialNetBitWriter ValueDataWriter(PackageMap);
 
 						if (FSpatialNetDeltaSerializeInfo::DeltaSerializeWrite(NetDriver, ValueDataWriter, Object, Parent.ArrayIndex, Parent.Property, NetDeltaStruct) || bIsInitialData)
 						{
@@ -69,24 +66,10 @@ bool ComponentFactory::FillSchemaObject(Schema_Object* ComponentObject, UObject*
 
 				if (!bProcessedFastArrayProperty)
 				{
-					AddProperty(ComponentObject, HandleIterator.Handle, Cmd.Property, Data, UnresolvedObjects, ClearedIds);
+					AddProperty(ComponentObject, HandleIterator.Handle, Cmd.Property, Data, ClearedIds);
 				}
 
-				if (UnresolvedObjects.Num() == 0)
-				{
-					bWroteSomething = true;
-				}
-				else
-				{
-					if (!bIsInitialData)
-					{
-						// Don't send updates for fields with unresolved objects, unless it's the initial data,
-						// in which case all fields should be populated.
-						Schema_ClearField(ComponentObject, HandleIterator.Handle);
-					}
-
-					PendingRepUnresolvedObjectsMap.Add(HandleIterator.Handle, UnresolvedObjects);
-				}
+				bWroteSomething = true;
 			}
 
 			if (Cmd.Type == ERepLayoutCmdType::DynamicArray)
@@ -104,44 +87,25 @@ bool ComponentFactory::FillSchemaObject(Schema_Object* ComponentObject, UObject*
 
 bool ComponentFactory::FillHandoverSchemaObject(Schema_Object* ComponentObject, UObject* Object, const FClassInfo& Info, const FHandoverChangeState& Changes, bool bIsInitialData, TArray<Schema_FieldId>* ClearedIds /* = nullptr */)
 {
-	bool bWroteSomething = false;
-
 	for (uint16 ChangedHandle : Changes)
 	{
 		check(ChangedHandle > 0 && ChangedHandle - 1 < Info.HandoverProperties.Num());
 		const FHandoverPropertyInfo& PropertyInfo = Info.HandoverProperties[ChangedHandle - 1];
 
 		const uint8* Data = (uint8*)Object + PropertyInfo.Offset;
-		FUnresolvedObjectsSet UnresolvedObjects;
 
-		AddProperty(ComponentObject, ChangedHandle, PropertyInfo.Property, Data, UnresolvedObjects, ClearedIds);
-
-		if (UnresolvedObjects.Num() == 0)
-		{
-			bWroteSomething = true;
-		}
-		else
-		{
-			if (!bIsInitialData)
-			{
-				// Don't send updates for fields with unresolved objects, unless it's the initial data,
-				// in which case all fields should be populated.
-				Schema_ClearField(ComponentObject, ChangedHandle);
-			}
-
-			PendingHandoverUnresolvedObjectsMap.Add(ChangedHandle, UnresolvedObjects);
-		}
+		AddProperty(ComponentObject, ChangedHandle, PropertyInfo.Property, Data, ClearedIds);
 	}
 
-	return bWroteSomething;
+	return Changes.Num() > 0;
 }
 
-void ComponentFactory::AddProperty(Schema_Object* Object, Schema_FieldId FieldId, UProperty* Property, const uint8* Data, TSet<TWeakObjectPtr<const UObject>>& UnresolvedObjects, TArray<Schema_FieldId>* ClearedIds)
+void ComponentFactory::AddProperty(Schema_Object* Object, Schema_FieldId FieldId, UProperty* Property, const uint8* Data, TArray<Schema_FieldId>* ClearedIds)
 {
 	if (UStructProperty* StructProperty = Cast<UStructProperty>(Property))
 	{
 		UScriptStruct* Struct = StructProperty->Struct;
-		FSpatialNetBitWriter ValueDataWriter(PackageMap, UnresolvedObjects);
+		FSpatialNetBitWriter ValueDataWriter(PackageMap);
 		bool bHasUnmapped = false;
 
 		if (Struct->StructFlags & STRUCT_NetSerializeNative)
@@ -216,63 +180,14 @@ void ComponentFactory::AddProperty(Schema_Object* Object, Schema_FieldId FieldId
 	}
 	else if (UObjectPropertyBase* ObjectProperty = Cast<UObjectPropertyBase>(Property))
 	{
-		FUnrealObjectRef ObjectRef = FUnrealObjectRef::NULL_OBJECT_REF;
-
 		UObject* ObjectValue = ObjectProperty->GetObjectPropertyValue(Data);
-
-		if (ObjectValue != nullptr && !ObjectValue->IsPendingKill())
-		{
-			FNetworkGUID NetGUID;
-			if (ObjectValue->IsSupportedForNetworking())
-			{
-				NetGUID = PackageMap->GetNetGUIDFromObject(ObjectValue);
-
-				if (!NetGUID.IsValid())
-				{
-					if (ObjectValue->IsFullNameStableForNetworking())
-					{
-						NetGUID = PackageMap->ResolveStablyNamedObject(ObjectValue);
-					}
-					else
-					{
-						NetGUID = PackageMap->TryResolveObjectAsEntity(ObjectValue);
-					}
-				}
-			}
-
-			// The secondary part of the check is needed if we couldn't assign an entity id (e.g. ran out of entity ids)
-			if (NetGUID.IsValid() || (ObjectValue->IsSupportedForNetworking() && !ObjectValue->IsFullNameStableForNetworking()))
-			{
-				ObjectRef = PackageMap->GetUnrealObjectRefFromNetGUID(NetGUID);
-			}
-			else
-			{
-				ObjectRef = FUnrealObjectRef::NULL_OBJECT_REF;
-			}
-
-			if (ObjectRef == FUnrealObjectRef::UNRESOLVED_OBJECT_REF)
-			{
-				// There are cases where something assigned a NetGUID without going through the FSpatialNetGUID (e.g. FObjectReplicator)
-				// Assign an UnrealObjectRef by going through the FSpatialNetGUID flow
-				if (ObjectValue->IsFullNameStableForNetworking())
-				{
-					PackageMap->ResolveStablyNamedObject(ObjectValue);
-					ObjectRef = PackageMap->GetUnrealObjectRefFromNetGUID(NetGUID);
-				}
-				else
-				{
-					UnresolvedObjects.Add(ObjectValue);
-					ObjectRef = FUnrealObjectRef::NULL_OBJECT_REF;
-				}
-			}
-		}
 
 		if (ObjectProperty->PropertyFlags & CPF_AlwaysInterested)
 		{
 			bInterestHasChanged = true;
 		}
 
-		AddObjectRefToSchema(Object, FieldId, ObjectRef);
+		AddObjectRefToSchema(Object, FieldId, FUnrealObjectRef::FromObjectPtr(ObjectValue, PackageMap));
 	}
 	else if (UNameProperty* NameProperty = Cast<UNameProperty>(Property))
 	{
@@ -291,7 +206,7 @@ void ComponentFactory::AddProperty(Schema_Object* Object, Schema_FieldId FieldId
 		FScriptArrayHelper ArrayHelper(ArrayProperty, Data);
 		for (int i = 0; i < ArrayHelper.Num(); i++)
 		{
-			AddProperty(Object, FieldId, ArrayProperty->Inner, ArrayHelper.GetRawPtr(i), UnresolvedObjects, ClearedIds);
+			AddProperty(Object, FieldId, ArrayProperty->Inner, ArrayHelper.GetRawPtr(i), ClearedIds);
 		}
 
 		if (ArrayHelper.Num() == 0 && ClearedIds)
@@ -307,7 +222,7 @@ void ComponentFactory::AddProperty(Schema_Object* Object, Schema_FieldId FieldId
 		}
 		else
 		{
-			AddProperty(Object, FieldId, EnumProperty->GetUnderlyingProperty(), Data, UnresolvedObjects, ClearedIds);
+			AddProperty(Object, FieldId, EnumProperty->GetUnderlyingProperty(), Data, ClearedIds);
 		}
 	}
 	else if (Property->IsA<UDelegateProperty>() || Property->IsA<UMulticastDelegateProperty>() || Property->IsA<UInterfaceProperty>())

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
@@ -308,7 +308,7 @@ void ComponentReader::ApplyProperty(Schema_Object* Object, Schema_FieldId FieldI
 		check(ObjectRef != FUnrealObjectRef::UNRESOLVED_OBJECT_REF);
 		bool bUnresolved = false;
 
-		UObject* ObjectValue = ObjectRef.ToObjectPtr(PackageMap, bUnresolved);
+		UObject* ObjectValue = FUnrealObjectRef::ToObjectPtr(ObjectRef, PackageMap, bUnresolved);
 
 		if (bUnresolved)
 		{

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetBitWriter.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetBitWriter.h
@@ -13,7 +13,7 @@ class USpatialPackageMapClient;
 class SPATIALGDK_API FSpatialNetBitWriter : public FNetBitWriter
 {
 public:
-	FSpatialNetBitWriter(USpatialPackageMapClient* InPackageMap, TSet<TWeakObjectPtr<const UObject>>& InUnresolvedObjects);
+	FSpatialNetBitWriter(USpatialPackageMapClient* InPackageMap);
 
 	using FArchive::operator<<; // For visibility of the overloads we don't override
 
@@ -23,6 +23,4 @@ public:
 
 protected:
 	void SerializeObjectRef(FUnrealObjectRef& ObjectRef);
-
-	TSet<TWeakObjectPtr<const UObject>>& UnresolvedObjects;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialPackageMapClient.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialPackageMapClient.h
@@ -51,6 +51,8 @@ public:
 	FUnrealObjectRef GetUnrealObjectRefFromObject(UObject* Object);
 	Worker_EntityId GetEntityIdFromObject(const UObject* Object);
 
+	AActor* GetSingletonByClassRef(const FUnrealObjectRef& SingletonClassRef);
+
 	// Expose FNetGUIDCache::CanClientLoadObject so we can include this info with UnrealObjectRef.
 	bool CanClientLoadObject(UObject* Object);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -108,7 +108,7 @@ public:
 
 	void FlushPackedRPCs();
 
-	RPCPayload CreateRPCPayloadFromParams(UObject* TargetObject, UFunction* Function, int ReliableRPCIndex, void* Params);
+	RPCPayload CreateRPCPayloadFromParams(UObject* TargetObject, const FUnrealObjectRef& TargetObjectRef, UFunction* Function, int ReliableRPCIndex, void* Params);
 	void GainAuthorityThenAddComponent(USpatialActorChannel* Channel, UObject* Object, const FClassInfo* Info);
 
 	// Creates an entity authoritative on this server worker, ensuring it will be able to receive updates for the GSM.

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.cpp
@@ -117,10 +117,9 @@ FUnrealObjectRef FUnrealObjectRef::FromObjectPtr(UObject* ObjectValue, USpatialP
 				// If this is a singleton that hasn't been resolved yet, send its class path instead.
 				if (ObjectValue->GetClass()->HasAnySpatialClassFlags(SPATIALCLASS_Singleton))
 				{
-					ObjectRef = FromObjectPtr(ObjectValue->GetClass(), PackageMap);
+					ObjectRef = GetSingletonClassRef(ObjectValue, PackageMap);
 					if (ObjectRef.IsValid())
 					{
-						ObjectRef.bUseSingletonClassPath = true;
 						return ObjectRef;
 					}
 				}
@@ -133,4 +132,14 @@ FUnrealObjectRef FUnrealObjectRef::FromObjectPtr(UObject* ObjectValue, USpatialP
 	}
 
 	return ObjectRef;
+}
+
+FUnrealObjectRef FUnrealObjectRef::GetSingletonClassRef(UObject* SingletonObject, USpatialPackageMapClient* PackageMap)
+{
+	FUnrealObjectRef ClassObjectRef = FromObjectPtr(SingletonObject->GetClass(), PackageMap);
+	if (ClassObjectRef.IsValid())
+	{
+		ClassObjectRef.bUseSingletonClassPath = true;
+	}
+	return ClassObjectRef;
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.cpp
@@ -20,6 +20,8 @@ UObject* FUnrealObjectRef::ToObjectPtr(const FUnrealObjectRef& ObjectRef, USpati
 	{
 		if (ObjectRef.bSingletonRef)
 		{
+			// This is a singleton ref, which means it's just the UnrealObjectRef of the singleton class, with this boolean set.
+			// Unset it to get the original singleton class UnrealObjectRef, and look it up in the PackageMap.
 			FUnrealObjectRef SingletonClassRef = ObjectRef;
 			SingletonClassRef.bSingletonRef = false;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.cpp
@@ -104,10 +104,8 @@ FUnrealObjectRef FUnrealObjectRef::FromObjectPtr(UObject* ObjectValue, USpatialP
 			else
 			{
 				// Check if the object is an actor or a subobject of an actor that is torn off or non-replicated.
-				if (ObjectValue->IsA<AActor>() || ObjectValue->GetOuter()->IsA<AActor>())
+				if (AActor* Actor = ObjectValue->IsA<AActor>() ? Cast<AActor>(ObjectValue) : ObjectValue->GetTypedOuter<AActor>())
 				{
-					AActor* Actor = ObjectValue->IsA<AActor>() ? Cast<AActor>(ObjectValue) : Cast<AActor>(ObjectValue->GetOuter());
-
 					if (Actor->GetTearOff() || !Actor->GetIsReplicated())
 					{
 						return FUnrealObjectRef::NULL_OBJECT_REF;

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.h
@@ -13,6 +13,7 @@ class USpatialPackageMapClient;
 struct FUnrealObjectRef
 {
 	FUnrealObjectRef() = default;
+	FUnrealObjectRef(const FUnrealObjectRef&) = default;
 
 	FUnrealObjectRef(Worker_EntityId Entity, uint32 Offset)
 		: Entity(Entity)
@@ -26,24 +27,6 @@ struct FUnrealObjectRef
 		, Outer(Outer)
 		, bNoLoadOnClient(bNoLoadOnClient)
 	{}
-
-	FUnrealObjectRef(const FUnrealObjectRef& In)
-		: Entity(In.Entity)
-		, Offset(In.Offset)
-		, Path(In.Path)
-		, Outer(In.Outer)
-		, bNoLoadOnClient(In.bNoLoadOnClient)
-	{}
-
-	FORCEINLINE FUnrealObjectRef& operator=(const FUnrealObjectRef& In)
-	{
-		Entity = In.Entity;
-		Offset = In.Offset;
-		Path = In.Path;
-		Outer = In.Outer;
-		bNoLoadOnClient = In.bNoLoadOnClient;
-		return *this;
-	}
 
 	FORCEINLINE FString ToString() const
 	{
@@ -86,6 +69,7 @@ struct FUnrealObjectRef
 		return (*this != NULL_OBJECT_REF && *this != UNRESOLVED_OBJECT_REF);
 	}
 
+	UObject* ToObjectPtr(USpatialPackageMapClient* PackageMap, bool& bOutUnresolved) const;
 	static FUnrealObjectRef FromObjectPtr(UObject* ObjectValue, USpatialPackageMapClient* PackageMap);
 
 	static const FUnrealObjectRef NULL_OBJECT_REF;
@@ -96,6 +80,7 @@ struct FUnrealObjectRef
 	SpatialGDK::TSchemaOption<FString> Path;
 	SpatialGDK::TSchemaOption<FUnrealObjectRef> Outer;
 	bool bNoLoadOnClient = false;
+	bool bSingletonRef = false;
 };
 
 inline uint32 GetTypeHash(const FUnrealObjectRef& ObjectRef)

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.h
@@ -57,9 +57,9 @@ struct FUnrealObjectRef
 		return Entity == Other.Entity &&
 			Offset == Other.Offset &&
 			((!Path && !Other.Path) || (Path && Other.Path && Path->Equals(*Other.Path))) &&
-			((!Outer && !Other.Outer) || (Outer && Other.Outer && *Outer == *Other.Outer));
-		// Intentionally don't compare bNoLoadOnClient since it does not affect equality.
-		// Intentionally don't compare bUseSingletonClassPath.
+			((!Outer && !Other.Outer) || (Outer && Other.Outer && *Outer == *Other.Outer)) &&
+			// Intentionally don't compare bNoLoadOnClient since it does not affect equality.
+			bUseSingletonClassPath == Other.bUseSingletonClassPath;
 	}
 
 	FORCEINLINE bool operator!=(const FUnrealObjectRef& Other) const
@@ -74,6 +74,7 @@ struct FUnrealObjectRef
 
 	static UObject* ToObjectPtr(const FUnrealObjectRef& ObjectRef, USpatialPackageMapClient* PackageMap, bool& bOutUnresolved);
 	static FUnrealObjectRef FromObjectPtr(UObject* ObjectValue, USpatialPackageMapClient* PackageMap);
+	static FUnrealObjectRef GetSingletonClassRef(UObject* SingletonObject, USpatialPackageMapClient* PackageMap);
 
 	static const FUnrealObjectRef NULL_OBJECT_REF;
 	static const FUnrealObjectRef UNRESOLVED_OBJECT_REF;
@@ -94,6 +95,6 @@ inline uint32 GetTypeHash(const FUnrealObjectRef& ObjectRef)
 	Result = (Result * 977u) + GetTypeHash(ObjectRef.Path);
 	Result = (Result * 977u) + GetTypeHash(ObjectRef.Outer);
 	// Intentionally don't hash bNoLoadOnClient.
-	// Intentionally don't hash bUseSingletonClassPath.
+	Result = (Result * 977u) + GetTypeHash(ObjectRef.bUseSingletonClassPath ? 1 : 0);
 	return Result;
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.h
@@ -59,6 +59,7 @@ struct FUnrealObjectRef
 			((!Path && !Other.Path) || (Path && Other.Path && Path->Equals(*Other.Path))) &&
 			((!Outer && !Other.Outer) || (Outer && Other.Outer && *Outer == *Other.Outer));
 		// Intentionally don't compare bNoLoadOnClient since it does not affect equality.
+		// Intentionally don't compare bUseSingletonClassPath.
 	}
 
 	FORCEINLINE bool operator!=(const FUnrealObjectRef& Other) const
@@ -82,7 +83,7 @@ struct FUnrealObjectRef
 	SpatialGDK::TSchemaOption<FString> Path;
 	SpatialGDK::TSchemaOption<FUnrealObjectRef> Outer;
 	bool bNoLoadOnClient = false;
-	bool bSingletonRef = false;
+	bool bUseSingletonClassPath = false;
 };
 
 inline uint32 GetTypeHash(const FUnrealObjectRef& ObjectRef)
@@ -93,5 +94,6 @@ inline uint32 GetTypeHash(const FUnrealObjectRef& ObjectRef)
 	Result = (Result * 977u) + GetTypeHash(ObjectRef.Path);
 	Result = (Result * 977u) + GetTypeHash(ObjectRef.Outer);
 	// Intentionally don't hash bNoLoadOnClient.
+	// Intentionally don't hash bUseSingletonClassPath.
 	return Result;
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.h
@@ -1,13 +1,14 @@
 #pragma once
 
-#include "Containers/UnrealString.h"
-#include "Templates/TypeHash.h"
+#include "CoreMinimal.h"
 
 #include "Utils/SchemaOption.h"
 
 #include <cstdint>
 
 using Worker_EntityId = std::int64_t;
+
+class USpatialPackageMapClient;
 
 struct FUnrealObjectRef
 {
@@ -84,6 +85,8 @@ struct FUnrealObjectRef
 	{
 		return (*this != NULL_OBJECT_REF && *this != UNRESOLVED_OBJECT_REF);
 	}
+
+	static FUnrealObjectRef FromObjectPtr(UObject* ObjectValue, USpatialPackageMapClient* PackageMap);
 
 	static const FUnrealObjectRef NULL_OBJECT_REF;
 	static const FUnrealObjectRef UNRESOLVED_OBJECT_REF;

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.h
@@ -28,6 +28,8 @@ struct FUnrealObjectRef
 		, bNoLoadOnClient(bNoLoadOnClient)
 	{}
 
+	FUnrealObjectRef& operator=(const FUnrealObjectRef&) = default;
+
 	FORCEINLINE FString ToString() const
 	{
 		return FString::Printf(TEXT("(entity ID: %lld, offset: %u)"), Entity, Offset);
@@ -69,7 +71,7 @@ struct FUnrealObjectRef
 		return (*this != NULL_OBJECT_REF && *this != UNRESOLVED_OBJECT_REF);
 	}
 
-	UObject* ToObjectPtr(USpatialPackageMapClient* PackageMap, bool& bOutUnresolved) const;
+	static UObject* ToObjectPtr(const FUnrealObjectRef& ObjectRef, USpatialPackageMapClient* PackageMap, bool& bOutUnresolved);
 	static FUnrealObjectRef FromObjectPtr(UObject* ObjectValue, USpatialPackageMapClient* PackageMap);
 
 	static const FUnrealObjectRef NULL_OBJECT_REF;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -144,6 +144,14 @@ namespace SpatialConstants
 	const Schema_FieldId MODIFY_SETTING_PAYLOAD_NAME_ID						= 1;
 	const Schema_FieldId MODIFY_SETTING_PAYLOAD_VALUE_ID					= 2;
 
+	// UnrealObjectRef Field IDs
+	const Schema_FieldId UNREAL_OBJECT_REF_ENTITY_ID						= 1;
+	const Schema_FieldId UNREAL_OBJECT_REF_OFFSET_ID						= 2;
+	const Schema_FieldId UNREAL_OBJECT_REF_PATH_ID							= 3;
+	const Schema_FieldId UNREAL_OBJECT_REF_NO_LOAD_ON_CLIENT_ID				= 4;
+	const Schema_FieldId UNREAL_OBJECT_REF_OUTER_ID							= 5;
+	const Schema_FieldId UNREAL_OBJECT_REF_USE_SINGLETON_CLASS_PATH_ID		= 6;
+
 	// UnrealRPCPayload Field IDs
 	const Schema_FieldId UNREAL_RPC_PAYLOAD_OFFSET_ID						= 1;
 	const Schema_FieldId UNREAL_RPC_PAYLOAD_RPC_INDEX_ID					= 2;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/ComponentFactory.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/ComponentFactory.h
@@ -19,16 +19,13 @@ class UProperty;
 
 enum EReplicatedPropertyGroup : uint32;
 
-using FUnresolvedObjectsSet = TSet<TWeakObjectPtr<const UObject>>;
-using FUnresolvedObjectsMap = TMap<Schema_FieldId, FUnresolvedObjectsSet>;
-
 namespace SpatialGDK
 {
 
 class SPATIALGDK_API ComponentFactory
 {
 public:
-	ComponentFactory(FUnresolvedObjectsMap& RepUnresolvedObjectsMap, FUnresolvedObjectsMap& HandoverUnresolvedObjectsMap, bool bInterestDirty, USpatialNetDriver* InNetDriver);
+	ComponentFactory(bool bInterestDirty, USpatialNetDriver* InNetDriver);
 
 	TArray<Worker_ComponentData> CreateComponentDatas(UObject* Object, const FClassInfo& Info, const FRepChangeState& RepChangeState, const FHandoverChangeState& HandoverChangeState);
 	TArray<Worker_ComponentUpdate> CreateComponentUpdates(UObject* Object, const FClassInfo& Info, Worker_EntityId EntityId, const FRepChangeState* RepChangeState, const FHandoverChangeState* HandoverChangeState);
@@ -47,19 +44,11 @@ private:
 
 	bool FillHandoverSchemaObject(Schema_Object* ComponentObject, UObject* Object, const FClassInfo& Info, const FHandoverChangeState& Changes, bool bIsInitialData, TArray<Schema_FieldId>* ClearedIds = nullptr);
 
-	Worker_ComponentData CreateInterestComponentData(UObject* Object, const FClassInfo& Info);
-	Worker_ComponentUpdate CreateInterestComponentUpdate(UObject* Object, const FClassInfo& Info);
-	Interest CreateInterestComponent(UObject* Object, const FClassInfo& Info);
-	void AddObjectToComponentInterest(UObject* Object, UObjectPropertyBase* Property, uint8* Data, ComponentInterest& ComponentInterest);
-
-	void AddProperty(Schema_Object* Object, Schema_FieldId FieldId, UProperty* Property, const uint8* Data, FUnresolvedObjectsSet& UnresolvedObjects, TArray<Schema_FieldId>* ClearedIds);
+	void AddProperty(Schema_Object* Object, Schema_FieldId FieldId, UProperty* Property, const uint8* Data, TArray<Schema_FieldId>* ClearedIds);
 
 	USpatialNetDriver* NetDriver;
 	USpatialPackageMapClient* PackageMap;
 	USpatialClassInfoManager* ClassInfoManager;
-
-	FUnresolvedObjectsMap& PendingRepUnresolvedObjectsMap;
-	FUnresolvedObjectsMap& PendingHandoverUnresolvedObjectsMap;
 
 	bool bInterestHasChanged;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SchemaUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SchemaUtils.h
@@ -109,22 +109,24 @@ inline WorkerRequirementSet GetWorkerRequirementSetFromSchema(Schema_Object* Obj
 
 inline void AddObjectRefToSchema(Schema_Object* Object, Schema_FieldId Id, const FUnrealObjectRef& ObjectRef)
 {
+	using namespace SpatialConstants;
+
 	Schema_Object* ObjectRefObject = Schema_AddObject(Object, Id);
 
-	Schema_AddEntityId(ObjectRefObject, 1, ObjectRef.Entity);
-	Schema_AddUint32(ObjectRefObject, 2, ObjectRef.Offset);
+	Schema_AddEntityId(ObjectRefObject, UNREAL_OBJECT_REF_ENTITY_ID, ObjectRef.Entity);
+	Schema_AddUint32(ObjectRefObject, UNREAL_OBJECT_REF_OFFSET_ID, ObjectRef.Offset);
 	if (ObjectRef.Path)
 	{
-		AddStringToSchema(ObjectRefObject, 3, *ObjectRef.Path);
-		Schema_AddBool(ObjectRefObject, 4, ObjectRef.bNoLoadOnClient);
+		AddStringToSchema(ObjectRefObject, UNREAL_OBJECT_REF_PATH_ID, *ObjectRef.Path);
+		Schema_AddBool(ObjectRefObject, UNREAL_OBJECT_REF_NO_LOAD_ON_CLIENT_ID, ObjectRef.bNoLoadOnClient);
 	}
 	if (ObjectRef.Outer)
 	{
-		AddObjectRefToSchema(ObjectRefObject, 5, *ObjectRef.Outer);
+		AddObjectRefToSchema(ObjectRefObject, UNREAL_OBJECT_REF_OUTER_ID, *ObjectRef.Outer);
 	}
-	if (ObjectRef.bSingletonRef)
+	if (ObjectRef.bUseSingletonClassPath)
 	{
-		Schema_AddBool(ObjectRefObject, 6, ObjectRef.bSingletonRef);
+		Schema_AddBool(ObjectRefObject, UNREAL_OBJECT_REF_USE_SINGLETON_CLASS_PATH_ID, ObjectRef.bUseSingletonClassPath);
 	}
 }
 
@@ -132,27 +134,29 @@ FUnrealObjectRef GetObjectRefFromSchema(Schema_Object* Object, Schema_FieldId Id
 
 inline FUnrealObjectRef IndexObjectRefFromSchema(Schema_Object* Object, Schema_FieldId Id, uint32 Index)
 {
+	using namespace SpatialConstants;
+
 	FUnrealObjectRef ObjectRef;
 
 	Schema_Object* ObjectRefObject = Schema_IndexObject(Object, Id, Index);
 
-	ObjectRef.Entity = Schema_GetEntityId(ObjectRefObject, 1);
-	ObjectRef.Offset = Schema_GetUint32(ObjectRefObject, 2);
-	if (Schema_GetObjectCount(ObjectRefObject, 3) > 0)
+	ObjectRef.Entity = Schema_GetEntityId(ObjectRefObject, UNREAL_OBJECT_REF_ENTITY_ID);
+	ObjectRef.Offset = Schema_GetUint32(ObjectRefObject, UNREAL_OBJECT_REF_OFFSET_ID);
+	if (Schema_GetObjectCount(ObjectRefObject, UNREAL_OBJECT_REF_PATH_ID) > 0)
 	{
-		ObjectRef.Path = GetStringFromSchema(ObjectRefObject, 3);
+		ObjectRef.Path = GetStringFromSchema(ObjectRefObject, UNREAL_OBJECT_REF_PATH_ID);
 	}
-	if (Schema_GetBoolCount(ObjectRefObject, 4) > 0)
+	if (Schema_GetBoolCount(ObjectRefObject, UNREAL_OBJECT_REF_NO_LOAD_ON_CLIENT_ID) > 0)
 	{
-		ObjectRef.bNoLoadOnClient = GetBoolFromSchema(ObjectRefObject, 4);
+		ObjectRef.bNoLoadOnClient = GetBoolFromSchema(ObjectRefObject, UNREAL_OBJECT_REF_NO_LOAD_ON_CLIENT_ID);
 	}
-	if (Schema_GetObjectCount(ObjectRefObject, 5) > 0)
+	if (Schema_GetObjectCount(ObjectRefObject, UNREAL_OBJECT_REF_OUTER_ID) > 0)
 	{
-		ObjectRef.Outer = GetObjectRefFromSchema(ObjectRefObject, 5);
+		ObjectRef.Outer = GetObjectRefFromSchema(ObjectRefObject, UNREAL_OBJECT_REF_OUTER_ID);
 	}
-	if (Schema_GetBoolCount(ObjectRefObject, 6) > 0)
+	if (Schema_GetBoolCount(ObjectRefObject, UNREAL_OBJECT_REF_USE_SINGLETON_CLASS_PATH_ID) > 0)
 	{
-		ObjectRef.bSingletonRef = GetBoolFromSchema(ObjectRefObject, 6);
+		ObjectRef.bUseSingletonClassPath = GetBoolFromSchema(ObjectRefObject, UNREAL_OBJECT_REF_USE_SINGLETON_CLASS_PATH_ID);
 	}
 
 	return ObjectRef;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SchemaUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SchemaUtils.h
@@ -122,6 +122,10 @@ inline void AddObjectRefToSchema(Schema_Object* Object, Schema_FieldId Id, const
 	{
 		AddObjectRefToSchema(ObjectRefObject, 5, *ObjectRef.Outer);
 	}
+	if (ObjectRef.bSingletonRef)
+	{
+		Schema_AddBool(ObjectRefObject, 6, ObjectRef.bSingletonRef);
+	}
 }
 
 FUnrealObjectRef GetObjectRefFromSchema(Schema_Object* Object, Schema_FieldId Id);
@@ -145,6 +149,10 @@ inline FUnrealObjectRef IndexObjectRefFromSchema(Schema_Object* Object, Schema_F
 	if (Schema_GetObjectCount(ObjectRefObject, 5) > 0)
 	{
 		ObjectRef.Outer = GetObjectRefFromSchema(ObjectRefObject, 5);
+	}
+	if (Schema_GetBoolCount(ObjectRefObject, 6) > 0)
+	{
+		ObjectRef.bSingletonRef = GetBoolFromSchema(ObjectRefObject, 6);
 	}
 
 	return ObjectRef;


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
If the singleton entity is not checked out at the time we want to set a property or call an RPC with a singleton actor as the argument, use its class path to make an UnrealObjectRef instead, indicating that it's the singleton actor with a bool.
This allows us to remove the queuing logic on the sending side, as the other cases have already been handled by the EntityPool.

#### Tests
Tested by having a non-GSM-authoritative server spawn a cube and assign a property to GameState. The property is replicated using the singleton class path and correctly resolved on the client when it checks out GameState.
Follow up task to write unit tests https://improbableio.atlassian.net/browse/UNR-1909

#### Primary reviewers
@m-samiec @aleximprobable 