### PR TITLE
UNR-1644: Schema compiler failure should fail schema generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fixes:
 - Fixed an issue that could cause multiple Channels to be created for an Actor.
 - PlayerControllers on non-auth servers now have BeginPlay called with correct authority.
+- When schema compiler fails, schema generation correctly shows an error.
 
 ## [`0.6.0`] - 2019-07-31
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -628,7 +628,7 @@ void ResetUsedNames()
  	}
 }
 
-void RunSchemaCompiler()
+bool RunSchemaCompiler()
 {
 	FString PluginDir = GetDefault<USpatialGDKEditorSettings>()->GetGDKPluginDirectory();
 
@@ -659,10 +659,12 @@ void RunSchemaCompiler()
 	if (ExitCode == 0)
 	{
 		UE_LOG(LogSpatialGDKSchemaGenerator, Log, TEXT("schema_compiler successfully generated schema descriptor: %s"), *SchemaCompilerOut);
+		return true;
 	}
 	else
 	{
 		UE_LOG(LogSpatialGDKSchemaGenerator, Error, TEXT("schema_compiler failed to generate schema descriptor: %s"), *SchemaCompilerErr);
+		return false;
 	}
 }
 
@@ -707,9 +709,10 @@ bool SpatialGDKGenerateSchema()
 	GenerateSchemaForSublevels(SchemaOutputPath, IdGenerator);
 	NextAvailableComponentId = IdGenerator.Peek();
 	SaveSchemaDatabase();
-	RunSchemaCompiler();
 
-	return true;
+	bool SchemaCompileSuccess = RunSchemaCompiler();
+
+	return SchemaCompileSuccess;
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -644,7 +644,11 @@ bool RunSchemaCompiler()
 	if (!FPaths::DirectoryExists(SchemaDescriptorDir))
 	{
 		IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
-		PlatformFile.CreateDirectoryTree(*SchemaDescriptorDir);
+		if (!PlatformFile.CreateDirectoryTree(*SchemaDescriptorDir))
+		{
+			UE_LOG(LogSpatialGDKSchemaGenerator, Error, TEXT("Could not create schema descriptor directory '%s'! Please make sure the parent directory is writeable."), *SchemaDescriptorDir);
+			return false;
+		}
 	}
 
 	FString SchemaCompilerArgs = FString::Printf(TEXT("--schema_path=\"%s\" --schema_path=\"%s\" --descriptor_set_out=\"%s\" --load_all_schema_on_schema_path"), *SchemaDir, *CoreSDKSchemaDir, *SchemaDescriptorOutput);
@@ -710,9 +714,7 @@ bool SpatialGDKGenerateSchema()
 	NextAvailableComponentId = IdGenerator.Peek();
 	SaveSchemaDatabase();
 
-	bool SchemaCompileSuccess = RunSchemaCompiler();
-
-	return SchemaCompileSuccess;
+	return RunSchemaCompiler();
 }
 
 #undef LOCTEXT_NAMESPACE


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
UNR-1644: Change SpatialGDKGenerateSchema to cause the window to display "schema generation failed" if schema compilation failed.

#### Release note
Bugfix: When schema compiler fails, schema generation correctly shows an error.

#### Tests
Running schema generation normally succeeds as normal. Deleting GDK schema files and running an iterative schema gen correctly produces an output.

How can this be verified by QA? 

Run an iterative schema gen that should succeed and confirm the window displays the succeed message, then force the iterative schema gen to fail (e.g. by deleting GDK schema files) and confirming the window displays an error message.

Also, delete the schema descriptor directory in a test project (spatial/build/assembly/schema) and set its parent directory to read-only (right click on directory -> properties -> select security and deny write). Running the full schema gen should fail. Deleting schema descriptor directory without changing access permissions should still result in schema gen success.

#### Primary reviewers
@joshuahuburn @improbable-valentyn 