### PR TITLE
Feature/unr 1998 enable network profiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new experimental CookAndGenerateSchemaCommandlet that generates required schema during a regular cook.
 - Added OverrideSpatialOffloading command line flag that allows toggling of offloading at launch time.
 - Added an AuthorityIntent component to be used in the future for UnrealGDK code to control loadbalancing.
+- Added support for RPC tracking and for actor property tracking via UE4s Network Profiler. This is a good proxy; Reasons for why it might not be fully accurate:
+	• the serialized size of a message is just the body contents. Typically something will send the message with the length prefixed, which might be varint encoded, and you pushing the size over some size can cause the encoding of the length be bigger
+	• similarly, if you push the message over some size it can cause fragmentation which means you now have to pay for the headers again
+	• if there is any compression or anything else going on, the number of bytes actually transferred because of this data can differ
+	• lastly somewhat philosophical question of who pays for the overhead of a packet and whether you attribute a part of it to each field or attribute it to the update itself, but I assume you care a bit less about this
 
 ### Breaking Changes:
 - If your project uses replicated subobjects that do not inherit from ActorComponent or GameplayAbility, you need to enable generating schema for them using SpatialType UCLASS specifier or by checking Spatial Type if it's a blueprint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new experimental CookAndGenerateSchemaCommandlet that generates required schema during a regular cook.
 - Added OverrideSpatialOffloading command line flag that allows toggling of offloading at launch time.
 - Added an AuthorityIntent component to be used in the future for UnrealGDK code to control loadbalancing.
-- Added support for RPC tracking and for actor property tracking via UE4s Network Profiler. This is a good proxy, but not fully accurate.
+- Added support for the UE4 Network Profile to measure relative size of RPC and Actor replication data.
 
 ### Breaking Changes:
 - If your project uses replicated subobjects that do not inherit from ActorComponent or GameplayAbility, you need to enable generating schema for them using SpatialType UCLASS specifier or by checking Spatial Type if it's a blueprint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added OverrideSpatialOffloading command line flag that allows toggling of offloading at launch time.
 - Added an AuthorityIntent component to be used in the future for UnrealGDK code to control loadbalancing.
 - Added support for RPC tracking and for actor property tracking via UE4s Network Profiler. This is a good proxy; Reasons for why it might not be fully accurate:
-	• the serialized size of a message is just the body contents. Typically something will send the message with the length prefixed, which might be varint encoded, and you pushing the size over some size can cause the encoding of the length be bigger
-	• similarly, if you push the message over some size it can cause fragmentation which means you now have to pay for the headers again
-	• if there is any compression or anything else going on, the number of bytes actually transferred because of this data can differ
-	• lastly somewhat philosophical question of who pays for the overhead of a packet and whether you attribute a part of it to each field or attribute it to the update itself, but I assume you care a bit less about this
 
 ### Breaking Changes:
 - If your project uses replicated subobjects that do not inherit from ActorComponent or GameplayAbility, you need to enable generating schema for them using SpatialType UCLASS specifier or by checking Spatial Type if it's a blueprint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new experimental CookAndGenerateSchemaCommandlet that generates required schema during a regular cook.
 - Added OverrideSpatialOffloading command line flag that allows toggling of offloading at launch time.
 - Added an AuthorityIntent component to be used in the future for UnrealGDK code to control loadbalancing.
-- Added support for RPC tracking and for actor property tracking via UE4s Network Profiler. This is a good proxy; Reasons for why it might not be fully accurate:
+- Added support for RPC tracking and for actor property tracking via UE4s Network Profiler. This is a good proxy, but not fully accurate.
 
 ### Breaking Changes:
 - If your project uses replicated subobjects that do not inherit from ActorComponent or GameplayAbility, you need to enable generating schema for them using SpatialType UCLASS specifier or by checking Spatial Type if it's a blueprint.

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -341,7 +341,9 @@ int64 USpatialActorChannel::ReplicateActor()
 	// ----------------------------------------------------------
 	// Replicate Actor and Component properties and RPCs
 	// ----------------------------------------------------------
-
+#if USE_NETWORK_PROFILER 
+	const uint32 ActorReplicateStartTime = GNetworkProfiler.IsTrackingEnabled() ? FPlatformTime::Cycles() : 0;
+#endif
 	// Epic does this at the net driver level, per connection. See UNetDriver::ServerReplicateActors().
 	// However, we have many player controllers sharing one connection, so we do it at the actor level before replication.
 	if (APlayerController* PlayerController = Cast<APlayerController>(Actor))
