### PR TITLE
Add an AuthorityIntent component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Avoid generating schema for all UObject subclasses. Actor, ActorComponent, GameplayAbility subclasses are enabled by default, other classes can be enabled using SpatialType UCLASS specifier.
 - Added new experimental CookAndGenerateSchemaCommandlet that generates required schema during a regular cook.
 - Added OverrideSpatialOffloading command line flag that allows toggling of offloading at launch time.
+- Added an AuthorityIntent component to be used in the future for UnrealGDK code to control loadbalancing.
 
 ### Breaking Changes:
 - If your project uses replicated subobjects that do not inherit from ActorComponent or GameplayAbility, you need to enable generating schema for them using SpatialType UCLASS specifier or by checking Spatial Type if it's a blueprint.

--- a/SpatialGDK/Extras/schema/authority_intent.schema
+++ b/SpatialGDK/Extras/schema/authority_intent.schema
@@ -1,0 +1,9 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+package unreal;
+
+component AuthorityIntent {
+     id = 9980;
+     // Id assigned to the Unreal server worker which should be authoritative for this entity.
+     // 0 is reserved as an invalid/unset value.
+     uint32 virtual_worker_id = 1;
+}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -128,6 +128,7 @@ void USpatialReceiver::OnAddComponent(const Worker_AddComponentOp& Op)
 	case SpatialConstants::ALWAYS_RELEVANT_COMPONENT_ID:
 	case SpatialConstants::CLIENT_RPC_ENDPOINT_COMPONENT_ID:
 	case SpatialConstants::SERVER_RPC_ENDPOINT_COMPONENT_ID:
+	case SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID:
 		// Ignore static spatial components as they are managed by the SpatialStaticComponentView.
 		return;
 	case SpatialConstants::SINGLETON_MANAGER_COMPONENT_ID:
@@ -1106,6 +1107,9 @@ void USpatialReceiver::OnComponentUpdate(const Worker_ComponentUpdateOp& Op)
 	case SpatialConstants::NETMULTICAST_RPCS_COMPONENT_ID:
 		HandleRPC(Op);
 		return;
+	case SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID:
+		check(false); // TODO(zoning): Handle updates to the entity's authority intent.
+		break;
 	}
 
 	// If this entity has a Tombstone component, abort all component processing

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -213,8 +213,8 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 	ComponentDatas.Add(Metadata(Class->GetName()).CreateMetadataData());
 	ComponentDatas.Add(SpawnData(Actor).CreateSpawnDataData());
 	ComponentDatas.Add(UnrealMetadata(StablyNamedObjectRef, ClientWorkerAttribute, Class->GetPathName(), bNetStartup).CreateUnrealMetadataData());
-	// TODO(zoning): For now, setting AuthorityIntent to 0, which is an invalid virutal worker ID.
-	ComponentDatas.Add(AuthorityIntent(0).CreateAuthorityIntentData());
+	// TODO(zoning): For now, setting AuthorityIntent to an invalid value.
+	ComponentDatas.Add(AuthorityIntent(SpatialConstants::INVALID_AUTHORITY_INTENT_ID).CreateAuthorityIntentData());
 
 	if (!Class->HasAnySpatialClassFlags(SPATIALCLASS_NotPersistent))
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -14,6 +14,7 @@
 #include "Interop/SpatialDispatcher.h"
 #include "Interop/SpatialReceiver.h"
 #include "Schema/AlwaysRelevant.h"
+#include "Schema/AuthorityIntent.h"
 #include "Schema/ClientRPCEndpoint.h"
 #include "Schema/Heartbeat.h"
 #include "Schema/Interest.h"
@@ -125,6 +126,7 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 	ComponentWriteAcl.Add(SpatialConstants::NETMULTICAST_RPCS_COMPONENT_ID, AuthoritativeWorkerRequirementSet);
 	ComponentWriteAcl.Add(SpatialConstants::DORMANT_COMPONENT_ID, AuthoritativeWorkerRequirementSet);
 	ComponentWriteAcl.Add(SpatialConstants::CLIENT_RPC_ENDPOINT_COMPONENT_ID, OwningClientOnlyRequirementSet);
