### PR TITLE
UNR 1132 Correct handling of unresolved reference in structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Servers maintain interest in AlwaysRelevant Actors.
 - The default cloud launch configuration is now empty.
 - Fixed an crash caused by attempting to read schema from an unloaded class.
+- Unresolved object references in replicated arrays of structs should now be properly handled and eventually resolved.
+
 
 ## [`0.7.0-preview`] - 2019-10-11
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -1144,7 +1144,7 @@ void USpatialActorChannel::RemoveRepNotifiesWithUnresolvedObjs(TArray<UProperty*
 			}
 
 			bool bIsSameRepNotify = RepLayout.Parents[ObjRef.Value.ParentIndex].Property == Property;
-			bool bIsArray = RepLayout.Parents[ObjRef.Value.ParentIndex].Property->ArrayDim > 1;
+			bool bIsArray = RepLayout.Parents[ObjRef.Value.ParentIndex].Property->ArrayDim > 1 || Cast<UArrayProperty>(Property) != nullptr;
 			if (bIsSameRepNotify && !bIsArray)
 			{
 				UE_LOG(LogSpatialActorChannel, Verbose, TEXT("RepNotify %s on %s ignored due to unresolved Actor"), *Property->GetName(), *Object->GetName());

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitReader.cpp
@@ -42,20 +42,27 @@ void FSpatialNetBitReader::DeserializeObjectRef(FUnrealObjectRef& ObjectRef)
 	SerializeBits(&ObjectRef.bUseSingletonClassPath, 1);
 }
 
-FArchive& FSpatialNetBitReader::operator<<(UObject*& Value)
+UObject* FSpatialNetBitReader::ReadObject(bool& bUnresolved)
 {
 	FUnrealObjectRef ObjectRef;
 
 	DeserializeObjectRef(ObjectRef);
 	check(ObjectRef != FUnrealObjectRef::UNRESOLVED_OBJECT_REF);
 
-	bool bUnresolved = false;
-	Value = FUnrealObjectRef::ToObjectPtr(ObjectRef, Cast<USpatialPackageMapClient>(PackageMap), bUnresolved);
+	UObject* Value = FUnrealObjectRef::ToObjectPtr(ObjectRef, Cast<USpatialPackageMapClient>(PackageMap), bUnresolved);
 
 	if (bUnresolved)
 	{
 		UnresolvedRefs.Add(ObjectRef);
 	}
+
+	return Value;
+}
+
+FArchive& FSpatialNetBitReader::operator<<(UObject*& Value)
+{
+	bool bUnresolved = false;
+	Value = ReadObject(bUnresolved);
 
 	return *this;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -9,6 +9,7 @@
 
 #include "EngineClasses/SpatialActorChannel.h"
 #include "EngineClasses/SpatialNetDriver.h"
+#include "EngineClasses/SpatialNetBitReader.h"
 #include "Interop/Connection/SpatialWorkerConnection.h"
 #include "Interop/SpatialReceiver.h"
 #include "Interop/SpatialSender.h"
@@ -290,9 +291,17 @@ bool USpatialPackageMapClient::IsEntityPoolReady() const
 bool USpatialPackageMapClient::SerializeObject(FArchive& Ar, UClass* InClass, UObject*& Obj, FNetworkGUID *OutNetGUID)
 {
 	// Super::SerializeObject is not called here on purpose
-	Ar << Obj;
+	if (Ar.IsSaving())
+	{
+		Ar << Obj;
+		return true;
+	}
 
-	return true;
+	FSpatialNetBitReader& Reader = static_cast<FSpatialNetBitReader&>(Ar);
+	bool bUnresolved = false;
+	Obj = Reader.ReadObject(bUnresolved);
+
+	return !bUnresolved;
 }
 
 FSpatialNetGUIDCache::FSpatialNetGUIDCache(USpatialNetDriver* InDriver)

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
@@ -265,7 +265,7 @@ void ComponentReader::ApplyProperty(Schema_Object* Object, Schema_FieldId FieldI
 
 		ReadStructProperty(ValueDataReader, StructProperty, NetDriver, Data, bHasUnmapped);
 
-		if (bHasUnmapped)
+		if (NewUnresolvedRefs.Num() > 0)
 		{
 			InObjectReferencesMap.Add(Offset, FObjectReferences(ValueData, CountBits, NewUnresolvedRefs, ShadowOffset, ParentIndex, Property));
 			UnresolvedRefs.Append(NewUnresolvedRefs);

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetBitReader.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetBitReader.h
@@ -22,6 +22,8 @@ public:
 
 	virtual FArchive& operator<<(struct FWeakObjectPtr& Value) override;
 
+	UObject* ReadObject(bool& bUnresolved);
+
 protected:
 	void DeserializeObjectRef(FUnrealObjectRef& ObjectRef);
 


### PR DESCRIPTION
#### Description
When replicating structs containing references to actors for which their entity had yet to be created, the field remained unresolved, even if we receive the entity later.
The code in ComponentReader::ApplyProperty did not take into account the array of unresolved references, instead relying on the bHasUnmapped flag, which was not flipped when there was unresolved reference.
Also, in SpatialActorChannel::RemoveRepNotifiesWithUnresolvedObjs, the rep notify was removed in the presence of unresolved references in arrays. The spec is to allow partial states in arrays, and rely on the customer to check the reference validity (I would be in favor of having an option for that, to be able to handle only fully resolved arrays).

#### Tests
Manually tested with an array of structs on the GameState populated early on startup, checked we received several RepNotify, converging to a fully resolved state.
Could deliver a map reproducing the issue. An automated C++ test could be built if we can setup a deployment to have a client and a server.

#### Documentation

#### Primary reviewers