### PR TITLE
Docs - fix the manual install flow

### DIFF
--- a/SpatialGDK/Documentation/content/get-started/build-unreal-fork.md
+++ b/SpatialGDK/Documentation/content/get-started/build-unreal-fork.md
@@ -71,21 +71,21 @@ In File Explorer, navigate to the root directory of your clone of the SpatialOS 
 In the same directory, double-click **GenerateProjectFiles.bat**.
 
 ### Step 5: Clone and install the plugin
-You need to clone the SpatialOS GDK plugin and install it in the UE fork and Example Project directory. You can follow either auto-install or manual-install, we recommend the auto-install.
+You need to clone the SpatialOS GDK plugin and install it in the UE fork and Example Project directory. You can follow either auto-install or manual-install, we recommend the auto-install. 
 
-> **Tip:** Use auto-install as this makes setting up the Example Project and Starter Template quicker. You will be able to follow tutorials based on the Example Project more quickly. If you follow manual-install, you will need to take extra steps to set up the Example Project or Starer Template and follow tutorials.
+This method will reduce the number of manual steps you have to do to get set up, and will install up the GDK as an Engine plugin rather than a Project plugin. This means you won't have to clone the GDK for each new project you set up.
 
 * **Auto-install** (Recommended) </br>
-To do this:</br>
 Still in File Explorer, in the root directory of your clone of the SpatialOS Unreal Engine fork, double-click **InstallGDK.bat**. </br>
 This process opens a command line window and runs some scripts - it can take a long time to complete. The command line window closes when the process has finished.
 
 <%(#Expandable title="What does `InstallGDK.bat` do?")%>
 The script automatically opens a command line window and performs the following:
-	* Clones the UnrealGDK into your EU fork's `Plugins` directory.
-	* Clones the [Example Project (`UnrealGDKExampleProject`)](https://github.com/spatialos/UnrealGDKExampleProject) into your Engine's `Samples` directory.
-	* Runs the GDK `Setup.bat` script to install the plugin into the cloned `UnrealGDKExampleProject` directory.
-	* Generates Visual Studio solution files for the `UnrealGDKExampleProject`.<br/>
+
+* Clones the UnrealGDK into your EU fork's `Plugins` directory 
+* Clones the Example Project into your Engine's `Samples` directory.
+* Sets up the GDK for use with the Example Project by running `Setup.bat` 
+* Generates Visual Studio solution files for the `UnrealGDKExampleProject`.<br/>
 <%(/Expandable)%>
 
 * **Manual-install**</br>

--- a/SpatialGDK/Documentation/content/get-started/build-unreal-fork.md
+++ b/SpatialGDK/Documentation/content/get-started/build-unreal-fork.md
@@ -117,6 +117,7 @@ Use as a base for creating your own project running on SpatialOS.
 <br/>
 
 </br>------</br>
-_2019-08-12 Page updated with editorial review: teminology and page formatting._</br>
+_2019-09-27 Page updated without editorial review: clearer explanation of the auto-install flow._</br>
+_2019-08-12 Page updated with editorial review: terminology and page formatting._</br>
 _2019-08-08 Page updated with editorial review: added clarification on SSH key and Linux dependencies._</br>
 _2019-05-30 Page updated with editorial review._

--- a/SpatialGDK/Documentation/content/get-started/build-unreal-fork.md
+++ b/SpatialGDK/Documentation/content/get-started/build-unreal-fork.md
@@ -82,7 +82,7 @@ This process opens a command line window and runs some scripts - it can take a l
 <%(#Expandable title="What does `InstallGDK.bat` do?")%>
 The script automatically opens a command line window and performs the following:
 
-* Clones the UnrealGDK into your EU fork's `Plugins` directory 
+* Clones the UnrealGDK into your UE fork's `Plugins` directory 
 * Clones the Example Project into your Engine's `Samples` directory.
 * Sets up the GDK for use with the Example Project by running `Setup.bat` 
 * Generates Visual Studio solution files for the `UnrealGDKExampleProject`.<br/>

--- a/SpatialGDK/Documentation/content/get-started/manual-engine-build.md
+++ b/SpatialGDK/Documentation/content/get-started/manual-engine-build.md
@@ -39,35 +39,17 @@ Visual Studio then builds Unreal Engine, which can take up to a couple of hours.
 
 You have now built Unreal Engine 4 with cross-compilation for Linux. 
 
-## Step 2: Clone and install the SpatialOS GDK for Unreal plugin
-
-You need to add the plugin to your project's plugins folder in order to use SpatialOS.
-
-To do this: 
-
-1. In File Explorer, navigate to the `<YourProject>\Game` directory and create a `Plugins` folder in this directory.
-1. In a terminal window, navigate to the `<YourProject>\Game\Plugins` directory and clone the [GDK for Unreal](https://github.com/spatialos/UnrealGDK) repository by running either:
-
-|  |  |
-| ----- | ---- |
-| HTTPS | `git clone https://github.com/spatialos/UnrealGDK.git` |
-| SSH | `git clone git@github.com:spatialos/UnrealGDK.git`|
-
-1. In File Explorer, navigate to the root directory of the GDK for Unreal repository (`<YourProject>\Game\Plugins\UnrealGDK\...`), and double-click `Setup.bat`. If you haven’t already signed into your SpatialOS account, the SpatialOS developer website may prompt you to sign in.
-
-When the build is complete, you can continue to _3 - Set up a project_.
-
-
 </br>
 #### **> Next:** 3 - Set up project
 
 Choose either:
 
-* [Set up the Example Project]({{urlRoot}}/content/get-started/example-project/exampleproject-intro) </br>
+* [Set up the Example Project]({{urlRoot}}/content/get-started/example-project/exampleproject-manual-setup) </br>
 The Example Project is a session-based FPS game. It gives an overview of the GDK and using SpatialOS, including deploying your game to SpatialOS locally and in the cloud.
-* [Set up the Starter Template]({{urlRoot}}/content/get-started/starter-template/get-started-template-intro) </br>
+* [Set up the Starter Template]({{urlRoot}}/content/get-started/starter-template/get-started-template-setup-manual) </br>
 Use as a base for creating your own project running on SpatialOS.
 
 </br>------</br>
+_2019-09-27 Page updated without editorial reivew: remove duplicate clone GDK instructions, link to correct project setup guides._</br>
 _2019-08-12 Page updated with editorial review: added to page orientation._
 

--- a/SpatialGDK/Documentation/content/get-started/starter-template/get-started-template-local.md
+++ b/SpatialGDK/Documentation/content/get-started/starter-template/get-started-template-local.md
@@ -94,7 +94,7 @@ You can switch between the two Editor windows to see and interact with each game
 **Note:** If the game does not run automatically after you have selected **New Editor Window (PIE)**, try selecting **Play** on the Editor toolbar. This should to start a local deployment and play the game.<br/><br/>
 
    ![]({{assetRoot}}assets/set-up-template/template-two-clients.png)<br/>
-   _Image: Two game clients running in Ubreal Editor_<br/></br>
+   _Image: Two game clients running in Unreal Editor_<br/></br>
 
 ### Step 3: Inspect and stop play
 


### PR DESCRIPTION
* Better explanation of auto-install
* Remove wrong GDK clone instruction https://docs.improbable.io/unreal/alpha/content/get-started/manual-engine-build#step-2-clone-and-install-the-spatialos-gdk-for-unreal-plugin - at this stage you don't yet have a project to set up so you can't clone the GDK into it
* Link to manual example/starter projects install guides from the manual install build 

Tested with improbadoc