### PR TITLE
Feature/unr 1936 move generators to spatialgdkeditor

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
@@ -1,0 +1,174 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "SpatialGDKDefaultLaunchConfigGenerator.h"
+
+#include "SpatialGDKEditorSettings.h"
+
+#include "Serialization/JsonWriter.h"
+#include "Misc/FileHelper.h"
+
+#include "CoreMinimal.h"
+
+DEFINE_LOG_CATEGORY(LogSpatialGDKDefaultLaunchConfigGenerator);
+
+#define LOCTEXT_NAMESPACE "SpatialGDKDefaultLaunchConfigGenerator"
+
+using namespace SpatialGDK;
+
+namespace
+{
+bool WriteFlagSection(TSharedRef< TJsonWriter<> > Writer, const FString& Key, const FString& Value)
+{
+	Writer->WriteObjectStart();
+		Writer->WriteValue(TEXT("name"), Key);
+		Writer->WriteValue(TEXT("value"), Value);
+	Writer->WriteObjectEnd();
+
+	return true;
+}
+
+bool WriteWorkerSection(TSharedRef< TJsonWriter<> > Writer, const FWorkerTypeLaunchSection& Worker)
+{
+	Writer->WriteObjectStart();
+		Writer->WriteValue(TEXT("worker_type"), *Worker.WorkerTypeName.ToString());
+		Writer->WriteArrayStart(TEXT("flags"));
+		for (const auto& Flag : Worker.Flags)
+		{
+			WriteFlagSection(Writer, Flag.Key, Flag.Value);
+		}
+		Writer->WriteArrayEnd();
+		Writer->WriteArrayStart(TEXT("permissions"));
+			Writer->WriteObjectStart();
+			if (Worker.WorkerPermissions.bAllPermissions)
+			{
+				Writer->WriteObjectStart(TEXT("all"));
+				Writer->WriteObjectEnd();
+			}
+			else
+			{
+				Writer->WriteObjectStart(TEXT("entity_creation"));
+					Writer->WriteValue(TEXT("allow"), Worker.WorkerPermissions.bAllowEntityCreation);
+				Writer->WriteObjectEnd();
+				Writer->WriteObjectStart(TEXT("entity_deletion"));
+					Writer->WriteValue(TEXT("allow"), Worker.WorkerPermissions.bAllowEntityDeletion);
+				Writer->WriteObjectEnd();
+				Writer->WriteObjectStart(TEXT("entity_query"));
+					Writer->WriteValue(TEXT("allow"), Worker.WorkerPermissions.bAllowEntityQuery);
+					Writer->WriteArrayStart("components");
+					for (const FString& Component : Worker.WorkerPermissions.Components)
+					{
+						Writer->WriteValue(Component);
+					}
+					Writer->WriteArrayEnd();
+				Writer->WriteObjectEnd();
+			}
+			Writer->WriteObjectEnd();
+		Writer->WriteArrayEnd();
+		if (Worker.MaxConnectionCapacityLimit > 0)
+		{
+			Writer->WriteObjectStart(TEXT("connection_capacity_limit"));
+				Writer->WriteValue(TEXT("max_capacity"), Worker.MaxConnectionCapacityLimit);
+			Writer->WriteObjectEnd();
+		}
+		if (Worker.bLoginRateLimitEnabled)
+		{
+			Writer->WriteObjectStart(TEXT("login_rate_limit"));
+				Writer->WriteValue(TEXT("duration"), Worker.LoginRateLimit.Duration);
+				Writer->WriteValue(TEXT("requests_per_duration"), Worker.LoginRateLimit.RequestsPerDuration);
+			Writer->WriteObjectEnd();
+		}
+	Writer->WriteObjectEnd();
+
+	return true;
+}
+
+bool WriteLoadbalancingSection(TSharedRef< TJsonWriter<> > Writer, const FName& WorkerType, const int32 Columns, const int32 Rows, const bool ManualWorkerConnectionOnly)
+{
+	Writer->WriteObjectStart();
+	Writer->WriteValue(TEXT("layer"), *WorkerType.ToString());
+		Writer->WriteObjectStart("rectangle_grid");
+			Writer->WriteValue(TEXT("cols"), Columns);
+			Writer->WriteValue(TEXT("rows"), Rows);
+		Writer->WriteObjectEnd();
+		Writer->WriteObjectStart(TEXT("options"));
+			Writer->WriteValue(TEXT("manual_worker_connection_only"), ManualWorkerConnectionOnly);
+		Writer->WriteObjectEnd();
+	Writer->WriteObjectEnd();
+
+	return true;
+}
+
+}
+
+bool GenerateDefaultLaunchConfig(const FString& LaunchConfigPath)
+{
+	if (const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>())
+	{
+		FString Text;
+		TSharedRef< TJsonWriter<> > Writer = TJsonWriterFactory<>::Create(&Text);
+
+		const FSpatialLaunchConfigDescription& LaunchConfigDescription = SpatialGDKEditorSettings->LaunchConfigDesc;
+
+		// Populate json file for launch config
+		Writer->WriteObjectStart(); // Start of json
+			Writer->WriteValue(TEXT("template"), LaunchConfigDescription.Template); // Template section
+			Writer->WriteObjectStart(TEXT("world")); // World section begin
+				Writer->WriteObjectStart(TEXT("dimensions"));
+					Writer->WriteValue(TEXT("x_meters"), LaunchConfigDescription.World.Dimensions.X);
+					Writer->WriteValue(TEXT("z_meters"), LaunchConfigDescription.World.Dimensions.Y);
+				Writer->WriteObjectEnd();
+			Writer->WriteValue(TEXT("chunk_edge_length_meters"), LaunchConfigDescription.World.ChunkEdgeLengthMeters);
+			Writer->WriteValue(TEXT("streaming_query_interval"), LaunchConfigDescription.World.StreamingQueryIntervalSeconds);
+			Writer->WriteArrayStart(TEXT("legacy_flags"));
+			for (auto& Flag : LaunchConfigDescription.World.LegacyFlags)
+			{
+				WriteFlagSection(Writer, Flag.Key, Flag.Value);
+			}
+			Writer->WriteArrayEnd();
+			Writer->WriteArrayStart(TEXT("legacy_javaparams"));
+			for (auto& Parameter : LaunchConfigDescription.World.LegacyJavaParams)
+			{
+				WriteFlagSection(Writer, Parameter.Key, Parameter.Value);
+			}
+			Writer->WriteArrayEnd();
+			Writer->WriteObjectStart(TEXT("snapshots"));
+				Writer->WriteValue(TEXT("snapshot_write_period_seconds"), LaunchConfigDescription.World.SnapshotWritePeriodSeconds);
+			Writer->WriteObjectEnd();
+		Writer->WriteObjectEnd(); // World section end
+		Writer->WriteObjectStart(TEXT("load_balancing")); // Load balancing section begin
+			Writer->WriteArrayStart("layer_configurations");
+			for (const FWorkerTypeLaunchSection& Worker : LaunchConfigDescription.ServerWorkers)
+			{
+				WriteLoadbalancingSection(Writer, Worker.WorkerTypeName, Worker.Columns, Worker.Rows, Worker.bManualWorkerConnectionOnly);
+			}
+			Writer->WriteArrayEnd();
+			Writer->WriteObjectEnd(); // Load balancing section end
+			Writer->WriteArrayStart(TEXT("workers")); // Workers section begin
+			for (const FWorkerTypeLaunchSection& Worker : LaunchConfigDescription.ServerWorkers)
+			{
+				WriteWorkerSection(Writer, Worker);
+			}
+			// Write the client worker section
+			FWorkerTypeLaunchSection ClientWorker;
+			ClientWorker.WorkerTypeName = SpatialConstants::DefaultClientWorkerType;
+			ClientWorker.WorkerPermissions.bAllPermissions = true;
+			ClientWorker.bLoginRateLimitEnabled = false;
+			WriteWorkerSection(Writer, ClientWorker);
+			Writer->WriteArrayEnd(); // Worker section end
+		Writer->WriteObjectEnd(); // End of json
+
+		Writer->Close();
+
+		if (!FFileHelper::SaveStringToFile(Text, *LaunchConfigPath))
+		{
+			UE_LOG(LogSpatialGDKDefaultLaunchConfigGenerator, Log, TEXT("Failed to write output file '%s'. It might be that the file is read-only."), *LaunchConfigPath);
+			return false;
+		}
+
+		return true;
+	}
+
+	return false;
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
@@ -7,8 +7,6 @@
 #include "Serialization/JsonWriter.h"
 #include "Misc/FileHelper.h"
 
-#include "CoreMinimal.h"
-
 DEFINE_LOG_CATEGORY(LogSpatialGDKDefaultLaunchConfigGenerator);
 
 #define LOCTEXT_NAMESPACE "SpatialGDKDefaultLaunchConfigGenerator"

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
@@ -30,10 +30,10 @@ bool WriteWorkerSection(TSharedRef< TJsonWriter<> > Writer, const FWorkerTypeLau
 	Writer->WriteObjectStart();
 		Writer->WriteValue(TEXT("worker_type"), *Worker.WorkerTypeName.ToString());
 		Writer->WriteArrayStart(TEXT("flags"));
-		for (const auto& Flag : Worker.Flags)
-		{
-			WriteFlagSection(Writer, Flag.Key, Flag.Value);
-		}
+			for (const auto& Flag : Worker.Flags)
+			{
+				WriteFlagSection(Writer, Flag.Key, Flag.Value);
+			}
 		Writer->WriteArrayEnd();
 		Writer->WriteArrayStart(TEXT("permissions"));
 			Writer->WriteObjectStart();
@@ -83,7 +83,7 @@ bool WriteWorkerSection(TSharedRef< TJsonWriter<> > Writer, const FWorkerTypeLau
 bool WriteLoadbalancingSection(TSharedRef< TJsonWriter<> > Writer, const FName& WorkerType, const int32 Columns, const int32 Rows, const bool ManualWorkerConnectionOnly)
 {
 	Writer->WriteObjectStart();
-	Writer->WriteValue(TEXT("layer"), *WorkerType.ToString());
+		Writer->WriteValue(TEXT("layer"), *WorkerType.ToString());
 		Writer->WriteObjectStart("rectangle_grid");
 			Writer->WriteValue(TEXT("cols"), Columns);
 			Writer->WriteValue(TEXT("rows"), Rows);
@@ -159,7 +159,7 @@ bool GenerateDefaultLaunchConfig(const FString& LaunchConfigPath)
 
 		if (!FFileHelper::SaveStringToFile(Text, *LaunchConfigPath))
 		{
-			UE_LOG(LogSpatialGDKDefaultLaunchConfigGenerator, Log, TEXT("Failed to write output file '%s'. It might be that the file is read-only."), *LaunchConfigPath);
+			UE_LOG(LogSpatialGDKDefaultLaunchConfigGenerator, Error, TEXT("Failed to write output file '%s'. It might be that the file is read-only."), *LaunchConfigPath);
 			return false;
 		}
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultWorkerJsonGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultWorkerJsonGenerator.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "SpatialGDKDefaultWorkerJsonGenerator.h"
+
+#include "SpatialGDKEditorSettings.h"
+
+#include "Misc/FileHelper.h"
+
+DEFINE_LOG_CATEGORY(LogSpatialGDKDefaultWorkerJsonGenerator);
+#define LOCTEXT_NAMESPACE "SpatialGDKDefaultWorkerJsonGenerator"
+
+bool GenerateDefaultWorkerJson(bool& bRedeployRequired)
+{
+	if (const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>())
+	{
+		const FString WorkerJsonDir = FSpatialGDKServicesModule::GetSpatialOSDirectory(TEXT("workers/unreal"));
+		const FString TemplateWorkerJsonPath = FSpatialGDKServicesModule::GetSpatialGDKPluginDirectory(TEXT("SpatialGDK/Extras/templates/WorkerJsonTemplate.json"));
+
+		const FSpatialLaunchConfigDescription& LaunchConfigDescription = SpatialGDKEditorSettings->LaunchConfigDesc;
+		for (const FWorkerTypeLaunchSection& Worker : LaunchConfigDescription.ServerWorkers)
+		{
+			FString JsonPath = FPaths::Combine(WorkerJsonDir, FString::Printf(TEXT("spatialos.%s.worker.json"), *Worker.WorkerTypeName.ToString()));
+			if (!FPaths::FileExists(JsonPath))
+			{
+				UE_LOG(LogSpatialGDKDefaultWorkerJsonGenerator, Verbose, TEXT("Could not find worker json at %s"), *JsonPath);
+				FString Contents;
+				if (FFileHelper::LoadFileToString(Contents, *TemplateWorkerJsonPath))
+				{
+					Contents.ReplaceInline(TEXT("{{WorkerTypeName}}"), *Worker.WorkerTypeName.ToString());
+					if (FFileHelper::SaveStringToFile(Contents, *JsonPath))
+					{
+						bRedeployRequired = true;
+						UE_LOG(LogSpatialGDKDefaultWorkerJsonGenerator, Verbose, TEXT("Wrote default worker json to %s"), *JsonPath)
+					}
+					else
+					{
+						UE_LOG(LogSpatialGDKDefaultWorkerJsonGenerator, Error, TEXT("Failed to write default worker json to %s"), *JsonPath)
+					}
+				}
+				else
+				{
+					UE_LOG(LogSpatialGDKDefaultWorkerJsonGenerator, Error, TEXT("Failed to read default worker json template at %s"), *TemplateWorkerJsonPath)
+				}
+			}
+			else
+			{
+				UE_LOG(LogSpatialGDKDefaultWorkerJsonGenerator, Verbose, TEXT("Found worker json at %s"), *JsonPath)
+			}
+		}
+
+		return true;
+	}
+
+	return false;
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultWorkerJsonGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultWorkerJsonGenerator.cpp
@@ -9,7 +9,7 @@
 DEFINE_LOG_CATEGORY(LogSpatialGDKDefaultWorkerJsonGenerator);
 #define LOCTEXT_NAMESPACE "SpatialGDKDefaultWorkerJsonGenerator"
 
-bool GenerateDefaultWorkerJson(bool& bRedeployRequired)
+bool GenerateDefaultWorkerJson(bool& bOutRedeployRequired)
 {
 	if (const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>())
 	{
@@ -29,7 +29,7 @@ bool GenerateDefaultWorkerJson(bool& bRedeployRequired)
 					Contents.ReplaceInline(TEXT("{{WorkerTypeName}}"), *Worker.WorkerTypeName.ToString());
 					if (FFileHelper::SaveStringToFile(Contents, *JsonPath))
 					{
-						bRedeployRequired = true;
+						bOutRedeployRequired = true;
 						UE_LOG(LogSpatialGDKDefaultWorkerJsonGenerator, Verbose, TEXT("Wrote default worker json to %s"), *JsonPath)
 					}
 					else

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKDefaultLaunchConfigGenerator.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKDefaultLaunchConfigGenerator.h
@@ -1,0 +1,9 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "Logging/LogMacros.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKDefaultLaunchConfigGenerator, Log, All);
+
+bool SPATIALGDKEDITOR_API GenerateDefaultLaunchConfig(const FString& LaunchConfigPath);

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKDefaultWorkerJsonGenerator.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKDefaultWorkerJsonGenerator.h
@@ -6,4 +6,4 @@
 
 DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKDefaultWorkerJsonGenerator, Log, All);
 
-SPATIALGDKEDITOR_API bool GenerateDefaultWorkerJson(bool& bRedeployRequired);
+SPATIALGDKEDITOR_API bool GenerateDefaultWorkerJson(bool& bOutRedeployRequired);

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKDefaultWorkerJsonGenerator.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKDefaultWorkerJsonGenerator.h
@@ -1,0 +1,9 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "Logging/LogMacros.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKDefaultWorkerJsonGenerator, Log, All);
+
+SPATIALGDKEDITOR_API bool GenerateDefaultWorkerJson(bool& bRedeployRequired);

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -15,7 +15,6 @@
 #include "LevelEditor.h"
 #include "Misc/FileHelper.h"
 #include "Misc/MessageDialog.h"
-#include "Serialization/JsonWriter.h"
 #include "SpatialGDKEditorToolbarCommands.h"
 #include "SpatialGDKEditorToolbarStyle.h"
 #include "Widgets/DeclarativeSyntaxSupport.h"
@@ -23,6 +22,7 @@
 #include "Widgets/Notifications/SNotificationList.h"
 
 #include "SpatialConstants.h"
+#include "SpatialGDKDefaultLaunchConfigGenerator.h"
 #include "SpatialGDKEditor.h"
 #include "SpatialGDKEditorSettings.h"
 #include "SpatialGDKServicesModule.h"
@@ -740,77 +740,6 @@ void FSpatialGDKEditorToolbarModule::ShowSimulatedPlayerDeploymentDialog()
 	FSlateApplication::Get().AddModalWindow(SimulatedPlayerDeploymentWindowPtr.ToSharedRef(), RootWindow);
 }
 
-bool FSpatialGDKEditorToolbarModule::GenerateDefaultLaunchConfig(const FString& LaunchConfigPath) const
-{
-	if (const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>())
-	{
-		FString Text;
-		TSharedRef< TJsonWriter<> > Writer = TJsonWriterFactory<>::Create(&Text);
-
-		const FSpatialLaunchConfigDescription& LaunchConfigDescription = SpatialGDKEditorSettings->LaunchConfigDesc;
-
-		// Populate json file for launch config
-		Writer->WriteObjectStart(); // Start of json
-			Writer->WriteValue(TEXT("template"), LaunchConfigDescription.Template); // Template section
-			Writer->WriteObjectStart(TEXT("world")); // World section begin
-				Writer->WriteObjectStart(TEXT("dimensions"));
-					Writer->WriteValue(TEXT("x_meters"), LaunchConfigDescription.World.Dimensions.X);
-					Writer->WriteValue(TEXT("z_meters"), LaunchConfigDescription.World.Dimensions.Y);
-				Writer->WriteObjectEnd();
-			Writer->WriteValue(TEXT("chunk_edge_length_meters"), LaunchConfigDescription.World.ChunkEdgeLengthMeters);
-			Writer->WriteValue(TEXT("streaming_query_interval"), LaunchConfigDescription.World.StreamingQueryIntervalSeconds);
-			Writer->WriteArrayStart(TEXT("legacy_flags"));
-			for (auto& Flag : LaunchConfigDescription.World.LegacyFlags)
-			{
-				WriteFlagSection(Writer, Flag.Key, Flag.Value);
-			}
-			Writer->WriteArrayEnd();
-			Writer->WriteArrayStart(TEXT("legacy_javaparams"));
-			for (auto& Parameter : LaunchConfigDescription.World.LegacyJavaParams)
-			{
-				WriteFlagSection(Writer, Parameter.Key, Parameter.Value);
-			}
-			Writer->WriteArrayEnd();
-			Writer->WriteObjectStart(TEXT("snapshots"));
-				Writer->WriteValue(TEXT("snapshot_write_period_seconds"), LaunchConfigDescription.World.SnapshotWritePeriodSeconds);
-			Writer->WriteObjectEnd();
-		Writer->WriteObjectEnd(); // World section end
-		Writer->WriteObjectStart(TEXT("load_balancing")); // Load balancing section begin
-			Writer->WriteArrayStart("layer_configurations");
-			for (const FWorkerTypeLaunchSection& Worker : LaunchConfigDescription.ServerWorkers)
-			{
-				WriteLoadbalancingSection(Writer, Worker.WorkerTypeName, Worker.Columns, Worker.Rows, Worker.bManualWorkerConnectionOnly);
-			}
-			Writer->WriteArrayEnd();
-			Writer->WriteObjectEnd(); // Load balancing section end
-			Writer->WriteArrayStart(TEXT("workers")); // Workers section begin
-			for (const FWorkerTypeLaunchSection& Worker : LaunchConfigDescription.ServerWorkers)
-			{
-				WriteWorkerSection(Writer, Worker);
-			}
-			// Write the client worker section
-			FWorkerTypeLaunchSection ClientWorker;
-			ClientWorker.WorkerTypeName = SpatialConstants::DefaultClientWorkerType;
-			ClientWorker.WorkerPermissions.bAllPermissions = true;
-			ClientWorker.bLoginRateLimitEnabled = false;
-			WriteWorkerSection(Writer, ClientWorker);
-			Writer->WriteArrayEnd(); // Worker section end
-		Writer->WriteObjectEnd(); // End of json
-
-		Writer->Close();
-
-		if (!FFileHelper::SaveStringToFile(Text, *LaunchConfigPath))
-		{
-			UE_LOG(LogSpatialGDKEditorToolbar, Log, TEXT("Failed to write output file '%s'. It might be that the file is read-only."), *LaunchConfigPath);
-			return false;
-		}
-
-		return true;
-	}
-
-	return false;
-}
-
 bool FSpatialGDKEditorToolbarModule::GenerateDefaultWorkerJson()
 {
 	if (const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>())
@@ -899,87 +828,6 @@ void FSpatialGDKEditorToolbarModule::GenerateSchema(bool bFullScan)
 			OnShowFailedNotification("Incremental Schema Generation failed");
 		}
 	}
-}
-
-bool FSpatialGDKEditorToolbarModule::WriteFlagSection(TSharedRef< TJsonWriter<> > Writer, const FString& Key, const FString& Value) const
-{
-	Writer->WriteObjectStart();
-		Writer->WriteValue(TEXT("name"), Key);
-		Writer->WriteValue(TEXT("value"), Value);
-	Writer->WriteObjectEnd();
-
-	return true;
-}
-
-bool FSpatialGDKEditorToolbarModule::WriteWorkerSection(TSharedRef< TJsonWriter<> > Writer, const FWorkerTypeLaunchSection& Worker) const
-{
-	Writer->WriteObjectStart();
-		Writer->WriteValue(TEXT("worker_type"), *Worker.WorkerTypeName.ToString());
-		Writer->WriteArrayStart(TEXT("flags"));
-		for (const auto& Flag : Worker.Flags)
-		{
-			WriteFlagSection(Writer, Flag.Key, Flag.Value);
-		}
-		Writer->WriteArrayEnd();
-		Writer->WriteArrayStart(TEXT("permissions"));
-			Writer->WriteObjectStart();
-			if (Worker.WorkerPermissions.bAllPermissions)
-			{
-				Writer->WriteObjectStart(TEXT("all"));
-				Writer->WriteObjectEnd();
-			}
-			else
-			{
-				Writer->WriteObjectStart(TEXT("entity_creation"));
-					Writer->WriteValue(TEXT("allow"), Worker.WorkerPermissions.bAllowEntityCreation);
-				Writer->WriteObjectEnd();
-				Writer->WriteObjectStart(TEXT("entity_deletion"));
-					Writer->WriteValue(TEXT("allow"), Worker.WorkerPermissions.bAllowEntityDeletion);
-				Writer->WriteObjectEnd();
-				Writer->WriteObjectStart(TEXT("entity_query"));
-					Writer->WriteValue(TEXT("allow"), Worker.WorkerPermissions.bAllowEntityQuery);
-					Writer->WriteArrayStart("components");
-					for (const FString& Component : Worker.WorkerPermissions.Components)
-					{
-						Writer->WriteValue(Component);
-					}
-					Writer->WriteArrayEnd();
-				Writer->WriteObjectEnd();
-			}
-			Writer->WriteObjectEnd();
-		Writer->WriteArrayEnd();
-		if (Worker.MaxConnectionCapacityLimit > 0)
-		{
-			Writer->WriteObjectStart(TEXT("connection_capacity_limit"));
-				Writer->WriteValue(TEXT("max_capacity"), Worker.MaxConnectionCapacityLimit);
-			Writer->WriteObjectEnd();
-		}
-		if (Worker.bLoginRateLimitEnabled)
-		{
-			Writer->WriteObjectStart(TEXT("login_rate_limit"));
-				Writer->WriteValue(TEXT("duration"), Worker.LoginRateLimit.Duration);
-				Writer->WriteValue(TEXT("requests_per_duration"), Worker.LoginRateLimit.RequestsPerDuration);
-			Writer->WriteObjectEnd();
-		}
-	Writer->WriteObjectEnd();
-
-	return true;
-}
-
-bool FSpatialGDKEditorToolbarModule::WriteLoadbalancingSection(TSharedRef< TJsonWriter<> > Writer, const FName& WorkerType, const int32 Columns, const int32 Rows, const bool ManualWorkerConnectionOnly) const
-{
-	Writer->WriteObjectStart();
-	Writer->WriteValue(TEXT("layer"), *WorkerType.ToString());
-		Writer->WriteObjectStart("rectangle_grid");
-			Writer->WriteValue(TEXT("cols"), Columns);
-			Writer->WriteValue(TEXT("rows"), Rows);
-		Writer->WriteObjectEnd();
-		Writer->WriteObjectStart(TEXT("options"));
-			Writer->WriteValue(TEXT("manual_worker_connection_only"), ManualWorkerConnectionOnly);
-		Writer->WriteObjectEnd();
-	Writer->WriteObjectEnd();
-
-	return true;
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -94,14 +94,9 @@ private:
 	void ShowFailedNotification(const FString& NotificationText);
 
 	bool ValidateGeneratedLaunchConfig() const;
-	bool GenerateDefaultLaunchConfig(const FString& LaunchConfigPath) const;
 	bool GenerateDefaultWorkerJson();
 
 	void GenerateSchema(bool bFullScan);
-
-	bool WriteFlagSection(TSharedRef< TJsonWriter<> > Writer, const FString& Key, const FString& Value) const;
-	bool WriteWorkerSection(TSharedRef< TJsonWriter<> > Writer, const FWorkerTypeLaunchSection& FWorkerTypeLaunchSection) const;
-	bool WriteLoadbalancingSection(TSharedRef< TJsonWriter<> > Writer, const FName& WorkerType, const int32 Columns, const int32 Rows, const bool bManualWorkerConnectionOnly) const;
 
 	static void ShowCompileLog();
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -94,7 +94,6 @@ private:
 	void ShowFailedNotification(const FString& NotificationText);
 
 	bool ValidateGeneratedLaunchConfig() const;
-	bool GenerateDefaultWorkerJson();
 
 	void GenerateSchema(bool bFullScan);
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
I've moved GenerateDefaultLaunchConfig and GenerateDefaultWorkerJson from SpatialGDKEditorToolbar to new files in SpatialGDKEditor.

#### Release note
This is an internal change that's not interesting to UnrealGDK customers.

#### Tests
Local deployment should start successfully.

#### Documentation
No doc update.

#### Primary reviewers
@joshuahuburn @improbable-valentyn 