### PR TITLE
Docs/doc 1266

### DIFF
--- a/SpatialGDK/Documentation/content/get-started/build-unreal-fork.md
+++ b/SpatialGDK/Documentation/content/get-started/build-unreal-fork.md
@@ -38,7 +38,7 @@ To get access to the SpatialOS Unreal Engine fork, you need to link your GitHub 
 
 ### Step 3: Add a new SSH key to your GitHub account
 
-If you have not already configured your GitHub account to use an SSH key, you must do so in order to automatically download the GDK repositories using **InstallGDK.bat** as part of the next setup step.
+If you have not already configured your GitHub account to use an SSH key, you must do this in order to automatically download the GDK repositories as part of the next setup step.
 
 To do this:
 

--- a/SpatialGDK/Documentation/content/get-started/build-unreal-fork.md
+++ b/SpatialGDK/Documentation/content/get-started/build-unreal-fork.md
@@ -82,4 +82,5 @@ Use as a base for creating your own project running on SpatialOS.
 <br/>
 
 ------</br>
-_2019-05-30 Page updated with editorial review_
+_2019-08-03 Page updated with editorial review: added clarification on SSH key and Linux dependencies._
+_2019-05-30 Page updated with editorial review._

--- a/SpatialGDK/Documentation/content/get-started/build-unreal-fork.md
+++ b/SpatialGDK/Documentation/content/get-started/build-unreal-fork.md
@@ -82,5 +82,5 @@ Use as a base for creating your own project running on SpatialOS.
 <br/>
 
 ------</br>
-_2019-08-03 Page updated with editorial review: added clarification on SSH key and Linux dependencies._
+_2019-08-08 Page updated with editorial review: added clarification on SSH key and Linux dependencies._
 _2019-05-30 Page updated with editorial review._

--- a/SpatialGDK/Documentation/content/get-started/build-unreal-fork.md
+++ b/SpatialGDK/Documentation/content/get-started/build-unreal-fork.md
@@ -53,16 +53,15 @@ To build the Unreal Engine Fork:
 2. In the same directory, double-click **GenerateProjectFiles.bat**. This file automatically sets up the project files required to build Unreal Engine.<br/>
 3. Double-click **InstallGDK.bat**
 This automatically opens a command line window and performs the following:
