### PR TITLE
Fix multi-engine CI if using branches containing slashes

### DIFF
--- a/ci/generate_and_upload_build_steps.sh
+++ b/ci/generate_and_upload_build_steps.sh
@@ -8,9 +8,9 @@ if [ -z "${ENGINE_VERSION}" ]; then
     echo "Generating build steps for each engine version listed in unreal-engine.version"  
     IFS=$'\n'
     for commit_hash in $(cat < ci/unreal-engine.version); do
-        sed "s/ENGINE_COMMIT_HASH_PLACEHOLDER/$commit_hash/g" ci/gdk_build_template.steps.yaml | buildkite-agent pipeline upload
+        sed "s|ENGINE_COMMIT_HASH_PLACEHOLDER|$commit_hash|g" ci/gdk_build_template.steps.yaml | buildkite-agent pipeline upload
     done
 else
     echo "Generating steps for the specified engine version: $ENGINE_VERSION" 
-    sed "s/ENGINE_COMMIT_HASH_PLACEHOLDER/$ENGINE_VERSION/g" ci/gdk_build_template.steps.yaml | buildkite-agent pipeline upload
+    sed "s|ENGINE_COMMIT_HASH_PLACEHOLDER|$ENGINE_VERSION|g" ci/gdk_build_template.steps.yaml | buildkite-agent pipeline upload
 fi;

--- a/ci/unreal-engine.version
+++ b/ci/unreal-engine.version
@@ -1,2 +1,2 @@
 HEAD 4.22-SpatialOSUnrealGDK
-HEAD 4.23-SpatialOSUnrealGDK
+HEAD bugfix/example-project-ci

--- a/ci/unreal-engine.version
+++ b/ci/unreal-engine.version
@@ -1,2 +1,2 @@
 HEAD 4.22-SpatialOSUnrealGDK
-HEAD bugfix/example-project-ci
+HEAD 4.23-SpatialOSUnrealGDK


### PR DESCRIPTION
#### Description
If using slashes in engine branch names to run CI against (such as "feature/awesome-feature"), the sed replace would break, so this PR just changes the delimiter character to the vertical bar/pipe |.
Branches should hopefully not contain this character.

#### Release note
Not needed - internal bugfix.

#### Tests
Doesn't work here: https://buildkite.com/improbable/unrealgdk-premerge/builds/6672#fa96a966-17ff-44bf-ab51-8de62f4e0600
Noticed this while doing https://github.com/spatialos/UnrealGDKExampleProject/pull/76 and it needs a change in the UnrealGDK too. Tested in the other PR by running CI, should work here too.

#### Documentation
N/A

#### Primary reviewers
@ImprobableVlad @joshuahuburn 