### PR TITLE
Bugfix - Deleted actor dormancy check

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1700,7 +1700,6 @@ bool USpatialReceiver::IsPendingOpsOnChannel(USpatialActorChannel* Channel)
 
 	// Don't allow Actors to go dormant if they have any pending operations waiting on their channel
 	check(Channel);
-	check(Channel->Actor);
 
 	for (const auto& UnresolvedRef : UnresolvedRefsMap)
 	{


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
It's possible to have an actor channel be ticked when it's actor has been deleted. Remove unneeded check which can crash when an actor channel which is pending dormancy has a deleted actor.

#### Primary reviewers
@m-samiec @improbable-valentyn 