### PR TITLE
Add MSVC install workaround to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [`0.7.0-preview`] - 2019-10-11
 
 ### New Known Issues:
-- MSVC v14.23 removes `typeinfo.h` and replaces it with `typeinfo`. This change causes errors when building the Unreal Engine. This issue affects Visual Studio 2019 users. Until [this proposed fix](https://github.com/EpicGames/UnrealEngine/pull/6226) is accepted by Epic Games, you can work around the issue by:
+- MSVC v14.23 removes `typeinfo.h` and replaces it with `typeinfo`. This change causes errors when building the Unreal Engine. This issue **only affects Visual Studio 2019** users. You can work around the issue by:
 1. Open Visual Studio Installer.
 1. Select "Modify" on your Visual Studio 2019 installation.
-1. Select the "Individual components" tab.
-1. Uncheck "MSVC v142 - VS 2019 C++ x64/x86 build tools (**v14.22**)".
-1. Check "MSVC v142 - VS 2019 C++ x64/x86 build tools (**v14.23**)".
-1. Select "Modify" to confirm your changes.
+1. In the Installation details section uncheck all workloads and components until only **Visual Studio code editor** remains.
+1. Select the following items in the Workloads tab:
+* **Universal Windows Platform development**
+* **.NET desktop development**
+* You must also select the **.NET Framework 4.6.2 development tools** component in the Installation details section.
+* **Desktop development with C++**
+* You must then deselect **MSVC v142 - VS 2019 C++ x64/x86 build tools (v14.23)**, which was added as part of the **Desktop development with C++** Workload. You will be notified that: "If you continue, we'll remove the componenet and any items liseted above that depend on it." Select remove to confirm your decision.
+* Lastly, add **MSVC v142 - VS 2019 C++ x64/x86 build tools (v14.22)** from the Individual components tab.
+5. Select "Modify" to confirm your changes.
 
 ### Breaking Changes:
 - If your project uses replicated subobjects that do not inherit from ActorComponent or GameplayAbility, you now need to enable generating schema for them using `SpatialType` UCLASS specifier, or by checking the Spatial Type checkbox on blueprints.


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
I've updated `CHANGELOG.md` to detail a work around for a breaking change that I believe Microsoft introduced in Visual Studio Installer **16.3.6**.

The breaking change re-maps component dependencies so that **MSVC v142 - VS 2019 C++ x64/x86 build tools (v14.23)**  is treated as a dependency for:

* **Game development with C++**
* **Unreal Engine installer**
* **C++ CMake tools for Windows**
* **C++ profiling tools**
* **Graphics debugger and GPU profiler for DirectX**

We previously worked around a separate breaking change that Microsoft had [inadvertently introduced](https://developercommunity.visualstudio.com/comments/752563/view.html) in **MSVC 14.23.28019** (a [minor](https://semver.org/) release) by telling users to uninstall **14.23** and install **14.23**, but that workaround is no longer possible because the re-mapped dependency tree forces the user to uninstall the required workloads and components listed above.

#### Release note
This is a release note.

#### Tests for change
I have manually executed the workaround detailed in this PR and then built the UE4 fork, build the Example Project, local and cloud deployed and playtested with two clients and one server.

#### Tests for working theory
This PR is premised on the fact that Microsoft have introduced a breaking change in Visual Studio Installer **16.3.6**. I came to this conclusion because I updated to **16.3.6** and then noticed that dependencies were mapped differently.

To confirm this thesis, I would need to download and install multiple versions of Visual Studio Installer, but I can't do this as I can only find download links for latest.

#### Documentation
This is documentation, but I will make the same change to CHANGELOG in `preview` and to the "get the dependencies" step on `docs-preview` for completeness.