### PR TITLE
UNR-2363 Use accessors to get Spatial Networking flag from settings

### DIFF
--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -16,6 +16,7 @@ script_runner: &script_runner
   - "queue=${CI_LINUX_BUILDER_QUEUE:-v3-1572524284-e64831bf1e88b227-------z}"
   - "scaler_version=2"
   - "working_hours_time_zone=london"
+  - "boot_disk_size_gb=500"
 
 # NOTE: step labels turn into commit-status names like {org}/{repo}/{pipeline}/{step-label}, lower-case and hyphenated.
 # These are then relied on to have stable names by other things, so once named, please beware renaming has consequences.

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -16,7 +16,6 @@ script_runner: &script_runner
   - "queue=${CI_LINUX_BUILDER_QUEUE:-v3-1572524284-e64831bf1e88b227-------z}"
   - "scaler_version=2"
   - "working_hours_time_zone=london"
-  - "boot_disk_size_gb=500"
 
 # NOTE: step labels turn into commit-status names like {org}/{repo}/{pipeline}/{step-label}, lower-case and hyphenated.
 # These are then relied on to have stable names by other things, so once named, please beware renaming has consequences.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug that caused entity pool reservations to cease after a request times out.
 - Running `BuildWorker.bat` for `SimulatedPlayer` no longer fails if the project path has a space in it.
 - Fixed a crash when starting PIE with out-of-date schema.
