### PR TITLE
Enabling pushing iOS command line arguments to builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - A warning is shown if a cloud deployment is launched with the `manual_worker_connection_only` flag set to true
 - Server travel supported for single server game worlds. Does not currently support zoning or off-loading.
 - Enabled the SpatialOS toolbar for MacOS.
+- Added a menu item to push additional arguments for iOS devices.
 
 ### Bug fixes:
 - Fixed a bug that could caused a name collision in schema for sublevels.

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -259,7 +259,7 @@ bool USpatialGDKEditorSettings::IsDeploymentConfigurationValid() const
 
 	if (IsManualWorkerConnectionSet(GetPrimaryLaunchConfigPath()))
 	{
-		if ((!FMessageDialog::Open(EAppMsgType::YesNo, LOCTEXT("AllowManualWorkerConnection", "Chosen launch configuration will not automatically launch servers. Do you want to continue?"))) == EAppReturnType::Yes)
+		if (FMessageDialog::Open(EAppMsgType::YesNo, LOCTEXT("AllowManualWorkerConnection", "Chosen launch configuration will not automatically launch servers. Do you want to continue?")) != EAppReturnType::Yes)
 		{
 			return false;
 		}

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -212,7 +212,7 @@ void FSpatialGDKEditorToolbarModule::MapActions(TSharedPtr<class FUICommandList>
 	InPluginCommands->MapAction(
 		FSpatialGDKEditorToolbarCommands::Get().UpdateIOSClient,
 		FExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::UpdateIOSClient),
-		FCanExecuteAction(),
+		FCanExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::UpdateIOSClientIsVisible),
 		FIsActionChecked(),
 		FIsActionButtonVisible::CreateRaw(this, &FSpatialGDKEditorToolbarModule::UpdateIOSClientIsVisible));
 }
@@ -902,7 +902,7 @@ void FSpatialGDKEditorToolbarModule::UpdateIOSClient() const
 	int32 ExitCode;
 
 #if PLATFORM_WINDOWS
-	FPlatformProcess::ExecProcess(*DeploymentServerExe, *DeploymentServerArguments &ExitCode, &DeploymentServerOutput, &StdErr);
+	FPlatformProcess::ExecProcess(*DeploymentServerExe, *DeploymentServerArguments, &ExitCode, &DeploymentServerOutput, &StdErr);
 #elif PLATFORM_MAC
 	FString MonoExe = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/ThirdParty/Mono/Mac/bin/mono")));
 	DeploymentServerArguments = FString::Printf(TEXT("%s %s"), *DeploymentServerExe, *DeploymentServerArguments);

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarCommands.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarCommands.cpp
@@ -16,7 +16,7 @@ void FSpatialGDKEditorToolbarCommands::RegisterCommands()
 	UI_COMMAND(OpenSimulatedPlayerConfigurationWindowAction, "Deploy", "Opens a configuration menu for cloud deployments.", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(StartSpatialService, "Start Service", "Starts the Spatial service daemon.", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(StopSpatialService, "Stop Service", "Stops the Spatial service daemon.", EUserInterfaceActionType::Button, FInputGesture());
-	UI_COMMAND(UpdateMobileClient, "Update mobile package", "Updates your mobile app on your device with the correct runtime ip.", EUserInterfaceActionType::Button, FInputGesture());
+	UI_COMMAND(UpdateIOSClient, "Update iOS app", "Updates your mobile app on your device with the correct runtime ip.", EUserInterfaceActionType::Button, FInputGesture());
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarCommands.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarCommands.cpp
@@ -16,6 +16,7 @@ void FSpatialGDKEditorToolbarCommands::RegisterCommands()
 	UI_COMMAND(OpenSimulatedPlayerConfigurationWindowAction, "Deploy", "Opens a configuration menu for cloud deployments.", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(StartSpatialService, "Start Service", "Starts the Spatial service daemon.", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(StopSpatialService, "Stop Service", "Stops the Spatial service daemon.", EUserInterfaceActionType::Button, FInputGesture());
+	UI_COMMAND(UpdateMobileClient, "Update mobile package", "Updates your mobile app on your device with the correct runtime ip.", EUserInterfaceActionType::Button, FInputGesture());
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -71,6 +71,8 @@ private:
 	bool StopSpatialServiceIsVisible() const;
 	bool StopSpatialServiceCanExecute() const;
 
+	bool UpdateIOSClientIsVisible() const;
+
 	void LaunchInspectorWebpageButtonClicked();
 	void CreateSnapshotButtonClicked();
 	void SchemaGenerateButtonClicked();
@@ -104,7 +106,7 @@ private:
 
 	FString GetOptionalExposedRuntimeIP() const;
 
-	void UpdateMobileClient() const;
+	void UpdateIOSClient() const;
 
 	static void ShowCompileLog();
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -104,6 +104,8 @@ private:
 
 	FString GetOptionalExposedRuntimeIP() const;
 
+	void UpdateMobileClient() const;
+
 	static void ShowCompileLog();
 
 	TSharedPtr<FUICommandList> PluginCommands;

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbarCommands.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbarCommands.h
@@ -32,5 +32,5 @@ public:
 
 	TSharedPtr<FUICommandInfo> StartSpatialService;
 	TSharedPtr<FUICommandInfo> StopSpatialService;
-	TSharedPtr<FUICommandInfo> UpdateMobileClient;
+	TSharedPtr<FUICommandInfo> UpdateIOSClient;
 };

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbarCommands.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbarCommands.h
@@ -32,4 +32,5 @@ public:
 
 	TSharedPtr<FUICommandInfo> StartSpatialService;
 	TSharedPtr<FUICommandInfo> StopSpatialService;
+	TSharedPtr<FUICommandInfo> UpdateMobileClient;
 };

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/SpatialGDKEditorToolbar.Build.cs
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/SpatialGDKEditorToolbar.Build.cs
@@ -21,6 +21,7 @@ public class SpatialGDKEditorToolbar : ModuleRules
                 "Engine",
                 "EngineSettings",
                 "InputCore",
+                "IOSRuntimeSettings",
                 "LevelEditor",
                 "Projects",
                 "Slate",


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
This PR enables adding & modifying iOS command line arguments to installed packages instead of having to hardcode all arguments in code.

#### Release note
still need to do that.

#### Tests
tested manually on mac & windows. 

#### Documentation
will be added to the iOS guide.
