### PR TITLE
Feature/gv 98 fix version file parsing

### DIFF
--- a/ci/get-engine.ps1
+++ b/ci/get-engine.ps1
@@ -18,7 +18,7 @@ pushd "$($gdk_home)"
             Write-Log "Using engine version defined by ENGINE_COMMIT_HASH: $($version_description)"
         } else {
             # Read Engine version from the file and trim any trailing white spaces and new lines.
-            $version_description = (Get-Content -Path "unreal-engine.version")[0].Trim()
+            $version_description = (Get-Content -Path "unreal-engine.version")[0]
             Write-Log "Using engine version found in unreal-engine.version file: $($version_description)"
         }
 

--- a/ci/get-engine.ps1
+++ b/ci/get-engine.ps1
@@ -18,7 +18,7 @@ pushd "$($gdk_home)"
             Write-Log "Using engine version defined by ENGINE_COMMIT_HASH: $($version_description)"
         } else {
             # Read Engine version from the file and trim any trailing white spaces and new lines.
-            $version_description = (Get-Content -Path "unreal-engine.version")[0]
+            $version_description = Get-Content -Path "unreal-engine.version" -First 1
             Write-Log "Using engine version found in unreal-engine.version file: $($version_description)"
         }
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Changed code from using an ambiguous delimiter during parsing, to explicitly getting the first line. This prevents errors as seen in https://buildkite.com/improbable/unrealgdkexampleproject-nightly/builds/151#003ae301-f7d7-4688-a95c-66704cf9bc22 .

#### Release note
This change is not customer facing. No release note has been added.

#### Tests
The fix has been tested locally.

#### Documentation
-

#### Primary reviewers
@joshuahuburn @mironec 