@@ -500,6 +502,9 @@ int64 USpatialActorChannel::ReplicateActor()
 			}
 		}
 	}
+#if USE_NETWORK_PROFILER 
+	NETWORK_PROFILER(GNetworkProfiler.TrackReplicateActor(Actor, RepFlags, FPlatformTime::Cycles() - ActorReplicateStartTime, Connection));
+#endif 
 
 	// If we evaluated everything, mark LastUpdateTime, even if nothing changed.
 	LastUpdateTime = Connection->Driver->Time;

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -706,7 +706,7 @@ ERPCResult USpatialSender::SendRPCInternal(UObject* TargetObject, UFunction* Fun
 			check(NetDriver->IsServer());
 
 			OutgoingOnCreateEntityRPCs.FindOrAdd(TargetObject).RPCs.Add(Payload);
-			NETWORK_PROFILER(GNetworkProfiler.TrackSendRPC(Channel->Actor, Function, 0, Params.Payload.CountDataBits(), 0, NetDriver->GetSpatialOSNetConnection()));
+			NETWORK_PROFILER(GNetworkProfiler.TrackSendRPC(Channel->Actor, Function, 0, Payload.CountDataBits(), 0, NetDriver->GetSpatialOSNetConnection()));
 #if !UE_BUILD_SHIPPING
 			NetDriver->SpatialMetrics->TrackSentRPC(Function, RPCInfo.Type, Payload.PayloadData.Num());
 #endif // !UE_BUILD_SHIPPING
@@ -731,7 +731,7 @@ ERPCResult USpatialSender::SendRPCInternal(UObject* TargetObject, UFunction* Fun
 		check(EntityId != SpatialConstants::INVALID_ENTITY_ID);
 		Worker_RequestId RequestId = Connection->SendCommandRequest(EntityId, &CommandRequest, SpatialConstants::UNREAL_RPC_ENDPOINT_COMMAND_ID);
 		
-		NETWORK_PROFILER(GNetworkProfiler.TrackSendRPC(Channel->Actor, Function, 0, Params.Payload.CountDataBits(), 0, NetDriver->GetSpatialOSNetConnection()));
+		NETWORK_PROFILER(GNetworkProfiler.TrackSendRPC(Channel->Actor, Function, 0, Payload.CountDataBits(), 0, NetDriver->GetSpatialOSNetConnection()));
 #if !UE_BUILD_SHIPPING
 		NetDriver->SpatialMetrics->TrackSentRPC(Function, RPCInfo.Type, Payload.PayloadData.Num());
 #endif // !UE_BUILD_SHIPPING
@@ -806,7 +806,7 @@ ERPCResult USpatialSender::SendRPCInternal(UObject* TargetObject, UFunction* Fun
 		if (bCanPackRPC)
 		{
 			ERPCResult Result = AddPendingRPC(TargetObject, Function, Payload, ComponentId, RPCInfo.Index);
-			NETWORK_PROFILER(GNetworkProfiler.TrackSendRPC(Channel->Actor, Function, 0, Params.Payload.CountDataBits(), 0, NetDriver->GetSpatialOSNetConnection()));
+			NETWORK_PROFILER(GNetworkProfiler.TrackSendRPC(Channel->Actor, Function, 0, Payload.CountDataBits(), 0, NetDriver->GetSpatialOSNetConnection()));
 #if !UE_BUILD_SHIPPING
 			if (Result == ERPCResult::Success)
 			{
@@ -825,7 +825,7 @@ ERPCResult USpatialSender::SendRPCInternal(UObject* TargetObject, UFunction* Fun
 			Worker_ComponentUpdate ComponentUpdate = CreateRPCEventUpdate(TargetObject, Payload, ComponentId, RPCInfo.Index);
 
 			Connection->SendComponentUpdate(EntityId, &ComponentUpdate);
-			NETWORK_PROFILER(GNetworkProfiler.TrackSendRPC(Channel->Actor, Function, 0, Params.Payload.CountDataBits(), 0, NetDriver->GetSpatialOSNetConnection()));
+			NETWORK_PROFILER(GNetworkProfiler.TrackSendRPC(Channel->Actor, Function, 0, Payload.CountDataBits(), 0, NetDriver->GetSpatialOSNetConnection()));
 #if !UE_BUILD_SHIPPING
 			NetDriver->SpatialMetrics->TrackSentRPC(Function, RPCInfo.Type, Payload.PayloadData.Num());
 #endif // !UE_BUILD_SHIPPING

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -4,6 +4,7 @@
 
 #include "GameFramework/PlayerController.h"
 #include "GameFramework/PlayerState.h"
+#include "Net/NetworkProfiler.h"
 
 #include "Engine/Engine.h"
 #include "EngineClasses/SpatialActorChannel.h"
@@ -705,6 +706,7 @@ ERPCResult USpatialSender::SendRPCInternal(UObject* TargetObject, UFunction* Fun
 			check(NetDriver->IsServer());
 
 			OutgoingOnCreateEntityRPCs.FindOrAdd(TargetObject).RPCs.Add(Payload);
+			NETWORK_PROFILER(GNetworkProfiler.TrackSendRPC(Channel->Actor, Function, 0, Params.Payload.CountDataBits(), 0, NetDriver->GetSpatialOSNetConnection()));
 #if !UE_BUILD_SHIPPING
 			NetDriver->SpatialMetrics->TrackSentRPC(Function, RPCInfo.Type, Payload.PayloadData.Num());
 #endif // !UE_BUILD_SHIPPING
@@ -728,7 +730,8 @@ ERPCResult USpatialSender::SendRPCInternal(UObject* TargetObject, UFunction* Fun
 
 		check(EntityId != SpatialConstants::INVALID_ENTITY_ID);
 		Worker_RequestId RequestId = Connection->SendCommandRequest(EntityId, &CommandRequest, SpatialConstants::UNREAL_RPC_ENDPOINT_COMMAND_ID);
-
+		
+		NETWORK_PROFILER(GNetworkProfiler.TrackSendRPC(Channel->Actor, Function, 0, Params.Payload.CountDataBits(), 0, NetDriver->GetSpatialOSNetConnection()));
 #if !UE_BUILD_SHIPPING
 		NetDriver->SpatialMetrics->TrackSentRPC(Function, RPCInfo.Type, Payload.PayloadData.Num());
 #endif // !UE_BUILD_SHIPPING
@@ -803,6 +806,7 @@ ERPCResult USpatialSender::SendRPCInternal(UObject* TargetObject, UFunction* Fun
 		if (bCanPackRPC)
 		{
 			ERPCResult Result = AddPendingRPC(TargetObject, Function, Payload, ComponentId, RPCInfo.Index);
+			NETWORK_PROFILER(GNetworkProfiler.TrackSendRPC(Channel->Actor, Function, 0, Params.Payload.CountDataBits(), 0, NetDriver->GetSpatialOSNetConnection()));
 #if !UE_BUILD_SHIPPING
 			if (Result == ERPCResult::Success)
 			{
@@ -821,6 +825,7 @@ ERPCResult USpatialSender::SendRPCInternal(UObject* TargetObject, UFunction* Fun
 			Worker_ComponentUpdate ComponentUpdate = CreateRPCEventUpdate(TargetObject, Payload, ComponentId, RPCInfo.Index);
 
 			Connection->SendComponentUpdate(EntityId, &ComponentUpdate);
+			NETWORK_PROFILER(GNetworkProfiler.TrackSendRPC(Channel->Actor, Function, 0, Params.Payload.CountDataBits(), 0, NetDriver->GetSpatialOSNetConnection()));
 #if !UE_BUILD_SHIPPING
 			NetDriver->SpatialMetrics->TrackSentRPC(Function, RPCInfo.Type, Payload.PayloadData.Num());
 #endif // !UE_BUILD_SHIPPING

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
@@ -76,6 +76,13 @@ bool ComponentFactory::FillSchemaObject(Schema_Object* ComponentObject, UObject*
 
 				bWroteSomething = true;
 #if USE_NETWORK_PROFILER
+				/**
+				 *  a good proxy. Reasons for why it might not be fully accurate:
+						• the serialized size of a message is just the body contents. Typically something will send the message with the length prefixed, which might be varint encoded, and you pushing the size over some size can cause the encoding of the length be bigger
+						• similarly, if you push the message over some size it can cause fragmentation which means you now have to pay for the headers again
+						• if there is any compression or anything else going on, the number of bytes actually transferred because of this data can differ
+						• lastly somewhat philosophical question of who pays for the overhead of a packet and whether you attribute a part of it to each field or attribute it to the update itself, but I assume you care a bit less about this
+				 */
 				const uint32 NumBytesEnd = Schema_GetWriteBufferLength(ComponentObject);
 				NETWORK_PROFILER(GNetworkProfiler.TrackReplicateProperty(Cmd.Property, (NumBytesEnd - NumBytesStart) * CHAR_BIT, nullptr));
 #endif

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
@@ -49,7 +49,7 @@ bool ComponentFactory::FillSchemaObject(Schema_Object* ComponentObject, UObject*
 
 				bool bProcessedFastArrayProperty = false;
 #if USE_NETWORK_PROFILER
-				const uint32 NumBitsStart = Schema_GetWriteBufferLength(ComponentObject);
+				const uint32 NumBytesStart = Schema_GetWriteBufferLength(ComponentObject);
 #endif
 				if (Cmd.Type == ERepLayoutCmdType::DynamicArray)
 				{
@@ -75,9 +75,9 @@ bool ComponentFactory::FillSchemaObject(Schema_Object* ComponentObject, UObject*
 				}
 
 				bWroteSomething = true;
-	#if USE_NETWORK_PROFILER
-				const uint32 NumBitsEnd = Schema_GetWriteBufferLength(ComponentObject);
-				NETWORK_PROFILER(GNetworkProfiler.TrackReplicateProperty(Cmd.Property, (NumBitsEnd - NumBitsStart) * CHAR_BIT, nullptr));
+#if USE_NETWORK_PROFILER
+				const uint32 NumBytesEnd = Schema_GetWriteBufferLength(ComponentObject);
+				NETWORK_PROFILER(GNetworkProfiler.TrackReplicateProperty(Cmd.Property, (NumBytesEnd - NumBytesStart) * CHAR_BIT, nullptr));
 #endif
 			}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
@@ -77,7 +77,7 @@ bool ComponentFactory::FillSchemaObject(Schema_Object* ComponentObject, UObject*
 				bWroteSomething = true;
 #if USE_NETWORK_PROFILER
 				/**
-				 *  a good proxy. Reasons for why it might not be fully accurate:
+				 *  A good proxy for how many bits are being sent for a propery. Reasons for why it might not be fully accurate:
 						• the serialized size of a message is just the body contents. Typically something will send the message with the length prefixed, which might be varint encoded, and you pushing the size over some size can cause the encoding of the length be bigger
 						• similarly, if you push the message over some size it can cause fragmentation which means you now have to pay for the headers again
 						• if there is any compression or anything else going on, the number of bytes actually transferred because of this data can differ


### PR DESCRIPTION
#### Description
Setup basic ue4 network profiler support. Tracks RPCs and actor property replication. Can be used with the standard network profiler commands (~NetProfiler). Can be opened with the network profiler tool. (needs to be built from Engine\Source\Programs\NetworkProfiler)

#### Release note
REQUIRED: Add a release note to the `##Unreleased` section of CHANGELOG.md. You can find guidance for writing useful release notes [here](../SpatialGDK/Extras/internal-documentation/how-to-write-good-release-notes.md). Documentation changes are exempt from this requirement.
- Added support for RPC tracking and for actor property tracking via UE4s Network Profiler. This is a good proxy; Reasons for why it might not be fully accurate:
	• the serialized size of a message is just the body contents. Typically something will send the message with the length prefixed, which might be varint encoded, and you pushing the size over some size can cause the encoding of the length be bigger
	• similarly, if you push the message over some size it can cause fragmentation which means you now have to pay for the headers again
	• if there is any compression or anything else going on, the number of bytes actually transferred because of this data can differ
	• lastly somewhat philosophical question of who pays for the overhead of a packet and whether you attribute a part of it to each field or attribute it to the update itself, but I assume you care a bit less about this

#### Tests
Tested in external project. Compared results with base ue4 seemed reasonably close, but not identical. Should be tested/reviewed by someone who understand the networking differences better. 

What automated tests are included in this PR?
None.

STRONGLY SUGGESTED: How can this be verified by QA?
Boot up something like shooter game, and compare spatial vs base ue4.

#### Documentation
This is a feature being supported by ue4, and documented as such. We'll need a disclaimer similar to unity's that the value is proxy and not equal to the exact bits sent over the network. https://docs.improbable.io/unity/alpha/modules/debug/network-analyzer

#### Primary reviewers
@yumnuska 