### PR TITLE
Bugfix/unr 2704 auth limbo

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -1194,18 +1194,20 @@ void USpatialActorChannel::UpdateEntityACLToNewOwner()
 	}
 }
 
-bool USpatialActorChannel::shouldChangeAuthorityIntent()
+bool USpatialActorChannel::ShouldChangeAuthorityIntent() const
 {
 	// The authority intent should be changed by this worker if the following conditions are satisfied:
 	//  - This worker has authority over the authority intent component
+	//  - The actor is not locked
 	//  - The authority intent should be changed, this could be because either:
 	//    - The actor no longer should be delegated to the virtual worker it currently is according to the load balancing strategy
 	//    - The actor is not delegated to a virtual worker
-	//  - The actor is not locked
+	bool bAuthorityIntentNeedsUpdating = NetDriver->LoadBalanceStrategy->ShouldRelinquishAuthority(*Actor) ||
+		NetDriver->StaticComponentView->GetComponentData<AuthorityIntent>(EntityId)->VirtualWorkerId == SpatialConstants::INVALID_VIRTUAL_WORKER_ID;
+
 	return NetDriver->StaticComponentView->HasAuthority(EntityId, SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID) &&
-		(NetDriver->LoadBalanceStrategy->ShouldRelinquishAuthority(*Actor) ||
-			NetDriver->StaticComponentView->GetComponentData<AuthorityIntent>(EntityId)->VirtualWorkerId == SpatialConstants::INVALID_VIRTUAL_WORKER_ID) &&
-		!NetDriver->LockingPolicy->IsLocked(Actor);
+		!NetDriver->LockingPolicy->IsLocked(Actor) &&
+		bAuthorityIntentNeedsUpdating;
 }
 
 void USpatialActorChannel::ClientProcessOwnershipChange(bool bNewNetOwned)

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -1196,7 +1196,7 @@ void USpatialActorChannel::UpdateEntityACLToNewOwner()
 
 bool USpatialActorChannel::shouldChangeAuthorityIntent()
 {
-	// The authority intent should be changed from this worker if the following conditions are satisfied:
+	// The authority intent should be changed by this worker if the following conditions are satisfied:
 	//  - This worker has authority over the authority intent component
 	//  - The authority intent should be changed, this could be because either:
 	//    - The actor no longer should be delegated to the virtual worker it currently is according to the load balancing strategy

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -1197,16 +1197,16 @@ void USpatialActorChannel::UpdateEntityACLToNewOwner()
 bool USpatialActorChannel::ShouldChangeAuthorityIntent() const
 {
 	// The authority intent should be changed by this worker if the following conditions are satisfied:
-	//  - This worker has authority over the authority intent component
 	//  - The authority intent should be changed, this could be because either:
 	//    - The actor no longer should be delegated to the virtual worker it currently is according to the load balancing strategy
 	//    - The actor is not delegated to a virtual worker
+	//  - This worker has authority over the authority intent component
 	//  - The actor is not locked (This check is cheap but we expect actors to rarely be locked so check it last)
 	bool bAuthorityIntentNeedsUpdating = NetDriver->LoadBalanceStrategy->ShouldRelinquishAuthority(*Actor) ||
 		NetDriver->StaticComponentView->GetComponentData<AuthorityIntent>(EntityId)->VirtualWorkerId == SpatialConstants::INVALID_VIRTUAL_WORKER_ID;
 
-	return NetDriver->StaticComponentView->HasAuthority(EntityId, SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID) &&
-		bAuthorityIntentNeedsUpdating &&
+	return bAuthorityIntentNeedsUpdating &&
+		NetDriver->StaticComponentView->HasAuthority(EntityId, SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID) &&
 		!NetDriver->LockingPolicy->IsLocked(Actor);
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -568,7 +568,7 @@ int64 USpatialActorChannel::ReplicateActor()
 	if (SpatialGDKSettings->bEnableUnrealLoadBalancer &&
 		// TODO: the 'bWroteSomethingImportant' check causes problems for actors that need to transition in groups (ex. Character, PlayerController, PlayerState),
 		// so disabling it for now.  Figure out a way to deal with this to recover the perf lost by calling ShouldChangeAuthority() frequently. [UNR-2387]
-		shouldChangeAuthorityIntent())
+		ShouldChangeAuthorityIntent())
 	{
 		const VirtualWorkerId NewAuthVirtualWorkerId = NetDriver->LoadBalanceStrategy->WhoShouldHaveAuthority(*Actor);
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -1198,16 +1198,16 @@ bool USpatialActorChannel::ShouldChangeAuthorityIntent() const
 {
 	// The authority intent should be changed by this worker if the following conditions are satisfied:
 	//  - This worker has authority over the authority intent component
-	//  - The actor is not locked
 	//  - The authority intent should be changed, this could be because either:
 	//    - The actor no longer should be delegated to the virtual worker it currently is according to the load balancing strategy
 	//    - The actor is not delegated to a virtual worker
+	//  - The actor is not locked (This check is cheap but we expect actors to rarely be locked so check it last)
 	bool bAuthorityIntentNeedsUpdating = NetDriver->LoadBalanceStrategy->ShouldRelinquishAuthority(*Actor) ||
 		NetDriver->StaticComponentView->GetComponentData<AuthorityIntent>(EntityId)->VirtualWorkerId == SpatialConstants::INVALID_VIRTUAL_WORKER_ID;
 
 	return NetDriver->StaticComponentView->HasAuthority(EntityId, SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID) &&
-		!NetDriver->LockingPolicy->IsLocked(Actor) &&
-		bAuthorityIntentNeedsUpdating;
+		bAuthorityIntentNeedsUpdating &&
+		!NetDriver->LockingPolicy->IsLocked(Actor);
 }
 
 void USpatialActorChannel::ClientProcessOwnershipChange(bool bNewNetOwned)

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -179,6 +179,8 @@ private:
 	
 	void UpdateEntityACLToNewOwner();
 
+	bool shouldChangeAuthorityIntent();
+
 public:
 	// If this actor channel is responsible for creating a new entity, this will be set to true once the entity creation request is issued.
 	bool bCreatedEntity;

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -179,7 +179,7 @@ private:
 	
 	void UpdateEntityACLToNewOwner();
 
-	bool shouldChangeAuthorityIntent();
+	bool ShouldChangeAuthorityIntent() const;
 
 public:
 	// If this actor channel is responsible for creating a new entity, this will be set to true once the entity creation request is issued.


### PR DESCRIPTION
#### Description
During tests with a single unreal worker using the unreal loadbalancer, any entities created before the virtual->physical worker mappings were known would be set to an invalid virtual worker ID and remain that way as the authority of the component could not be relinquished. This resulted in a lot of warnings. 

This PR makes it such that any authority intent which specifies an invalid virtual worker ID is marked as "should change" in order to refresh until the worker mapping is available.

#### Release note
(Does this require a release note?)

#### Tests
The same test, with verbose logging, showing that even though entities were spawning with the incorrect authority intents at first were then updated to be set to the correct virtual worker.

#### Documentation
There's a comment about why actors would need to have their authority changed