### PR TITLE
UNR-2094 Remove shootergame reference (it's on 4.20)

### DIFF
--- a/SpatialGDK/Documentation/content/tutorials/tutorial-porting-guide.md
+++ b/SpatialGDK/Documentation/content/tutorials/tutorial-porting-guide.md
@@ -30,4 +30,6 @@ Before porting your project you _**must**_ follow:
 
 <br/>
 
-<br/>------------<br/>2019-07-16 Page updated with editorial review.<br/>
+<br/>------------<br/>
+2019-09-17 Page updated without editorial review - removal of ShooterGame reference.<br/>
+2019-07-16 Page updated with editorial review.<br/>

--- a/SpatialGDK/Documentation/content/tutorials/tutorial-porting-guide.md
+++ b/SpatialGDK/Documentation/content/tutorials/tutorial-porting-guide.md
@@ -10,11 +10,6 @@ This guide shows you how to port your own Unreal project to the GDK; you will mo
 We recommend following steps 1 to 3 of the [Get started]({{urlRoot}}/content/get-started/introduction) guide and setting up the [Example Project]({{urlRoot}}/content/get-started/example-project/exampleproject-intro) before porting your project. This gives you an overview of the GDK and using SpatialOS.
 <br/>
 
-**Tip: Reference project**
-<br/>
- As you port your own Unreal project to SpatialOS, you could use our pre-ported [Unreal Shooter Game](https://docs.unrealengine.com/en-us/Resources/SampleGames/ShooterGame) as a reference. You should already have this project as it is included in the `Samples` directory of [the SpatialOS Unreal Engine fork](https://github.com/improbableio/UnrealEngine) which you downloaded as part of the _Get started_ steps. </br>
-(If you want to see the game running, there's a [video on youtube](https://www.youtube.com/watch?v=xojgH7hJgQs&feature=youtu.be) to check out.)
-
 ## **Terms used in this guide**
 
 - `<GameRoot>` - The directory containing your project's `.uproject` file and `Source` directory.  

--- a/SpatialGDK/Documentation/content/tutorials/tutorial-porting-guide.md
+++ b/SpatialGDK/Documentation/content/tutorials/tutorial-porting-guide.md
@@ -31,5 +31,5 @@ Before porting your project you _**must**_ follow:
 <br/>
 
 <br/>------------<br/>
-2019-09-17 Page updated without editorial review - removal of ShooterGame reference.<br/>
-2019-07-16 Page updated with editorial review.<br/>
+*2019-09-17 Page updated without editorial review - removal of ShooterGame reference.*<br/>
+*2019-07-16 Page updated with editorial review.*<br/>


### PR DESCRIPTION
The shootergame reference project is on 4.20 so no longer valid now that users default to 4.22

This PR removes the docs mention of it. We also need to remove it from the fork UNR-2094