### PR TITLE
Fix ProcessUserConsoleInput incorrectly short circuiting

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
@@ -136,10 +136,7 @@ bool USpatialGameInstance::ProcessConsoleExec(const TCHAR* Cmd, FOutputDevice& A
 			return true;
 		}
 
-		if (NetDriver->SpatialDebugger && NetDriver->SpatialDebugger->ProcessConsoleExec(Cmd, Ar, Executor))
-		{
-			return true;
-		}
+		return NetDriver->SpatialDebugger && NetDriver->SpatialDebugger->ProcessConsoleExec(Cmd, Ar, Executor);
 	}
 	return true;
 }


### PR DESCRIPTION
By wrapping that statement in an `if`, we were incorrectly returning `true` since we would get to line 143, which would cause the engine to think the console command was successfully executed.