### PR TITLE
Don't initialize worker translator if load balancer disabled

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -314,7 +314,10 @@ void USpatialNetDriver::CreateAndInitializeCoreClasses()
 	StaticComponentView = NewObject<USpatialStaticComponentView>();
 	SnapshotManager = NewObject<USnapshotManager>();
 	SpatialMetrics = NewObject<USpatialMetrics>();
-	VirtualWorkerTranslator = MakeUnique<SpatialVirtualWorkerTranslator>();
+	if (GetDefault<USpatialGDKSettings>()->bEnableUnrealLoadBalancer)
+	{
+		VirtualWorkerTranslator = MakeUnique<SpatialVirtualWorkerTranslator>();
+	}
 
 #if !UE_BUILD_SHIPPING
 	// If metrics display is enabled, spawn a singleton actor to replicate the information to each client
@@ -328,10 +331,13 @@ void USpatialNetDriver::CreateAndInitializeCoreClasses()
 	Sender->Init(this, &TimerManager);
 	Receiver->Init(this, &TimerManager);
 	GlobalStateManager->Init(this, &TimerManager);
-	VirtualWorkerTranslator->Init(this);
-	// TODO(zoning): This currently hard codes the desired number of virtual workers. This should be retrieved
-	// from the configuration.
-	VirtualWorkerTranslator->SetDesiredVirtualWorkerCount(2);
+	if (GetDefault<USpatialGDKSettings>()->bEnableUnrealLoadBalancer)
+	{
+		VirtualWorkerTranslator->Init(this);
+		// TODO(zoning): This currently hard codes the desired number of virtual workers. This should be retrieved
+		// from the configuration.
+		VirtualWorkerTranslator->SetDesiredVirtualWorkerCount(2);
+	}
 	SnapshotManager->Init(this);
 	PlayerSpawner->Init(this, &TimerManager);
 	SpatialMetrics->Init(this);

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslator.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslator.cpp
@@ -20,7 +20,7 @@ void SpatialVirtualWorkerTranslator::Init(USpatialNetDriver* InNetDriver)
 {
 	NetDriver = InNetDriver;
 	// If this is being run from tests, NetDriver will be null.
-	WorkerId = (NetDriver != nullptr) ? NetDriver->Connection->GetWorkerId() : "InvalidWorkerId";
+	WorkerId = (NetDriver != nullptr && NetDriver->Connection != nullptr) ? NetDriver->Connection->GetWorkerId() : "InvalidWorkerId";
 }
 
 void SpatialVirtualWorkerTranslator::SetDesiredVirtualWorkerCount(uint32 NumberOfVirtualWorkers)

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -40,6 +40,7 @@ USpatialGDKSettings::USpatialGDKSettings(const FObjectInitializer& ObjectInitial
 	, bEnableOffloading(false)
 	, ServerWorkerTypes({ SpatialConstants::DefaultServerWorkerType })
 	, WorkerLogLevel(ESettingsWorkerLogVerbosity::Warning)
+	, bEnableUnrealLoadBalancer(false)
 {
 	DefaultReceptionistHost = SpatialConstants::LOCAL_HOST;
 }


### PR DESCRIPTION
#### Description
Don't initialize worker translator if load balancer disabled.

This PR is just for the 0.8.0-rc, and a related fix has already gone into master, however as the fix was wrapped in a larger refactor, I've just re-implemented the required bits. This will cause a conflict when we merge back into master.

#### Primary reviewers
@MatthewSandfordImprobable @oblm 