### PR TITLE
Move RPC types into separate enum, remove old reliable RPC checking

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1276,22 +1276,13 @@ void USpatialNetDriver::ProcessRPC(AActor* Actor, UObject* SubObject, UFunction*
 		return;
 	}
 
-	int ReliableRPCIndex = 0;
-	if (GetDefault<USpatialGDKSettings>()->bCheckRPCOrder)
-	{
-		if (Function->HasAnyFunctionFlags(FUNC_NetReliable) && !Function->HasAnyFunctionFlags(FUNC_NetMulticast))
-		{
-			ReliableRPCIndex = GetNextReliableRPCId(Actor, FunctionFlagsToRPCType(Function->FunctionFlags), CallingObject);
-		}
-	}
-
 	FUnrealObjectRef CallingObjectRef = PackageMap->GetUnrealObjectRefFromObject(CallingObject);
 	if (!CallingObjectRef.IsValid())
 	{
 		UE_LOG(LogSpatialOSNetDriver, Warning, TEXT("The target object %s is unresolved; RPC %s will be dropped."), *CallingObject->GetFullName(), *Function->GetName());
 		return;
 	}
-	RPCPayload Payload = Sender->CreateRPCPayloadFromParams(CallingObject, CallingObjectRef, Function, ReliableRPCIndex, Parameters);
+	RPCPayload Payload = Sender->CreateRPCPayloadFromParams(CallingObject, CallingObjectRef, Function, Parameters);
 
 	Sender->ProcessOrQueueOutgoingRPC(CallingObjectRef, MoveTemp(Payload));
 }
