### PR TITLE
Update the translator to query for connection entities

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -322,6 +322,9 @@ void USpatialNetDriver::CreateAndInitializeCoreClasses()
 	Receiver->Init(this, &TimerManager);
 	GlobalStateManager->Init(this, &TimerManager);
 	VirtualWorkerTranslator->Init(this);
+	// TODO(zoning): This currently hard codes the desired number of virtual workers. This should be retrieved
+	// from the configuration.
+	VirtualWorkerTranslator->SetDesiredVirtualWorkerCount(2);
 	SnapshotManager->Init(this);
 	PlayerSpawner->Init(this, &TimerManager);
 	SpatialMetrics->Init(this);

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslator.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslator.cpp
@@ -3,6 +3,8 @@
 #include "EngineClasses/SpatialVirtualWorkerTranslator.h"
 #include "EngineClasses/SpatialNetDriver.h"
 #include "Interop/Connection/SpatialWorkerConnection.h"
+#include "Interop/SpatialReceiver.h"
+#include "Interop/SpatialStaticComponentView.h"
 #include "SpatialConstants.h"
 #include "Utils/SchemaUtils.h"
 
@@ -11,31 +13,64 @@ DEFINE_LOG_CATEGORY(LogSpatialVirtualWorkerTranslator);
 SpatialVirtualWorkerTranslator::SpatialVirtualWorkerTranslator()
 	: NetDriver(nullptr)
 {
+	bWorkerEntityQueryInFlight = false;
+	bIsReady = false;
+	DesiredVirtualWorkerCount = 0;
 }
 
 void SpatialVirtualWorkerTranslator::Init(USpatialNetDriver* InNetDriver)
 {
 	NetDriver = InNetDriver;
+	if (NetDriver != nullptr)
+	{
+		WorkerId = NetDriver->Connection->GetWorkerId();
+	}
+	else
+	{
+		WorkerId = "InvalidWorkerId";
+	}
 }
+
+void SpatialVirtualWorkerTranslator::SetDesiredVirtualWorkerCount(uint32 NumberOfVirtualWorkers)
+{
+	// Currently, this should only be called once on startup. In the future we may allow for more
+	// flexibility. 
+	if (bIsReady)
+	{
+		UE_LOG(LogSpatialVirtualWorkerTranslator, Warning, TEXT("(%s) SetDesiredVirtualWorkerCount called after the translator is ready, ignoring."), *WorkerId);
+	}
+
+	DesiredVirtualWorkerCount = NumberOfVirtualWorkers;
+	for (uint32 i = 0; i < NumberOfVirtualWorkers; i++)
+	{
+		UnassignedVirtualWorkers.Enqueue(i);
+	}
+
+	// TODO(zoning): We likely want to not declare ready until we have received the connection entity query and have
+	// synchronized with the strategy and enforcer.
+	bIsReady = true;
+}
+
 
 const FString* SpatialVirtualWorkerTranslator::GetPhysicalWorkerForVirtualWorker(VirtualWorkerId id)
 {
 	return VirtualToPhysicalWorkerMapping.Find(id);
 }
 
-void SpatialVirtualWorkerTranslator::ApplyVirtualWorkerManagerData(const Worker_ComponentData& Data)
+void SpatialVirtualWorkerTranslator::ApplyVirtualWorkerManagerData(Schema_Object* ComponentObject)
 {
-	if (NetDriver)
-	{
-		UE_LOG(LogSpatialVirtualWorkerTranslator, Log, TEXT("(%s) ApplyVirtualWorkerManagerData"), *NetDriver->Connection->GetWorkerId());
-	}
-
-	Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
-
-	VirtualToPhysicalWorkerMapping.Empty();
+    UE_LOG(LogSpatialVirtualWorkerTranslator, Log, TEXT("(%s) ApplyVirtualWorkerManagerData"), *WorkerId);
 
 	// The translation schema is a list of Mappings, where each entry has a virtual and physical worker ID. 
 	ApplyMappingFromSchema(ComponentObject);
+
+	if (NetDriver)
+	{
+		for (auto& Entry : VirtualToPhysicalWorkerMapping)
+		{
+			UE_LOG(LogSpatialVirtualWorkerTranslator, Log, TEXT("(%s) assignment: %d - %s"), *WorkerId, Entry.Key, *(Entry.Value));
+		}
+	}
 }
 
 void SpatialVirtualWorkerTranslator::OnComponentUpdated(const Worker_ComponentUpdateOp& Op)
