### PR TITLE
Check for entity in view before erroring in create response

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -903,7 +903,7 @@ void USpatialActorChannel::OnCreateEntityResponse(const Worker_CreateEntityRespo
 		}
 #if !UE_BUILD_SHIPPING
 		// Commands can timeout locally, but still be processed by the runtime. When this occurs, our follow up `CreateEntityRequest` will be
-		// superfluous, as the entity will already be created. If we detect that the entity is already in our view, reduce the message serverity 
+		// superfluous, as the entity will already be created. If we detect that the entity is already in our view, reduce the message severity
 		else if (NetDriver->StaticComponentView->GetComponentData<SpatialGDK::Position>(GetEntityId()) == nullptr)
 		{
 			UE_LOG(LogSpatialActorChannel, Error, TEXT("Failed to create entity for actor %s: Reason: %s"), *Actor->GetName(), UTF8_TO_TCHAR(Op.message));

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -203,7 +203,7 @@ void USpatialActorChannel::UpdateShadowData()
 {
 	check(Actor);
 
-	// If this channel was responsible for creating the channel, we do not want to initialize our shadow data
+	// If this channel was responsible for creating the actor, we do not want to initialize our shadow data
 	// to the latest state since there could have been state that has changed between creation of the entity
 	// and gaining of authority. Revisit this with UNR-1034
 	// TODO: UNR-1029 - log when the shadow data differs from the current state of the Actor.
@@ -351,8 +351,7 @@ int64 USpatialActorChannel::ReplicateActor()
 
 	// Epic does this at the net driver level, per connection. See UNetDriver::ServerReplicateActors().
 	// However, we have many player controllers sharing one connection, so we do it at the actor level before replication.
-	APlayerController* PlayerController = Cast<APlayerController>(Actor);
-	if (PlayerController)
+	if (APlayerController* PlayerController = Cast<APlayerController>(Actor))
 	{
 		PlayerController->SendClientAdjustment();
 	}
@@ -421,6 +420,7 @@ int64 USpatialActorChannel::ReplicateActor()
 			Actor->ReplicateSubobjects(this, &Bunch, &RepFlags);
 
 			Sender->SendCreateEntityRequest(this);
+			bCreatedEntity = true;
 
 			// Since we've tried to create this Actor in Spatial, we no longer have authority over the actor since it hasn't been delegated to us.
 			Actor->Role = ROLE_SimulatedProxy;
@@ -896,21 +896,27 @@ void USpatialActorChannel::OnCreateEntityResponse(const Worker_CreateEntityRespo
 
 	if (Op.status_code != WORKER_STATUS_CODE_SUCCESS)
 	{
-		// UNR-630 - Temporary hack to avoid failure to create entities due to timeout on large maps
 		if (Op.status_code == WORKER_STATUS_CODE_TIMEOUT)
 		{
 			UE_LOG(LogSpatialActorChannel, Warning, TEXT("Failed to create entity for actor %s Reason: %s. Retrying..."), *Actor->GetName(), UTF8_TO_TCHAR(Op.message));
 			Sender->SendCreateEntityRequest(this);
 		}
-		else
+#if !UE_BUILD_SHIPPING
+		// Commands can timeout locally, but still be processed by the runtime. When this occurs, our follow up `CreateEntityRequest` will be
+		// superfluous, as the entity will already be created. If we detect that the entity is already in our view, reduce the message serverity 
+		else if (NetDriver->StaticComponentView->GetComponentData<SpatialGDK::Position>(GetEntityId()) == nullptr)
 		{
 			UE_LOG(LogSpatialActorChannel, Error, TEXT("Failed to create entity for actor %s: Reason: %s"), *Actor->GetName(), UTF8_TO_TCHAR(Op.message));
 		}
+		else
+		{
+			UE_LOG(LogSpatialActorChannel, Verbose, TEXT("Failed to create entity for actor %s, entity already in view : Reason: %s"), *Actor->GetName(), UTF8_TO_TCHAR(Op.message));
+		}
+#endif // !UE_BUILD_SHIPPING
 
 		return;
 	}
 
-	bCreatedEntity = true;
 	UE_LOG(LogSpatialActorChannel, Verbose, TEXT("Created entity (%lld) for: %s."), Op.entity_id, *Actor->GetName());
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -177,7 +177,7 @@ private:
 	void UpdateEntityACLToNewOwner();
 
 public:
-	// If this actor channel is responsible for creating a new entity, this will be set to true once the entity is created.
+	// If this actor channel is responsible for creating a new entity, this will be set to true once the entity creation request is issued.
 	bool bCreatedEntity;
 
 	// If this actor channel is responsible for creating a new entity, this will be set to true during initial replication.


### PR DESCRIPTION
#### Description
Entity creations can timeout locally, and still be processed by the runtime. In these instances, we get an error when our follow up entity creation command fails. Attempt to detect this scenario and suppress error. Also moved the bCreatedEntity set value to a path that's sure to be caught in the same scenario.

#### Release note
Bugfix: Additional create entity requests don't erroneous error

#### Primary reviewers
@cmsmithio @improbable-valentyn 