### PR TITLE
UNR-1993 Worker Metrics Delegate

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialDispatcher.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialDispatcher.cpp
@@ -9,23 +9,15 @@
 #include "Interop/SpatialWorkerFlags.h"
 #include "UObject/UObjectIterator.h"
 #include "Utils/OpUtils.h"
+#include "Utils/SpatialMetrics.h"
 
 
 DEFINE_LOG_CATEGORY(LogSpatialView);
-
-void USpatialDispatcher::WorkerMetricsTestDelegate(Worker_MetricsOp Op)
-{
-	UE_LOG(LogSpatialView, Display, TEXT("METRIIICCSSS"));
-}
 
 void USpatialDispatcher::Init(USpatialNetDriver* InNetDriver)
 {
 	NetDriver = InNetDriver;
 	Receiver = InNetDriver->Receiver;
-	WorkerMetricsRecievedDelegate.AddLambda([this](Worker_MetricsOp Op)
-	{
-		WorkerMetricsTestDelegate(Op);
-	});
 	StaticComponentView = InNetDriver->StaticComponentView;
 }
 
@@ -111,13 +103,7 @@ void USpatialDispatcher::ProcessOps(Worker_OpList* OpList)
 			UE_LOG(LogSpatialView, Log, TEXT("SpatialOS Worker Log: %s"), UTF8_TO_TCHAR(Op->log_message.message));
 			break;
 		case WORKER_OP_TYPE_METRICS:
-			// Majority of metrics are gauge metrics and it appears there are also histogram metrics. Let's print them all for now.
-			// TODO: We want to turn this delegate into key and value rather than Op.
-			UE_LOG(LogSpatialView, Display, TEXT("SpatialOS Metrics"));
-			if (WorkerMetricsRecievedDelegate.IsBound())
-			{
-				WorkerMetricsRecievedDelegate.Broadcast(Op->metrics);
-			}
+			HandleWorkerMetrics(Op);
 			break;
 		case WORKER_OP_TYPE_DISCONNECT:
 			Receiver->OnDisconnect(Op->disconnect);
@@ -131,7 +117,29 @@ void USpatialDispatcher::ProcessOps(Worker_OpList* OpList)
 	Receiver->FlushRemoveComponentOps();
 	Receiver->FlushRetryRPCs();
 }
