### PR TITLE
Fix worker region collision

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
@@ -185,6 +185,7 @@ void ASpatialDebugger::OnRep_SetWorkerRegions()
 		{
 			AWorkerRegion* WorkerRegion = GetWorld()->SpawnActor<AWorkerRegion>(SpawnParams);
 			WorkerRegion->Init(WorkerRegionMaterial, WorkerRegionData.Color, WorkerRegionData.Extents);
+			WorkerRegion->SetActorEnableCollision(false);
 		}
 	}
 }


### PR DESCRIPTION
### Description
Worker region Actors collide with some actors it seems, discovered in GASTest where the player can stand on top of the worker region:

![image](https://user-images.githubusercontent.com/9222722/72539869-e9067680-3877-11ea-9b34-ae4a6d1920af.png)

One line fix adding `WorkerRegion->SetActorEnableCollision(false)` to the spawning logic:

![image](https://user-images.githubusercontent.com/9222722/72539790-cbd1a800-3877-11ea-9b48-66ec9a2a9453.png)