@@ -46,9 +81,40 @@ void SpatialVirtualWorkerTranslator::OnComponentUpdated(const Worker_ComponentUp
 	}
 }
 
-// The translation schema is a list of Mappings, where each entry has a virtual and physical worker ID. 
+void SpatialVirtualWorkerTranslator::AuthorityChanged(const Worker_AuthorityChangeOp& AuthOp)
+{
+	const bool bAuthoritative = AuthOp.authority == WORKER_AUTHORITY_AUTHORITATIVE;
+
+	if (AuthOp.component_id == SpatialConstants::VIRTUAL_WORKER_TRANSLATION_MAPPING_ID)
+	{
+		UE_LOG(LogSpatialVirtualWorkerTranslator, Log, TEXT("(%s) Authority over the VirtualWorkerTranslator has changed. This worker %s authority."), *WorkerId, bAuthoritative ? TEXT("now has") : TEXT("does not have"));
+
+		if (bAuthoritative)
+		{
+			// TODO(zoning): The prototype had an unassigned workers list. Need to follow up with Tim/Chris about whether
+			// that is necessary or we can continue to use the (possibly) stale list until we receive the query response.
+
+			// Query for all connection entities, so we can detect if some worker has died and needs to be updated in
+			// the mapping.
+			QueryForWorkerEntities();
+		}
+	}
+	// TODO(zoning): If authority is received on the ACL component, we may need to update it.
+}
+
+// The translation schema is a list of Mappings, where each entry has a virtual and physical worker ID.
+// This method should only be called on workers who are not authoritative over the mapping.
+// TODO(harkness): Is this true? I think this will be called once the first time we get authority?
 void SpatialVirtualWorkerTranslator::ApplyMappingFromSchema(Schema_Object* Object)
 {
+	if (NetDriver != nullptr &&
+		NetDriver->StaticComponentView->HasAuthority(SpatialConstants::INITIAL_VIRTUAL_WORKER_TRANSLATOR_ENTITY_ID, SpatialConstants::VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID))
+	{
+		UE_LOG(LogSpatialVirtualWorkerTranslator, Log, TEXT("(%s) ApplyMappingFromSchema called, but this worker is authoritative, ignoring"), *WorkerId);
+	}
+
+	// Resize the map to accept the new data.
+	VirtualToPhysicalWorkerMapping.Empty();
 	int32 TranslationCount = (int32)Schema_GetObjectCount(Object, SpatialConstants::VIRTUAL_WORKER_TRANSLATION_MAPPING_ID);
 	VirtualToPhysicalWorkerMapping.Reserve(TranslationCount);
 
@@ -73,4 +139,142 @@ void SpatialVirtualWorkerTranslator::WriteMappingToSchema(Schema_Object* Object)
 		Schema_AddUint32(EntryObject, SpatialConstants::MAPPING_VIRTUAL_WORKER_ID, Entry.Key);
 		SpatialGDK::AddStringToSchema(EntryObject, SpatialConstants::MAPPING_PHYSICAL_WORKER_NAME, Entry.Value);
 	}
