### PR TITLE
DOC-1256 clarify status of zoning and offloading

### DIFF
--- a/SpatialGDK/Documentation/content/actor-handover.md
+++ b/SpatialGDK/Documentation/content/actor-handover.md
@@ -1,7 +1,9 @@
 <%(TOC)%>
 # Actor handover between server-workers
 
-Actor handover (`handover`) is a `UPROPERTY` specifier. It allows games built in Unreal (which uses single-server architecture) to take advantage of SpatialOS’ distributed, persistent server architecture. 
+Actor handover (`handover`) is a `UPROPERTY` specifier. It allows games built in Unreal (which uses single-server architecture) to take advantage of [zoning]({{urlRoot}}/content/glossary#zoning), which is one of the GDK's options for multiserver development.
+
+> **Note:** Support for zoning is currently in pre-alpha. We invite you to try out the [multiserver zoning shooter tutorial]({{urlRoot}}/content/tutorials/multiserver-shooter/tutorial-multiserver-intro) and learn about how it works, but we don’t recommend you start developing features that use zoning yet.
 
 In Unreal’s native single-server architecture, your game server holds the canonical state of the whole game world. As there is a single game server, there are Actor properties that the server doesn’t need to share with any other server or clients. These properties only need to exist in the game server’s local process space.
 

--- a/SpatialGDK/Documentation/content/authority.md
+++ b/SpatialGDK/Documentation/content/authority.md
@@ -59,22 +59,20 @@ Actor on **non-owning client**:
 
 ## GDK authority
 
-Because you can use the GDK with multiple [server-workers]({{urlRoot}}/content/glossary#worker) using [zoning]({{urlRoot}}/content/glossary#zoning), authority needs to be dictated by SpatialOS so that it is shared between server-workers. This means server-workers have authority over some Actors but don’t have authority over other Actors, depending on how SpatialOS assigns authority. **This is a key difference between the GDK and native Unreal networking!**
+Because you can use the GDK with multiple [server-workers instances]({{urlRoot}}/content/glossary#worker) using [zoning]({{urlRoot}}/content/glossary#zoning), SpatialOS needs to specify authority, so that it can allocate it appropriately between server-worker instances. This means that, when you use zoning, at any given moment, server-worker instances might have authority over only some Actors, depending on how SpatialOS assigns authority. **This is a key difference between the GDK and native Unreal networking!**
 
 > **Note:** Support for zoning is currently in pre-alpha. We invite you to try out the [multiserver zoning shooter tutorial]({{urlRoot}}/content/tutorials/multiserver-shooter/tutorial-multiserver-intro) and learn about how it works, but we don’t recommend you start developing features that use zoning yet.
 
-We use the term “authoritative” when a server-worker has authority over an Actor and “non-authoritative” when it doesn’t.
-
-In the GDK, a server-worker is authoritative over an Actor if it has authority over the [schema]({{urlRoot}}/content/glossary#schema) [component]({{urlRoot}}/content/glossary#spatialos-component) `Position`. 
+In the GDK, a server-worker has authority over an Actor if it has authority over the [schema]({{urlRoot}}/content/glossary#schema) [component]({{urlRoot}}/content/glossary#spatialos-component) `Position`. 
 
 So, in the GDK multiserver scenario, authority looks like this:
 
-Actor on **authoritative server-worker**:
+Actor on **server-worker that has authority**:
 
 * `Role = ROLE_Authority`
 * `RemoteRole = ROLE_SimulatedProxy`
 
-Actor on **non-authoritative server-worker**:
+Actor on **server-worker that doesn't have authority**:
 
 * `Role = ROLE_SimulatedProxy`
 * `RemoteRole = ROLE_Authority`
@@ -84,16 +82,16 @@ Actor on **[client-worker]({{urlRoot}}/content/glossary#worker)**:
 * `Role = ROLE_SimulatedProxy`
 * `RemoteRole = ROLE_Authority`
 
-The GDK models owning connections using a schema component which represents the `ClientRPC`s. The worker authoritative over the `ClientRPC` schema [component]({{urlRoot}}/content/glossary#spatialos-component) is the client which owns the Actor.
+The GDK models owning connections using a schema component which represents the `ClientRPC`s. The worker that has authority over the `ClientRPC` schema [component]({{urlRoot}}/content/glossary#spatialos-component) is the client which owns the Actor.
 
-In the same example as above, with the `PlayerController`, `Character` and gun, the client-worker would be authoritative over the `ClientRPC` schema component on the `PlayerController`, `Character` and gun [entities]({{urlRoot}}/content/glossary#entity). Authority over this schema component dictates the assignment of `ROLE_AutonomousProxy`.
+In the same example as above, with the `PlayerController`, `Character` and gun, the client-worker would have authority over the `ClientRPC` schema component on the `PlayerController`, `Character` and gun [entities]({{urlRoot}}/content/glossary#entity). Authority over this schema component dictates the assignment of `ROLE_AutonomousProxy`.
 
-Actor on **authoritative server-worker** with an **owning connection**:
+Actor on **server-worker that has authority** with an **owning connection**:
 
 * `Role = ROLE_Authority`
 * `RemoteRole = ROLE_AutonomousProxy`
 
-Actor on **non-authoritative server-worker** with an **owning connection**:
+Actor on **server-worker that doesn't have authority** with an **owning connection**:
 
 * `Role = ROLE_SimulatedProxy`
 * `RemoteRole = ROLE_Authority`

--- a/SpatialGDK/Documentation/content/authority.md
+++ b/SpatialGDK/Documentation/content/authority.md
@@ -65,7 +65,7 @@ As the GDK works with multiple [server-workers]({{urlRoot}}/content/glossary#wor
 
 In the GDK, a server-worker is authoritative over an Actor if it has authority over the [schema]({{urlRoot}}/content/glossary#schema) [component]({{urlRoot}}/content/glossary#spatialos-component) `Position`. 
 
-So, in the SpatialOS GDK multiserver scenario, authority looks like this:
+So, in the GDK multiserver scenario, authority looks like this:
 
 Actor on **authoritative server-worker**:
 

--- a/SpatialGDK/Documentation/content/authority.md
+++ b/SpatialGDK/Documentation/content/authority.md
@@ -59,9 +59,11 @@ Actor on **non-owning client**:
 
 ## GDK authority
 
-As the GDK works with multiple [server-workers]({{urlRoot}}/content/glossary#worker), rather than a single server, authority needs to be dictated by SpatialOS so that authority is shared between server-workers. This means server-workers have authority over some Actors but don’t have authority over other Actors, depending on how SpatialOS assigns authority. **This is a key difference between the GDK and native Unreal networking!**
+As the GDK can work with multiple [server-workers]({{urlRoot}}/content/glossary#worker) using [zoning]({{urlRoot}}/content/glossary#zoning), authority needs to be dictated by SpatialOS so that it is shared between server-workers. This means server-workers have authority over some Actors but don’t have authority over other Actors, depending on how SpatialOS assigns authority. **This is a key difference between the GDK and native Unreal networking!**
 
-> We use the term “authoritative” when a server-worker has authority over an Actor and “non-authoritative” when it doesn’t.
+> **Note:** Support for zoning is currently in pre-alpha. We invite you to try out the [multiserver zoning shooter tutorial]({{urlRoot}}/content/tutorials/multiserver-shooter/tutorial-multiserver-intro) and learn about how it works, but we don’t recommend you start developing features that use zoning yet.
+
+We use the term “authoritative” when a server-worker has authority over an Actor and “non-authoritative” when it doesn’t.
 
 In the GDK, a server-worker is authoritative over an Actor if it has authority over the [schema]({{urlRoot}}/content/glossary#schema) [component]({{urlRoot}}/content/glossary#spatialos-component) `Position`. 
 

--- a/SpatialGDK/Documentation/content/authority.md
+++ b/SpatialGDK/Documentation/content/authority.md
@@ -59,7 +59,7 @@ Actor on **non-owning client**:
 
 ## GDK authority
 
-As the GDK can work with multiple [server-workers]({{urlRoot}}/content/glossary#worker) using [zoning]({{urlRoot}}/content/glossary#zoning), authority needs to be dictated by SpatialOS so that it is shared between server-workers. This means server-workers have authority over some Actors but don’t have authority over other Actors, depending on how SpatialOS assigns authority. **This is a key difference between the GDK and native Unreal networking!**
+Because you can use the GDK with multiple [server-workers]({{urlRoot}}/content/glossary#worker) using [zoning]({{urlRoot}}/content/glossary#zoning), authority needs to be dictated by SpatialOS so that it is shared between server-workers. This means server-workers have authority over some Actors but don’t have authority over other Actors, depending on how SpatialOS assigns authority. **This is a key difference between the GDK and native Unreal networking!**
 
 > **Note:** Support for zoning is currently in pre-alpha. We invite you to try out the [multiserver zoning shooter tutorial]({{urlRoot}}/content/tutorials/multiserver-shooter/tutorial-multiserver-intro) and learn about how it works, but we don’t recommend you start developing features that use zoning yet.
 

--- a/SpatialGDK/Documentation/content/cross-server-rpcs.md
+++ b/SpatialGDK/Documentation/content/cross-server-rpcs.md
@@ -3,11 +3,13 @@
 
 In native-Unreal networking, [RPCs (Unreal documentation)](https://docs.unrealengine.com/en-us/Gameplay/Networking/Actors/RPCs) are functions which either the client or the server use to send messages to each other over a network connection. 
 
-Cross-server RPCs are a custom solution to take advantage of the SpatialOS distributed server architecture.
+Cross-server RPCs are a custom solution to take advantage of the [zoning]({{urlRoot}}/content/glossary#zoning), which is one of the GDK's options for multiserver development.
+
+> **Note:** Support for zoning is currently in pre-alpha. We invite you to try out the [multiserver zoning shooter tutorial]({{urlRoot}}/content/tutorials/multiserver-shooter/tutorial-multiserver-intro) and learn about how it works, but we don’t recommend you start developing features that use zoning yet.
 
 In Unreal’s native single-client architecture, your game server holds the canonical state of the whole game world. As there is a single game server, it has complete authority over all server Actors and so it is able to invoke and execute functions on Actors unhindered. 
 
-In SpatialOS games, there can be more than one server; these multiple servers are known as “server-workers”. (Find out more about server-workers as well as “client-workers” in the [glossary]({{urlRoot}}/content/glossary#worker).) As a SpatialOS game runs across many server-workers, SpatialOS server-workers have the concept of “worker authority” - where only one server-worker at a time is able to invoke and execute functions on Actors. (Find out more about authority in the [glossary]({{urlRoot}}/content/glossary#authority).)
+In SpatialOS games, there can be more than one server; these multiple servers are known as “server-workers”. (Find out more about server-workers as well as “client-workers” in the [glossary]({{urlRoot}}/content/glossary#worker).) In a SpatialOS game that runs across many server-workers, SpatialOS server-workers have the concept of “worker authority” - where only one server-worker at a time is able to invoke and execute functions on Actors. (Find out more about authority in the [glossary]({{urlRoot}}/content/glossary#authority).)
 
 As Unreal expects there to be only one server, rather than several servers, the GDK has a custom solution to take advantage of the SpatialOS distributed server architecture. This involves handling the scenario where a server-worker attempts to invoke an RPC on an Actor that another server-worker has [authority]({{urlRoot}}/content/glossary#worker) over. This custom solution is the cross-server RPC. The GDK offers cross-server RPC in addition to support for the [native RPC types that Unreal provides (Unreal documentation)](https://docs.unrealengine.com/en-us/Gameplay/Networking/Actors/RPCs).
 

--- a/SpatialGDK/Documentation/content/cross-server-rpcs.md
+++ b/SpatialGDK/Documentation/content/cross-server-rpcs.md
@@ -3,17 +3,17 @@
 
 In native-Unreal networking, [RPCs (Unreal documentation)](https://docs.unrealengine.com/en-us/Gameplay/Networking/Actors/RPCs) are functions which either the client or the server use to send messages to each other over a network connection. 
 
-Cross-server RPCs are a custom solution to take advantage of the [zoning]({{urlRoot}}/content/glossary#zoning), which is one of the GDK's options for multiserver development.
+Cross-server RPCs facilitate [zoning]({{urlRoot}}/content/glossary#zoning), which is one of the GDK's options for multiserver development.
 
 > **Note:** Support for zoning is currently in pre-alpha. We invite you to try out the [multiserver zoning shooter tutorial]({{urlRoot}}/content/tutorials/multiserver-shooter/tutorial-multiserver-intro) and learn about how it works, but we don’t recommend you start developing features that use zoning yet.
 
-In Unreal’s native single-client architecture, your game server holds the canonical state of the whole game world. As there is a single game server, it has complete authority over all server Actors and so it is able to invoke and execute functions on Actors unhindered. 
+In Unreal’s native single-server architecture, your game server holds the canonical state of the whole game world. As there is a single game server, it has complete authority over all server Actors and so it is able to invoke and execute functions on Actors unhindered. 
 
 In SpatialOS games, there can be more than one server; these multiple servers are known as “server-workers”. (Find out more about server-workers as well as “client-workers” in the [glossary]({{urlRoot}}/content/glossary#worker).) In a SpatialOS game that runs across many server-workers, SpatialOS server-workers have the concept of “worker authority” - where only one server-worker at a time is able to invoke and execute functions on Actors. (Find out more about authority in the [glossary]({{urlRoot}}/content/glossary#authority).)
 
 As Unreal expects there to be only one server, rather than several servers, the GDK has a custom solution to take advantage of the SpatialOS distributed server architecture. This involves handling the scenario where a server-worker attempts to invoke an RPC on an Actor that another server-worker has [authority]({{urlRoot}}/content/glossary#worker) over. This custom solution is the cross-server RPC. The GDK offers cross-server RPC in addition to support for the [native RPC types that Unreal provides (Unreal documentation)](https://docs.unrealengine.com/en-us/Gameplay/Networking/Actors/RPCs).
 
-When a cross-server RPC is invoked by a non-authoritative server-worker, SpatialOS routes the execution through the SpatialOS [Runtime]({{urlRoot}}/content/glossary#spatialos-runtime) to the authoritative server-worker - this authoritative server-worker executes the RPC.
+When a cross-server RPC is invoked by a server-worker, SpatialOS routes the execution through the SpatialOS [Runtime]({{urlRoot}}/content/glossary#spatialos-runtime) to the server-worker that has authority - this server-worker executes the RPC.
 
 The example diagram below shows a player successfully shooting another player’s hat across a server-worker boundary.
 
@@ -55,13 +55,13 @@ To set up a cross-server RPC in a Blueprint, follow the same instructions as you
 
 The tables below show where cross-server RPCs are executed based on where they were invoked. (To make it easier to follow, the tables use the same format as the [Unreal documentation on RPCs](https://docs.unrealengine.com/en-us/Gameplay/Networking/Actors/RPCs#rpcinvokedfromtheserver).)
 
-#### Invoking a cross-server RPC from an authoritative server-worker
+#### Invoking a cross-server RPC from a server-worker that has authority over an Actor
 
 | **Actor ownership** | **Cross-server RPC**
 |-----------|---------
-| Client-owned Actor | Runs on the authoritative server-worker
-| Server-owned Actor | Runs on the authoritative server-worker
-| Unowned Actor | Runs on the authoritative server-worker
+| Client-owned Actor | Runs on the server-worker that has authority
+| Server-owned Actor | Runs on the server-worker that has authority
+| Unowned Actor | Runs on the server-worker that has authority
 
 #### Invoking a cross-server RPC from a client-worker
 

--- a/SpatialGDK/Documentation/content/get-started/introduction.md
+++ b/SpatialGDK/Documentation/content/get-started/introduction.md
@@ -18,11 +18,11 @@ After you set up with the Example Project or Starter Template, you can check out
 Use the Deployment Manager to launch multiple deployments of the Example Project in the cloud - useful for time-limited match-based games, such as battle royales.
 </br>
 </br>
-* **The Multiserver Shooter tutorial**: </br>
-Learn more about the the GDK's functionality by implement shooting across the boundaries of different servers simulating one game world. In this tutorial, you will set up a new game; the Mutliserver Shooter Game.
+* **The multiserver zoning shooter tutorial**: </br>
+Learn more about the the GDK's functionality by implementing shooting across the boundaries of different servers simulating one game world. In this tutorial, you will set up a new game; the Mutliserver Shooter Game.
 </br>
 </br>
-* **The Porting guide**: <br/>
+* **The porting guide**: <br/>
 Port your existing UE project to SpatialOS.
 <br/>
 

--- a/SpatialGDK/Documentation/content/get-started/introduction.md
+++ b/SpatialGDK/Documentation/content/get-started/introduction.md
@@ -19,7 +19,7 @@ Use the Deployment Manager to launch multiple deployments of the Example Project
 </br>
 </br>
 * **The multiserver zoning shooter tutorial**: </br>
-Learn more about the the GDK's functionality by implementing shooting across the boundaries of different servers simulating one game world. In this tutorial, you will set up a new game; the Mutliserver Shooter Game.
+Learn more about the the GDK's functionality by implementing shooting across the boundaries of different servers computing one game world. In this tutorial, you will set up a new game; the Mutliserver Shooter Game.
 </br>
 </br>
 * **The porting guide**: <br/>

--- a/SpatialGDK/Documentation/content/glossary.md
+++ b/SpatialGDK/Documentation/content/glossary.md
@@ -24,9 +24,9 @@ Actor groups facilitate multiserver functionality through [offloading](#offloadi
 
 > **Find out more:**
 > 
-> [Actor groups]({{urlRoot}}/content/workers/offloading-concept#actor-groups)
-> [The SpatialOS Runtime Settings panel]({{urlRoot/}}content/unreal-editor-interface/runtime-settings)
-> [Offloading overview]({{urlRoot}}/content/workers/offloading-concept)
+> * [Actor groups]({{urlRoot}}/content/workers/offloading-concept#actor-groups)
+> * [The SpatialOS Runtime Settings panel]({{urlRoot/}}content/unreal-editor-interface/runtime-settings)
+> * [Offloading overview]({{urlRoot}}/content/workers/offloading-concept)
 
 ### Actor handover
 Actor handover (`handover`) is a GDK-specific `UPROPERTY` tag. It allows games built in Unreal (which uses single-server architecture) to take advantage of SpatialOS’ distributed, persistent server architecture. See [Actor property handover between server-workers]({{urlRoot}}/content/actor-handover.md).

--- a/SpatialGDK/Documentation/content/glossary.md
+++ b/SpatialGDK/Documentation/content/glossary.md
@@ -20,18 +20,20 @@ Note that this SpatialOS documentation assumes you are developing a SpatialOS ga
 ## GDK for Unreal terms
 
 ### Actor groups
-To facilitate [offloading](#offloading), we've created the concept of Actor groups to help you configure which Actor types a given server-worker type has [authority](#authority) over. In the Unreal Editor, you can create Actor groups, assign Actor classes to a group, and then assign each group to a server-worker type.
+Actor groups facilitate multiserver functionality through [offloading](#offloading). You set them up to configure which Actor types instances of a [server-worker type](#worker-types-and-instances) have [authority](#authority) over. In the Unreal Editor, you can create Actor groups, assign Actor classes to a group, and then assign each group to a server-worker type via the SpatialOS Runtime Settings panel.
 
 > **Find out more:**
 > 
 > [Actor groups]({{urlRoot}}/content/workers/offloading-concept#actor-groups)
+> [The SpatialOS Runtime Settings panel]({{urlRoot/}}content/unreal-editor-interface/runtime-settings)
+> [Offloading overview]({{urlRoot}}/content/workers/offloading-concept)
 
 ### Actor handover
 Actor handover (`handover`) is a GDK-specific `UPROPERTY` tag. It allows games built in Unreal (which uses single-server architecture) to take advantage of SpatialOS’ distributed, persistent server architecture. See [Actor property handover between server-workers]({{urlRoot}}/content/actor-handover.md).
 
 ### Authority
 
-If a [server-worker instance](#server-workers) has authority over an Actor, the server-worker instance can make changes to the Actor by sending updates to the [SpatialOS Runtime](#spatialos-runtime). A server-worker instance has authority over an Actor if it has authority over the equivalent [entity](#entity)’s [SpatialOS component](#spatialos-component) `Position`. 
+When a [server-worker instance](#server-workers) has authority over an Actor, the server-worker instance can make changes to the Actor by sending updates to the [SpatialOS Runtime](#spatialos-runtime). A server-worker instance has authority over an Actor if it has authority over the equivalent [entity](#entity)’s [SpatialOS component](#spatialos-component) `Position`. 
 
 Client-worker instances never have authority over Actors. However, like in native Unreal, they can have [ownership](#ownership). 
 
@@ -48,7 +50,7 @@ In a game with just one server-worker instance (which is the default for the GDK
 To enable the network stacks of Unreal and SpatialOS to interoperate, we've implemented [Dynamic Typebindings]({{urlRoot}}/content/dynamic-typebindings.md). `Dynamic Typebindings` operate at runtime so your that your iteration speed is not affected despite your network code running on a completely different represenetations than Unreal's.
 
 ### Cross-server RPCs
-These handle the scenario where a [server-worker](#worker) needs to execute an operation on an Actor that another server-worker has [authority](#authority) over. When a cross-server RPC is invoked by a non-authoritative server-worker, the execution is routed through SpatialOS to the authoritative server-worker - this authoritative server-worker executes the RPC. (See the documentation on [Cross-server RPCs]({{urlRoot}}/content/cross-server-rpcs)).
+These handle the scenario where a [server-worker](#worker) needs to execute an operation on an Actor that another server-worker has [authority](#authority) over. When a cross-server RPC is invoked by a server-worker that doesn't have authority, the execution is routed through SpatialOS to the server-worker that has authority - this server-worker executes the RPC. (See the documentation on [Cross-server RPCs]({{urlRoot}}/content/cross-server-rpcs)).
 
 ### Global State Manager
 The Global State Manager (GSM):
@@ -83,9 +85,9 @@ You can define interest in three ways, which you can use alongside each other:
 
 ### Offloading
 
-Offloading is one of the multiserver options for working with SpatialOS. It involves allocating the [authority](#authority) over specific [Actor groups](#actor-groups) to a [server-worker instance](#worker-types-and-worker-instances) other than your main Unreal server-worker instance. 
+Offloading is one of the multiserver options for working with SpatialOS.  The functionality of the main out-of-the-box Unreal [server-worker type](#server-workers) is split between two server-worker types. For example, you could create an AI server-worker type and offload the AI computation from the main Unreal server-worker type onto it.
 
-For example, you could offload computationally expensive but latency-tolerant systems, such as advanced AI or large-scale background physics simulation, so that your main server-worker instance can run other systems at a larger scale.
+Advanced AI and large-scale background physics computation are good candidates for offloading as they are computationally expensive but latency-tolerant. This would leave your game's out-of-the-box main server-worker instance to run other game systems at a larger scale.
 
 > **Find out more**
 > 
@@ -206,7 +208,7 @@ The Inspector is a web-based tool that you use to explore the internal state of 
 * how much [load](https://docs.improbable.io/reference/latest/shared/glossary#load-balancing) the workers are under.
 * which [entities](#entity) are in the SpatialOS world.
 * what their [SpatialOS components](#spatialos-component)’ [properties]({{urlRoot}}/content/spatialos-concepts/world-entities-components#entities-and-components) are.
-* which workers are authoritative over each SpatialOS component.
+* which workers have authority over each SpatialOS component.
 
 > **Find out more**
 >
@@ -482,7 +484,7 @@ Once you’ve chosen a label for the worker type (for example, myWorkerType), yo
 
 ### Zoning
 
-Zoning is one of the multiserver options for working with SpatialOS. It involves splitting up the world into zones, known as “areas of [authority](#authority)”, with a different [server-worker instance](#server-workers) responsible for each. A server-worker instance can make updates only to Actors that are in its area of authority.
+Zoning is one of the multiserver options for working with SpatialOS (the other option is [offloading](#offloading)). It involves splitting up the world into zones, known as “areas of [authority](#authority)”, with a different [server-worker instance](#server-workers) responsible for each. A server-worker instance can make updates only to Actors that are in its area of authority.
 
 > **Note:** Support for zoning is currently in pre-alpha. We invite you to try out the [multiserver zoning shooter tutorial]({{urlRoot}}/content/tutorials/multiserver-shooter/tutorial-multiserver-intro) and learn about how it works, but we don’t recommend you start developing features that use zoning yet.
 <br><br>
@@ -492,6 +494,7 @@ Zoning is one of the multiserver options for working with SpatialOS. It involves
 
 <br/>
 <br/>------<br/>
-_2019-07-30 Added Actor groups, offloading_
+_2019-08-08 Page updated with editorial review: updated Actor groups, offloading, zoning, workers, authority_
+<br/>_2019-07-30 Page updated without editorial review: added Actor groups, offloading_
 <br/>_2019-06-15 Added layers, non-Unreal layers, network operations (ops)_
 <br/>_2019-03-15 Page updated with editorial review_

--- a/SpatialGDK/Documentation/content/glossary.md
+++ b/SpatialGDK/Documentation/content/glossary.md
@@ -83,7 +83,9 @@ You can define interest in three ways, which you can use alongside each other:
 
 ### Offloading
 
-Offloading is when you allocate the [authority](#authority) over specific [Actor groups](#actor-groups) to a [server-worker instance](#worker-types-and-worker-instances) other than the main Unreal server-worker instance. For example, you could offload computationally expensive but latency-tolerant systems, such as advanced AI or large-scale background physics simulation, so that your main server-worker instance can run other systems at a larger scale.
+Offloading is one of the multiserver options for working with SpatialOS. It involves allocating the [authority](#authority) over specific [Actor groups](#actor-groups) to a [server-worker instance](#worker-types-and-worker-instances) other than your main Unreal server-worker instance. 
+
+For example, you could offload computationally expensive but latency-tolerant systems, such as advanced AI or large-scale background physics simulation, so that your main server-worker instance can run other systems at a larger scale.
 
 > **Find out more**
 > 
@@ -438,17 +440,20 @@ When you create a worker type using the [Worker SDK](#spatialos-sdks), each work
 
 #### Server-workers
 
-A server-worker [instance](#worker-types-and-worker-instances) equates to a server in native Unreal networking but, unlike Unreal networking, in SpatialOS you can have more than one server-worker instance (see [Zoning](#zoning)). A server-worker instance’s lifecycle is managed by SpatialOS. When you run a SpatialOS [deployment](#deployment) of your game, the [SpatialOS Runtime]#spatialos-runtime) starts and stops server-worker instances.
+A server-worker [instance](#worker-types-and-worker-instances) equates to a server in native Unreal networking but, unlike Unreal networking, in SpatialOS you can have more than one server-worker instance (see [Zoning](#zoning)). A server-worker instance’s lifecycle is managed by SpatialOS. When you run a SpatialOS [deployment](#deployment) of your game, the [SpatialOS Runtime](#spatialos-runtime) starts and stops server-worker instances.
 
-The GDK sets up one server-worker type for you by default. This default server-worker type is an Unreal server-worker, computing Unreal functionality - you can add additional non-Unreal server-worker types.
+##### Single server vs multiserver
+The GDK sets up one server-worker type for you by default: an Unreal server-worker, computing Unreal functionality. Out of the box, you can have a single instance of this type. However, there are also two multiserver options for working with SpatialOS: [offloading](#offloading) and [zoning](#zoning) (note that zoning is currently in pre-alpha).
 
-For example, you could set up an additional server-worker type to implement player logic and another to implement AI logic. 
+You can also add additional non-Unreal server-worker types. For example, you could set up an additional server-worker type to implement player logic and another to implement AI logic. 
 
 **Note:** In a local deployment, the server-worker instances run on your development computer. In a cloud deployment, the server-worker instances run in the cloud. For more information, see [Deployment](#deployment).
 
 > **Find out more**
 > 
-> [Non-Unreal server-worker types]({{urlRoot}}/content/workers/non-unreal-server-worker-types)
+> * [Non-Unreal server-worker types]({{urlRoot}}/content/workers/non-unreal-server-worker-types)
+> * [Offloading]({{urlRoot}}/content/workers/offloading-concept/)
+> * [Multiserver zoning shooter tutorial]({{urlRoot}}/content/tutorials/multiserver-shooter/tutorial-multiserver-intro)
 
 <!-- TODO How do you set up worker types in Unreal https://improbableio.atlassian.net/browse/DOC-1064 -->
 <!-- TODO Offloading info added here:  https://improbableio.atlassian.net/browse/DOC-1064 -->
@@ -477,8 +482,10 @@ Once you’ve chosen a label for the worker type (for example, myWorkerType), yo
 
 ### Zoning
 
-Zoning is when you have multiple [server-worker instances](#server-workers) computing your [game world](#game-world), and each instance is responsible for computing the Actors in a particular spatial area.
+Zoning is one of the multiserver options for working with SpatialOS. It involves splitting up the world into zones, known as “areas of [authority](#authority)”, with a different [server-worker instance](#server-workers) responsible for each. A server-worker instance can make updates only to Actors that are in its area of authority.
 
+> **Note:** Support for zoning is currently in pre-alpha. We invite you to try out the [multiserver zoning shooter tutorial]({{urlRoot}}/content/tutorials/multiserver-shooter/tutorial-multiserver-intro) and learn about how it works, but we don’t recommend you start developing features that use zoning yet.
+<br><br>
 > **Find out more**
 >
 > [Multiserver zoning shooter tutorial]({{urlRoot}}/content/tutorials/multiserver-shooter/tutorial-multiserver-intro)

--- a/SpatialGDK/Documentation/content/glossary.md
+++ b/SpatialGDK/Documentation/content/glossary.md
@@ -20,7 +20,7 @@ Note that this SpatialOS documentation assumes you are developing a SpatialOS ga
 ## GDK for Unreal terms
 
 ### Actor groups
-To facilitate offloading, we've created the concept of Actor groups to help you configure which Actor types a given server-worker type will have authority over. In the Unreal Editor, you can create Actor groups, assign Actor classes to a group, and then assign each group to a server-worker type.
+To facilitate [offloading](#offloading), we've created the concept of Actor groups to help you configure which Actor types a given server-worker type has [authority](#authority) over. In the Unreal Editor, you can create Actor groups, assign Actor classes to a group, and then assign each group to a server-worker type.
 
 > **Find out more:**
 > 
@@ -31,13 +31,13 @@ Actor handover (`handover`) is a GDK-specific `UPROPERTY` tag. It allows games b
 
 ### Authority
 
-A [server-worker instance](#server-workers) has authority over an Actor if it has authority over the equivalent [entity](#entity)’s [SpatialOS component] `Position`. Having authority means it can make changes to the Actor by sending updates to the [SpatialOS Runtime](#spatialos-runtime). 
+If a [server-worker instance](#server-workers) has authority over an Actor, the server-worker instance can make changes to the Actor by sending updates to the [SpatialOS Runtime](#spatialos-runtime). A server-worker instance has authority over an Actor if it has authority over the equivalent [entity](#entity)’s [SpatialOS component](#spatialos-component) `Position`. 
 
 Client-worker instances never have authority over Actors. However, like in native Unreal, they can have [ownership](#ownership). 
 
 In a game with just one server-worker instance (which is the default for the GDK), that server-worker instance has authority over all the Actors in the game. In a game with more than one server-worker instance, different server-worker instances have authority over different Actors:
 
-* with offloading, the server-worker instance that has authority over an Actor always stays the same. <!-- TODO add link to offloading doc -->
+* with [offloading]({{urlRoot}}/content/workers/offloading-concept), the server-worker instance that has authority over an Actor always stays the same.
 * with [zoning](#zoning) (currently in pre-alpha), the server-worker instance that has authority over an Actor can change as the Actor moves around, but only one instance can have authority over an Actor at any one time.
 
 > **Find out more:**
@@ -83,7 +83,7 @@ You can define interest in three ways, which you can use alongside each other:
 
 ### Offloading
 
-Offloading is the new architecture that the SpatialOS GDK for Unreal provides to allocate the authority of specific [Actor groups]({{urlRoot}}/content/workers/offloading-concept#actor-groups) from the main Unreal server-worker instance to a different server-worker instance. By using offloading, you can save the resources of the main Unreal server-worker instance when you want to build richer game features.
+Offloading is when you allocate the [authority](#authority) over specific [Actor groups](#actor-groups) to a [server-worker instance](#worker-types-and-worker-instances) other than the main Unreal server-worker instance. For example, you could offload computationally expensive but latency-tolerant systems, such as advanced AI or large-scale background physics simulation, so that your main server-worker instance can run other systems at a larger scale.
 
 > **Find out more**
 > 
@@ -475,20 +475,13 @@ Once you’ve chosen a label for the worker type (for example, myWorkerType), yo
 >
 > [Worker configuration file `worker.json`](https://docs.improbable.io/reference/latest/shared/worker-configuration/worker-configuration)
 
-### Worker types
-
-> First, see [workers](#worker).
-
-There are two generic types of worker that define how you would want to connect these workers and what kind of capabilities they have:
-
-* [server-worker](#server-workers)
-* [client-worker](#client-workers)
-
-Within these broad types, you can define your own worker sub-types to create more specialized workers.
-
 ### Zoning
 
-Zoning is when you split out the computation of the SpatialOS world spatially, so that each [worker instance](#worker-types-and-worker-instances) of a particular type is responsible for computing the objects in a particular area.
+Zoning is when you have multiple [server-worker instances](#server-workers) computing your [game world](#game-world), and each instance is responsible for computing the Actors in a particular spatial area.
+
+> **Find out more**
+>
+> [Multiserver zoning shooter tutorial]({{urlRoot}}/content/tutorials/multiserver-shooter/tutorial-multiserver-intro)
 
 <br/>
 <br/>------<br/>

--- a/SpatialGDK/Documentation/content/spatialos-concepts/schema-and-snapshots.md
+++ b/SpatialGDK/Documentation/content/spatialos-concepts/schema-and-snapshots.md
@@ -6,7 +6,7 @@
 Schema is a set of definitions which represent your game’s objects in SpatialOS as entities. Schema is defined in .schema files and written in schemalang by the GDK.</br>
 Select **Schema** from the GDK toolbar and the GDK generates schema files and their contents for you, so you do not have to write or edit schema files manually.
 
-SpatialOS uses schema to generate APIs specific to the entity components in your project. You can then use these APIs in your game's [worker types]({{urlRoot}}/content/glossary#worker-types) so their instances can interact with [entity components]({{urlRoot}}/content/glossary#spatialos-component).
+SpatialOS uses schema to generate APIs specific to the entity components in your project. You can then use these APIs in your game's [worker types]({{urlRoot}}/content/glossary#worker-types-and-worker-instances) so their instances can interact with [entity components]({{urlRoot}}/content/glossary#spatialos-component).
 
 You can find out how to use schema in the [schema reference documentation]({{urlRoot}}/content/how-to-use-schema)
 

--- a/SpatialGDK/Documentation/content/technical-overview/gdk-concepts.md
+++ b/SpatialGDK/Documentation/content/technical-overview/gdk-concepts.md
@@ -14,7 +14,7 @@ Key concepts in Unreal Engine map to concepts in the GDK, as shown in the table 
 | RPC | SpatialOS component’s command or event | A type of data stored in a SpatialOS component. Note that a SpatialOS component’s command is **not** the same as an Unreal command. |
 | Owning connection | EntityACL component | |
 | Conditional property replication | Dynamic `component_delivery` filter | |
-| Server | Server-worker instance | You can have multiple server-worker instances running the cloud element of your game. |
+| Server | Server-worker instance | You can have one or more server-worker instances running the cloud element of your game. |
 
 You can find out more about [entities]({{urlRoot}}/content/glossary#entity), SpatialOS [components]({{urlRoot}}/content/glossary#spatialos-component) and their properties, commands, and events, as well as [server-workers]({{urlRoot}}/content/glossary#worker), in the [glossary]({{urlRoot}}/content/glossary).
 
@@ -22,24 +22,24 @@ You can find out more about [entities]({{urlRoot}}/content/glossary#entity), Spa
 We’ve introduced some new concepts to facilitate the fact that SpatialOS enables you to spread computation between multiple servers - known as “server-worker instances” in SpatialOS.
 
 ### Offloading
-Offloading is the new architecture that the SpatialOS GDK for Unreal provides to allocate the authority of specific Actor groups from the main Unreal server worker instance to a different worker instance. By using offloading, you can save the resources of the main Unreal server-worker instance when you want to build richer game features.
+Offloading is when you allocate the authority over specific groups of Actors to a server-worker instance other than your main Unreal server-worker instance. By using offloading, you can save the resources of the main Unreal server-worker instance when you want to build richer game features.
 
 <%(Lightbox image="{{assetRoot}}assets/offloading-diagram.png")%>
-_Offloading: Offloaded Unreal server-worker instance has authority only over Red Actors and the Main Unreal server-worker instance that runs major game systems has authority over all Actors except the Red Actors._
+_Offloading: The offloaded server-worker instance has authority only over Red Actors, and the main Unreal server-worker instance that runs major game systems has authority over all other Actors._
 
 For more information, see [Offloading overview]({{urlRoot}}/content/workers/offloading-concept).
 
 ### Actor groups
-To facilitate offloading, we've created the concept of Actor groups to help you configure what Actor types that a given server-worker type has authority over. In the Unreal Editor, you can create Actor groups, assign Actor classes to a group, and then assign each group to a server-worker type.
+To facilitate offloading, we've created the concept of Actor groups to help you configure the Actor types that a given type of server-worker instance has authority over. In the Unreal Editor, you can create Actor groups, assign Actor classes to a group, and then assign each group to a server-worker type.
 
-Before you start to use offloading in your game, ensure that you’re familiar with the [best practices for using offloading]({{urlRoot}}/content/workers/offloading-concept#best-practices) and [offloading workflow]({{urlRoot}}/content/workers/set-up-offloading).
+Before you start to use offloading in your game, make sure that you’re familiar with the [best practices]({{urlRoot}}/content/workers/offloading-concept#best-practices) and with how to [set up your game feature for offloading]({{urlRoot}}/content/workers/set-up-offloading).
 
 ### Zoning
-Because the GDK uses SpatialOS networking, you can have multiple server-worker instances simulating your game world. This allows you to extend the size of the world.
+Because the GDK uses SpatialOS networking, you can use multiple server-worker instances to compute your game world. This enables you to extend the size of the world. We call this _zoning_ - splitting up the world into zones, known as “areas of authority”.
 
-We call this _zoning_ - splitting up the world into zones, known as “areas of authority”. Each area is simulated by one server-worker instance. This means that only one server-worker instance has authority to make updates to SpatialOS components at a time.
+Each server-worker instance has a different area of authority, and can make updates only to Actors that are in its area of authority.
 
-> Support for zoning is currently in pre-alpha. We invite you to try out the [Multiserver Shooter tutorial]({{urlRoot}}/content/tutorials/multiserver-shooter/tutorial-multiserver-intro) and learn about how it works, but we don’t recommend you start developing features that use zoning yet.
+> **Note:** Support for zoning is currently in pre-alpha. We invite you to try out the [multiserver zoning shooter tutorial]({{urlRoot}}/content/tutorials/multiserver-shooter/tutorial-multiserver-intro) and learn about how it works, but we don’t recommend you start developing features that use zoning yet.
 
 ### Cross-server RPCs
 To facilitate zoning, we created the concept of a cross-server RPC to make updates to Actors, known as “entities” in SpatialOS. This is a type of RPC that enables a server-worker instance  which does not have authority over an entity to tell the server-worker instance that does have authority over that entity to make an update to it. This is necessary if you’re using zoning because areas of authority mean that one server-worker instance can't make updates to every entity in the world; it can make updates only to the entities in its area of authority.
@@ -65,7 +65,7 @@ void TakeDamage(int Damage);
 For more information, see the documentation on [cross-server RPCs]({{urlRoot}}/content/cross-server-rpcs).
 
 ### Actor handover
-If your game uses zoning, you need to make sure that entities can move seamlessly between areas of authority and the relevant server-worker instances can simulate them. 
+If your game uses zoning, you need to make sure that entities can move seamlessly between areas of authority and the relevant server-worker instances can compute them. 
 
 In Unreal’s single-server architecture, authority over an Actor stays with the single server; an Actor’s properties never leave the server’s memory. With multiple server-worker instances in SpatialOS, authority needs to pass from one server-worker instance to another as an Actor moves around the game world. Passing authority, known as “Actor handover”, allows the second server-worker instance to continue where the first one left off. You set this up by adding the `Handover` tag to the Actor’s properties. 
 
@@ -78,7 +78,7 @@ In Unreal’s single-server architecture, authority over an Actor stays with the
 
  _An AI following a player across the boundary between two server-worker instances' areas of authority. To demonstrate Actor handover, the AI changes its material every time authority is handed over._
 
-See the [Multiserver Shooter tutorial]({{urlRoot}}/content/tutorials/multiserver-shooter/tutorial-multiserver-intro) for a tutorial that demonstrates this functionality.
+See the [multiserver zoning shooter tutorial]({{urlRoot}}/content/tutorials/multiserver-shooter/tutorial-multiserver-intro) for a tutorial that demonstrates this functionality.
 
 For more information, see the documentation on [Actor handover]({{urlRoot}}/content/actor-handover).
 
@@ -89,15 +89,15 @@ You create a Singleton Actor by tagging an Actor with the `SpatialType=Singleton
 
 For more information, see the documentation on [Singleton Actors]({{urlRoot}}/content/singleton-actors).
 
-### Actor Throttling
-We have introduced a concept of 'Actor Throttling' in order to optimize server performance when using the Unreal GDK, it can be accessed via the [Runtime Settings]({{urlRoot}}/content/unreal-editor-interface/runtime-settings). With the Unreal GDK it is possible to have multiple servers simulating on the same game world, this means that no one server could have a full view of the entire world at once. Additionally, servers in the Unreal GDK replicate actors only to a single connection to SpatialOS rather than to each individual client as in native Unreal. To accommodate this, in order to keep the state of the SpatialOS simulation accurate, all actors which are in a particular server's view are marked as relevant for replication on each frame. This can however cause performance issues if there are say, 3000 actors on a single server. 
+### Actor throttling
+We have introduced a concept of 'Actor throttling' in order to optimize server performance when using the Unreal GDK, it can be accessed via the [Runtime Settings]({{urlRoot}}/content/unreal-editor-interface/runtime-settings). With the Unreal GDK it is possible to have multiple servers computing on the same game world, this means that no one server could have a full view of the entire world at once. Additionally, servers in the Unreal GDK replicate actors only to a single connection to SpatialOS rather than to each individual client as in native Unreal. To accommodate this, in order to keep the state of the SpatialOS simulation accurate, all actors which are in a particular server's view are marked as relevant for replication on each frame. This can however cause performance issues if there are say, 3000 actors on a single server. 
 
 The concept of Actor Throttling allows you to set a simple limit on the number of actors which can be replicated to SpatialOS in each frame and can help boost server performance. The number set in the throttle will dictate how many actors can be replicated, with the highest priority actors (using Unreal's actor priority system) being replicated first.
 
 We recommend using Actor Throttling with a combination of Unreal's Net Update Frequency, as this will limit the number of actors which are added to the 'ConsiderList' for replication in order to optimize your servers performance. Experiment with the limit by setting it high and then lowering over time until you see client latency issues in a realistic game scenario. 
 
 ## Non-Unreal computation
-By default, the GDK uses a single Unreal server-worker type (the template for a server-worker instance) to handle all server-side computation. However, you can set up additional server-worker types that do not use Unreal or the GDK. 
+By default, the GDK uses a single Unreal server-worker type (which is like a mold for a server-worker instance) to handle all server-side computation. However, you can set up additional server-worker types that do not use Unreal or the GDK. 
 
 You can use these non-Unreal server-worker types to modularize your game’s functionality so you can re-use the functionality across different games. For example, you could use a non-Unreal server-worker type written in Python that interacts with a database or other third-party service, such as [Firebase](https://firebase.google.com/) or [PlayFab](https://playfab.com/).
 
@@ -105,8 +105,8 @@ For more information, see the documentation on [non-Unreal server-worker types](
 
 
 <br/>------------<br/>
-_2019-07-31 Page updated with limited editorial review: Actor Throttling added_<br/>
-_2019-07-26 Page updated with limited editorial review: offloading, Actor group added_<br/>
+_2019-07-31 Page updated with limited editorial review: added Actor throttling_<br/>
+_2019-07-26 Page updated with limited editorial review: added offloading and Actor groups_<br/>
 _2019-04-11 Page updated with limited editorial review_<br/>
 _2019-04-25 Page added with editorial review_
 [//]: # (TODO: https://improbableio.atlassian.net/browse/DOC-1142)

--- a/SpatialGDK/Documentation/content/technical-overview/gdk-concepts.md
+++ b/SpatialGDK/Documentation/content/technical-overview/gdk-concepts.md
@@ -22,9 +22,9 @@ You can find out more about [entities]({{urlRoot}}/content/glossary#entity), Spa
 We’ve introduced some new concepts to facilitate the fact that SpatialOS enables you to spread computation between multiple servers - known as “server-worker instances” in SpatialOS.
 
 ### Offloading
-Offloading is one of the multiserver options for working with SpatialOS. It involves allocating the authority over specific groups of Actors to a server-worker instance other than your main Unreal server-worker instance. 
+Offloading is one of the multiserver options for working with SpatialOS. The functionality of the main out-of-the-box Unreal server-worker type is split between two server-worker types. For example, you could create an AI server-worker type and offload the AI computation from the main Unreal server-worker type onto it.
 
-For example, you could offload computationally expensive but latency-tolerant systems, such as advanced AI or large-scale background physics simulation, so that your main server-worker instance can run other systems at a larger scale.
+Advanced AI and large-scale background physics computation are good candidates for offloading as they are computationally expensive but latency-tolerant. This would leave your game's out-of-the-box main server-worker instance to run other game systems at a larger scale.
 
 <%(Lightbox image="{{assetRoot}}assets/offloading-diagram.png")%>
 _Offloading: The offloaded server-worker instance has authority only over Red Actors, and the main Unreal server-worker instance that runs major game systems has authority over all other Actors._
@@ -37,7 +37,7 @@ To facilitate offloading, we've created the concept of Actor groups to help you 
 Before you start to use offloading in your game, make sure that you’re familiar with the [best practices]({{urlRoot}}/content/workers/offloading-concept#best-practices) and with how to [set up your game feature for offloading]({{urlRoot}}/content/workers/set-up-offloading).
 
 ### Zoning
-Like [offloading](#offloading), zoning is a multiserver option for working with SpatialOS. It involves splitting up the world into zones, known as “areas of authority”, with a different server-worker instance responsible for each. A server-worker instance can make updates only to Actors that are in its area of authority.
+Zoning is another multiserver option for working with SpatialOS. It works differently from [offloading](#offloading). Zoning involves sharing the server computation load by splitting up the world into areas of authority, with a different server-worker instance responsible for the computation of each area. A server-worker instance can make updates only to Actors that are in its area of authority.
 
 > **Note:** Support for zoning is currently in pre-alpha. We invite you to try out the [multiserver zoning shooter tutorial]({{urlRoot}}/content/tutorials/multiserver-shooter/tutorial-multiserver-intro) and learn about how it works, but we don’t recommend you start developing features that use zoning yet.
 
@@ -97,7 +97,9 @@ The concept of Actor Throttling allows you to set a simple limit on the number o
 We recommend using Actor Throttling with a combination of Unreal's Net Update Frequency, as this will limit the number of actors which are added to the 'ConsiderList' for replication in order to optimize your servers performance. Experiment with the limit by setting it high and then lowering over time until you see client latency issues in a realistic game scenario. 
 
 ## Non-Unreal computation
-By default, the GDK uses a single Unreal server-worker type (which is like a mold for a server-worker instance) to handle all server-side computation. However, you can set up additional server-worker types that do not use Unreal or the GDK. 
+By default, the GDK uses a single Unreal server-worker type to handle all server-side computation. (A server-worker type is a server-worker definition. It's a mold which SpatialOS uses to spin up the server-worker instances which compute your game at runtime.) 
+
+However, in addition to the out-of-the-box main Unreal server type, you can set up additional server-worker types that do not use Unreal or the GDK.
 
 You can use these non-Unreal server-worker types to modularize your game’s functionality so you can re-use the functionality across different games. For example, you could use a non-Unreal server-worker type written in Python that interacts with a database or other third-party service, such as [Firebase](https://firebase.google.com/) or [PlayFab](https://playfab.com/).
 
@@ -105,6 +107,7 @@ For more information, see the documentation on [non-Unreal server-worker types](
 
 
 <br/>------------<br/>
+_2019-08-08 Page updated with editorial review: updated offloading, Actor groups, zoning_</br>
 _2019-07-31 Page updated with limited editorial review: added Actor throttling_<br/>
 _2019-07-26 Page updated with limited editorial review: added offloading and Actor groups_<br/>
 _2019-04-11 Page updated with limited editorial review_<br/>

--- a/SpatialGDK/Documentation/content/technical-overview/gdk-concepts.md
+++ b/SpatialGDK/Documentation/content/technical-overview/gdk-concepts.md
@@ -22,7 +22,9 @@ You can find out more about [entities]({{urlRoot}}/content/glossary#entity), Spa
 We’ve introduced some new concepts to facilitate the fact that SpatialOS enables you to spread computation between multiple servers - known as “server-worker instances” in SpatialOS.
 
 ### Offloading
-Offloading is when you allocate the authority over specific groups of Actors to a server-worker instance other than your main Unreal server-worker instance. By using offloading, you can save the resources of the main Unreal server-worker instance when you want to build richer game features.
+Offloading is one of the multiserver options for working with SpatialOS. It involves allocating the authority over specific groups of Actors to a server-worker instance other than your main Unreal server-worker instance. 
+
+For example, you could offload computationally expensive but latency-tolerant systems, such as advanced AI or large-scale background physics simulation, so that your main server-worker instance can run other systems at a larger scale.
 
 <%(Lightbox image="{{assetRoot}}assets/offloading-diagram.png")%>
 _Offloading: The offloaded server-worker instance has authority only over Red Actors, and the main Unreal server-worker instance that runs major game systems has authority over all other Actors._
@@ -35,9 +37,7 @@ To facilitate offloading, we've created the concept of Actor groups to help you 
 Before you start to use offloading in your game, make sure that you’re familiar with the [best practices]({{urlRoot}}/content/workers/offloading-concept#best-practices) and with how to [set up your game feature for offloading]({{urlRoot}}/content/workers/set-up-offloading).
 
 ### Zoning
-Because the GDK uses SpatialOS networking, you can use multiple server-worker instances to compute your game world. This enables you to extend the size of the world. We call this _zoning_ - splitting up the world into zones, known as “areas of authority”.
-
-Each server-worker instance has a different area of authority, and can make updates only to Actors that are in its area of authority.
+Like [offloading](#offloading), zoning is a multiserver option for working with SpatialOS. It involves splitting up the world into zones, known as “areas of authority”, with a different server-worker instance responsible for each. A server-worker instance can make updates only to Actors that are in its area of authority.
 
 > **Note:** Support for zoning is currently in pre-alpha. We invite you to try out the [multiserver zoning shooter tutorial]({{urlRoot}}/content/tutorials/multiserver-shooter/tutorial-multiserver-intro) and learn about how it works, but we don’t recommend you start developing features that use zoning yet.
 

--- a/SpatialGDK/Documentation/content/technical-overview/gdk-principles.md
+++ b/SpatialGDK/Documentation/content/technical-overview/gdk-principles.md
@@ -18,7 +18,7 @@ The SpatialOS Game Development Kit (GDK) for Unreal is a plugin which allows you
 
     You don’t have to make these technical tradeoffs with the GDK. SpatialOS can spread computation across multiple servers, allowing for far more complex games and much higher player counts.</br></br>
 
-    > This will be enabled by [zoning]({{urlRoot}}/content/technical-overview/gdk-concepts#zoning), which is currently in pre-alpha. We invite you to try out the [multiserver zoning shooter tutorial]({{urlRoot}}/content/tutorials/multiserver-shooter/tutorial-multiserver-intro) and learn about how it works, but we don’t recommend you start developing features that use zoning yet.
+    > This is enabled by [offloading]({{urlRoot}}/content/technical-overview/gdk-concepts#offloading) and will be enabled by [zoning]({{urlRoot}}/content/technical-overview/gdk-concepts#zoning). Zoning is currently in pre-alpha. We invite you to try out the [multiserver zoning shooter tutorial]({{urlRoot}}/content/tutorials/multiserver-shooter/tutorial-multiserver-intro) and learn about how it works, but we don’t recommend you start developing features that use zoning yet.
 
 * **Open development**
     

--- a/SpatialGDK/Documentation/content/technical-overview/gdk-principles.md
+++ b/SpatialGDK/Documentation/content/technical-overview/gdk-principles.md
@@ -18,7 +18,7 @@ The SpatialOS Game Development Kit (GDK) for Unreal is a plugin which allows you
 
     You don’t have to make these technical tradeoffs with the GDK. SpatialOS can spread computation across multiple servers, allowing for far more complex games and much higher player counts.</br></br>
 
-    > This will be enabled by [Zoning]({{urlRoot}}/content/technical-overview/gdk-concepts#zoning), which is currently in pre-alpha. We invite you to try out the [Multiserver Shooter tutorial]({{urlRoot}}/content/tutorials/multiserver-shooter/tutorial-multiserver-intro) and learn about how it works, but we don’t recommend you start developing features that use zoning yet.
+    > This will be enabled by [zoning]({{urlRoot}}/content/technical-overview/gdk-concepts#zoning), which is currently in pre-alpha. We invite you to try out the [multiserver zoning shooter tutorial]({{urlRoot}}/content/tutorials/multiserver-shooter/tutorial-multiserver-intro) and learn about how it works, but we don’t recommend you start developing features that use zoning yet.
 
 * **Open development**
     

--- a/SpatialGDK/Documentation/content/tutorials/multiserver-shooter/tutorial-multiserver-intro.md
+++ b/SpatialGDK/Documentation/content/tutorials/multiserver-shooter/tutorial-multiserver-intro.md
@@ -1,8 +1,8 @@
 <%(TOC)%>
 # Tutorials and guides
 ## Multiserver zoning shooter tutorial
-<%(Callout type="warn" message="This tutorial is a preview demonstrating early multiserver zoning functionality in the GDK. Please note we do not recommend development of multiserver projects using server zoning at this time. </br>
-For more information on multiserver zoning, follow our [development roadmap](https://github.com/spatialos/UnrealGDK/projects/1) and [Unreal features support]({{urlRoot}}/unreal-features-support) pages.")%>	
+<%(Callout type="warn" message="This tutorial is a preview demonstrating early multiserver zoning functionality in the GDK. Please note we do not recommend development of multiserver projects using server [zoning]({{urlRoot}}/content/glossary#worker) at this time. </br></br>
+For more information on multiserver zoning, see our [development roadmap](https://github.com/spatialos/UnrealGDK/projects/1) and [Unreal features support]({{urlRoot}}/unreal-features-support) pages.")%>	
 
 
 > This tutorial uses the Example Project from the GDK's [setup guide]({{urlRoot}}/content/get-started/example-project/exampleproject-intro).</br>
@@ -13,7 +13,7 @@ For more information on multiserver zoning, follow our [development roadmap](htt
 
 
 
-Following this tutorial, you implement cross-server remote procedure calls (RPCs) for simple first-person shooter functionality in the GDK's Example Project. The end result is a multiplayer, cloud-hosted Unreal game running across multiple [server-workers]({{urlRoot}}/content/glossary#worker) that players can seamlessly move between and shoot across. It demonstrates multiserver [zoning]({{urlRoot}}/content/glossary#worker) and looks something like the animation below.</br></br>
+Following this tutorial, you implement cross-server remote procedure calls (RPCs) for simple first-person shooter functionality in the GDK's Example Project. The end result is a multiplayer, cloud-hosted Unreal game running across multiple [server-workers]({{urlRoot}}/content/glossary#worker) that players can seamlessly move between and shoot across. It demonstrates multiserver [zoning]({{urlRoot}}/content/glossary#server-workers) and looks something like the animation below.</br></br>
 
 ![]({{assetRoot}}assets/tutorial/cross-server-shooting.gif)
 _Image: Example of cross-server shooting using multiserver zoning functionality._ </br></br>
@@ -24,7 +24,7 @@ The tutorial demonstrates that the workflows and iteration speed you’re used t
 
 Before starting this tutorial you need to complete the [Example Project setup guide]({{urlRoot}}/content/get-started/example-project/exampleproject-intro). Following this, you clone or download and set up all the elements of the GDK and its dependencies, including the Example Project.
 
-To follow the Multiserver zoning shooter tutorial, you need to change your Example Project branch from `release` (which is the default) to `multiserver-tutorial-start`. To do this:
+To follow the multiserver zoning shooter tutorial, you need to change your Example Project branch from `release` (which is the default) to `multiserver-tutorial-start`. To do this:
 
 1. If you have Unreal Editor open, close it.
 2. In GitHub, change your Example Project branch to `multiserver-tutorial-start`.</br>

--- a/SpatialGDK/Documentation/content/tutorials/offloading-tutorial/offloading-gameplay-changes.md
+++ b/SpatialGDK/Documentation/content/tutorials/offloading-tutorial/offloading-gameplay-changes.md
@@ -57,7 +57,7 @@ Mention weapon to allow it to be used for the bots.
 
 ### Ensure that code get executed on the correct server worker
 
-With the introduction of offloading, it is no longer enough to check whether the netmode is a dedicated server to ensure that logic is run on the authoritative worker. An actor could now be authoritatively updated from any given server type and therefore it is important to be mindful of checking whether the current server worker has authority over the entity. Below are a few example snippets from the UEquipmentComponent where such checks were added to ensure correct flow:
+With the introduction of offloading, it is no longer enough to check whether the netmode is a dedicated server to ensure that logic is run on the worker that has authority. An actor could now be updated from any given server type and therefore it is important to be mindful of checking whether the current server worker has authority over the entity. Below are a few example snippets from the UEquipmentComponent where such checks were added to ensure correct flow:
 
 ```
 void UEquippedComponent::SpawnStarterTemplates(FGDKMetaData MetaData)

--- a/SpatialGDK/Documentation/content/tutorials/porting-guide/tutorial-portingguide-logs.md
+++ b/SpatialGDK/Documentation/content/tutorials/porting-guide/tutorial-portingguide-logs.md
@@ -25,7 +25,7 @@ You can change:
 If you haven't already, check out:
 
 - The tutorial on [multiple deployments for session-based games]({{urlRoot}}/content/tutorials/deployment-manager/tutorial-deploymentmgr-intro).
-- The Multiserver Shooter tutorial to learn how to implement [cross-server interactions]({{urlRoot}}/content/tutorials/multiserver-shooter/tutorial-multiserver-intro).  
+- The multiserver zoning shooter tutorial to learn how to implement [cross-server interactions]({{urlRoot}}/content/tutorials/multiserver-shooter/tutorial-multiserver-intro).  
 
 Also check out the documentation on [cross-server RPCs]({{urlRoot}}/content/cross-server-rpcs), [handover]({{urlRoot}}/content/actor-handover) and [Singleton Actors]({{urlRoot}}/content/singleton-actors).
 

--- a/SpatialGDK/Documentation/content/workers/offloading-concept.md
+++ b/SpatialGDK/Documentation/content/workers/offloading-concept.md
@@ -2,7 +2,29 @@
 
 # Overview
 
-Offloading is when you allocate the [authority](#authority) over specific [Actor groups](#actor-groups) to a [server-worker instance](#worker-types-and-worker-instances) other than your main Unreal server-worker instance.
+You can set up your project so more than one server-worker instance computes the game.
+
+There are two ways to share the compute load:
+
+* **Multiserver zoning**
+    
+    Two or more instances of a server-worker type compute the same functionality simultaneously and share the compute load between them.
+
+    For example, you have two instances of the out-of-the-box main Unreal server-worker type sharing all the server functionality.
+
+    You are likely to set up this load sharing spatially so that each server-worker instance computes a geographical area of the game world.
+
+* **Multiserver offloading**
+
+    The functionality of the out-of-the-box Unreal server-worker type is split between two server-worker types.
+
+    For example, you could create an AI server-worker type and offload the AI computation from the main Unreal server-worker type onto it.
+
+    This means your game runs on two worker instances, both of different server-worker types but sharing the load.
+
+Offloading frees up server-worker computation capacity to allow richer game features.
+
+To set up offloading, you allocate the [authority]({{urlRoot}}/content/glossary#authority) over specific [Actor groups]({{urlRoot}}/content/glossary#actor-groups) to a new [server-worker type]({{urlRoot}}/content/glossary#worker-types-and-worker-instances), not the out-of-the-box Unreal server-worker type.
 
 In Unreal’s native single-server architecture, the server runs many of the major game systems such as physics simulation, AI decision-making, and navigation. It also processes and validates input from game clients. Using the GDK allows you to execute latency-tolerant systems on a separate server-worker instance.
 
@@ -15,9 +37,9 @@ _Offloading: Offloaded Unreal server-worker instance has authority only over **R
 
 ## Actor groups
 
-To facilitate offloading, we've created the concept of Actor groups to help you configure which Actor types a given server-worker type will have authority over. In the Unreal Editor, you can create Actor groups, assign Actor classes to a group, and then assign each group to a server-worker type.
+Actor groups facilitate multiserver functionality through offloading. You set them up to configure which Actor types instances of a [server-worker type]({{urlRoot}}/content/glossary#worker-types-and-worker-instances) have [authority]({{urlRoot}}/content/glossary#authority) over. In the Unreal Editor, you can create Actor groups, assign Actor classes to a group, and then assign each group to a server-worker type via the SpatialOS Runtime Settings panel.
 
-Before you start to use offloading in your game, ensure that you’re familiar with the [best practices for using offloading]({{urlRoot}}/content/workers/offloading-concept#best-practices) and [offloading workflow]({{urlRoot}}/content/workers/set-up-offloading).
+For guidance on offloading, see the documentation on offloading [best practices]({{urlRoot}}/content/workers/offloading-concept#best-practices) and [how to set up your game for offloading]({{urlRoot}}/content/workers/set-up-offloading).
 
 To get started with configuring Actor groups, see [Offloading example project]({{urlRoot}}/content/tutorials/offloading-tutorial/offloading-intro).
 
@@ -47,6 +69,8 @@ Before you offload Actors, consider the following scenarios that you need to upd
     However, this might cause issues when the initialization logic in the calls such as `BeginPlay` and `PostInitializeComponent` is executed on the wrong server-worker instance. You can usually work around these issues using callbacks / RepNotify-s on the main Unreal server-worker instance to defer the execution of such logic until when the correct server-worker instance has authority over the offloaded Actor.
 
 <br/>------------<br/>
+_2019-08-08 Page updated with editorial review: updated first part of overview_
+<br>
 _2019-07-26 Page added with limited editorial review_
 <br/>
 <br/>

--- a/SpatialGDK/Documentation/content/workers/offloading-concept.md
+++ b/SpatialGDK/Documentation/content/workers/offloading-concept.md
@@ -2,7 +2,7 @@
 
 # Overview
 
-Offloading is when you allocate the [authority](#authority) over specific [Actor groups](#actor-groups) to a [server-worker instance](#worker-types-and-worker-instances) other than the main Unreal server-worker instance. By using offloading, you can save the resources of the main Unreal server-worker instance when you want to build richer game features.
+Offloading is when you allocate the [authority](#authority) over specific [Actor groups](#actor-groups) to a [server-worker instance](#worker-types-and-worker-instances) other than your main Unreal server-worker instance.
 
 In Unreal’s native single-server architecture, the server runs many of the major game systems such as physics simulation, AI decision-making, and navigation. It also processes and validates input from game clients. Using the GDK allows you to execute latency-tolerant systems on a separate server-worker instance.
 

--- a/SpatialGDK/Documentation/content/workers/offloading-concept.md
+++ b/SpatialGDK/Documentation/content/workers/offloading-concept.md
@@ -2,7 +2,7 @@
 
 # Overview
 
-Offloading is the new architecture that the SpatialOS GDK for Unreal provides to allocate the authority of specific Actor groups from the main Unreal server-worker instance to a different server-worker instance. By using offloading, you can save the resources of the main Unreal server-worker instance when you want to build richer game features.
+Offloading is when you allocate the [authority](#authority) over specific [Actor groups](#actor-groups) to a [server-worker instance](#worker-types-and-worker-instances) other than the main Unreal server-worker instance. By using offloading, you can save the resources of the main Unreal server-worker instance when you want to build richer game features.
 
 In Unreal’s native single-server architecture, the server runs many of the major game systems such as physics simulation, AI decision-making, and navigation. It also processes and validates input from game clients. Using the GDK allows you to execute latency-tolerant systems on a separate server-worker instance.
 

--- a/SpatialGDK/Documentation/index.md
+++ b/SpatialGDK/Documentation/index.md
@@ -24,9 +24,9 @@ After you set up the SpatialOS GDK Starter Template or the Example
 Project, you can learn more about the GDK’s functionality with:
 <img src="{{assetRoot}}assets/example-project/example-project-headline.png" style=" float: right; margin: 0; display: block; width: 60%; padding: 20px 20px"/>
 
-* **The offloading example project tutorial**: learn how to offload groups of actors to separate Unreal server-workers
+* **The offloading example project tutorial**: learn how to offload groups of actors to separate Unreal server-workers.
 * **The tutorial on multiple deployments for session-based games**: upload a session-based FPS example game to the cloud.
-* **The multiserver zoning shooter tutorial**: implement shooting across the boundaries of different servers simulating one game world.
+* **The multiserver zoning shooter tutorial**: implement shooting across the boundaries of different servers computing one game world.
 * **The porting guide**: porting your existing UE project to SpatialOS.
 * **The database sync worker tutorial**: learn how to integrate the Database Sync Worker Example in your GDK project
 
@@ -48,4 +48,5 @@ Project, you can learn more about the GDK’s functionality with:
 ### **> Next:** [Get Started]({{urlRoot}}/content/get-started/dependencies.md)
 
 </br>------</br>
+_2019-08-08 Page updated with editorial review: renamed "multiserver shooter tutorial" to "multiserver zoning shooter tutorial"_ 
 _2019-07-31 Page updated with limited editorial review_

--- a/SpatialGDK/Documentation/index.md
+++ b/SpatialGDK/Documentation/index.md
@@ -9,7 +9,7 @@ The SpatialOS Game Development Kit (GDK) for Unreal is an [Unreal Engine plugin]
 SpatialOS provides:<br/>
 
 * **Global hosting**: Scalable dedicated hosting for your game in every major gaming region.<br/>
-* **Easy playtesting**: Deploy and test your game from the start of development, and distribute it to your team and players quickly and easily with a ready-made link. Scale-test your build by connecting in Simulated Players.<br/>
+* **Easy playtesting**: Deploy and test your game from the start of development, and distribute it to your team and players quickly and easily with a ready-made link. Scale-test your build by connecting in simulated players.<br/>
 * **Profiling and debugging tools**: Logs and metrics out of the box to help you quickly understand any bugs and performance issues.
 * **Single and multiserver networking**: Use one or multiple server-worker instances simulating your game world, enabling greater numbers of Actors, players and gameplay systems. This is available today through the offloading architecture, in which you allocate the authority of specific Actor groups from the main Unreal server worker instance to a different worker. This is available as a preview - not recommended for development - through the zoning architecture, in which the world is split into zones of authority for each server-worker. 
 
@@ -26,7 +26,7 @@ Project, you can learn more about the GDK’s functionality with:
 
 * **The offloading example project tutorial**: learn how to offload groups of actors to separate Unreal server-workers
 * **The tutorial on multiple deployments for session-based games**: upload a session-based FPS example game to the cloud.
-* **The multiserver shooter tutorial**: implement shooting across the boundaries of different servers simulating one game world.
+* **The multiserver zoning shooter tutorial**: implement shooting across the boundaries of different servers simulating one game world.
 * **The porting guide**: porting your existing UE project to SpatialOS.
 * **The database sync worker tutorial**: learn how to integrate the Database Sync Worker Example in your GDK project
 

--- a/SpatialGDK/Documentation/index.md
+++ b/SpatialGDK/Documentation/index.md
@@ -1,6 +1,6 @@
 ![GDK for Unreal Documentation]({{assetRoot}}assets/spatialos-gdkforunreal-header.png)
 
-<%(Callout  message="The SpatialOS GDK for Unreal is in alpha. It is ready to use for development of games using a single Unreal server, or using multiple servers in an offloading architecture. It it not yet recommended for development of multiserver games using the zoning architecture, and is not ready for public releases. For more information, please follow our [development roadmap](https://github.com/spatialos/UnrealGDK/projects/1) and [Unreal features support]({{urlRoot}}/unreal-features-support) pages.")%>
+<%(Callout  message="The SpatialOS GDK for Unreal is in alpha. It is ready to use for development of games using a single Unreal server, or using multiple servers in an [offloading]({{urlRoot}}/content/glossary#offloading) architecture. It it not yet recommended for development of multiserver games using the [zoning]({{urlRoot}}/content/glossary#zoning) architecture, and is not ready for public releases. For more information, see our [development roadmap](https://github.com/spatialos/UnrealGDK/projects/1) and [Unreal features support]({{urlRoot}}/unreal-features-support) page.")%>
 
 The SpatialOS Game Development Kit (GDK) for Unreal is an [Unreal Engine plugin](https://docs.unrealengine.com/en-US/Programming/Plugins/index.html) which gives you the features of SpatialOS, within the familiar workflows and APIs of Unreal. 
 

--- a/SpatialGDK/Documentation/unreal-features-support.md
+++ b/SpatialGDK/Documentation/unreal-features-support.md
@@ -389,7 +389,7 @@ Support of Unreal features with the GDK in a single server-worker configuration:
 
 </table>
 
-## Multiserver Support
+## Multiserver support
 
 The table for multiserver support is coming soon. 
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description

- updated multiserver shooter name
- improved some definitions in the glossary (offloading, authority, zoning) and in the GDK concepts page (Actor groups, zoning, offloading)
- improved offloading definition in the new offloading page intro (for consistency) but DIDN'T touch the rest of that page
- added info where necessary, about (1) offloading and zoning being two multiserver options, (2) zoning being in pre-alpha, and (3) single server being the default
- some driveby updates

#### Primary reviewers
@ElleEss 