### PR TITLE
[UNR-2190] Bugfix: Add message in ClassInfoManager if we force a synchronous load

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealMetadata.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealMetadata.h
@@ -87,6 +87,11 @@ struct UnrealMetadata : Component
 		}
 		else
 		{
+			TSoftObjectPtr<UClass> ClassPtr = TSoftObjectPtr<UClass>(ClassPath);
+			if (!ClassPtr.IsValid())
+			{
+				UE_LOG(LogSpatialClassInfoManager, Log, TEXT("Class %s not loaded, will be synchronously loaded now."), *ClassPath);
+			}
 			Class = LoadObject<UClass>(nullptr, *ClassPath);
 		}
 


### PR DESCRIPTION
#### Description
When receiving an Actor, we will synchronously load the Class if it is not present in memory using LoadObject. This has the undesired effect of flushing any async loading happening at the time, causing hitches.

Before we fix the issue, this log message will allow developers to see which classes are causing the hitches, and preload them on the client.