@@ -2053,108 +2044,6 @@ void USpatialNetDriver::WipeWorld(const USpatialNetDriver::PostWorldWipeDelegate
 	if (Cast<USpatialGameInstance>(GetWorld()->GetGameInstance())->bResponsibleForSnapshotLoading)
 	{
 		SnapshotManager->WorldWipe(LoadSnapshotAfterWorldWipe);
-	}
-}
-
-uint32 USpatialNetDriver::GetNextReliableRPCId(AActor* Actor, ERPCType RPCType, UObject* TargetObject)
-{
-	if (!ReliableRPCIdMap.Contains(Actor))
-	{
-		ReliableRPCIdMap.Add(Actor);
-	}
-	FRPCTypeToReliableRPCIdMap& ReliableRPCIds = ReliableRPCIdMap[Actor];
-
-	if (FReliableRPCId* RPCIdEntry = ReliableRPCIds.Find(RPCType))
-	{
-		if (!RPCIdEntry->WorkerId.IsEmpty())
-		{
-			// We previously used to receive RPCs of this type, now we're about to send one, so we reset the reliable RPC index.
-			// This should only be possible for CrossServer RPCs.
-			check(RPCType == ERPCType::CrossServer);
-			UE_LOG(LogSpatialOSNetDriver, Verbose, TEXT("Actor %s, object %s: Used to receive reliable CrossServer RPCs from worker %s, now about to send one. The entity must have crossed boundary."),
-				*Actor->GetName(), *TargetObject->GetName(), *RPCIdEntry->WorkerId);
-			RPCIdEntry->WorkerId = FString();
-			RPCIdEntry->RPCId = 0;
-		}
-	}
-	else
-	{
-		// Add an entry for this RPC type with empty WorkerId and RPCId = 0
-		ReliableRPCIds.Add(RPCType);
-	}
-
-	return ++ReliableRPCIds[RPCType].RPCId;
-}
-
-void USpatialNetDriver::OnReceivedReliableRPC(AActor* Actor, ERPCType RPCType, FString WorkerId, uint32 RPCId, UObject* TargetObject, UFunction* Function)
-{
-	if (!ReliableRPCIdMap.Contains(Actor))
-	{
-		ReliableRPCIdMap.Add(Actor);
-	}
-	FRPCTypeToReliableRPCIdMap& ReliableRPCIds = ReliableRPCIdMap[Actor];
-
-	if (FReliableRPCId* RPCIdEntry = ReliableRPCIds.Find(RPCType))
-	{
-		if (WorkerId != RPCIdEntry->WorkerId)
-		{
-			if (RPCIdEntry->WorkerId.IsEmpty())
-			{
-				// We previously used to send RPCs of this type, now we received one. This should only be possible for CrossServer RPCs.
-				check(RPCType == ERPCType::CrossServer);
-				UE_LOG(LogSpatialOSNetDriver, Verbose, TEXT("Actor %s, object %s: Used to send reliable CrossServer RPCs, now received one from worker %s. The entity must have crossed boundary."),
-					*Actor->GetName(), *TargetObject->GetName(), *WorkerId);
-			}
-			else
-			{
-				// We received an RPC from a different worker than the one we used to receive RPCs of this type from.
-				UE_LOG(LogSpatialOSNetDriver, Verbose, TEXT("Actor %s, object %s: Received a reliable %s RPC from a different worker %s. Previously received from worker %s."),
-					*Actor->GetName(), *TargetObject->GetName(), *RPCTypeToString(RPCType), *WorkerId, *RPCIdEntry->WorkerId);
-			}
-			RPCIdEntry->WorkerId = WorkerId;
-		}
-		else if (RPCId != RPCIdEntry->RPCId + 1)
-		{
-			if (RPCId < RPCIdEntry->RPCId)
-			{
-				UE_LOG(LogSpatialOSNetDriver, Warning, TEXT("Actor %s: Reliable %s RPC received out of order! Previously received RPC: %s, target %s, index %d. Now received: %s, target %s, index %d. Sender: %s"),
-					*Actor->GetName(), *RPCTypeToString(RPCType), *RPCIdEntry->LastRPCName, *RPCIdEntry->LastRPCTarget, RPCIdEntry->RPCId, *Function->GetName(), *TargetObject->GetName(), RPCId, *WorkerId);
-			}
-			else if (RPCId == RPCIdEntry->RPCId)
-			{
-				UE_LOG(LogSpatialOSNetDriver, Warning, TEXT("Actor %s: Reliable %s RPC index duplicated! Previously received RPC: %s, target %s, index %d. Now received: %s, target %s, index %d. Sender: %s"),
-					*Actor->GetName(), *RPCTypeToString(RPCType), *RPCIdEntry->LastRPCName, *RPCIdEntry->LastRPCTarget, RPCIdEntry->RPCId, *Function->GetName(), *TargetObject->GetName(), RPCId, *WorkerId);
-			}
-			else
-			{
-				UE_LOG(LogSpatialOSNetDriver, Warning, TEXT("Actor %s: One or more reliable %s RPCs skipped! Previously received RPC: %s, target %s, index %d. Now received: %s, target %s, index %d. Sender: %s"),
-					*Actor->GetName(), *RPCTypeToString(RPCType), *RPCIdEntry->LastRPCName, *RPCIdEntry->LastRPCTarget, RPCIdEntry->RPCId, *Function->GetName(), *TargetObject->GetName(), RPCId, *WorkerId);
-			}
-		}
-
-		RPCIdEntry->RPCId = RPCId;
-		RPCIdEntry->LastRPCTarget = TargetObject->GetName();
-		RPCIdEntry->LastRPCName = Function->GetName();
-	}
-	else
-	{
-		ReliableRPCIds.Add(RPCType, FReliableRPCId(WorkerId, RPCId, TargetObject->GetName(), Function->GetName()));
-	}
-}
-
-void USpatialNetDriver::OnRPCAuthorityGained(AActor* Actor, ERPCType RPCType)
-{
-	// When we gain authority on an RPC component of an actor that we previously received RPCs for, reset the reliable RPC counter.
-	// This is to account for the case where the actor crosses to another worker, receives a couple of reliable RPCs, and comes back
-	// to the original worker.
-	if (FRPCTypeToReliableRPCIdMap* ReliableRPCIds = ReliableRPCIdMap.Find(Actor))
-	{
-		if (ReliableRPCIds->Contains(RPCType))
-		{
-			UE_LOG(LogSpatialOSNetDriver, Verbose, TEXT("Actor %s: Gained authority over %s RPC component. Resetting previous reliable RPC counter."),
-				*Actor->GetName(), *RPCTypeToString(RPCType));
-			ReliableRPCIds->Remove(RPCType);
-		}
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
@@ -67,40 +67,40 @@ FORCEINLINE UClass* ResolveClass(FString& ClassPath)
 	return Class;
 }
 
-ESchemaComponentType GetRPCType(UFunction* RemoteFunction)
+ERPCType GetRPCType(UFunction* RemoteFunction)
 {
 	if (RemoteFunction->HasAnyFunctionFlags(FUNC_NetMulticast))
 	{
-		return SCHEMA_NetMulticastRPC;
+		return ERPCType::NetMulticast;
 	}
 	else if (RemoteFunction->HasAnyFunctionFlags(FUNC_NetCrossServer))
 	{
-		return SCHEMA_CrossServerRPC;
+		return ERPCType::CrossServer;
 	}
 	else if (RemoteFunction->HasAnyFunctionFlags(FUNC_NetReliable))
 	{
 		if (RemoteFunction->HasAnyFunctionFlags(FUNC_NetClient))
 		{
-			return SCHEMA_ClientReliableRPC;
+			return ERPCType::ClientReliable;
 		}
 		else if (RemoteFunction->HasAnyFunctionFlags(FUNC_NetServer))
 		{
-			return SCHEMA_ServerReliableRPC;
+			return ERPCType::ServerReliable;
 		}
 	}
 	else
 	{
 		if (RemoteFunction->HasAnyFunctionFlags(FUNC_NetClient))
 		{
-			return SCHEMA_ClientUnreliableRPC;
+			return ERPCType::ClientUnreliable;
 		}
 		else if (RemoteFunction->HasAnyFunctionFlags(FUNC_NetServer))
 		{
-			return SCHEMA_ServerUnreliableRPC;
+			return ERPCType::ServerUnreliable;
 		}
 	}
 
-	return SCHEMA_Invalid;
+	return ERPCType::Invalid;
 }
 
 void USpatialClassInfoManager::CreateClassInfoForClass(UClass* Class)
@@ -122,8 +122,8 @@ void USpatialClassInfoManager::CreateClassInfoForClass(UClass* Class)
 
 	for (UFunction* RemoteFunction : RelevantClassFunctions)
 	{
-		ESchemaComponentType RPCType = GetRPCType(RemoteFunction);
-		checkf(RPCType != SCHEMA_Invalid, TEXT("Could not determine RPCType for RemoteFunction: %s"), *GetPathNameSafe(RemoteFunction));
+		ERPCType RPCType = GetRPCType(RemoteFunction);
+		checkf(RPCType != ERPCType::Invalid, TEXT("Could not determine RPCType for RemoteFunction: %s"), *GetPathNameSafe(RemoteFunction));
 
 		FRPCInfo RPCInfo;
 		RPCInfo.Type = RPCType;

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -490,18 +490,6 @@ void USpatialReceiver::HandleActorAuthority(const Worker_AuthorityChangeOp& Op)
 			Sender->SendServerEndpointReadyUpdate(Op.entity_id);
 		}
 	}
