### PR TITLE
Fix garbage collection during schema generation

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
@@ -80,7 +80,7 @@ bool FSpatialGDKEditor::GenerateSchema(bool bFullScan)
 		{
 			bSchemaGeneratorRunning = false;
 			LoadedAssets.Empty();
-			CollectGarbage(RF_NoFlags, true);
+			CollectGarbage(GARBAGE_COLLECTION_KEEPFLAGS, true);
 			return false;
 		}
 	}
@@ -120,7 +120,7 @@ bool FSpatialGDKEditor::GenerateSchema(bool bFullScan)
 	{
 		Progress.EnterProgressFrame(10.f);
 		LoadedAssets.Empty();
-		CollectGarbage(RF_NoFlags, true);
+		CollectGarbage(GARBAGE_COLLECTION_KEEPFLAGS, true);
 	}
 
 	GetMutableDefault<UGeneralProjectSettings>()->bSpatialNetworking = bCachedSpatialNetworking;


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Epic's code usually passes `GARBAGE_COLLECTION_KEEPFLAGS` to `CollectGarbage`, which resolves to a `RF_Standalone` in editor and `RF_NoFlags` otherwise.
I believe this is the reason schema generation sometimes caused ensures to be fired in `FSoftObjectPath::SetPath` (`Cannot create SoftObjectPath with short package name <something>! You must pass in fully qualified package names`)

#### Primary reviewers
@mattyoung-improbable @m-samiec 