### PR TITLE
Destroy SpatialWorkerConnection when destroying the NetDriver to be able to disconnect from SpatialOS

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
@@ -74,9 +74,12 @@ void USpatialGameInstance::CreateNewSpatialWorkerConnection()
 
 void USpatialGameInstance::DestroySpatialWorkerConnection()
 {
-	SpatialConnection->DestroyConnection();
-	SpatialConnection->ConditionalBeginDestroy();
-	SpatialConnection = nullptr;
+	if (SpatialConnection != nullptr)
+	{
+		SpatialConnection->DestroyConnection();
+		SpatialConnection->ConditionalBeginDestroy();
+		SpatialConnection = nullptr;
+	}
 }
 
 #if WITH_EDITOR

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
@@ -72,6 +72,13 @@ void USpatialGameInstance::CreateNewSpatialWorkerConnection()
 	SpatialConnection->Init(this);
 }
 
+void USpatialGameInstance::DestroySpatialWorkerConnection()
+{
+	SpatialConnection->DestroyConnection();
+	SpatialConnection->ConditionalBeginDestroy();
+	SpatialConnection = nullptr;
+}
+
 #if WITH_EDITOR
 FGameInstancePIEResult USpatialGameInstance::StartPlayInEditorGameInstance(ULocalPlayer* LocalPlayer, const FGameInstancePIEParameters& Params)
 {

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
@@ -77,7 +77,6 @@ void USpatialGameInstance::DestroySpatialWorkerConnection()
 	if (SpatialConnection != nullptr)
 	{
 		SpatialConnection->DestroyConnection();
-		SpatialConnection->ConditionalBeginDestroy();
 		SpatialConnection = nullptr;
 	}
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -574,7 +574,7 @@ void USpatialNetDriver::BeginDestroy()
 		// Destroy the connection to disconnect from SpatialOS if we aren't meant to persist it.
 		if (!bPersistSpatialConnection)
 		{
-			Connection->DestroyConnection();
+			Cast<USpatialGameInstance>(GetWorld()->GetGameInstance())->DestroySpatialWorkerConnection();
 			Connection = nullptr;
 		}
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -563,10 +563,21 @@ void USpatialNetDriver::BeginDestroy()
 {
 	Super::BeginDestroy();
 
-	// If we are still connected, cleanup our corresponding worker entity if it exists.
+	// If we are still connected...
 	if (Connection != nullptr && WorkerEntityId != SpatialConstants::INVALID_ENTITY_ID)
 	{
-		Connection->SendDeleteEntityRequest(WorkerEntityId);
+		// cleanup our corresponding worker entity if it exists.
+		if (WorkerEntityId != SpatialConstants::INVALID_ENTITY_ID)
+		{
+			Connection->SendDeleteEntityRequest(WorkerEntityId);
+		}
+		
+		// destroy the connection to disconnect from SpatialOS if we aren't meant to persist it.
+		if (!bPersistSpatialConnection)
+		{
+			Connection->DestroyConnection();
+			Connection = nullptr;
+		}
 	}
 
 #if WITH_EDITOR

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -563,16 +563,15 @@ void USpatialNetDriver::BeginDestroy()
 {
 	Super::BeginDestroy();
 
-	// If we are still connected...
-	if (Connection != nullptr && WorkerEntityId != SpatialConstants::INVALID_ENTITY_ID)
+	if (Connection != nullptr)
 	{
-		// cleanup our corresponding worker entity if it exists.
+		// Cleanup our corresponding worker entity if it exists.
 		if (WorkerEntityId != SpatialConstants::INVALID_ENTITY_ID)
 		{
 			Connection->SendDeleteEntityRequest(WorkerEntityId);
 		}
 		
-		// destroy the connection to disconnect from SpatialOS if we aren't meant to persist it.
+		// Destroy the connection to disconnect from SpatialOS if we aren't meant to persist it.
 		if (!bPersistSpatialConnection)
 		{
 			Connection->DestroyConnection();

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -195,10 +195,7 @@ void USpatialNetDriver::InitiateConnectionToSpatialOS(const FURL& URL)
 	if (!bPersistSpatialConnection)
 	{
 		// Destroy the old connection
-		if (USpatialWorkerConnection* OldConnection = GameInstance->GetSpatialWorkerConnection())
-		{
-			OldConnection->DestroyConnection();
-		}
+		GameInstance->DestroySpatialWorkerConnection();
 
 		// Create a new SpatialWorkerConnection in the SpatialGameInstance.
 		GameInstance->CreateNewSpatialWorkerConnection();

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialGameInstance.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialGameInstance.h
@@ -35,6 +35,9 @@ public:
 	// The SpatialWorkerConnection must always be owned by the SpatialGameInstance and so must be created here to prevent TrimMemory from deleting it during Browse.
 	void CreateNewSpatialWorkerConnection();
 
+	// Destroying the SpatialWorkerConnection disconnects us from SpatialOS.
+	void DestroySpatialWorkerConnection();
+
 	FORCEINLINE USpatialWorkerConnection* GetSpatialWorkerConnection() { return SpatialConnection; }
 
 	void HandleOnConnected();


### PR DESCRIPTION
Previously, there was no way to disconnect from SpatialOS as a client once you've connected to it. We now destroy the SpatialWorkerConnection when destroying the NetDriver if we don't persist it.