### PR TITLE
Before sorting actors based on distance to the player, remove any wea…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Unresolved object references in replicated arrays of structs should now be properly handled and eventually resolved.
 - Fix tombstone-related assert that could fire and bring down the editor.
 - Actors placed in the level with bNetLoadOnClient=false that go out of view will now be reloaded if they come back into view.
+- Fix crash in SpatialDebugger caused by dereference of invalid weak pointer
 
 ## [`0.7.1-preview`] - 2019-12-06
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
@@ -49,6 +49,14 @@ void ASpatialDebugger::Tick(float DeltaSeconds)
 
 	if (!NetDriver->IsServer())
 	{
+		for (TMap<Worker_EntityId_Key, TWeakObjectPtr<AActor>>::TIterator It = EntityActorMapping.CreateIterator(); It; ++It)
+		{
+			if (It->Value.Get() == nullptr)
+			{
+				It.RemoveCurrent();
+			}
+		}
+
 		// Since we have no guarantee on the order we'll receive the PC/Pawn/PlayerState
 		// over the wire, we check here once per tick (currently 1 Hz tick rate) to setup our local pointers.
 		// Note that we can capture the PC in OnEntityAdded() since we know we will only receive one of those.

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
@@ -51,7 +51,7 @@ void ASpatialDebugger::Tick(float DeltaSeconds)
 	{
 		for (TMap<Worker_EntityId_Key, TWeakObjectPtr<AActor>>::TIterator It = EntityActorMapping.CreateIterator(); It; ++It)
 		{
-			if (It->Value.Get() == nullptr)
+			if (!It->Value.IsValid())
 			{
 				It.RemoveCurrent();
 			}


### PR DESCRIPTION
…k pointers that no longer point to valid actors

**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Fix crash in SpatialDebugger caused by dereference of invalid weak pointer

#### Release note
CHANGELOG.md updated

#### Tests
Verified SpatialDebugger still works correctly with this change

STRONGLY SUGGESTED: How can this be verified by QA?

#### Documentation
CHANGELOG.md

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.