-	* Sets `LINUX_MULTIARCH_ROOT` as an environment variable, required for the Linux Cross-Compilation process (see https://docs.unrealengine.com/en-US/Platforms/Linux/GettingStarted/index.html)
 	* Clones the UnrealGDK into your Engine's `Plugins` directory
 	* Clones the [UnrealGDKExampleProject](https://github.com/spatialos/UnrealGDKExampleProject) into your Engine's `Samples` directory
 	* Runs the Unreal GDK `Setup.bat` script to install the GDK into the cloned `UnrealGDKExampleProject` directory
 	* Generates Visual Studio solution files for the `UnrealGDKExampleProject`<br/>
 This process can take a long time to complete. The command line window closes when the process has finished.    <br/>
 1. In the same directory, open **UE4.sln** in Visual Studio.
-1. In Visual Studio, on the toolbar, navigate to **Build** > **Configuration Manager**; set your active solution configuration to **Development Editor** and your active solution platform to **Win64**.
-1. In the Solution Explorer window, right-click on the **UE4** project and select **Set as StartUp Project**
-1. In the Solution Explorer window, right-click on the **UE4** project and select **Build** (you may be prompted to install some dependencies first). <br>
+2. In Visual Studio, on the toolbar, navigate to **Build** > **Configuration Manager**; set your active solution configuration to **Development Editor** and your active solution platform to **Win64**.
+3. In the Solution Explorer window, right-click on the **UE4** project and select **Set as StartUp Project**
+4. In the Solution Explorer window, right-click on the **UE4** project and select **Build** (you may be prompted to install some dependencies first). <br>
 
 Visual Studio then builds Unreal Engine, which can take up to a couple of hours.
 

--- a/SpatialGDK/Documentation/content/get-started/build-unreal-fork.md
+++ b/SpatialGDK/Documentation/content/get-started/build-unreal-fork.md
@@ -38,9 +38,12 @@ To get access to the SpatialOS Unreal Engine fork, you need to link your GitHub 
 
 ### Step 3: Add a new SSH key to your GitHub account
 
-You must add an SSH key to your GitHub account in order to automatically download the GDK repositories as part of this setup step.
+If you have not already configured your GitHub account to use an SSH key, you must do so in order to automatically download the GDK repositories using **InstallGDK.bat** as part of the next setup step.
 
-To do this, follow the GitHub tutorial on [Adding a new SSH key to your GitHub account (GitHub Documentation)](https://help.github.com/en/articles/adding-a-new-ssh-key-to-your-github-account)
+To do this:
+
+1. Before you generate an SSH key, you can check to see if you have any existing SSH keys by following the GitHub tutorial [Checking for existing SSH keys](https://help.github.com/en/articles/checking-for-existing-ssh-keys).
+1. If you don't have an existing key, then generate a new SSH key by following the GitHub tutorial [Adding a new SSH key to your GitHub account (GitHub Documentation)](https://help.github.com/en/articles/adding-a-new-ssh-key-to-your-github-account).
 
 ### Step 4: Build the Unreal Engine Fork
 

--- a/SpatialGDK/Documentation/content/get-started/dependencies.md
+++ b/SpatialGDK/Documentation/content/get-started/dependencies.md
@@ -52,5 +52,5 @@ To build the GDK for Unreal you need the following software installed on your ma
 <br/>
 
 ------</br>
-_2019-08-03 Page updated with editorial review: text clarification only._
+_2019-08-08 Page updated with editorial review: text clarification only._
 _2019-07-22 Page updated with limited editorial review_

--- a/SpatialGDK/Documentation/content/get-started/dependencies.md
+++ b/SpatialGDK/Documentation/content/get-started/dependencies.md
@@ -52,4 +52,5 @@ To build the GDK for Unreal you need the following software installed on your ma
 <br/>
 
 ------</br>
+_2019-08-03 Page updated with editorial review: text clarification only._
 _2019-07-22 Page updated with limited editorial review_

--- a/SpatialGDK/Documentation/content/get-started/dependencies.md
+++ b/SpatialGDK/Documentation/content/get-started/dependencies.md
@@ -43,7 +43,7 @@ To build the GDK for Unreal you need the following software installed on your ma
     - **Desktop development with C++**<br>
     - **Game development with C++**, including the optional **Unreal Engine installer** component.
 - [**Linux Cross-Compilation toolchain**](https://docs.unrealengine.com/en-US/Platforms/Linux/GettingStarted/index.html)
-    - You need a version of Unreal's Linux Cross-Compilation toolchain in order to compile your Linux server-workers on Windows. See the linked Unreal documentation to find the correct one for your version of the Engine.
+    - You need to download and install Unreal's Linux Cross-Compilation toolchain in order to build Linux server-workers using your Windows machine. Use the Unreal documentation link above to install `-v13 clang-7.0.1-based`, the appropriate toolchain for Unreal Engine 4.22.
 
 </br>
 </br>


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
* Clarifies that if you already have an SSH key setup you don't need a new one.
* Clarifies that **InstallGDK.bat** does not set the `LINUX_MULTIARCH_ROOT`.
* Clarifies that you must download and install the Linux Cross-Compilation toolchain from the Unreal docs link, and explicitly states the required version. This is vital because at no point in the onboarding flow up to this moment have we told the user we use UE 4.22.

#### Release note
None, This simply clarifies information that was implicit and/or scattered before.

#### Tests
Rendered and linted in improbadoc.

#### Documentation
This is documentation