### PR TITLE
Actor Replication Net Relevancy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Visual Studio 2019 is now supported.
 - Added toolbar and commandlet options to delete the schema database.
 - Added a check for schema and snapshot before attempting to start a local deployment. If either are missing then an error message will be displayed.
-- Added optional net relevancy check in replication prioritization. If enabled, an actor will only be replicated if at least one player controller falls within its net view cull distance or if the actor is set to be always relevant
+- Added optional net relevancy check in replication prioritization. If enabled, an actor will only be replicated if IsNetRelevantFor is true for one of the connected client's views.
 
 ### Bug fixes:
 - Fixed an issue that could cause multiple Channels to be created for an Actor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Visual Studio 2019 is now supported.
 - Added toolbar and commandlet options to delete the schema database.
 - Added a check for schema and snapshot before attempting to start a local deployment. If either are missing then an error message will be displayed.
+- Added optional net relevancy check in replication prioritization. If enabled, an actor will only be replicated if at least one player controller falls within its net view cull distance or if the actor is set to be always relevant
 
 ### Bug fixes:
 - Fixed an issue that could cause multiple Channels to be created for an Actor.

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -691,18 +691,16 @@ void USpatialNetDriver::OnOwnerUpdated(AActor* Actor)
 // Returns true if this actor should replicate to *any* of the passed in connections
 static FORCEINLINE_DEBUGGABLE bool IsActorRelevantToConnection(const AActor* Actor, UActorChannel* ActorChannel, const TArray<FNetViewer>& ConnectionViewers)
 {
-	// If an actor is set to be always relevant, no need to evaluate connection relevancy.
-	// An actor without a channel yet will need to be replicated at least once to have an
-	// actor channel and entity created for it
-	if (Actor->bAlwaysRelevant || ActorChannel == nullptr)
+	// An actor without a channel yet will need to be replicated at least
+	// once to have a channel and entity created for it
+	if (ActorChannel == nullptr)
 	{
 		return true;
 	}
 
-	for (auto viewer : ConnectionViewers)
+	for (const auto& Viewer : ConnectionViewers)
 	{
-		// Do a net relevancy check for Actor in net view cull distance for viewer
-		if (Actor->IsNetRelevantFor(viewer.InViewer, viewer.ViewTarget, viewer.ViewLocation))
+		if (Actor->IsNetRelevantFor(Viewer.InViewer, Viewer.ViewTarget, Viewer.ViewLocation))
 		{
 			return true;
 		}
@@ -842,8 +840,7 @@ int32 USpatialNetDriver::ServerReplicateActors_PrioritizeActors(UNetConnection* 
 
 			UE_LOG(LogSpatialOSNetDriver, Verbose, TEXT("Actor %s will be replicated on the catch-all connection"), *Actor->GetName());
 
-			// If Net Relevancy is enabled in the GDK settings, the actors relevancy
-			// for replication is determined by distance from each player controllers in game
+			// Check actor relevancy if Net Relevancy is enabled in the GDK settings
 			if (bNetRelevancyEnabled && !IsActorRelevantToConnection(Actor, Channel, ConnectionViewers))
 			{
 				// If not relevant (and we don't have a channel), skip

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -843,7 +843,7 @@ int32 USpatialNetDriver::ServerReplicateActors_PrioritizeActors(UNetConnection* 
 			// Check actor relevancy if Net Relevancy is enabled in the GDK settings
 			if (bNetRelevancyEnabled && !IsActorRelevantToConnection(Actor, Channel, ConnectionViewers))
 			{
-				// If not relevant (and we don't have a channel), skip
+				// Early out and do not replicate if actor is not relevant
 				continue;
 			}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -817,7 +817,7 @@ int32 USpatialNetDriver::ServerReplicateActors_PrioritizeActors(UNetConnection* 
 		AGameNetworkManager* const NetworkManager = World->NetworkManager;
 		const bool bLowNetBandwidth = NetworkManager ? NetworkManager->IsInLowBandwidthMode() : false;
 
-		const bool bNetRelevancy = GetDefault<USpatialGDKSettings>()->UseIsActorRelevantForConnection;
+		const bool bNetRelevancyEnabled = GetDefault<USpatialGDKSettings>()->UseIsActorRelevantForConnection;
 
 		for (FNetworkObjectInfo* ActorInfo : ConsiderList)
 		{
@@ -842,10 +842,9 @@ int32 USpatialNetDriver::ServerReplicateActors_PrioritizeActors(UNetConnection* 
 
 			UE_LOG(LogSpatialOSNetDriver, Verbose, TEXT("Actor %s will be replicated on the catch-all connection"), *Actor->GetName());
 
-			// SpatialGDK: Here, Unreal does initial relevancy checking and level load checking.
-			// We have removed the level load check because it doesn't apply.
-			// Relevancy checking is also mostly just a pass through, might be removed later.
-			if (bNetRelevancy && !IsActorRelevantToConnection(Actor, Channel, ConnectionViewers))
+			// If Net Relevancy is enabled in the GDK settings, the actors relevancy
+			// for replication is determined by distance from each player controllers in game
+			if (bNetRelevancyEnabled && !IsActorRelevantToConnection(Actor, Channel, ConnectionViewers))
 			{
 				// If not relevant (and we don't have a channel), skip
 				continue;

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -19,6 +19,7 @@ USpatialGDKSettings::USpatialGDKSettings(const FObjectInitializer& ObjectInitial
 	, HeartbeatTimeoutSeconds(10.0f)
 	, ActorReplicationRateLimit(0)
 	, EntityCreationRateLimit(0)
+	, UseIsActorRelevantForConnection(false)
 	, OpsUpdateRate(1000.0f)
 	, bEnableHandover(true)
 	, MaxNetCullDistanceSquared(900000000.0f) // Set to twice the default Actor NetCullDistanceSquared (300m)

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -50,7 +50,7 @@ void GatherClientInterestDistances()
 		}
 
 		const AActor* IteratedDefaultActor = Cast<AActor>(It->GetDefaultObject());
-		if (IteratedDefaultActor->NetCullDistanceSquared != DefaultDistanceSquared)
+		if (IteratedDefaultActor->NetCullDistanceSquared > DefaultDistanceSquared)
 		{
 			float ActorNetCullDistanceSquared = IteratedDefaultActor->NetCullDistanceSquared;
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -50,7 +50,7 @@ void GatherClientInterestDistances()
 		}
 
 		const AActor* IteratedDefaultActor = Cast<AActor>(It->GetDefaultObject());
-		if (IteratedDefaultActor->NetCullDistanceSquared > DefaultDistanceSquared)
+		if (IteratedDefaultActor->NetCullDistanceSquared != DefaultDistanceSquared)
 		{
 			float ActorNetCullDistanceSquared = IteratedDefaultActor->NetCullDistanceSquared;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -73,6 +73,13 @@ public:
 	uint32 EntityCreationRateLimit;
 
 	/**
+	 * When enabled only entities which are in the net relevancy range of player controllers will be replicated to SpatialOS.
+	 * This should only be used in single server configurations. The state of the world in the inspector will no longer be up to date.
+	 */
+	UPROPERTY(EditAnywhere, config, Category = "Replication", meta = (ConfigRestartRequired = false, DisplayName = "Only Replicate Net Relevant Actors"))
+	bool UseIsActorRelevantForConnection;
+
+	/**
 	* Specifies the rate, in number of times per second, at which server-worker instance updates are sent to and received from the SpatialOS Runtime.
 	* Default:1000/s
 	*/

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -73,7 +73,7 @@ public:
 	uint32 EntityCreationRateLimit;
 
 	/**
-	 * When enabled only entities which are in the net relevancy range of player controllers will be replicated to SpatialOS.
+	 * When enabled, only entities which are in the net relevancy range of player controllers will be replicated to SpatialOS.
 	 * This should only be used in single server configurations. The state of the world in the inspector will no longer be up to date.
 	 */
 	UPROPERTY(EditAnywhere, config, Category = "Replication", meta = (ConfigRestartRequired = false, DisplayName = "Only Replicate Net Relevant Actors"))


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Add net relevancy check to replicating actors. When prioritizing actors for replication, the position of each actor is checked against the NetViewCullDistance of each player controller present in the game. If the actor is not withing these ranges or is not bAlwaysRelevant, it will no longer be replicated.

#### Tests
Tested this branch and master branch in a large scale game with Unreal performance stat capturing enabled to diff and performance gain.

#### Primary reviewers
@m-samiec @improbable-valentyn 