### PR TITLE
UNR-2352 Pop & locking actors

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -562,8 +562,8 @@ int64 USpatialActorChannel::ReplicateActor()
 		// TODO: the 'bWroteSomethingImportant' check causes problems for actors that need to transition in groups (ex. Character, PlayerController, PlayerState),
 		// so disabling it for now.  Figure out a way to deal with this to recover the perf lost by calling ShouldChangeAuthority() frequently. [UNR-2387]
 		NetDriver->StaticComponentView->HasAuthority(EntityId, SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID) &&
-		!NetDriver->LockingPolicy->IsLocked(Actor) &&
-		NetDriver->LoadBalanceStrategy->ShouldRelinquishAuthority(*Actor))
+		NetDriver->LoadBalanceStrategy->ShouldRelinquishAuthority(*Actor) &&
+		!NetDriver->LockingPolicy->IsLocked(Actor))
 	{
 		const VirtualWorkerId NewAuthVirtualWorkerId = NetDriver->LoadBalanceStrategy->WhoShouldHaveAuthority(*Actor);
 		if (NewAuthVirtualWorkerId != SpatialConstants::INVALID_VIRTUAL_WORKER_ID)

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -562,7 +562,8 @@ int64 USpatialActorChannel::ReplicateActor()
 		NetDriver->LoadBalanceStrategy != nullptr &&
 		// TODO: the 'bWroteSomethingImportant' check causes problems for actors that need to transition in groups (ex. Character, PlayerController, PlayerState),
 		// so disabling it for now.  Figure out a way to deal with this to recover the perf lost by calling ShouldChangeAuthority() frequently. [UNR-2387]
-		Actor->HasAuthority() &&
+		NetDriver->StaticComponentView->HasAuthority(EntityId, SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID) &&
+		!NetDriver->LockingPolicy->IsLocked(Actor) &&
 		NetDriver->LoadBalanceStrategy->ShouldRelinquishAuthority(*Actor))
 	{
 		const VirtualWorkerId NewAuthVirtualWorkerId = NetDriver->LoadBalanceStrategy->WhoShouldHaveAuthority(*Actor);

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -559,7 +559,6 @@ int64 USpatialActorChannel::ReplicateActor()
 	}
 
 	if (SpatialGDKSettings->bEnableUnrealLoadBalancer &&
-		NetDriver->LoadBalanceStrategy != nullptr &&
 		// TODO: the 'bWroteSomethingImportant' check causes problems for actors that need to transition in groups (ex. Character, PlayerController, PlayerState),
 		// so disabling it for now.  Figure out a way to deal with this to recover the perf lost by calling ShouldChangeAuthority() frequently. [UNR-2387]
 		NetDriver->StaticComponentView->HasAuthority(EntityId, SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID) &&

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -28,6 +28,7 @@
 #include "Interop/SpatialSender.h"
 #include "LoadBalancing/AbstractLBStrategy.h"
 #include "LoadBalancing/GridBasedLBStrategy.h"
+#include "LoadBalancing/ReferenceCountedLockingPolicy.h"
 #include "Schema/AlwaysRelevant.h"
 #include "SpatialConstants.h"
 #include "SpatialGDKSettings.h"
@@ -39,7 +40,6 @@
 #include "Utils/SpatialMetrics.h"
 #include "Utils/SpatialMetricsDisplay.h"
 #include "Utils/SpatialStatics.h"
-#include "LoadBalancing/ReferenceCountedLockingPolicy.h"
 
 #if WITH_EDITOR
 #include "Settings/LevelEditorPlaySettings.h"

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -39,6 +39,7 @@
 #include "Utils/SpatialMetrics.h"
 #include "Utils/SpatialMetricsDisplay.h"
 #include "Utils/SpatialStatics.h"
+#include "LoadBalancing/ReferenceCountedLockingPolicy.h"
 
 #if WITH_EDITOR
 #include "Settings/LevelEditorPlaySettings.h"
@@ -459,6 +460,16 @@ void USpatialNetDriver::CreateAndInitializeCoreClasses()
 				LoadBalanceStrategy = NewObject<UAbstractLBStrategy>(this, SpatialSettings->LoadBalanceStrategy);
 			}
 			LoadBalanceStrategy->Init(this);