-
-	if (GetDefault<USpatialGDKSettings>()->bCheckRPCOrder && Op.authority == WORKER_AUTHORITY_AUTHORITATIVE)
-	{
-		ESchemaComponentType ComponentType = ClassInfoManager->GetCategoryByComponentId(Op.component_id);
-		if (Op.component_id == SpatialConstants::CLIENT_RPC_ENDPOINT_COMPONENT_ID ||
-			Op.component_id == SpatialConstants::SERVER_RPC_ENDPOINT_COMPONENT_ID ||
-			Op.component_id == SpatialConstants::NETMULTICAST_RPCS_COMPONENT_ID)
-		{
-			// This will be called multiple times on each RPC component.
-			NetDriver->OnRPCAuthorityGained(Actor, ComponentType);
-		}
-	}
 }
 
 bool USpatialReceiver::IsReceivedEntityTornOff(Worker_EntityId EntityId)
@@ -1518,34 +1506,11 @@ ERPCResult USpatialReceiver::ApplyRPCInternal(UObject* TargetObject, UFunction* 
 	RPCPayload PayloadCopy = Payload;
 	FSpatialNetBitReader PayloadReader(PackageMap, PayloadCopy.PayloadData.GetData(), PayloadCopy.CountDataBits(), UnresolvedRefs);
 
-	int ReliableRPCId = 0;
-	if (GetDefault<USpatialGDKSettings>()->bCheckRPCOrder)
-	{
-		if (Function->HasAnyFunctionFlags(FUNC_NetReliable) && !Function->HasAnyFunctionFlags(FUNC_NetMulticast))
-		{
-			PayloadReader << ReliableRPCId;
-		}
-	}
-
 	TSharedPtr<FRepLayout> RepLayout = NetDriver->GetFunctionRepLayout(Function);
 	RepLayout_ReceivePropertiesForRPC(*RepLayout, PayloadReader, Parms);
 
 	if ((UnresolvedRefs.Num() == 0) || bApplyWithUnresolvedRefs)
 	{
-		if (GetDefault<USpatialGDKSettings>()->bCheckRPCOrder)
-		{
-			if (Function->HasAnyFunctionFlags(FUNC_NetReliable) && !Function->HasAnyFunctionFlags(FUNC_NetMulticast))
-			{
-				AActor* Actor = Cast<AActor>(TargetObject);
-				if (Actor == nullptr)
-				{
-					Actor = Cast<AActor>(TargetObject->GetOuter());
-					check(Actor);
-				}
-				NetDriver->OnReceivedReliableRPC(Actor, FunctionFlagsToRPCType(Function->FunctionFlags), SenderWorkerId, ReliableRPCId, TargetObject, Function);
-			}
-		}
-
 		TargetObject->ProcessEvent(Function, Parms);
 		Result = ERPCResult::Success;
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1542,7 +1542,7 @@ ERPCResult USpatialReceiver::ApplyRPCInternal(UObject* TargetObject, UFunction* 
 					Actor = Cast<AActor>(TargetObject->GetOuter());
 					check(Actor);
 				}
-				NetDriver->OnReceivedReliableRPC(Actor, FunctionFlagsToRPCSchemaType(Function->FunctionFlags), SenderWorkerId, ReliableRPCId, TargetObject, Function);
+				NetDriver->OnReceivedReliableRPC(Actor, FunctionFlagsToRPCType(Function->FunctionFlags), SenderWorkerId, ReliableRPCId, TargetObject, Function);
 			}
 		}
 
