### PR TITLE
[UNR-2275] Track references to replicated objects in order to restore them when they move out and in relevance.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased-`x.y.z`] - 2020-xx-xx
 
-- Minor spelling fix to connection log message
-- The GDK now uses SpatialOS `14.3.0`.
-- Added %s token to debug strings in GlobalStateManager to display actor class name in log
-- The server no longer crashes, when received RPCs are processed recursively.
-- DeploymentLauncher can parse a .pb.json launch configuration.
-- DeploymentLauncher can launch a Simulated Player deployment independently from the target deployment.
-- Track properties containing references to replicated actors, in order to resolve them again if the actor they reference moves out and back into relevance.
-Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-deployment-name> <sim-deployment-name> <sim-deployment-json> <sim-deployment-region> <num-sim-players> <auto-connect>`
-
 ### Features:
 - The GDK now uses SpatialOS `14.3.0`.
 - In local deployments of the Example Project you can now launch Simulated Players in one click. Running `LaunchSimPlayerClient.bat` will launch a single Simulated Player client. Running `Launch10SimPlayerClients.bat` will launch 10.
@@ -65,6 +56,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - The server no longer crashes, when received RPCs are processed recursively.
 - Fix to serialize SoftObjectPointers when they are not resolved yet.
 - Fix to handle replicated properties depending on asynchronously loaded packages.
+- Track properties containing references to replicated actors, in order to resolve them again if the actor they reference moves out and back into relevance.
 
 ## [`0.8.0-preview`] - 2019-12-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased-`x.y.z`] - 2020-xx-xx
 
+- Minor spelling fix to connection log message
+- The GDK now uses SpatialOS `14.3.0`.
+- Added %s token to debug strings in GlobalStateManager to display actor class name in log
+- The server no longer crashes, when received RPCs are processed recursively.
+- DeploymentLauncher can parse a .pb.json launch configuration.
+- DeploymentLauncher can launch a Simulated Player deployment independently from the target deployment.
+- Track properties containing references to replicated actors, in order to resolve them again if the actor they reference moves out and back into relevance.
+Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-deployment-name> <sim-deployment-name> <sim-deployment-json> <sim-deployment-region> <num-sim-players> <auto-connect>`
+
 ### Features:
 - The GDK now uses SpatialOS `14.3.0`.
 - In local deployments of the Example Project you can now launch Simulated Players in one click. Running `LaunchSimPlayerClient.bat` will launch a single Simulated Player client. Running `Launch10SimPlayerClients.bat` will launch 10.

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitReader.cpp
@@ -9,8 +9,9 @@
 
 DEFINE_LOG_CATEGORY(LogSpatialNetBitReader);
 
-FSpatialNetBitReader::FSpatialNetBitReader(USpatialPackageMapClient* InPackageMap, uint8* Source, int64 CountBits, TSet<FUnrealObjectRef>& InUnresolvedRefs)
+FSpatialNetBitReader::FSpatialNetBitReader(USpatialPackageMapClient* InPackageMap, uint8* Source, int64 CountBits, TSet<FUnrealObjectRef>& InDynamicRefs, TSet<FUnrealObjectRef>& InUnresolvedRefs)
 	: FNetBitReader(InPackageMap, Source, CountBits)
+	, DynamicRefs(InDynamicRefs)
 	, UnresolvedRefs(InUnresolvedRefs) {}
 
 void FSpatialNetBitReader::DeserializeObjectRef(FUnrealObjectRef& ObjectRef)
