### PR TITLE
[UNR-2434][MS] Removing logic from schema generator that used to look…

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -443,26 +443,13 @@ bool IsSupportedClass(const UClass* SupportedClass)
 		if (SupportedClass->HasAnySpatialClassFlags(SPATIALCLASS_NotSpatialType))
 		{
 			UE_LOG(LogSpatialGDKSchemaGenerator, Verbose, TEXT("[%s] Has NotSpatialType flag, not supported for schema gen."), *GetPathNameSafe(SupportedClass));
-			return false;
+		}
+		else
+		{
+			UE_LOG(LogSpatialGDKSchemaGenerator, Verbose, TEXT("[%s] Has neither a SpatialType or NotSpatialType flag."), *GetPathNameSafe(SupportedClass));
 		}
 
-		// Need to check if super class is supported here because some blueprints don't appear to inherit SpatialFlags correctly until
-		// recompiled and saved. See [UNR-2172].
-		UClass* Class = SupportedClass->GetSuperClass();
-		while (Class != nullptr)
-		{
-			if (Class->HasAnySpatialClassFlags(SPATIALCLASS_SpatialType | SPATIALCLASS_NotSpatialType))
-			{
-				break;
-			}
-			Class = Class->GetSuperClass();
-		}
-
-		if (Class == nullptr || !Class->HasAnySpatialClassFlags(SPATIALCLASS_SpatialType))
-		{
-			UE_LOG(LogSpatialGDKSchemaGenerator, Verbose, TEXT("[%s] No SpatialType flag, not supported for schema gen."), *GetPathNameSafe(SupportedClass));
-			return false;
-		}
+		return false;
 	}
 
 	if (SupportedClass->HasAnyClassFlags(CLASS_LayoutChanging))


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Removing logic from schema generator that used to look up the parent tree to find the correct spatial flags. This logic is now done as part of UClass::Serialize.

#### Primary reviewers
@mattyoung-improbable 
@m-samiec 