### PR TITLE
Feature/unr 1961 disable serverqbi in offloading

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -435,8 +435,23 @@ void USpatialSender::CreateServerWorkerEntity(int AttemptCounter)
 	ComponentWriteAcl.Add(SpatialConstants::INTEREST_COMPONENT_ID, WorkerIdPermission);
 
 	QueryConstraint Constraint;
-	// Ensure server worker receives the GSM entity
-	Constraint.EntityIdConstraint = SpatialConstants::INITIAL_GLOBAL_STATE_MANAGER_ENTITY_ID;
+
+	const USpatialGDKSettings* SpatialGDKSettings = GetDefault<USpatialGDKSettings>();
+	if (SpatialGDKSettings->bEnableServerQBI && SpatialGDKSettings->bEnableOffloading)
+	{
+		UE_LOG(LogSpatialSender, Warning, TEXT("For performance reasons, it's recommended to disable server QBI when using offloading"));
+	}
+
+	if (!SpatialGDKSettings->bEnableServerQBI && SpatialGDKSettings->bEnableOffloading)
+	{
+		// In offloading scenarios, hijack the server worker entity to ensure each server has interest in all entities
+		Constraint.ComponentConstraint = SpatialConstants::POSITION_COMPONENT_ID;
+	}
+	else
+	{
+		// Ensure server worker receives the GSM entity
+		Constraint.EntityIdConstraint = SpatialConstants::INITIAL_GLOBAL_STATE_MANAGER_ENTITY_ID;
+	}
 
 	Query Query;
 	Query.Constraint = Constraint;

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -112,6 +112,40 @@ Worker_ComponentUpdate InterestFactory::CreateInterestUpdate() const
 	return CreateInterest().CreateInterestUpdate();
 }
 
+Interest InterestFactory::CreateServerWorkerInterest()
+{
+	QueryConstraint Constraint;
+
+	const USpatialGDKSettings* SpatialGDKSettings = GetDefault<USpatialGDKSettings>();
+	if (SpatialGDKSettings->bEnableServerQBI && SpatialGDKSettings->bEnableOffloading)
+	{
+		UE_LOG(LogInterestFactory, Warning, TEXT("For performance reasons, it's recommended to disable server QBI when using offloading"));
+	}
+
+	if (!SpatialGDKSettings->bEnableServerQBI && SpatialGDKSettings->bEnableOffloading)
+	{
+		// In offloading scenarios, hijack the server worker entity to ensure each server has interest in all entities
+		Constraint.ComponentConstraint = SpatialConstants::POSITION_COMPONENT_ID;
+	}
+	else
+	{
+		// Ensure server worker receives the GSM entity
+		Constraint.EntityIdConstraint = SpatialConstants::INITIAL_GLOBAL_STATE_MANAGER_ENTITY_ID;
+	}
+
+	Query Query;
+	Query.Constraint = Constraint;
+	Query.FullSnapshotResult = true;
+
+	ComponentInterest Queries;
+	Queries.Queries.Add(Query);
+
+	Interest ServerInterest;
+	ServerInterest.ComponentInterestMap.Add(SpatialConstants::POSITION_COMPONENT_ID, Queries);
+
+	return ServerInterest;
+}
+
 Interest InterestFactory::CreateInterest() const
 {
 	if (!GetDefault<USpatialGDKSettings>()->bUsingQBI)

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/InterestFactory.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/InterestFactory.h
@@ -26,6 +26,8 @@ public:
 	Worker_ComponentData CreateInterestData() const;
 	Worker_ComponentUpdate CreateInterestUpdate() const;
 
+	static Interest CreateServerWorkerInterest();
+
 private:
 	Interest CreateInterest() const;
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -438,7 +438,7 @@ bool FSpatialGDKEditorToolbarModule::ValidateGeneratedLaunchConfig() const
 			return (Section.Rows * Section.Columns) > 1;
 		}))
 	{
-		const EAppReturnType::Type Result = FMessageDialog::Open(EAppMsgType::YesNo, FText::FromString(TEXT("Property handover is disabled and multiple launch servers are specified.\nThis is not supported.\n\nDo you want to configure your project settings now?")));
+		const EAppReturnType::Type Result = FMessageDialog::Open(EAppMsgType::YesNo, FText::FromString(TEXT("Property handover is disabled and a zoned deployment is specified.\nThis is not supported.\n\nDo you want to configure your project settings now?")));
 
 		if (Result == EAppReturnType::Yes)
 		{


### PR DESCRIPTION
#### Description
When serverQBI is switched off, servers in offloaded deployments will have interest in all entities in a deployment.

#### Release note
Feature: When serverQBI is switched off, servers in offloaded deployments will have interest in all entities in a deployment.

#### Tests
Ran a local offloaded scenario and validated that my offloaded worker had interest in non-authoritative entities using the inspector.

#### Primary reviewers
@samiwh @aleximprobable 