### PR TITLE
Note that InstallGDK always checks out release.

### DIFF
--- a/SpatialGDK/Documentation/content/get-started/build-unreal-fork.md
+++ b/SpatialGDK/Documentation/content/get-started/build-unreal-fork.md
@@ -50,18 +50,21 @@ To do this:
 To build the Unreal Engine fork: 
 
 1. Run **Setup.bat**, found in the root directory of your clone of Unreal Engine.
-2. In the same directory, double-click **GenerateProjectFiles.bat**. This file automatically sets up the project files required to build Unreal Engine.<br/>
-3. Double-click **InstallGDK.bat**
+1. In the same directory, double-click **GenerateProjectFiles.bat**. This file automatically sets up the project files required to build Unreal Engine.<br/>
+1. Double-click **InstallGDK.bat**
 This automatically opens a command line window and performs the following:
-	* Clones the UnrealGDK into your Engine's `Plugins` directory
+	* Clones the [UnrealGDK](https://github.com/spatialos/UnrealGDK) into your Engine's `Plugins` directory
 	* Clones the [UnrealGDKExampleProject](https://github.com/spatialos/UnrealGDKExampleProject) into your Engine's `Samples` directory
 	* Runs the Unreal GDK `Setup.bat` script to install the GDK into the cloned `UnrealGDKExampleProject` directory
 	* Generates Visual Studio solution files for the `UnrealGDKExampleProject`<br/>
 This process can take a long time to complete. The command line window closes when the process has finished.    <br/>
+
+	> **TIP:** **InstallGDK.bat** clones the `release` branches of [UnrealGDK](https://github.com/spatialos/UnrealGDK) & [UnrealGDKExampleProject](https://github.com/spatialos/UnrealGDKExampleProject), ensuring compatibility with the `x.yy-SpatialOSUnrealGDK-release` branch of the the Unreal Engine fork that you cloned in [step 2](#step-2-clone-the-unreal-engine-fork-repository).
+
 1. In the same directory, open **UE4.sln** in Visual Studio.
-2. In Visual Studio, on the toolbar, navigate to **Build** > **Configuration Manager**; set your active solution configuration to **Development Editor** and your active solution platform to **Win64**.
-3. In the Solution Explorer window, right-click on the **UE4** project and select **Set as StartUp Project**
-4. In the Solution Explorer window, right-click on the **UE4** project and select **Build** (you may be prompted to install some dependencies first). <br>
+1. In Visual Studio, on the toolbar, navigate to **Build** > **Configuration Manager**; set your active solution configuration to **Development Editor** and your active solution platform to **Win64**.
+1. In the Solution Explorer window, right-click on the **UE4** project and select **Set as StartUp Project**
+1. In the Solution Explorer window, right-click on the **UE4** project and select **Build** (you may be prompted to install some dependencies first). <br>
 
 Visual Studio then builds Unreal Engine, which can take up to a couple of hours.
 

--- a/SpatialGDK/Documentation/content/glossary.md
+++ b/SpatialGDK/Documentation/content/glossary.md
@@ -20,12 +20,12 @@ Note that this SpatialOS documentation assumes you are developing a SpatialOS ga
 ## GDK for Unreal terms
 
 ### Actor groups
-Actor groups facilitate multiserver functionality through [offloading](#offloading). You set them up to configure which Actor types instances of a [server-worker type](#worker-types-and-instances) have [authority](#authority) over. In the Unreal Editor, you can create Actor groups, assign Actor classes to a group, and then assign each group to a server-worker type via the SpatialOS Runtime Settings panel.
+Actor groups facilitate multiserver functionality through [offloading](#offloading). You set them up to configure which Actor types instances of a [server-worker type](#worker-types-and-worker-instances) have [authority](#authority) over. In the Unreal Editor, you can create Actor groups, assign Actor classes to a group, and then assign each group to a server-worker type via the SpatialOS Runtime Settings panel.
 
 > **Find out more:**
 > 
 > * [Actor groups]({{urlRoot}}/content/workers/offloading-concept#actor-groups)
-> * [The SpatialOS Runtime Settings panel]({{urlRoot/}}content/unreal-editor-interface/runtime-settings)
+> * [The SpatialOS Runtime Settings panel]({{urlRoot}}/content/unreal-editor-interface/runtime-settings)
 > * [Offloading overview]({{urlRoot}}/content/workers/offloading-concept)
 
 ### Actor handover

--- a/SpatialGDK/Documentation/content/pricing-and-support/versioning-scheme.md
+++ b/SpatialGDK/Documentation/content/pricing-and-support/versioning-scheme.md
@@ -67,7 +67,7 @@ In summary:
 
 ### Unreal Engine fork branches
 
-The [Unreal Engine fork](https://github.com/improbableio/UnrealEngine) follows the versioning and branches pattern described above, but the branch names have `X.XX-SpatialOSUnrealGDK` following prepended to them (where `X.XX` is the Unreal Engine version of the fork.)
+The [Unreal Engine fork](https://github.com/improbableio/UnrealEngine) follows the versioning and branching pattern described above, but the branch names are prefixed with `x.yy-SpatialOSUnrealGDK-` following pre to them (where `x.yy` is the Unreal Engine version that was forked.)
 
 For example:
 
@@ -75,6 +75,8 @@ For example:
 *   ``4.22-SpatialOSUnrealGDK-preview``
 
 when Unreal Engine 4.22 is the version supported.
+
+> **TIP:** The **InstallGDK.bat** script used in [Get and build the GDK's Unreal Engine fork]({{urlRoot}}//content/get-started/build-unreal-fork#step-4-build-the-unreal-engine-fork) clones the `release` branches of [UnrealGDK](https://github.com/spatialos/UnrealGDK) & [UnrealGDKExampleProject](https://github.com/spatialos/UnrealGDKExampleProject), ensuring compatibility with the `x.yy-SpatialOSUnrealGDK-release` branch of the the Unreal Engine fork that you cloned during the [setup process]({{urlRoot}}//content/get-started/build-unreal-fork#step-4-build-the-unreal-engine-fork#step-2-clone-the-unreal-engine-fork-repository). If you choose to develop using the `preview` branch, or to checkout a `git tag` of a specific version, you must `git checkout` the corresponding version in all three of these repositories to ensure compatibility.
 
 ## Unreal Engine version support
 


### PR DESCRIPTION
#### Description
* This change notes that `InstallGDK.bat` is not git branch aware, meaning that it always checks out the `release` versions of `UnrealGDK` and `UnrealGDKExampleProject`, even if you're on `preview` or an old release tag.
* I also drive by fixed some broken links that had entered the codebased because we don't yet automatically lint docs pre-merge.

#### Release note
None

#### Tests
Rendered and linted.