### PR TITLE
Ensure that ActorInterestQueries specify a result type

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/ActorInterestComponent.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/ActorInterestComponent.cpp
@@ -20,7 +20,7 @@ void UActorInterestComponent::CreateQueries(const USpatialClassInfoManager& Clas
 		{
 			SpatialGDK::QueryConstraint ComponentConstraints;
 			QueryData.Constraint->CreateConstraint(ClassInfoManager, ComponentConstraints);
-		
+
 			NewQuery.Constraint.AndConstraint.Add(ComponentConstraints);
 			NewQuery.Constraint.AndConstraint.Add(AdditionalConstraints);
 		}
@@ -29,6 +29,7 @@ void UActorInterestComponent::CreateQueries(const USpatialClassInfoManager& Clas
 			QueryData.Constraint->CreateConstraint(ClassInfoManager, NewQuery.Constraint);
 		}
 		NewQuery.Frequency = QueryData.Frequency;
+		NewQuery.FullSnapshotResult = true;
 
 		if (NewQuery.Constraint.IsValid())
 		{


### PR DESCRIPTION
#### Description
Drive-by fix to ensure that queries created by the ActorInterestQueryComponent specify a result type. Fixes an issue in Edmonton prototype where queries weren't returning any result.

#### Primary reviewers
@m-samiec 