### PR TITLE
UNR-2194 Only use Owner's Spatial position if the owner is replicated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue that would prevent player movement in a zoned deployment.
 - Fixed an issue that could cause queued incoming RPCs with unresolved references to never be processed.
 - Muticast RPCs, that are sent shortly after an actor is created, are now correctly processed by all clients.
+- Fixed an issue where the owner's Spatial position was used even if it wasn't replicated.
 
 ## [`0.6.1`] - 2019-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue that would prevent player movement in a zoned deployment.
 - Fixed an issue that could cause queued incoming RPCs with unresolved references to never be processed.
 - Muticast RPCs, that are sent shortly after an actor is created, are now correctly processed by all clients.
-- Fixed an issue where the owner's Spatial position was used even if it wasn't replicated.
+- When replicating an actor, the owner's Spatial position will no longer be used if it isn't replicated.
 
 ## [`0.6.1`] - 2019-08-15
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -1029,7 +1029,7 @@ FVector USpatialActorChannel::GetActorSpatialPosition(AActor* InActor)
 		USceneComponent* PawnRootComponent = Controller->GetPawn()->GetRootComponent();
 		Location = PawnRootComponent ? PawnRootComponent->GetComponentLocation() : FVector::ZeroVector;
 	}
-	else if (InActor->GetOwner() != nullptr && InActor->GetIsReplicated())
+	else if (InActor->GetOwner() != nullptr && InActor->GetOwner()->GetIsReplicated())
 	{
 		return GetActorSpatialPosition(InActor->GetOwner());
 	}


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
This fixes the issue where projectiles would have their Spatial position at origin.

#### Release note
Fixed an issue where the owner's Spatial position was used even if it wasn't replicated.

#### Primary reviewers
@m-samiec @oblm 