### PR TITLE
Update the BuildKite agent selection labels

### DIFF
--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -7,11 +7,14 @@ agent_transients: &agent_transients
 
 common: &common
   agents:
+    - "agent_count=1"
     - "capable_of_building=gdk-for-unreal"
     - "environment=production"
+    - "machine_type=quad"  # this name matches to SpatialOS node-size names
     - "platform=windows"
     - "permission_set=builder"
-    - "queue=v2-1551960839-2fc9bbe6e15deffd-------z"
+    - "scaler_version=2"
+    - "queue=${CI_WINDOWS_BUILDER_QUEUE:-v3-1562267374-ab36457a07f081fe-------z}"
   retry:
     automatic:
       - <<: *agent_transients


### PR DESCRIPTION
The pre-merge jobs on docs PRs are hanging because they aren't assigned an agent, this is because of the recent migration to scaler v2. The change I've made is to bring `docs-release` inline with `release`.