+}
+
+// This method is called on the worker who is authoritative over the translation mapping. Based on the results of the
+// system entity query, assign the VirtualWorkerIds to the workers represented by the system entities.
+void SpatialVirtualWorkerTranslator::ConstructVirtualWorkerMappingFromQueryResponse(const Worker_EntityQueryResponseOp& Op)
+{
+	// The query response is an array of entities. Each of these represents a worker.
+	for (uint32_t i = 0; i < Op.result_count; ++i)
+	{
+		for (uint32_t j = 0; j < Op.results[i].component_count; j++)
+		{
+			Worker_ComponentData Data = Op.results[i].components[j];
+			// System entities which represent workers have a component on them which specifies the SpatialOS worker ID,
+			// which is the string we use to refer to them as a physical worker ID.
+			if (Data.component_id == SpatialConstants::WORKER_COMPONENT_ID)
+			{
+				Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
+
+				const FString& WorkerType = SpatialGDK::GetStringFromSchema(ComponentObject, SpatialConstants::WORKER_TYPE_ID);
+
+				// TODO(zoning): Currently, this only works if server workers never die. Once we want to support replacing
+				// workers, this will need to process UnassignWorker before processing AssignWorker.
+				if (WorkerType.Equals(SpatialConstants::DefaultServerWorkerType.ToString()) &&
+					!UnassignedVirtualWorkers.IsEmpty())
+				{
+					AssignWorker(SpatialGDK::GetStringFromSchema(ComponentObject, SpatialConstants::WORKER_ID_ID));
+				}
+			}
+		}
+	}
+}
+
+// This will be called on the worker authoritative for the translation mapping to push the new version of the map
+// to the spatialOS storage.
+void SpatialVirtualWorkerTranslator::SendVirtualWorkerMappingUpdate()
+{
+	if (!bIsReady || NetDriver == nullptr)
+	{
+		return;
+	}
+
+	UE_LOG(LogSpatialVirtualWorkerTranslator, Log, TEXT("(%s) SendVirtualWorkerMappingUpdate"), *WorkerId);
+
+	check(NetDriver->StaticComponentView->HasAuthority(SpatialConstants::INITIAL_VIRTUAL_WORKER_TRANSLATOR_ENTITY_ID, SpatialConstants::VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID));
+
+	// Construct the mapping update based on the local virtual worker to physical worker mapping.
+	Worker_ComponentUpdate Update = {};
+	Update.component_id = SpatialConstants::VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID;
+	Update.schema_type = Schema_CreateComponentUpdate();
+	Schema_Object* UpdateObject = Schema_GetComponentUpdateFields(Update.schema_type);
+
+	WriteMappingToSchema(UpdateObject);
+
+	NetDriver->Connection->SendComponentUpdate(SpatialConstants::INITIAL_VIRTUAL_WORKER_TRANSLATOR_ENTITY_ID, &Update);
+
+	// Broadcast locally since we won't receive the ComponentUpdate on this worker.
+	// This is disabled until the Enforcer is available to update ACLs.
+	// OnWorkerAssignmentChanged.Broadcast(VirtualWorkerAssignment);
+}
+
+void SpatialVirtualWorkerTranslator::QueryForWorkerEntities()
+{
+	if (!bIsReady || NetDriver == nullptr)
+	{
+		return;
+	}
+
+	UE_LOG(LogSpatialVirtualWorkerTranslator, Log, TEXT("(%s) Sending query for WorkerEntities"), *WorkerId);
+
+	checkf(!bWorkerEntityQueryInFlight, TEXT("(%s) Trying to query for worker entities while a previous query is still in flight!"), *WorkerId);
+
+	if (!NetDriver->StaticComponentView->HasAuthority(SpatialConstants::INITIAL_VIRTUAL_WORKER_TRANSLATOR_ENTITY_ID, SpatialConstants::VIRTUAL_WORKER_TRANSLATION_MAPPING_ID))
+	{
+		UE_LOG(LogSpatialVirtualWorkerTranslator, Log, TEXT("(%s) Trying QueryForWorkerEntities, but don't have authority over VIRTUAL_WORKER_MANAGER_COMPONENT.  Aborting processing."), *WorkerId);
+		return;
+	}
+
+	// Create a query for all the system entities which represent workers. This will be used
+	// to find physical workers which the virtual workers will map to.
+	Worker_ComponentConstraint WorkerEntityComponentConstraint{};
+	WorkerEntityComponentConstraint.component_id = SpatialConstants::WORKER_COMPONENT_ID;
+
+	Worker_Constraint WorkerEntityConstraint{};
+	WorkerEntityConstraint.constraint_type = WORKER_CONSTRAINT_TYPE_COMPONENT;
+	WorkerEntityConstraint.constraint.component_constraint = WorkerEntityComponentConstraint;
+
+	Worker_EntityQuery WorkerEntityQuery{};
+	WorkerEntityQuery.constraint = WorkerEntityConstraint;
+	WorkerEntityQuery.result_type = WORKER_RESULT_TYPE_SNAPSHOT;
+
+	Worker_RequestId RequestID;
+	RequestID = NetDriver->Connection->SendEntityQueryRequest(&WorkerEntityQuery);
+
+	// The Lambda below allows the translator to deal with the returned list of connection entities when they are received.
+	// Note that this worker may have lost authority for the translation mapping in the meantime, so it's possible the
+	// returned information will be thrown away.
+	EntityQueryDelegate WorkerEntityQueryDelegate;
+	WorkerEntityQueryDelegate.BindLambda([this](const Worker_EntityQueryResponseOp& Op)
+	{
+		if (!NetDriver->StaticComponentView->HasAuthority(SpatialConstants::INITIAL_VIRTUAL_WORKER_TRANSLATOR_ENTITY_ID, SpatialConstants::VIRTUAL_WORKER_TRANSLATION_MAPPING_ID))
+		{
+			UE_LOG(LogSpatialVirtualWorkerTranslator, Log, TEXT("(%s) Received response to WorkerEntityQuery, but don't have authority over VIRTUAL_WORKER_MANAGER_COMPONENT.  Aborting processing."), *WorkerId);
+		}
+		else if (Op.status_code != WORKER_STATUS_CODE_SUCCESS)
+		{
+			UE_LOG(LogSpatialVirtualWorkerTranslator, Log, TEXT("(%s) Could not find Worker Entities via entity query: %s"), *WorkerId, UTF8_TO_TCHAR(Op.message));
+		}
+		else if (Op.result_count == 0)
+		{
+			UE_LOG(LogSpatialVirtualWorkerTranslator, Log, TEXT("(%s) Worker Entity query shows that Worker Entities do not yet exist in the world."), *WorkerId);
+		}
+		else
+		{
+			UE_LOG(LogSpatialVirtualWorkerTranslator, Log, TEXT("(%s) Processing Worker Entity query response"), *WorkerId);
+			ConstructVirtualWorkerMappingFromQueryResponse(Op);
+			SendVirtualWorkerMappingUpdate();
+		}
+
+		bWorkerEntityQueryInFlight = false;
+	});
+
+	bWorkerEntityQueryInFlight = true;
+
+	NetDriver->Receiver->AddEntityQueryDelegate(RequestID, WorkerEntityQueryDelegate);
+}
+
+void SpatialVirtualWorkerTranslator::AssignWorker(const PhysicalWorkerName& Name)
+{
+	check(!UnassignedVirtualWorkers.IsEmpty());
+	check(NetDriver->StaticComponentView->HasAuthority(SpatialConstants::INITIAL_VIRTUAL_WORKER_TRANSLATOR_ENTITY_ID, SpatialConstants::VIRTUAL_WORKER_TRANSLATION_MAPPING_ID));
+
+	// Get a VirtualWorkerId from the list of unassigned work.
+	VirtualWorkerId Id;
+	UnassignedVirtualWorkers.Dequeue(Id);
+
+	VirtualToPhysicalWorkerMapping.Add(Id, Name);
+
+	UE_LOG(LogSpatialVirtualWorkerTranslator, Log, TEXT("(%s) Assigned VirtualWorker %d to simulate on Worker %s"), *WorkerId, Id, *Name);
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -14,6 +14,7 @@
 #include "EngineClasses/SpatialGameInstance.h"
 #include "EngineClasses/SpatialNetConnection.h"
 #include "EngineClasses/SpatialPackageMapClient.h"
+#include "EngineClasses/SpatialVirtualWorkerTranslator.h"
 #include "Interop/Connection/SpatialWorkerConnection.h"
 #include "Interop/GlobalStateManager.h"
 #include "Interop/SpatialPlayerSpawner.h"
@@ -154,6 +155,13 @@ void USpatialReceiver::OnAddComponent(const Worker_AddComponentOp& Op)
 		{
 			// This would normally get registered through the channel cleanup, but we don't have one for this entity
 			NetDriver->RegisterDormantEntityId(Op.entity_id);
+		}
+		return;
+	case SpatialConstants::VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID:
+		if (NetDriver->VirtualWorkerTranslator != nullptr)
+		{
+			Schema_Object* ComponentObject = Schema_GetComponentDataFields(Op.data.schema_type);
+			NetDriver->VirtualWorkerTranslator->ApplyVirtualWorkerManagerData(ComponentObject);
 		}
 		return;
 	}