+		}
+
+		if (SpatialSettings->LockingPolicy == nullptr)
+		{
+			UE_LOG(LogSpatialOSNetDriver, Error, TEXT("If EnableUnrealLoadBalancer is set, there must be a Locking Policy set. Using default policy."));
+			LockingPolicy = NewObject<UReferenceCountedLockingPolicy>(this);
+		}
+		else
+		{
+			LockingPolicy = NewObject<UAbstractLockingPolicy>(this, SpatialSettings->LockingPolicy);
 		}
 
 		VirtualWorkerTranslator = MakeUnique<SpatialVirtualWorkerTranslator>();

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/ReferenceCountedLockingPolicy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/ReferenceCountedLockingPolicy.cpp
@@ -13,6 +13,12 @@ DEFINE_LOG_CATEGORY(LogReferenceCountedLockingPolicy);
 
 bool UReferenceCountedLockingPolicy::CanAcquireLock(AActor* Actor) const
 {
+	if (Actor == nullptr)
+	{
+		UE_LOG(LogReferenceCountedLockingPolicy, Error, TEXT("Failed to lock nullptr actor"));
+		return false;
+	}
+
 	const USpatialNetDriver* NetDriver = Cast<USpatialNetDriver>(Actor->GetWorld()->GetNetDriver());
 	const Worker_EntityId EntityId = NetDriver->PackageMap->GetEntityIdFromObject(Actor);
 
@@ -43,8 +49,8 @@ ActorLockToken UReferenceCountedLockingPolicy::AcquireLock(AActor* Actor, FStrin
 		UE_LOG(LogReferenceCountedLockingPolicy, Error, TEXT("Called AcquireLock when CanAcquireLock returned false. Actor: %s."), *GetNameSafe(Actor));
 		return SpatialConstants::INVALID_ACTOR_LOCK_TOKEN;
 	}
-	MigrationLockElement* ActorLockingState = ActorToLockingState.Find(Actor);
-	if (ActorLockingState != nullptr)
+
+	if (MigrationLockElement* ActorLockingState = ActorToLockingState.Find(Actor))
 	{
 		++ActorLockingState->LockCount;
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/ReferenceCountedLockingPolicy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/ReferenceCountedLockingPolicy.cpp
@@ -25,13 +25,13 @@ bool UReferenceCountedLockingPolicy::CanAcquireLock(AActor* Actor) const
 	const bool bHasAuthority = NetDriver->StaticComponentView->GetAuthority(EntityId, SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID) == WORKER_AUTHORITY_AUTHORITATIVE;
 	if (!bHasAuthority)
 	{
-		UE_LOG(LogReferenceCountedLockingPolicy, Log, TEXT("Can not lock actor migration. Do not have authority. Actor: %s"), *Actor->GetName());
+		UE_LOG(LogReferenceCountedLockingPolicy, Verbose, TEXT("Can not lock actor migration. Do not have authority. Actor: %s"), *Actor->GetName());
 	}
 	const bool bHasAuthorityIntent = NetDriver->VirtualWorkerTranslator->GetLocalVirtualWorkerId() ==
 		NetDriver->StaticComponentView->GetComponentData<SpatialGDK::AuthorityIntent>(EntityId)->VirtualWorkerId;
 	if (!bHasAuthorityIntent)
 	{
-		UE_LOG(LogReferenceCountedLockingPolicy, Log, TEXT("Can not lock actor migration. Authority intent does not match this worker. Actor: %s"), *Actor->GetName());
+		UE_LOG(LogReferenceCountedLockingPolicy, Verbose, TEXT("Can not lock actor migration. Authority intent does not match this worker. Actor: %s"), *Actor->GetName());
 	}
 	return bHasAuthorityIntent && bHasAuthority;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/ReferenceCountedLockingPolicy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/ReferenceCountedLockingPolicy.cpp
@@ -11,28 +11,19 @@
 
 DEFINE_LOG_CATEGORY(LogReferenceCountedLockingPolicy);
 
-ActorLockToken UReferenceCountedLockingPolicy::AcquireLock(const AActor* Actor, FString DebugString)
+bool UReferenceCountedLockingPolicy::CanAcquireLock(AActor* Actor) const
 {
-	check(Actor != nullptr);
-	if (!CanAcquireLock(Actor)) {
-		UE_LOG(LogReferenceCountedLockingPolicy, Error, TEXT("Called AcquireLock when CanAcquireLock returned false. Actor: %s."), *Actor->GetName());
-		return SpatialConstants::INVALID_ACTOR_LOCK_TOKEN;
-	}
-	++ActorToReferenceCount.FindOrAdd(Actor);
-	UE_LOG(LogReferenceCountedLockingPolicy, Log, TEXT("Acquiring migration lock. "
-		"Actor: %s. Lock name: %s. Token %d: Locks held: %d."), *Actor->GetName(), *DebugString, NextToken, *ActorToReferenceCount.Find(Actor));
-	TokenToNameAndActor.Emplace(NextToken, LockNameAndActor{ MoveTemp(DebugString), Actor });
-	return NextToken++;
-}
+	const USpatialNetDriver* NetDriver = Cast<USpatialNetDriver>(Actor->GetWorld()->GetNetDriver());
+	const Worker_EntityId EntityId = NetDriver->PackageMap->GetEntityIdFromObject(Actor);
 
-bool UReferenceCountedLockingPolicy::CanAcquireLock(const AActor* Actor) const
-{
-	check(Actor != nullptr);
-	const auto* NetDriver = Cast<USpatialNetDriver>(Actor->GetWorld()->GetNetDriver());
-	const auto EntityId = NetDriver->PackageMap->GetEntityIdFromObject(Actor);
+	if (EntityId == SpatialConstants::INVALID_ENTITY_ID)
+	{
+		UE_LOG(LogReferenceCountedLockingPolicy, Error, TEXT("CanAcquireLock called for actor without corresponding entity ID. Actor: %s"), *Actor->GetName());
+		return false;
+	}
 
 	const bool HasAuthIntent = NetDriver->VirtualWorkerTranslator->GetLocalVirtualWorkerId() ==
-			NetDriver->StaticComponentView->GetComponentData<SpatialGDK::AuthorityIntent>(EntityId)->VirtualWorkerId;
+		NetDriver->StaticComponentView->GetComponentData<SpatialGDK::AuthorityIntent>(EntityId)->VirtualWorkerId;
 	const bool HasAuth = NetDriver->StaticComponentView->GetAuthority(EntityId, SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID) == WORKER_AUTHORITY_AUTHORITATIVE;
 	if (!HasAuth)
 	{
@@ -45,6 +36,33 @@ bool UReferenceCountedLockingPolicy::CanAcquireLock(const AActor* Actor) const
 	return HasAuthIntent && HasAuth;
 }
 
+ActorLockToken UReferenceCountedLockingPolicy::AcquireLock(AActor* Actor, FString DebugString)
+{
+	if (!CanAcquireLock(Actor))
+	{
+		UE_LOG(LogReferenceCountedLockingPolicy, Error, TEXT("Called AcquireLock when CanAcquireLock returned false. Actor: %s."), *GetNameSafe(Actor));
+		return SpatialConstants::INVALID_ACTOR_LOCK_TOKEN;
+	}
+	LockingState* ActorLockingState = ActorToLockingState.Find(Actor);
+	if (ActorLockingState != nullptr)
+	{
+		++ActorLockingState->LockCount;
+	}
+	else
+	{
+		Actor->OnDestroyed.AddDynamic(this, &UReferenceCountedLockingPolicy::OnLockedActorDeleted);
+		ActorToLockingState.Add(Actor, LockingState{ 1, [this, Actor]
+		{
+			Actor->OnDestroyed.RemoveDynamic(this, &UReferenceCountedLockingPolicy::OnLockedActorDeleted);
+		} });
+	}
+
+	UE_LOG(LogReferenceCountedLockingPolicy, Log, TEXT("Acquiring migration lock. "
+		"Actor: %s. Lock name: %s. Token %d: Locks held: %d."), *GetNameSafe(Actor), *DebugString, NextToken, ActorToLockingState.Find(Actor)->LockCount);
+	TokenToNameAndActor.Emplace(NextToken, LockNameAndActor{ MoveTemp(DebugString), Actor });
+	return NextToken++;
+}
+
 void UReferenceCountedLockingPolicy::ReleaseLock(ActorLockToken Token)
 {
 	const auto NameAndActor = TokenToNameAndActor.FindAndRemoveChecked(Token);
@@ -52,26 +70,45 @@ void UReferenceCountedLockingPolicy::ReleaseLock(ActorLockToken Token)
 	const FString& Name = NameAndActor.LockName;
 	UE_LOG(LogReferenceCountedLockingPolicy, Log, TEXT("Releasing actor migration lock. Actor: %s. Token: %d. Lock name: %s"), *Actor->GetName(), Token, *Name);
 
-	check(ActorToReferenceCount.Contains(Actor));
+	check(ActorToLockingState.Contains(Actor));
 
 	{
 		// Reduce the reference count and erase the entry if reduced to 0.
-		auto CountIt = ActorToReferenceCount.CreateKeyIterator(Actor);
-		auto& Count = CountIt.Value();
-		if (Count == 1)
+		auto CountIt = ActorToLockingState.CreateKeyIterator(Actor);
+		LockingState& ActorLockingState = CountIt.Value();
+		if (ActorLockingState.LockCount == 1)
 		{
 			UE_LOG(LogReferenceCountedLockingPolicy, Log, TEXT("Actor migration no longer locked. Actor: %s"), *Actor->GetName(), *Name);
+			ActorLockingState.UnbindActorDeletionDelegateFunc();
 			CountIt.RemoveCurrent();
 		}
 		else
 		{
-			--Count;
+			--ActorLockingState.LockCount;
 		}
 	}
 }
 
 bool UReferenceCountedLockingPolicy::IsLocked(const AActor* Actor) const
-{
+	{
 	check(Actor != nullptr);
-	return ActorToReferenceCount.Contains(Actor);
+	return ActorToLockingState.Contains(Actor);
+}
+
+void UReferenceCountedLockingPolicy::OnLockedActorDeleted(AActor* DestroyedActor)
+{
+	// iterate through actor to lock state tokens and delete debug strings
+	TArray<ActorLockToken> TokensToRemove;
+	for (const auto& KeyValuePair : TokenToNameAndActor)
+	{
+		if (KeyValuePair.Value.Actor == DestroyedActor)
+		{
+			TokensToRemove.Add(KeyValuePair.Key);
+		}
+	}
+	for (const auto& Token : TokensToRemove)
+	{
+		TokenToNameAndActor.Remove(Token);
+	}
+	ActorToLockingState.Remove(DestroyedActor);
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/ReferenceCountedLockingPolicy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/ReferenceCountedLockingPolicy.cpp
@@ -1,0 +1,82 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "LoadBalancing/ReferenceCountedLockingPolicy.h"
+#include "GameFramework/Actor.h"
+
+#include "EngineClasses/SpatialNetDriver.h"
+#include "EngineClasses/SpatialPackageMapClient.h"
+#include "Interop/SpatialStaticComponentView.h"
+#include "Schema/AuthorityIntent.h"
+
+DEFINE_LOG_CATEGORY(LogReferenceCountedLockingPolicy);
+
+ActorLockToken UReferenceCountedLockingPolicy::AcquireLock(const AActor* Actor)
+{
+	check(Actor != nullptr);
+	check(CanAcquireLock(Actor))
+	++ActorToReferenceCount.FindOrAdd(Actor);
+	TokenToNameAndActor.Emplace(NextToken, LockNameAndActor{ FString(), Actor });
+	UE_LOG(LogReferenceCountedLockingPolicy, Log, TEXT("Acquiring migration lock. Actor: %s. Locks held: %d."), *Actor->GetName(), *ActorToReferenceCount.Find(Actor));
+	return NextToken++;
+}
+
+ActorLockToken UReferenceCountedLockingPolicy::AcquireLock(const AActor* Actor, FString DebugString)
+{
+	check(Actor != nullptr);
+	check(CanAcquireLock(Actor))
+	++ActorToReferenceCount.FindOrAdd(Actor);
+	UE_LOG(LogReferenceCountedLockingPolicy, Log, TEXT("Acquiring migration lock. "
+		"Actor: %s. Lock name: %s. Token %d: Locks held: %d."), *Actor->GetName(), *DebugString, NextToken, *ActorToReferenceCount.Find(Actor));
+	TokenToNameAndActor.Emplace(NextToken, LockNameAndActor{ MoveTemp(DebugString), Actor });
+	return NextToken++;
+}
+
+bool UReferenceCountedLockingPolicy::CanAcquireLock(const AActor* Actor) const
+{
+	const auto* NetDriver = Cast<USpatialNetDriver>(Actor->GetWorld()->GetNetDriver());
+	const auto EntityId = NetDriver->PackageMap->GetEntityIdFromObject(Actor);
+
+	const bool HasAuthIntent = NetDriver->VirtualWorkerTranslator->GetLocalVirtualWorkerId() ==
+			NetDriver->StaticComponentView->GetComponentData<SpatialGDK::AuthorityIntent>(EntityId)->VirtualWorkerId;
+	const bool HasAuth = NetDriver->StaticComponentView->GetAuthority(EntityId, SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID) == WORKER_AUTHORITY_AUTHORITATIVE;
+	if (!HasAuth)
+	{
+		UE_LOG(LogReferenceCountedLockingPolicy, Log, TEXT("Can not lock actor migration. Do not have authority. Actor: %s"), *Actor->GetName());
+	}
+	if (!HasAuthIntent)
+	{
+		UE_LOG(LogReferenceCountedLockingPolicy, Log, TEXT("Can not lock actor migration. Authority intent does not match this worker. Actor: %s"), *Actor->GetName());
+	}
+	return HasAuthIntent && HasAuth;
+}
+
+void UReferenceCountedLockingPolicy::ReleaseLock(ActorLockToken Token)
+{
+	const auto NameAndActor = TokenToNameAndActor.FindAndRemoveChecked(Token);
+	const AActor* Actor = NameAndActor.Actor;
+	const FString& Name = NameAndActor.LockName;
+	UE_LOG(LogReferenceCountedLockingPolicy, Log, TEXT("Releasing actor migration lock. Actor: %s. Token: %d. Lock name: %s"), *Actor->GetName(), Token, *Name);
+
+	check(ActorToReferenceCount.Contains(Actor));
+
+	{
+		// Reduce the reference count and erase the entry if reduced to 0.
+		auto CountIt = ActorToReferenceCount.CreateKeyIterator(Actor);
+		auto& Count = CountIt.Value();
+		if (Count == 1)
+		{
+			UE_LOG(LogReferenceCountedLockingPolicy, Log, TEXT("Actor migration no longer lock. Actor: %s"), *Actor->GetName(), *Name);
+			CountIt.RemoveCurrent();
+		}
+		else
+		{
+			--Count;
+		}
+	}
+}
+
+bool UReferenceCountedLockingPolicy::IsLocked(const AActor* Actor) const
+{
+	check(Actor != nullptr);
+	return ActorToReferenceCount.Contains(Actor);
+}

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/ReferenceCountedLockingPolicy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/ReferenceCountedLockingPolicy.cpp
@@ -22,18 +22,18 @@ bool UReferenceCountedLockingPolicy::CanAcquireLock(AActor* Actor) const
 		return false;
 	}
 
-	const bool HasAuthIntent = NetDriver->VirtualWorkerTranslator->GetLocalVirtualWorkerId() ==
-		NetDriver->StaticComponentView->GetComponentData<SpatialGDK::AuthorityIntent>(EntityId)->VirtualWorkerId;
-	const bool HasAuth = NetDriver->StaticComponentView->GetAuthority(EntityId, SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID) == WORKER_AUTHORITY_AUTHORITATIVE;
-	if (!HasAuth)
+	const bool bHasAuthority = NetDriver->StaticComponentView->GetAuthority(EntityId, SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID) == WORKER_AUTHORITY_AUTHORITATIVE;
+	if (!bHasAuthority)
 	{
 		UE_LOG(LogReferenceCountedLockingPolicy, Log, TEXT("Can not lock actor migration. Do not have authority. Actor: %s"), *Actor->GetName());
 	}
-	if (!HasAuthIntent)
+	const bool bHasAuthorityIntent = NetDriver->VirtualWorkerTranslator->GetLocalVirtualWorkerId() ==
+		NetDriver->StaticComponentView->GetComponentData<SpatialGDK::AuthorityIntent>(EntityId)->VirtualWorkerId;
+	if (!bHasAuthorityIntent)
 	{
 		UE_LOG(LogReferenceCountedLockingPolicy, Log, TEXT("Can not lock actor migration. Authority intent does not match this worker. Actor: %s"), *Actor->GetName());
 	}
-	return HasAuthIntent && HasAuth;
+	return bHasAuthorityIntent && bHasAuthority;
 }
 
 ActorLockToken UReferenceCountedLockingPolicy::AcquireLock(AActor* Actor, FString DebugString)

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/ReferenceCountedLockingPolicy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/ReferenceCountedLockingPolicy.cpp
@@ -78,7 +78,7 @@ void UReferenceCountedLockingPolicy::ReleaseLock(ActorLockToken Token)
 		LockingState& ActorLockingState = CountIt.Value();
 		if (ActorLockingState.LockCount == 1)
 		{
-			UE_LOG(LogReferenceCountedLockingPolicy, Log, TEXT("Actor migration no longer locked. Actor: %s"), *Actor->GetName(), *Name);
+			UE_LOG(LogReferenceCountedLockingPolicy, Log, TEXT("Actor migration no longer locked. Actor: %s"), *Actor->GetName());
 			ActorLockingState.UnbindActorDeletionDelegateFunc();
 			CountIt.RemoveCurrent();
 		}
@@ -90,8 +90,12 @@ void UReferenceCountedLockingPolicy::ReleaseLock(ActorLockToken Token)
 }
 
 bool UReferenceCountedLockingPolicy::IsLocked(const AActor* Actor) const
+{
+	if (Actor == nullptr)
 	{
-	check(Actor != nullptr);
+		UE_LOG(LogReferenceCountedLockingPolicy, Warning, TEXT("IsLocked called for nullptr"));
+		return false;
+	}
 	return ActorToLockingState.Contains(Actor);
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Schema/UnrealObjectRef.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Schema/UnrealObjectRef.cpp
@@ -3,12 +3,13 @@
 #include "Schema/UnrealObjectRef.h"
 
 #include "EngineClasses/SpatialPackageMapClient.h"
+#include "SpatialConstants.h"
 #include "Utils/SchemaUtils.h"
 
 DEFINE_LOG_CATEGORY_STATIC(LogUnrealObjectRef, Log, All);
 
-const FUnrealObjectRef FUnrealObjectRef::NULL_OBJECT_REF = FUnrealObjectRef(0, 0);
-const FUnrealObjectRef FUnrealObjectRef::UNRESOLVED_OBJECT_REF = FUnrealObjectRef(0, 1);
+const FUnrealObjectRef FUnrealObjectRef::NULL_OBJECT_REF = FUnrealObjectRef(SpatialConstants::INVALID_ENTITY_ID, 0);
+const FUnrealObjectRef FUnrealObjectRef::UNRESOLVED_OBJECT_REF = FUnrealObjectRef(SpatialConstants::INVALID_ENTITY_ID, 1);
 
 UObject* FUnrealObjectRef::ToObjectPtr(const FUnrealObjectRef& ObjectRef, USpatialPackageMapClient* PackageMap, bool& bOutUnresolved)
 {

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -10,6 +10,7 @@
 #include "Interop/SpatialSnapshotManager.h"
 #include "Utils/SpatialActorGroupManager.h"
 
+#include "LoadBalancing/AbstractLockingPolicy.h"
 #include "SpatialConstants.h"
 #include "SpatialGDKSettings.h"
 
@@ -146,6 +147,8 @@ public:
 	ASpatialDebugger* SpatialDebugger;
 	UPROPERTY()
 	UAbstractLBStrategy* LoadBalanceStrategy;
+	UPROPERTY()
+	UAbstractLockingPolicy* LockingPolicy;
 
 	TUniquePtr<SpatialActorGroupManager> ActorGroupManager;
 	TUniquePtr<SpatialLoadBalanceEnforcer> LoadBalanceEnforcer;

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLBStrategy.h
@@ -42,7 +42,7 @@ public:
 	virtual TSet<VirtualWorkerId> GetVirtualWorkerIds() const PURE_VIRTUAL(UAbstractLBStrategy::GetVirtualWorkerIds, return {};)
 
 	virtual bool ShouldRelinquishAuthority(const AActor& Actor) const { return false; }
-	virtual VirtualWorkerId WhoShouldHaveAuthority(const AActor& Actor) const PURE_VIRTUAL(UAbstractLBStrategy::WhoShouldHaveAuthority, return SpatialConstants::INVALID_VIRTUAL_WORKER_ID; )
+	virtual VirtualWorkerId WhoShouldHaveAuthority(const AActor& Actor) const PURE_VIRTUAL(UAbstractLBStrategy::WhoShouldHaveAuthority, return SpatialConstants::INVALID_VIRTUAL_WORKER_ID;)
 
 protected:
 

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLockingPolicy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLockingPolicy.h
@@ -13,6 +13,6 @@ class SPATIALGDK_API UAbstractLockingPolicy : public UObject
 
 public:
 	virtual ActorLockToken AcquireLock(AActor* Actor, FString LockName = "") PURE_VIRTUAL(UAbstractLockingPolicy::AcquireLock, return SpatialConstants::INVALID_ACTOR_LOCK_TOKEN;);
-	virtual void ReleaseLock(ActorLockToken) PURE_VIRTUAL(UAbstractLockingPolicy::ReleaseLock, return;);
+	virtual void ReleaseLock(ActorLockToken Token) PURE_VIRTUAL(UAbstractLockingPolicy::ReleaseLock, return;);
 	virtual bool IsLocked(const AActor* Actor) const PURE_VIRTUAL(UAbstractLockingPolicy::IsLocked, return false;);
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLockingPolicy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLockingPolicy.h
@@ -13,8 +13,7 @@ class SPATIALGDK_API UAbstractLockingPolicy : public UObject
 
 public:
 	virtual bool CanAcquireLock(const AActor* Actor) const PURE_VIRTUAL(UAbstractLockingPolicy::CanAcquireLock, return false;);
-	virtual bool IsLocked(const AActor* Actor) const PURE_VIRTUAL(UAbstractLockingPolicy::IsLocked, return false;);
-	virtual ActorLockToken AcquireLock(const AActor* Actor, FString LockName) PURE_VIRTUAL(UAbstractLockingPolicy::AcquireLock, return 0;);
-	virtual ActorLockToken AcquireLock(const AActor* Actor) PURE_VIRTUAL(UAbstractLockingPolicy::AcquireLock, return 0;);
+	virtual ActorLockToken AcquireLock(const AActor* Actor, FString LockName = "") PURE_VIRTUAL(UAbstractLockingPolicy::AcquireLock, return SpatialConstants::INVALID_ACTOR_LOCK_TOKEN;);
 	virtual void ReleaseLock(ActorLockToken) PURE_VIRTUAL(UAbstractLockingPolicy::ReleaseLock, return;);
+	virtual bool IsLocked(const AActor* Actor) const PURE_VIRTUAL(UAbstractLockingPolicy::IsLocked, return false;);
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLockingPolicy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLockingPolicy.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "GameFramework/Actor.h"
-
 #include "SpatialConstants.h"
+
+#include "GameFramework/Actor.h"
 
 #include "AbstractLockingPolicy.generated.h"
 
@@ -12,8 +12,7 @@ class SPATIALGDK_API UAbstractLockingPolicy : public UObject
 	GENERATED_BODY()
 
 public:
-	virtual bool CanAcquireLock(const AActor* Actor) const PURE_VIRTUAL(UAbstractLockingPolicy::CanAcquireLock, return false;);
-	virtual ActorLockToken AcquireLock(const AActor* Actor, FString LockName = "") PURE_VIRTUAL(UAbstractLockingPolicy::AcquireLock, return SpatialConstants::INVALID_ACTOR_LOCK_TOKEN;);
+	virtual ActorLockToken AcquireLock(AActor* Actor, FString LockName = "") PURE_VIRTUAL(UAbstractLockingPolicy::AcquireLock, return SpatialConstants::INVALID_ACTOR_LOCK_TOKEN;);
 	virtual void ReleaseLock(ActorLockToken) PURE_VIRTUAL(UAbstractLockingPolicy::ReleaseLock, return;);
 	virtual bool IsLocked(const AActor* Actor) const PURE_VIRTUAL(UAbstractLockingPolicy::IsLocked, return false;);
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLockingPolicy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLockingPolicy.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "GameFramework/Actor.h"
+
+#include "SpatialConstants.h"
+
+#include "AbstractLockingPolicy.generated.h"
+
+UCLASS(abstract)
+class SPATIALGDK_API UAbstractLockingPolicy : public UObject
+{
+	GENERATED_BODY()
+
+public:
+	virtual bool CanAcquireLock(const AActor* Actor) const PURE_VIRTUAL(UAbstractLockingPolicy::CanAcquireLock, return false;);
+	virtual bool IsLocked(const AActor* Actor) const PURE_VIRTUAL(UAbstractLockingPolicy::IsLocked, return false;);
+	virtual ActorLockToken AcquireLock(const AActor* Actor, FString LockName) PURE_VIRTUAL(UAbstractLockingPolicy::AcquireLock, return 0;);
+	virtual ActorLockToken AcquireLock(const AActor* Actor) PURE_VIRTUAL(UAbstractLockingPolicy::AcquireLock, return 0;);
+	virtual void ReleaseLock(ActorLockToken) PURE_VIRTUAL(UAbstractLockingPolicy::ReleaseLock, return;);
+};

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/ReferenceCountedLockingPolicy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/ReferenceCountedLockingPolicy.h
@@ -1,0 +1,40 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "Containers/Map.h"
+#include "Containers/UnrealString.h"
+#include "GameFramework/Actor.h"
+
+#include "AbstractLockingPolicy.h"
+#include "ReferenceCountedLockingPolicy.generated.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogReferenceCountedLockingPolicy, Log, All)
+
+UCLASS()
+class SPATIALGDK_API UReferenceCountedLockingPolicy : public UAbstractLockingPolicy
+{
+	GENERATED_BODY()
+
+public:
+	virtual ActorLockToken AcquireLock(const AActor* Actor) override;
+	virtual ActorLockToken AcquireLock(const AActor* Actor, FString DebugString) override;
+
+	virtual void ReleaseLock(ActorLockToken Token) override;
+
+	virtual bool IsLocked(const AActor* Actor) const override;
+
+	virtual bool CanAcquireLock(const AActor* Actor) const override;
+
+private:
+	struct LockNameAndActor
+	{
+		FString LockName;
+		const AActor* Actor;
+	};
+
+	TMap<const AActor*, int32> ActorToReferenceCount;
+	TMap<ActorLockToken, LockNameAndActor> TokenToNameAndActor;
+
+	ActorLockToken NextToken = 1;
+};

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/ReferenceCountedLockingPolicy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/ReferenceCountedLockingPolicy.h
@@ -25,10 +25,9 @@ public:
 	virtual bool IsLocked(const AActor* Actor) const override;
 
 private:
-	struct LockingState
+	struct MigrationLockElement
 	{
 		int32 LockCount;
-		
 		TFunction<void()> UnbindActorDeletionDelegateFunc;
 	};
 
@@ -43,7 +42,7 @@ private:
 
 	bool CanAcquireLock(AActor* Actor) const;
 
-	TMap<const AActor*, LockingState> ActorToLockingState;
+	TMap<const AActor*, MigrationLockElement> ActorToLockingState;
 	TMap<ActorLockToken, LockNameAndActor> TokenToNameAndActor;
 
 	ActorLockToken NextToken = 1;

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/ReferenceCountedLockingPolicy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/ReferenceCountedLockingPolicy.h
@@ -2,11 +2,11 @@
 
 #pragma once
 
+#include "AbstractLockingPolicy.h"
 #include "Containers/Map.h"
 #include "Containers/UnrealString.h"
 #include "GameFramework/Actor.h"
 
-#include "AbstractLockingPolicy.h"
 #include "ReferenceCountedLockingPolicy.generated.h"
 
 DECLARE_LOG_CATEGORY_EXTERN(LogReferenceCountedLockingPolicy, Log, All)
@@ -17,14 +17,14 @@ class SPATIALGDK_API UReferenceCountedLockingPolicy : public UAbstractLockingPol
 	GENERATED_BODY()
 
 public:
-	virtual ActorLockToken AcquireLock(const AActor* Actor) override;
-	virtual ActorLockToken AcquireLock(const AActor* Actor, FString DebugString) override;
+	virtual bool CanAcquireLock(const AActor* Actor) const override;
 
+	virtual ActorLockToken AcquireLock(const AActor* Actor, FString DebugString = "") override;
+
+	// This should only be called during the lifetime of the locked actor
 	virtual void ReleaseLock(ActorLockToken Token) override;
 
 	virtual bool IsLocked(const AActor* Actor) const override;
-
-	virtual bool CanAcquireLock(const AActor* Actor) const override;
 
 private:
 	struct LockNameAndActor

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialCommonTypes.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialCommonTypes.h
@@ -14,6 +14,7 @@ using Worker_RequestId_Key = int64;
 
 using VirtualWorkerId = uint32;
 using PhysicalWorkerName = FString;
+using ActorLockToken = int64;
 
 using WorkerAttributeSet = TArray<FString>;
 using WorkerRequirementSet = TArray<WorkerAttributeSet>;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -173,6 +173,7 @@ const Schema_FieldId PLAYER_SPAWNER_SPAWN_PLAYER_COMMAND_ID = 1;
 // AuthorityIntent codes and Field IDs.
 const Schema_FieldId AUTHORITY_INTENT_VIRTUAL_WORKER_ID					= 1;
 const VirtualWorkerId INVALID_VIRTUAL_WORKER_ID							= 0;
+const ActorLockToken INVALID_ACTOR_LOCK_TOKEN							= 0;
 
 // VirtualWorkerTranslation Field IDs.
 const Schema_FieldId VIRTUAL_WORKER_TRANSLATION_MAPPING_ID				= 1;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -172,8 +172,6 @@ const Schema_FieldId PLAYER_SPAWNER_SPAWN_PLAYER_COMMAND_ID = 1;
 
 // AuthorityIntent codes and Field IDs.
 const Schema_FieldId AUTHORITY_INTENT_VIRTUAL_WORKER_ID					= 1;
-const VirtualWorkerId INVALID_VIRTUAL_WORKER_ID							= 0;
-const ActorLockToken INVALID_ACTOR_LOCK_TOKEN							= 0;
 
 // VirtualWorkerTranslation Field IDs.
 const Schema_FieldId VIRTUAL_WORKER_TRANSLATION_MAPPING_ID				= 1;
@@ -191,6 +189,9 @@ const float FIRST_COMMAND_RETRY_WAIT_SECONDS = 0.2f;
 const uint32 MAX_NUMBER_COMMAND_ATTEMPTS = 5u;
 
 const FName DefaultActorGroup = FName(TEXT("Default"));
+
+const VirtualWorkerId INVALID_VIRTUAL_WORKER_ID = 0;
+const ActorLockToken INVALID_ACTOR_LOCK_TOKEN = 0;
 
 const WorkerAttributeSet UnrealServerAttributeSet = TArray<FString>{DefaultServerWorkerType.ToString()};
 const WorkerAttributeSet UnrealClientAttributeSet = TArray<FString>{DefaultClientWorkerType.ToString()};

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -6,7 +6,8 @@
 #include "Engine/EngineTypes.h"
 #include "Misc/Paths.h"
 #include "Utils/SpatialActorGroupManager.h"
-#include "Utils/SpatialDebugger.h"
+#include "LoadBalancing/AbstractLBStrategy.h"
+#include "LoadBalancing/AbstractLockingPolicy.h"
 
 #include "SpatialGDKSettings.generated.h"
 
@@ -212,7 +213,10 @@ public:
 	FWorkerType LoadBalancingWorkerType;
 
 	UPROPERTY(EditAnywhere, Config, Category = "Load Balancing", meta = (EditCondition = "bEnableUnrealLoadBalancer"))
-	TSubclassOf<class UAbstractLBStrategy> LoadBalanceStrategy;
+	TSubclassOf<UAbstractLBStrategy> LoadBalanceStrategy;
+
+	UPROPERTY(EditAnywhere, Config, Category = "Load Balancing", meta = (EditCondition = "bEnableUnrealLoadBalancer"))
+	TSubclassOf<UAbstractLockingPolicy> LockingPolicy;
 
 	UPROPERTY(EditAnywhere, Config, Category = "Replication", meta = (DisplayName = "Use RPC Ring Buffers"))
 	bool bUseRPCRingBuffers;

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/GridBasedLBStrategyTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/GridBasedLBStrategyTest.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
 #include "CoreMinimal.h"
+#include "Engine/Engine.h"
 #include "Engine/World.h"
 #include "LoadBalancing/GridBasedLBStrategy.h"
 #include "GameFramework/DefaultPawn.h"
@@ -17,10 +18,10 @@
 // Test Globals
 namespace
 {
-	UWorld* TestWorld;
-	TMap<FName, AActor*> TestActors;
-	UGridBasedLBStrategy* Strat;
-}
+
+UWorld* TestWorld;
+TMap<FName, AActor*> TestActors;
+UGridBasedLBStrategy* Strat;
 
 // Copied from AutomationCommon::GetAnyGameWorld()
 UWorld* GetAnyGameWorld()
@@ -201,6 +202,8 @@ GRIDBASEDLBSTRATEGY_TEST(GIVEN_grid_is_not_ready_WHEN_local_virtual_worker_id_is
 
 	return true;
 }
+
+}  // anonymous namespace
 
 GRIDBASEDLBSTRATEGY_TEST(GIVEN_a_single_cell_and_valid_local_id_WHEN_should_relinquish_called_THEN_returns_false)
 {

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/ReferenceCountedLockingPolicy/ReferenceCountedLockingPolicyTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/ReferenceCountedLockingPolicy/ReferenceCountedLockingPolicyTest.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
 #include "LoadBalancing/ReferenceCountedLockingPolicy.h"
 #include "TestDefinitions.h"
 

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/ReferenceCountedLockingPolicy/ReferenceCountedLockingPolicyTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/ReferenceCountedLockingPolicy/ReferenceCountedLockingPolicyTest.cpp
@@ -1,10 +1,10 @@
+#include "LoadBalancing/ReferenceCountedLockingPolicy.h"
 #include "TestDefinitions.h"
+
 #include "Engine/Engine.h"
 #include "GameFramework/GameStateBase.h"
-#include "Tests/AutomationCommon.h"
 #include "GameFramework/DefaultPawn.h"
-
-#include "LoadBalancing/ReferenceCountedLockingPolicy.h"
+#include "Tests/AutomationCommon.h"
 
 #define REFERENCECOUNTEDLOCKINGPOLICY_TEST(TestName) \
 	GDK_TEST(Core, UReferenceCountedLockingPolicy, TestName)

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/ReferenceCountedLockingPolicy/ReferenceCountedLockingPolicyTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/ReferenceCountedLockingPolicy/ReferenceCountedLockingPolicyTest.cpp
@@ -1,0 +1,117 @@
+#include "TestDefinitions.h"
+#include "Engine/Engine.h"
+#include "GameFramework/GameStateBase.h"
+#include "Tests/AutomationCommon.h"
+#include "GameFramework/DefaultPawn.h"
+
+#include "LoadBalancing/ReferenceCountedLockingPolicy.h"
+
+#define REFERENCECOUNTEDLOCKINGPOLICY_TEST(TestName) \
+	GDK_TEST(Core, UReferenceCountedLockingPolicy, TestName)
+
+namespace
+{
+
+struct TestData
+{
+	UWorld* TestWorld;
+	TMap<FName, AActor*> TestActors;
+	UReferenceCountedLockingPolicy* LockingPolicy;
+};
+
+struct TestDataDeleter
+{
+	void operator()(TestData* Data) const noexcept
+	{
+		Data->LockingPolicy->RemoveFromRoot();
+		delete Data;
+	}
+};
+
+TSharedPtr<TestData> MakeNewTestData()
+{
+	TSharedPtr<TestData> Data(new TestData, TestDataDeleter());
+	Data->LockingPolicy = NewObject<UReferenceCountedLockingPolicy>();
+	Data->LockingPolicy->AddToRoot();
+	return Data;
+}
+
+// Copied from AutomationCommon::GetAnyGameWorld()
+UWorld* GetAnyGameWorld()
+{
+	UWorld* World = nullptr;
+	const TIndirectArray<FWorldContext>& WorldContexts = GEngine->GetWorldContexts();
+	for (const FWorldContext& Context : WorldContexts)
+	{
+		if ((Context.WorldType == EWorldType::PIE || Context.WorldType == EWorldType::Game)
+			&& (Context.World() != nullptr))
+		{
+			World = Context.World();
+			break;
+		}
+	}
+
+	return World;
+}
+
+DEFINE_LATENT_AUTOMATION_COMMAND_ONE_PARAMETER(FWaitForWorld, TSharedPtr<TestData>, Data);
+bool FWaitForWorld::Update()
+{
+	Data->TestWorld = GetAnyGameWorld();
+
+	if (Data->TestWorld && Data->TestWorld->AreActorsInitialized())
+	{
+		AGameStateBase* GameState = Data->TestWorld->GetGameState();
+		if (GameState && GameState->HasMatchStarted())
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+DEFINE_LATENT_AUTOMATION_COMMAND_TWO_PARAMETER(FSpawnActor, TSharedPtr<TestData>, Data, FName, Handle);
+bool FSpawnActor::Update()
+{
+	FActorSpawnParameters SpawnParams;
+	SpawnParams.bNoFail = true;
+	SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+
+	AActor* Actor = Data->TestWorld->SpawnActor<ADefaultPawn>(SpawnParams);
+	Data->TestActors.Add(Handle, Actor);
+
+	return true;
+}
+
+DEFINE_LATENT_AUTOMATION_COMMAND_TWO_PARAMETER(FWaitForActor, TSharedPtr<TestData>, Data, FName, Handle);
+bool FWaitForActor::Update()
+{
+	AActor* Actor = Data->TestActors[Handle];
+	return (IsValid(Actor) && Actor->IsActorInitialized() && Actor->HasActorBegunPlay());
+}
+
+DEFINE_LATENT_AUTOMATION_COMMAND_FOUR_PARAMETER(FTestIsLocked, FAutomationTestBase*, Test, TSharedPtr<TestData>, Data, FName, Handle, bool, bExpected);
+bool FTestIsLocked::Update()
+{
+	AActor* Actor = Data->TestActors[Handle];
+	const bool bIsLocked = Data->LockingPolicy->IsLocked(Actor);
+	Test->TestEqual(FString::Printf(TEXT("Is locked. Actual: %d. Expected: %d"), bIsLocked, bExpected), bIsLocked, bExpected);
+	return true;
+}
+
+}  // anonymous namespace
+
+
+REFERENCECOUNTEDLOCKINGPOLICY_TEST(GIVEN_an_actor_has_not_been_locked_WHEN_IsLocked_is_called_THEN_returns_false)
+{
+	AutomationOpenMap("/Engine/Maps/Entry");
+
+	TSharedPtr<TestData> Data = MakeNewTestData();
+	ADD_LATENT_AUTOMATION_COMMAND(FWaitForWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FSpawnActor(Data, "Actor"));
+	ADD_LATENT_AUTOMATION_COMMAND(FWaitForActor(Data, "Actor"));
+	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", false));
+
+	return true;
+}


### PR DESCRIPTION
Review in COMMIT ORDER for MAXIMUM CLARITY

#### Description
##### Core Implementation
This is in `AbstractLockingPolicy` and `ReferenceCountedLockingPolicy` and is ready for review. The relationship between these two classes is very similar to the relationship between the abstract and grid-based LB strategies. They are set in the same settings location and instantiated in the same net driver code. The `SpatialActorChannel` conditional for changing auth intent now also checks that an actor is not locked before sending an update.

##### SpatialLockingComponent
Currently, actors are made lockable through manually adding a new ActorComponent `SpatialLockingComponent` which effectively exposes the LockingPolicy for that actor. This was the fastest path to having a working test gym, as well as having a way to replicate the locking state to the client for the SpatialDebugger to visualise. Reasons against this in the long term are: 1) gives us more to maintain 2) gives blueprint accessibility to a sharp tool that could be misused. We considered moving the actor component to purely exist in the gym but then the spatial debugger wouldn't have any way to access the lock state. Changing the way the spatial debugger works is something I'd advocate, and have ideas about, and am following up with Chris. Regardless, the usefulness of having this actor component vs. not exposing something so powerful straight to blueprint is a separate discussion that can be had.

##### Acceptance Criteria
- Gameplay code can lock an actor and even if that actor would switch authority based on the LBStrategy, it will remain authoritative on the original server.
- Example in the test gym where an actor starts on server A, is locked in C++ code on server A, then moves to server B and remains authoritative on server A then...
- ... the lock is released and it DOES switch authority to server B.
- ... moves back to server A, then the lock is released and it DOES NOT switch authority to server B.
- Similar examples as above for locking used from a blueprint.
- Unit tests for locking code to test multiple locks on the same actor being locked and released in different orders without causing deadlock.
- Debugging log messages in code to expose which locks are currently held on an actor.
- Draft documentation examples for using the locking API to lock both within C++ code and blueprint code.

#### Release note
WIP, will probably be taken from docs draft.

#### Tests
##### How did you test these changes prior to submitting this pull request?
Functionality add to handover gym in [this PR](https://github.com/spatialos/UnrealGDKTestGyms/pull/13). 

##### What automated tests are included in this PR?
Unit tests are blocked on fixing the authority model with migration.
There is one unit test, and the the framework to make the others.

##### How can this be verified by QA?
Open the Handover Gym using [this branch](https://github.com/spatialos/UnrealGDKTestGyms/pull/13) of the UnrealGDKTestGyms repo, and press L to toggle the lock state of all actors in the scene. The AC steps can then be followed.

#### Documentation
Draft documentation is [here](https://docs.google.com/document/d/1RPltp7EeNTHzyj0xMGe-2AQ7rUtUtnyJLljV1PIIm_0/edit?usp=sharing)

#### Reviewers
