### PR TITLE
Feature/unr 2565 spatial debugging component

### DIFF
--- a/RequireSetup
+++ b/RequireSetup
@@ -1,4 +1,4 @@
 Increment the below number whenever it is required to run Setup.bat as part of a new commit.
 Our git hooks will detect this file has been updated and automatically run Setup.bat on pull.
 
-45
+46

--- a/SpatialGDK/Extras/schema/spatial_debugging.schema
+++ b/SpatialGDK/Extras/schema/spatial_debugging.schema
@@ -4,7 +4,7 @@ package unreal;
 component SpatialDebugging {
      id = 9975;
 
-     // Id assigned to the Unreal server worker which should be authoritative for this entity.
+     // Id assigned to the Unreal server worker which is authoritative for this entity.
      // 0 is reserved as an invalid/unset value.
      uint32 authoritative_virtual_worker_id = 1;
 

--- a/SpatialGDK/Extras/schema/spatial_debugging.schema
+++ b/SpatialGDK/Extras/schema/spatial_debugging.schema
@@ -1,0 +1,23 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+package unreal;
+
+component SpatialDebugging {
+     id = 9975;
+
+     // Id assigned to the Unreal server worker which should be authoritative for this entity.
+     // 0 is reserved as an invalid/unset value.
+     uint32 authoritative_virtual_worker_id = 1;
+
+     // The color for the authoritative virtual worker.
+     uint32 authoritative_color = 2;
+
+     // Id assigned to the Unreal server worker which should be authoritative for this entity.
+     // 0 is reserved as an invalid/unset value.
+     uint32 intent_virtual_worker_id = 3;
+
+     // The color for the intended virtual worker.
+     uint32 intent_color = 4;
+
+     // Whether or not the entity is locked.
+     bool is_locked = 5;
+}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -29,6 +29,7 @@
 #include "Utils/ComponentReader.h"
 #include "Utils/ErrorCodeRemapping.h"
 #include "Utils/RepLayoutUtils.h"
+#include "Utils/SpatialDebugger.h"
 #include "Utils/SpatialMetrics.h"
 
 DEFINE_LOG_CATEGORY(LogSpatialReceiver);
@@ -396,6 +397,11 @@ void USpatialReceiver::HandleActorAuthority(const Worker_AuthorityChangeOp& Op)
 	if (LoadBalanceEnforcer != nullptr)
 	{
 		LoadBalanceEnforcer->AuthorityChanged(Op);
+	}
+
+	if (NetDriver->SpatialDebugger != nullptr)
+	{
+		NetDriver->SpatialDebugger->AuthorityChanged(Op);
 	}
 
 	AActor* Actor = Cast<AActor>(NetDriver->PackageMap->GetObjectFromEntityId(Op.entity_id));

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1318,6 +1318,7 @@ void USpatialReceiver::OnComponentUpdate(const Worker_ComponentUpdateOp& Op)
 	case SpatialConstants::RPCS_ON_ENTITY_CREATION_ID:
 	case SpatialConstants::DEBUG_METRICS_COMPONENT_ID:
 	case SpatialConstants::ALWAYS_RELEVANT_COMPONENT_ID:
+	case SpatialConstants::SPATIAL_DEBUGGING_COMPONENT_ID:
 		UE_LOG(LogSpatialReceiver, Verbose, TEXT("Entity: %d Component: %d - Skipping because this is hand-written Spatial component"), Op.entity_id, Op.update.component_id);
 		return;
 	case SpatialConstants::GSM_SHUTDOWN_COMPONENT_ID:
@@ -1348,9 +1349,6 @@ void USpatialReceiver::OnComponentUpdate(const Worker_ComponentUpdateOp& Op)
 		{
 			LoadBalanceEnforcer->OnAuthorityIntentComponentUpdated(Op);
 		}
-		return;
-	case SpatialConstants::SPATIAL_DEBUGGING_COMPONENT_ID:
-		// TODO(harkness): Add code to process the debugging component.
 		return;
 	case SpatialConstants::VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID:
 		if (NetDriver->VirtualWorkerTranslator.IsValid())

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -162,6 +162,7 @@ void USpatialReceiver::OnAddComponent(const Worker_AddComponentOp& Op)
 	case SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID:
 	case SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID:
 	case SpatialConstants::MULTICAST_RPCS_COMPONENT_ID:
+	case SpatialConstants::SPATIAL_DEBUGGING_COMPONENT_ID:
 		// Ignore static spatial components as they are managed by the SpatialStaticComponentView.
 		return;
 	case SpatialConstants::SINGLETON_MANAGER_COMPONENT_ID:
@@ -1341,6 +1342,9 @@ void USpatialReceiver::OnComponentUpdate(const Worker_ComponentUpdateOp& Op)
 		{
 			LoadBalanceEnforcer->OnAuthorityIntentComponentUpdated(Op);
 		}
+		return;
+	case SpatialConstants::SPATIAL_DEBUGGING_COMPONENT_ID:
+		// TODO(harkness): Add code to process the debugging component.
 		return;
 	case SpatialConstants::VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID:
 		if (NetDriver->VirtualWorkerTranslator.IsValid())

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -401,7 +401,7 @@ void USpatialReceiver::HandleActorAuthority(const Worker_AuthorityChangeOp& Op)
 
 	if (NetDriver->SpatialDebugger != nullptr)
 	{
-		NetDriver->SpatialDebugger->AuthorityChanged(Op);
+		NetDriver->SpatialDebugger->ActorAuthorityChanged(Op);
 	}
 
 	AActor* Actor = Cast<AActor>(NetDriver->PackageMap->GetObjectFromEntityId(Op.entity_id));

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -24,7 +24,6 @@
 #include "Schema/ServerRPCEndpointLegacy.h"
 #include "Schema/Singleton.h"
 #include "Schema/SpawnData.h"
-#include "Schema/SpatialDebugging.h"
 #include "Schema/StandardLibrary.h"
 #include "Schema/Tombstone.h"
 #include "Schema/UnrealMetadata.h"
@@ -36,6 +35,7 @@
 #include "Utils/InterestFactory.h"
 #include "Utils/RepLayoutUtils.h"
 #include "Utils/SpatialActorUtils.h"
+#include "Utils/SpatialDebugger.h"
 #include "Utils/SpatialLatencyTracer.h"
 #include "Utils/SpatialMetrics.h"
 
@@ -505,16 +505,7 @@ void USpatialSender::SendAuthorityIntentUpdate(const AActor& Actor, VirtualWorke
 	// If the SpatialDebugger is enabled, also update the authority intent virtual worker ID and color.
 	if (NetDriver->SpatialDebugger != nullptr)
 	{
-		SpatialDebugging* DebuggingInfo = StaticComponentView->GetComponentData<SpatialDebugging>(EntityId);
-		check(DebuggingInfo != nullptr);
-		DebuggingInfo->IntentVirtualWorkerId = NewAuthoritativeVirtualWorkerId;
-
-		const PhysicalWorkerName* NewAuthoritativePhysicalWorkerName = NetDriver->VirtualWorkerTranslator->GetPhysicalWorkerForVirtualWorker(NewAuthoritativeVirtualWorkerId);
-		check(NewAuthoritativePhysicalWorkerName != nullptr);
-
-		DebuggingInfo->IntentColor = SpatialGDK::GetColorForWorkerName(*NewAuthoritativePhysicalWorkerName);
-		Worker_ComponentUpdate DebuggingUpdate = DebuggingInfo->CreateSpatialDebuggingUpdate();
-		Connection->SendComponentUpdate(EntityId, &DebuggingUpdate);
+		NetDriver->SpatialDebugger->ActorAuthorityIntentChanged(EntityId, NewAuthoritativeVirtualWorkerId);
 	}
 
 	Worker_ComponentUpdate Update = AuthorityIntentComponent->CreateAuthorityIntentUpdate();

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStaticComponentView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStaticComponentView.cpp
@@ -13,8 +13,8 @@
 #include "Schema/ServerEndpoint.h"
 #include "Schema/ServerRPCEndpointLegacy.h"
 #include "Schema/Singleton.h"
-#include "Schema/SpawnData.h"
 #include "Schema/SpatialDebugging.h"
+#include "Schema/SpawnData.h"
 #include "Schema/UnrealMetadata.h"
 
 Worker_Authority USpatialStaticComponentView::GetAuthority(Worker_EntityId EntityId, Worker_ComponentId ComponentId) const

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStaticComponentView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStaticComponentView.cpp
@@ -14,6 +14,7 @@
 #include "Schema/ServerRPCEndpointLegacy.h"
 #include "Schema/Singleton.h"
 #include "Schema/SpawnData.h"
+#include "Schema/SpatialDebugging.h"
 #include "Schema/UnrealMetadata.h"
 
 Worker_Authority USpatialStaticComponentView::GetAuthority(Worker_EntityId EntityId, Worker_ComponentId ComponentId) const
@@ -98,6 +99,9 @@ void USpatialStaticComponentView::OnAddComponent(const Worker_AddComponentOp& Op
 	case SpatialConstants::MULTICAST_RPCS_COMPONENT_ID:
 		Data = MakeUnique<SpatialGDK::ComponentStorage<SpatialGDK::MulticastRPCs>>(Op.data);
 		break;
+	case SpatialConstants::SPATIAL_DEBUGGING_COMPONENT_ID:
+		Data = MakeUnique<SpatialGDK::ComponentStorage<SpatialGDK::SpatialDebugging>>(Op.data);
+		break;
 	default:
 		// Component is not hand written, but we still want to know the existence of it on this entity.
 		Data = nullptr;
@@ -148,6 +152,9 @@ void USpatialStaticComponentView::OnComponentUpdate(const Worker_ComponentUpdate
 		break;
 	case SpatialConstants::MULTICAST_RPCS_COMPONENT_ID:
 		Component = GetComponentData<SpatialGDK::MulticastRPCs>(Op.entity_id);
+		break;
+	case SpatialConstants::SPATIAL_DEBUGGING_COMPONENT_ID:
+		Component = GetComponentData<SpatialGDK::SpatialDebugging>(Op.entity_id);
 		break;
 	default:
 		return;

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -13,10 +13,12 @@
 #include "Schema/ServerRPCEndpointLegacy.h"
 #include "Schema/RPCPayload.h"
 #include "Schema/Singleton.h"
+#include "Schema/SpatialDebugging.h"
 #include "Schema/SpawnData.h"
 #include "Utils/ComponentFactory.h"
 #include "Utils/InterestFactory.h"
 #include "Utils/SpatialActorUtils.h"
+#include "Utils/SpatialDebugger.h"
 
 #include "Engine.h"
  
@@ -212,6 +214,15 @@ TArray<Worker_ComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 	if (SpatialSettings->bEnableUnrealLoadBalancer)
 	{
 		ComponentDatas.Add(AuthorityIntent::CreateAuthorityIntentData(NetDriver->VirtualWorkerTranslator->GetLocalVirtualWorkerId()));
+	}
+
+	if (NetDriver->SpatialDebugger != nullptr)
+	{
+		VirtualWorkerId IntentVirtualWorkerId = NetDriver->VirtualWorkerTranslator->GetLocalVirtualWorkerId();
+		FColor IntentColor = NetDriver->SpatialDebugger->GetVirtualWorkerColor(IntentVirtualWorkerId);
+		SpatialDebugging DebuggingInfo(SpatialConstants::INVALID_VIRTUAL_WORKER_ID, FColor::Magenta, IntentVirtualWorkerId, IntentColor, false);
+
+		ComponentDatas.Add(DebuggingInfo.CreateSpatialDebuggingData());
 	}
 
 	if (Class->HasAnySpatialClassFlags(SPATIALCLASS_Singleton))

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -226,9 +226,10 @@ TArray<Worker_ComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 			VirtualWorkerId IntentVirtualWorkerId = NetDriver->VirtualWorkerTranslator->GetLocalVirtualWorkerId();
 
 			const PhysicalWorkerName* PhysicalWorkerName = NetDriver->VirtualWorkerTranslator->GetPhysicalWorkerForVirtualWorker(IntentVirtualWorkerId);
-			FColor IntentColor = PhysicalWorkerName == nullptr ? FColor::Magenta : SpatialGDK::GetColorForWorkerName(*PhysicalWorkerName);
+			FColor InvalidServerTintColor = NetDriver->SpatialDebugger->InvalidServerTintColor;
+			FColor IntentColor = PhysicalWorkerName == nullptr ? InvalidServerTintColor : SpatialGDK::GetColorForWorkerName(*PhysicalWorkerName);
 
-			SpatialDebugging DebuggingInfo(SpatialConstants::INVALID_VIRTUAL_WORKER_ID, FColor::Magenta, IntentVirtualWorkerId, IntentColor, false);
+			SpatialDebugging DebuggingInfo(SpatialConstants::INVALID_VIRTUAL_WORKER_ID, InvalidServerTintColor, IntentVirtualWorkerId, IntentColor, false);
 			ComponentDatas.Add(DebuggingInfo.CreateSpatialDebuggingData());
 		}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InspectionColors.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InspectionColors.cpp
@@ -11,103 +11,104 @@
 
 namespace SpatialGDK
 {
-	namespace
+
+namespace
+{
+	const int32 MIN_HUE = 10;
+	const int32 MAX_HUE = 350;
+	const int32 MIN_SATURATION = 60;
+	const int32 MAX_SATURATION = 100;
+	const int32 MIN_LIGHTNESS = 25;
+	const int32 MAX_LIGHTNESS = 60;
+
+	int64 GenerateValueFromThresholds(int64 Hash, int32 Min, int32 Max)
 	{
-		const int32 MIN_HUE = 10;
-		const int32 MAX_HUE = 350;
-		const int32 MIN_SATURATION = 60;
-		const int32 MAX_SATURATION = 100;
-		const int32 MIN_LIGHTNESS = 25;
-		const int32 MAX_LIGHTNESS = 60;
-
-		int64 GenerateValueFromThresholds(int64 Hash, int32 Min, int32 Max)
-		{
-			return Hash % FMath::Abs(Max - Min) + Min;
-		}
-
-		FColor HSLtoRGB(double Hue, double Saturation, double Lightness)
-		{
-			// const[h, s, l] = hsl;
-			// Must be fractions of 1
-
-			const double c = (1 - FMath::Abs(2 * Lightness / 100 - 1)) * Saturation / 100;
-			const double x = c * (1 - FMath::Abs(FMath::Fmod((Hue / 60), 2) - 1));
-			const double m = Lightness / 100 - c / 2;
-
-			double r = 0;
-			double g = 0;
-			double b = 0;
-
-			if (0 <= Hue && Hue < 60) {
-				r = c;
-				g = x;
-				b = 0;
-			}
-			else if (60 <= Hue && Hue < 120) {
-				r = x;
-				g = c;
-				b = 0;
-			}
-			else if (120 <= Hue && Hue < 180) {
-				r = 0;
-				g = c;
-				b = x;
-			}
-			else if (180 <= Hue && Hue < 240) {
-				r = 0;
-				g = x;
-				b = c;
-			}
-			else if (240 <= Hue && Hue < 300) {
-				r = x;
-				g = 0;
-				b = c;
-			}
-			else if (300 <= Hue && Hue <= 360) {
-				r = c;
-				g = 0;
-				b = x;
-			}
-			r = (r + m) * 255;
-			g = (g + m) * 255;
-			b = (b + m) * 255;
-
-			return FColor{ static_cast<uint8>(r), static_cast<uint8>(g), static_cast<uint8>(b) };
-		}
-
-		int64 DJBReverseHash(const PhysicalWorkerName& WorkerName) {
-			const int32 StringLength = WorkerName.Len();
-			int64 Hash = 5381;
-			for (int32 i = StringLength - 1; i > 0; --i) {
-				// We're mimicking the Inspector logic which is in JS. In JavaScript,
-				// a number is stored as a 64-bit floating point number but the bit-wise
-				// operation is performed on a 32-bit integer i.e. to perform a
-				// bit-operation JavaScript converts the number into a 32-bit binary
-				// number (signed) and perform the operation and convert back the result
-				// to a 64-bit number.
-				// Ideally, this would just be ((static_cast<int32>(Hash)) << 5) but left
-				// shifting a signed int with overflow is undefined so we have to memcpy
-				// to an unsigned.
-				uint64 BitShiftingScratchRegister;
-				std::memcpy(&BitShiftingScratchRegister, &Hash, sizeof(int64));
-				int32 BitShiftedHash = static_cast<int32>((BitShiftingScratchRegister << 5) & 0xFFFFFFFF);
-				Hash = BitShiftedHash + Hash + static_cast<int32>(WorkerName[i]);
-			}
-			return FMath::Abs(Hash);
-		}
+		return Hash % FMath::Abs(Max - Min) + Min;
 	}
 
-	FColor GetColorForWorkerName(const PhysicalWorkerName& WorkerName)
+	FColor HSLtoRGB(double Hue, double Saturation, double Lightness)
 	{
-		int64 Hash = DJBReverseHash(WorkerName);
+		// const[h, s, l] = hsl;
+		// Must be fractions of 1
 
-		const double Lightness = GenerateValueFromThresholds(Hash, MIN_LIGHTNESS, MAX_LIGHTNESS);
-		const double Saturation = GenerateValueFromThresholds(Hash, MIN_SATURATION, MAX_SATURATION);
-		// Provides additional color variance for potentially sequential hashes
-		auto abs = FMath::Abs((double)Hash / Saturation + Lightness);
-		Hash = FMath::FloorToInt(abs);
-		const double Hue = GenerateValueFromThresholds(Hash, MIN_HUE, MAX_HUE);
+		const double c = (1 - FMath::Abs(2 * Lightness / 100 - 1)) * Saturation / 100;
+		const double x = c * (1 - FMath::Abs(FMath::Fmod((Hue / 60), 2) - 1));
+		const double m = Lightness / 100 - c / 2;
 
-		return SpatialGDK::HSLtoRGB(Hue, Saturation, Lightness);
+		double r = 0;
+		double g = 0;
+		double b = 0;
+
+		if (0 <= Hue && Hue < 60) {
+			r = c;
+			g = x;
+			b = 0;
+		}
+		else if (60 <= Hue && Hue < 120) {
+			r = x;
+			g = c;
+			b = 0;
+		}
+		else if (120 <= Hue && Hue < 180) {
+			r = 0;
+			g = c;
+			b = x;
+		}
+		else if (180 <= Hue && Hue < 240) {
+			r = 0;
+			g = x;
+			b = c;
+		}
+		else if (240 <= Hue && Hue < 300) {
+			r = x;
+			g = 0;
+			b = c;
+		}
+		else if (300 <= Hue && Hue <= 360) {
+			r = c;
+			g = 0;
+			b = x;
+		}
+		r = (r + m) * 255;
+		g = (g + m) * 255;
+		b = (b + m) * 255;
+
+		return FColor{ static_cast<uint8>(r), static_cast<uint8>(g), static_cast<uint8>(b) };
 	}
+
+	int64 DJBReverseHash(const PhysicalWorkerName& WorkerName) {
+		const int32 StringLength = WorkerName.Len();
+		int64 Hash = 5381;
+		for (int32 i = StringLength - 1; i > 0; --i) {
+			// We're mimicking the Inspector logic which is in JS. In JavaScript,
+			// a number is stored as a 64-bit floating point number but the bit-wise
+			// operation is performed on a 32-bit integer i.e. to perform a
+			// bit-operation JavaScript converts the number into a 32-bit binary
+			// number (signed) and perform the operation and convert back the result
+			// to a 64-bit number.
+			// Ideally, this would just be ((static_cast<int32>(Hash)) << 5) but left
+			// shifting a signed int with overflow is undefined so we have to memcpy
+			// to an unsigned.
+			uint64 BitShiftingScratchRegister;
+			std::memcpy(&BitShiftingScratchRegister, &Hash, sizeof(int64));
+			int32 BitShiftedHash = static_cast<int32>((BitShiftingScratchRegister << 5) & 0xFFFFFFFF);
+			Hash = BitShiftedHash + Hash + static_cast<int32>(WorkerName[i]);
+		}
+		return FMath::Abs(Hash);
+	}
+}
+
+FColor GetColorForWorkerName(const PhysicalWorkerName& WorkerName)
+{
+	int64 Hash = DJBReverseHash(WorkerName);
+
+	const double Lightness = GenerateValueFromThresholds(Hash, MIN_LIGHTNESS, MAX_LIGHTNESS);
+	const double Saturation = GenerateValueFromThresholds(Hash, MIN_SATURATION, MAX_SATURATION);
+	// Provides additional color variance for potentially sequential hashes
+	auto abs = FMath::Abs((double)Hash / Saturation + Lightness);
+	Hash = FMath::FloorToInt(abs);
+	const double Hue = GenerateValueFromThresholds(Hash, MIN_HUE, MAX_HUE);
+
+	return SpatialGDK::HSLtoRGB(Hue, Saturation, Lightness);
+}
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InspectionColors.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InspectionColors.cpp
@@ -1,0 +1,113 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "Utils/InspectionColors.h"
+
+#include "Containers/UnrealString.h"
+#include "Math/Color.h"
+#include "Math/UnrealMathUtility.h"
+#include "Misc/Char.h"
+
+#include "cstring"
+
+namespace SpatialGDK
+{
+	namespace
+	{
+		const int32 MIN_HUE = 10;
+		const int32 MAX_HUE = 350;
+		const int32 MIN_SATURATION = 60;
+		const int32 MAX_SATURATION = 100;
+		const int32 MIN_LIGHTNESS = 25;
+		const int32 MAX_LIGHTNESS = 60;
+
+		int64 GenerateValueFromThresholds(int64 Hash, int32 Min, int32 Max)
+		{
+			return Hash % FMath::Abs(Max - Min) + Min;
+		}
+
+		FColor HSLtoRGB(double Hue, double Saturation, double Lightness)
+		{
+			// const[h, s, l] = hsl;
+			// Must be fractions of 1
+
+			const double c = (1 - FMath::Abs(2 * Lightness / 100 - 1)) * Saturation / 100;
+			const double x = c * (1 - FMath::Abs(FMath::Fmod((Hue / 60), 2) - 1));
+			const double m = Lightness / 100 - c / 2;
+
+			double r = 0;
+			double g = 0;
+			double b = 0;
+
+			if (0 <= Hue && Hue < 60) {
+				r = c;
+				g = x;
+				b = 0;
+			}
+			else if (60 <= Hue && Hue < 120) {
+				r = x;
+				g = c;
+				b = 0;
+			}
+			else if (120 <= Hue && Hue < 180) {
+				r = 0;
+				g = c;
+				b = x;
+			}
+			else if (180 <= Hue && Hue < 240) {
+				r = 0;
+				g = x;
+				b = c;
+			}
+			else if (240 <= Hue && Hue < 300) {
+				r = x;
+				g = 0;
+				b = c;
+			}
+			else if (300 <= Hue && Hue <= 360) {
+				r = c;
+				g = 0;
+				b = x;
+			}
+			r = (r + m) * 255;
+			g = (g + m) * 255;
+			b = (b + m) * 255;
+
+			return FColor{ static_cast<uint8>(r), static_cast<uint8>(g), static_cast<uint8>(b) };
+		}
+
+		int64 DJBReverseHash(const PhysicalWorkerName& WorkerName) {
+			const int32 StringLength = WorkerName.Len();
+			int64 Hash = 5381;
+			for (int32 i = StringLength - 1; i > 0; --i) {
+				// We're mimicking the Inspector logic which is in JS. In JavaScript,
+				// a number is stored as a 64-bit floating point number but the bit-wise
+				// operation is performed on a 32-bit integer i.e. to perform a
+				// bit-operation JavaScript converts the number into a 32-bit binary
+				// number (signed) and perform the operation and convert back the result
+				// to a 64-bit number.
+				// Ideally, this would just be ((static_cast<int32>(Hash)) << 5) but left
+				// shifting a signed int with overflow is undefined so we have to memcpy
+				// to an unsigned.
+				uint64 BitShiftingScratchRegister;
+				std::memcpy(&BitShiftingScratchRegister, &Hash, sizeof(int64));
+				int32 BitShiftedHash = static_cast<int32>((BitShiftingScratchRegister << 5) & 0xFFFFFFFF);
+				Hash = BitShiftedHash + Hash + static_cast<int32>(WorkerName[i]);
+			}
+			return FMath::Abs(Hash);
+		}
+	}
+
+	FColor GetColorForWorkerName(const PhysicalWorkerName& WorkerName)
+	{
+		int64 Hash = DJBReverseHash(WorkerName);
+
+		const double Lightness = GenerateValueFromThresholds(Hash, MIN_LIGHTNESS, MAX_LIGHTNESS);
+		const double Saturation = GenerateValueFromThresholds(Hash, MIN_SATURATION, MAX_SATURATION);
+		// Provides additional color variance for potentially sequential hashes
+		auto abs = FMath::Abs((double)Hash / Saturation + Lightness);
+		Hash = FMath::FloorToInt(abs);
+		const double Hue = GenerateValueFromThresholds(Hash, MIN_HUE, MAX_HUE);
+
+		return SpatialGDK::HSLtoRGB(Hue, Saturation, Lightness);
+	}
+}

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
@@ -262,10 +262,9 @@ void ASpatialDebugger::OnEntityRemoved(const Worker_EntityId EntityId)
 
 void ASpatialDebugger::ActorAuthorityChanged(const Worker_AuthorityChangeOp& AuthOp) const
 {
-	check(AuthOp.component_id == SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID);
 	const bool bAuthoritative = AuthOp.authority == WORKER_AUTHORITY_AUTHORITATIVE;
 
-	if (bAuthoritative)
+	if (bAuthoritative && AuthOp.component_id == SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID)
 	{
 		if (NetDriver->VirtualWorkerTranslator == nullptr)
 		{

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
@@ -262,9 +262,10 @@ void ASpatialDebugger::OnEntityRemoved(const Worker_EntityId EntityId)
 
 void ASpatialDebugger::ActorAuthorityChanged(const Worker_AuthorityChangeOp& AuthOp) const
 {
+	check(AuthOp.component_id == SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID);
 	const bool bAuthoritative = AuthOp.authority == WORKER_AUTHORITY_AUTHORITATIVE;
 
-	if (bAuthoritative && AuthOp.component_id == SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID)
+	if (bAuthoritative)
 	{
 		if (NetDriver->VirtualWorkerTranslator == nullptr)
 		{
@@ -306,7 +307,6 @@ void ASpatialDebugger::ActorAuthorityIntentChanged(Worker_EntityId EntityId, Vir
 	DebuggingInfo->IntentColor = SpatialGDK::GetColorForWorkerName(*NewAuthoritativePhysicalWorkerName);
 	Worker_ComponentUpdate DebuggingUpdate = DebuggingInfo->CreateSpatialDebuggingUpdate();
 	NetDriver->Connection->SendComponentUpdate(EntityId, &DebuggingUpdate);
-
 }
 
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
@@ -7,6 +7,7 @@
 #include "Interop/SpatialStaticComponentView.h"
 #include "LoadBalancing/WorkerRegion.h"
 #include "Schema/AuthorityIntent.h"
+#include "Schema/SpatialDebugging.h"
 #include "SpatialCommonTypes.h"
 #include "Utils/InspectionColors.h"
 
@@ -259,6 +260,41 @@ void ASpatialDebugger::OnEntityRemoved(const Worker_EntityId EntityId)
 	EntityActorMapping.Remove(EntityId);
 }
 
+void ASpatialDebugger::AuthorityChanged(const Worker_AuthorityChangeOp& AuthOp)
+{
+	const bool bAuthoritative = AuthOp.authority == WORKER_AUTHORITY_AUTHORITATIVE;
+
+	if (bAuthoritative && AuthOp.component_id == SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID)
+	{
+		if (NetDriver->VirtualWorkerTranslator == nullptr)
+		{
+			// Currently, there's nothing to display in the debugger other than load balancing information.
+			return;
+		}
+
+		VirtualWorkerId LocalVirtualWorkerId = NetDriver->VirtualWorkerTranslator->GetLocalVirtualWorkerId();
+		FColor LocalVirtualWorkerColor = SpatialGDK::GetColorForWorkerName(NetDriver->VirtualWorkerTranslator->GetLocalPhysicalWorkerName());
+
+		SpatialDebugging* DebuggingInfo = NetDriver->StaticComponentView->GetComponentData<SpatialDebugging>(AuthOp.entity_id);
+		if (DebuggingInfo == nullptr)
+		{
+			// Some entities won't have debug info, so create it now.
+			SpatialDebugging NewDebuggingInfo(LocalVirtualWorkerId, LocalVirtualWorkerColor, SpatialConstants::INVALID_VIRTUAL_WORKER_ID, InvalidServerTintColor, false);
+			Worker_ComponentData DebuggingData = NewDebuggingInfo.CreateSpatialDebuggingData();
+			NetDriver->Connection->SendAddComponent(AuthOp.entity_id, &DebuggingData);
+			return;
+		}
+		else
+		{
+			DebuggingInfo->AuthoritativeVirtualWorkerId = LocalVirtualWorkerId;
+			DebuggingInfo->AuthoritativeColor = LocalVirtualWorkerColor;
+			Worker_ComponentUpdate DebuggingUpdate = DebuggingInfo->CreateSpatialDebuggingUpdate();
+			NetDriver->Connection->SendComponentUpdate(AuthOp.entity_id, &DebuggingUpdate);
+		}
+	}
+}
+
+
 void ASpatialDebugger::DrawTag(UCanvas* Canvas, const FVector2D& ScreenLocation, const Worker_EntityId EntityId, const FString& ActorName)
 {
 	SCOPE_CYCLE_COUNTER(STAT_DrawTag);
@@ -266,10 +302,18 @@ void ASpatialDebugger::DrawTag(UCanvas* Canvas, const FVector2D& ScreenLocation,
 	// TODO: Smarter positioning of elements so they're centered no matter how many are enabled https://improbableio.atlassian.net/browse/UNR-2360.
 	int32 HorizontalOffset = -32.0f;
 
+	check(NetDriver != nullptr && !NetDriver->IsServer());
+	if (!NetDriver->StaticComponentView->HasComponent(EntityId, SpatialConstants::SPATIAL_DEBUGGING_COMPONENT_ID))
+	{
+		return;
+	}
+
+	const SpatialDebugging* DebuggingInfo = NetDriver->StaticComponentView->GetComponentData<SpatialDebugging>(EntityId);
+
 	if (bShowLock)
 	{
 		SCOPE_CYCLE_COUNTER(STAT_DrawIcons);
-		const bool bIsLocked = GetLockStatus(EntityId);
+		const bool bIsLocked = DebuggingInfo->IsLocked;
 		const EIcon LockIcon = bIsLocked ? ICON_LOCKED : ICON_UNLOCKED;
 
 		Canvas->SetDrawColor(FColor::White);
@@ -280,7 +324,7 @@ void ASpatialDebugger::DrawTag(UCanvas* Canvas, const FVector2D& ScreenLocation,
 	if (bShowAuth)
 	{
 		SCOPE_CYCLE_COUNTER(STAT_DrawIcons);
-		const FColor& ServerWorkerColor = GetServerWorkerColor(EntityId);
+		const FColor& ServerWorkerColor = DebuggingInfo->AuthoritativeColor;
 		Canvas->SetDrawColor(FColor::White);
 		Canvas->DrawIcon(Icons[ICON_AUTH], ScreenLocation.X + HorizontalOffset, ScreenLocation.Y, 1.0f);
 		HorizontalOffset += 16.0f;
@@ -292,7 +336,7 @@ void ASpatialDebugger::DrawTag(UCanvas* Canvas, const FVector2D& ScreenLocation,
 	if (bShowAuthIntent)
 	{
 		SCOPE_CYCLE_COUNTER(STAT_DrawIcons);
-		const FColor& VirtualWorkerColor = GetVirtualWorkerColor(EntityId);
+		const FColor& VirtualWorkerColor = DebuggingInfo->IntentColor;
 		Canvas->SetDrawColor(FColor::White);
 		Canvas->DrawIcon(Icons[ICON_AUTH_INTENT], ScreenLocation.X + HorizontalOffset, ScreenLocation.Y, 1.0f);
 		HorizontalOffset += 16.0f;
@@ -406,64 +450,6 @@ void ASpatialDebugger::DrawDebugLocalPlayer(UCanvas* Canvas)
 			ScreenLocation.Y -= PLAYER_TAG_VERTICAL_OFFSET;
 		}
 	}
-}
-
-FColor ASpatialDebugger::GetVirtualWorkerColor(const Worker_EntityId EntityId) const
-{
-	check(NetDriver != nullptr && !NetDriver->IsServer());
-	if (!NetDriver->StaticComponentView->HasComponent(EntityId, SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID))
-	{
-		return InvalidServerTintColor;
-	}
-	const AuthorityIntent* AuthorityIntentComponent = NetDriver->StaticComponentView->GetComponentData<AuthorityIntent>(EntityId);
-	const int32 VirtualWorkerId = AuthorityIntentComponent->VirtualWorkerId;
-
-	const PhysicalWorkerName* PhysicalWorkerName = nullptr;
-	if (NetDriver->VirtualWorkerTranslator)
-	{
-		PhysicalWorkerName = NetDriver->VirtualWorkerTranslator->GetPhysicalWorkerForVirtualWorker(VirtualWorkerId);
-	}
-
-	if (PhysicalWorkerName == nullptr)
-	{
-		// This can happen if the client hasn't yet received the VirtualWorkerTranslator mapping
-		return InvalidServerTintColor;
-	}
-	return SpatialGDK::GetColorForWorkerName(*PhysicalWorkerName);
-}
-
-FColor ASpatialDebugger::GetServerWorkerColor(const Worker_EntityId EntityId) const
-{
-	check(NetDriver != nullptr && !NetDriver->IsServer());
-
-	const PhysicalWorkerName& AuthoritativeWorkerFromACL = GetAuthoritativeWorkerFromACL(EntityId);
-
-	const FString WorkerNamePrefix = FString{ "workerId:" };
-	if (!AuthoritativeWorkerFromACL.StartsWith(*WorkerNamePrefix)) {
-		// The ACL entry is not an explicit worker ID, this may happen at startup when it's just
-		// the UnrealWorker attribute, just return invalid for now.
-		return InvalidServerTintColor;
-	}
-	return SpatialGDK::GetColorForWorkerName(AuthoritativeWorkerFromACL.RightChop(WorkerNamePrefix.Len()));
-}
-
-const PhysicalWorkerName& ASpatialDebugger::GetAuthoritativeWorkerFromACL(const Worker_EntityId EntityId) const
-{
-	const SpatialGDK::EntityAcl* AclData = NetDriver->StaticComponentView->GetComponentData<SpatialGDK::EntityAcl>(EntityId);
-	const WorkerRequirementSet* WriteAcl = AclData->ComponentWriteAcl.Find(SpatialConstants::POSITION_COMPONENT_ID);
-
-	check(WriteAcl != nullptr);
-	check(WriteAcl->Num() == 1);
-	check((*WriteAcl)[0].Num() == 1);
-
-	return (*WriteAcl)[0][0];
-}
-
-// TODO: Implement once this functionality is available https://improbableio.atlassian.net/browse/UNR-2361.
-bool ASpatialDebugger::GetLockStatus(const Worker_EntityId Entityid)
-{
-	check(NetDriver != nullptr && !NetDriver->IsServer());
-	return false;
 }
 
 void ASpatialDebugger::SpatialToggleDebugger()

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/SpatialDebugging.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/SpatialDebugging.h
@@ -15,7 +15,7 @@ namespace SpatialGDK
 // SpatialDebugger on clients but which would not normally be available to clients.
 struct SpatialDebugging : Component
 {
-	static const Worker_ComponentId ComponentId = SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID;
+	static const Worker_ComponentId ComponentId = SpatialConstants::SPATIAL_DEBUGGING_COMPONENT_ID;
 
 	SpatialDebugging()
 		: AuthoritativeVirtualWorkerId(SpatialConstants::INVALID_VIRTUAL_WORKER_ID)

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/SpatialDebugging.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/SpatialDebugging.h
@@ -1,0 +1,110 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "Schema/Component.h"
+#include "SpatialCommonTypes.h"
+#include "Utils/SchemaUtils.h"
+
+#include <WorkerSDK/improbable/c_schema.h>
+
+namespace SpatialGDK
+{
+
+// The SpatialDebugging component exists to hold information which needs to be displayed by the
+// SpatialDebugger on clients but which would not normally be available to clients.
+struct SpatialDebugging : Component
+{
+	static const Worker_ComponentId ComponentId = SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID;
+
+	SpatialDebugging()
+		: AuthoritativeVirtualWorkerId(SpatialConstants::INVALID_VIRTUAL_WORKER_ID)
+		, AuthoritativeColor()
+		, IntentVirtualWorkerId(SpatialConstants::INVALID_VIRTUAL_WORKER_ID)
+		, IntentColor()
+		, IsLocked(false)
+	{}
+
+	SpatialDebugging(const VirtualWorkerId AuthoritativeVirtualWorkerIdIn, const FColor& AuthoritativeColorIn, const VirtualWorkerId IntentVirtualWorkerIdIn, const FColor& IntentColorIn, bool IsLockedIn)
+	{
+		AuthoritativeVirtualWorkerId = AuthoritativeVirtualWorkerIdIn;
+		AuthoritativeColor = AuthoritativeColorIn;
+		IntentVirtualWorkerId = IntentVirtualWorkerIdIn;
+		IntentColor = IntentColorIn;
+		IsLocked = IsLockedIn;
+	}
+
+	SpatialDebugging(const Worker_ComponentData& Data)
+	{
+		Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
+
+		AuthoritativeVirtualWorkerId = Schema_GetUint32(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_AUTHORITATIVE_VIRTUAL_WORKER_ID);
+		AuthoritativeColor = FColor(Schema_GetUint32(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_AUTHORITATIVE_COLOR));
+		IntentVirtualWorkerId = Schema_GetUint32(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_INTENT_VIRTUAL_WORKER_ID);
+		IntentColor = FColor(Schema_GetUint32(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_INTENT_COLOR));
+		IsLocked = Schema_GetBool(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_IS_LOCKED);
+	}
+
+	Worker_ComponentData CreateSpatialDebuggingData()
+	{
+		Worker_ComponentData Data = {};
+		Data.component_id = ComponentId;
+		Data.schema_type = Schema_CreateComponentData();
+		Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
+
+		Schema_AddUint32(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_AUTHORITATIVE_VIRTUAL_WORKER_ID, AuthoritativeVirtualWorkerId);
+		Schema_AddUint32(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_AUTHORITATIVE_COLOR, AuthoritativeColor.DWColor());
+		Schema_AddUint32(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_INTENT_VIRTUAL_WORKER_ID, IntentVirtualWorkerId);
+		Schema_AddUint32(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_INTENT_COLOR, IntentColor.DWColor());
+		Schema_AddBool(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_IS_LOCKED, IsLocked);
+
+		return Data;
+	}
+
+	Worker_ComponentUpdate CreateSpatialDebuggingUpdate()
+	{
+		Worker_ComponentUpdate Update = {};
+		Update.component_id = ComponentId;
+		Update.schema_type = Schema_CreateComponentUpdate();
+		Schema_Object* ComponentObject = Schema_GetComponentUpdateFields(Update.schema_type);
+
+		Schema_AddUint32(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_AUTHORITATIVE_VIRTUAL_WORKER_ID, AuthoritativeVirtualWorkerId);
+		Schema_AddUint32(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_AUTHORITATIVE_COLOR, AuthoritativeColor.DWColor());
+		Schema_AddUint32(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_INTENT_VIRTUAL_WORKER_ID, IntentVirtualWorkerId);
+		Schema_AddUint32(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_INTENT_COLOR, IntentColor.DWColor());
+		Schema_AddBool(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_IS_LOCKED, IsLocked);
+
+		return Update;
+	}
+
+	void ApplyComponentUpdate(const Worker_ComponentUpdate& Update)
+	{
+		Schema_Object* ComponentObject = Schema_GetComponentUpdateFields(Update.schema_type);
+
+		AuthoritativeVirtualWorkerId = Schema_GetUint32(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_AUTHORITATIVE_VIRTUAL_WORKER_ID);
+		AuthoritativeColor = FColor(Schema_GetUint32(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_AUTHORITATIVE_COLOR));
+		IntentVirtualWorkerId = Schema_GetUint32(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_INTENT_VIRTUAL_WORKER_ID);
+		IntentColor = FColor(Schema_GetUint32(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_INTENT_COLOR));
+		IsLocked = Schema_GetBool(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_IS_LOCKED);
+	}
+
+	// Id of the Unreal server worker which is authoritative for the entity.
+	// 0 is reserved as an invalid/unset value.
+	VirtualWorkerId AuthoritativeVirtualWorkerId;
+
+	// The color for the authoritative virtual worker.
+	FColor AuthoritativeColor;
+
+	// Id of the Unreal server worker which should be authoritative for the entity.
+	// 0 is reserved as an invalid/unset value.
+	VirtualWorkerId IntentVirtualWorkerId;
+
+	// The color for the intended virtual worker.
+	FColor IntentColor;
+
+	// Whether or not the entity is locked.
+	bool IsLocked;
+};
+
+} // namespace SpatialGDK
+

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -112,6 +112,7 @@ const Worker_ComponentId VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID        = 9979;
 const Worker_ComponentId CLIENT_ENDPOINT_COMPONENT_ID					= 9978;
 const Worker_ComponentId SERVER_ENDPOINT_COMPONENT_ID					= 9977;
 const Worker_ComponentId MULTICAST_RPCS_COMPONENT_ID					= 9976;
+const Worker_ComponentId SPATIAL_DEBUGGING_COMPONENT_ID					= 9975;
 
 const Worker_ComponentId STARTING_GENERATED_COMPONENT_ID				= 10000;
 
@@ -183,6 +184,13 @@ const PhysicalWorkerName TRANSLATOR_UNSET_PHYSICAL_NAME = FString("UnsetWorkerNa
 // WorkerEntity Field IDs.
 const Schema_FieldId WORKER_ID_ID										= 1;
 const Schema_FieldId WORKER_TYPE_ID										= 2;
+
+// SpatialDebugger Field IDs.
+const Schema_FieldId SPATIAL_DEBUGGING_AUTHORITATIVE_VIRTUAL_WORKER_ID   = 1;
+const Schema_FieldId SPATIAL_DEBUGGING_AUTHORITATIVE_COLOR               = 2;
+const Schema_FieldId SPATIAL_DEBUGGING_INTENT_VIRTUAL_WORKER_ID          = 3;
+const Schema_FieldId SPATIAL_DEBUGGING_INTENT_COLOR                      = 4;
+const Schema_FieldId SPATIAL_DEBUGGING_IS_LOCKED                         = 5;
 
 // Reserved entity IDs expire in 5 minutes, we will refresh them every 3 minutes to be safe.
 const float ENTITY_RANGE_EXPIRATION_INTERVAL_SECONDS = 180.0f;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/InspectionColors.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/InspectionColors.h
@@ -3,115 +3,12 @@
 #pragma once
 
 #include "SpatialCommonTypes.h"
-#include "Containers/UnrealString.h"
 #include "Math/Color.h"
-#include "Math/UnrealMathUtility.h"
-#include "Misc/Char.h"
-
-#include "cstring"
 
 // Mimicking Inspector V2 coloring from platform/js/console/src/inspector-v2/styles/colors.ts
 
 namespace SpatialGDK
 {
-	namespace
-	{
-		const int32 MIN_HUE = 10;
-		const int32 MAX_HUE = 350;
-		const int32 MIN_SATURATION = 60;
-		const int32 MAX_SATURATION = 100;
-		const int32 MIN_LIGHTNESS = 25;
-		const int32 MAX_LIGHTNESS = 60;
-
-		int64 GenerateValueFromThresholds(int64 Hash, int32 Min, int32 Max)
-		{
-			return Hash % FMath::Abs(Max - Min) + Min;
-		}
-
-		FColor HSLtoRGB(double Hue, double Saturation, double Lightness)
-		{
-			// const[h, s, l] = hsl;
-			// Must be fractions of 1
-
-			const double c = (1 - FMath::Abs(2 * Lightness / 100 - 1)) * Saturation / 100;
-			const double x = c * (1 - FMath::Abs(FMath::Fmod((Hue / 60), 2) - 1));
-			const double m = Lightness / 100 - c / 2;
-
-			double r = 0;
-			double g = 0;
-			double b = 0;
-
-			if (0 <= Hue && Hue < 60) {
-				r = c;
-				g = x;
-				b = 0;
-			}
-			else if (60 <= Hue && Hue < 120) {
-				r = x;
-				g = c;
-				b = 0;
-			}
-			else if (120 <= Hue && Hue < 180) {
-				r = 0;
-				g = c;
-				b = x;
-			}
-			else if (180 <= Hue && Hue < 240) {
-				r = 0;
-				g = x;
-				b = c;
-			}
-			else if (240 <= Hue && Hue < 300) {
-				r = x;
-				g = 0;
-				b = c;
-			}
-			else if (300 <= Hue && Hue <= 360) {
-				r = c;
-				g = 0;
-				b = x;
-			}
-			r = (r + m) * 255;
-			g = (g + m) * 255;
-			b = (b + m) * 255;
-
-			return FColor{ static_cast<uint8>(r), static_cast<uint8>(g), static_cast<uint8>(b) };
-		}
-
-		int64 DJBReverseHash(const PhysicalWorkerName& WorkerName) {
-			const int32 StringLength = WorkerName.Len();
-			int64 Hash = 5381;
-			for (int32 i = StringLength - 1; i > 0; --i) {
-				// We're mimicking the Inspector logic which is in JS. In JavaScript,
-				// a number is stored as a 64-bit floating point number but the bit-wise
-				// operation is performed on a 32-bit integer i.e. to perform a
-				// bit-operation JavaScript converts the number into a 32-bit binary
-				// number (signed) and perform the operation and convert back the result
-				// to a 64-bit number.
-				// Ideally, this would just be ((static_cast<int32>(Hash)) << 5) but left
-				// shifting a signed int with overflow is undefined so we have to memcpy
-				// to an unsigned.
-				uint64 BitShiftingScratchRegister;
-				std::memcpy(&BitShiftingScratchRegister, &Hash, sizeof(int64));
-				int32 BitShiftedHash = static_cast<int32>((BitShiftingScratchRegister << 5) & 0xFFFFFFFF);
-				Hash = BitShiftedHash + Hash + static_cast<int32>(WorkerName[i]);
-			}
-			return FMath::Abs(Hash);
-		}
-	}
-
 	// Argument expected in the form: UnrealWorker1a2s3d4f...
-	FColor GetColorForWorkerName(const PhysicalWorkerName& WorkerName)
-	{
-		int64 Hash = DJBReverseHash(WorkerName);
-
-		const double Lightness = GenerateValueFromThresholds(Hash, MIN_LIGHTNESS, MAX_LIGHTNESS);
-		const double Saturation = GenerateValueFromThresholds(Hash, MIN_SATURATION, MAX_SATURATION);
-		// Provides additional color variance for potentially sequential hashes
-		auto abs = FMath::Abs((double)Hash / Saturation + Lightness);
-		Hash = FMath::FloorToInt(abs);
-		const double Hue = GenerateValueFromThresholds(Hash, MIN_HUE, MAX_HUE);
-
-		return SpatialGDK::HSLtoRGB(Hue, Saturation, Lightness);
-	}
+	FColor GetColorForWorkerName(const PhysicalWorkerName& WorkerName);
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialDebugger.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialDebugger.h
@@ -122,7 +122,8 @@ public:
 	UFUNCTION()
 	virtual void OnRep_SetWorkerRegions();
 
-	void AuthorityChanged(const Worker_AuthorityChangeOp& AuthOp);
+	void ActorAuthorityChanged(const Worker_AuthorityChangeOp& AuthOp) const;
+	void ActorAuthorityIntentChanged(Worker_EntityId EntityId, VirtualWorkerId NewIntentVirtualWorkerId) const;
 
 private:
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialDebugger.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialDebugger.h
@@ -122,6 +122,9 @@ public:
 	UFUNCTION()
 	virtual void OnRep_SetWorkerRegions();
 
+	FColor GetServerWorkerColor(const Worker_EntityId EntityId) const;
+	FColor GetVirtualWorkerColor(const Worker_EntityId EntityId) const;
+
 private:
 
 	void LoadIcons();
@@ -136,8 +139,6 @@ private:
 	void DrawTag(UCanvas* Canvas, const FVector2D& ScreenLocation, const Worker_EntityId EntityId, const FString& ActorName);
 	void DrawDebugLocalPlayer(UCanvas* Canvas);
 
-	FColor GetServerWorkerColor(const Worker_EntityId EntityId) const;
-	FColor GetVirtualWorkerColor(const Worker_EntityId EntityId) const;
 	const FString& GetAuthoritativeWorkerFromACL(const Worker_EntityId EntityId) const;
 
 	bool GetLockStatus(const Worker_EntityId EntityId);

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialDebugger.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialDebugger.h
@@ -122,6 +122,8 @@ public:
 	UFUNCTION()
 	virtual void OnRep_SetWorkerRegions();
 
+	void AuthorityChanged(const Worker_AuthorityChangeOp& AuthOp);
+
 private:
 
 	void LoadIcons();
@@ -135,12 +137,6 @@ private:
 
 	void DrawTag(UCanvas* Canvas, const FVector2D& ScreenLocation, const Worker_EntityId EntityId, const FString& ActorName);
 	void DrawDebugLocalPlayer(UCanvas* Canvas);
-
-	FColor GetServerWorkerColor(const Worker_EntityId EntityId) const;
-	FColor GetVirtualWorkerColor(const Worker_EntityId EntityId) const;
-	const FString& GetAuthoritativeWorkerFromACL(const Worker_EntityId EntityId) const;
-
-	bool GetLockStatus(const Worker_EntityId EntityId);
 
 	static const int ENTITY_ACTOR_MAP_RESERVATION_COUNT = 512;
 	static const int PLAYER_TAG_VERTICAL_OFFSET = 18;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialDebugger.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialDebugger.h
@@ -122,9 +122,6 @@ public:
 	UFUNCTION()
 	virtual void OnRep_SetWorkerRegions();
 
-	FColor GetServerWorkerColor(const Worker_EntityId EntityId) const;
-	FColor GetVirtualWorkerColor(const Worker_EntityId EntityId) const;
-
 private:
 
 	void LoadIcons();
@@ -139,6 +136,8 @@ private:
 	void DrawTag(UCanvas* Canvas, const FVector2D& ScreenLocation, const Worker_EntityId EntityId, const FString& ActorName);
 	void DrawDebugLocalPlayer(UCanvas* Canvas);
 
+	FColor GetServerWorkerColor(const Worker_EntityId EntityId) const;
+	FColor GetVirtualWorkerColor(const Worker_EntityId EntityId) const;
 	const FString& GetAuthoritativeWorkerFromACL(const Worker_EntityId EntityId) const;
 
 	bool GetLockStatus(const Worker_EntityId EntityId);

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
@@ -843,6 +843,7 @@ SCHEMA_GENERATOR_TEST(GIVEN_source_and_destination_of_well_known_schema_files_WH
 		"singleton.schema",
 		"spawndata.schema",
 		"spawner.schema",
+		"spatial_debugging.schema",
 		"tombstone.schema",
 		"unreal_metadata.schema",
 		"virtual_worker_translation.schema"


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description

This adds a component to hold the information needed by SpatialDebugger. It's not as scary as it looks... honest. 

Changes that look scary but aren't: InspectionColors. I moved the functions out of the .h file and into a .cpp file. No content was changed at all, that should be a no-op, it just let me use the code elsewhere.

Changes that are meaningful, but pretty tedious and straightforward: SpatialDebugging.h. It's a lot of boilerplate on packing and unpacking schema. Nothing terribly complicated, but a lot of lines of code.

What's actually meaningful and a bit complicated: Reading/Writing the schema. 
1. For basic reading and writing from schema, the data lives in the StaticComponentView.
2. There are two places the SpatialDebugging information could be created. 
   First, in entity creation, where the authority intent is assigned, but not the authority. 
   Second, if a worker gets the entity over the wire with no SpatialDebugging component. If the server gets an authority gained, it will write a new Debugging component with it's own authority info.
3. There are two places the SpatialDebugging component is updated. 
   First, in authority gained if it exists, the component is updated to reflect the new authority. 
   Second, if a server is giving up authority, when the intent is written of the new server, it will also update the Debugging component. 

Locking isn't written to the Debugging component yet.

#### Release note
REQUIRED: Add a release note to the `##Unreleased` section of CHANGELOG.md. You can find guidance for writing useful release notes [here](../SpatialGDK/Extras/internal-documentation/how-to-write-good-release-notes.md). Documentation changes are exempt from this requirement.