@@ -1138,6 +1146,13 @@ void USpatialReceiver::OnComponentUpdate(const Worker_ComponentUpdateOp& Op)
 	case SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID:
 		check(false); // TODO(zoning): Handle updates to the entity's authority intent.
 		break;
+	case SpatialConstants::VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID:
+		if (NetDriver->VirtualWorkerTranslator != nullptr)
+		{
+			Schema_Object* ComponentObject = Schema_GetComponentUpdateFields(Op.update.schema_type);
+			NetDriver->VirtualWorkerTranslator->ApplyVirtualWorkerManagerData(ComponentObject);
+		}
+		return;
 	}
 
 	if (Op.update.component_id < SpatialConstants::MAX_RESERVED_SPATIAL_SYSTEM_COMPONENT_ID)

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -146,6 +146,8 @@ public:
 
 	Worker_EntityId WorkerEntityId = SpatialConstants::INVALID_ENTITY_ID;
 
+	TUniquePtr<SpatialVirtualWorkerTranslator> VirtualWorkerTranslator;
+
 	TMap<UClass*, TPair<AActor*, USpatialActorChannel*>> SingletonActorChannels;
 
 	bool IsAuthoritativeDestructionAllowed() const { return bAuthoritativeDestruction; }
@@ -184,7 +186,6 @@ public:
 #endif
 
 private:
