### PR TITLE
UNR-1878: Generate Schema Crashes if SchemaDatabase is locked by another process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fixes:
 - Fixed an issue that could cause multiple Channels to be created for an Actor.
 - PlayerControllers on non-auth servers now have BeginPlay called with correct authority.
+- Generating schema when the schema database is locked by another process will no longer crash the editor.
 
 ## [`0.6.0`] - 2019-07-31
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Added SAVE_NoError save flag to SavePackage() to prevent the error being thrown that was locking up the editor when trying to access a locked file.

Modified some of the logic behind error messaging to ensure this case was correctly reported as a failed schema generation.

#### Release note
Generating schema when the schema database is locked by another process will no longer crash the editor.

#### Tests
Successfully reproduced the bug following steps in associated ticket prior to fix. Bug no longer occurs when following the same steps or when attempting to lock the schema database in other ways.

#### Documentation
Bug fix release note.