### PR TITLE
UNR-2193 Dropped Multicast RPCs Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format of this Changelog is based on [Keep a Changelog](https://keepachangel
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased-`x.y.z`] - 2019-xx-xx
+- Multicast RPCs are now processed after the EntityCreation request is satisfied.
 
 ## [`0.7.0`] - 2019-10-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Streaming levels with query-based interest (QBI) enabled no longer produces errors if the player connection owns unreplicated actors.
 - Fixed an issue that would prevent player movement in a zoned deployment.
 - Fixed an issue that could cause queued incoming RPCs with unresolved references to never be processed.
-- Multicast RPCs are now processed after the EntityCreation request is satisfied.
+- Muticast RPCs, that are sent shortly after after an actor is created, are now correctly processed by all clients.
 
 ## [`0.6.1`] - 2019-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ The format of this Changelog is based on [Keep a Changelog](https://keepachangel
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased-`x.y.z`] - 2019-xx-xx
-- Multicast RPCs are now processed after the EntityCreation request is satisfied.
 
 ## [`0.7.0`] - 2019-10-04
 
@@ -47,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Streaming levels with query-based interest (QBI) enabled no longer produces errors if the player connection owns unreplicated actors.
 - Fixed an issue that would prevent player movement in a zoned deployment.
 - Fixed an issue that could cause queued incoming RPCs with unresolved references to never be processed.
+- Multicast RPCs are now processed after the EntityCreation request is satisfied.
 
 ## [`0.6.1`] - 2019-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Streaming levels with query-based interest (QBI) enabled no longer produces errors if the player connection owns unreplicated actors.
 - Fixed an issue that would prevent player movement in a zoned deployment.
 - Fixed an issue that could cause queued incoming RPCs with unresolved references to never be processed.
-- Muticast RPCs, that are sent shortly after after an actor is created, are now correctly processed by all clients.
+- Muticast RPCs, that are sent shortly after an actor is created, are now correctly processed by all clients.
 
 ## [`0.6.1`] - 2019-08-15
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -689,28 +689,19 @@ ERPCResult USpatialSender::SendRPCInternal(UObject* TargetObject, UFunction* Fun
 	}
 	const FRPCInfo& RPCInfo = ClassInfoManager->GetRPCInfo(TargetObject, Function);
 
-	if (Channel->bCreatingNewEntity)
-	{
-		if (Function->HasAnyFunctionFlags(FUNC_NetClient | FUNC_NetMulticast))
-		{
-			if (Function->HasAnyFunctionFlags(FUNC_NetMulticast))
-			{
-				// TODO: UNR-1437 - Add Support for Multicast RPCs on Entity Creation
-				UE_LOG(LogSpatialSender, Warning, TEXT("NetMulticast RPC %s triggered on Object %s too close to initial creation."), *Function->GetName(), *TargetObject->GetName());
-			}
-			check(NetDriver->IsServer());
+ 	if (Channel->bCreatingNewEntity)
+ 	{
+ 		if (Function->HasAnyFunctionFlags(FUNC_NetClient))
+ 		{
+ 			check(NetDriver->IsServer());
 
-			OutgoingOnCreateEntityRPCs.FindOrAdd(TargetObject).RPCs.Add(Payload);
-#if !UE_BUILD_SHIPPING
-			NetDriver->SpatialMetrics->TrackSentRPC(Function, RPCInfo.Type, Payload.PayloadData.Num());
-#endif // !UE_BUILD_SHIPPING
-			return ERPCResult::Success;
-		}
-		else
-		{
-			UE_LOG(LogSpatialSender, Warning, TEXT("CrossServer RPC %s triggered on Object %s too close to initial creation."), *Function->GetName(), *TargetObject->GetName());
-		}
-	}
+ 			OutgoingOnCreateEntityRPCs.FindOrAdd(TargetObject).RPCs.Add(Payload);
+ #if !UE_BUILD_SHIPPING
+ 			NetDriver->SpatialMetrics->TrackSentRPC(Function, RPCInfo.Type, Payload.PayloadData.Num());
+ #endif // !UE_BUILD_SHIPPING
+ 			return ERPCResult::Success;
+ 		}
+ 	}
 
 	Worker_EntityId EntityId = SpatialConstants::INVALID_ENTITY_ID;
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Fixed a bug with multicast RPCs, that were not processed if called close to entity creation.

#### Release note
Updated CHANGELOG.md.

#### Tests
Mutlicast called close to entity creation are now processed.

#### Documentation
Mutlicast called close to entity creation are now processed.

#### Primary reviewers
@improbable-valentyn @m-samiec 