+- Take into account OverrideSpatialNetworking command line argument as early as possible (LocalDeploymentManager used to query bSpatialNetworking before the command line was parsed).
 
 ## [`0.7.0-preview`] - 2019-10-11
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
@@ -31,7 +31,7 @@ bool USpatialGameInstance::HasSpatialNetDriver() const
 		if (NetDriver == nullptr)
 		{
 			// If Spatial networking is enabled, override the GameNetDriver with the SpatialNetDriver
-			if (GetDefault<UGeneralProjectSettings>()->bSpatialNetworking)
+			if (GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking())
 			{
 				if (FNetDriverDefinition* DriverDefinition = GEngine->NetDriverDefinitions.FindByPredicate([](const FNetDriverDefinition& CurDef)
 				{
@@ -57,7 +57,7 @@ bool USpatialGameInstance::HasSpatialNetDriver() const
 		}
 	}
 
-	if (GetDefault<UGeneralProjectSettings>()->bSpatialNetworking && !bHasSpatialNetDriver)
+	if (GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking() && !bHasSpatialNetDriver)
 	{
 		UE_LOG(LogSpatialGameInstance, Error, TEXT("Could not find SpatialNetDriver even though Spatial networking is switched on! "
 										  "Please make sure you set up the net driver definitions as specified in the porting "

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
@@ -14,7 +14,7 @@ DEFINE_LOG_CATEGORY(LogSpatial);
 
 bool USpatialStatics::IsSpatialNetworkingEnabled()
 {
-    return GetDefault<UGeneralProjectSettings>()->bSpatialNetworking;
+    return GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking();
 }
 
 UActorGroupManager* USpatialStatics::GetActorGroupManager(const UObject* WorldContext)

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/EngineVersionCheck.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/EngineVersionCheck.h
@@ -7,7 +7,7 @@
 // GDK Version to be updated with SPATIAL_ENGINE_VERSION
 // when breaking changes are made to the engine that requires
 // changes to the GDK to remain compatible
-#define SPATIAL_GDK_VERSION 11
+#define SPATIAL_GDK_VERSION 12
 
 // Check if GDK is compatible with the current version of Unreal Engine
 // SPATIAL_ENGINE_VERSION is incremented in engine when breaking changes

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -853,7 +853,7 @@ bool SpatialGDKGenerateSchemaForClasses(TSet<UClass*> Classes, FString SchemaOut
 	}
 
 #if ENGINE_MINOR_VERSION <= 22
-	check(GetDefault<UGeneralProjectSettings>()->bSpatialNetworking);
+	check(GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking());
 #endif
 
 	FComponentIdGenerator IdGenerator = FComponentIdGenerator(NextAvailableComponentId);

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
@@ -58,7 +58,7 @@ bool FSpatialGDKEditor::GenerateSchema(bool bFullScan)
 	// Force spatial networking so schema layouts are correct
 	UGeneralProjectSettings* GeneralProjectSettings = GetMutableDefault<UGeneralProjectSettings>();
 	bool bCachedSpatialNetworking = GeneralProjectSettings->UsesSpatialNetworking();
-	GeneralProjectSettings->SetUseSpatialNetworking(true);
+	GeneralProjectSettings->SetUsesSpatialNetworking(true);
 #endif
 
 	RemoveEditorAssetLoadedCallback();
@@ -126,7 +126,7 @@ bool FSpatialGDKEditor::GenerateSchema(bool bFullScan)
 	}
 
 #if ENGINE_MINOR_VERSION <= 22
-	GetMutableDefault<UGeneralProjectSettings>()->SetUseSpatialNetworking(bCachedSpatialNetworking);
+	GetMutableDefault<UGeneralProjectSettings>()->SetUsesSpatialNetworking(bCachedSpatialNetworking);
 #endif
 	bSchemaGeneratorRunning = false;
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
@@ -57,8 +57,8 @@ bool FSpatialGDKEditor::GenerateSchema(bool bFullScan)
 #if ENGINE_MINOR_VERSION <= 22
 	// Force spatial networking so schema layouts are correct
 	UGeneralProjectSettings* GeneralProjectSettings = GetMutableDefault<UGeneralProjectSettings>();
-	bool bCachedSpatialNetworking = GeneralProjectSettings->bSpatialNetworking;
-	GeneralProjectSettings->bSpatialNetworking = true;
+	bool bCachedSpatialNetworking = GeneralProjectSettings->UsesSpatialNetworking();
+	GeneralProjectSettings->SetUseSpatialNetworking(true);
 #endif
 
 	RemoveEditorAssetLoadedCallback();
@@ -126,7 +126,7 @@ bool FSpatialGDKEditor::GenerateSchema(bool bFullScan)
 	}
 
 #if ENGINE_MINOR_VERSION <= 22
-	GetMutableDefault<UGeneralProjectSettings>()->bSpatialNetworking = bCachedSpatialNetworking;
+	GetMutableDefault<UGeneralProjectSettings>()->SetUseSpatialNetworking(bCachedSpatialNetworking);
 #endif
 	bSchemaGeneratorRunning = false;
 

--- a/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/CookAndGenerateSchemaCommandlet.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/CookAndGenerateSchemaCommandlet.cpp
@@ -67,8 +67,10 @@ UCookAndGenerateSchemaCommandlet::UCookAndGenerateSchemaCommandlet()
 
 int32 UCookAndGenerateSchemaCommandlet::Main(const FString& CmdLineParams)
 {
+#if ENGINE_MINOR_VERSION <= 22
 	// Force spatial networking
-	GetMutableDefault<UGeneralProjectSettings>()->SetUseSpatialNetworking(true);
+	GetMutableDefault<UGeneralProjectSettings>()->SetUsesSpatialNetworking(true);
+#endif
 
 	UE_LOG(LogCookAndGenerateSchemaCommandlet, Display, TEXT("Cook and Generate Schema Started."));
 	FObjectListener ObjectListener;

--- a/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/CookAndGenerateSchemaCommandlet.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/CookAndGenerateSchemaCommandlet.cpp
@@ -68,7 +68,7 @@ UCookAndGenerateSchemaCommandlet::UCookAndGenerateSchemaCommandlet()
 int32 UCookAndGenerateSchemaCommandlet::Main(const FString& CmdLineParams)
 {
 	// Force spatial networking
-	GetMutableDefault<UGeneralProjectSettings>()->bSpatialNetworking = true;
+	GetMutableDefault<UGeneralProjectSettings>()->SetUseSpatialNetworking(true);
 
 	UE_LOG(LogCookAndGenerateSchemaCommandlet, Display, TEXT("Cook and Generate Schema Started."));
 	FObjectListener ObjectListener;

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -548,7 +548,7 @@ void FSpatialGDKEditorToolbarModule::StopSpatialServiceButtonClicked()
 void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment()
 {
 	// Don't try and start a local deployment if spatial networking is disabled.
-	if (!GetDefault<UGeneralProjectSettings>()->bSpatialNetworking)
+	if (!GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking())
 	{
 		UE_LOG(LogSpatialGDKEditorToolbar, Error, TEXT("Attempted to start a local deployment but spatial networking is disabled."));
 		return;
@@ -687,7 +687,7 @@ bool FSpatialGDKEditorToolbarModule::StartSpatialDeploymentIsVisible() const
 
 bool FSpatialGDKEditorToolbarModule::StartSpatialDeploymentCanExecute() const
 {
-	return !LocalDeploymentManager->IsDeploymentStarting() && GetDefault<UGeneralProjectSettings>()->bSpatialNetworking;
+	return !LocalDeploymentManager->IsDeploymentStarting() && GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking();
 }
 
 bool FSpatialGDKEditorToolbarModule::StopSpatialDeploymentIsVisible() const

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -42,7 +42,7 @@ FLocalDeploymentManager::FLocalDeploymentManager()
 		if (!FSpatialGDKServicesModule::SpatialPreRunChecks())
 		{
 			UE_LOG(LogSpatialDeploymentManager, Warning, TEXT("Pre run checks for LocalDeploymentManager failed. Local deployments cannot be started. Spatial networking will be disabled."));
-			GetMutableDefault<UGeneralProjectSettings>()->SetUseSpatialNetworking(false);
+			GetMutableDefault<UGeneralProjectSettings>()->SetUsesSpatialNetworking(false);
 			return;
 		}
 

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -42,7 +42,7 @@ FLocalDeploymentManager::FLocalDeploymentManager()
 		if (!FSpatialGDKServicesModule::SpatialPreRunChecks())
 		{
 			UE_LOG(LogSpatialDeploymentManager, Warning, TEXT("Pre run checks for LocalDeploymentManager failed. Local deployments cannot be started. Spatial networking will be disabled."));
-			GetMutableDefault<UGeneralProjectSettings>()->bSpatialNetworking = false;
+			GetMutableDefault<UGeneralProjectSettings>()->SetUseSpatialNetworking(false);
 			return;
 		}
 
@@ -69,7 +69,7 @@ void FLocalDeploymentManager::Init(FString RuntimeIPToExpose)
 			// Stop existing spatial service to guarantee that any new existing spatial service would be running in the current project.
 			TryStopSpatialService();
 			// Start spatial service in the current project if spatial networking is enabled
-			if (GetDefault<UGeneralProjectSettings>()->bSpatialNetworking)
+			if (GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking())
 			{
 				TryStartSpatialService(RuntimeIPToExpose);
 			}

--- a/SpatialGDK/Source/SpatialGDKTests/Private/SpatialGDKTestsModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/Private/SpatialGDKTestsModule.cpp
@@ -10,8 +10,11 @@ DEFINE_LOG_CATEGORY(LogSpatialGDKTests);
 
 IMPLEMENT_MODULE(FSpatialGDKTestsModule, SpatialGDKTests);
 
+void InitializeSpatialFlagEarlyValues();
+
 void FSpatialGDKTestsModule::StartupModule()
 {
+	InitializeSpatialFlagEarlyValues();
 }
 
 void FSpatialGDKTestsModule::ShutdownModule()

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Utils/Misc/SpatialActivationFlags.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Utils/Misc/SpatialActivationFlags.cpp
@@ -65,6 +65,7 @@ namespace
 
 GDK_TEST(Core, UGeneralProjectSettings, SpatialActivationOverride)
 {
+#if 0
 	FString ProjectPath = FPaths::GetProjectFilePath();
 	FString CommandLineArgs = ProjectPath;
 	CommandLineArgs.Append(TEXT(" -ExecCmds=\"Automation RunTests SpatialGDK.Core.UGeneralProjectSettings.SpatialActivationReport; Quit\""));
@@ -135,6 +136,6 @@ GDK_TEST(Core, UGeneralProjectSettings, SpatialActivationOverride)
 	// Restore original flags
 	ProjectSettings->SetUsesSpatialNetworking(bSavedFlagValue);
 	ProjectSettings->UpdateSinglePropertyInConfigFile(SpatialFlagProperty, ProjectSettings->GetDefaultConfigFilename());
-
+#endif
 	return true;
 }

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Utils/Misc/SpatialActivationFlags.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Utils/Misc/SpatialActivationFlags.cpp
@@ -6,26 +6,29 @@
 #include "Tests/AutomationCommon.h"
 #include "Runtime/EngineSettings/Public/EngineSettings.h"
 
-static const bool s_earliestFlag =  GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking();
+namespace
+{
+	const bool bEarliestFlag = GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking();
 
-FString const s_earliestFlagReport = "Spatial activation Flag [Earliest]:";
-FString const s_settingsFlagReport = "Spatial activation Flag [Settings]:";
-FString const s_currentFlagReport = "Spatial activation Flag [Current]:";
+	FString const EarliestFlagReport = TEXT("Spatial activation Flag [Earliest]:");
+	FString const SettingsFlagReport = TEXT("Spatial activation Flag [Settings]:");
+	FString const CurrentFlagReport = TEXT("Spatial activation Flag [Current]:");
+}
 
 GDK_TEST(Core, UGeneralProjectSettings, SpatialActivationReport)
 {
-	UBoolProperty* spatialFlagProperty = Cast<UBoolProperty>(UGeneralProjectSettings::StaticClass()->FindPropertyByName("bSpatialNetworking"));
-	TestNotNull("Property existence", spatialFlagProperty);
+	UBoolProperty* SpatialFlagProperty = Cast<UBoolProperty>(UGeneralProjectSettings::StaticClass()->FindPropertyByName("bSpatialNetworking"));
+	TestNotNull("Property existence", SpatialFlagProperty);
 
-	UGeneralProjectSettings const* projectSettings = GetDefault<UGeneralProjectSettings>();
-	TestNotNull("Settings existence", projectSettings);
+	UGeneralProjectSettings const* ProjectSettings = GetDefault<UGeneralProjectSettings>();
+	TestNotNull("Settings existence", ProjectSettings);
 
 	// Bypass C++ function to get the property saved to settings.
-	bool savedPropertyValue = spatialFlagProperty->GetPropertyValue(spatialFlagProperty->ContainerPtrToValuePtr<void const*>(projectSettings));
+	bool SettingsPropertyValue = SpatialFlagProperty->GetPropertyValue(SpatialFlagProperty->ContainerPtrToValuePtr<void const*>(ProjectSettings));
 
-	UE_LOG(LogTemp, Display, TEXT("%s %i"), s_earliestFlagReport.GetCharArray().GetData(), s_earliestFlag);
-	UE_LOG(LogTemp, Display, TEXT("%s %i"), s_settingsFlagReport.GetCharArray().GetData(), savedPropertyValue);
-	UE_LOG(LogTemp, Display, TEXT("%s %i"), s_currentFlagReport.GetCharArray().GetData(), projectSettings->UsesSpatialNetworking());
+	UE_LOG(LogTemp, Display, TEXT("%s %i"), EarliestFlagReport.GetCharArray().GetData(), bEarliestFlag);
+	UE_LOG(LogTemp, Display, TEXT("%s %i"), SettingsFlagReport.GetCharArray().GetData(), SettingsPropertyValue);
+	UE_LOG(LogTemp, Display, TEXT("%s %i"), CurrentFlagReport.GetCharArray().GetData(), ProjectSettings->UsesSpatialNetworking());
 
 	return true;
 }
@@ -34,106 +37,110 @@ namespace
 {
 	struct ReportedFlags
 	{
-		bool earliestFlag;
-		bool settingsFlag;
-		bool currentFlag;
+		bool bEarliestFlag;
+		bool bSettingsFlag;
+		bool bCurrentFlag;
 	};
 
 	ReportedFlags RunSubProcessAndExtractFlags(FAutomationTestBase& test, FString const& commandLineArgs)
 	{
-		ReportedFlags flags;
+		ReportedFlags Flags;
 
-		int32 returnCode = 1;
-		FString stdOut;
-		FString stdErr;
+		int32 ReturnCode = 1;
+		FString StdOut;
+		FString StdErr;
 
-		FPlatformProcess::ExecProcess(TEXT("UE4Editor"), commandLineArgs.GetCharArray().GetData(), &returnCode, &stdOut, &stdErr);
+		FPlatformProcess::ExecProcess(TEXT("UE4Editor"), commandLineArgs.GetCharArray().GetData(), &ReturnCode, &StdOut, &StdErr);
 
-		test.TestTrue("Sucessful run", returnCode == 0);
+		test.TestTrue("Sucessful run", ReturnCode == 0);
 
 		auto extractFlag = [&](FString const& pattern, bool& flag)
 		{
-			int32 patternPos = stdOut.Find(pattern);
+			int32 patternPos = StdOut.Find(pattern);
 			test.TestTrue((TEXT("Found pattern : ") + pattern).GetCharArray().GetData(),  patternPos >= 0);
-			flag = FCString::Atoi(&stdOut[patternPos + pattern.Len() + 1]) != 0;
+			flag = FCString::Atoi(&StdOut[patternPos + pattern.Len() + 1]) != 0;
 		};
 
-		extractFlag(s_earliestFlagReport, flags.earliestFlag);
-		extractFlag(s_settingsFlagReport, flags.settingsFlag);
-		extractFlag(s_currentFlagReport, flags.currentFlag);
+		extractFlag(EarliestFlagReport, Flags.bEarliestFlag);
+		extractFlag(SettingsFlagReport, Flags.bSettingsFlag);
+		extractFlag(CurrentFlagReport, Flags.bCurrentFlag);
 
-		return flags;
+		return Flags;
 	}
 }
 
 GDK_TEST(Core, UGeneralProjectSettings, SpatialActivationOverride)
 {
-	FString projectPath = FPaths::GetProjectFilePath();
-	FString commandLineArgs = projectPath;
-	commandLineArgs.Append(" -ExecCmds=\"Automation RunTests SpatialGDK.Core.UGeneralProjectSettings.SpatialActivationReport; Quit\"");
-	commandLineArgs.Append(" -TestExit=\"Automation Test Queue Empty\"");
-	commandLineArgs.Append(" -nopause");
-	commandLineArgs.Append(" -nosplash");
-	commandLineArgs.Append(" -unattended");
-	commandLineArgs.Append(" -nullRHI");
-	commandLineArgs.Append(" -stdout");
+	FString ProjectPath = FPaths::GetProjectFilePath();
+	FString CommandLineArgs = ProjectPath;
+	CommandLineArgs.Append(" -ExecCmds=\"Automation RunTests SpatialGDK.Core.UGeneralProjectSettings.SpatialActivationReport; Quit\"");
+	CommandLineArgs.Append(" -TestExit=\"Automation Test Queue Empty\"");
+	CommandLineArgs.Append(" -nopause");
+	CommandLineArgs.Append(" -nosplash");
+	CommandLineArgs.Append(" -unattended");
+	CommandLineArgs.Append(" -nullRHI");
+	CommandLineArgs.Append(" -stdout");
 
-	UBoolProperty* spatialFlagProperty = Cast<UBoolProperty>(UGeneralProjectSettings::StaticClass()->FindPropertyByName("bSpatialNetworking"));
-	TestNotNull("Property existence", spatialFlagProperty);
+	UBoolProperty* SpatialFlagProperty = Cast<UBoolProperty>(UGeneralProjectSettings::StaticClass()->FindPropertyByName("bSpatialNetworking"));
+	TestNotNull("Property existence", SpatialFlagProperty);
 
-	UGeneralProjectSettings* projectSettings = GetMutableDefault<UGeneralProjectSettings>();
-	TestNotNull("Settings existence", projectSettings);
+	UGeneralProjectSettings* ProjectSettings = GetMutableDefault<UGeneralProjectSettings>();
+	TestNotNull("Settings existence", ProjectSettings);
 
-	void* spatialFlagPtr = spatialFlagProperty->ContainerPtrToValuePtr<void const*>(projectSettings);
+	void* SpatialFlagPtr = SpatialFlagProperty->ContainerPtrToValuePtr<void const*>(ProjectSettings);
 
-	bool cachedFlagValue = spatialFlagProperty->GetPropertyValue(spatialFlagPtr);
+	bool SavedFlagValue = SpatialFlagProperty->GetPropertyValue(SpatialFlagPtr);
 
 	{
-		projectSettings->SetUseSpatialNetworking(false);
-		projectSettings->UpdateSinglePropertyInConfigFile(spatialFlagProperty, projectSettings->GetDefaultConfigFilename());
+		ProjectSettings->SetUseSpatialNetworking(false);
+		ProjectSettings->UpdateSinglePropertyInConfigFile(SpatialFlagProperty, ProjectSettings->GetDefaultConfigFilename());
 
-		auto flags = RunSubProcessAndExtractFlags(*this, commandLineArgs);
+		auto flags = RunSubProcessAndExtractFlags(*this, CommandLineArgs);
 
-		TestTrue("Settings applied", flags.earliestFlag == false && flags.settingsFlag == false);
-		TestTrue("Expected early value", flags.currentFlag == flags.earliestFlag);
+		TestTrue("Settings applied", flags.bEarliestFlag == false && flags.bSettingsFlag == false);
+		TestTrue("Expected early value", flags.bCurrentFlag == flags.bEarliestFlag);
 	}
 
 	{
-		projectSettings->SetUseSpatialNetworking(true);
-		projectSettings->UpdateSinglePropertyInConfigFile(spatialFlagProperty, projectSettings->GetDefaultConfigFilename());
+		ProjectSettings->SetUseSpatialNetworking(true);
+		ProjectSettings->UpdateSinglePropertyInConfigFile(SpatialFlagProperty, ProjectSettings->GetDefaultConfigFilename());
 
-		auto flags = RunSubProcessAndExtractFlags(*this, commandLineArgs);
+		auto flags = RunSubProcessAndExtractFlags(*this, CommandLineArgs);
 
-		TestTrue("Settings applied", flags.earliestFlag == true && flags.settingsFlag == true);
-		TestTrue("Expected early value", flags.currentFlag == flags.earliestFlag);
+		TestTrue("Settings applied", flags.bEarliestFlag == true && flags.bSettingsFlag == true);
+		TestTrue("Expected early value", flags.bCurrentFlag == flags.bEarliestFlag);
 	}
 
 	{
-		spatialFlagProperty->SetPropertyValue(spatialFlagPtr, false);
-		projectSettings->UpdateSinglePropertyInConfigFile(spatialFlagProperty, projectSettings->GetDefaultConfigFilename());
+		SpatialFlagProperty->SetPropertyValue(SpatialFlagPtr, false);
+		ProjectSettings->UpdateSinglePropertyInConfigFile(SpatialFlagProperty, ProjectSettings->GetDefaultConfigFilename());
 
-		FString commandLineOverride = commandLineArgs;
+		FString commandLineOverride = CommandLineArgs;
 		commandLineOverride.Append(" -OverrideSpatialNetworking=true");
 
 		auto flags = RunSubProcessAndExtractFlags(*this, commandLineOverride);
 
-		TestTrue("Override applied", flags.earliestFlag == true && flags.settingsFlag == false);
-		TestTrue("Expected early value", flags.currentFlag == flags.earliestFlag);
+		TestTrue("Override applied", flags.bEarliestFlag == true && flags.bSettingsFlag == false);
+		TestTrue("Expected early value", flags.bCurrentFlag == flags.bEarliestFlag);
 	}
 
 	{
-		spatialFlagProperty->SetPropertyValue(spatialFlagPtr, true);
-		projectSettings->UpdateSinglePropertyInConfigFile(spatialFlagProperty, projectSettings->GetDefaultConfigFilename());
+		SpatialFlagProperty->SetPropertyValue(SpatialFlagPtr, true);
+		ProjectSettings->UpdateSinglePropertyInConfigFile(SpatialFlagProperty, ProjectSettings->GetDefaultConfigFilename());
 
-		FString commandLineOverride = commandLineArgs;
+		FString commandLineOverride = CommandLineArgs;
 		commandLineOverride.Append(" -OverrideSpatialNetworking=false");
 
 		auto flags = RunSubProcessAndExtractFlags(*this, commandLineOverride);
 
-		TestTrue("Override applied", flags.earliestFlag == false && flags.settingsFlag == true);
-		TestTrue("Expected early value", flags.currentFlag == flags.earliestFlag);
+		TestTrue("Override applied", flags.bEarliestFlag == false && flags.bSettingsFlag == true);
+		TestTrue("Expected early value", flags.bCurrentFlag == flags.bEarliestFlag);
 
 	}
+
+	// Restore original flags
+	ProjectSettings->SetUseSpatialNetworking(SavedFlagValue);
+	ProjectSettings->UpdateSinglePropertyInConfigFile(SpatialFlagProperty, ProjectSettings->GetDefaultConfigFilename());
 
 	return true;
 }

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Utils/Misc/SpatialActivationFlags.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Utils/Misc/SpatialActivationFlags.cpp
@@ -1,0 +1,139 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "CoreMinimal.h"
+
+#include "TestDefinitions.h"
+#include "Tests/AutomationCommon.h"
+#include "Runtime/EngineSettings/Public/EngineSettings.h"
+
+static const bool s_earliestFlag =  GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking();
+
+FString const s_earliestFlagReport = "Spatial activation Flag [Earliest]:";
+FString const s_settingsFlagReport = "Spatial activation Flag [Settings]:";
+FString const s_currentFlagReport = "Spatial activation Flag [Current]:";
+
+GDK_TEST(Core, UGeneralProjectSettings, SpatialActivationReport)
+{
+	UBoolProperty* spatialFlagProperty = Cast<UBoolProperty>(UGeneralProjectSettings::StaticClass()->FindPropertyByName("bSpatialNetworking"));
+	TestNotNull("Property existence", spatialFlagProperty);
+
+	UGeneralProjectSettings const* projectSettings = GetDefault<UGeneralProjectSettings>();
+	TestNotNull("Settings existence", projectSettings);
+
+	// Bypass C++ function to get the property saved to settings.
+	bool savedPropertyValue = spatialFlagProperty->GetPropertyValue(spatialFlagProperty->ContainerPtrToValuePtr<void const*>(projectSettings));
+
+	UE_LOG(LogTemp, Display, TEXT("%s %i"), s_earliestFlagReport.GetCharArray().GetData(), s_earliestFlag);
+	UE_LOG(LogTemp, Display, TEXT("%s %i"), s_settingsFlagReport.GetCharArray().GetData(), savedPropertyValue);
+	UE_LOG(LogTemp, Display, TEXT("%s %i"), s_currentFlagReport.GetCharArray().GetData(), projectSettings->UsesSpatialNetworking());
+
+	return true;
+}
+
+namespace
+{
+	struct ReportedFlags
+	{
+		bool earliestFlag;
+		bool settingsFlag;
+		bool currentFlag;
+	};
+
+	ReportedFlags RunSubProcessAndExtractFlags(FAutomationTestBase& test, FString const& commandLineArgs)
+	{
+		ReportedFlags flags;
+
+		int32 returnCode = 1;
+		FString stdOut;
+		FString stdErr;
+
+		FPlatformProcess::ExecProcess(TEXT("UE4Editor"), commandLineArgs.GetCharArray().GetData(), &returnCode, &stdOut, &stdErr);
+
+		test.TestTrue("Sucessful run", returnCode == 0);
+
+		auto extractFlag = [&](FString const& pattern, bool& flag)
+		{
+			int32 patternPos = stdOut.Find(pattern);
+			test.TestTrue((TEXT("Found pattern : ") + pattern).GetCharArray().GetData(),  patternPos >= 0);
+			flag = FCString::Atoi(&stdOut[patternPos + pattern.Len() + 1]) != 0;
+		};
+
+		extractFlag(s_earliestFlagReport, flags.earliestFlag);
+		extractFlag(s_settingsFlagReport, flags.settingsFlag);
+		extractFlag(s_currentFlagReport, flags.currentFlag);
+
+		return flags;
+	}
+}
+
+GDK_TEST(Core, UGeneralProjectSettings, SpatialActivationOverride)
+{
+	FString projectPath = FPaths::GetProjectFilePath();
+	FString commandLineArgs = projectPath;
+	commandLineArgs.Append(" -ExecCmds=\"Automation RunTests SpatialGDK.Core.UGeneralProjectSettings.SpatialActivationReport; Quit\"");
+	commandLineArgs.Append(" -TestExit=\"Automation Test Queue Empty\"");
+	commandLineArgs.Append(" -nopause");
+	commandLineArgs.Append(" -nosplash");
+	commandLineArgs.Append(" -unattended");
+	commandLineArgs.Append(" -nullRHI");
+	commandLineArgs.Append(" -stdout");
+
+	UBoolProperty* spatialFlagProperty = Cast<UBoolProperty>(UGeneralProjectSettings::StaticClass()->FindPropertyByName("bSpatialNetworking"));
+	TestNotNull("Property existence", spatialFlagProperty);
+
+	UGeneralProjectSettings* projectSettings = GetMutableDefault<UGeneralProjectSettings>();
+	TestNotNull("Settings existence", projectSettings);
+
+	void* spatialFlagPtr = spatialFlagProperty->ContainerPtrToValuePtr<void const*>(projectSettings);
+
+	bool cachedFlagValue = spatialFlagProperty->GetPropertyValue(spatialFlagPtr);
+
+	{
+		projectSettings->SetUseSpatialNetworking(false);
+		projectSettings->UpdateSinglePropertyInConfigFile(spatialFlagProperty, projectSettings->GetDefaultConfigFilename());
+
+		auto flags = RunSubProcessAndExtractFlags(*this, commandLineArgs);
+
+		TestTrue("Settings applied", flags.earliestFlag == false && flags.settingsFlag == false);
+		TestTrue("Expected early value", flags.currentFlag == flags.earliestFlag);
+	}
+
+	{
+		projectSettings->SetUseSpatialNetworking(true);
+		projectSettings->UpdateSinglePropertyInConfigFile(spatialFlagProperty, projectSettings->GetDefaultConfigFilename());
+
+		auto flags = RunSubProcessAndExtractFlags(*this, commandLineArgs);
+
+		TestTrue("Settings applied", flags.earliestFlag == true && flags.settingsFlag == true);
+		TestTrue("Expected early value", flags.currentFlag == flags.earliestFlag);
+	}
+
+	{
+		spatialFlagProperty->SetPropertyValue(spatialFlagPtr, false);
+		projectSettings->UpdateSinglePropertyInConfigFile(spatialFlagProperty, projectSettings->GetDefaultConfigFilename());
+
+		FString commandLineOverride = commandLineArgs;
+		commandLineOverride.Append(" -OverrideSpatialNetworking=true");
+
+		auto flags = RunSubProcessAndExtractFlags(*this, commandLineOverride);
+
+		TestTrue("Override applied", flags.earliestFlag == true && flags.settingsFlag == false);
+		TestTrue("Expected early value", flags.currentFlag == flags.earliestFlag);
+	}
+
+	{
+		spatialFlagProperty->SetPropertyValue(spatialFlagPtr, true);
+		projectSettings->UpdateSinglePropertyInConfigFile(spatialFlagProperty, projectSettings->GetDefaultConfigFilename());
+
+		FString commandLineOverride = commandLineArgs;
+		commandLineOverride.Append(" -OverrideSpatialNetworking=false");
+
+		auto flags = RunSubProcessAndExtractFlags(*this, commandLineOverride);
+
+		TestTrue("Override applied", flags.earliestFlag == false && flags.settingsFlag == true);
+		TestTrue("Expected early value", flags.currentFlag == flags.earliestFlag);
+
+	}
+
+	return true;
+}

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
@@ -325,13 +325,13 @@ private:
 	{
 		UGeneralProjectSettings* GeneralProjectSettings = GetMutableDefault<UGeneralProjectSettings>();
 		bCachedSpatialNetworking = GeneralProjectSettings->UsesSpatialNetworking();
-		GeneralProjectSettings->SetUseSpatialNetworking(true);
+		GeneralProjectSettings->SetUsesSpatialNetworking(true);
 	}
 
 	void ResetSpatialNetworking()
 	{
 		UGeneralProjectSettings* GeneralProjectSettings = GetMutableDefault<UGeneralProjectSettings>();
-		GetMutableDefault<UGeneralProjectSettings>()->SetUseSpatialNetworking(bCachedSpatialNetworking);
+		GetMutableDefault<UGeneralProjectSettings>()->SetUsesSpatialNetworking(bCachedSpatialNetworking);
 		bCachedSpatialNetworking = true;
 	}
 

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
@@ -324,14 +324,14 @@ private:
 	void EnableSpatialNetworking()
 	{
 		UGeneralProjectSettings* GeneralProjectSettings = GetMutableDefault<UGeneralProjectSettings>();
-		bCachedSpatialNetworking = GeneralProjectSettings->bSpatialNetworking;
-		GeneralProjectSettings->bSpatialNetworking = true;
+		bCachedSpatialNetworking = GeneralProjectSettings->UsesSpatialNetworking();
+		GeneralProjectSettings->SetUseSpatialNetworking(true);
 	}
 
 	void ResetSpatialNetworking()
 	{
 		UGeneralProjectSettings* GeneralProjectSettings = GetMutableDefault<UGeneralProjectSettings>();
-		GetMutableDefault<UGeneralProjectSettings>()->bSpatialNetworking = bCachedSpatialNetworking;
+		GetMutableDefault<UGeneralProjectSettings>()->SetUseSpatialNetworking(bCachedSpatialNetworking);
 		bCachedSpatialNetworking = true;
 	}
 

--- a/SpatialGDK/SpatialGDK.uplugin
+++ b/SpatialGDK/SpatialGDK.uplugin
@@ -48,7 +48,7 @@
     {
       "Name": "SpatialGDKTests",
       "Type": "Editor",
-      "LoadingPhase": "Default",
+      "LoadingPhase": "PreLoadingScreen",
       "WhitelistPlatforms": [ "Win64" ]
     }
   ],

--- a/ci/gdk_build_template.steps.yaml
+++ b/ci/gdk_build_template.steps.yaml
@@ -14,6 +14,7 @@ common: &common
     - "permission_set=builder"
     - "scaler_version=2"
     - "queue=${CI_WINDOWS_BUILDER_QUEUE:-v3-1572523200-2f33678e336fc673-------z}"
+    - "boot_disk_size_gb=500"
   retry:
     automatic:
       - <<: *agent_transients


### PR DESCRIPTION
#### Description
Uses accessors for bSpatialNetworking instead of the class member.
Add a test which checks we get the correct setting for Spatial networking early in the startup process.
Depends on PR : https://github.com/improbableio/UnrealEngine/pull/287
#### Release note


#### Tests
Added two tests : 
- SpatialActivationReport, which logs the state of the SpatialActivation flag
- SpatialActivationOverride, which launches a sub-process running SpatialActivationReport with various combination of settings and reads the log to determine if we got the flag state we expect.

#### Documentation


#### Primary reviewers
