### PR TITLE
UNR-1942 - Switch validity checks to use whats defaulted

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -215,8 +215,8 @@ bool USpatialGDKEditorSettings::IsDeploymentConfigurationValid() const
 	bool result = IsAssemblyNameValid(AssemblyName) &&
 		IsDeploymentNameValid(PrimaryDeploymentName) &&
 		IsProjectNameValid(ProjectName) &&
-		!SnapshotPath.FilePath.IsEmpty() &&
-		!PrimaryLaunchConfigPath.FilePath.IsEmpty() &&
+		!GetSnapshotPath().IsEmpty() &&
+		!GetPrimaryLanchConfigPath().IsEmpty() &&
 		IsRegionCodeValid(PrimaryDeploymentRegionCode);
 
 	if (IsSimulatedPlayersEnabled())


### PR DESCRIPTION
#### Description
Running a cloud deployment within the editor could result in an non-descript "Deployment configuration is not valid" error. This was because the default snapshot and launch config files that are used to populate the window aren't used in the validity checks when running. Switching the validity check to use the same method that populates the window fixes this.

#### Tests
Ran cloud launch from within the editor

#### Primary reviewers
@WVerlaek @joshuahuburn 