### PR TITLE
Added CN Locator endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Features listed in the internal section are not ready to use but, in the spirit of open development, we detail every change we make to the GDK.
 - The GDK is now compatible with the `CN` launch region. When Improbable's online services are fully working in China, they will work with this version of the GDK. You will be able to create SpatialOS Deployments in China by specifying the `CN` region in the Deployment Launcher.
 - `Setup.bat` and `Setup.sh` both accept the `--china` flag, which will be required in order to run SpatialOS CLI commands in the `CN` region.
-- **SpatialOS GDK for Unreal** > **Editor Settings** now contains a **Region Settings** section. You will be required to set **Region where services are located** to `CN` in order to create SpatialOS Deployments in China.
+- **SpatialOS GDK for Unreal** > **Runtime Settings** now contains a **Region Settings** section. You will be required to set **Region where services are located** to `CN` in order to create SpatialOS Deployments in China.
 
 ## [`0.6.2`] - 2019-10-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased-`x.y.z`] - 2019-xx-xx
 
+## [`0.6.5`] - 2020-01-13
+### Internal:
+Features listed in the internal section are not ready to use but, in the spirit of open development, we detail every change we make to the GDK.
+- **SpatialOS GDK for Unreal** > **Editor Settings** > **Region Settings** has been moved to **SpatialOS GDK for Unreal** > **Runtime Settings** > **Region Settings**.
+- Local deployments can now be launched in China, when the **Region where services are located** is set to `CN`.
+
 ## [`0.6.4`] - 2019-12-13
 ### Bug fixes: 
 - The Inspector button in the SpatialOS GDK for Unreal toolbar now opens the correct URL.
@@ -18,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Features listed in the internal section are not ready to use but, in the spirit of open development, we detail every change we make to the GDK.
 - The GDK is now compatible with the `CN` launch region. When Improbable's online services are fully working in China, they will work with this version of the GDK. You will be able to create SpatialOS Deployments in China by specifying the `CN` region in the Deployment Launcher.
 - `Setup.bat` and `Setup.sh` both accept the `--china` flag, which will be required in order to run SpatialOS CLI commands in the `CN` region.
