### PR TITLE
Add domain env var to setup.sh

### DIFF
--- a/Setup.sh
+++ b/Setup.sh
@@ -19,7 +19,10 @@ BINARIES_DIR="$(pwd)/SpatialGDK/Binaries/ThirdParty/Improbable"
 SCHEMA_COPY_DIR="$(pwd)/../../../spatial/schema/unreal/gdk"
 SCHEMA_STD_COPY_DIR="$(pwd)/../../../spatial/build/dependencies/schema/standard_library"
 SPATIAL_DIR="$(pwd)/../../../spatial"
-
+DOMAIN_ENVIRONMENT_VAR=
+if [[ "$*" == "--china" ]]; then
+    DOMAIN_ENVIRONMENT_VAR=--domain spatialoschina.com --environment cn-production
+fi
 
 echo "Setup the git hooks"
 if [[ -e .git/hooks ]]; then


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
The domain env for Setup.sh was missed during the merge from 0.7.1-preview into master. This adds it back in.

#### Primary reviewers
@improbable-danny @oblm @jessicafalk 