### PR TITLE
UNR-2364 Crash in ProcessRPCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format of this Changelog is based on [Keep a Changelog](https://keepachangel
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased-`x.y.z`] - 2019-xx-xx
+- The server no longer crashes, when received RPCs are processed recursively.
 
 ### Features:
 - Added partial framework for use in future UnrealGDK controlled loadbalancing.

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCContainer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCContainer.cpp
@@ -128,7 +128,7 @@ void FRPCContainer::ProcessRPCs()
 {
 	if (bAlreadyProcessingRPCs)
 	{
-		UE_LOG(LogRPCContainer, Warning, TEXT("Calling ProcessRPCs recursively, ignoring the call"));
+		UE_LOG(LogRPCContainer, Log, TEXT("Calling ProcessRPCs recursively, ignoring the call"));
 		return;
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCContainer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCContainer.cpp
@@ -126,10 +126,18 @@ void FRPCContainer::ProcessRPCs(FArrayOfParams& RPCList)
 
 void FRPCContainer::ProcessRPCs()
 {
+	if (bAlreadyProcessingRPCs)
+	{
+		UE_LOG(LogRPCContainer, Warning, TEXT("Calling ProcessRPCs recursively, ignoring the call"));
+		return;
+	}
+
+	bAlreadyProcessingRPCs = true;
+
 	for (auto& RPCs : QueuedRPCs)
 	{
 		FRPCMap& MapOfQueues = RPCs.Value;
-		for(auto It = MapOfQueues.CreateIterator(); It; ++It)
+		for (auto It = MapOfQueues.CreateIterator(); It; ++It)
 		{
 			FArrayOfParams& RPCList = It.Value();
 			ProcessRPCs(RPCList);
@@ -139,6 +147,8 @@ void FRPCContainer::ProcessRPCs()
 			}
 		}
 	}
+
+	bAlreadyProcessingRPCs = false;
 }
 
 bool FRPCContainer::ObjectHasRPCsQueuedOfType(const Worker_EntityId& EntityId, ESchemaComponentType Type) const

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/RPCContainer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/RPCContainer.h
@@ -110,4 +110,5 @@ private:
 	bool ApplyFunction(FPendingRPCParams& Params);
 	RPCContainerType QueuedRPCs;
 	FProcessRPCDelegate ProcessingFunction;
+	bool bAlreadyProcessingRPCs = false;
 };


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
The server no longer crashes, when received RPCs are processed recursively.

#### Release note
Updated CHANGELOG.md.

#### Tests
Tested with Scavengers

#### Documentation
Updated CHANGELOG.md.

#### Primary reviewers
@m-samiec 