### PR TITLE
[UNR-2275] Assert called when an actor channel is cleaned up multiple times

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -2072,6 +2072,7 @@ void USpatialNetDriver::RemoveActorChannel(Worker_EntityId EntityId, USpatialAct
 	{
 		Receiver->CleanupRepStateMap(ChannelRefs.Value);
 	}
+	Channel.ObjectReferenceMap.Empty();
 
 	if (!EntityToActorChannel.Contains(EntityId))
 	{


### PR DESCRIPTION
#### Description
When an actor channel is cleaned up/closed multiple times, it can happen that the invariant that the channel's Ref map and the receiver's ref map are in bijection is broken, because we forgot to empty the reference map when cleaned up from USpatialNetDriver::RemoveActorChannel
An annoying non-fatal assertion was triggered on the second call to CleanupRepStateMap.