- 
+
+void USpatialDispatcher::HandleWorkerMetrics(Worker_Op* Op)
+{
+	UE_LOG(LogSpatialView, Display, TEXT("SpatialOS Metrics"));
+	if (NetDriver->SpatialMetrics->WorkerMetricsRecieved.IsBound())
+	{
+		int32 NumMetrics = Op->metrics.metrics.gauge_metric_count;
+
+		if (NumMetrics > 0)
+		{
+			// Construct a map to store all the metrics and pass it to the users delegate
+			TMap<FString, double> WorkerMetrics;
+
+			for (int32 i = 0; i < NumMetrics; i++)
+			{
+				WorkerMetrics.Add(Op->metrics.metrics.gauge_metrics[i].key, Op->metrics.metrics.gauge_metrics[i].value);
+			}
+
+			NetDriver->SpatialMetrics->WorkerMetricsRecieved.Broadcast(WorkerMetrics);
+		}
+	}
+}
+
 bool USpatialDispatcher::IsExternalSchemaOp(Worker_Op* Op) const
 {
 	Worker_ComponentId ComponentId = SpatialGDK::GetComponentId(Op);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialDispatcher.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialDispatcher.cpp
@@ -103,7 +103,9 @@ void USpatialDispatcher::ProcessOps(Worker_OpList* OpList)
 			UE_LOG(LogSpatialView, Log, TEXT("SpatialOS Worker Log: %s"), UTF8_TO_TCHAR(Op->log_message.message));
 			break;
 		case WORKER_OP_TYPE_METRICS:
+#if !UE_BUILD_SHIPPING
 			NetDriver->SpatialMetrics->HandleWorkerMetrics(Op);
+#endif
 			break;
 		case WORKER_OP_TYPE_DISCONNECT:
 			Receiver->OnDisconnect(Op->disconnect);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialDispatcher.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialDispatcher.cpp
@@ -120,7 +120,6 @@ void USpatialDispatcher::ProcessOps(Worker_OpList* OpList)
 
 void USpatialDispatcher::HandleWorkerMetrics(Worker_Op* Op)
 {
-	UE_LOG(LogSpatialView, Display, TEXT("SpatialOS Metrics"));
 	if (NetDriver->SpatialMetrics->WorkerMetricsRecieved.IsBound())
 	{
 		int32 NumMetrics = Op->metrics.metrics.gauge_metric_count;

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialDispatcher.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialDispatcher.cpp
@@ -103,7 +103,7 @@ void USpatialDispatcher::ProcessOps(Worker_OpList* OpList)
 			UE_LOG(LogSpatialView, Log, TEXT("SpatialOS Worker Log: %s"), UTF8_TO_TCHAR(Op->log_message.message));
 			break;
 		case WORKER_OP_TYPE_METRICS:
-			HandleWorkerMetrics(Op);
+			NetDriver->SpatialMetrics->HandleWorkerMetrics(Op);
 			break;
 		case WORKER_OP_TYPE_DISCONNECT:
 			Receiver->OnDisconnect(Op->disconnect);
@@ -116,27 +116,6 @@ void USpatialDispatcher::ProcessOps(Worker_OpList* OpList)
 
 	Receiver->FlushRemoveComponentOps();
 	Receiver->FlushRetryRPCs();
-}
-
-void USpatialDispatcher::HandleWorkerMetrics(Worker_Op* Op)
-{
-	if (NetDriver->SpatialMetrics->WorkerMetricsRecieved.IsBound())
-	{
-		int32 NumMetrics = Op->metrics.metrics.gauge_metric_count;
-
-		if (NumMetrics > 0)
-		{
-			// Construct a map to store all the metrics and pass it to the users delegate
-			TMap<FString, double> WorkerMetrics;
-
-			for (int32 i = 0; i < NumMetrics; i++)
-			{
-				WorkerMetrics.Add(Op->metrics.metrics.gauge_metrics[i].key, Op->metrics.metrics.gauge_metrics[i].value);
-			}
-
-			NetDriver->SpatialMetrics->WorkerMetricsRecieved.Broadcast(WorkerMetrics);
-		}
-	}
 }
 
 bool USpatialDispatcher::IsExternalSchemaOp(Worker_Op* Op) const

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialDispatcher.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialDispatcher.cpp
@@ -13,10 +13,19 @@
 
 DEFINE_LOG_CATEGORY(LogSpatialView);
 
+void USpatialDispatcher::WorkerMetricsTestDelegate(Worker_MetricsOp Op)
+{
+	UE_LOG(LogSpatialView, Display, TEXT("METRIIICCSSS"));
+}
+
 void USpatialDispatcher::Init(USpatialNetDriver* InNetDriver)
 {
 	NetDriver = InNetDriver;
 	Receiver = InNetDriver->Receiver;
+	WorkerMetricsRecievedDelegate.AddLambda([this](Worker_MetricsOp Op)
+	{
+		WorkerMetricsTestDelegate(Op);
+	});
 	StaticComponentView = InNetDriver->StaticComponentView;
 }
 
@@ -102,8 +111,14 @@ void USpatialDispatcher::ProcessOps(Worker_OpList* OpList)
 			UE_LOG(LogSpatialView, Log, TEXT("SpatialOS Worker Log: %s"), UTF8_TO_TCHAR(Op->log_message.message));
 			break;
 		case WORKER_OP_TYPE_METRICS:
+			// Majority of metrics are gauge metrics and it appears there are also histogram metrics. Let's print them all for now.
+			// TODO: We want to turn this delegate into key and value rather than Op.
+			UE_LOG(LogSpatialView, Display, TEXT("SpatialOS Metrics"));
+			if (WorkerMetricsRecievedDelegate.IsBound())
+			{
+				WorkerMetricsRecievedDelegate.Broadcast(Op->metrics);
+			}
 			break;
-
 		case WORKER_OP_TYPE_DISCONNECT:
 			Receiver->OnDisconnect(Op->disconnect);
 			break;
@@ -116,7 +131,7 @@ void USpatialDispatcher::ProcessOps(Worker_OpList* OpList)
 	Receiver->FlushRemoveComponentOps();
 	Receiver->FlushRetryRPCs();
 }
-
+ 
 bool USpatialDispatcher::IsExternalSchemaOp(Worker_Op* Op) const
 {
 	Worker_ComponentId ComponentId = SpatialGDK::GetComponentId(Op);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1700,7 +1700,7 @@ void USpatialReceiver::ResolvePendingOperations_Internal(UObject* Object, const 
 	UE_LOG(LogSpatialReceiver, Verbose, TEXT("Resolving pending object refs and RPCs which depend on object: %s %s."), *Object->GetName(), *ObjectRef.ToString());
 
 	ResolveIncomingOperations(Object, ObjectRef);
-	if (Object->GetClass()->HasAnySpatialClassFlags(SPATIALCLASS_Singleton))
+	if (Object->GetClass()->HasAnySpatialClassFlags(SPATIALCLASS_Singleton) && !Object->IsFullNameStableForNetworking())
 	{
 		// When resolving a singleton, also resolve using class path (in case any properties
 		// were set from a server that hasn't resolved the singleton yet)

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetrics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetrics.cpp
@@ -24,11 +24,6 @@ void USpatialMetrics::Init(USpatialNetDriver* InNetDriver)
 
 	bRPCTrackingEnabled = false;
 	RPCTrackingStartTime = 0.0f;
-
-	WorkerMetricsRecievedDelegate.AddLambda([this](TMap<FString, double> WorkerMetrics)
-	{
-		WorkerMetricsTestDelegate(WorkerMetrics);
-	});
 }
 
 void USpatialMetrics::TickMetrics()
@@ -293,12 +288,4 @@ void USpatialMetrics::TrackSentRPC(UFunction* Function, ESchemaComponentType RPC
 	RPCStat& Stat = RecentRPCs[FunctionName];
 	Stat.Calls++;
 	Stat.TotalPayload += PayloadSize;
-}
-
-void USpatialMetrics::WorkerMetricsTestDelegate(TMap<FString, double> WorkerMetrics)
-{
-	for (auto& WorkerMetric : WorkerMetrics)
-	{
-		UE_LOG(LogSpatialMetrics, Display, TEXT("Key: %s - Value: %f"), *WorkerMetric.Key, WorkerMetric.Value);
-	}
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetrics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetrics.cpp
@@ -289,3 +289,25 @@ void USpatialMetrics::TrackSentRPC(UFunction* Function, ESchemaComponentType RPC
 	Stat.Calls++;
 	Stat.TotalPayload += PayloadSize;
 }
+
+void USpatialMetrics::HandleWorkerMetrics(Worker_Op* Op)
+{
+	if (WorkerMetricsRecieved.IsBound())
+	{
+		int32 NumMetrics = Op->metrics.metrics.gauge_metric_count;
+
+		if (NumMetrics > 0)
+		{
+			// Construct a map to store all the metrics and pass it to the users delegate
+			TMap<FString, double> WorkerMetrics;
+			WorkerMetrics.Reserve(NumMetrics);
+
+			for (int32 i = 0; i < NumMetrics; i++)
+			{
+				WorkerMetrics.Add(Op->metrics.metrics.gauge_metrics[i].key, Op->metrics.metrics.gauge_metrics[i].value);
+			}
+
+			WorkerMetricsRecieved.Broadcast(WorkerMetrics);
+		}
+	}
+}

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetrics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetrics.cpp
@@ -24,6 +24,11 @@ void USpatialMetrics::Init(USpatialNetDriver* InNetDriver)
 
 	bRPCTrackingEnabled = false;
 	RPCTrackingStartTime = 0.0f;
+
+	WorkerMetricsRecievedDelegate.AddLambda([this](TMap<FString, double> WorkerMetrics)
+	{
+		WorkerMetricsTestDelegate(WorkerMetrics);
+	});
 }
 
 void USpatialMetrics::TickMetrics()
@@ -288,4 +293,12 @@ void USpatialMetrics::TrackSentRPC(UFunction* Function, ESchemaComponentType RPC
 	RPCStat& Stat = RecentRPCs[FunctionName];
 	Stat.Calls++;
 	Stat.TotalPayload += PayloadSize;
+}
+
+void USpatialMetrics::WorkerMetricsTestDelegate(TMap<FString, double> WorkerMetrics)
+{
+	for (auto& WorkerMetric : WorkerMetrics)
+	{
+		UE_LOG(LogSpatialMetrics, Display, TEXT("Key: %s - Value: %f"), *WorkerMetric.Key, WorkerMetric.Value);
+	}
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialDispatcher.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialDispatcher.h
@@ -31,7 +31,7 @@ public:
 
 	void Init(USpatialNetDriver* NetDriver);
 	void ProcessOps(Worker_OpList* OpList);
-	void HandleWorkerMetrics(Worker_Op* Op);
+
 	// The following 2 methods should *only* be used by the Startup OpList Queueing flow
 	// from the SpatialNetDriver, and should be temporary since an alternative solution will be available via the Worker SDK soon.
 	void MarkOpToSkip(const Worker_Op* Op);

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialDispatcher.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialDispatcher.h
@@ -29,6 +29,7 @@ class SPATIALGDK_API USpatialDispatcher : public UObject
 public:
 	using FCallbackId = uint32;
 
+	void WorkerMetricsTestDelegate(Worker_MetricsOp Op);
 	void Init(USpatialNetDriver* NetDriver);
 	void ProcessOps(Worker_OpList* OpList);
 	// The following 2 methods should *only* be used by the Startup OpList Queueing flow
@@ -46,6 +47,10 @@ public:
 	FCallbackId OnCommandRequest(Worker_ComponentId ComponentId, const TFunction<void(const Worker_CommandRequestOp&)>& Callback);
 	FCallbackId OnCommandResponse(Worker_ComponentId ComponentId, const TFunction<void(const Worker_CommandResponseOp&)>& Callback);
 	bool RemoveOpCallback(FCallbackId Id);
+
+	// The user can bind their own delegate to handle worker metrics.
+	DECLARE_MULTICAST_DELEGATE_OneParam(WorkerMetricsDelegate, Worker_MetricsOp)
+	WorkerMetricsDelegate WorkerMetricsRecievedDelegate;
 
 private:
 	struct UserOpCallbackData

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialDispatcher.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialDispatcher.h
@@ -29,9 +29,9 @@ class SPATIALGDK_API USpatialDispatcher : public UObject
 public:
 	using FCallbackId = uint32;
 
-	void WorkerMetricsTestDelegate(Worker_MetricsOp Op);
 	void Init(USpatialNetDriver* NetDriver);
 	void ProcessOps(Worker_OpList* OpList);
+	void HandleWorkerMetrics(Worker_Op* Op);
 	// The following 2 methods should *only* be used by the Startup OpList Queueing flow
 	// from the SpatialNetDriver, and should be temporary since an alternative solution will be available via the Worker SDK soon.
 	void MarkOpToSkip(const Worker_Op* Op);
@@ -47,10 +47,6 @@ public:
 	FCallbackId OnCommandRequest(Worker_ComponentId ComponentId, const TFunction<void(const Worker_CommandRequestOp&)>& Callback);
 	FCallbackId OnCommandResponse(Worker_ComponentId ComponentId, const TFunction<void(const Worker_CommandResponseOp&)>& Callback);
 	bool RemoveOpCallback(FCallbackId Id);
-
-	// The user can bind their own delegate to handle worker metrics.
-	DECLARE_MULTICAST_DELEGATE_OneParam(WorkerMetricsDelegate, Worker_MetricsOp)
-	WorkerMetricsDelegate WorkerMetricsRecievedDelegate;
 
 private:
 	struct UserOpCallbackData

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetrics.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetrics.h
@@ -46,8 +46,6 @@ public:
 
 	void TrackSentRPC(UFunction* Function, ESchemaComponentType RPCType, int PayloadSize);
 
-	void WorkerMetricsTestDelegate(TMap<FString, double> WorkerMetrics);
-
 	// The user can bind their own delegate to handle worker metrics.
 	typedef TMap<FString, double> WorkerMetrics;
 	DECLARE_MULTICAST_DELEGATE_OneParam(WorkerMetricsDelegate, WorkerMetrics)

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetrics.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetrics.h
@@ -46,6 +46,8 @@ public:
 
 	void TrackSentRPC(UFunction* Function, ESchemaComponentType RPCType, int PayloadSize);
 
+	void HandleWorkerMetrics(Worker_Op* Op);
+
 	// The user can bind their own delegate to handle worker metrics.
 	typedef TMap<FString, double> WorkerMetrics;
 	DECLARE_MULTICAST_DELEGATE_OneParam(WorkerMetricsDelegate, WorkerMetrics)

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetrics.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetrics.h
@@ -46,6 +46,13 @@ public:
 
 	void TrackSentRPC(UFunction* Function, ESchemaComponentType RPCType, int PayloadSize);
 
+	void WorkerMetricsTestDelegate(TMap<FString, double> WorkerMetrics);
+
+	// The user can bind their own delegate to handle worker metrics.
+	typedef TMap<FString, double> WorkerMetrics;
+	DECLARE_MULTICAST_DELEGATE_OneParam(WorkerMetricsDelegate, WorkerMetrics)
+	WorkerMetricsDelegate WorkerMetricsRecieved;
+
 private:
 	UPROPERTY()
 	USpatialNetDriver* NetDriver;


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Added a simple multicast delegate that users can bind to in `SpatialMetrics` when a Worker Metrics Op is received. 

#### Release note
Feature: Added a delegate to `SpatialMetrics` which triggers when worker metrics have been received.

#### Tests
Printed the result of the map passed to the delegate and it works.

#### Primary reviewers
@m-samiec 	@mattyoung-improbable 	