-	TUniquePtr<SpatialVirtualWorkerTranslator> VirtualWorkerTranslator;
 	TUniquePtr<FSpatialOutputDevice> SpatialOutputDevice;
 
 	TMap<Worker_EntityId_Key, USpatialActorChannel*> EntityToActorChannel;

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialVirtualWorkerTranslator.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialVirtualWorkerTranslator.h
@@ -33,7 +33,7 @@ public:
 	// the next mapping update.
 	const FString* GetPhysicalWorkerForVirtualWorker(VirtualWorkerId id);
 
-	// On receiving an version of the translation state, apply that to the internal mapping.
+	// On receiving a version of the translation state, apply that to the internal mapping.
 	void ApplyVirtualWorkerManagerData(Schema_Object* ComponentObject);
 
 	void OnComponentUpdated(const Worker_ComponentUpdateOp& Op);

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialVirtualWorkerTranslator.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialVirtualWorkerTranslator.h
@@ -57,10 +57,14 @@ private:
 	// The WorkerId of this worker, for logging purposes.
 	FString WorkerId;
 
+	// Serialization and deserialization of the mapping.
 	void ApplyMappingFromSchema(Schema_Object* Object);
 	void WriteMappingToSchema(Schema_Object* Object);
 
+	// The following methods are used to query the Runtime for all worker entities and update the mapping
+	// based on the response.
 	void QueryForWorkerEntities();
+	void WorkerEntityQueryDelegate(const Worker_EntityQueryResponseOp& Op);
 	void ConstructVirtualWorkerMappingFromQueryResponse(const Worker_EntityQueryResponseOp& Op);
 	void SendVirtualWorkerMappingUpdate();
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialVirtualWorkerTranslator.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialVirtualWorkerTranslator.h
@@ -21,22 +21,49 @@ public:
 
 	void Init(USpatialNetDriver* InNetDriver);
 
+	// Returns true if the Translator has received the information needed to map virtual workers to physical workers.
+	// Currently that is only the number of virtual workers desired.
+	bool IsReady() const { return bIsReady; }
+
+	void SetDesiredVirtualWorkerCount(uint32 NumberOfVirtualWorkers);
+
 	// Returns the name of the worker currently assigned to VirtualWorkerId id or nullptr if there is
 	// no worker assigned.
 	// TODO(harkness): Do we want to copy this data? Otherwise it's only guaranteed to be valid until
 	// the next mapping update.
 	const FString* GetPhysicalWorkerForVirtualWorker(VirtualWorkerId id);
 
-	// On receiving an update to the translation state, apply that to the internal mapping.
-	void ApplyVirtualWorkerManagerData(const Worker_ComponentData& Data);
+	// On receiving an version of the translation state, apply that to the internal mapping.
+	void ApplyVirtualWorkerManagerData(Schema_Object* ComponentObject);
 
 	void OnComponentUpdated(const Worker_ComponentUpdateOp& Op);
+
+	// Authority may change on one of two components we care about:
+	// 1) The translation component, in which case this worker is now authoritative on the virtual to physical worker translation.
+	// 2) The ACL component for some entity, in which case this worker is now authoritative for the entity and will be
+	// responsible for updating the ACL in the future if this worker loses authority.
+	void AuthorityChanged(const Worker_AuthorityChangeOp& AuthChangeOp);
 
 private:
 	USpatialNetDriver* NetDriver;
 
 	TMap<VirtualWorkerId, PhysicalWorkerName>  VirtualToPhysicalWorkerMapping;
+	TQueue<VirtualWorkerId> UnassignedVirtualWorkers;
+
+	bool bWorkerEntityQueryInFlight;
+
+	bool bIsReady;
+	uint32 DesiredVirtualWorkerCount;
+
+	// The WorkerId of this worker, for logging purposes.
+	FString WorkerId;
 
 	void ApplyMappingFromSchema(Schema_Object* Object);
 	void WriteMappingToSchema(Schema_Object* Object);
