### PR TITLE
Fix tracking of number of tests

### DIFF
--- a/ci/report-tests.ps1
+++ b/ci/report-tests.ps1
@@ -118,7 +118,7 @@ $test_summary = [pscustomobject]@{
     unreal_engine_commit = "$env:ENGINE_COMMIT_HASH"
     passed_all_tests = $tests_passed
     tests_duration_seconds = $test_results_obj.totalDuration
-    num_tests = $test_results_obj.succeeded + $test_results_obj.failed
+    num_tests = $total_tests_run
     num_gdk_tests = $num_gdk_tests
 }
 $test_summary | ConvertTo-Json -Compress | Set-Content -Path "$test_result_dir\test_summary_$env:BUILDKITE_STEP_ID.json"


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Tiny change to upload the correct number of tests

#### Release note
Not customer facing. No release note has been added.

#### Tests
The slack messages are displaying the correct amount, that value is now used.

#### Documentation
No new documentation has been added.

#### Primary reviewers
@michelefabris @mironec 