@@ -1833,7 +1833,7 @@ void USpatialReceiver::ProcessOrQueueIncomingRPC(const FUnrealObjectRef& InTarge
 	const FClassInfo& ClassInfo = ClassInfoManager->GetOrCreateClassInfoByObject(TargetObject);
 	UFunction* Function = ClassInfo.RPCs[InPayload.Index];
 	const FRPCInfo& RPCInfo = ClassInfoManager->GetRPCInfo(TargetObject, Function);
-	ESchemaComponentType Type = RPCInfo.Type;
+	ERPCType Type = RPCInfo.Type;
 
 	IncomingRPCs.ProcessOrQueueRPC(InTargetObjectRef, Type, MoveTemp(InPayload));
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -30,7 +30,6 @@ USpatialGDKSettings::USpatialGDKSettings(const FObjectInitializer& ObjectInitial
 	, bEnableMetricsDisplay(false)
 	, MetricsReportRate(2.0f)
 	, bUseFrameTimeAsLoad(false)
-	, bCheckRPCOrder(false)
 	, bBatchSpatialPositionUpdates(true)
 	, MaxDynamicallyAttachedSubobjectsPerClass(3)
 	, bEnableServerQBI(true)

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCContainer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCContainer.cpp
@@ -82,7 +82,7 @@ namespace
 	}
 }
 
-FPendingRPCParams::FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, ESchemaComponentType InType, RPCPayload&& InPayload)
+FPendingRPCParams::FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, ERPCType InType, RPCPayload&& InPayload)
 	: ObjectRef(InTargetObjectRef)
 	, Payload(MoveTemp(InPayload))
 	, Timestamp(FDateTime::Now())
@@ -90,7 +90,7 @@ FPendingRPCParams::FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, 
 {
 }
 
-void FRPCContainer::ProcessOrQueueRPC(const FUnrealObjectRef& TargetObjectRef, ESchemaComponentType Type, RPCPayload&& Payload)
+void FRPCContainer::ProcessOrQueueRPC(const FUnrealObjectRef& TargetObjectRef, ERPCType Type, RPCPayload&& Payload)
 {
 	FPendingRPCParams Params {TargetObjectRef, Type, MoveTemp(Payload)};
 
@@ -159,7 +159,7 @@ void FRPCContainer::DropForEntity(const Worker_EntityId& EntityId)
 	}
 }
 
