### PR TITLE
UNR-2318 stop spatial service which runs in different project

### DIFF
--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -289,7 +289,7 @@ bool FLocalDeploymentManager::LocalDeploymentPreRunChecks()
 
 	if (!bSpatialServiceInProjectDirectory)
 	{
-		if (FMessageDialog::Open(EAppMsgType::YesNo, LOCTEXT("StopSpatailServiceFromDifferentProject", "Another SpatialOS service is already running in another project. Would you like to stop it?")) == EAppReturnType::Yes)
+		if (FMessageDialog::Open(EAppMsgType::YesNo, LOCTEXT("StopSpatialServiceFromDifferentProject", "Another SpatialOS service is already running in another project. Would you like to stop it?")) == EAppReturnType::Yes)
 		{
 			bSuccess = TryStopSpatialService();
 		}

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -287,6 +287,18 @@ bool FLocalDeploymentManager::LocalDeploymentPreRunChecks()
 		}
 	}
 
+	if (!bSpatialServiceInProjectDirectory)
+	{
+		if (FMessageDialog::Open(EAppMsgType::YesNo, LOCTEXT("StopSpatailServiceFromDifferentProject", "Another SpatialOS service is already running in another project. Would you like to stop it?")) == EAppReturnType::Yes)
+		{
+			bSuccess = TryStopSpatialService();
+		}
+		else
+		{
+			bSuccess = false;
+		}
+	}
+
 	return bSuccess;
 }
 


### PR DESCRIPTION

#### Description
In this diff when user start a local deployment I check that it's running in the correct directory. If it's running from a wrong directory I show dialog and stop the service which is already running.  

#### Release note
REQUIRED: Add a release note to the `##Unreleased` section of CHANGELOG.md. You can find guidance for writing useful release notes [here](../SpatialGDK/Extras/internal-documentation/how-to-write-good-release-notes.md). Documentation changes are exempt from this requirement.

#### Tests
1. Start a spatialos service from another project. 
2. Go to the target project and try to start a local deployment.
3. See the dialogue to stop an already running service. 
4. Click yes
5. Service which is running in a wrong project is stopped. Local deployment and spatial service started successfully. 

#### Documentation
Do we need a documentation here?
We should check a dialogue window text.

#### Primary reviewers
@joshuahuburn 