+	ComponentWriteAcl.Add(SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID, AuthoritativeWorkerRequirementSet);
 
 	if (Actor->IsNetStartupActor())
 	{
@@ -211,6 +213,8 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 	ComponentDatas.Add(Metadata(Class->GetName()).CreateMetadataData());
 	ComponentDatas.Add(SpawnData(Actor).CreateSpawnDataData());
 	ComponentDatas.Add(UnrealMetadata(StablyNamedObjectRef, ClientWorkerAttribute, Class->GetPathName(), bNetStartup).CreateUnrealMetadataData());
+	// TODO(zoning): For now, setting AuthorityIntent to 0, which is an invalid virutal worker ID.
+	ComponentDatas.Add(AuthorityIntent(0).CreateAuthorityIntentData());
 
 	if (!Class->HasAnySpatialClassFlags(SPATIALCLASS_NotPersistent))
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStaticComponentView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStaticComponentView.cpp
@@ -2,6 +2,7 @@
 
 #include "Interop/SpatialStaticComponentView.h"
 
+#include "Schema/AuthorityIntent.h"
 #include "Schema/ClientRPCEndpoint.h"
 #include "Schema/Component.h"
 #include "Schema/Heartbeat.h"
@@ -81,6 +82,9 @@ void USpatialStaticComponentView::OnAddComponent(const Worker_AddComponentOp& Op
 	case SpatialConstants::SERVER_RPC_ENDPOINT_COMPONENT_ID:
 		Data = MakeUnique<SpatialGDK::ComponentStorage<SpatialGDK::ServerRPCEndpoint>>(Op.data);
 		break;
+	case SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID:
+		Data = MakeUnique<SpatialGDK::ComponentStorage<SpatialGDK::AuthorityIntent>>(Op.data);
+		break;
 	default:
 		// Component is not hand written, but we still want to know the existence of it on this entity.
 		Data = nullptr;
@@ -119,6 +123,9 @@ void USpatialStaticComponentView::OnComponentUpdate(const Worker_ComponentUpdate
 		break;
 	case SpatialConstants::SERVER_RPC_ENDPOINT_COMPONENT_ID:
 		Component = GetComponentData<SpatialGDK::ServerRPCEndpoint>(Op.entity_id);
+		break;
+	case SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID:
+		Component = GetComponentData<SpatialGDK::AuthorityIntent>(Op.entity_id);
 		break;
 	default:
 		return;

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/AuthorityIntent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/AuthorityIntent.h
@@ -1,0 +1,69 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "Schema/Component.h"
+#include "Utils/SchemaUtils.h"
+
+#include <WorkerSDK/improbable/c_schema.h>
+
+namespace SpatialGDK
+{
+
+// The AuthorityIntent component is a piece of the Zoning solution for the UnrealGDK. For each
+// entity in SpatialOS, Unreal will use the AuthorityIntent to indicate which Unreal server worker
+// should be authoritative for the entity. No Unreal worker should write to an entity if the
+// VirtualWorkerId set here doesn't match the worker's Id. 
+struct AuthorityIntent : Component
+{
+	static const Worker_ComponentId ComponentId = SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID;
+
+	AuthorityIntent() = default;
+
+	AuthorityIntent(uint32 InVirtualWorkerId)
+		: VirtualWorkerId(InVirtualWorkerId) {}
+
+	AuthorityIntent(const Worker_ComponentData& Data)
+	{
+		Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
+
+		VirtualWorkerId = Schema_GetUint32(ComponentObject, 1);
+	}
+
+	Worker_ComponentData CreateAuthorityIntentData()
+	{
+		Worker_ComponentData Data = {};
+		Data.component_id = ComponentId;
+		Data.schema_type = Schema_CreateComponentData();
+		Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
+
+		Schema_AddUint32(ComponentObject, 1, VirtualWorkerId);
+
+		return Data;
+	}
+
+	Worker_ComponentUpdate CreateAuthorityIntentUpdate()
+	{
+		Worker_ComponentUpdate Update = {};
+		Update.component_id = ComponentId;
+		Update.schema_type = Schema_CreateComponentUpdate();
+		Schema_Object* ComponentObject = Schema_GetComponentUpdateFields(Update.schema_type);
+
+		Schema_AddUint32(ComponentObject, 1, VirtualWorkerId);
+
+		return Update;
+	}
+
+	void ApplyComponentUpdate(const Worker_ComponentUpdate& Update)
+	{
+		Schema_Object* ComponentObject = Schema_GetComponentUpdateFields(Update.schema_type);
+		VirtualWorkerId = Schema_GetUint32(ComponentObject, 1);
+	}
+
+	// Id of the Unreal server worker which should be authoritative for the entity.
+	// 0 is reserved as an invalid/unset value.
+	uint32 VirtualWorkerId;
+};
+
+} // namespace SpatialGDK
+

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/AuthorityIntent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/AuthorityIntent.h
@@ -27,7 +27,7 @@ struct AuthorityIntent : Component
 	{
 		Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
 
-		VirtualWorkerId = Schema_GetUint32(ComponentObject, 1);
+		VirtualWorkerId = Schema_GetUint32(ComponentObject, SpatialConstants::AUTHORITY_INTENT_VIRTUAL_WORKER_ID);
 	}
 
 	Worker_ComponentData CreateAuthorityIntentData()
@@ -37,7 +37,7 @@ struct AuthorityIntent : Component
 		Data.schema_type = Schema_CreateComponentData();
 		Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
 
-		Schema_AddUint32(ComponentObject, 1, VirtualWorkerId);
+		Schema_AddUint32(ComponentObject, SpatialConstants::AUTHORITY_INTENT_VIRTUAL_WORKER_ID, VirtualWorkerId);
 
 		return Data;
 	}
@@ -49,7 +49,7 @@ struct AuthorityIntent : Component
 		Update.schema_type = Schema_CreateComponentUpdate();
 		Schema_Object* ComponentObject = Schema_GetComponentUpdateFields(Update.schema_type);
 
-		Schema_AddUint32(ComponentObject, 1, VirtualWorkerId);
+		Schema_AddUint32(ComponentObject, SpatialConstants::AUTHORITY_INTENT_VIRTUAL_WORKER_ID, VirtualWorkerId);
 
 		return Update;
 	}
@@ -57,7 +57,7 @@ struct AuthorityIntent : Component
 	void ApplyComponentUpdate(const Worker_ComponentUpdate& Update)
 	{
 		Schema_Object* ComponentObject = Schema_GetComponentUpdateFields(Update.schema_type);
-		VirtualWorkerId = Schema_GetUint32(ComponentObject, 1);
+		VirtualWorkerId = Schema_GetUint32(ComponentObject, SpatialConstants::AUTHORITY_INTENT_VIRTUAL_WORKER_ID);
 	}
 
 	// Id of the Unreal server worker which should be authoritative for the entity.

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -170,6 +170,10 @@ namespace SpatialConstants
 
 	const Schema_FieldId PLAYER_SPAWNER_SPAWN_PLAYER_COMMAND_ID = 1;
 
+	// AuthorityIntent codes and Field IDs.
+	const Schema_FieldId AUTHORITY_INTENT_VIRTUAL_WORKER_ID					= 1;
+	const uint32 INVALID_AUTHORITY_INTENT_ID                                = 0;
+
 	// Reserved entity IDs expire in 5 minutes, we will refresh them every 3 minutes to be safe.
 	const float ENTITY_RANGE_EXPIRATION_INTERVAL_SECONDS = 180.0f;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -116,6 +116,7 @@ namespace SpatialConstants
 	const Worker_ComponentId ALWAYS_RELEVANT_COMPONENT_ID					= 9983;
 	const Worker_ComponentId TOMBSTONE_COMPONENT_ID                         = 9982;
 	const Worker_ComponentId DORMANT_COMPONENT_ID							= 9981;
+	const Worker_ComponentId AUTHORITY_INTENT_COMPONENT_ID                  = 9980;
 
 	const Worker_ComponentId STARTING_GENERATED_COMPONENT_ID				= 10000;
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Add a managed component to track the virtual worker ID. This is the first step in UnrealGDK-controlled zoning behavior. In this PR, we create the component in schema, add functionality to read and set the component value, and create the component with a value when we create a new entity. Future PRs will restrict worker behavior based on the value of the component and will track the physical worker ID to virtual worker ID mapping.

#### Release note
- Added an AuthorityIntent component to be used in the future for UnrealGDK code to control loadbalancing.

#### Tests
How did you test these changes prior to submitting this pull request?
Ran the starter project in the inspector and verified that the worker created entities had an AuthorityIntent component which had the virtualWorkerId set to 0.

What automated tests are included in this PR?
None.

STRONGLY SUGGESTED: How can this be verified by QA?
QA can test by verifying in the inspector.

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?
Release note, eventually feature page once the feature is complete. In-code documentation of the purpose of the component.

#### Primary reviewers
@yumnuska @cmsmithio 