### PR TITLE
UNR-1402: Crash when attempting to replicate a non supported type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fixes:
 - Fixed an issue that could cause multiple Channels to be created for an Actor.
 - PlayerControllers on non-auth servers now have BeginPlay called with correct authority.
+- Attempting to replicate unsupported types (such as TMap) produce a log error rather than crashing the game.
 
 ## [`0.6.0`] - 2019-07-31
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
@@ -318,11 +318,15 @@ void ComponentFactory::AddProperty(Schema_Object* Object, Schema_FieldId FieldId
 	}
 	else if (Property->IsA<UMapProperty>())
 	{
-		UE_LOG(LogComponentFactory, Error, TEXT("Replicated TMaps are not supported."));
+		UE_LOG(LogComponentFactory, Error, TEXT("Class %s with name %s in field %d: Replicated TMaps are not supported."), *Property->GetClass()->GetName(), *Property->GetName(), FieldId);
+	}
+	else if (Property->IsA<USetProperty>())
+	{
+		UE_LOG(LogComponentFactory, Error, TEXT("Class %s with name %s in field %d: Replicated TSets are not supported."), *Property->GetClass()->GetName(), *Property->GetName(), FieldId);
 	}
 	else
 	{
-		UE_LOG(LogComponentFactory, Error, TEXT("Tried to add unknown property in field %d"), FieldId);
+		UE_LOG(LogComponentFactory, Error, TEXT("Class %s with name %s in field %d: Attempted to add unknown property type."), *Property->GetClass()->GetName(), *Property->GetName(), FieldId);
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
@@ -16,6 +16,8 @@
 #include "Utils/RepLayoutUtils.h"
 #include "Utils/InterestFactory.h"
 
+DEFINE_LOG_CATEGORY(LogComponentFactory);
+
 namespace SpatialGDK
 {
 
@@ -314,9 +316,13 @@ void ComponentFactory::AddProperty(Schema_Object* Object, Schema_FieldId FieldId
 	{
 		// These properties can be set to replicate, but won't serialize across the network.
 	}
+	else if (Property->IsA<UMapProperty>())
+	{
+		UE_LOG(LogComponentFactory, Error, TEXT("Replicated TMaps are not supported."));
+	}
 	else
 	{
-		checkf(false, TEXT("Tried to add unknown property in field %d"), FieldId);
+		UE_LOG(LogComponentFactory, Error, TEXT("Tried to add unknown property in field %d"), FieldId);
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/ComponentFactory.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/ComponentFactory.h
@@ -9,6 +9,8 @@
 #include <WorkerSDK/improbable/c_schema.h>
 #include <WorkerSDK/improbable/c_worker.h>
 
+DECLARE_LOG_CATEGORY_EXTERN(LogComponentFactory, Log, All);
+
 class USpatialNetDriver;
 class USpatialPackageMap;
 class USpatialClassInfoManager;


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Unreal produces a warning (rather than crashing the game) if the game attempts to replicate an unsupported type (such as TMap). This PR changes the GDK to match this behaviour.

#### Release note
Attempting to replicate unsupported types (such as TMap) produce a log error rather than crashing the game.

#### Tests
Tested by replicating a TMap in GDKCharacter in the example project and verifying that the game no longer crashed but produced an error.

How can this be verified by QA?

Create an actor that contains a replicated TMap property and play with spatial. The game should run normally with an error message in the output.

#### Primary reviewers
@joshuahuburn @improbable-valentyn