### PR TITLE
Bugfix/gsc 1513 fixing get actor spatial position for spectator mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Fixed a bug that caused queued RPCs to spam logs when an entity is deleted.
 - Take into account OverrideSpatialNetworking command line argument as early as possible (LocalDeploymentManager used to query bSpatialNetworking before the command line was parsed).
 - Servers maintain interest in AlwaysRelevant Actors.
+- GetActorSpatialPosition now returns last spectator sync location while player is spectating.
 - The default cloud launch configuration is now empty.
 - Fixed an crash caused by attempting to read schema from an unloaded class.
 - Unresolved object references in replicated arrays of structs should now be properly handled and eventually resolved.

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialActorUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialActorUtils.h
@@ -9,6 +9,7 @@
 #include "EngineClasses/SpatialNetConnection.h"
 #include "GameFramework/Actor.h"
 #include "GameFramework/Controller.h"
+#include "GameFramework/PlayerController.h"
 
 namespace SpatialGDK
 {
@@ -36,6 +37,17 @@ inline FVector GetActorSpatialPosition(const AActor* InActor)
 	{
 		USceneComponent* PawnRootComponent = Controller->GetPawn()->GetRootComponent();
 		Location = PawnRootComponent ? PawnRootComponent->GetComponentLocation() : FVector::ZeroVector;
+	}
+	else if (const APlayerController* PlayerController = Cast<APlayerController>(Controller))
+	{
+		if (PlayerController->IsInState(NAME_Spectating))
+		{
+			Location = PlayerController->LastSpectatorSyncLocation;
+		}
+		else
+		{
+			Location = PlayerController->GetFocalLocation();
+		}
 	}
 	else if (InActor->GetOwner() != nullptr && InActor->GetOwner()->GetIsReplicated())
 	{

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialActorUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialActorUtils.h
@@ -29,6 +29,7 @@ inline FVector GetActorSpatialPosition(const AActor* InActor)
 	FVector Location = FVector::ZeroVector;
 
 	// If the Actor is a Controller, use its Pawn's position,
+	// Otherwise if the Actor is a PlayerController, use its last spectator sync location, otherwise its focal point
 	// Otherwise if the Actor has an Owner, use its position.
 	// Otherwise if the Actor has a well defined location then use that
 	// Otherwise use the origin


### PR DESCRIPTION
Description
Changed the GetActorSpatialPostion to use the last sync spectator position if the actor is a player controller and in spectating mode. Otherwise if it is a player controller and not spectating use its focallocation. 

Release note
REQUIRED: Add a release note to the ##Unreleased section of CHANGELOG.md. You can find guidance for writing useful release notes here. Documentation changes are exempt from this requirement.

Tests
I built and deployed this change in a game and verified that I could fly around have things update

STRONGLY SUGGESTED: How can this be verified by QA?
Do a deploy, start spectating and see if the requested position is matching the clients location.

Documentation
Updated the comment about the function

Primary reviewers
@yumnuska @improbable-valentyn