### PR TITLE
Bugfix/unr 2504 fix pie entity deletion issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Fixed an crash caused by attempting to read schema from an unloaded class.
 - Unresolved object references in replicated arrays of structs should now be properly handled and eventually resolved.
 - Fix tombstone-related assert that could fire and bring down the editor.
+- Delete entities on PIE shutdown rather than tombstoning.  Additionally, delete all entities on shutdown even if the server isn't authoritative over them.
 
 ## [`0.7.0-preview`] - 2019-10-11
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -170,8 +170,9 @@ bool USpatialActorChannel::CleanUp(const bool bForDestroy, EChannelCloseReason C
 			NetDriver->GetActorChannelByEntityId(EntityId) != nullptr &&
 			CloseReason != EChannelCloseReason::Dormancy)
 		{
-			// If we're a server worker, and the entity hasn't already been cleaned up, delete it on shutdown.
-			DeleteEntityIfAuthoritative();
+			// TODO - How to handle multiserver entity deletion on PIE shutdown - https://improbableio.atlassian.net/browse/UNR-2506
+			const FEntityRetirementSettings EntityRetirementSettings{ EEntityRetireMode::DELETE };
+			Sender->RetireEntity(EntityId, EntityRetirementSettings);
 		}
 #endif // WITH_EDITOR
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -1224,11 +1224,20 @@ void USpatialSender::UpdateInterestComponent(AActor* Actor)
 	Connection->SendComponentUpdate(EntityId, &Update);
 }
 
+#if WITH_EDITOR
+void USpatialSender::RetireEntity(const Worker_EntityId EntityId, const FEntityRetirementSettings& EntityRetirementSettings)
+#else
 void USpatialSender::RetireEntity(const Worker_EntityId EntityId)
+#endif
 {
 	if (AActor* Actor = Cast<AActor>(PackageMap->GetObjectFromEntityId(EntityId).Get()))
 	{
+#if WITH_EDITOR
+		if (Actor->IsNetStartupActor() &&
+		EntityRetirementSettings.StartupActorRetireMode == EEntityRetireMode::TOMBSTONE)
+#else
 		if (Actor->IsNetStartupActor())
+#endif
 		{
 			Receiver->RemoveActor(EntityId);
 			// In the case that this is a startup actor, we won't actually delete the entity in SpatialOS.  Instead we'll Tombstone it.

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -55,6 +55,19 @@ struct FPendingRPC
 	Schema_EntityId Entity;
 };
 
+#if WITH_EDITOR
+enum EEntityRetireMode : uint8
+{
+	DELETE,
+	TOMBSTONE
+};
+
+struct FEntityRetirementSettings
+{
+	EEntityRetireMode StartupActorRetireMode;
+};
+#endif
+
 // TODO: Clear TMap entries when USpatialActorChannel gets deleted - UNR:100
 // care for actor getting deleted before actor channel
 using FChannelObjectPair = TPair<TWeakObjectPtr<USpatialActorChannel>, TWeakObjectPtr<UObject>>;
@@ -85,8 +98,11 @@ public:
 	void SendRemoveComponent(Worker_EntityId EntityId, const FClassInfo& Info);
 
 	void SendCreateEntityRequest(USpatialActorChannel* Channel);
+#if WITH_EDITOR
+	void RetireEntity(const Worker_EntityId EntityId, const FEntityRetirementSettings& = FEntityRetirementSettings{ EEntityRetireMode::TOMBSTONE });
+#else
 	void RetireEntity(const Worker_EntityId EntityId);
-
+#endif
 	void SendRequestToClearRPCsOnEntityCreation(Worker_EntityId EntityId);
 	void ClearRPCsOnEntityCreation(Worker_EntityId EntityId);
 


### PR DESCRIPTION
…y, delete all entities on shutdown even if the server isn't authoritative over them.

**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Delete entities on PIE shutdown rather than tombstoning.  Additionally, delete all entities on shutdown even if the server isn't authoritative over them.

#### Release note
Note added to CHANGELOG.md

#### Tests
Spatial + PIE and cloud deploy - verified tombstone functionality still works as expected.
Also, when shutting down a PIE session, verified that all entities in the Inspector (except GSM and Spawner) are deleted.

STRONGLY SUGGESTED: How can this be verified by QA?
As described above in tests.

#### Documentation
Release note.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.