### PR TITLE
UNR-1937 - BuildProject.bat filepaths for engine and project plugin

### DIFF
--- a/SpatialGDK/Documentation/content/cloud-deployment-workflow.md
+++ b/SpatialGDK/Documentation/content/cloud-deployment-workflow.md
@@ -12,9 +12,17 @@ You may find the following command-line snippets useful as reference:
 
 ### Build server-worker assembly
 
+Engine plugin filepath (default):</br>
 ```
-Game\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat <YourProject>Server Linux Development <YourProject>.uproject
+UnrealEngine\Engine\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat <YourProject>Server Linux Development <YourProject>.uproject
 ```
+</br>
+
+Project plugin filepath:</br>
+```
+<YourProject>\Game\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat <YourProject>Server Linux Development <YourProject>.uproject
+```
+</br></br>
 
 Replacing `<YourProject>` with the name of your Unreal project. 
 
@@ -22,9 +30,17 @@ For more information on the available options when using `BuildWorker.bat`, plea
 
 ### Build client-worker assembly
 
+Engine plugin filepath (default):</br>
 ```
-Game\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat <YourProject> Win64 Development <YourProject>.uproject
+UnrealEngine\Engine\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat <YourProject> Win64 Development <YourProject>.uproject
 ```
+<br/>
+
+Project plugin filepath:</br>
+```
+<YourProject>\Game\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat <YourProject> Win64 Development <YourProject>.uproject
+```
+<br/><br/>
 
 Replacing `<YourProject>` with the name of your Unreal project.
 
@@ -50,19 +66,19 @@ You can launch a cloud deployment using the Unreal Editor or the SpatialOS CLI. 
     This opens the cloud deployment dialog box.
     <%(Lightbox title ="Cloud Deployment" image="{{assetRoot}}assets/screen-grabs/cloud-deploy.png")%>
     <br/>_Image: The Cloud Deployment settings dialog box_<br/>
