### PR TITLE
Bugfix Skip forcing spatial networking if -pak argument is present

### DIFF
--- a/RequireSetup
+++ b/RequireSetup
@@ -1,4 +1,4 @@
 Increment the below number whenever it is required to run Setup.bat as part of a new commit.
 Our git hooks will detect this file has been updated and automatically run Setup.bat on pull.
 
-37
+38

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Build/Build.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Build/Build.cs
@@ -178,7 +178,14 @@ exit /b !ERRORLEVEL!";
 
                 var windowsNoEditorPath = Path.Combine(stagingDir, "WindowsNoEditor");
 
-                ForceSpatialNetworkingInConfig(windowsNoEditorPath, baseGameName);
+                if (additionalUATArgs.Contains("-pak"))
+                {
+                    Console.WriteLine("Cannot force bSpatialNetworking with -pak argument.");
+                }
+                else
+                {
+                    ForceSpatialNetworkingInConfig(windowsNoEditorPath, baseGameName);
+                }
 
                 // Add a _ to the start of the exe name, to ensure it is the exe selected by the launcher.
                 // TO-DO: Remove this once LAUNCH-341 has been completed, and the _ is no longer necessary.
@@ -237,7 +244,14 @@ exit /b !ERRORLEVEL!";
 
                 var linuxSimulatedPlayerPath = Path.Combine(stagingDir, "LinuxNoEditor");
 
-                ForceSpatialNetworkingInConfig(linuxSimulatedPlayerPath, baseGameName);
+                if (additionalUATArgs.Contains("-pak"))
+                {
+                    Console.WriteLine("Cannot force bSpatialNetworking with -pak argument.");
+                }
+                else
+                {
+                    ForceSpatialNetworkingInConfig(linuxSimulatedPlayerPath, baseGameName);
+                }
 
                 LinuxScripts.WriteWithLinuxLineEndings(LinuxScripts.GetSimulatedPlayerWorkerShellScript(baseGameName), Path.Combine(linuxSimulatedPlayerPath, "StartSimulatedClient.sh"));
                 LinuxScripts.WriteWithLinuxLineEndings(LinuxScripts.GetSimulatedPlayerCoordinatorShellScript(baseGameName), Path.Combine(linuxSimulatedPlayerPath, "StartCoordinator.sh"));
@@ -304,7 +318,14 @@ exit /b !ERRORLEVEL!";
                 var assemblyPlatform = isLinux ? "Linux" : "Windows";
                 var serverPath = Path.Combine(stagingDir, assemblyPlatform + "Server");
 
-                ForceSpatialNetworkingInConfig(serverPath, baseGameName);
+                if (additionalUATArgs.Contains("-pak"))
+                {
+                    Console.WriteLine("Cannot force bSpatialNetworking with -pak argument.");
+                }
+                else
+                {
+                    ForceSpatialNetworkingInConfig(serverPath, baseGameName);
+                }
 
                 if (isLinux)
                 {


### PR DESCRIPTION
#### Description
Don't try to force SpatialNetworking if using pak files, since the staged file is not present.

#### Tests
Tested with BuildWorker.bat locally.

STRONGLY SUGGESTED: How can this be verified by QA?
Using UnrealGDKTestGyms project:
1. Run BuildProject.bat
2. Verify that ```Forcing bSpatialNetworking to True``` appears in logs for all workers built.
3. Edit BuildProject.bat, add `-pak` to BuildWorker.bat lines (before `|| goto :error`)
4. Run modified BuildProject.bat
5. Verify that ```Cannot force bSpatialNetworking with -pak argument.``` appears  in logs for all workers built (and it succeeds)