-- **SpatialOS GDK for Unreal** > **Runtime Settings** now contains a **Region Settings** section. You will be required to set **Region where services are located** to `CN` in order to create SpatialOS Deployments in China.
+- **SpatialOS GDK for Unreal** > **Editor Settings** now contains a **Region Settings** section. You will be required to set **Region where services are located** to `CN` in order to create SpatialOS Deployments in China.
 
 ## [`0.6.2`] - 2019-10-10
 

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -36,6 +36,7 @@ USpatialGDKSettings::USpatialGDKSettings(const FObjectInitializer& ObjectInitial
 	, bEnableServerQBI(bUsingQBI)
 	, bPackRPCs(true)
 	, bUseDevelopmentAuthenticationFlow(false)
+	, ServicesRegion(EServicesRegion::Default)
 	, DefaultWorkerType(FWorkerType(SpatialConstants::DefaultServerWorkerType))
 	, bEnableOffloading(false)
 	, ServerWorkerTypes({ SpatialConstants::DefaultServerWorkerType })

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
@@ -94,10 +94,16 @@ struct FReceptionistConfig : public FConnectionConfig
 
 struct FLocatorConfig : public FConnectionConfig
 {
-	FLocatorConfig()
-		: LocatorHost(SpatialConstants::LOCATOR_HOST) {
+	FLocatorConfig() {
 		const TCHAR* CommandLine = FCommandLine::Get();
-		FParse::Value(CommandLine, TEXT("locatorHost"), LocatorHost);
+		if (!FParse::Value(CommandLine, TEXT("locatorHost"), LocatorHost)) {
+			if (GetDefault<USpatialGDKSettings>()->IsRunningInChina()) {
+				LocatorHost = SpatialConstants::LOCATOR_HOST_CN;
+			}
+			else {
+				LocatorHost = SpatialConstants::LOCATOR_HOST;
+			}
+		}
 		FParse::Value(CommandLine, TEXT("playerIdentityToken"), PlayerIdentityToken);
 		FParse::Value(CommandLine, TEXT("loginToken"), LoginToken);
 	}

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
@@ -94,10 +94,13 @@ struct FReceptionistConfig : public FConnectionConfig
 
 struct FLocatorConfig : public FConnectionConfig
 {
-	FLocatorConfig() {
+	FLocatorConfig()
+	{
 		const TCHAR* CommandLine = FCommandLine::Get();
-		if (!FParse::Value(CommandLine, TEXT("locatorHost"), LocatorHost)) {
-			if (GetDefault<USpatialGDKSettings>()->IsRunningInChina()) {
+		if (!FParse::Value(CommandLine, TEXT("locatorHost"), LocatorHost))
+		{
+			if (GetDefault<USpatialGDKSettings>()->IsRunningInChina())
+			{
 				LocatorHost = SpatialConstants::LOCATOR_HOST_CN;
 			}
 			else {

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -199,6 +199,7 @@ namespace SpatialConstants
 	const FString SPATIALOS_METRICS_DYNAMIC_FPS = TEXT("Dynamic.FPS");
 
 	const FString LOCATOR_HOST = TEXT("locator.improbable.io");
+	const FString LOCATOR_HOST_CN = TEXT("locator.spatialoschina.com");
 	const uint16 LOCATOR_PORT = 443;
 
 	const FString DEVELOPMENT_AUTH_PLAYER_ID = TEXT("Player Id");

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -9,6 +9,16 @@
 
 #include "SpatialGDKSettings.generated.h"
 
+UENUM()
+namespace EServicesRegion
+{
+	enum Type
+	{
+		Default,
+		CN
+	};
+}
+
 UCLASS(config = SpatialGDKSettings, defaultconfig)
 class SPATIALGDK_API USpatialGDKSettings : public UObject
 {
@@ -160,6 +170,9 @@ public:
 	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection", meta = (ConfigRestartRequired = false))
 	FString DevelopmentDeploymentToConnect;
 
+	UPROPERTY(EditAnywhere, Config, Category = "Region settings", meta = (ConfigRestartRequired = true, DisplayName = "Region where services are located"))
+	TEnumAsByte<EServicesRegion::Type> ServicesRegion;
+
 	/** Single server worker type to launch when offloading is disabled, fallback server worker type when offloading is enabled (owns all actor classes by default). */
 	UPROPERTY(EditAnywhere, Config, Category = "Offloading")
 	FWorkerType DefaultWorkerType;
@@ -175,4 +188,6 @@ public:
 	/** Available server worker types. */
 	UPROPERTY(Config)
 	TSet<FName> ServerWorkerTypes;
+
+	FORCEINLINE bool IsRunningInChina() const { return ServicesRegion == EServicesRegion::CN; }
 };

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -26,7 +26,6 @@ USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& O
 	, PrimaryDeploymentRegionCode(ERegionCode::US)
 	, SimulatedPlayerLaunchConfigPath(FSpatialGDKServicesModule::GetSpatialGDKPluginDirectory(TEXT("SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/SpatialConfig/cloud_launch_sim_player_deployment.json")))
 	, SimulatedPlayerDeploymentRegionCode(ERegionCode::US)
-	, ServicesRegion(EServicesRegion::Default)
 {
 	SpatialOSLaunchConfig.FilePath = GetSpatialOSLaunchConfig();
 	SpatialOSSnapshotFile = GetSpatialOSSnapshotFile();

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -211,16 +211,6 @@ namespace ERegionCode
 	};
 }
 
-UENUM()
-namespace EServicesRegion
-{
-	enum Type
-	{
-		Default,
-		CN
-	};
-}
-
 UCLASS(config = SpatialGDKEditorSettings, defaultconfig)
 class SPATIALGDKEDITOR_API USpatialGDKEditorSettings : public UObject
 {
@@ -308,9 +298,6 @@ private:
 
 	UPROPERTY(EditAnywhere, config, Category = "Simulated Players", meta = (EditCondition = "bSimulatedPlayersIsEnabled", ConfigRestartRequired = false, DisplayName = "Number of simulated players"))
 		uint32 NumberOfSimulatedPlayers;
-
-	UPROPERTY(EditAnywhere, Config, Category = "Region settings", meta = (ConfigRestartRequired = true, DisplayName = "Region where services are located"))
-	TEnumAsByte<EServicesRegion::Type> ServicesRegion;
 
 	static bool IsAssemblyNameValid(const FString& Name);
 	static bool IsProjectNameValid(const FString& Name);
@@ -466,6 +453,4 @@ public:
 	}
 
 	bool IsDeploymentConfigurationValid() const;
-
-	FORCEINLINE bool IsRunningInChina() const { return ServicesRegion == EServicesRegion::CN; }
 };

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -73,7 +73,7 @@ void FSpatialGDKEditorToolbarModule::StartupModule()
 	FSpatialGDKServicesModule& GDKServices = FModuleManager::GetModuleChecked<FSpatialGDKServicesModule>("SpatialGDKServices");
 	LocalDeploymentManager = GDKServices.GetLocalDeploymentManager();
 	LocalDeploymentManager->SetAutoDeploy(GetDefault<USpatialGDKEditorSettings>()->bAutoStartLocalDeployment);
-	LocalDeploymentManager->SetInChina(GetDefault<USpatialGDKEditorSettings>()->IsRunningInChina());
+	LocalDeploymentManager->SetInChina(GetDefault<USpatialGDKSettings>()->IsRunningInChina());
 
 	// Bind the play button delegate to starting a local spatial deployment.
 	if (!UEditorEngine::TryStartSpatialDeployment.IsBound() && GetDefault<USpatialGDKEditorSettings>()->bAutoStartLocalDeployment)


### PR DESCRIPTION
- Added CN locator endpoint
- Moved ServerRegion from SpatialGDKEditorSettings to SpatialGDKSettings

**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Locator endpoints can now follow the Server Region setting.

#### Release note
Updated.

#### Tests
Change the Region Settings in SpatialOS GDK for Unreal > Runtime Settings to CN and see if it connects to the CN environment.

#### Documentation
N/A