### PR TITLE
Updated the Keep your GDK up to date guide

### DIFF
--- a/SpatialGDK/Documentation/content/get-started/build-unreal-fork.md
+++ b/SpatialGDK/Documentation/content/get-started/build-unreal-fork.md
@@ -5,7 +5,7 @@
 
 To use the SpatialOS GDK for Unreal, you first need to download and build the SpatialOS fork of Unreal Engine (UE). You will download and install the GDK for Unreal plugin.
 
-**Note:** If you cloned an earlier version of the fork and plugin, the setup steps below may cause errors. See the [Keep your GDK up to date]({{urlRoot}}/content/upgrading#step-2-update-your-unreal-engine-fork-and-plugin) for guidance on installing the latest versions.
+**Note:** If you cloned an earlier version of the fork and plugin, the setup steps below may cause errors. See the [Keep your GDK up to date]({{urlRoot}}/content/upgrading) for guidance on installing the latest versions.
 
 ### Step 1: Join the Epic Games organization on GitHub
 

--- a/SpatialGDK/Documentation/content/get-started/dependencies.md
+++ b/SpatialGDK/Documentation/content/get-started/dependencies.md
@@ -52,7 +52,7 @@ To build the GDK for Unreal you need the following software installed on your ma
     - **Game development with C++**, including the optional **Unreal Engine installer** component.
 
 - [**Linux Cross-Compilation toolchain**](https://docs.unrealengine.com/en-US/Platforms/Linux/GettingStarted/index.html)
-    - You need to download and install Unreal's Linux Cross-Compilation toolchain in order to build Linux server-workers using your Windows machine. Use the Unreal documentation link above to install `-v13 clang-7.0.1-based`, the appropriate toolchain for Unreal Engine 4.22.
+    - You need to download and install Unreal's Linux Cross-Compilation toolchain in order to build Linux server-workers using your Windows machine. Use the Unreal documentation link above to install `-v15 clang-8.0.1-based`, the appropriate toolchain for Unreal Engine 4.23.
 
 </br>
 #### **> Next:** [2 - Set up the fork and plugin]({{urlRoot}}/content/get-started/build-unreal-fork.md)

--- a/SpatialGDK/Documentation/content/pricing-and-support/versioning-scheme.md
+++ b/SpatialGDK/Documentation/content/pricing-and-support/versioning-scheme.md
@@ -71,10 +71,10 @@ The [Unreal Engine fork](https://github.com/improbableio/UnrealEngine) follows t
 
 For example:
 
-*   ``4.22-SpatialOSUnrealGDK-release`` (default)
-*   ``4.22-SpatialOSUnrealGDK-preview``
+*   ``4.23-SpatialOSUnrealGDK-release`` (default)
+*   ``4.23-SpatialOSUnrealGDK-preview``
 
-when Unreal Engine 4.22 is the version supported.
+when Unreal Engine 4.23 is the version supported.
 
 ## Unreal Engine version support
 

--- a/SpatialGDK/Documentation/content/upgrading.md
+++ b/SpatialGDK/Documentation/content/upgrading.md
@@ -5,30 +5,40 @@ To use the SpatialOS GDK for Unreal, you need software from two git repositories
 
 * [The SpatialOS Unreal Engine fork](https://github.com/improbableio/UnrealEngine)
 * [The GDK](https://github.com/spatialos/UnrealGDK)<br>
+
 You download both of these as part of the [Get started]({{urlRoot}}/content/get-started/introduction) steps. <br/>
-To ensure you benefit from the most up-to-date functionality, always develop your game on the latest version of the software by regularly updating it. Whenever you update your GDK software, you **must** also update your SpatialOS Unreal Engine fork software. If you don't, you might get errors from them being out of synch.
+
+To ensure you benefit from the most up-to-date functionality, always develop your game on the latest version of the software by regularly updating it. Whenever you update your GDK software, you **must** also update your SpatialOS Unreal Engine fork software. If you don't, you'll encounter errors caused by them being out of sync.
 
 We recommend that you update your version of the GDK and SpatialOS Unreal Engine fork every week.  To do this, follow the steps below.
 
-## Step 1: Ensure you're on the release branches
+## Step 1: Decide which branch you want to use.
 
-If you followed our [Get started]({{urlRoot}}/content/get-started/introduction) guide, you have these repositories cloned on your computer.<br>
+We publish the GDK and its corresponding SpatialOS Unreal Engine fork on two release branches: `release` and `preview`. The most stable version is `release`, the most up to date is `preview`. You must choose which one you want to use.
 
-* Your `UnrealEngine` repository should have the branch ending with `-SpatialOSUnrealGDK-release`checked out.<br>
-* Your `UnrealGDK` repository should have the `release` branch checked out.<br>
+> For more information about the different GDK branches and their maturity, see the [Versioning scheme page]({{urlRoot}}/content/pricing-and-support/versioning-scheme).
+
+## Step 2: Check the corresponding Unreal Engine version.
+
+The GDK only supports one version of Unreal Engine at a time. You can tell which version this is by reading the release notes on the [releases page](https://github.com/spatialos/UnrealGDK/releases) of the `UnrealGDK`. Each release states: "The corresponding Engine version is: x.xx-SpatialOSUnrealGDK" (where `x.xx` is the Unreal Engine version of the fork.)
+
+## Step 3: Ensure you're on the branch you want
+
+If you followed our [Get started]({{urlRoot}}/content/get-started/introduction) guide, you already have these repositories cloned on your computer.<br>
 
 You can find out which branch you have checked out by following the instructions below:<br>
 
 1. In a terminal of your choice, change directory to the root of the repository.<br>
-1. Run `git status`.
-This should return `On branch *-SpatialOSUnrealGDK-release` in your `UnrealEngine` repository and `On branch release` in your `UnrealGDK` repository.<br>
-If it returns a different branch, run `git checkout <branch-name>` to check out the branch that you want.
+1. Run `git status`.<br>
 
-> For more information about the different GDK branches and their maturity, see the [Versioning scheme page]({{urlRoot}}/content/pricing-and-support/versioning-scheme).
+    Your `UnrealEngine` repository should have a branch starting with the correct Unreal Engine version and ending with `-SpatialOSUnrealGDK-release` or `-SpatialOSUnrealGDK-preview` checked out.<br>
 
-## Step 2: Update your Unreal Engine fork and plugin
+    Your `UnrealGDK` repository should have the `release` or `preview` branch checked out.<br>
+1. If `git status` returns a different branch, run `git checkout <branch-name>` to check out the branch that you want.
 
-Before you begin, read the release notes on the releases page of the [`UnrealGDK` GitHub](https://github.com/spatialos/UnrealGDK/releases) so you understand the changes that you're about to download.
+## Step 4: Update your Unreal Engine fork and plugin
+
+Before you update, read the release notes on the [releases page](https://github.com/spatialos/UnrealGDK/releases) of the `UnrealGDK` GitHub so you understand the changes that you're about to download. Pay close attention to the **Breaking Changes** section, as these changes may require you to make changes to your project.
 
 To update your Unreal Engine fork and GDK to the latest version, complete the following steps:
 
@@ -43,20 +53,19 @@ Right-click on your `.uproject` file and select **Generate Visual Studio project
 
 You are now on the latest GDK and the latest SpatialOS Unreal Engine fork.
 
-## Optional: upgrade your clang version 
+## Step 5: Update your clang version, rebuild your Engine and your Project
 
-If you're also upgrading your Unreal Engine version, you need to ensure you have the up to date version of Linux cross-compilation (clang), for SpatialOS to be able to build targeting Linux (for cloud deployments). 
+This step is only required if you checked out an `UnrealEngine` branch with a new Unreal Engine version, for example, if you moved from `4.22-SpatialOSUnrealGDK-release` to `4.23-SpatialOSUnrealGDK-release`.
 
-1. Check [which version of clang](https://docs.unrealengine.com/en-US/Platforms/Linux/GettingStarted/index.html) corresponds to your Engine version and download it
-1. Ensure the `LINUX_MULTIARCH_ROOT` environment variable is set to the new clang folder
-1. Run `GenerateProjectFiles.bat` in the engine
-1. Build the Engine
-1. In your project, right click on .uproject file and `Generate Project Files` again
-1. Build the project
-
+1. Download and install the [version of clang](https://docs.unrealengine.com/en-US/Platforms/Linux/GettingStarted/index.html) that corresponds to your Engine version.
+1. Run `Setup.bat`, which is located in the root directory of the `UnrealEngine` repository.
+1. Run `GenerateProjectFiles.bat`, which is in the same root directory.
+1. Open **UE4.sln** in Visual Studio and build it.
+1. In your project, right click on **.uproject** file and `Generate Project Files`.
+1. Open your project's **.sln** in Visual Studio and build it.
 
 Be sure to join the community on our <a href="https://forums.improbable.io" data-track-link="Join Forums Clicked|product=Docs" target="_blank">forums</a> or on <a href="https://discord.gg/vAT7RSU" data-track-link="Join Discord Clicked|product=Docs|platform=Win|label=Win" target="_blank">Discord</a>. We announce GDK versions there.
 
 
 <br/>------<br/>
-_2019-07-31 Page updated with limited editorial review_
+_2019-11-14 Page updated with limited editorial review_

--- a/SpatialGDK/Documentation/unreal-features-support.md
+++ b/SpatialGDK/Documentation/unreal-features-support.md
@@ -357,7 +357,7 @@ Support of Unreal features with the GDK in a single server-worker configuration:
     <td></td>
 </tr>
   <tr>
-    <td>UE4 4.22 Support</td>
+    <td>Unreal Engine 4.23</td>
     <td class="supported"></td>
     <td></td>
 </tr>


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Updated the Keep your GDK up to date guide to:
* Acknowledge the existence of `preview`
* Tell users that they must re-build when upgrading Unreal Engine version.

#### Release note
https://github.com/spatialos/UnrealGDK/pull/1494

#### Tests
Rendered and linted in improbadoc.

#### Documentation
This is documentation. It looks like this (ignore the asset lint errors, that's a known lint bug):

![screencapture-localhost-8080-reference-1-0-content-upgrading-2019-11-14-14_02_44](https://user-images.githubusercontent.com/19690292/68865222-5e27c500-06ea-11ea-8ae8-d1ecf3ea01d5.png)