-bool FRPCContainer::ObjectHasRPCsQueuedOfType(const Worker_EntityId& EntityId, ESchemaComponentType Type) const
+bool FRPCContainer::ObjectHasRPCsQueuedOfType(const Worker_EntityId& EntityId, ERPCType Type) const
 {
 	if(const FRPCMap* MapOfQueues = QueuedRPCs.Find(Type))
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetrics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetrics.cpp
@@ -152,13 +152,13 @@ void USpatialMetrics::SpatialStopRPCMetrics()
 
 		FString SeparatorLine = FString::Printf(TEXT("-------------------+-%s-+------------+------------+---------------+--------------+------------"), *FString::ChrN(MaxRPCNameLen, '-'));
 
-		ESchemaComponentType PrevType = SCHEMA_Invalid;
+		ERPCType PrevType = ERPCType::Invalid;
 		for (RPCStat& Stat : RecentRPCArray)
 		{
 			FString RPCTypeField;
 			if (Stat.Type != PrevType)
 			{
-				RPCTypeField = RPCSchemaTypeToString(Stat.Type);
+				RPCTypeField = RPCTypeToString(Stat.Type);
 				PrevType = Stat.Type;
 				UE_LOG(LogSpatialMetrics, Log, TEXT("%s"), *SeparatorLine);
 			}
@@ -268,7 +268,7 @@ void USpatialMetrics::OnModifySettingCommand(Schema_Object* CommandPayload)
 	SpatialModifySetting(Name, Value);
 }
 
-void USpatialMetrics::TrackSentRPC(UFunction* Function, ESchemaComponentType RPCType, int PayloadSize)
+void USpatialMetrics::TrackSentRPC(UFunction* Function, ERPCType RPCType, int PayloadSize)
 {
 	if (!bRPCTrackingEnabled)
 	{

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -161,9 +161,9 @@ public:
 	int32 GetConsiderListSize() const { return ConsiderListSize; }
 #endif
 
-	uint32 GetNextReliableRPCId(AActor* Actor, ESchemaComponentType RPCType, UObject* TargetObject);
-	void OnReceivedReliableRPC(AActor* Actor, ESchemaComponentType RPCType, FString WorkerId, uint32 RPCId, UObject* TargetObject, UFunction* Function);
-	void OnRPCAuthorityGained(AActor* Actor, ESchemaComponentType RPCType);
+	uint32 GetNextReliableRPCId(AActor* Actor, ERPCType RPCType, UObject* TargetObject);
+	void OnReceivedReliableRPC(AActor* Actor, ERPCType RPCType, FString WorkerId, uint32 RPCId, UObject* TargetObject, UFunction* Function);
+	void OnRPCAuthorityGained(AActor* Actor, ERPCType RPCType);
 
 	struct FReliableRPCId
 	{
@@ -175,7 +175,7 @@ public:
 		FString LastRPCTarget;
 		FString LastRPCName;
 	};
-	using FRPCTypeToReliableRPCIdMap = TMap<ESchemaComponentType, FReliableRPCId>;
+	using FRPCTypeToReliableRPCIdMap = TMap<ERPCType, FReliableRPCId>;
 	// Per actor, maps from RPC type to the reliable RPC index used to detect if reliable RPCs go out of order.
 	TMap<TWeakObjectPtr<AActor>, FRPCTypeToReliableRPCIdMap> ReliableRPCIdMap;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -161,24 +161,6 @@ public:
 	int32 GetConsiderListSize() const { return ConsiderListSize; }
 #endif
 
-	uint32 GetNextReliableRPCId(AActor* Actor, ERPCType RPCType, UObject* TargetObject);
-	void OnReceivedReliableRPC(AActor* Actor, ERPCType RPCType, FString WorkerId, uint32 RPCId, UObject* TargetObject, UFunction* Function);
-	void OnRPCAuthorityGained(AActor* Actor, ERPCType RPCType);
-
-	struct FReliableRPCId
-	{
-		FReliableRPCId() = default;
-		FReliableRPCId(FString InWorkerId, uint32 InRPCId, FString InRPCTarget, FString InRPCName) : WorkerId(InWorkerId), RPCId(InRPCId), LastRPCTarget(InRPCTarget), LastRPCName(InRPCName) {}
-
-		FString WorkerId;
-		uint32 RPCId = 0;
-		FString LastRPCTarget;
-		FString LastRPCName;
-	};
-	using FRPCTypeToReliableRPCIdMap = TMap<ERPCType, FReliableRPCId>;
-	// Per actor, maps from RPC type to the reliable RPC index used to detect if reliable RPCs go out of order.
-	TMap<TWeakObjectPtr<AActor>, FRPCTypeToReliableRPCIdMap> ReliableRPCIdMap;
-
 	void DelayedSendDeleteEntityRequest(Worker_EntityId EntityId, float Delay);
 
 #if WITH_EDITOR

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialClassInfoManager.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialClassInfoManager.h
@@ -31,7 +31,7 @@ FORCEINLINE ESchemaComponentType GetGroupFromCondition(ELifetimeCondition Condit
 
 struct FRPCInfo
 {
-	ESchemaComponentType Type;
+	ERPCType Type;
 	uint32 Index;
 };
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -136,7 +136,7 @@ private:
 	TArray<Worker_InterestOverride> CreateComponentInterestForActor(USpatialActorChannel* Channel, bool bIsNetOwned);
 	// RPC Tracking
 #if !UE_BUILD_SHIPPING
-	void TrackRPC(AActor* Actor, UFunction* Function, const RPCPayload& Payload, const ESchemaComponentType RPCType);
+	void TrackRPC(AActor* Actor, UFunction* Function, const RPCPayload& Payload, const ERPCType RPCType);
 #endif
 private:
 	UPROPERTY()

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -108,7 +108,7 @@ public:
 
 	void FlushPackedRPCs();
 
-	RPCPayload CreateRPCPayloadFromParams(UObject* TargetObject, const FUnrealObjectRef& TargetObjectRef, UFunction* Function, int ReliableRPCIndex, void* Params);
+	RPCPayload CreateRPCPayloadFromParams(UObject* TargetObject, const FUnrealObjectRef& TargetObjectRef, UFunction* Function, void* Params);
 	void GainAuthorityThenAddComponent(USpatialActorChannel* Channel, UObject* Object, const FClassInfo* Info);
 
 	// Creates an entity authoritative on this server worker, ensuring it will be able to receive updates for the GSM.
@@ -126,7 +126,7 @@ private:
 	void AddTombstoneToEntity(const Worker_EntityId EntityId);
 
 	// RPC Construction
-	FSpatialNetBitWriter PackRPCDataToSpatialNetBitWriter(UFunction* Function, void* Parameters, int ReliableRPCId) const;
+	FSpatialNetBitWriter PackRPCDataToSpatialNetBitWriter(UFunction* Function, void* Parameters) const;
 
 	Worker_CommandRequest CreateRPCCommandRequest(UObject* TargetObject, const RPCPayload& Payload, Worker_ComponentId ComponentId, Schema_FieldId CommandIndex, Worker_EntityId& OutEntityId);
 	Worker_CommandRequest CreateRetryRPCCommandRequest(const FReliableRPCForRetry& RPC, uint32 TargetObjectOffset);

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -10,6 +10,8 @@
 #include <WorkerSDK/improbable/c_schema.h>
 #include <WorkerSDK/improbable/c_worker.h>
 
+#include "SpatialConstants.generated.h"
+
 enum ESchemaComponentType : int32
 {
 	SCHEMA_Invalid = -1,
@@ -21,58 +23,61 @@ enum ESchemaComponentType : int32
 
 	SCHEMA_Count,
 
-	// RPCs
-	SCHEMA_ClientReliableRPC,
-	SCHEMA_ClientUnreliableRPC,
-	SCHEMA_ServerReliableRPC,
-	SCHEMA_ServerUnreliableRPC,
-	SCHEMA_NetMulticastRPC,
-	SCHEMA_CrossServerRPC,
-
-
 	// Iteration helpers
 	SCHEMA_Begin = SCHEMA_Data,
 };
 
-FORCEINLINE ESchemaComponentType FunctionFlagsToRPCSchemaType(EFunctionFlags FunctionFlags)
+UENUM()
+enum class ERPCType : uint8
+{
+	Invalid,
+	ClientReliable,
+	ClientUnreliable,
+	ServerReliable,
+	ServerUnreliable,
+	NetMulticast,
+	CrossServer
+};
+
+FORCEINLINE ERPCType FunctionFlagsToRPCType(EFunctionFlags FunctionFlags)
 {
 	if (FunctionFlags & FUNC_NetClient)
 	{
-		return SCHEMA_ClientReliableRPC;
+		return ERPCType::ClientReliable;
 	}
 	else if (FunctionFlags & FUNC_NetServer)
 	{
-		return SCHEMA_ServerReliableRPC;
+		return ERPCType::ServerReliable;
 	}
 	else if (FunctionFlags & FUNC_NetMulticast)
 	{
-		return SCHEMA_NetMulticastRPC;
+		return ERPCType::NetMulticast;
 	}
 	else if (FunctionFlags & FUNC_NetCrossServer)
 	{
-		return SCHEMA_CrossServerRPC;
+		return ERPCType::CrossServer;
 	}
 	else
 	{
-		return SCHEMA_Invalid;
+		return ERPCType::Invalid;
 	}
 }
 
-FORCEINLINE FString RPCSchemaTypeToString(ESchemaComponentType RPCType)
+FORCEINLINE FString RPCTypeToString(ERPCType RPCType)
 {
 	switch (RPCType)
 	{
-	case SCHEMA_ClientReliableRPC:
+	case ERPCType::ClientReliable:
 		return TEXT("Client, Reliable");
-	case SCHEMA_ClientUnreliableRPC:
+	case ERPCType::ClientUnreliable:
 		return TEXT("Client, Unreliable");
-	case SCHEMA_ServerReliableRPC:
+	case ERPCType::ServerReliable:
 		return TEXT("Server, Reliable");
-	case SCHEMA_ServerUnreliableRPC:
+	case ERPCType::ServerUnreliable:
 		return TEXT("Server, Unreliable");
-	case SCHEMA_NetMulticastRPC:
+	case ERPCType::NetMulticast:
 		return TEXT("Multicast");
-	case SCHEMA_CrossServerRPC:
+	case ERPCType::CrossServer:
 		return TEXT("CrossServer");
 	}
 
@@ -244,25 +249,25 @@ namespace SpatialConstants
 
 } // ::SpatialConstants
 
-FORCEINLINE Worker_ComponentId SchemaComponentTypeToWorkerComponentId(ESchemaComponentType SchemaType)
+FORCEINLINE Worker_ComponentId RPCTypeToWorkerComponentId(ERPCType RPCType)
 {
-	switch (SchemaType)
+	switch (RPCType)
 	{
-	case SCHEMA_CrossServerRPC:
+	case ERPCType::CrossServer:
 	{
 		return SpatialConstants::SERVER_RPC_ENDPOINT_COMPONENT_ID;
 	}
-	case SCHEMA_NetMulticastRPC:
+	case ERPCType::NetMulticast:
 	{
 		return SpatialConstants::NETMULTICAST_RPCS_COMPONENT_ID;
 	}
-	case SCHEMA_ClientReliableRPC:
-	case SCHEMA_ClientUnreliableRPC:
+	case ERPCType::ClientReliable:
+	case ERPCType::ClientUnreliable:
 	{
 		return SpatialConstants::SERVER_RPC_ENDPOINT_COMPONENT_ID;
 	}
-	case SCHEMA_ServerReliableRPC:
-	case SCHEMA_ServerUnreliableRPC:
+	case ERPCType::ServerReliable:
+	case ERPCType::ServerUnreliable:
 	{
 		return SpatialConstants::CLIENT_RPC_ENDPOINT_COMPONENT_ID;
 	}

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -144,11 +144,6 @@ public:
 	UPROPERTY(EditAnywhere, config, Category = "Metrics", meta = (ConfigRestartRequired = false))
 	bool bUseFrameTimeAsLoad;
 
-	// TODO: UNR-1653 Redesign bCheckRPCOrder Tests functionality
-	/** Include an order index with reliable RPCs and warn if they are executed out of order.*/
-	UPROPERTY(config, meta = (ConfigRestartRequired = false))
-	bool bCheckRPCOrder;
-
 	/** Batch entity position updates to be processed on a single frame.*/
 	UPROPERTY(config, meta = (ConfigRestartRequired = false))
 	bool bBatchSpatialPositionUpdates;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/RPCContainer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/RPCContainer.h
@@ -65,7 +65,7 @@ struct FRPCErrorInfo
 
 struct SPATIALGDK_API FPendingRPCParams
 { 
-	FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, ESchemaComponentType InType, SpatialGDK::RPCPayload&& InPayload);
+	FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, ERPCType InType, SpatialGDK::RPCPayload&& InPayload);
 
 	// Moveable, not copyable.
 	FPendingRPCParams() = delete;
@@ -79,7 +79,7 @@ struct SPATIALGDK_API FPendingRPCParams
 	SpatialGDK::RPCPayload Payload;
 
 	FDateTime Timestamp;
-	ESchemaComponentType Type;
+	ERPCType Type;
 };
 
 class SPATIALGDK_API FRPCContainer
@@ -94,18 +94,18 @@ public:
 	~FRPCContainer() = default;
 
 	void BindProcessingFunction(const FProcessRPCDelegate& Function);
-	void ProcessOrQueueRPC(const FUnrealObjectRef& InTargetObjectRef, ESchemaComponentType InType, SpatialGDK::RPCPayload&& InPayload);
+	void ProcessOrQueueRPC(const FUnrealObjectRef& InTargetObjectRef, ERPCType InType, SpatialGDK::RPCPayload&& InPayload);
 	void ProcessRPCs();
 	void DropForEntity(const Worker_EntityId& EntityId);
 
-	bool ObjectHasRPCsQueuedOfType(const Worker_EntityId& EntityId, ESchemaComponentType Type) const;
+	bool ObjectHasRPCsQueuedOfType(const Worker_EntityId& EntityId, ERPCType Type) const;
 
 	static const double SECONDS_BEFORE_WARNING;
 
 private:
 	using FArrayOfParams = TArray<FPendingRPCParams>;
 	using FRPCMap = TMap<Worker_EntityId_Key, FArrayOfParams>;
-	using RPCContainerType = TMap<ESchemaComponentType, FRPCMap>;
+	using RPCContainerType = TMap<ERPCType, FRPCMap>;
 
 	void ProcessRPCs(FArrayOfParams& RPCList);
 	bool ApplyFunction(FPendingRPCParams& Params);

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetrics.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetrics.h
@@ -43,7 +43,7 @@ public:
 	void SpatialModifySetting(const FString& Name, float Value);
 	void OnModifySettingCommand(Schema_Object* CommandPayload);
 
-	void TrackSentRPC(UFunction* Function, ESchemaComponentType RPCType, int PayloadSize);
+	void TrackSentRPC(UFunction* Function, ERPCType RPCType, int PayloadSize);
 
 	void HandleWorkerMetrics(Worker_Op* Op);
 
@@ -70,7 +70,7 @@ private:
 	// tracking on the server.
 	struct RPCStat
 	{
-		ESchemaComponentType Type;
+		ERPCType Type;
 		FString Name;
 		int Calls;
 		int TotalPayload;

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Utils/RPCContainer/ObjectSpy.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Utils/RPCContainer/ObjectSpy.cpp
@@ -4,22 +4,22 @@
 
 // If this assertion fails, then TypeToArray and ArrayToType
 // functions have to be updated correspondingly
-static_assert(sizeof(ESchemaComponentType) == sizeof(int32), "");
+static_assert(sizeof(ERPCType) == sizeof(uint8), "");
 
-TArray<uint8> SpyUtils::SchemaTypeToByteArray(ESchemaComponentType Type)
+TArray<uint8> SpyUtils::RPCTypeToByteArray(ERPCType Type)
 {
-	int32 ConvertedType = static_cast<int32>(Type);
-	return TArray<uint8>(reinterpret_cast<uint8*>(&ConvertedType), sizeof(ConvertedType));
+	uint8 ConvertedType = static_cast<uint8>(Type);
+	return TArray<uint8>(&ConvertedType, sizeof(ConvertedType));
 }
 
-ESchemaComponentType SpyUtils::ByteArrayToSchemaType(const TArray<uint8>& Array)
+ERPCType SpyUtils::ByteArrayToRPCType(const TArray<uint8>& Array)
 {
-	return ESchemaComponentType(*reinterpret_cast<const int32*>(&Array[0]));
+	return ERPCType(Array[0]);
 }
 
 FRPCErrorInfo UObjectSpy::ProcessRPC(const FPendingRPCParams& Params)
 {
-	ESchemaComponentType Type = SpyUtils::ByteArrayToSchemaType(Params.Payload.PayloadData);
+	ERPCType Type = SpyUtils::ByteArrayToRPCType(Params.Payload.PayloadData);
 	ProcessedRPCIndices.FindOrAdd(Type).Push(Params.Payload.Index);
 	return FRPCErrorInfo{ nullptr, nullptr, true, ERPCQueueType::Send, ERPCResult::Success };
 }

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Utils/RPCContainer/ObjectSpy.h
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Utils/RPCContainer/ObjectSpy.h
@@ -10,8 +10,8 @@
 
 namespace SpyUtils
 {
-	TArray<uint8> SchemaTypeToByteArray(ESchemaComponentType Type);
-	ESchemaComponentType ByteArrayToSchemaType(const TArray<uint8>& Array);
+	TArray<uint8> RPCTypeToByteArray(ERPCType Type);
+	ERPCType ByteArrayToRPCType(const TArray<uint8>& Array);
 } // namespace SpyUtils
 
 UCLASS()
@@ -21,5 +21,5 @@ class UObjectSpy : public UObject
 public:
 	FRPCErrorInfo ProcessRPC(const FPendingRPCParams& Params);
 
-	TMap<ESchemaComponentType, TArray<uint32>> ProcessedRPCIndices;
+	TMap<ERPCType, TArray<uint32>> ProcessedRPCIndices;
 };

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Utils/RPCContainer/RPCContainerTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Utils/RPCContainer/RPCContainerTest.cpp
@@ -18,8 +18,8 @@ using namespace SpatialGDK;
 
 namespace
 {
-	ESchemaComponentType AnySchemaComponentType = ESchemaComponentType::SCHEMA_ClientReliableRPC;
-	ESchemaComponentType AnyOtherSchemaComponentType = ESchemaComponentType::SCHEMA_ClientUnreliableRPC;
+	ERPCType AnySchemaComponentType = ERPCType::ClientReliable;
+	ERPCType AnyOtherSchemaComponentType = ERPCType::ClientUnreliable;
 
 	FUnrealObjectRef GenerateObjectRef(UObject* TargetObject)
 	{
@@ -32,10 +32,10 @@ namespace
 		return FreeIndex++;
 	}
 
-	FPendingRPCParams CreateMockParameters(UObject* TargetObject, ESchemaComponentType Type)
+	FPendingRPCParams CreateMockParameters(UObject* TargetObject, ERPCType Type)
 	{
 		// Use PayloadData as a place to store RPC type
-		RPCPayload Payload(0, GeneratePayloadFunctionIndex(), SpyUtils::SchemaTypeToByteArray(Type));
+		RPCPayload Payload(0, GeneratePayloadFunctionIndex(), SpyUtils::RPCTypeToByteArray(Type));
 		int ReliableRPCIndex = 0;
 
 		FUnrealObjectRef ObjectRef = GenerateObjectRef(TargetObject);
@@ -159,7 +159,7 @@ RPCCONTAINER_TEST(GIVEN_a_container_storing_multiple_values_of_different_type_WH
 	FRPCContainer RPCs;
 	RPCs.BindProcessingFunction(FProcessRPCDelegate::CreateUObject(TargetObject, &UObjectSpy::ProcessRPC));
 
-	TMap<ESchemaComponentType, TArray<uint32>> RPCIndices;
+	TMap<ERPCType, TArray<uint32>> RPCIndices;
 
 	for (int i = 0; i < 4; ++i)
 	{


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
RPC types were previously in ESchemaComponentType, but they didn't actually correspond to separate schema components (reliable and unreliable RPCs went through the same component). This will also make things cleaner for the ring buffer PR.

Additionally, I removed the old reliable RPC order checking as it hasn't been used for a while and the functionality is going to be redundant once we have ring buffers.

#### Primary reviewers
@m-samiec @aleximprobable 