### PR TITLE
[UNR-2426] Fix ComponentConstraint not finding any component IDs

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialInterestConstraints.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialInterestConstraints.cpp
@@ -114,16 +114,23 @@ void UActorClassConstraint::CreateConstraint(const USpatialClassInfoManager& Cla
 
 void UComponentClassConstraint::CreateConstraint(const USpatialClassInfoManager& ClassInfoManager, SpatialGDK::QueryConstraint& OutConstraint) const
 {
-	if (!ComponentClass.Get())
+	if (!ComponentClass.Get() || !ActorClass.Get())
 	{
 		return;
 	}
 
-	TArray<Worker_ComponentId> ComponentIds = ClassInfoManager.GetComponentIdsForClassHierarchy(*ComponentClass.Get(), bIncludeDerivedClasses);
-	for (Worker_ComponentId ComponentId : ComponentIds)
+	TArray<Worker_ComponentId> ComponentIds = ClassInfoManager.GetComponentIdsForComponentClassHierarchy(*ActorClass.Get(), *ComponentClass.Get(), bIncludeDerivedClasses);
+	if (ComponentIds.Num() > 1)
 	{
-		SpatialGDK::QueryConstraint ComponentTypeConstraint;
-		ComponentTypeConstraint.ComponentConstraint = ComponentId;
-		OutConstraint.OrConstraint.Add(ComponentTypeConstraint);
+		for (Worker_ComponentId ComponentId : ComponentIds)
+		{
+			SpatialGDK::QueryConstraint ComponentTypeConstraint;
+			ComponentTypeConstraint.ComponentConstraint = ComponentId;
+			OutConstraint.OrConstraint.Add(ComponentTypeConstraint);
+		}
+	}
+	else if (ComponentIds.Num() == 1)
+	{
+		OutConstraint.ComponentConstraint = ComponentIds[0];
 	}
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialClassInfoManager.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialClassInfoManager.h
@@ -110,6 +110,9 @@ public:
 
 	Worker_ComponentId GetComponentIdForClass(const UClass& Class) const;
 	TArray<Worker_ComponentId> GetComponentIdsForClassHierarchy(const UClass& BaseClass, const bool bIncludeDerivedTypes = true) const;
+
+	Worker_ComponentId GetComponentIdForComponentClass(const UClass& ActorClass, const UClass& ComponentClass) const;
+	TArray<Worker_ComponentId> GetComponentIdsForComponentClassHierarchy(const UClass& ActorClass, const UClass& ComponentClass, const bool bIncludeDerivedTypes = true) const;
 	
 	const FRPCInfo& GetRPCInfo(UObject* Object, UFunction* Function);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialInterestConstraints.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialInterestConstraints.h
@@ -281,11 +281,14 @@ public:
 
 	virtual void CreateConstraint(const USpatialClassInfoManager& ClassInfoManager, SpatialGDK::QueryConstraint& OutConstraint) const override;
 
+	UPROPERTY(BlueprintReadOnly, EditDefaultsOnly, Category = "Actor Class Constraint")
+	TSubclassOf<AActor> ActorClass;
+
 	/** The base type of component that this constraint will capture. */
 	UPROPERTY(BlueprintReadOnly, EditDefaultsOnly, Category = "Component Class Constraint")
 	TSubclassOf<UActorComponent> ComponentClass;
 
 	/** Whether this constraint should capture derived types. */
-	UPROPERTY(BlueprintReadOnly, EditDefaultsOnly, Category = "Component Class Constraint")
+	UPROPERTY(BlueprintReadOnly, EditDefaultsOnly, Category = "Actor Class Constraint")
 	bool bIncludeDerivedClasses = true;
 };


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Fixes UNR-2426 but also requires an ActorClass constraint on a
ComponentConstraint.

Currently the ComponentConstraint looks up the Component ClassPath
using the map for Actor ClassPaths, this will never return a
Component ID for a component. Now this uses the ActorClass to lookup the
generated component for the ActorComponent.

The ActorClass is needed as the GDK generates new components for
each Actor when an ActorComponent is attached.

#### Release note
REQUIRED: Add a release note to the `##Unreleased` section of CHANGELOG.md. You can find guidance for writing useful release notes [here](../SpatialGDK/Extras/internal-documentation/how-to-write-good-release-notes.md). Documentation changes are exempt from this requirement.

#### Tests
Tested by adding a component constraint in a query. Previously the query was empty, now the query shows a component ID.