-}; 
+
+	void QueryForWorkerEntities();
+	void ConstructVirtualWorkerMappingFromQueryResponse(const Worker_EntityQueryResponseOp& Op);
+	void SendVirtualWorkerMappingUpdate();
+
+	void AssignWorker(const FString& WorkerId);
+};

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialVirtualWorkerTranslator.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialVirtualWorkerTranslator.h
@@ -53,7 +53,6 @@ private:
 	bool bWorkerEntityQueryInFlight;
 
 	bool bIsReady;
-	uint32 DesiredVirtualWorkerCount;
 
 	// The WorkerId of this worker, for logging purposes.
 	FString WorkerId;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -87,7 +87,8 @@ namespace SpatialConstants
 		INVALID_ENTITY_ID = 0,
 		INITIAL_SPAWNER_ENTITY_ID = 1,
 		INITIAL_GLOBAL_STATE_MANAGER_ENTITY_ID = 2,
-		FIRST_AVAILABLE_ENTITY_ID = 3,
+		INITIAL_VIRTUAL_WORKER_TRANSLATOR_ENTITY_ID = 3,
+		FIRST_AVAILABLE_ENTITY_ID = 4,
 	};
 
 	const Worker_ComponentId INVALID_COMPONENT_ID							= 0;
@@ -97,6 +98,8 @@ namespace SpatialConstants
 	const Worker_ComponentId POSITION_COMPONENT_ID							= 54;
 	const Worker_ComponentId PERSISTENCE_COMPONENT_ID						= 55;
 	const Worker_ComponentId INTEREST_COMPONENT_ID							= 58;
+	// This is a component on per-worker system entities.
+	const Worker_ComponentId WORKER_COMPONENT_ID							= 60;
 
 	const Worker_ComponentId MAX_RESERVED_SPATIAL_SYSTEM_COMPONENT_ID		= 100;
 
@@ -175,12 +178,16 @@ namespace SpatialConstants
 
 	// AuthorityIntent codes and Field IDs.
 	const Schema_FieldId AUTHORITY_INTENT_VIRTUAL_WORKER_ID					= 1;
-	const uint32 INVALID_VIRTUAL_WORKER_ID                                = 0;
+	const uint32 INVALID_VIRTUAL_WORKER_ID									= 0;
 
 	// VirtualWorkerTranslation Field IDs.
 	const Schema_FieldId VIRTUAL_WORKER_TRANSLATION_MAPPING_ID				= 1;
 	const Schema_FieldId MAPPING_VIRTUAL_WORKER_ID							= 1;
 	const Schema_FieldId MAPPING_PHYSICAL_WORKER_NAME						= 2;
+
+	// WorkerEntity Field IDs.
+	const Schema_FieldId WORKER_ID_ID										= 1;
+	const Schema_FieldId WORKER_TYPE_ID										= 2;
 
 	// Reserved entity IDs expire in 5 minutes, we will refresh them every 3 minutes to be safe.
 	const float ENTITY_RANGE_EXPIRATION_INTERVAL_SECONDS = 180.0f;

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/EngineClasses/SpatialVirtualWorkerTranslator/SpatialVirtualWorkerTranslatorTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/EngineClasses/SpatialVirtualWorkerTranslator/SpatialVirtualWorkerTranslatorTest.cpp
@@ -13,6 +13,26 @@
 #define VIRTUALWORKERTRANSLATOR_TEST(TestName) \
 	TEST(Core, SpatialVirtualWorkerTranslator, TestName)
 