-1. Enter your project name. This will be something like `beta_someword_anotherword_000`, and you can find it in the Console.
-1. In the **Assembly Name** field, enter the name you gave your assembly.
-1. In the **Deployment Name** field, enter a name for your deployment. This labels the deployment in the [Console]({{urlRoot}}/content/glossary#console).
-1. Leave the Snapshot File field as it is. In the **Launch Config File** field, enter the path to the launch configuration file for this deployment (including the file name).
-1. (Optional) If needed, change the **Region**.
-1. (Optional) Create an additional deployment with [simulated players]({{urlRoot}}/content/simulated-players) that connect to your main game deployment. Simulated players are game clients running in the cloud, mimicking real players of your game from a connection flow and server-worker load perspective. This means they’re useful for scale testing. 
+2. Enter your project name. This will be something like `beta_someword_anotherword_000`, and you can find it in the Console.
+3. In the **Assembly Name** field, enter the name you gave your assembly.
+4. In the **Deployment Name** field, enter a name for your deployment. This labels the deployment in the [Console]({{urlRoot}}/content/glossary#console).
+5. Leave the Snapshot File field as it is. In the **Launch Config File** field, enter the path to the launch configuration file for this deployment (including the file name).
+6. (Optional) If needed, change the **Region**.
+7. (Optional) Create an additional deployment with [simulated players]({{urlRoot}}/content/simulated-players) that connect to your main game deployment. Simulated players are game clients running in the cloud, mimicking real players of your game from a connection flow and server-worker load perspective. This means they’re useful for scale testing. 
 
     To create an additional deployment with simulated players, in the **Simulated Players** section:
 	1. Check the box next to **Add simulated players**.
-	1. In the **Deployment Name** field, enter enter a name for your simulated player  deployment. This labels the deployment in the [Console]({{urlRoot}}/content/glossary#console).
-	1. In the **Number of Simulated Players** field, choose the number of simulated players you want to start. 
-	1. (Optional) If needed, change the **Region**.
-1. Click **Launch Deployment**.
+	2. In the **Deployment Name** field, enter enter a name for your simulated player  deployment. This labels the deployment in the [Console]({{urlRoot}}/content/glossary#console).
+	3. In the **Number of Simulated Players** field, choose the number of simulated players you want to start. 
+	4. (Optional) If needed, change the **Region**.
+8. Click **Launch Deployment**.
 
 Your deployment(s) won’t launch instantly. A console window is displayed where you can see their progress.
 

--- a/SpatialGDK/Documentation/content/cloud-deployment-workflow.md
+++ b/SpatialGDK/Documentation/content/cloud-deployment-workflow.md
@@ -12,17 +12,17 @@ You may find the following command-line snippets useful as reference:
 
 ### Build server-worker assembly
 
+The filepath you use depends on whether you have the `UnrealGDK` plugin set up as an *engine* plugin or as a *project* plugin. If you followed the default setup instructions which use the `InstallGDK.bat` script, you have it set up as an *engine* plugin.
+
 Engine plugin filepath (default):</br>
 ```
 UnrealEngine\Engine\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat <YourProject>Server Linux Development <YourProject>.uproject
 ```
-</br>
 
 Project plugin filepath:</br>
 ```
 <YourProject>\Game\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat <YourProject>Server Linux Development <YourProject>.uproject
 ```
-</br></br>
 
 Replacing `<YourProject>` with the name of your Unreal project. 
 
@@ -30,17 +30,17 @@ For more information on the available options when using `BuildWorker.bat`, plea
 
 ### Build client-worker assembly
 
+The filepath you use depends on whether you have the `UnrealGDK` plugin set up as an *engine* plugin or as a *project* plugin. If you followed the default setup instructions which use the `InstallGDK.bat` script, you have it set up as an *engine* plugin.
+
 Engine plugin filepath (default):</br>
 ```
 UnrealEngine\Engine\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat <YourProject> Win64 Development <YourProject>.uproject
 ```
-<br/>
 
 Project plugin filepath:</br>
 ```
 <YourProject>\Game\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat <YourProject> Win64 Development <YourProject>.uproject
 ```
-<br/><br/>
 
 Replacing `<YourProject>` with the name of your Unreal project.
 

--- a/SpatialGDK/Documentation/content/get-started/example-project/exampleproject-cloud-deployment.md
+++ b/SpatialGDK/Documentation/content/get-started/example-project/exampleproject-cloud-deployment.md
@@ -60,8 +60,8 @@ There are two ways to build workers, and you can choose which one to use. You ne
   When you use this script with no flags, it automatically builds both the server-workers and client-workers to run your game in the cloud. It then compresses your workers and saves them as .zip files to the `<ProjectRoot>\spatial\build\assembly\worker` directory, ready to upload. Use the script with no flags if you want to build server-workers and client-workers at the same time.<br/></br>
   To do this: </br>
     1. Close your Unreal Editor - if the Editor is open when you try to build workers, the command fails.
-    2. In File Explorer, navigate to the `UnrealGDKExampleProject` directory.
-    2. Double-click `BuildProject.bat`. </br>
+    1. In File Explorer, navigate to the `UnrealGDKExampleProject` directory.
+    1. Double-click `BuildProject.bat`. </br>
        This opens a command line window and automatically builds your client-workers and server-workers.
 </br></br>
 Problems building workers? See the [Troubleshooting](#troubleshooting) guide below.
@@ -73,28 +73,28 @@ During development, you might want to, for example:</br> * cook a headless stand
 <%(/Expandable)%>
 For now, you need to build server-workers and client-workers, so if you haven't run `BuildProject.bat` from File Explorer you need to:</br></br>
     1. Close your Unreal Editor - if the Editor is open when you try to build workers, the command fails.
-    2. Open a terminal window and navigate to the `UnrealGDKExampleProject` directory.
-    3. Run the `BuildProject.bat` command to build a server-worker using the filepath and flags below. </br>
-    The filepath you use depends on whether you used auto-install or manual-install when you cloned and set up the GDK's fork and plugin. <br/></br>
-        * Auto-install filepath:</br>
+    1. Open a terminal window and navigate to the `UnrealGDKExampleProject` directory.
+    1. Run the `BuildProject.bat` command to build a server-worker using the filepath and flags below. </br>
+    The filepath you use depends on whether you have the `UnrealGDK` plugin set up as an *engine* plugin or as a *project* plugin. If you followed the default setup instructions which use the `InstallGDK.bat` script, you have it set up as an *engine* plugin. <br/></br>
+        * Engine plugin filepath (default):</br>
         ```
-        Game\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat GDKShooterServer Linux Development GDKShooter.uproject
+        UnrealEngine\Engine\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat GDKShooterServer Linux Development GDKShooter.uproject
         ```
         </br>
-        * Manual-install filepath:</br>
+        * Project plugin filepath:</br>
         ```
-        Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat GDKShooterServer Linux Development GDKShooter.uproject
+        UnrealGDKExampleProject\Game\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat GDKShooterServer Linux Development GDKShooter.uproject
         ```
         </br></br>
-    4. Now run the `BuildProject.bat` command to build a client-worker: <br/><br/>
-        * Auto-install filepath:</br>
+    1. Now run the `BuildProject.bat` command to build a client-worker: <br/><br/>
+        * Engine plugin filepath (default):</br>
         ```
-        Game\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat GDKShooter Win64 Development GDKShooter.uproject
+        UnrealEngine\Engine\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat GDKShooter Win64 Development GDKShooter.uproject
         ```
         <br/>
-        * Manual-install filepath:</br>
+        * Project plugin filepath:</br>
         ```
-        Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat GDKShooter Win64 Development GDKShooter.uproject
+         UnrealGDKExampleProject\Game\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat GDKShooter Win64 Development GDKShooter.uproject
         ```
         <br/><br/>
 

--- a/SpatialGDK/Documentation/content/get-started/example-project/exampleproject-local-deployment.md
+++ b/SpatialGDK/Documentation/content/get-started/example-project/exampleproject-local-deployment.md
@@ -78,7 +78,7 @@ To launch a local deployment in your Unreal Editor, set up the networking and ru
 1. From the Editor toolbar, open the **Play** drop-down menu:</br></br>
     ![Multiplayer Options]({{assetRoot}}assets/set-up-template/template-multiplayer-options.png))<br/>
    _Image: The Unreal Editor toolbar's **Play** drop-down menu, with the relevant options hightlighted_</br></br>
-2. To set up the networking:</br>
+1. To set up the networking:</br>
 In the **Multiplayer Options** section of the window:</br>
  * enter the number of players as `2`,</br>
  * check the **Run Dedicated Server** setting and</br>
@@ -87,7 +87,7 @@ In the **Multiplayer Options** section of the window:</br>
 The **Spatial Networking** option is the networking switch; you use this to switch your game's deployment from native Unreal networking to SpatialOS networking.</br></br>
 
 
-3. Now, run the game: in the **Modes** section of the window, select **New Editor Window (PIE)**.</br> 
+1. Now, run the game: in the **Modes** section of the window, select **New Editor Window (PIE)**.</br> 
 You are now running one game server and two game clients in a local deployment in your Unreal Editor. (If it doesn't run, see **Note** below.)</br>
 
 **What's running?**</br>
@@ -118,7 +118,7 @@ You can find out more about the Inspector and the Console in the [Glossary]({{ur
     ![]({{assetRoot}}assets/set-up-template/template-two-client-inspector.png)<br/>
     _Image: The Inspector on the SpatialOS Console_
 </br></br>
-2. When you’re done, select **Stop** on the Unreal toolbar to stop the client.
+1. When you’re done, select **Stop** on the Unreal toolbar to stop the client.
 
     ![]({{assetRoot}}assets/toolbar/stop-button-native.png)<br/>
     _Image: Unreal toolbar's **Stop** button_</br></br>
@@ -140,7 +140,7 @@ To do this:
 
     If you haven't modified anything related to replication, you don't need to regenerate schema and SpatialOS continues to use the running deployment. </br></br>
 
-2. To test your changes, select **Play** on the Unreal toolbar; this starts your game's clients and server-worker instances.
+1. To test your changes, select **Play** on the Unreal toolbar; this starts your game's clients and server-worker instances.
 
 <%(#Expandable title="Locak deployment workflow summary")%>
 There is a sumary on the [Local deployment workflow]({{urlRoot}}/content/local-deployment-workflow) page. It is the same as the one here.

--- a/SpatialGDK/Documentation/content/get-started/starter-template/get-started-template-cloud.md
+++ b/SpatialGDK/Documentation/content/get-started/starter-template/get-started-template-cloud.md
@@ -76,28 +76,28 @@ During development, you might want to, for example:</br> * cook a headless stand
 <%(/Expandable)%>
 For now, you need to build server-workers and client-workers, so if you haven't run `BuildProject.bat` from File Explorer you need to:</br>
   1. Close your Unreal Editor - if the Editor is open when you try to build workers, the command fails.
-  2. Open a terminal window and navigate to the `<ProjectRoot>` directory.
-  3. Run the `BuildProject.bat` command to build a server-worker using the filepath and flags below. </br>
-  The filepath you use depends on whether you used auto-install or manual-install when you cloned and set up the GDK's fork and plugin. <br/><br/>
-      * Auto-install filepath:</br>
+  1. Open a terminal window and navigate to the `<ProjectRoot>` directory.
+  1. Run the `BuildProject.bat` command to build a server-worker using the filepath and flags below. </br>
+  The filepath you use depends on whether you have the `UnrealGDK` plugin set up as an *engine* plugin or as a *project* plugin. If you followed the default setup instructions which use the `InstallGDK.bat` script, you have it set up as an *engine* plugin. <br/></br>
+      * Engine plugin filepath (default):</br>
       ```
-      Game\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat YourProjectServer Linux Development YourProject.uproject
+      UnrealEngine\Engine\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat <YourProject>Server Linux Development <YourProject>.uproject
       ```
       </br>
-      * Manual-install filepath:</br>
+      * Project plugin filepath:</br>
       ```
-      Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat YourProjectServer Linux Development YourProject.uproject
+      <YourProject>\Game\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat <YourProject>Server Linux Development <YourProject>.uproject
       ```
       </br></br>
-  4. Now run the `BuildProject.bat` command to build a client-worker: <br/></br>
-      * Auto-install filepath:</br>
+  1. Now run the `BuildProject.bat` command to build a client-worker: <br/><br/>
+      * Engine plugin filepath (default):</br>
       ```
-      Game\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat <YourProject> Win64 Development <YourProject>.uproject
+      UnrealEngine\Engine\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat <YourProject> Win64 Development <YourProject>.uproject
       ```
       <br/>
-      * Manual-install filepath:</br>
+      * Project plugin filepath:</br>
       ```
-      Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat <YourProject> Win64 Development <YourProject>.uproject
+        <YourProject>\Game\Plugins\UnrealGDK\SpatialGDK\Build\Scripts\BuildWorker.bat <YourProject> Win64 Development <YourProject>.uproject
       ```
       <br/><br/>
 


### PR DESCRIPTION
This explains to users going through the Template and Example Project Cloud Deployment guide how to use BuildProject.bat based on whether they have a project or engine plugin.

The Cloud Deployment Workflows page is also updated to reflect both options (engine and project plugin) as that was missed out (feedback raised by Tom Looman [here](https://docs.google.com/document/d/1kx02Jw1GdGQpMWgwaMKChvoxPpCnh4rqFBI7e9e-4ik/edit))

Tested with improbadoc

