### PR TITLE
Removed Validity check for LoadBalancer

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -47,7 +47,6 @@ void USpatialReceiver::Init(USpatialNetDriver* InNetDriver, FTimerManager* InTim
 	PackageMap = InNetDriver->PackageMap;
 	ClassInfoManager = InNetDriver->ClassInfoManager;
 	GlobalStateManager = InNetDriver->GlobalStateManager;
-	check(!InNetDriver->IsServer() || InNetDriver->LoadBalanceEnforcer.IsValid());
 	LoadBalanceEnforcer = InNetDriver->LoadBalanceEnforcer.Get();
 	TimerManager = InTimerManager;
 
@@ -1151,7 +1150,7 @@ void USpatialReceiver::OnComponentUpdate(const Worker_ComponentUpdateOp& Op)
 		HandleRPC(Op);
 		return;
 	case SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID:
-		if (NetDriver->IsServer())
+		if (NetDriver->IsServer() && (LoadBalanceEnforcer != nullptr))
 		{
 			LoadBalanceEnforcer->OnAuthorityIntentComponentUpdated(Op);
 		}


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Removed Validity check for LoadBalancer, since it can be null if not specified in UE4 settings.

#### Release note
No release note update.

#### Tests
Verified that UE4 doesn't crash when the LoadBalancer is not specified.

#### Documentation
No doc update

#### Primary reviewers
@ImprobableNic @m-samiec 