### PR TITLE
[UNR-2220] Bugfix: Force bSpatialNetworking in CookAndGenerateSchema

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/CookAndGenerateSchemaCommandlet.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/CookAndGenerateSchemaCommandlet.cpp
@@ -59,6 +59,9 @@ UCookAndGenerateSchemaCommandlet::UCookAndGenerateSchemaCommandlet()
 
 int32 UCookAndGenerateSchemaCommandlet::Main(const FString& CmdLineParams)
 {
+	// Force spatial networking
+	GetMutableDefault<UGeneralProjectSettings>()->bSpatialNetworking = true;
+
 	UE_LOG(LogCookAndGenerateSchemaCommandlet, Display, TEXT("Cook and Generate Schema Started."));
 	FObjectListener ObjectListener;
 	TSet<FSoftClassPath> ReferencedClasses;

--- a/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/CookAndGenerateSchemaCommandlet.h
+++ b/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/CookAndGenerateSchemaCommandlet.h
@@ -10,9 +10,23 @@ DECLARE_LOG_CATEGORY_EXTERN(LogCookAndGenerateSchemaCommandlet, Log, All);
 
 struct FObjectListener;
 /**
+ * -- EXPERIMENTAL --
  * This Commandlet generates schema and performs a cook command.
  * It supports the same set of arguments as cook. It will only generate
  * schema for blueprints required by the cook.
+ *
+ * Usage:
+ * Engine\Binaries\Win64\UE4Editor-Cmd.exe <PathToGame>.uproject -run=CookAndGenerateSchema -targetplatform=LinuxServer -SkipShaderCompile  <...Native Cook Params>
+ *
+ * Known Issues:
+ * - SchemaDatabase.uasset will need to be cooked again after running this Commandlet, potentially with [-iterate] flag.
+ * - [-iterate] flag will result in schema only generated for dirty packages, you maintain previous .schema files if you want to use this flag.
+ *
+ * Recommended Workflow:
+ *  1. Run CookAndGenerateSchema for a LinuxServer platform with [-SkipShaderCompile] for needed maps WITHOUT [-iterate]
+ *  2. Run GenerateSchemaAndSnapshots with [-SkipSchema] for needed maps.
+ *  2. BuildCookRun for the same platform WITH [-iterate]
+ *  3. BuildCookRun other platforms
  */
 UCLASS()
 class SPATIALGDKEDITORCOMMANDLET_API UCookAndGenerateSchemaCommandlet : public UCookCommandlet

--- a/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/GenerateSchemaAndSnapshotsCommandlet.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/GenerateSchemaAndSnapshotsCommandlet.cpp
@@ -41,10 +41,17 @@ int32 UGenerateSchemaAndSnapshotsCommandlet::Main(const FString& Args)
 		return 1;
 	}
 
-	// Do full schema generation
-	if (!GenerateSchema(SpatialGDKEditor))
+	if (Switches.Contains("SkipSchema"))
 	{
-		return 1;
+		UE_LOG(LogSpatialGDKEditorCommandlet, Display, TEXT("Skipping schema generation"));
+	}
+	else
+	{
+		// Do full schema generation
+		if (!GenerateSchema(SpatialGDKEditor))
+		{
+			return 1;
+		}
 	}
 
 	if (Params.Contains(MapPathsParamName))

--- a/SpatialGDK/Source/SpatialGDKEditorCommandlet/SpatialGDKEditorCommandlet.Build.cs
+++ b/SpatialGDK/Source/SpatialGDKEditorCommandlet/SpatialGDKEditorCommandlet.Build.cs
@@ -14,8 +14,8 @@ public class SpatialGDKEditorCommandlet : ModuleRules
 				"Core",
 				"CoreUObject",
 				"Engine",
-                "EngineSettings",
-                "SpatialGDK",
+				"EngineSettings",
+				"SpatialGDK",
 				"SpatialGDKEditor",
 				"UnrealEd",
 			});

--- a/SpatialGDK/Source/SpatialGDKEditorCommandlet/SpatialGDKEditorCommandlet.Build.cs
+++ b/SpatialGDK/Source/SpatialGDKEditorCommandlet/SpatialGDKEditorCommandlet.Build.cs
@@ -14,7 +14,8 @@ public class SpatialGDKEditorCommandlet : ModuleRules
 				"Core",
 				"CoreUObject",
 				"Engine",
-				"SpatialGDK",
+                "EngineSettings",
+                "SpatialGDK",
 				"SpatialGDKEditor",
 				"UnrealEd",
 			});


### PR DESCRIPTION
#### Description
CookAndGenerateSchema commandlet will crash if bSpatialNetworking is false, so this PR forces it to true before running.

This PR also includes:
- A `SkipSchema` switch added to GenerateSchemaAndSnapshots commandlet to skip over schema generation
- Some initial documentation (in header comment) to CookAndGeneratSchema