### PR TITLE
UNR-2025 Add a component to track Authority Interest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Avoid generating schema for all UObject subclasses. Actor, ActorComponent, GameplayAbility subclasses are enabled by default, other classes can be enabled using SpatialType UCLASS specifier.
 - Added new experimental CookAndGenerateSchemaCommandlet that generates required schema during a regular cook.
 - Added OverrideSpatialOffloading command line flag that allows toggling of offloading at launch time.
+- Added an AuthorityIntent component to be used in the future for UnrealGDK code to control loadbalancing.
 
 ### Breaking Changes:
 - If your project uses replicated subobjects that do not inherit from ActorComponent or GameplayAbility, you need to enable generating schema for them using SpatialType UCLASS specifier or by checking Spatial Type if it's a blueprint.
@@ -26,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - It is now possible to specify in Unreal which actors should not persist as entities in the Snapshot.
 - Deleted startup actors are now tracked
 - The GDK now uses SpatialOS `14.1.0`.
+- Added a user bindable delegate to SpatialMetrics which triggers when worker metrics have been received.
+- Local deployments now create a new log file known as 'launch.log' which will contain logs relating to starting and running a deployment. Additionally it will contain worker logs which are forwarded to the SpatialOS runtime.
+- Added a new setting to SpatialOS Runtime Settings 'Worker Log Level' which allows configuration of which verbosity of worker logs gets forwarded to the SpatialOS runtime.
+- Added a new developer tool called 'Spatial Output Log' which will show local deployment logs from the 'launch.log' file.
 
 ### Bug fixes:
 - Fixed a bug where the spatial daemon started even with spatial networking disabled.

--- a/SpatialGDK/Extras/schema/authority_intent.schema
+++ b/SpatialGDK/Extras/schema/authority_intent.schema
@@ -1,0 +1,9 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+package unreal;
+
+component AuthorityIntent {
+     id = 9980;
+     // Id assigned to the Unreal server worker which should be authoritative for this entity.
+     // 0 is reserved as an invalid/unset value.
+     uint32 virtual_worker_id = 1;
+}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialOutputDevice.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialOutputDevice.cpp
@@ -5,7 +5,7 @@
 #include "Interop/Connection/SpatialWorkerConnection.h"
 
 FSpatialOutputDevice::FSpatialOutputDevice(USpatialWorkerConnection* InConnection, FName LoggerName, int32 InPIEIndex)
-	: FilterLevel(ELogVerbosity::Warning)
+	: FilterLevel(ELogVerbosity::Type(GetDefault<USpatialGDKSettings>()->WorkerLogLevel.GetValue()))
 	, Connection(InConnection)
 	, WorkerName(LoggerName)
 	, PIEIndex(InPIEIndex)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -128,6 +128,7 @@ void USpatialReceiver::OnAddComponent(const Worker_AddComponentOp& Op)
 	case SpatialConstants::ALWAYS_RELEVANT_COMPONENT_ID:
 	case SpatialConstants::CLIENT_RPC_ENDPOINT_COMPONENT_ID:
 	case SpatialConstants::SERVER_RPC_ENDPOINT_COMPONENT_ID:
+	case SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID:
 		// Ignore static spatial components as they are managed by the SpatialStaticComponentView.
 		return;
 	case SpatialConstants::SINGLETON_MANAGER_COMPONENT_ID:
@@ -1106,6 +1107,9 @@ void USpatialReceiver::OnComponentUpdate(const Worker_ComponentUpdateOp& Op)
 	case SpatialConstants::NETMULTICAST_RPCS_COMPONENT_ID:
 		HandleRPC(Op);
 		return;
+	case SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID:
+		check(false); // TODO(zoning): Handle updates to the entity's authority intent.
+		break;
 	}
 
 	// If this entity has a Tombstone component, abort all component processing

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -14,6 +14,7 @@
 #include "Interop/SpatialDispatcher.h"
 #include "Interop/SpatialReceiver.h"
 #include "Schema/AlwaysRelevant.h"
+#include "Schema/AuthorityIntent.h"
 #include "Schema/ClientRPCEndpoint.h"
 #include "Schema/Heartbeat.h"
 #include "Schema/Interest.h"
