### PR TITLE
Add breaking change entry for replicated subobjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Avoid generating schema for all UObject subclasses. Actor, ActorComponent, GameplayAbility subclasses are enabled by default, other classes can be enabled using SpatialType UCLASS specifier.
 - Added new experimental CookAndGenerateSchemaCommandlet that generates required schema during a regular cook.
 
+### Breaking Changes
+- If your project uses replicated subobjects that do not inherit from ActorComponent or GameplayAbility, you need to enable generating schema for them using SpatialType UCLASS specifier or by checking Spatial Type if it's a blueprint.
+
 ### Features:
 - Visual Studio 2019 is now supported.
 - Added toolbar and commandlet options to delete the schema database.


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Added a breaking change entry to CHANGELOG for replicated subobjects that don't inherit from ActorComponent or GameplayAbility.

#### Primary reviewers
@oblm @m-samiec 