### PR TITLE
[UNR-2195] Fix component updates being dropped when waking up an actor

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -230,7 +230,6 @@ void USpatialReceiver::ProcessRemoveComponent(const Worker_RemoveComponentOp& Op
 	{
 		if (Op.component_id == SpatialConstants::DORMANT_COMPONENT_ID)
 		{
-			// Receive would normally create channel in ReceiveActor - we need to recreate it here
 			RecreateDormantSpatialChannel(Actor, Op.entity_id);
 			
 		}
@@ -1133,14 +1132,13 @@ void USpatialReceiver::OnComponentUpdate(const Worker_ComponentUpdateOp& Op)
 		// If there is no actor channel as a result of the actor being dormant, then assume the actor is about to become active.
 		if (const Dormant* DormantComponent = StaticComponentView->GetComponentData<Dormant>(Op.entity_id))
 		{
-			AActor* Actor = Cast<AActor>(PackageMap->GetObjectFromEntityId(Op.entity_id));
-			if (Actor != nullptr)
+			if (AActor* Actor = Cast<AActor>(PackageMap->GetObjectFromEntityId(Op.entity_id)))
 			{
 				RecreateDormantSpatialChannel(Actor, Op.entity_id);
 			}
 			else
 			{
-				UE_LOG(LogSpatialReceiver, Warning, TEXT("Worker: %s Dormant actor (entity: %d) has been deleted on the client but we have received a component update (id: %d) from the server."), *NetDriver->Connection->GetWorkerId(), Op.entity_id, Op.update.component_id);
+				UE_LOG(LogSpatialReceiver, Warning, TEXT("Worker: %s Dormant actor (entity: %d) has been deleted on this worker but we have received a component update (id: %d) from the server."), *NetDriver->Connection->GetWorkerId(), Op.entity_id, Op.update.component_id);
 			}
 		}
 		else

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1138,12 +1138,12 @@ void USpatialReceiver::OnComponentUpdate(const Worker_ComponentUpdateOp& Op)
 			}
 			else
 			{
-				UE_LOG(LogSpatialReceiver, Warning, TEXT("Worker: %s Dormant actor (entity: %d) has been deleted on this worker but we have received a component update (id: %d) from the server."), *NetDriver->Connection->GetWorkerId(), Op.entity_id, Op.update.component_id);
+				UE_LOG(LogSpatialReceiver, Warning, TEXT("Worker: %s Dormant actor (entity: %lld) has been deleted on this worker but we have received a component update (id: %d) from the server."), *NetDriver->Connection->GetWorkerId(), Op.entity_id, Op.update.component_id);
 			}
 		}
 		else
 		{
-			UE_LOG(LogSpatialReceiver, Log, TEXT("Worker: %s Entity: %d Component: %d - No actor channel for update. This most likely occured due to the component updates that are sent when authority is lost during entity deletion."), *NetDriver->Connection->GetWorkerId(), Op.entity_id, Op.update.component_id);
+			UE_LOG(LogSpatialReceiver, Log, TEXT("Worker: %s Entity: %lld Component: %d - No actor channel for update. This most likely occured due to the component updates that are sent when authority is lost during entity deletion."), *NetDriver->Connection->GetWorkerId(), Op.entity_id, Op.update.component_id);
 			return;
 		}
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -232,7 +232,6 @@ void USpatialReceiver::ProcessRemoveComponent(const Worker_RemoveComponentOp& Op
 		if (Op.component_id == SpatialConstants::DORMANT_COMPONENT_ID)
 		{
 			RecreateDormantSpatialChannel(Actor, Op.entity_id);
-			
 		}
 		else if (UObject* Object = PackageMap->GetObjectFromUnrealObjectRef(FUnrealObjectRef(Op.entity_id, Op.component_id)).Get())
 		{

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -212,6 +212,7 @@ void USpatialReceiver::RemoveComponentOpsForEntity(Worker_EntityId EntityId)
 
 void USpatialReceiver::RecreateDormantSpatialChannel(AActor* Actor, Worker_EntityId EntityID)
 {
+	// Receive would normally create channel in ReceiveActor - this function is used to recreate the channel after waking up a dormant actor
 	USpatialActorChannel* Channel = NetDriver->GetOrCreateSpatialActorChannel(Actor);
 	check(!Channel->bCreatingNewEntity);
 	check(Channel->GetEntityId() == EntityID);

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -163,6 +163,7 @@ private:
 	AActor* TryGetOrCreateActor(SpatialGDK::UnrealMetadata* UnrealMetadata, SpatialGDK::SpawnData* SpawnData);
 	AActor* CreateActor(SpatialGDK::UnrealMetadata* UnrealMetadata, SpatialGDK::SpawnData* SpawnData);
 
+	void RecreateDormantSpatialChannel(AActor* Actor, Worker_EntityId EntityID);
 	void ProcessRemoveComponent(const Worker_RemoveComponentOp& Op);
 
 	static FTransform GetRelativeSpawnTransform(UClass* ActorClass, FTransform SpawnTransform);

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -163,6 +163,7 @@ private:
 	AActor* TryGetOrCreateActor(SpatialGDK::UnrealMetadata* UnrealMetadata, SpatialGDK::SpawnData* SpawnData);
 	AActor* CreateActor(SpatialGDK::UnrealMetadata* UnrealMetadata, SpatialGDK::SpawnData* SpawnData);
 
+	// Receive would normally create channel in ReceiveActor - this function is used to recreate the channel after waking up a dormant actor
 	void RecreateDormantSpatialChannel(AActor* Actor, Worker_EntityId EntityID);
 	void ProcessRemoveComponent(const Worker_RemoveComponentOp& Op);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -163,7 +163,6 @@ private:
 	AActor* TryGetOrCreateActor(SpatialGDK::UnrealMetadata* UnrealMetadata, SpatialGDK::SpawnData* SpawnData);
 	AActor* CreateActor(SpatialGDK::UnrealMetadata* UnrealMetadata, SpatialGDK::SpawnData* SpawnData);
 
-	// Receive would normally create channel in ReceiveActor - this function is used to recreate the channel after waking up a dormant actor
 	void RecreateDormantSpatialChannel(AActor* Actor, Worker_EntityId EntityID);
 	void ProcessRemoveComponent(const Worker_RemoveComponentOp& Op);
 


### PR DESCRIPTION
#### Description
When an actor wakes up and updates a replicated variable at approximately the same time, it is possible that on the receiving side these updates arrive in reverse order, causing the update to the variable to be dropped. This change fixes this issue by creating a channel on component update - anticipating the wake up.

#### Release note
Should not need one, as it should just go under dormancy fixes.

#### Tests
An intially dormant actor with a repnotified variable - manual.
May need more investigation, which I believe @aleximprobable may do.

#### Documentation
N/A.

#### Primary reviewers
@aleximprobable @m-samiec 