@@ -54,6 +55,10 @@ UObject* FSpatialNetBitReader::ReadObject(bool& bUnresolved)
 	if (bUnresolved)
 	{
 		UnresolvedRefs.Add(ObjectRef);
+	}
+	else if (Value && !Value->IsFullNameStableForNetworking())
+	{
+		DynamicRefs.Add(ObjectRef);
 	}
 
 	return Value;

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1852,7 +1852,7 @@ void USpatialNetDriver::ProcessPendingDormancy()
 			USpatialActorChannel* Channel = PendingDormantChannel.Get();
 			if (Channel->Actor != nullptr)
 			{
-				if (Receiver->IsPendingOpsOnChannel(Channel))
+				if (Receiver->IsPendingOpsOnChannel(*Channel))
 				{
 					RemainingChannels.Emplace(PendingDormantChannel);
 					continue;
@@ -2066,8 +2066,13 @@ void USpatialNetDriver::AddActorChannel(Worker_EntityId EntityId, USpatialActorC
 	EntityToActorChannel.Add(EntityId, Channel);
 }
 
-void USpatialNetDriver::RemoveActorChannel(Worker_EntityId EntityId)
+void USpatialNetDriver::RemoveActorChannel(Worker_EntityId EntityId, USpatialActorChannel& Channel)
 {
+	for (auto& ChannelRefs : Channel.ObjectReferenceMap)
+	{
+		Receiver->CleanupRepStateMap(ChannelRefs.Value);
+	}
+
 	if (!EntityToActorChannel.Contains(EntityId))
 	{
 		UE_LOG(LogSpatialOSNetDriver, Verbose, TEXT("RemoveActorChannel: Failed to find entity/channel mapping for entity %lld."), EntityId);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -291,15 +291,16 @@ void USpatialReceiver::ProcessRemoveComponent(const Worker_RemoveComponentOp& Op
 
 	if (AActor* Actor = Cast<AActor>(PackageMap->GetObjectFromEntityId(Op.entity_id).Get()))
 	{
+		FUnrealObjectRef ObjectRef(Op.entity_id, Op.component_id);
 		if (Op.component_id == SpatialConstants::DORMANT_COMPONENT_ID)
 		{
 			RecreateDormantSpatialChannel(Actor, Op.entity_id);
 		}
-		else if (UObject* Object = PackageMap->GetObjectFromUnrealObjectRef(FUnrealObjectRef(Op.entity_id, Op.component_id)).Get())
+		else if (UObject* Object = PackageMap->GetObjectFromUnrealObjectRef(ObjectRef).Get())
 		{
 			if (USpatialActorChannel* Channel = NetDriver->GetActorChannelByEntityId(Op.entity_id))
 			{
-				Channel->CreateSubObjects.Remove(Object);
+				Channel->OnSubobjectDeleted(ObjectRef, Object);
 
 				Actor->OnSubobjectDestroyFromReplication(Object);
 
@@ -740,7 +741,7 @@ void USpatialReceiver::ReceiveActor(Worker_EntityId EntityId)
 
 			if (PendingAddComponent.EntityId == EntityId)
 			{
-				ApplyComponentDataOnActorCreation(EntityId, *PendingAddComponent.Data->ComponentData, Channel, ActorClassInfo);
+				ApplyComponentDataOnActorCreation(EntityId, *PendingAddComponent.Data->ComponentData, *Channel, ActorClassInfo);
 			}
 		}
 
@@ -833,14 +834,35 @@ void USpatialReceiver::RemoveActor(Worker_EntityId EntityId)
 		return;
 	}
 
-	// If the entity is to be deleted after having been torn off, ignore the request (but clean up the channel if it has not been cleaned up already).
-	if (Actor->GetTearOff())
+	if (USpatialActorChannel* ActorChannel = NetDriver->GetActorChannelByEntityId(EntityId))
 	{
-		if (USpatialActorChannel* ActorChannel = NetDriver->GetActorChannelByEntityId(EntityId))
+		for (UObject* SubObject : ActorChannel->CreateSubObjects)
+		{
+			if (SubObject)
+			{
+				FUnrealObjectRef ObjectRef = FUnrealObjectRef::FromObjectPtr(SubObject, Cast<USpatialPackageMapClient>(PackageMap));
+				// Unmap this object so we can remap it if it becomes relevant again in the future
+				MoveMappedObjectToUnmapped(ObjectRef);
+			}
+		}
+
+		FUnrealObjectRef ObjectRef = FUnrealObjectRef::FromObjectPtr(Actor, Cast<USpatialPackageMapClient>(PackageMap));
+		// Unmap this object so we can remap it if it becomes relevant again in the future
+		MoveMappedObjectToUnmapped(ObjectRef);
+
+		for (auto& ChannelRefs : ActorChannel->ObjectReferenceMap)
+		{
+			CleanupRepStateMap(ChannelRefs.Value);
+		}
+
+		ActorChannel->ObjectReferenceMap.Empty();
+
+		// If the entity is to be deleted after having been torn off, ignore the request (but clean up the channel if it has not been cleaned up already).
+		if (Actor->GetTearOff())
 		{
 			ActorChannel->ConditionalCleanUp(false, EChannelCloseReason::TearOff);
+			return;
 		}
-		return;
 	}
 
 	// Actor is a startup actor that is a part of the level.  If it's not Tombstone'd, then it
@@ -1016,9 +1038,9 @@ FTransform USpatialReceiver::GetRelativeSpawnTransform(UClass* ActorClass, FTran
 	return NewTransform;
 }
 
-void USpatialReceiver::ApplyComponentDataOnActorCreation(Worker_EntityId EntityId, const Worker_ComponentData& Data, USpatialActorChannel* Channel, const FClassInfo& ActorClassInfo)
+void USpatialReceiver::ApplyComponentDataOnActorCreation(Worker_EntityId EntityId, const Worker_ComponentData& Data, USpatialActorChannel& Channel, const FClassInfo& ActorClassInfo)
 {
-	AActor* Actor = Channel->GetActor();
+	AActor* Actor = Channel.GetActor();
 
 	uint32 Offset = 0;
 	bool bFoundOffset = ClassInfoManager->GetOffsetByComponentId(Data.component_id, Offset);
@@ -1045,10 +1067,10 @@ void USpatialReceiver::ApplyComponentDataOnActorCreation(Worker_EntityId EntityI
 
 		PackageMap->ResolveSubobject(TargetObject.Get(), FUnrealObjectRef(EntityId, Offset));
 
-		Channel->CreateSubObjects.Add(TargetObject.Get());
+		Channel.CreateSubObjects.Add(TargetObject.Get());
 	}
 
-	ApplyComponentData(TargetObject.Get(), Channel, Data);
+	ApplyComponentData(Channel, *TargetObject , Data);
 }
 
 void USpatialReceiver::HandleIndividualAddComponent(const Worker_AddComponentOp& Op)
@@ -1065,7 +1087,10 @@ void USpatialReceiver::HandleIndividualAddComponent(const Worker_AddComponentOp&
 	// Object already exists, we can apply data directly.
 	if (UObject* Object = PackageMap->GetObjectFromUnrealObjectRef(FUnrealObjectRef(Op.entity_id, Offset)).Get())
 	{
-		ApplyComponentData(Object, NetDriver->GetActorChannelByEntityId(Op.entity_id), Op.data);
+		if (USpatialActorChannel* Channel = NetDriver->GetActorChannelByEntityId(Op.entity_id))
+		{
+			ApplyComponentData(*Channel, *Object, Op.data);
+		}
 		return;
 	}
 
@@ -1141,7 +1166,7 @@ void USpatialReceiver::AttachDynamicSubobject(AActor* Actor, Worker_EntityId Ent
 		TPair<Worker_EntityId_Key, Worker_ComponentId> EntityComponentPair = MakeTuple(static_cast<Worker_EntityId_Key>(EntityId), ComponentId);
 
 		PendingAddComponentWrapper& AddComponent = PendingDynamicSubobjectComponents[EntityComponentPair];
-		ApplyComponentData(Subobject, NetDriver->GetActorChannelByEntityId(EntityId), *AddComponent.Data->ComponentData);
+		ApplyComponentData(*Channel, *Subobject, *AddComponent.Data->ComponentData);
 		PendingDynamicSubobjectComponents.Remove(EntityComponentPair);
 	});
 
@@ -1152,18 +1177,75 @@ void USpatialReceiver::AttachDynamicSubobject(AActor* Actor, Worker_EntityId Ent
 	}
 }
 
-void USpatialReceiver::ApplyComponentData(UObject* TargetObject, USpatialActorChannel* Channel, const Worker_ComponentData& Data)
+struct USpatialReceiver::RepStateUpdateHelper
+{
+	RepStateUpdateHelper(USpatialActorChannel& Channel, UObject& TargetObject)
+		: ObjectPtr(MakeWeakObjectPtr(&TargetObject))
+		, ObjectRepState(Channel.ObjectReferenceMap.Find(ObjectPtr))
+	{
+	}
+
+	~RepStateUpdateHelper()
+	{
+		check(bUpdatePerfomed);
+	}
+
+	FObjectReferencesMap& GetRefMap()
+	{
+		if (ObjectRepState)
+		{
+			return ObjectRepState->ReferenceMap;
+		}
+		return TempRefMap;
+	}
+
+	void Update(USpatialReceiver& Receiver, USpatialActorChannel& Channel, UObject& TargetObject, bool bReferencesChanged)
+	{
+		check(!bUpdatePerfomed);
+
+		if (bReferencesChanged)
+		{
+			if (ObjectRepState == nullptr && TempRefMap.Num() > 0)
+			{
+				ObjectRepState = &Channel.ObjectReferenceMap.Add(ObjectPtr, FSpatialObjectRepState(FChannelObjectPair(&Channel, ObjectPtr)));
+				ObjectRepState->ReferenceMap = MoveTemp(TempRefMap);
+			}
+
+			if (ObjectRepState)
+			{
+				ObjectRepState->UpdateRefToRepStateMap(Receiver.ObjectRefToRepStateMap);
+
+				if (ObjectRepState->ReferencedObj.Num() == 0)
+				{
+					Channel.ObjectReferenceMap.Remove(ObjectPtr);
+				}
+			}
+		}
+#if DO_CHECK
+		bUpdatePerfomed = true;
+#endif
+	}
+
+	//TSet<FUnrealObjectRef> UnresolvedRefs;
+private:
+	FObjectReferencesMap TempRefMap;
+	TWeakObjectPtr<UObject> ObjectPtr;
+	FSpatialObjectRepState* ObjectRepState;
+#if DO_CHECK
+	bool bUpdatePerfomed = false;
+#endif
+};
+
+void USpatialReceiver::ApplyComponentData(USpatialActorChannel& Channel, UObject& TargetObject, const Worker_ComponentData& Data)
 {
 	UClass* Class = ClassInfoManager->GetClassByComponentId(Data.component_id);
 	checkf(Class, TEXT("Component %d isn't hand-written and not present in ComponentToClassMap."), Data.component_id);
-
-	FChannelObjectPair ChannelObjectPair(Channel, TargetObject);
 
 	ESchemaComponentType ComponentType = ClassInfoManager->GetCategoryByComponentId(Data.component_id);
 
 	if (ComponentType == SCHEMA_Data || ComponentType == SCHEMA_OwnerOnly)
 	{
-		if (ComponentType == SCHEMA_Data && TargetObject->IsA<UActorComponent>())
+		if (ComponentType == SCHEMA_Data && TargetObject.IsA<UActorComponent>())
 		{
 			Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
 			bool bReplicates = !!Schema_IndexBool(ComponentObject, SpatialConstants::ACTOR_COMPONENT_REPLICATES_ID, 0);
@@ -1172,28 +1254,27 @@ void USpatialReceiver::ApplyComponentData(UObject* TargetObject, USpatialActorCh
 				return;
 			}
 		}
+		RepStateUpdateHelper RepStateHelper(Channel, TargetObject);
 
-		FObjectReferencesMap& ObjectReferencesMap = UnresolvedRefsMap.FindOrAdd(ChannelObjectPair);
-		TSet<FUnrealObjectRef> UnresolvedRefs;
+		ComponentReader Reader(NetDriver, RepStateHelper.GetRefMap());
+		bool bOutReferencesChanged = false;
+		Reader.ApplyComponentData(Data, TargetObject, Channel, /* bIsHandover */ false, bOutReferencesChanged);
 
-		ComponentReader Reader(NetDriver, ObjectReferencesMap, UnresolvedRefs);
-		Reader.ApplyComponentData(Data, TargetObject, Channel, /* bIsHandover */ false);
-
-		QueueIncomingRepUpdates(ChannelObjectPair, ObjectReferencesMap, UnresolvedRefs);
+		RepStateHelper.Update(*this, Channel, TargetObject, bOutReferencesChanged);
 	}
 	else if (ComponentType == SCHEMA_Handover)
 	{
-		FObjectReferencesMap& ObjectReferencesMap = UnresolvedRefsMap.FindOrAdd(ChannelObjectPair);
-		TSet<FUnrealObjectRef> UnresolvedRefs;
+		RepStateUpdateHelper RepStateHelper(Channel, TargetObject);
 
-		ComponentReader Reader(NetDriver, ObjectReferencesMap, UnresolvedRefs);
-		Reader.ApplyComponentData(Data, TargetObject, Channel, /* bIsHandover */ true);
+		ComponentReader Reader(NetDriver, RepStateHelper.GetRefMap());
+		bool bOutReferencesChanged = false;
+		Reader.ApplyComponentData(Data, TargetObject, Channel, /* bIsHandover */ true, bOutReferencesChanged);
 
-		QueueIncomingRepUpdates(ChannelObjectPair, ObjectReferencesMap, UnresolvedRefs);
+		RepStateHelper.Update(*this, Channel, TargetObject, bOutReferencesChanged);
 	}
 	else
 	{
-		UE_LOG(LogSpatialReceiver, Verbose, TEXT("Entity: %d Component: %d - Skipping because RPC components don't have actual data."), Channel->GetEntityId(), Data.component_id);
+		UE_LOG(LogSpatialReceiver, Verbose, TEXT("Entity: %d Component: %d - Skipping because RPC components don't have actual data."), Channel.GetEntityId(), Data.component_id);
 	}
 }
 
@@ -1338,7 +1419,7 @@ void USpatialReceiver::OnComponentUpdate(const Worker_ComponentUpdateOp& Op)
 
 	if (Category == ESchemaComponentType::SCHEMA_Data || Category == ESchemaComponentType::SCHEMA_OwnerOnly)
 	{
-		ApplyComponentUpdate(Op.update, TargetObject, Channel, /* bIsHandover */ false);
+		ApplyComponentUpdate(Op.update, *TargetObject, *Channel, /* bIsHandover */ false);
 	}
 	else if (Category == ESchemaComponentType::SCHEMA_Handover)
 	{
@@ -1348,7 +1429,7 @@ void USpatialReceiver::OnComponentUpdate(const Worker_ComponentUpdateOp& Op)
 			return;
 		}
 
-		ApplyComponentUpdate(Op.update, TargetObject, Channel, /* bIsHandover */ true);
+		ApplyComponentUpdate(Op.update, *TargetObject, *Channel, /* bIsHandover */ true);
 	}
 	else
 	{
@@ -1597,29 +1678,28 @@ void USpatialReceiver::ReceiveCommandResponse(const Worker_CommandResponseOp& Op
 	}
 }
 
-void USpatialReceiver::ApplyComponentUpdate(const Worker_ComponentUpdate& ComponentUpdate, UObject* TargetObject, USpatialActorChannel* Channel, bool bIsHandover)
+void USpatialReceiver::ApplyComponentUpdate(const Worker_ComponentUpdate& ComponentUpdate, UObject& TargetObject, USpatialActorChannel& Channel, bool bIsHandover)
 {
-	FChannelObjectPair ChannelObjectPair(Channel, TargetObject);
+	RepStateUpdateHelper RepStateHelper(Channel, TargetObject);
 
-	FObjectReferencesMap& ObjectReferencesMap = UnresolvedRefsMap.FindOrAdd(ChannelObjectPair);
-	TSet<FUnrealObjectRef> UnresolvedRefs;
-	ComponentReader Reader(NetDriver, ObjectReferencesMap, UnresolvedRefs);
-	Reader.ApplyComponentUpdate(ComponentUpdate, TargetObject, Channel, bIsHandover);
+	ComponentReader Reader(NetDriver, RepStateHelper.GetRefMap());
+	bool bOutReferencesChanged = false;
+	Reader.ApplyComponentUpdate(ComponentUpdate, TargetObject, Channel, bIsHandover, bOutReferencesChanged);
 
 	// This is a temporary workaround, see UNR-841:
 	// If the update includes tearoff, close the channel and clean up the entity.
-	if (TargetObject->IsA<AActor>() && ClassInfoManager->GetCategoryByComponentId(ComponentUpdate.component_id) == SCHEMA_Data)
+	if (TargetObject.IsA<AActor>() && ClassInfoManager->GetCategoryByComponentId(ComponentUpdate.component_id) == SCHEMA_Data)
 	{
 		Schema_Object* ComponentObject = Schema_GetComponentUpdateFields(ComponentUpdate.schema_type);
 
 		// Check if bTearOff has been set to true
 		if (GetBoolFromSchema(ComponentObject, SpatialConstants::ACTOR_TEAROFF_ID))
 		{
-			Channel->ConditionalCleanUp(false, EChannelCloseReason::TearOff);
+			Channel.ConditionalCleanUp(false, EChannelCloseReason::TearOff);
 		}
 	}
 
-	QueueIncomingRepUpdates(ChannelObjectPair, ObjectReferencesMap, UnresolvedRefs);
+	RepStateHelper.Update(*this, Channel, TargetObject, bOutReferencesChanged);
 }
 
 ERPCResult USpatialReceiver::ApplyRPCInternal(UObject* TargetObject, UFunction* Function, const RPCPayload& Payload, const FString& SenderWorkerId, bool bApplyWithUnresolvedRefs /* = false */)
@@ -1630,9 +1710,9 @@ ERPCResult USpatialReceiver::ApplyRPCInternal(UObject* TargetObject, UFunction* 
 	FMemory::Memzero(Parms, Function->ParmsSize);
 
 	TSet<FUnrealObjectRef> UnresolvedRefs;
-
+	TSet<FUnrealObjectRef> MappedRefs;
 	RPCPayload PayloadCopy = Payload;
-	FSpatialNetBitReader PayloadReader(PackageMap, PayloadCopy.PayloadData.GetData(), PayloadCopy.CountDataBits(), UnresolvedRefs);
+	FSpatialNetBitReader PayloadReader(PackageMap, PayloadCopy.PayloadData.GetData(), PayloadCopy.CountDataBits(), MappedRefs, UnresolvedRefs);
 
 	TSharedPtr<FRepLayout> RepLayout = NetDriver->GetFunctionRepLayout(Function);
 	RepLayout_ReceivePropertiesForRPC(*RepLayout, PayloadReader, Parms);
@@ -1884,16 +1964,15 @@ void USpatialReceiver::OnDisconnect(Worker_DisconnectOp& Op)
 	}
 }
 
-bool USpatialReceiver::IsPendingOpsOnChannel(USpatialActorChannel* Channel)
+bool USpatialReceiver::IsPendingOpsOnChannel(USpatialActorChannel& Channel)
 {
 	SCOPE_CYCLE_COUNTER(STAT_SpatialPendingOpsOnChannel);
 
 	// Don't allow Actors to go dormant if they have any pending operations waiting on their channel
-	check(Channel);
 
-	for (const auto& UnresolvedRef : UnresolvedRefsMap)
+	for (const auto& RefMap : Channel.ObjectReferenceMap)
 	{
-		if (UnresolvedRef.Key.Key == Channel)
+		if (RefMap.Value.HasUnresolved())
 		{
 			return true;
 		}
@@ -1901,7 +1980,7 @@ bool USpatialReceiver::IsPendingOpsOnChannel(USpatialActorChannel* Channel)
 
 	for (const auto& ActorRequest : PendingActorRequests)
 	{
-		if (ActorRequest.Value == Channel)
+		if (ActorRequest.Value == &Channel)
 		{
 			return true;
 		}
@@ -1916,19 +1995,6 @@ void USpatialReceiver::ClearPendingRPCs(Worker_EntityId EntityId)
 	IncomingRPCs.DropForEntity(EntityId);
 }
 
-void USpatialReceiver::QueueIncomingRepUpdates(FChannelObjectPair ChannelObjectPair, const FObjectReferencesMap& ObjectReferencesMap, const TSet<FUnrealObjectRef>& UnresolvedRefs)
-{
-	for (const FUnrealObjectRef& UnresolvedRef : UnresolvedRefs)
-	{
-		UE_LOG(LogSpatialReceiver, Log, TEXT("Added pending incoming property for object ref: %s, target object: %s"), *UnresolvedRef.ToString(), *ChannelObjectPair.Value->GetName());
-		IncomingRefsMap.FindOrAdd(UnresolvedRef).Add(ChannelObjectPair);
-	}
-
-	if (ObjectReferencesMap.Num() == 0)
-	{
-		UnresolvedRefsMap.Remove(ChannelObjectPair);
-	}
-}
 
 void USpatialReceiver::ProcessOrQueueIncomingRPC(const FUnrealObjectRef& InTargetObjectRef, SpatialGDK::RPCPayload InPayload)
 {
@@ -1979,7 +2045,7 @@ void USpatialReceiver::ResolveIncomingOperations(UObject* Object, const FUnrealO
 	// TODO: queue up resolved objects since they were resolved during process ops
 	// and then resolve all of them at the end of process ops - UNR:582
 
-	TSet<FChannelObjectPair>* TargetObjectSet = IncomingRefsMap.Find(ObjectRef);
+	TSet<FChannelObjectPair>* TargetObjectSet = ObjectRefToRepStateMap.Find(ObjectRef);
 	if (!TargetObjectSet)
 	{
 		return;
@@ -1987,22 +2053,32 @@ void USpatialReceiver::ResolveIncomingOperations(UObject* Object, const FUnrealO
 
 	UE_LOG(LogSpatialReceiver, Verbose, TEXT("Resolving incoming operations depending on object ref %s, resolved object: %s"), *ObjectRef.ToString(), *Object->GetName());
 
-	for (FChannelObjectPair& ChannelObjectPair : *TargetObjectSet)
+	for (auto ChannelObjectIter = TargetObjectSet->CreateIterator(); ChannelObjectIter; ++ChannelObjectIter)
 	{
-		FObjectReferencesMap* UnresolvedRefs = UnresolvedRefsMap.Find(ChannelObjectPair);
-		if (!UnresolvedRefs)
+		USpatialActorChannel* DependentChannel = ChannelObjectIter->Key.Get();
+		if (!DependentChannel)
 		{
+			ChannelObjectIter.RemoveCurrent();
 			continue;
 		}
 
-		if (!ChannelObjectPair.Key.IsValid() || !ChannelObjectPair.Value.IsValid())
+		UObject* ReplicatingObject = ChannelObjectIter->Value.Get();
+
+		if (!ReplicatingObject)
 		{
-			UnresolvedRefsMap.Remove(ChannelObjectPair);
+			if (DependentChannel->ObjectReferenceMap.Find(ChannelObjectIter->Value))
+			{
+				DependentChannel->ObjectReferenceMap.Remove(ChannelObjectIter->Value);
+				ChannelObjectIter.RemoveCurrent();
+			}
 			continue;
 		}
 
-		USpatialActorChannel* DependentChannel = ChannelObjectPair.Key.Get();
-		UObject* ReplicatingObject = ChannelObjectPair.Value.Get();
+		FSpatialObjectRepState* RepState = DependentChannel->ObjectReferenceMap.Find(ChannelObjectIter->Value);
+		if (!RepState || !RepState->UnresolvedRefs.Contains(ObjectRef))
+		{
+			continue;
+		}
 
 		// Check whether the resolved object has been torn off, or is on an actor that has been torn off.
 		if (AActor* AsActor = Cast<AActor>(ReplicatingObject))
@@ -2010,7 +2086,7 @@ void USpatialReceiver::ResolveIncomingOperations(UObject* Object, const FUnrealO
 			if (AsActor->GetTearOff())
 			{
 				UE_LOG(LogSpatialActorChannel, Log, TEXT("Actor to be resolved was torn off, so ignoring incoming operations. Object ref: %s, resolved object: %s"), *ObjectRef.ToString(), *Object->GetName());
-				UnresolvedRefsMap.Remove(ChannelObjectPair);
+				DependentChannel->ObjectReferenceMap.Remove(ChannelObjectIter->Value);
 				continue;
 			}
 		}
@@ -2019,38 +2095,32 @@ void USpatialReceiver::ResolveIncomingOperations(UObject* Object, const FUnrealO
 			if (OuterActor->GetTearOff())
 			{
 				UE_LOG(LogSpatialActorChannel, Log, TEXT("Owning Actor of the object to be resolved was torn off, so ignoring incoming operations. Object ref: %s, resolved object: %s"), *ObjectRef.ToString(), *Object->GetName());
-				UnresolvedRefsMap.Remove(ChannelObjectPair);
+				DependentChannel->ObjectReferenceMap.Remove(ChannelObjectIter->Value);
 				continue;
 			}
 		}
 
-		bool bStillHasUnresolved = false;
 		bool bSomeObjectsWereMapped = false;
 		TArray<UProperty*> RepNotifies;
 
 		FRepLayout& RepLayout = DependentChannel->GetObjectRepLayout(ReplicatingObject);
 		FRepStateStaticBuffer& ShadowData = DependentChannel->GetObjectStaticBuffer(ReplicatingObject);
 
-		ResolveObjectReferences(RepLayout, ReplicatingObject, *UnresolvedRefs, ShadowData.GetData(), (uint8*)ReplicatingObject, ReplicatingObject->GetClass()->GetPropertiesSize(), RepNotifies, bSomeObjectsWereMapped, bStillHasUnresolved);
+		ResolveObjectReferences(RepLayout, ReplicatingObject, *RepState, RepState->ReferenceMap, ShadowData.GetData(), (uint8*)ReplicatingObject, ReplicatingObject->GetClass()->GetPropertiesSize(), RepNotifies, bSomeObjectsWereMapped);
 
 		if (bSomeObjectsWereMapped)
 		{
-			DependentChannel->RemoveRepNotifiesWithUnresolvedObjs(RepNotifies, RepLayout, *UnresolvedRefs, ReplicatingObject);
+			DependentChannel->RemoveRepNotifiesWithUnresolvedObjs(RepNotifies, RepLayout, RepState->ReferenceMap, ReplicatingObject);
 
 			UE_LOG(LogSpatialReceiver, Verbose, TEXT("Resolved for target object %s"), *ReplicatingObject->GetName());
 			DependentChannel->PostReceiveSpatialUpdate(ReplicatingObject, RepNotifies);
 		}
 
-		if (!bStillHasUnresolved)
-		{
-			UnresolvedRefsMap.Remove(ChannelObjectPair);
-		}
+		RepState->UnresolvedRefs.Remove(ObjectRef);
 	}
-
-	IncomingRefsMap.Remove(ObjectRef);
 }
 
-void USpatialReceiver::ResolveObjectReferences(FRepLayout& RepLayout, UObject* ReplicatedObject, FObjectReferencesMap& ObjectReferencesMap, uint8* RESTRICT StoredData, uint8* RESTRICT Data, int32 MaxAbsOffset, TArray<UProperty*>& RepNotifies, bool& bOutSomeObjectsWereMapped, bool& bOutStillHasUnresolved)
+void USpatialReceiver::ResolveObjectReferences(FRepLayout& RepLayout, UObject* ReplicatedObject, FSpatialObjectRepState& RepState, FObjectReferencesMap& ObjectReferencesMap, uint8* RESTRICT StoredData, uint8* RESTRICT Data, int32 MaxAbsOffset, TArray<UProperty*>& RepNotifies, bool& bOutSomeObjectsWereMapped)
 {
 	for (auto It = ObjectReferencesMap.CreateIterator(); It; ++It)
 	{
@@ -2087,21 +2157,13 @@ void USpatialReceiver::ResolveObjectReferences(FRepLayout& RepLayout, UObject* R
 
 			int32 NewMaxOffset = Array->Num() * Property->ElementSize;
 
-			bool bArrayHasUnresolved = false;
-			ResolveObjectReferences(RepLayout, ReplicatedObject, *ObjectReferences.Array, bIsHandover ? nullptr : (uint8*)StoredArray->GetData(), (uint8*)Array->GetData(), NewMaxOffset, RepNotifies, bOutSomeObjectsWereMapped, bArrayHasUnresolved);
-			if (!bArrayHasUnresolved)
-			{
-				It.RemoveCurrent();
-			}
-			else
-			{
-				bOutStillHasUnresolved = true;
-			}
+			ResolveObjectReferences(RepLayout, ReplicatedObject, RepState, *ObjectReferences.Array, bIsHandover ? nullptr : (uint8*)StoredArray->GetData(), (uint8*)Array->GetData(), NewMaxOffset, RepNotifies, bOutSomeObjectsWereMapped);
 			continue;
 		}
 
 		bool bResolvedSomeRefs = false;
 		UObject* SinglePropObject = nullptr;
+		FUnrealObjectRef SinglePropRef = FUnrealObjectRef::NULL_OBJECT_REF;
 
 		for (auto UnresolvedIt = ObjectReferences.UnresolvedRefs.CreateIterator(); UnresolvedIt; ++UnresolvedIt)
 		{
@@ -2115,13 +2177,15 @@ void USpatialReceiver::ResolveObjectReferences(FRepLayout& RepLayout, UObject* R
 
 				UE_LOG(LogSpatialReceiver, Verbose, TEXT("ResolveObjectReferences: Resolved object ref: Offset: %d, Object ref: %s, PropName: %s, ObjName: %s"), AbsOffset, *ObjectRef.ToString(), *Property->GetNameCPP(), *Object->GetName());
 
-				UnresolvedIt.RemoveCurrent();
-				bResolvedSomeRefs = true;
-
 				if (ObjectReferences.bSingleProp)
 				{
 					SinglePropObject = Object;
+					SinglePropRef = ObjectRef;
 				}
+
+				UnresolvedIt.RemoveCurrent();
+
+				bResolvedSomeRefs = true;
 			}
 		}
 
@@ -2144,28 +2208,32 @@ void USpatialReceiver::ResolveObjectReferences(FRepLayout& RepLayout, UObject* R
 				check(ObjectProperty);
 
 				ObjectProperty->SetObjectPropertyValue(Data + AbsOffset, SinglePropObject);
+				ObjectReferences.MappedRefs.Add(SinglePropRef);
 			}
 			else if (ObjectReferences.bFastArrayProp)
 			{
+				TSet<FUnrealObjectRef> NewMappedRefs;
 				TSet<FUnrealObjectRef> NewUnresolvedRefs;
-				FSpatialNetBitReader ValueDataReader(PackageMap, ObjectReferences.Buffer.GetData(), ObjectReferences.NumBufferBits, NewUnresolvedRefs);
+				FSpatialNetBitReader ValueDataReader(PackageMap, ObjectReferences.Buffer.GetData(), ObjectReferences.NumBufferBits, NewMappedRefs, NewUnresolvedRefs);
 
 				check(Property->IsA<UArrayProperty>());
 				UScriptStruct* NetDeltaStruct = GetFastArraySerializerProperty(Cast<UArrayProperty>(Property));
 
 				FSpatialNetDeltaSerializeInfo::DeltaSerializeRead(NetDriver, ValueDataReader, ReplicatedObject, Parent->ArrayIndex, Parent->Property, NetDeltaStruct);
 
-				if (NewUnresolvedRefs.Num() > 0)
-				{
-					bOutStillHasUnresolved = true;
-				}
+				ObjectReferences.MappedRefs.Append(NewMappedRefs);
 			}
 			else
 			{
+				TSet<FUnrealObjectRef> NewMappedRefs;
 				TSet<FUnrealObjectRef> NewUnresolvedRefs;
-				FSpatialNetBitReader BitReader(PackageMap, ObjectReferences.Buffer.GetData(), ObjectReferences.NumBufferBits, NewUnresolvedRefs);
+				FSpatialNetBitReader BitReader(PackageMap, ObjectReferences.Buffer.GetData(), ObjectReferences.NumBufferBits, NewMappedRefs, NewUnresolvedRefs);
 				check(Property->IsA<UStructProperty>());
-				ReadStructProperty(BitReader, Cast<UStructProperty>(Property), NetDriver, Data + AbsOffset, bOutStillHasUnresolved);
+
+				bool bHasUnresolved = false;
+				ReadStructProperty(BitReader, Cast<UStructProperty>(Property), NetDriver, Data + AbsOffset, bHasUnresolved);
+
+				ObjectReferences.MappedRefs.Append(NewMappedRefs);
 			}
 
 			if (Parent && Parent->Property->HasAnyPropertyFlags(CPF_RepNotify))
@@ -2175,15 +2243,6 @@ void USpatialReceiver::ResolveObjectReferences(FRepLayout& RepLayout, UObject* R
 					RepNotifies.AddUnique(Parent->Property);
 				}
 			}
-		}
-
-		if (ObjectReferences.UnresolvedRefs.Num() > 0)
-		{
-			bOutStillHasUnresolved = true;
-		}
-		else
-		{
-			It.RemoveCurrent();
 		}
 	}
 }
@@ -2312,6 +2371,23 @@ void USpatialReceiver::OnAsyncPackageLoaded(const FName& PackageName, UPackage* 
 			for (QueuedOpForAsyncLoad& Op : AsyncLoadEntity.PendingOps)
 			{
 				HandleQueuedOpForAsyncLoad(Op);
+			}
+		}
+	}
+}
+
+void USpatialReceiver::MoveMappedObjectToUnmapped(const FUnrealObjectRef& Ref)
+{
+	if (TSet<FChannelObjectPair>* RepStatesWithMappedRef = ObjectRefToRepStateMap.Find(Ref))
+	{
+		for (const FChannelObjectPair& ChannelObject : *RepStatesWithMappedRef)
+		{
+			if (USpatialActorChannel* Channel = ChannelObject.Key.Get())
+			{
+				if (FSpatialObjectRepState* RepState = Channel->ObjectReferenceMap.Find(ChannelObject.Value))
+				{
+					RepState->MoveMappedObjectToUnmapped(Ref);
+				}
 			}
 		}
 	}
@@ -2457,4 +2533,33 @@ USpatialReceiver::CriticalSectionSaveState::~CriticalSectionSaveState()
 		Receiver.PendingAddComponents = MoveTemp(PendingAddComponents);
 	}
 	Receiver.bInCriticalSection = bInCriticalSection;
+}
+
+namespace
+{
+	FString GetObjectNameFromRepState(const FSpatialObjectRepState& RepState)
+	{
+		if (UObject* Obj = RepState.GetChannelObjectPair().Value.Get())
+		{
+			return Obj->GetName();
+		}
+		return TEXT("<unknown>");
+	}
+}
+
+void USpatialReceiver::CleanupRepStateMap(FSpatialObjectRepState& RepState)
+{
+	for (const FUnrealObjectRef& Ref : RepState.ReferencedObj)
+	{
+		TSet<FChannelObjectPair>* RepStatesWithMappedRef = ObjectRefToRepStateMap.Find(Ref);
+		if (ensureMsgf(RepStatesWithMappedRef, TEXT("Ref to entity %lld on object %s is missing its referenced entry in the Ref/RepState map"), Ref.Entity, *GetObjectNameFromRepState(RepState)))
+		{
+			checkf(RepStatesWithMappedRef->Contains(RepState.GetChannelObjectPair()), TEXT("Ref to entity %lld on object %s is missing its referenced entry in the Ref/RepState map"), Ref.Entity, *GetObjectNameFromRepState(RepState));
+			RepStatesWithMappedRef->Remove(RepState.GetChannelObjectPair());
+			if (RepStatesWithMappedRef->Num() == 0)
+			{
+				ObjectRefToRepStateMap.Remove(Ref);
+			}
+		}
+	}
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
@@ -16,21 +16,79 @@
 
 DEFINE_LOG_CATEGORY(LogSpatialComponentReader);
 
+namespace
+{
+	bool FORCEINLINE ObjectRefSetsAreSame(const TSet< FUnrealObjectRef >& A, const TSet< FUnrealObjectRef >& B)
+	{
+		if (A.Num() != B.Num())
+		{
+			return false;
+		}
+
+		for (const FUnrealObjectRef& CompareRef : A)
+		{
+			if (!B.Contains(CompareRef))
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	bool ReferencesChanged(FObjectReferencesMap& InObjectReferencesMap, int32 Offset, bool bHasReferences, const TSet<FUnrealObjectRef>& NewDynamicRefs, const TSet<FUnrealObjectRef> NewUnresolvedRefs)
+	{
+		FObjectReferences* CurEntry = InObjectReferencesMap.Find(Offset);
+
+		if (bHasReferences ^ (CurEntry != nullptr))
+		{
+			return true;
+		}
+		if (CurEntry && bHasReferences)
+		{
+			return !ObjectRefSetsAreSame(NewDynamicRefs, CurEntry->MappedRefs) || !ObjectRefSetsAreSame(NewUnresolvedRefs, CurEntry->UnresolvedRefs);
+		}
+		return false;
+	}
+
+	bool ReferencesChanged(FObjectReferencesMap& InObjectReferencesMap, int32 Offset, bool bHasReferences, const FUnrealObjectRef& ObjectRef, bool bUnresolved)
+	{
+		FObjectReferences* CurEntry = InObjectReferencesMap.Find(Offset);
+
+		if (bHasReferences ^ (CurEntry != nullptr))
+		{
+			return true;
+		}
+		if (CurEntry && bHasReferences)
+		{
+			if (!bUnresolved)
+			{
+				return CurEntry->MappedRefs.Num() != 1 || CurEntry->UnresolvedRefs.Num() != 0 || *CurEntry->MappedRefs.begin() != ObjectRef;
+			}
+			else
+			{
+				return CurEntry->MappedRefs.Num() != 0 || CurEntry->UnresolvedRefs.Num() != 1 || *CurEntry->UnresolvedRefs.begin() != ObjectRef;
+			}
+
+		}
+		return false;
+	}
+}
+
 namespace SpatialGDK
 {
 
-ComponentReader::ComponentReader(USpatialNetDriver* InNetDriver, FObjectReferencesMap& InObjectReferencesMap, TSet<FUnrealObjectRef>& InUnresolvedRefs)
+ComponentReader::ComponentReader(USpatialNetDriver* InNetDriver, FObjectReferencesMap& InObjectReferencesMap/*, TSet<FUnrealObjectRef>& InUnresolvedRefs*/)
 	: PackageMap(InNetDriver->PackageMap)
 	, NetDriver(InNetDriver)
 	, ClassInfoManager(InNetDriver->ClassInfoManager)
 	, RootObjectReferencesMap(InObjectReferencesMap)
-	, UnresolvedRefs(InUnresolvedRefs)
 {
 }
 
-void ComponentReader::ApplyComponentData(const Worker_ComponentData& ComponentData, UObject* Object, USpatialActorChannel* Channel, bool bIsHandover)
+void ComponentReader::ApplyComponentData(const Worker_ComponentData& ComponentData, UObject& Object, USpatialActorChannel& Channel, bool bIsHandover, bool& bOutReferencesChanged)
 {
-	if (Object->IsPendingKill())
+	if (Object.IsPendingKill())
 	{
 		return;
 	}
@@ -43,17 +101,17 @@ void ComponentReader::ApplyComponentData(const Worker_ComponentData& ComponentDa
 
 	if (bIsHandover)
 	{
-		ApplyHandoverSchemaObject(ComponentObject, Object, Channel, true, UpdatedIds, ComponentData.component_id);
+		ApplyHandoverSchemaObject(ComponentObject, Object, Channel, true, UpdatedIds, ComponentData.component_id, bOutReferencesChanged);
 	}
 	else
 	{
-		ApplySchemaObject(ComponentObject, Object, Channel, true, UpdatedIds, ComponentData.component_id);
+		ApplySchemaObject(ComponentObject, Object, Channel, true, UpdatedIds, ComponentData.component_id, bOutReferencesChanged);
 	}
 }
 
-void ComponentReader::ApplyComponentUpdate(const Worker_ComponentUpdate& ComponentUpdate, UObject* Object, USpatialActorChannel* Channel, bool bIsHandover)
+void ComponentReader::ApplyComponentUpdate(const Worker_ComponentUpdate& ComponentUpdate, UObject& Object, USpatialActorChannel& Channel, bool bIsHandover, bool& bOutReferencesChanged)
 {
-	if (Object->IsPendingKill())
+	if (Object.IsPendingKill())
 	{
 		return;
 	}
@@ -77,18 +135,18 @@ void ComponentReader::ApplyComponentUpdate(const Worker_ComponentUpdate& Compone
 	{
 		if (bIsHandover)
 		{
-			ApplyHandoverSchemaObject(ComponentObject, Object, Channel, false, UpdatedIds, ComponentUpdate.component_id);
+			ApplyHandoverSchemaObject(ComponentObject, Object, Channel, false, UpdatedIds, ComponentUpdate.component_id, bOutReferencesChanged);
 		}
 		else
 		{
-			ApplySchemaObject(ComponentObject, Object, Channel, false, UpdatedIds, ComponentUpdate.component_id);
+			ApplySchemaObject(ComponentObject, Object, Channel, false, UpdatedIds, ComponentUpdate.component_id, bOutReferencesChanged);
 		}
 	}
 }
 
-void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject* Object, USpatialActorChannel* Channel, bool bIsInitialData, const TArray<Schema_FieldId>& UpdatedIds, Worker_ComponentId ComponentId)
+void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject& Object, USpatialActorChannel& Channel, bool bIsInitialData, const TArray<Schema_FieldId>& UpdatedIds, Worker_ComponentId ComponentId, bool& bOutReferencesChanged)
 {
-	FObjectReplicator* Replicator = Channel->PreReceiveSpatialUpdate(Object);
+	FObjectReplicator* Replicator = Channel.PreReceiveSpatialUpdate(&Object);
 	if (Replicator == nullptr)
 	{
 		// Can't apply this schema object. Error printed from PreReceiveSpatialUpdate.
@@ -100,11 +158,11 @@ void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject*
 	TArray<FHandleToCmdIndex>& BaseHandleToCmdIndex = Replicator->RepLayout->BaseHandleToCmdIndex;
 	TArray<FRepParentCmd>& Parents = Replicator->RepLayout->Parents;
 
-	bool bIsAuthServer = Channel->IsAuthoritativeServer();
-	bool bAutonomousProxy = Channel->IsClientAutonomousProxy();
+	bool bIsAuthServer = Channel.IsAuthoritativeServer();
+	bool bAutonomousProxy = Channel.IsClientAutonomousProxy();
 	bool bIsClient = NetDriver->GetNetMode() == NM_Client;
 
-	FSpatialConditionMapFilter ConditionMap(Channel, bIsClient);
+	FSpatialConditionMapFilter ConditionMap(&Channel, bIsClient);
 
 	TArray<UProperty*> RepNotifies;
 
@@ -113,7 +171,7 @@ void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject*
 		// FieldId is the same as rep handle
 		if (FieldId == 0 || (int)FieldId - 1 >= BaseHandleToCmdIndex.Num())
 		{
-			UE_LOG(LogSpatialComponentReader, Error, TEXT("ApplySchemaObject: Encountered an invalid field Id while applying schema. Object: %s, Field: %d, Entity: %lld, Component: %d"), *Object->GetPathName(), FieldId, Channel->GetEntityId(), ComponentId);
+			UE_LOG(LogSpatialComponentReader, Error, TEXT("ApplySchemaObject: Encountered an invalid field Id while applying schema. Object: %s, Field: %d, Entity: %lld, Component: %d"), *Object.GetPathName(), FieldId, Channel.GetEntityId(), ComponentId);
 			continue;
 		}
 
@@ -127,14 +185,14 @@ void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject*
 			// This swaps Role/RemoteRole as we write it
 			const FRepLayoutCmd& SwappedCmd = (!bIsAuthServer && Parent.RoleSwapIndex != -1) ? Cmds[Parents[Parent.RoleSwapIndex].CmdStart] : Cmd;
 
-			uint8* Data = (uint8*)Object + SwappedCmd.Offset;
+			uint8* Data = (uint8*)&Object + SwappedCmd.Offset;
 
 			if (Cmd.Type == ERepLayoutCmdType::DynamicArray)
 			{
 				UArrayProperty* ArrayProperty = Cast<UArrayProperty>(Cmd.Property);
 				if (ArrayProperty == nullptr)
 				{
-					UE_LOG(LogSpatialComponentReader, Error, TEXT("Failed to apply Schema Object %s. One of it's properties is null"), *Object->GetName());
+					UE_LOG(LogSpatialComponentReader, Error, TEXT("Failed to apply Schema Object %s. One of it's properties is null"), *Object.GetName());
 					continue;
 				}
 
@@ -143,32 +201,39 @@ void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject*
 				{
 					TArray<uint8> ValueData = GetBytesFromSchema(ComponentObject, FieldId);
 					int64 CountBits = ValueData.Num() * 8;
+					TSet<FUnrealObjectRef> NewMappedRefs;
 					TSet<FUnrealObjectRef> NewUnresolvedRefs;
-					FSpatialNetBitReader ValueDataReader(PackageMap, ValueData.GetData(), CountBits, NewUnresolvedRefs);
+					FSpatialNetBitReader ValueDataReader(PackageMap, ValueData.GetData(), CountBits, NewMappedRefs, NewUnresolvedRefs);
 
 					if (ValueData.Num() > 0)
 					{
-						FSpatialNetDeltaSerializeInfo::DeltaSerializeRead(NetDriver, ValueDataReader, Object, Parent.ArrayIndex, Parent.Property, NetDeltaStruct);
+						FSpatialNetDeltaSerializeInfo::DeltaSerializeRead(NetDriver, ValueDataReader, &Object, Parent.ArrayIndex, Parent.Property, NetDeltaStruct);
 					}
 
-					if (NewUnresolvedRefs.Num() > 0)
+					FObjectReferences* CurEntry = RootObjectReferencesMap.Find(SwappedCmd.Offset);
+					const bool bHasReferences = NewUnresolvedRefs.Num() > 0 || NewMappedRefs.Num() > 0;
+
+					if (ReferencesChanged(RootObjectReferencesMap, SwappedCmd.Offset, bHasReferences, NewMappedRefs, NewUnresolvedRefs))
 					{
-						RootObjectReferencesMap.Add(SwappedCmd.Offset, FObjectReferences(ValueData, CountBits, NewUnresolvedRefs, ShadowOffset, Cmd.ParentIndex, ArrayProperty, /* bFastArrayProp */ true));
-						UnresolvedRefs.Append(NewUnresolvedRefs);
-					}
-					else if (RootObjectReferencesMap.Find(SwappedCmd.Offset))
-					{
-						RootObjectReferencesMap.Remove(SwappedCmd.Offset);
+						if (bHasReferences)
+						{
+							RootObjectReferencesMap.Add(SwappedCmd.Offset, FObjectReferences(ValueData, CountBits, MoveTemp(NewMappedRefs), MoveTemp(NewUnresolvedRefs), ShadowOffset, Cmd.ParentIndex, ArrayProperty, /* bFastArrayProp */ true));
+						}
+						else
+						{
+							RootObjectReferencesMap.Remove(SwappedCmd.Offset);
+						}
+						bOutReferencesChanged = true;
 					}
 				}
 				else
 				{
-					ApplyArray(ComponentObject, FieldId, RootObjectReferencesMap, ArrayProperty, Data, SwappedCmd.Offset, ShadowOffset, Cmd.ParentIndex);
+					ApplyArray(ComponentObject, FieldId, RootObjectReferencesMap, ArrayProperty, Data, SwappedCmd.Offset, ShadowOffset, Cmd.ParentIndex, bOutReferencesChanged);
 				}
 			}
 			else
 			{
-				ApplyProperty(ComponentObject, FieldId, RootObjectReferencesMap, 0, Cmd.Property, Data, SwappedCmd.Offset, ShadowOffset, Cmd.ParentIndex);
+				ApplyProperty(ComponentObject, FieldId, RootObjectReferencesMap, 0, Cmd.Property, Data, SwappedCmd.Offset, ShadowOffset, Cmd.ParentIndex, bOutReferencesChanged);
 			}
 
 			if (Cmd.Property->GetFName() == NAME_RemoteRole)
@@ -211,68 +276,74 @@ void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject*
 		}
 	}
 
-	Channel->RemoveRepNotifiesWithUnresolvedObjs(RepNotifies, *Replicator->RepLayout, RootObjectReferencesMap, Object);
+	Channel.RemoveRepNotifiesWithUnresolvedObjs(RepNotifies, *Replicator->RepLayout, RootObjectReferencesMap, &Object);
 
-	Channel->PostReceiveSpatialUpdate(Object, RepNotifies);
+	Channel.PostReceiveSpatialUpdate(&Object, RepNotifies);
 }
 
-void ComponentReader::ApplyHandoverSchemaObject(Schema_Object* ComponentObject, UObject* Object, USpatialActorChannel* Channel, bool bIsInitialData, const TArray<Schema_FieldId>& UpdatedIds, Worker_ComponentId ComponentId)
+void ComponentReader::ApplyHandoverSchemaObject(Schema_Object* ComponentObject, UObject& Object, USpatialActorChannel& Channel, bool bIsInitialData, const TArray<Schema_FieldId>& UpdatedIds, Worker_ComponentId ComponentId, bool& bOutReferencesChanged)
 {
-	FObjectReplicator* Replicator = Channel->PreReceiveSpatialUpdate(Object);
+	FObjectReplicator* Replicator = Channel.PreReceiveSpatialUpdate(&Object);
 	if (Replicator == nullptr)
 	{
 		// Can't apply this schema object. Error printed from PreReceiveSpatialUpdate.
 		return;
 	}
 
-	const FClassInfo& ClassInfo = ClassInfoManager->GetOrCreateClassInfoByClass(Object->GetClass());
+	const FClassInfo& ClassInfo = ClassInfoManager->GetOrCreateClassInfoByClass(Object.GetClass());
 
 	for (uint32 FieldId : UpdatedIds)
 	{
 		// FieldId is the same as handover handle
 		if (FieldId == 0 || (int)FieldId - 1 >= ClassInfo.HandoverProperties.Num())
 		{
-			UE_LOG(LogSpatialComponentReader, Error, TEXT("ApplyHandoverSchemaObject: Encountered an invalid field Id while applying schema. Object: %s, Field: %d, Entity: %lld, Component: %d"), *Object->GetPathName(), FieldId, Channel->GetEntityId(), ComponentId);
+			UE_LOG(LogSpatialComponentReader, Error, TEXT("ApplyHandoverSchemaObject: Encountered an invalid field Id while applying schema. Object: %s, Field: %d, Entity: %lld, Component: %d"), *Object.GetPathName(), FieldId, Channel.GetEntityId(), ComponentId);
 			continue;
 		}
 		const FHandoverPropertyInfo& PropertyInfo = ClassInfo.HandoverProperties[FieldId - 1];
 
-		uint8* Data = (uint8*)Object + PropertyInfo.Offset;
+		uint8* Data = (uint8*)&Object + PropertyInfo.Offset;
 
 		if (UArrayProperty* ArrayProperty = Cast<UArrayProperty>(PropertyInfo.Property))
 		{
-			ApplyArray(ComponentObject, FieldId, RootObjectReferencesMap, ArrayProperty, Data, PropertyInfo.Offset, -1, -1);
+			ApplyArray(ComponentObject, FieldId, RootObjectReferencesMap, ArrayProperty, Data, PropertyInfo.Offset, -1, -1, bOutReferencesChanged);
 		}
 		else
 		{
-			ApplyProperty(ComponentObject, FieldId, RootObjectReferencesMap, 0, PropertyInfo.Property, Data, PropertyInfo.Offset, -1, -1);
+			ApplyProperty(ComponentObject, FieldId, RootObjectReferencesMap, 0, PropertyInfo.Property, Data, PropertyInfo.Offset, -1, -1, bOutReferencesChanged);
 		}
 	}
 
-	Channel->PostReceiveSpatialUpdate(Object, TArray<UProperty*>());
+	Channel.PostReceiveSpatialUpdate(&Object, TArray<UProperty*>());
 }
 
-void ComponentReader::ApplyProperty(Schema_Object* Object, Schema_FieldId FieldId, FObjectReferencesMap& InObjectReferencesMap, uint32 Index, UProperty* Property, uint8* Data, int32 Offset, int32 ShadowOffset, int32 ParentIndex)
+void ComponentReader::ApplyProperty(Schema_Object* Object, Schema_FieldId FieldId, FObjectReferencesMap& InObjectReferencesMap, uint32 Index, UProperty* Property, uint8* Data, int32 Offset, int32 ShadowOffset, int32 ParentIndex, bool& bOutReferencesChanged)
 {
 	if (UStructProperty* StructProperty = Cast<UStructProperty>(Property))
 	{
 		TArray<uint8> ValueData = IndexBytesFromSchema(Object, FieldId, Index);
 		// A bit hacky, we should probably include the number of bits with the data instead.
 		int64 CountBits = ValueData.Num() * 8;
+		TSet<FUnrealObjectRef> NewDynamicRefs;
 		TSet<FUnrealObjectRef> NewUnresolvedRefs;
-		FSpatialNetBitReader ValueDataReader(PackageMap, ValueData.GetData(), CountBits, NewUnresolvedRefs);
+		FSpatialNetBitReader ValueDataReader(PackageMap, ValueData.GetData(), CountBits, NewDynamicRefs, NewUnresolvedRefs);
 		bool bHasUnmapped = false;
 
 		ReadStructProperty(ValueDataReader, StructProperty, NetDriver, Data, bHasUnmapped);
+		const bool bHasReferences = NewDynamicRefs.Num() > 0 || NewUnresolvedRefs.Num() > 0;
 
-		if (NewUnresolvedRefs.Num() > 0)
+		if (ReferencesChanged(InObjectReferencesMap, Offset, bHasReferences, NewDynamicRefs, NewUnresolvedRefs))
 		{
-			InObjectReferencesMap.Add(Offset, FObjectReferences(ValueData, CountBits, NewUnresolvedRefs, ShadowOffset, ParentIndex, Property));
-			UnresolvedRefs.Append(NewUnresolvedRefs);
-		}
-		else if (InObjectReferencesMap.Find(Offset))
-		{
-			InObjectReferencesMap.Remove(Offset);
+			if (bHasReferences)
+			{
+				InObjectReferencesMap.Add(Offset, FObjectReferences(ValueData, CountBits, MoveTemp(NewDynamicRefs), MoveTemp(NewUnresolvedRefs), ShadowOffset, ParentIndex, Property));
+			}
+			else
+			{
+				InObjectReferencesMap.Remove(Offset);
+			}
+			
+			bOutReferencesChanged = true;
 		}
 	}
 	else if (UBoolProperty* BoolProperty = Cast<UBoolProperty>(Property))
@@ -334,23 +405,27 @@ void ComponentReader::ApplyProperty(Schema_Object* Object, Schema_FieldId FieldI
 			bool bUnresolved = false;
 			UObject* ObjectValue = FUnrealObjectRef::ToObjectPtr(ObjectRef, PackageMap, bUnresolved);
 
-			if (bUnresolved)
+			const bool bHasReferences = bUnresolved || (ObjectValue && !ObjectValue->IsFullNameStableForNetworking());
+
+			if (ReferencesChanged(InObjectReferencesMap, Offset, bHasReferences, ObjectRef, bUnresolved))
 			{
-				InObjectReferencesMap.Add(Offset, FObjectReferences(ObjectRef, ShadowOffset, ParentIndex, Property));
-				UnresolvedRefs.Add(ObjectRef);
+				if (bHasReferences)
+				{
+					InObjectReferencesMap.Add(Offset, FObjectReferences(ObjectRef, bUnresolved, ShadowOffset, ParentIndex, Property));
+				}
+				else
+				{
+					InObjectReferencesMap.Remove(Offset);
+				}
+				bOutReferencesChanged = true;
 			}
-			else
+			if(!bUnresolved)
 			{
 				ObjectProperty->SetObjectPropertyValue(Data, ObjectValue);
 				if (ObjectValue != nullptr)
 				{
 					checkf(ObjectValue->IsA(ObjectProperty->PropertyClass), TEXT("Object ref %s maps to object %s with the wrong class."), *ObjectRef.ToString(), *ObjectValue->GetFullName());
 				}
-			}
-
-			if (!bUnresolved && InObjectReferencesMap.Find(Offset))
-			{
-				InObjectReferencesMap.Remove(Offset);
 			}
 		}
 	}
@@ -374,7 +449,7 @@ void ComponentReader::ApplyProperty(Schema_Object* Object, Schema_FieldId FieldI
 		}
 		else
 		{
-			ApplyProperty(Object, FieldId, InObjectReferencesMap, Index, EnumProperty->GetUnderlyingProperty(), Data, Offset, ShadowOffset, ParentIndex);
+			ApplyProperty(Object, FieldId, InObjectReferencesMap, Index, EnumProperty->GetUnderlyingProperty(), Data, Offset, ShadowOffset, ParentIndex, bOutReferencesChanged);
 		}
 	}
 	else
@@ -383,7 +458,7 @@ void ComponentReader::ApplyProperty(Schema_Object* Object, Schema_FieldId FieldI
 	}
 }
 
-void ComponentReader::ApplyArray(Schema_Object* Object, Schema_FieldId FieldId, FObjectReferencesMap& InObjectReferencesMap, UArrayProperty* Property, uint8* Data, int32 Offset, int32 ShadowOffset, int32 ParentIndex)
+void ComponentReader::ApplyArray(Schema_Object* Object, Schema_FieldId FieldId, FObjectReferencesMap& InObjectReferencesMap, UArrayProperty* Property, uint8* Data, int32 Offset, int32 ShadowOffset, int32 ParentIndex, bool& bOutReferencesChanged)
 {
 	FObjectReferencesMap* ArrayObjectReferences;
 	bool bNewArrayMap = false;
@@ -407,7 +482,7 @@ void ComponentReader::ApplyArray(Schema_Object* Object, Schema_FieldId FieldId, 
 	for (int i = 0; i < Count; i++)
 	{
 		int32 ElementOffset = i * Property->Inner->ElementSize;
-		ApplyProperty(Object, FieldId, *ArrayObjectReferences, i, Property->Inner, ArrayHelper.GetRawPtr(i), ElementOffset, ElementOffset, ParentIndex);
+		ApplyProperty(Object, FieldId, *ArrayObjectReferences, i, Property->Inner, ArrayHelper.GetRawPtr(i), ElementOffset, ElementOffset, ParentIndex, bOutReferencesChanged);
 	}
 
 	if (ArrayObjectReferences->Num() > 0)

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetBitReader.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetBitReader.h
@@ -14,7 +14,7 @@ class USpatialPackageMapClient;
 class SPATIALGDK_API FSpatialNetBitReader : public FNetBitReader
 {
 public:
-	FSpatialNetBitReader(USpatialPackageMapClient* InPackageMap, uint8* Source, int64 CountBits, TSet<FUnrealObjectRef>& InUnresolvedRefs);
+	FSpatialNetBitReader(USpatialPackageMapClient* InPackageMap, uint8* Source, int64 CountBits, TSet<FUnrealObjectRef>& InDynamicRefs, TSet<FUnrealObjectRef>& InUnresolvedRefs);
 
 	using FArchive::operator<<; // For visibility of the overloads we don't override
 
@@ -27,5 +27,6 @@ public:
 protected:
 	void DeserializeObjectRef(FUnrealObjectRef& ObjectRef);
 
+	TSet<FUnrealObjectRef>& DynamicRefs;
 	TSet<FUnrealObjectRef>& UnresolvedRefs;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -103,7 +103,7 @@ public:
 	void PostSpawnPlayerController(APlayerController* PlayerController, const FString& WorkerAttribute);
 
 	void AddActorChannel(Worker_EntityId EntityId, USpatialActorChannel* Channel);
-	void RemoveActorChannel(Worker_EntityId EntityId);
+	void RemoveActorChannel(Worker_EntityId EntityId, USpatialActorChannel& Channel);
 	TMap<Worker_EntityId_Key, USpatialActorChannel*>& GetEntityToActorChannelMap();
 
 	USpatialActorChannel* GetOrCreateSpatialActorChannel(UObject* TargetObject);

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -40,57 +40,6 @@ struct PendingAddComponentWrapper
 	TUniquePtr<SpatialGDK::DynamicComponent> Data;
 };
 
-struct FObjectReferences
-{
-	FObjectReferences() = default;
-	FObjectReferences(FObjectReferences&& Other)
-		: UnresolvedRefs(MoveTemp(Other.UnresolvedRefs))
-		, bSingleProp(Other.bSingleProp)
-		, bFastArrayProp(Other.bFastArrayProp)
-		, Buffer(MoveTemp(Other.Buffer))
-		, NumBufferBits(Other.NumBufferBits)
-		, Array(MoveTemp(Other.Array))
-		, ShadowOffset(Other.ShadowOffset)
-		, ParentIndex(Other.ParentIndex)
-		, Property(Other.Property) {}
-
-	// Single property constructor
-	FObjectReferences(const FUnrealObjectRef& InUnresolvedRef, int32 InCmdIndex, int32 InParentIndex, UProperty* InProperty)
-		: bSingleProp(true), bFastArrayProp(false), ShadowOffset(InCmdIndex), ParentIndex(InParentIndex), Property(InProperty)
-	{
-		UnresolvedRefs.Add(InUnresolvedRef);
-	}
-
-	// Struct (memory stream) constructor
-	FObjectReferences(const TArray<uint8>& InBuffer, int32 InNumBufferBits, const TSet<FUnrealObjectRef>& InUnresolvedRefs, int32 InCmdIndex, int32 InParentIndex, UProperty* InProperty, bool InFastArrayProp = false)
-		: UnresolvedRefs(InUnresolvedRefs), bSingleProp(false), bFastArrayProp(InFastArrayProp), Buffer(InBuffer), NumBufferBits(InNumBufferBits), ShadowOffset(InCmdIndex), ParentIndex(InParentIndex), Property(InProperty) {}
-
-	// Array constructor
-	FObjectReferences(FObjectReferencesMap* InArray, int32 InCmdIndex, int32 InParentIndex, UProperty* InProperty)
-		: bSingleProp(false), bFastArrayProp(false), Array(InArray), ShadowOffset(InCmdIndex), ParentIndex(InParentIndex), Property(InProperty) {}
-
-	TSet<FUnrealObjectRef>				UnresolvedRefs;
-
-	bool								bSingleProp;
-	bool								bFastArrayProp;
-	TArray<uint8>						Buffer;
-	int32								NumBufferBits;
-
-	TUniquePtr<FObjectReferencesMap>	Array;
-	int32								ShadowOffset;
-	int32								ParentIndex;
-	UProperty*							Property;
-};
-
-struct FPendingSubobjectAttachment
-{
-	USpatialActorChannel* Channel;
-	const FClassInfo* Info;
-	TWeakObjectPtr<UObject> Subobject;
-
-	TSet<Worker_ComponentId> PendingAuthorityDelegations;
-};
-
 DECLARE_DELEGATE_OneParam(EntityQueryDelegate, const Worker_EntityQueryResponseOp&);
 DECLARE_DELEGATE_OneParam(ReserveEntityIDsDelegate, const Worker_ReserveEntityIdsResponseOp&);
 DECLARE_DELEGATE_OneParam(CreateEntityDelegate, const Worker_CreateEntityResponseOp&);
@@ -142,10 +91,15 @@ public:
 	void OnDisconnect(Worker_DisconnectOp& Op);
 
 	void RemoveActor(Worker_EntityId EntityId);
-	bool IsPendingOpsOnChannel(USpatialActorChannel* Channel);
+	bool IsPendingOpsOnChannel(USpatialActorChannel& Channel);
 
 	void ClearPendingRPCs(Worker_EntityId EntityId);
+
+	void CleanupRepStateMap(FSpatialObjectRepState& Replicator);
+	void MoveMappedObjectToUnmapped(const FUnrealObjectRef&);
+
 private:
+
 	void EnterCriticalSection();
 	void LeaveCriticalSection();
 
@@ -165,16 +119,16 @@ private:
 
 	void HandleRPCLegacy(const Worker_ComponentUpdateOp& Op);
 	void ProcessRPCEventField(Worker_EntityId EntityId, const Worker_ComponentUpdateOp &Op, const Worker_ComponentId RPCEndpointComponentId, bool bPacked);
-
 	void HandleRPC(const Worker_ComponentUpdateOp& Op);
 
-	void ApplyComponentDataOnActorCreation(Worker_EntityId EntityId, const Worker_ComponentData& Data, USpatialActorChannel* Channel, const FClassInfo& ActorClassInfo);
-	void ApplyComponentData(UObject* TargetObject, USpatialActorChannel* Channel, const Worker_ComponentData& Data);
+	void ApplyComponentDataOnActorCreation(Worker_EntityId EntityId, const Worker_ComponentData& Data, USpatialActorChannel& Channel, const FClassInfo& ActorClassInfo);
+	void ApplyComponentData(USpatialActorChannel& Channel, UObject& TargetObject, const Worker_ComponentData& Data);
+	
 	// This is called for AddComponentOps not in a critical section, which means they are not a part of the initial entity creation.
 	void HandleIndividualAddComponent(const Worker_AddComponentOp& Op);
 	void AttachDynamicSubobject(AActor* Actor, Worker_EntityId EntityId, const FClassInfo& Info);
 
-	void ApplyComponentUpdate(const Worker_ComponentUpdate& ComponentUpdate, UObject* TargetObject, USpatialActorChannel* Channel, bool bIsHandover);
+	void ApplyComponentUpdate(const Worker_ComponentUpdate& ComponentUpdate, UObject& TargetObject, USpatialActorChannel& Channel, bool bIsHandover);
 
 	FRPCErrorInfo ApplyRPC(const FPendingRPCParams& Params);
 	ERPCResult ApplyRPCInternal(UObject* TargetObject, UFunction* Function, const SpatialGDK::RPCPayload& Payload, const FString& SenderWorkerId, bool bApplyWithUnresolvedRefs = false);
@@ -183,14 +137,12 @@ private:
 
 	bool IsReceivedEntityTornOff(Worker_EntityId EntityId);
 
-	void QueueIncomingRepUpdates(FChannelObjectPair ChannelObjectPair, const FObjectReferencesMap& ObjectReferencesMap, const TSet<FUnrealObjectRef>& UnresolvedRefs);
-
 	void ProcessOrQueueIncomingRPC(const FUnrealObjectRef& InTargetObjectRef, SpatialGDK::RPCPayload InPayload);
 
 	void ResolvePendingOperations_Internal(UObject* Object, const FUnrealObjectRef& ObjectRef);
 	void ResolveIncomingOperations(UObject* Object, const FUnrealObjectRef& ObjectRef);
 
-	void ResolveObjectReferences(FRepLayout& RepLayout, UObject* ReplicatedObject, FObjectReferencesMap& ObjectReferencesMap, uint8* RESTRICT StoredData, uint8* RESTRICT Data, int32 MaxAbsOffset, TArray<UProperty*>& RepNotifies, bool& bOutSomeObjectsWereMapped, bool& bOutStillHasUnresolved);
+	void ResolveObjectReferences(FRepLayout& RepLayout, UObject* ReplicatedObject, FSpatialObjectRepState& RepState, FObjectReferencesMap& ObjectReferencesMap, uint8* RESTRICT StoredData, uint8* RESTRICT Data, int32 MaxAbsOffset, TArray<UProperty*>& RepNotifies, bool& bOutSomeObjectsWereMapped);
 
 	void ProcessQueuedResolvedObjects();
 	void ProcessQueuedActorRPCsOnEntityCreation(AActor* Actor, SpatialGDK::RPCsOnEntityCreation& QueuedRPCs);
@@ -243,7 +195,6 @@ private:
 	// END TODO
 
 public:
-	TMap<FUnrealObjectRef, TSet<FChannelObjectPair>> IncomingRefsMap;
 
 	TMap<TPair<Worker_EntityId_Key, Worker_ComponentId>, TSharedRef<FPendingSubobjectAttachment>> PendingEntitySubobjectDelegations;
 
@@ -275,10 +226,15 @@ private:
 
 	SpatialGDK::SpatialRPCService* RPCService;
 
-	// TODO: Figure out how to remove entries when Channel/Actor gets deleted - UNR:100
-	TMap<FChannelObjectPair, FObjectReferencesMap> UnresolvedRefsMap;
-	TArray<TPair<UObject*, FUnrealObjectRef>> ResolvedObjectQueue;
+	// Helper struct to manage FSpatialObjectRepState update cycle.
+	struct RepStateUpdateHelper;
 
+	// Map from references to replicated objects to properties using these references.
+	// Useful to manage entities going in and out of interest, in order to recover references to actors.
+	FObjectToRepStateMap ObjectRefToRepStateMap;
+
+	TArray<TPair<UObject*, FUnrealObjectRef>> ResolvedObjectQueue;
+	
 	FRPCContainer IncomingRPCs;
 
 	bool bInCriticalSection;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialCommonTypes.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialCommonTypes.h
@@ -21,6 +21,6 @@ using WorkerRequirementSet = TArray<WorkerAttributeSet>;
 using WriteAclMap = TMap<Worker_ComponentId, WorkerRequirementSet>;
 
 using FChannelObjectPair = TPair<TWeakObjectPtr<class USpatialActorChannel>, TWeakObjectPtr<UObject>>;
-struct FObjectReferences;
-using FObjectReferencesMap = TMap<int32, FObjectReferences>;
+using FObjectReferencesMap = TMap<int32, struct FObjectReferences>;
 using FReliableRPCMap = TMap<Worker_RequestId_Key, TSharedRef<struct FReliableRPCForRetry>>;
+using FObjectToRepStateMap = TMap <struct FUnrealObjectRef, TSet<FChannelObjectPair> >;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/ComponentReader.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/ComponentReader.h
@@ -13,17 +13,17 @@ namespace SpatialGDK
 class ComponentReader
 {
 public:
-	ComponentReader(class USpatialNetDriver* InNetDriver, FObjectReferencesMap& InObjectReferencesMap, TSet<FUnrealObjectRef>& InUnresolvedRefs);
+	ComponentReader(class USpatialNetDriver* InNetDriver, FObjectReferencesMap& InObjectReferencesMap);
 
-	void ApplyComponentData(const Worker_ComponentData& ComponentData, UObject* Object, USpatialActorChannel* Channel, bool bIsHandover);
-	void ApplyComponentUpdate(const Worker_ComponentUpdate& ComponentUpdate, UObject* Object, USpatialActorChannel* Channel, bool bIsHandover);
+	void ApplyComponentData(const Worker_ComponentData& ComponentData, UObject& Object, USpatialActorChannel& Channel, bool bIsHandover, bool& bOutReferencesChanged);
+	void ApplyComponentUpdate(const Worker_ComponentUpdate& ComponentUpdate, UObject& Object, USpatialActorChannel& Channel, bool bIsHandover, bool& bOutReferencesChanged);
 
 private:
-	void ApplySchemaObject(Schema_Object* ComponentObject, UObject* Object, USpatialActorChannel* Channel, bool bIsInitialData, const TArray<Schema_FieldId>& UpdatedIds, Worker_ComponentId ComponentId);
-	void ApplyHandoverSchemaObject(Schema_Object* ComponentObject, UObject* Object, USpatialActorChannel* Channel, bool bIsInitialData, const TArray<Schema_FieldId>& UpdatedIds, Worker_ComponentId ComponentId);
+	void ApplySchemaObject(Schema_Object* ComponentObject, UObject& Object, USpatialActorChannel& Channel, bool bIsInitialData, const TArray<Schema_FieldId>& UpdatedIds, Worker_ComponentId ComponentId, bool& bOutReferencesChanged);
+	void ApplyHandoverSchemaObject(Schema_Object* ComponentObject, UObject& Object, USpatialActorChannel& Channel, bool bIsInitialData, const TArray<Schema_FieldId>& UpdatedIds, Worker_ComponentId ComponentId, bool& bOutReferencesChanged);
 
-	void ApplyProperty(Schema_Object* Object, Schema_FieldId FieldId, FObjectReferencesMap& InObjectReferencesMap, uint32 Index, UProperty* Property, uint8* Data, int32 Offset, int32 CmdIndex, int32 ParentIndex);
-	void ApplyArray(Schema_Object* Object, Schema_FieldId FieldId, FObjectReferencesMap& InObjectReferencesMap, UArrayProperty* Property, uint8* Data, int32 Offset, int32 CmdIndex, int32 ParentIndex);
+	void ApplyProperty(Schema_Object* Object, Schema_FieldId FieldId, FObjectReferencesMap& InObjectReferencesMap, uint32 Index, UProperty* Property, uint8* Data, int32 Offset, int32 CmdIndex, int32 ParentIndex, bool& bOutReferencesChanged);
+	void ApplyArray(Schema_Object* Object, Schema_FieldId FieldId, FObjectReferencesMap& InObjectReferencesMap, UArrayProperty* Property, uint8* Data, int32 Offset, int32 CmdIndex, int32 ParentIndex, bool& bOutReferencesChanged);
 
 	uint32 GetPropertyCount(const Schema_Object* Object, Schema_FieldId Id, UProperty* Property);
 
@@ -32,7 +32,6 @@ private:
 	class USpatialNetDriver* NetDriver;
 	class USpatialClassInfoManager* ClassInfoManager;
 	FObjectReferencesMap& RootObjectReferencesMap;
-	TSet<FUnrealObjectRef>& UnresolvedRefs;
 };
 
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -204,7 +204,7 @@ struct FSpatialLaunchConfigDescription
 	FWorldLaunchSection World;
 
 	/** Worker-specific configuration parameters. */
-	UPROPERTY(Category = "SpatialGDK", EditAnywhere, config)
+	UPROPERTY(Category = "SpatialGDK", EditAnywhere, config, meta = (TitleProperty = "WorkerTypeName"))
 	TArray<FWorkerTypeLaunchSection> ServerWorkers;
 };
 


### PR DESCRIPTION
#### Description
Unlike what the vanilla net driver was doing, we did not track references to replicated actors in replicated properties. It allows restoring pointer in replicated properties to the right actor when they become relevant again.
This is is an addition to how we currently handle unresolved references, since it works only the first time a property is replicated.
This PR essentially add tracking to properties referencing replicated actors, similar to what Unreal was doing, only with FUnrealObjectRef instead of NetworkGUID.
FObjectReferencesMap are extended to also remember the mapped references, and they are wrapped into a utility class, FSpatialObjectRepState.
Then, for each reference, we will add this additional RepState to a map, USpatialReceiver::ObjectRefToRepStateMap.
When an actor is destroyed, we will use this map to move mapped references to unresolved ones, allowing us to resolve them when the actor becomes available again.

#### Release note

#### Tests
https://github.com/spatialos/UnrealGDKTestGyms/pull/11

#### Documentation

#### Primary reviewers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spatialos/unrealgdk/1551)
<!-- Reviewable:end -->