@@ -125,6 +126,7 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 	ComponentWriteAcl.Add(SpatialConstants::NETMULTICAST_RPCS_COMPONENT_ID, AuthoritativeWorkerRequirementSet);
 	ComponentWriteAcl.Add(SpatialConstants::DORMANT_COMPONENT_ID, AuthoritativeWorkerRequirementSet);
 	ComponentWriteAcl.Add(SpatialConstants::CLIENT_RPC_ENDPOINT_COMPONENT_ID, OwningClientOnlyRequirementSet);
+	ComponentWriteAcl.Add(SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID, AuthoritativeWorkerRequirementSet);
 
 	if (Actor->IsNetStartupActor())
 	{
@@ -211,6 +213,8 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 	ComponentDatas.Add(Metadata(Class->GetName()).CreateMetadataData());
 	ComponentDatas.Add(SpawnData(Actor).CreateSpawnDataData());
 	ComponentDatas.Add(UnrealMetadata(StablyNamedObjectRef, ClientWorkerAttribute, Class->GetPathName(), bNetStartup).CreateUnrealMetadataData());
+	// TODO(zoning): For now, setting AuthorityIntent to 0, which is an invalid virutal worker ID.
+	ComponentDatas.Add(AuthorityIntent(0).CreateAuthorityIntentData());
 
 	if (!Class->HasAnySpatialClassFlags(SPATIALCLASS_NotPersistent))
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStaticComponentView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStaticComponentView.cpp
@@ -2,6 +2,7 @@
 
 #include "Interop/SpatialStaticComponentView.h"
 
+#include "Schema/AuthorityIntent.h"
 #include "Schema/ClientRPCEndpoint.h"
 #include "Schema/Component.h"
 #include "Schema/Heartbeat.h"
@@ -81,6 +82,9 @@ void USpatialStaticComponentView::OnAddComponent(const Worker_AddComponentOp& Op
 	case SpatialConstants::SERVER_RPC_ENDPOINT_COMPONENT_ID:
 		Data = MakeUnique<SpatialGDK::ComponentStorage<SpatialGDK::ServerRPCEndpoint>>(Op.data);
 		break;
+	case SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID:
+		Data = MakeUnique<SpatialGDK::ComponentStorage<SpatialGDK::AuthorityIntent>>(Op.data);
+		break;
 	default:
 		// Component is not hand written, but we still want to know the existence of it on this entity.
 		Data = nullptr;
@@ -119,6 +123,9 @@ void USpatialStaticComponentView::OnComponentUpdate(const Worker_ComponentUpdate
 		break;
 	case SpatialConstants::SERVER_RPC_ENDPOINT_COMPONENT_ID:
 		Component = GetComponentData<SpatialGDK::ServerRPCEndpoint>(Op.entity_id);
+		break;
+	case SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID:
+		Component = GetComponentData<SpatialGDK::AuthorityIntent>(Op.entity_id);
 		break;
 	default:
 		return;

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -39,6 +39,7 @@ USpatialGDKSettings::USpatialGDKSettings(const FObjectInitializer& ObjectInitial
 	, DefaultWorkerType(FWorkerType(SpatialConstants::DefaultServerWorkerType))
 	, bEnableOffloading(false)
 	, ServerWorkerTypes({ SpatialConstants::DefaultServerWorkerType })
+	, WorkerLogLevel(ESettingsWorkerLogVerbosity::Warning)
 {
 	DefaultReceptionistHost = SpatialConstants::LOCAL_HOST;
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/AuthorityIntent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/AuthorityIntent.h
@@ -1,0 +1,69 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "Schema/Component.h"
+#include "Utils/SchemaUtils.h"
+
+#include <WorkerSDK/improbable/c_schema.h>
+
+namespace SpatialGDK
+{
+
+// The AuthorityIntent component is a piece of the Zoning solution for the UnrealGDK. For each
+// entity in SpatialOS, Unreal will use the AuthorityIntent to indicate which Unreal server worker
+// should be authoritative for the entity. No Unreal worker should write to an entity if the
+// VirtualWorkerId set here doesn't match the worker's Id. 
+struct AuthorityIntent : Component
+{
+	static const Worker_ComponentId ComponentId = SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID;
+
+	AuthorityIntent() = default;
+
+	AuthorityIntent(uint32 InVirtualWorkerId)
+		: VirtualWorkerId(InVirtualWorkerId) {}
+
+	AuthorityIntent(const Worker_ComponentData& Data)
+	{
+		Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
+
+		VirtualWorkerId = Schema_GetUint32(ComponentObject, 1);
+	}
+
+	Worker_ComponentData CreateAuthorityIntentData()
+	{
+		Worker_ComponentData Data = {};
+		Data.component_id = ComponentId;
+		Data.schema_type = Schema_CreateComponentData();
+		Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
+
+		Schema_AddUint32(ComponentObject, 1, VirtualWorkerId);
+
+		return Data;
+	}
+
+	Worker_ComponentUpdate CreateAuthorityIntentUpdate()
+	{
+		Worker_ComponentUpdate Update = {};
+		Update.component_id = ComponentId;
+		Update.schema_type = Schema_CreateComponentUpdate();
+		Schema_Object* ComponentObject = Schema_GetComponentUpdateFields(Update.schema_type);
+
+		Schema_AddUint32(ComponentObject, 1, VirtualWorkerId);
+
+		return Update;
+	}
+
+	void ApplyComponentUpdate(const Worker_ComponentUpdate& Update)
+	{
+		Schema_Object* ComponentObject = Schema_GetComponentUpdateFields(Update.schema_type);
+		VirtualWorkerId = Schema_GetUint32(ComponentObject, 1);
+	}
+
+	// Id of the Unreal server worker which should be authoritative for the entity.
+	// 0 is reserved as an invalid/unset value.
+	uint32 VirtualWorkerId;
+};
+
+} // namespace SpatialGDK
+

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -116,6 +116,7 @@ namespace SpatialConstants
 	const Worker_ComponentId ALWAYS_RELEVANT_COMPONENT_ID					= 9983;
 	const Worker_ComponentId TOMBSTONE_COMPONENT_ID                         = 9982;
 	const Worker_ComponentId DORMANT_COMPONENT_ID							= 9981;
+	const Worker_ComponentId AUTHORITY_INTENT_COMPONENT_ID                  = 9980;
 
 	const Worker_ComponentId STARTING_GENERATED_COMPONENT_ID				= 10000;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -9,6 +9,24 @@
 
 #include "SpatialGDKSettings.generated.h"
 
+/**
+ * Enum that maps Unreal's log verbosity to allow use in settings.
+**/
+UENUM()
+namespace ESettingsWorkerLogVerbosity
+{
+	enum Type
+	{
+		Fatal = 1,
+		Error,
+		Warning,
+		Display,
+		Log,
+		Verbose,
+		VeryVerbose,
+	};
+}
+
 UCLASS(config = SpatialGDKSettings, defaultconfig)
 class SPATIALGDK_API USpatialGDKSettings : public UObject
 {
@@ -179,4 +197,8 @@ public:
 	/** Available server worker types. */
 	UPROPERTY(Config)
 	TSet<FName> ServerWorkerTypes;
+
+	/** Controls the verbosity of worker logs which are sent to SpatialOS. These logs will appear in the Spatial Output and launch.log */
+	UPROPERTY(EditAnywhere, config, Category = "Logging", meta = (ConfigRestartRequired = false, DisplayName = "Worker Log Level"))
+	TEnumAsByte<ESettingsWorkerLogVerbosity::Type> WorkerLogLevel;
 };

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -14,7 +14,7 @@
 
 DEFINE_LOG_CATEGORY(LogSpatialDeploymentManager);
 
-static const FString SpatialServiceVersion(TEXT("20190716.094149.1b6d448edd"));
+static const FString SpatialServiceVersion(TEXT("20190930.180414.3b04a59226"));
 
 FLocalDeploymentManager::FLocalDeploymentManager()
 	: bLocalDeploymentRunning(false)
@@ -303,6 +303,7 @@ bool FLocalDeploymentManager::TryStartSpatialService()
 	FString SpatialServiceStartArgs = FString::Printf(TEXT("service start --version=%s"), *SpatialServiceVersion);
 	FString ServiceStartResult;
 	int32 ExitCode;
+
 	FSpatialGDKServicesModule::ExecuteAndReadOutput(FSpatialGDKServicesModule::GetSpatialExe(), SpatialServiceStartArgs, FSpatialGDKServicesModule::GetSpatialOSDirectory(), ServiceStartResult, ExitCode);
 
 	bStartingSpatialService = false;
@@ -335,6 +336,7 @@ bool FLocalDeploymentManager::TryStopSpatialService()
 	FString SpatialServiceStartArgs = TEXT("service stop");
 	FString ServiceStopResult;
 	int32 ExitCode;
+
 	FSpatialGDKServicesModule::ExecuteAndReadOutput(FSpatialGDKServicesModule::GetSpatialExe(), SpatialServiceStartArgs, FSpatialGDKServicesModule::GetSpatialOSDirectory(), ServiceStopResult, ExitCode);
 	bStoppingSpatialService = false;
 

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SSpatialOutputLog.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SSpatialOutputLog.cpp
@@ -1,0 +1,288 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "SSpatialOutputLog.h"
+
+#include "Async/Async.h"
+#include "DirectoryWatcherModule.h"
+#include "Editor.h"
+#include "Misc/CoreDelegates.h"
+#include "Misc/FileHelper.h"
+#include "Modules/ModuleManager.h"
+#include "SlateOptMacros.h"
+#include "SpatialGDKServicesModule.h"
+
+#define LOCTEXT_NAMESPACE "SSpatialOutputLog"
+
+DEFINE_LOG_CATEGORY(LogSpatialOutputLog);
+
+static const FString LocalDeploymentLogsDir(FSpatialGDKServicesModule::GetSpatialOSDirectory(TEXT("logs/localdeployment")));
+static const FString LaunchLogFilename(TEXT("launch.log"));
+static const float PollTimeInterval(0.05f);
+
+void FArchiveLogFileReader::UpdateFileSize()
+{
+	Size = IFileManager::Get().GetStatData(*Filename).FileSize;
+}
+
+TUniquePtr<FArchiveLogFileReader> SSpatialOutputLog::CreateLogFileReader(const TCHAR* InFilename, uint32 Flags, uint32 BufferSize)
+{
+	IFileHandle* Handle = FPlatformFileManager::Get().GetPlatformFile().OpenRead(InFilename, !!(Flags & FILEREAD_AllowWrite));
+	if (Handle == nullptr)
+	{
+		if (!(Flags & FILEREAD_NoFail))
+		{
+			UE_LOG(LogSpatialOutputLog, Error, TEXT("Failed to read file: %s"), InFilename);
+		}
+
+		return nullptr;
+	}
+
+	return MakeUnique<FArchiveLogFileReader>(Handle, InFilename, Handle->Size(), BufferSize);
+}
+
+BEGIN_SLATE_FUNCTION_BUILD_OPTIMIZATION
+void SSpatialOutputLog::Construct(const FArguments& InArgs)
+{
+	SOutputLog::Construct(SOutputLog::FArguments());
+
+	// Remove ourselves as the constructor of our parent (SOutputLog) added 'this' as a remote output device.
+	GLog->RemoveOutputDevice(this);
+
+	LogReader.Reset();
+
+	StartUpLogDirectoryWatcher(LocalDeploymentLogsDir);
+
+	// Set the LogReader to the latest launch.log if we can.
+	ReadLatestLogFile();
+}
+END_SLATE_FUNCTION_BUILD_OPTIMIZATION
+
+void SSpatialOutputLog::ReadLatestLogFile()
+{
+	FString LatestLogDir;
+	FDateTime LatestLogDirTime;
+
+	// Go through all log directories in the spatial logs and find the most recently created (if one exists) and print the log file to the Spatial Output.
+	bool bGetLatestLogDir = IFileManager::Get().IterateDirectoryStat(*LocalDeploymentLogsDir, [&LatestLogDir, &LatestLogDirTime](const TCHAR* FileName, const FFileStatData& FileStats)
+	{
+		if (FileStats.bIsDirectory)
+		{
+			if (FileStats.CreationTime > LatestLogDirTime)
+			{
+				LatestLogDir = FString(FileName);
+				LatestLogDirTime = FileStats.CreationTime;
+			}
+		}
+
+		return true;
+	});
+
+	if (bGetLatestLogDir)
+	{
+		ResetPollingLogFile(FPaths::Combine(LatestLogDir, LaunchLogFilename));
+	}
+}
+
+SSpatialOutputLog::~SSpatialOutputLog()
+{
+	CloseLogReader();
+
+	ShutdownLogDirectoryWatcher(LocalDeploymentLogsDir);
+}
+
+void SSpatialOutputLog::StartUpLogDirectoryWatcher(const FString& LogDirectory)
+{
+	// This function will be called from the Slate thread and thus we must switch to the Game thread to create the Directory Watcher.
+	AsyncTask(ENamedThreads::GameThread, [this, LogDirectory]
+	{
+		FDirectoryWatcherModule& DirectoryWatcherModule = FModuleManager::LoadModuleChecked<FDirectoryWatcherModule>(TEXT("DirectoryWatcher"));
+		if (IDirectoryWatcher* DirectoryWatcher = DirectoryWatcherModule.Get())
+		{
+			// Watch the log directory for changes.
+			if (!FPaths::DirectoryExists(LogDirectory))
+			{
+				UE_LOG(LogSpatialOutputLog, Error, TEXT("Local deployment log directory does not exist!"));
+				return;
+			}
+
+			LogDirectoryChangedDelegate = IDirectoryWatcher::FDirectoryChanged::CreateRaw(this, &SSpatialOutputLog::OnLogDirectoryChanged);
+			DirectoryWatcher->RegisterDirectoryChangedCallback_Handle(LogDirectory, LogDirectoryChangedDelegate, LogDirectoryChangedDelegateHandle, IDirectoryWatcher::WatchOptions::IncludeDirectoryChanges | IDirectoryWatcher::WatchOptions::IgnoreChangesInSubtree);
+		}
+	});
+}
+
+void SSpatialOutputLog::OnLogDirectoryChanged(const TArray<FFileChangeData>& FileChanges)
+{
+	// If this is a new folder creation then switch to watching the log files in that new log folder.
+	for (const FFileChangeData& FileChange : FileChanges)
+	{
+		if (FileChange.Action == FFileChangeData::FCA_Added)
+		{
+			// Now we can start reading the new log file in the new log folder.
+			ResetPollingLogFile(FPaths::Combine(FileChange.Filename, LaunchLogFilename));
+			return;
+		}
+	}
+}
+
+void SSpatialOutputLog::ShutdownLogDirectoryWatcher(const FString& LogDirectory)
+{
+	AsyncTask(ENamedThreads::GameThread, [LogDirectory, LogDirectoryChangedDelegateHandle = LogDirectoryChangedDelegateHandle]
+	{
+		FDirectoryWatcherModule& DirectoryWatcherModule = FModuleManager::LoadModuleChecked<FDirectoryWatcherModule>(TEXT("DirectoryWatcher"));
+		if (IDirectoryWatcher* DirectoryWatcher = DirectoryWatcherModule.Get())
+		{
+			DirectoryWatcher->UnregisterDirectoryChangedCallback_Handle(LogDirectory, LogDirectoryChangedDelegateHandle);
+		}
+	});
+}
+
+void SSpatialOutputLog::CloseLogReader()
+{
+	if (GEditor != nullptr)
+	{
+		// Delete the old timer if one exists.
+		GEditor->GetTimerManager()->ClearTimer(PollTimer);
+	}
+
+	FScopeLock CloseLock(&LogReaderMutex);
+
+	// Clean up the the previous file reader if it existed.
+	if (LogReader.IsValid())
+	{
+		LogReader->Close();
+		LogReader = nullptr;
+	}
+}
+
+void SSpatialOutputLog::ResetPollingLogFile(const FString& LogFilePath)
+{
+	CloseLogReader();
+
+	FScopeLock CreateLock(&LogReaderMutex);
+
+	// FILEREAD_AllowWrite is required as we must match the permissions of the other processes writing to our log file in order to read from it.
+	LogReader = CreateLogFileReader(*LogFilePath, FILEREAD_AllowWrite, PLATFORM_FILE_READER_BUFFER_SIZE);
+
+	if (LogReader.IsValid())
+	{
+		PollLogFile(LogFilePath);
+	}
+	else
+	{
+		UE_LOG(LogSpatialOutputLog, Error, TEXT("Could not set up log file reader for %s"), *LogFilePath);
+	}
+}
+
+void SSpatialOutputLog::PollLogFile(const FString& LogFilePath)
+{
+	// Poll log files in a background thread since we are doing a lot of string operations.
+	AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [this, LogFilePath]
+	{
+		FScopeLock PollLock(&LogReaderMutex);
+
+		if (!LogReader.IsValid())
+		{
+			UE_LOG(LogSpatialOutputLog, Error, TEXT("Attempted to read from log file but LogReader is not valid."));
+			return;
+		}
+
+		FScopedLoadingState ScopedLoadingState(*LogFilePath);
+
+		// Find out the current size of the log file. This is a cheaper operation than opening a new file reader on every poll.
+		LogReader->UpdateFileSize();
+
+		const int32 SizeDifference = LogReader->TotalSize() - LogReader->Tell();
+
+		// New log lines have been added, serialize them.
+		if (SizeDifference > 0)
+		{
+			uint8* Ch = static_cast<uint8*>(FMemory::Malloc(SizeDifference));
+
+			LogReader->Serialize(Ch, SizeDifference);
+
+			FString ReadResult;
+			FFileHelper::BufferToString(ReadResult, Ch, SizeDifference);
+
+			TArray<FString> LogLines;
+
+			// All log lines begin with 'time='. We use this as our log line delimiter.
+			ReadResult.ParseIntoArray(LogLines, TEXT("time="), true);
+
+			for (const FString& LogLine : LogLines)
+			{
+				FormatAndPrintRawLogLine(LogLine);
+			}
+
+			FMemory::Free(Ch);
+		}
+
+		StartPollTimer(LogFilePath);
+	});
+}
+
+void SSpatialOutputLog::StartPollTimer(const FString& LogFilePath)
+{
+	// Start a timer to read the log file every PollTimeInterval seconds
+	// Timers must be started on the game thread.
+	AsyncTask(ENamedThreads::GameThread, [this, LogFilePath]
+	{
+		// It's possible that GEditor won't exist when shutting down.
+		if (GEditor != nullptr)
+		{
+			GEditor->GetTimerManager()->SetTimer(PollTimer, [this, LogFilePath]()
+			{
+				PollLogFile(LogFilePath);
+			}, PollTimeInterval, false);
+		}
+	});
+}
+
+void SSpatialOutputLog::FormatAndPrintRawLogLine(const FString& LogLine)
+{
+	// Log lines have the format time=LOG_TIME level=LOG_LEVEL logger=LOG_CATEGORY msg=LOG_MESSAGE
+	FString LogTime;
+	FString LogLevelAndRest;
+	FString LogLevelText;
+	FString LogCategoryAndRest;
+	FString LogCategory;
+	FString LogMessage;
+
+	LogLine.Split(TEXT("level="), &LogTime, &LogLevelAndRest);
+	LogLevelAndRest.Split(TEXT("logger="), &LogLevelText, &LogCategoryAndRest);
+	LogCategoryAndRest.Split(TEXT("msg="), &LogCategory, &LogMessage);
+
+	// Log categories take the form "improbable.deployment.InternalGameLauncher", we filter to the last category to make it more human readable.
+	LogCategory.Split(TEXT("."), nullptr, &LogCategory, ESearchCase::IgnoreCase, ESearchDir::FromEnd);
+
+	ELogVerbosity::Type LogVerbosity = ELogVerbosity::Display;
+
+	if (LogLevelText.Contains(TEXT("error")))
+	{
+		LogVerbosity = ELogVerbosity::Error;
+	}
+	else if (LogLevelText.Contains(TEXT("warn")))
+	{
+		LogVerbosity = ELogVerbosity::Warning;
+	}
+	else if (LogLevelText.Contains(TEXT("debug")))
+	{
+		LogVerbosity = ELogVerbosity::Verbose;
+	}
+	else if (LogLevelText.Contains(TEXT("verbose")))
+	{
+		LogVerbosity = ELogVerbosity::Verbose;
+	}
+	else
+	{
+		LogVerbosity = ELogVerbosity::Log;
+	}
+
+	// Serialization must be done on the game thread.
+	AsyncTask(ENamedThreads::GameThread, [this, LogMessage, LogVerbosity, LogCategory]
+	{
+		Serialize(*LogMessage, LogVerbosity, FName(*LogCategory));
+	});
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SSpatialOutputLog.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SSpatialOutputLog.h
@@ -1,0 +1,56 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Developer/OutputLog/Private/SOutputLog.h"
+#include "HAL/FileManagerGeneric.h"
+#include "IDirectoryWatcher.h"
+#include "SlateFwd.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogSpatialOutputLog, Log, All);
+
+// Child class of the file reader used by Unreal but with the ability to update the known file size.
+// This allows us to read a log file while it is being written to.
+class FArchiveLogFileReader : public FArchiveFileReaderGeneric
+{
+public:
+	FArchiveLogFileReader(IFileHandle* InHandle, const TCHAR* InFilename, int64 InSize, uint32 InBufferSize /*= PLATFORM_FILE_READER_BUFFER_SIZE*/)
+		: FArchiveFileReaderGeneric(InHandle, InFilename, InSize, InBufferSize)
+	{}
+	void UpdateFileSize();
+};
+
+class SSpatialOutputLog : public SOutputLog
+{
+public:
+	SLATE_BEGIN_ARGS(SSpatialOutputLog) {}
+
+	SLATE_END_ARGS()
+
+	~SSpatialOutputLog();
+
+	void Construct(const FArguments& InArgs);
+
+	TUniquePtr<FArchiveLogFileReader> CreateLogFileReader(const TCHAR* InFilename, uint32 Flags, uint32 BufferSize);
+
+private:
+	void ReadLatestLogFile();
+	void ResetPollingLogFile(const FString& LogFilePath);
+	void StartPollTimer(const FString& LogFilePath);
+	void PollLogFile(const FString& LogFilePath);
+	void CloseLogReader();
+
+	void FormatAndPrintRawLogLine(const FString& LogLine);
+
+	void StartUpLogDirectoryWatcher(const FString& LogDirectory);
+	void ShutdownLogDirectoryWatcher(const FString& LogDirectory);
+	void OnLogDirectoryChanged(const TArray<FFileChangeData>& FileChanges);
+
+	FDelegateHandle LogDirectoryChangedDelegateHandle;
+	IDirectoryWatcher::FDirectoryChanged LogDirectoryChangedDelegate;
+
+	FTimerHandle PollTimer;
+	TUniquePtr<FArchiveLogFileReader> LogReader;
+	FCriticalSection LogReaderMutex;
+};

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialGDKServicesModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialGDKServicesModule.cpp
@@ -2,12 +2,17 @@
 
 #include "SpatialGDKServicesModule.h"
 
-#include "HAL/PlatformFilemanager.h"
+#include "Editor/WorkspaceMenuStructure/Public/WorkspaceMenuStructure.h"
+#include "Editor/WorkspaceMenuStructure/Public/WorkspaceMenuStructureModule.h"
+#include "EditorStyleSet.h"
+#include "Framework/Application/SlateApplication.h"
+#include "Framework/Docking/TabManager.h"
 #include "Misc/FileHelper.h"
-#include "Misc/PackageName.h"
+#include "SSpatialOutputLog.h"
 #include "Serialization/JsonReader.h"
 #include "Serialization/JsonSerializer.h"
 #include "SpatialGDKServicesPrivate.h"
+#include "Widgets/Docking/SDockTab.h"
 
 #define LOCTEXT_NAMESPACE "FSpatialGDKServicesModule"
 
@@ -17,13 +22,34 @@ IMPLEMENT_MODULE(FSpatialGDKServicesModule, SpatialGDKServices);
 
 const FString SpatialExe = TEXT("spatial.exe");
 const FString SpotExe = FSpatialGDKServicesModule::GetSpatialGDKPluginDirectory(TEXT("SpatialGDK/Binaries/ThirdParty/Improbable/Programs/spot.exe"));
+static const FName SpatialOutputLogTabName = FName(TEXT("SpatialOutputLog"));
+
+TSharedRef<SDockTab> SpawnSpatialOutputLog(const FSpawnTabArgs& Args)
+{
+	return SNew(SDockTab)
+		.Icon(FEditorStyle::GetBrush("Log.TabIcon"))
+		.TabRole(ETabRole::NomadTab)
+		.Label(NSLOCTEXT("SpatialOutputLog", "TabTitle", "Spatial Output"))
+		[
+			SNew(SSpatialOutputLog)
+		];
+}
 
 void FSpatialGDKServicesModule::StartupModule()
 {
+	FGlobalTabmanager::Get()->RegisterNomadTabSpawner(SpatialOutputLogTabName, FOnSpawnTab::CreateStatic(&SpawnSpatialOutputLog))
+		.SetDisplayName(NSLOCTEXT("UnrealEditor", "SpatialOutputLogTab", "Spatial Output Log"))
+		.SetTooltipText(NSLOCTEXT("UnrealEditor", "SpatialOutputLogTooltipText", "Open the Spatial Output Log tab."))
+		.SetGroup(WorkspaceMenu::GetMenuStructure().GetDeveloperToolsLogCategory())
+		.SetIcon(FSlateIcon(FEditorStyle::GetStyleSetName(), "Log.TabIcon"));
 }
 
 void FSpatialGDKServicesModule::ShutdownModule()
 {
+	if (FSlateApplication::IsInitialized())
+	{
+		FGlobalTabmanager::Get()->UnregisterNomadTabSpawner(SpatialOutputLogTabName);
+	}
 }
 
 FString FSpatialGDKServicesModule::ProjectName = FSpatialGDKServicesModule::ParseProjectName();

--- a/SpatialGDK/Source/SpatialGDKServices/SpatialGDKServices.Build.cs
+++ b/SpatialGDK/Source/SpatialGDKServices/SpatialGDKServices.Build.cs
@@ -11,13 +11,18 @@ public class SpatialGDKServices : ModuleRules
 
 		PrivateDependencyModuleNames.AddRange(
 			new string[] {
+				"EditorStyle",
+				"Engine",
+				"OutputLog",
+				"Slate",
+				"SlateCore",
 				"Core",
 				"CoreUObject",
-				"Engine",
 				"EngineSettings",
-				"UnrealEd",
 				"Json",
-				"JsonUtilities"
-            });
+				"JsonUtilities",
+				"UnrealEd"
+			}
+		);
 	}
 }

--- a/ci/unreal-engine.version
+++ b/ci/unreal-engine.version
@@ -1,1 +1,1 @@
-UnrealEngine-fddd0d4996f7281553ca9a33a15a22f710a5e780
+UnrealEngine-7e26e1d9e8aa11981b27683c3bb1cf22d384cbc0


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Add a managed component to track the virtual worker ID. This is the first step in UnrealGDK-controlled zoning behavior. In this PR, we create the component in schema, add functionality to read and set the component value, and create the component with a value when we create a new entity. Future PRs will restrict worker behavior based on the value of the component and will track the physical worker ID to virtual worker ID mapping.

#### Release note
- Added an AuthorityIntent component to be used in the future for UnrealGDK code to control loadbalancing.

#### Tests
How did you test these changes prior to submitting this pull request?
Ran the starter project in the inspector and verified that the worker created entities had an AuthorityIntent component which had the virtualWorkerId set to 0.

What automated tests are included in this PR?
None.

STRONGLY SUGGESTED: How can this be verified by QA?
QA can test by verifying in the inspector.

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?
Release note, eventually feature page once the feature is complete. In-code documentation of the purpose of the component.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@yumnuska @cmsmithio 