### PR TITLE
UNR-2419: make gdk setup self-contained

### DIFF
--- a/ci/setup-gdk.ps1
+++ b/ci/setup-gdk.ps1
@@ -1,7 +1,8 @@
 # Expects gdk_home, which is not the GDK location in the engine
+# This script is used directly as part of the UnrealGDKExampleProject CI, so providing default values is strictly necessary
 param (
-    [string] $gdk_path,
-    [string] $msbuild_path
+    [string] $gdk_path = "$gdk_home",
+    [string] $msbuild_path = "$((Get-Item 'Env:programfiles(x86)').Value)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin\MSBuild.exe" ## Location of MSBuild.exe on the build agent, as it only has the build tools, not the full visual studio
 )
 
 pushd $gdk_path


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
A previous change removed default arguments from the `setup-gdk.ps1` script. However, as the CI in other repositories made use of this script in isolation, removing the default arguments was a breaking change for these pipelines. This PR restores the defaults for these arguments.

#### Release note
This change is not customer facing, no release note has been added.

#### Tests
A new build was kicked off on the `UnrealGKDExampleProject` CI that uses this branch of the UnrealGDK. The new build is passes the `build-editor` step that previously broke due to missing arguments.

Example of broken build:
https://buildkite.com/improbable/unrealgdkexampleproject-nightly/builds/223#b50751cf-2511-4b20-ada7-57aee4b73e03

New test build:
https://buildkite.com/improbable/unrealgdkexampleproject-nightly/builds/226#557aaa71-51e7-4ae4-b718-fb21ecce9bfe

#### Documentation
An additional line of documentation has been included for this small change.

#### Primary reviewers
@mironec @joshuahuburn @aleximprobable 