### PR TITLE
No longer register actors which are singletons and also stably named

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1700,7 +1700,7 @@ void USpatialReceiver::ResolvePendingOperations_Internal(UObject* Object, const 
 	UE_LOG(LogSpatialReceiver, Verbose, TEXT("Resolving pending object refs and RPCs which depend on object: %s %s."), *Object->GetName(), *ObjectRef.ToString());
 
 	ResolveIncomingOperations(Object, ObjectRef);
-	if (Object->GetClass()->HasAnySpatialClassFlags(SPATIALCLASS_Singleton))
+	if (Object->GetClass()->HasAnySpatialClassFlags(SPATIALCLASS_Singleton) && !Object->IsFullNameStableForNetworking())
 	{
 		// When resolving a singleton, also resolve using class path (in case any properties
 		// were set from a server that hasn't resolved the singleton yet)


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Fixes an issue where we try to register the level actor twice as it's both a singleton and a stably named actor.
This was triggering a checkfslow in `FSpatialNetGUIDCache::RegisterObjectRef` when running in debug

#### Release note
Bugfix: No longer register level actors twice in the GUIDCache.

#### Tests
Had consistent repro on registering level actors twice when booting to any map. Post fix the level actor is only registered once.

How can this be verified by QA?: Boot into a debug build of any map and the checkf at `FSpatialNetGUIDCache::RegisterObjectRef` does not trigger.

#### Primary reviewers
@improbable-valentyn @m-samiec 