### PR TITLE
Bugfix/unr 2607 SpatialDebugger crashfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - The command line argument "receptionistHost <URL>" will now not override connections to "127.0.0.1".
 - The receptionist will now be used for appropriate URLs after connecting to a locator URL.
 - You can now access the worker flags via `USpatialStatics::GetWorkerFlag` instead of `USpatialWorkerFlags::GetWorkerFlag`.
+- Fix crash in SpatialDebugger when GDK-space load balancing is disabled.
 
 ## [`0.8.0-preview`] - 2019-12-17
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
@@ -352,7 +352,7 @@ FColor ASpatialDebugger::GetVirtualWorkerColor(const Worker_EntityId EntityId) c
 	const PhysicalWorkerName* PhysicalWorkerName = nullptr;
 	if (NetDriver->VirtualWorkerTranslator)
 	{
-		NetDriver->VirtualWorkerTranslator->GetPhysicalWorkerForVirtualWorker(VirtualWorkerId);
+		PhysicalWorkerName = NetDriver->VirtualWorkerTranslator->GetPhysicalWorkerForVirtualWorker(VirtualWorkerId);
 	}
 
 	if (PhysicalWorkerName == nullptr)

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
@@ -348,8 +348,15 @@ FColor ASpatialDebugger::GetVirtualWorkerColor(const Worker_EntityId EntityId) c
 	}
 	const AuthorityIntent* AuthorityIntentComponent = NetDriver->StaticComponentView->GetComponentData<AuthorityIntent>(EntityId);
 	const int32 VirtualWorkerId = AuthorityIntentComponent->VirtualWorkerId;
-	const PhysicalWorkerName* PhysicalWorkerName = NetDriver->VirtualWorkerTranslator->GetPhysicalWorkerForVirtualWorker(VirtualWorkerId);
-	if (PhysicalWorkerName == nullptr) {
+
+	const PhysicalWorkerName* PhysicalWorkerName = nullptr;
+	if (NetDriver->VirtualWorkerTranslator)
+	{
+		NetDriver->VirtualWorkerTranslator->GetPhysicalWorkerForVirtualWorker(VirtualWorkerId);
+	}
+
+	if (PhysicalWorkerName == nullptr)
+	{
 		// This can happen if the client hasn't yet received the VirtualWorkerTranslator mapping
 		return InvalidServerTintColor;
 	}


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Fix SpatialDebugger crash fetching virtual worker color with GDK-space load balancing disabled.

#### Release note
CHANGELOG.md updated.

#### Tests
Verified when using PIE with GDK-space load balancing disabled and SpatialDebugger enabled, it no longer crashes.

STRONGLY SUGGESTED: How can this be verified by QA?
As described under Tests above.

#### Documentation
release note

#### Primary reviewers
@alastairdglennie 