### PR TITLE
[UNR-2187] Bugfix Handover causing crashes in net dormancy

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -87,10 +87,28 @@ void USpatialActorChannel::Init(UNetConnection* InConnection, int32 ChannelIndex
 {
 	Super::Init(InConnection, ChannelIndex, CreateFlag);
 
+	// Actor Channels are pooled, so we must initialize internal state here.
+	bCreatedEntity = false;
+	bCreatingNewEntity = false;
+	EntityId = SpatialConstants::INVALID_ENTITY_ID;
+	bInterestDirty = false;
+	bNetOwned = false;
+	LastPositionSinceUpdate = FVector::ZeroVector;
+	TimeWhenPositionLastUpdated = 0.0f;
+
+	PendingDynamicSubobjects.Empty();
+	SavedOwnerWorkerAttribute.Empty();
+
+	FramesTillDormancyAllowed = 0;
+
+	ActorHandoverShadowData = nullptr;
+	HandoverShadowDataMap.Empty();
+
 	NetDriver = Cast<USpatialNetDriver>(Connection->Driver);
 	check(NetDriver);
 	Sender = NetDriver->Sender;
 	Receiver = NetDriver->Receiver;
+
 }
 
 void USpatialActorChannel::DeleteEntityIfAuthoritative()

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -108,7 +108,6 @@ void USpatialActorChannel::Init(UNetConnection* InConnection, int32 ChannelIndex
 	check(NetDriver);
 	Sender = NetDriver->Sender;
 	Receiver = NetDriver->Receiver;
-
 }
 
 void USpatialActorChannel::DeleteEntityIfAuthoritative()


### PR DESCRIPTION
#### Description
Switching an actor from awake → dormant → awake can crash UE4 when handover data is enabled. This bug was caused by SpatialActorChannel not being properly reset when reused (from pool). The fix initializes all state in the Init function that is called by the pooling system.

#### Tests
Tested locally with modified crashbot gym with & without offloading enabled.