### PR TITLE
UNR-1957: Generate schema commandlet crashes because editor is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue that could cause multiple Channels to be created for an Actor.
 - PlayerControllers on non-auth servers now have BeginPlay called with correct authority.
 - When schema compiler fails, schema generation correctly shows an error.
+- Fixed crash with GenerateSchemaCommandlet.
 
 ## [`0.6.0`] - 2019-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue that could cause multiple Channels to be created for an Actor.
 - PlayerControllers on non-auth servers now have BeginPlay called with correct authority.
 - When schema compiler fails, schema generation correctly shows an error.
-- Fixed crash with GenerateSchemaCommandlet.
+- Fixed crash during initialization when running GenerateSchemaCommandlet.
 
 ## [`0.6.0`] - 2019-07-31
 

--- a/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/GenerateSchemaCommandlet.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/GenerateSchemaCommandlet.cpp
@@ -7,7 +7,7 @@
 UGenerateSchemaCommandlet::UGenerateSchemaCommandlet()
 {
 	IsClient = false;
-	IsEditor = false;
+	IsEditor = true;
 	IsServer = false;
 	LogToConsole = true;
 }


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Change IsEditor = True in GenerateSchemaCommandlet.cpp to fix crash with GenerateSchemaCommandlet.

#### Release note
Fixed crash with GenerateSchemaCommandlet.

#### Tests
Run GenerateSchemaCommandlet and verify that the program does not crash.


#### Primary reviewers
@joshuahuburn  @mattyoung-improbable 