### PR TITLE
CI: correct triggered pipeline name

### DIFF
--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -39,7 +39,7 @@ steps:
       - "UnrealEngine/Engine/Programs/AutomationTool/Saved/Logs/*"
 
   # Trigger an Example Project build for any merges into master, preview or release branches of UnrealGDK
-  - trigger: "unrealgdkthirdpersonshooter-nightly"
+  - trigger: "unrealgdkexampleproject-nightly"
     label: "Post merge Example Project build"
     branches: "master preview release"
     async: true


### PR DESCRIPTION
Changing to trigger the Example Project not the Third Person Shooter build as a postmerge into master, preview or release branches.

Related ticket: UNR-2019

#### Description
Describe your changes here.

#### Release note
No need, it's a BuildKite fix.

#### Tests
No need, it's a BuildKite fix.