+VIRTUALWORKERTRANSLATOR_TEST(Given_init_is_not_called_THEN_return_not_ready)
+{
+	TUniquePtr<SpatialVirtualWorkerTranslator> translator = MakeUnique<SpatialVirtualWorkerTranslator>();
+
+	TestFalse("Uninitialized Translator is not ready.", translator->IsReady());
+
+	return true;
+}
+
+VIRTUALWORKERTRANSLATOR_TEST(Given_init_and_set_desired_worker_count_called_THEN_return_ready)
+{
+	TUniquePtr<SpatialVirtualWorkerTranslator> translator = MakeUnique<SpatialVirtualWorkerTranslator>();
+	translator->Init(nullptr);
+	translator->SetDesiredVirtualWorkerCount(1);  // unimportant random value.
+
+	TestTrue("Initialized Translator is ready.", translator->IsReady());
+
+	return true;
+}
+
 VIRTUALWORKERTRANSLATOR_TEST(Given_no_mapping_WHEN_nothing_has_changed_THEN_return_no_mappings)
 {
 	// The class is initialized with no data.
@@ -46,8 +66,48 @@ VIRTUALWORKERTRANSLATOR_TEST(Given_no_mapping_WHEN_it_is_updated_THEN_return_the
 	SpatialGDK::AddStringToSchema(SecondEntryObject, SpatialConstants::MAPPING_PHYSICAL_WORKER_NAME, "VW_F");
 
 	// Now apply the mapping to the translator and test the result.
-	translator->ApplyVirtualWorkerManagerData(Data);
+	Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
+	translator->ApplyVirtualWorkerManagerData(ComponentObject);
 	
+	TestTrue("There is a mapping for virtual worker 2", translator->GetPhysicalWorkerForVirtualWorker(2) != nullptr);
+	TestTrue("VW_B overwritten with VW_E", translator->GetPhysicalWorkerForVirtualWorker(2)->Equals("VW_E"));
+
+	TestTrue("There is a mapping for virtual worker 3", translator->GetPhysicalWorkerForVirtualWorker(3) != nullptr);
+	TestTrue("VW_B overwritten with VW_F", translator->GetPhysicalWorkerForVirtualWorker(3)->Equals("VW_F"));
+
+	TestTrue("There is no mapping for virtual worker 1", translator->GetPhysicalWorkerForVirtualWorker(1) == nullptr);
+
+	return true;
+}
+
+VIRTUALWORKERTRANSLATOR_TEST(Given_no_mapping_WHEN_query_response_received_THEN_return_the_updated_mapping)
+{
+	// The class is initialized with no data.
+	TUniquePtr<SpatialVirtualWorkerTranslator> translator = MakeUnique<SpatialVirtualWorkerTranslator>();
+
+	
+
+	// Create a base mapping.
+	Worker_ComponentData Data = {};
+	Data.component_id = SpatialConstants::VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID;
+	Data.schema_type = Schema_CreateComponentData();
+	Schema_Object* DataObject = Schema_GetComponentDataFields(Data.schema_type);
+
+	// The mapping only has the following entries:
+	// 	VirtualToPhysicalWorkerMapping.Add(2, "VW_E");
+	// 	VirtualToPhysicalWorkerMapping.Add(3, "VW_F");
+	Schema_Object* FirstEntryObject = Schema_AddObject(DataObject, SpatialConstants::VIRTUAL_WORKER_TRANSLATION_MAPPING_ID);
+	Schema_AddUint32(FirstEntryObject, SpatialConstants::MAPPING_VIRTUAL_WORKER_ID, 2);
+	SpatialGDK::AddStringToSchema(FirstEntryObject, SpatialConstants::MAPPING_PHYSICAL_WORKER_NAME, "VW_E");
+
+	Schema_Object* SecondEntryObject = Schema_AddObject(DataObject, SpatialConstants::VIRTUAL_WORKER_TRANSLATION_MAPPING_ID);
+	Schema_AddUint32(SecondEntryObject, SpatialConstants::MAPPING_VIRTUAL_WORKER_ID, 3);
+	SpatialGDK::AddStringToSchema(SecondEntryObject, SpatialConstants::MAPPING_PHYSICAL_WORKER_NAME, "VW_F");
+
+	// Now apply the mapping to the translator and test the result.
+	Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
+	translator->ApplyVirtualWorkerManagerData(ComponentObject);
+
 	TestTrue("There is a mapping for virtual worker 2", translator->GetPhysicalWorkerForVirtualWorker(2) != nullptr);
 	TestTrue("VW_B overwritten with VW_E", translator->GetPhysicalWorkerForVirtualWorker(2)->Equals("VW_E"));
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Update the VirtualWorkerTranslator to query for worker system entities to assign virtual workers to.

#### Release note
REQUIRED: Add a release note to the `##Unreleased` section of CHANGELOG.md. You can find guidance for writing useful release notes [here](../SpatialGDK/Extras/internal-documentation/how-to-write-good-release-notes.md). Documentation changes are exempt from this requirement.

#### Tests
Some automated tests included. Really want to have a fake NetDriver to test with, but that's outside the scope of the PR. Can't be tested by QA until the glue task is done.

#### Documentation
Code comments, no public docs yet. 

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.