### PR TITLE
UNR-2571: enable command line parsing in shipping

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -63,6 +63,10 @@ void USpatialGDKSettings::PostInitProperties()
 {
 	Super::PostInitProperties();
 
+#if !ALLOW_SPATIAL_CMDLINE_PARSING
+	return;
+#endif
+
 	// Check any command line overrides for using QBI, Offloading (after reading the config value):
 	const TCHAR* CommandLine = FCommandLine::Get();
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
This PR is required to enable the toggling of the 'OverideSpatialNetworking` flag from the command line within your build config.

Related 4.22 engine PR: https://github.com/improbableio/UnrealEngine/pull/329

#### Release note
REQUIRED: Add a release note to the `##Unreleased` section of CHANGELOG.md. You can find guidance for writing useful release notes [here](../SpatialGDK/Extras/internal-documentation/how-to-write-good-release-notes.md). Documentation changes are exempt from this requirement.

#### Tests
How did you test these changes prior to submitting this pull request?
What automated tests are included in this PR?

STRONGLY SUGGESTED: How can this be verified by QA?

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

#### Primary reviewers
@TeriDrummond @m-samiec 