### PR TITLE
[UNR-2738] Fix dynamic subobject references not being set correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [`0.8.1-preview`] - 2020-xx-xx
 
 ### Bug fixes:
-- Replicated references to newly created dynamic subobjects should now be resolved correctly.
+- Replicated references to newly created dynamic subobjects will now be resolved correctly.
 
 ## [`0.8.0-preview`] - 2019-12-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased-`x.y.z`] - 20xx-xx-xx
 
+## [`0.8.1-preview`] - 2020-xx-xx
+
+### Bug fixes:
+- Replicated references to newly created dynamic subobjects should now be resolved correctly.
+
 ## [`0.8.0-preview`] - 2019-12-17
 
 ### Breaking Changes:

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -577,7 +577,7 @@ void USpatialActorChannel::DynamicallyAttachSubobject(UObject* Object)
 	}
 	else
 	{
-		Info = TryResolveNewDynamicSubobjectAndGetClassInfo(Object);
+		Info = NetDriver->PackageMap->TryResolveNewDynamicSubobjectAndGetClassInfo(Object, EntityId, NetDriver->ClassInfoManager);
 
 		if (Info == nullptr)
 		{
@@ -619,14 +619,6 @@ bool USpatialActorChannel::IsListening() const
 	}
 
 	return false;
-}
-
-const FClassInfo* USpatialActorChannel::TryResolveNewDynamicSubobjectAndGetClassInfo(UObject* Object)
-{
-	const FClassInfo* Info = NetDriver->ClassInfoManager->GetClassInfoForNewSubobject(Object, EntityId, NetDriver->PackageMap);
-	NetDriver->PackageMap->ResolveSubobject(Object, NetDriver->PackageMap->GetUnrealObjectRefForSubobject(EntityId, Info));
-
-	return Info;
 }
 
 bool USpatialActorChannel::ReplicateSubobject(UObject* Object, const FReplicationFlags& RepFlags)

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -623,30 +623,8 @@ bool USpatialActorChannel::IsListening() const
 
 const FClassInfo* USpatialActorChannel::TryResolveNewDynamicSubobjectAndGetClassInfo(UObject* Object)
 {
-	const FClassInfo* Info = nullptr;
-
-	const FClassInfo& SubobjectInfo = NetDriver->ClassInfoManager->GetOrCreateClassInfoByClass(Object->GetClass());
-
-	// Find the first ClassInfo relating to a dynamic subobject
-	// which has not been used on this entity.
-	for (const auto& DynamicSubobjectInfo : SubobjectInfo.DynamicSubobjectInfo)
-	{
-		if (!NetDriver->PackageMap->GetObjectFromUnrealObjectRef(FUnrealObjectRef(EntityId, DynamicSubobjectInfo->SchemaComponents[SCHEMA_Data])).IsValid())
-		{
-			Info = &DynamicSubobjectInfo.Get();
-			break;
-		}
-	}
-
-	// If all ClassInfos are used up, we error.
-	if (Info == nullptr)
-	{
-		UE_LOG(LogSpatialActorChannel, Error, TEXT("Too many dynamic subobjects of type %s attached to Actor %s! Please increase"
-			" the max number of dynamically attached subobjects per class in the SpatialOS runtime settings."), *Object->GetClass()->GetName(), *Actor->GetName());
-		return Info;
-	}
-
-	NetDriver->PackageMap->ResolveSubobject(Object, FUnrealObjectRef(EntityId, Info->SchemaComponents[SCHEMA_Data]));
+	const FClassInfo* Info = NetDriver->ClassInfoManager->GetClassInfoForNewSubobject(Object, EntityId, NetDriver->PackageMap);
+	NetDriver->PackageMap->ResolveSubobject(Object, NetDriver->PackageMap->GetUnrealObjectRefForSubobject(EntityId, Info));
 
 	return Info;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -577,7 +577,7 @@ void USpatialActorChannel::DynamicallyAttachSubobject(UObject* Object)
 	}
 	else
 	{
-		Info = NetDriver->PackageMap->TryResolveNewDynamicSubobjectAndGetClassInfo(Object, EntityId, NetDriver->ClassInfoManager);
+		Info = NetDriver->PackageMap->TryResolveNewDynamicSubobjectAndGetClassInfo(Object);
 
 		if (Info == nullptr)
 		{

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -297,6 +297,12 @@ bool USpatialPackageMapClient::SerializeObject(FArchive& Ar, UClass* InClass, UO
 
 const FClassInfo* USpatialPackageMapClient::TryResolveNewDynamicSubobjectAndGetClassInfo(UObject* Object, Worker_EntityId EntityId, USpatialClassInfoManager* ClassInfoManager)
 {
+	FUnrealObjectRef Ref = GetUnrealObjectRefFromObject(Object);
+	if (Ref.IsValid())
+	{
+		UE_LOG(LogSpatialPackageMap, Error, TEXT("Trying to resolve a dynamic subobject twice! Object %s, EntityId %d."), Object ? *Object->GetName() : TEXT("null"), EntityId);
+	}
+
 	const FClassInfo* Info = ClassInfoManager->GetClassInfoForNewSubobject(Object, EntityId, this);
 
 	// If we don't get the info, an error is logged in the above function, that we have exceeded the maximum number of dynamic subobjects on the entity

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -301,7 +301,7 @@ const FClassInfo* USpatialPackageMapClient::TryResolveNewDynamicSubobjectAndGetC
 	if (Ref.IsValid())
 	{
 		UE_LOG(LogSpatialPackageMap, Error, TEXT("Trying to resolve a dynamic subobject twice! Object %s, EntityId %d."), Object ? *Object->GetName() : TEXT("null"), EntityId);
-		return;
+		return nullptr;
 	}
 
 	const FClassInfo* Info = ClassInfoManager->GetClassInfoForNewSubobject(Object, EntityId, this);

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -295,6 +295,11 @@ bool USpatialPackageMapClient::SerializeObject(FArchive& Ar, UClass* InClass, UO
 	return true;
 }
 
+FUnrealObjectRef USpatialPackageMapClient::GetUnrealObjectRefForSubobject(Worker_EntityId EntityId, const FClassInfo* Info)
+{
+	return FUnrealObjectRef(EntityId, Info->SchemaComponents[SCHEMA_Data]);
+}
+
 FSpatialNetGUIDCache::FSpatialNetGUIDCache(USpatialNetDriver* InDriver)
 	: FNetGUIDCache(InDriver)
 {

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -298,7 +298,6 @@ bool USpatialPackageMapClient::SerializeObject(FArchive& Ar, UClass* InClass, UO
 const FClassInfo* USpatialPackageMapClient::TryResolveNewDynamicSubobjectAndGetClassInfo(UObject* Object)
 {
 	AActor* Actor = Object->GetTypedOuter<AActor>();
-	TryResolveObjectAsEntity(Actor);	// Make sure the actor is resolved
 
 	Worker_EntityId EntityId = GetEntityIdFromObject(Actor);
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -297,8 +297,7 @@ bool USpatialPackageMapClient::SerializeObject(FArchive& Ar, UClass* InClass, UO
 
 const FClassInfo* USpatialPackageMapClient::TryResolveNewDynamicSubobjectAndGetClassInfo(UObject* Object)
 {
-	AActor* Actor = Object->GetTypedOuter<AActor>();
-
+	AActor* Actor = Object ? Object->GetTypedOuter<AActor>() : nullptr;
 	Worker_EntityId EntityId = GetEntityIdFromObject(Actor);
 
 	if (EntityId != SpatialConstants::INVALID_ENTITY_ID)

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -301,6 +301,7 @@ const FClassInfo* USpatialPackageMapClient::TryResolveNewDynamicSubobjectAndGetC
 	if (Ref.IsValid())
 	{
 		UE_LOG(LogSpatialPackageMap, Error, TEXT("Trying to resolve a dynamic subobject twice! Object %s, EntityId %d."), Object ? *Object->GetName() : TEXT("null"), EntityId);
+		return;
 	}
 
 	const FClassInfo* Info = ClassInfoManager->GetClassInfoForNewSubobject(Object, EntityId, this);

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -295,9 +295,17 @@ bool USpatialPackageMapClient::SerializeObject(FArchive& Ar, UClass* InClass, UO
 	return true;
 }
 
-FUnrealObjectRef USpatialPackageMapClient::GetUnrealObjectRefForSubobject(Worker_EntityId EntityId, const FClassInfo* Info)
+const FClassInfo* USpatialPackageMapClient::TryResolveNewDynamicSubobjectAndGetClassInfo(UObject* Object, Worker_EntityId EntityId, USpatialClassInfoManager* ClassInfoManager)
 {
-	return FUnrealObjectRef(EntityId, Info->SchemaComponents[SCHEMA_Data]);
+	const FClassInfo* Info = ClassInfoManager->GetClassInfoForNewSubobject(Object, EntityId, this);
+
+	// If we don't get the info, an error is logged in the above function, that we have exceeded the maximum number of dynamic subobjects on the entity
+	if (Info)
+	{
+		ResolveSubobject(Object, FUnrealObjectRef(EntityId, Info->SchemaComponents[SCHEMA_Data]));
+	}
+
+	return Info;
 }
 
 FSpatialNetGUIDCache::FSpatialNetGUIDCache(USpatialNetDriver* InDriver)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
@@ -467,7 +467,7 @@ bool USpatialClassInfoManager::IsSublevelComponent(Worker_ComponentId ComponentI
 	return SchemaDatabase->LevelComponentIds.Contains(ComponentId);
 }
 
-const FClassInfo * USpatialClassInfoManager::GetClassInfoForNewSubobject(const UObject * Object, Worker_EntityId EntityId, USpatialPackageMapClient* PackageMapClient)
+const FClassInfo* USpatialClassInfoManager::GetClassInfoForNewSubobject(const UObject * Object, Worker_EntityId EntityId, USpatialPackageMapClient* PackageMapClient)
 {
 	const FClassInfo* Info = nullptr;
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
@@ -487,7 +487,7 @@ const FClassInfo* USpatialClassInfoManager::GetClassInfoForNewSubobject(const UO
 	// If all ClassInfos are used up, we error.
 	if (Info == nullptr)
 	{
-		AActor* Actor = Cast<AActor>(PackageMapClient->GetObjectFromEntityId(EntityId));
+		const AActor* Actor = Cast<AActor>(PackageMapClient->GetObjectFromEntityId(EntityId));
 		UE_LOG(LogSpatialPackageMap, Error, TEXT("Too many dynamic subobjects of type %s attached to Actor %s! Please increase"
 			" the max number of dynamically attached subobjects per class in the SpatialOS runtime settings."), *Object->GetClass()->GetName(), *GetNameSafe(Actor));
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
@@ -467,7 +467,7 @@ bool USpatialClassInfoManager::IsSublevelComponent(Worker_ComponentId ComponentI
 	return SchemaDatabase->LevelComponentIds.Contains(ComponentId);
 }
 
-const FClassInfo * USpatialClassInfoManager::GetClassInfoForNewSubobject(UObject * Object, Worker_EntityId EntityId, USpatialPackageMapClient* PackageMapClient)
+const FClassInfo * USpatialClassInfoManager::GetClassInfoForNewSubobject(const UObject * Object, Worker_EntityId EntityId, USpatialPackageMapClient* PackageMapClient)
 {
 	const FClassInfo* Info = nullptr;
 
@@ -489,7 +489,7 @@ const FClassInfo * USpatialClassInfoManager::GetClassInfoForNewSubobject(UObject
 	{
 		AActor* Actor = Cast<AActor>(PackageMapClient->GetObjectFromEntityId(EntityId));
 		UE_LOG(LogSpatialPackageMap, Error, TEXT("Too many dynamic subobjects of type %s attached to Actor %s! Please increase"
-			" the max number of dynamically attached subobjects per class in the SpatialOS runtime settings."), *Object->GetClass()->GetName(), Actor ? *Actor->GetName() : TEXT("null"));
+			" the max number of dynamically attached subobjects per class in the SpatialOS runtime settings."), *Object->GetClass()->GetName(), *GetNameSafe(Actor));
 	}
 
 	return Info;

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -285,7 +285,7 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 			// If this object is not in the PackageMap, it has been dynamically created.
 			if (!PackageMap->GetUnrealObjectRefFromObject(Subobject).IsValid())
 			{
-				const FClassInfo* SubobjectInfo = NetDriver->PackageMap->TryResolveNewDynamicSubobjectAndGetClassInfo(Subobject, Channel->GetEntityId(), NetDriver->ClassInfoManager);
+				const FClassInfo* SubobjectInfo = NetDriver->PackageMap->TryResolveNewDynamicSubobjectAndGetClassInfo(Subobject);
 
 				if (SubobjectInfo == nullptr)
 				{

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -285,7 +285,7 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 			// If this object is not in the PackageMap, it has been dynamically created.
 			if (!PackageMap->GetUnrealObjectRefFromObject(Subobject).IsValid())
 			{
-				const FClassInfo* SubobjectInfo = Channel->TryResolveNewDynamicSubobjectAndGetClassInfo(Subobject);
+				const FClassInfo* SubobjectInfo = NetDriver->PackageMap->TryResolveNewDynamicSubobjectAndGetClassInfo(Subobject, Channel->GetEntityId(), NetDriver->ClassInfoManager);
 
 				if (SubobjectInfo == nullptr)
 				{

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -285,7 +285,7 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 			// If this object is not in the PackageMap, it has been dynamically created.
 			if (!PackageMap->GetUnrealObjectRefFromObject(Subobject).IsValid())
 			{
-				const FClassInfo* SubobjectInfo = NetDriver->PackageMap->TryResolveNewDynamicSubobjectAndGetClassInfo(Subobject);
+				const FClassInfo* SubobjectInfo = PackageMap->TryResolveNewDynamicSubobjectAndGetClassInfo(Subobject);
 
 				if (SubobjectInfo == nullptr)
 				{

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -159,7 +159,6 @@ public:
 	FORCEINLINE bool GetInterestDirty() const { return bInterestDirty; }
 
 	bool IsListening() const;
-	const FClassInfo* TryResolveNewDynamicSubobjectAndGetClassInfo(UObject* Object);
 
 protected:
 	// Begin UChannel interface

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialPackageMapClient.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialPackageMapClient.h
@@ -62,7 +62,7 @@ public:
 
 	virtual bool SerializeObject(FArchive& Ar, UClass* InClass, UObject*& Obj, FNetworkGUID *OutNetGUID = NULL) override;
 
-	const FClassInfo* TryResolveNewDynamicSubobjectAndGetClassInfo(UObject* Object, Worker_EntityId EntityId, USpatialClassInfoManager* ClassInfoManager);
+	const FClassInfo* TryResolveNewDynamicSubobjectAndGetClassInfo(UObject* Object);
 
 private:
 	UPROPERTY()

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialPackageMapClient.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialPackageMapClient.h
@@ -62,12 +62,9 @@ public:
 
 	virtual bool SerializeObject(FArchive& Ar, UClass* InClass, UObject*& Obj, FNetworkGUID *OutNetGUID = NULL) override;
 
-	static FUnrealObjectRef GetUnrealObjectRefForSubobject(Worker_EntityId EntityId, const FClassInfo* Info);
+	const FClassInfo* TryResolveNewDynamicSubobjectAndGetClassInfo(UObject* Object, Worker_EntityId EntityId, USpatialClassInfoManager* ClassInfoManager);
 
 private:
-	UPROPERTY()
-	USpatialClassInfoManager* ClassInfoManager;
-
 	UPROPERTY()
 	UEntityPool* EntityPool;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialPackageMapClient.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialPackageMapClient.h
@@ -14,7 +14,6 @@
 
 DECLARE_LOG_CATEGORY_EXTERN(LogSpatialPackageMap, Log, All);
 
-class USpatialClassInfoManager;
 class USpatialNetDriver;
 class UEntityPool;
 class FTimerManager;

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialPackageMapClient.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialPackageMapClient.h
@@ -62,6 +62,8 @@ public:
 
 	virtual bool SerializeObject(FArchive& Ar, UClass* InClass, UObject*& Obj, FNetworkGUID *OutNetGUID = NULL) override;
 
+	static FUnrealObjectRef GetUnrealObjectRefForSubobject(Worker_EntityId EntityId, const FClassInfo* Info);
+
 private:
 	UPROPERTY()
 	USpatialClassInfoManager* ClassInfoManager;

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialClassInfoManager.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialClassInfoManager.h
@@ -115,6 +115,7 @@ public:
 
 	uint32 GetComponentIdFromLevelPath(const FString& LevelPath);
 	bool IsSublevelComponent(Worker_ComponentId ComponentId);
+	const FClassInfo* GetClassInfoForNewSubobject(UObject* Object, Worker_EntityId EntityId, USpatialPackageMapClient* PackageMapClient);
 
 	UPROPERTY()
 	USchemaDatabase* SchemaDatabase;

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialClassInfoManager.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialClassInfoManager.h
@@ -115,6 +115,8 @@ public:
 
 	uint32 GetComponentIdFromLevelPath(const FString& LevelPath);
 	bool IsSublevelComponent(Worker_ComponentId ComponentId);
+
+	// Tries to find ClassInfo corresponding to an unused dynamic subobject on the given entity
 	const FClassInfo* GetClassInfoForNewSubobject(UObject* Object, Worker_EntityId EntityId, USpatialPackageMapClient* PackageMapClient);
 
 	UPROPERTY()

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialClassInfoManager.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialClassInfoManager.h
@@ -117,7 +117,7 @@ public:
 	bool IsSublevelComponent(Worker_ComponentId ComponentId);
 
 	// Tries to find ClassInfo corresponding to an unused dynamic subobject on the given entity
-	const FClassInfo* GetClassInfoForNewSubobject(UObject* Object, Worker_EntityId EntityId, USpatialPackageMapClient* PackageMapClient);
+	const FClassInfo* GetClassInfoForNewSubobject(const UObject* Object, Worker_EntityId EntityId, USpatialPackageMapClient* PackageMapClient);
 
 	UPROPERTY()
 	USchemaDatabase* SchemaDatabase;

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.cpp
@@ -123,7 +123,7 @@ FUnrealObjectRef FUnrealObjectRef::FromObjectPtr(UObject* ObjectValue, USpatialP
 				}
 
 				// Check if the object is a newly referenced dynamic subobject, in which case we can create the object ref if we have the entity id of the parent actor.
-				if (ObjectValue->IsA<UActorComponent>())
+				if (!ObjectValue->IsA<AActor>())
 				{
 					PackageMap->TryResolveNewDynamicSubobjectAndGetClassInfo(ObjectValue);
 					ObjectRef = PackageMap->GetUnrealObjectRefFromObject(ObjectValue); // This should now be valid, as we resolve the object in the line before

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.cpp
@@ -125,17 +125,20 @@ FUnrealObjectRef FUnrealObjectRef::FromObjectPtr(UObject* ObjectValue, USpatialP
 				}
 
 				// Check if the object is a newly referenced dynamic subobject, in which case we can create the object ref if we have the entity id of the parent actor.
-				if (ObjectValue->IsA<UActorComponent>() && PackageMap->GetEntityIdFromObject(ObjectValue->GetTypedOuter<AActor>()) != SpatialConstants::INVALID_ENTITY_ID)
+				if (ObjectValue->IsA<UActorComponent>())
 				{
 					// This is quite hacky, maybe there is a better way?
 					AActor* Actor = ObjectValue->GetTypedOuter<AActor>();
 					Worker_EntityId EntityId = PackageMap->GetEntityIdFromObject(Actor);
 
-					PackageMap->TryResolveNewDynamicSubobjectAndGetClassInfo(ObjectValue, EntityId, Cast<USpatialNetDriver>(Actor->GetNetDriver())->ClassInfoManager);
-					ObjectRef = PackageMap->GetUnrealObjectRefFromObject(ObjectValue); // This should now be valid, as we resolve the object in the line before
-					if (ObjectRef.IsValid())
+					if (EntityId != SpatialConstants::INVALID_ENTITY_ID)
 					{
-						return ObjectRef;
+						PackageMap->TryResolveNewDynamicSubobjectAndGetClassInfo(ObjectValue, EntityId, Cast<USpatialNetDriver>(Actor->GetNetDriver())->ClassInfoManager);
+						ObjectRef = PackageMap->GetUnrealObjectRefFromObject(ObjectValue); // This should now be valid, as we resolve the object in the line before
+						if (ObjectRef.IsValid())
+						{
+							return ObjectRef;
+						}
 					}
 				}
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.cpp
@@ -66,8 +66,6 @@ FUnrealObjectRef FUnrealObjectRef::FromObjectPtr(UObject* ObjectValue, USpatialP
 
 	if (ObjectValue != nullptr && !ObjectValue->IsPendingKill())
 	{
-		UE_LOG(LogTemp, Log, TEXT("FromObjectPtr: %s"), *ObjectValue->GetName());
-
 		FNetworkGUID NetGUID;
 		if (ObjectValue->IsSupportedForNetworking())
 		{
@@ -147,8 +145,6 @@ FUnrealObjectRef FUnrealObjectRef::FromObjectPtr(UObject* ObjectValue, USpatialP
 			}
 		}
 	}
-
-	if(ObjectValue != nullptr) UE_LOG(LogTemp, Log, TEXT("FromObjectPtr: %s (late)"), *ObjectRef.ToString());
 
 	return ObjectRef;
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.cpp
@@ -127,18 +127,11 @@ FUnrealObjectRef FUnrealObjectRef::FromObjectPtr(UObject* ObjectValue, USpatialP
 				// Check if the object is a newly referenced dynamic subobject, in which case we can create the object ref if we have the entity id of the parent actor.
 				if (ObjectValue->IsA<UActorComponent>())
 				{
-					// This is quite hacky, maybe there is a better way?
-					AActor* Actor = ObjectValue->GetTypedOuter<AActor>();
-					Worker_EntityId EntityId = PackageMap->GetEntityIdFromObject(Actor);
-
-					if (EntityId != SpatialConstants::INVALID_ENTITY_ID)
+					PackageMap->TryResolveNewDynamicSubobjectAndGetClassInfo(ObjectValue);
+					ObjectRef = PackageMap->GetUnrealObjectRefFromObject(ObjectValue); // This should now be valid, as we resolve the object in the line before
+					if (ObjectRef.IsValid())
 					{
-						PackageMap->TryResolveNewDynamicSubobjectAndGetClassInfo(ObjectValue, EntityId, Cast<USpatialNetDriver>(Actor->GetNetDriver())->ClassInfoManager);
-						ObjectRef = PackageMap->GetUnrealObjectRefFromObject(ObjectValue); // This should now be valid, as we resolve the object in the line before
-						if (ObjectRef.IsValid())
-						{
-							return ObjectRef;
-						}
+						return ObjectRef;
 					}
 				}
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.cpp
@@ -129,12 +129,12 @@ FUnrealObjectRef FUnrealObjectRef::FromObjectPtr(UObject* ObjectValue, USpatialP
 				// Check if the object is a newly referenced dynamic subobject, in which case we can create the object ref if we have the entity id of the parent actor.
 				if (ObjectValue->IsA<UActorComponent>() && PackageMap->GetEntityIdFromObject(ObjectValue->GetTypedOuter<AActor>()) != SpatialConstants::INVALID_ENTITY_ID)
 				{
-					// This is very hacky, refactor
+					// This is quite hacky, maybe there is a better way?
 					AActor* Actor = ObjectValue->GetTypedOuter<AActor>();
 					Worker_EntityId EntityId = PackageMap->GetEntityIdFromObject(Actor);
-					USpatialActorChannel* Channel = Cast<USpatialNetDriver>(Actor->GetNetDriver())->GetActorChannelByEntityId(EntityId);
-					const FClassInfo* Info = Channel->TryResolveNewDynamicSubobjectAndGetClassInfo(ObjectValue);
-					ObjectRef = PackageMap->GetUnrealObjectRefForSubobject(EntityId, Info);
+
+					PackageMap->TryResolveNewDynamicSubobjectAndGetClassInfo(ObjectValue, EntityId, Cast<USpatialNetDriver>(Actor->GetNetDriver())->ClassInfoManager);
+					ObjectRef = PackageMap->GetUnrealObjectRefFromObject(ObjectValue); // This should now be valid, as we resolve the object in the line before
 					if (ObjectRef.IsValid())
 					{
 						return ObjectRef;

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.cpp
@@ -3,8 +3,6 @@
 #include "Schema/UnrealObjectRef.h"
 
 #include "EngineClasses/SpatialPackageMapClient.h"
-#include "SpatialConstants.h"
-#include "EngineClasses/SpatialActorChannel.h"
 #include "Utils/SchemaUtils.h"
 
 DEFINE_LOG_CATEGORY_STATIC(LogUnrealObjectRef, Log, All);


### PR DESCRIPTION
#### Description
If creating a subobject and setting a replicated reference to it in approximately the same tick, the reference would be set to null forever. This fixes the issue by resolving the dynamic subobject earlier in replication.

#### Release note
Replicated references to newly created dynamic subobjects should now be resolved correctly.

#### Tests
Created DynamicComponentTest in EngineNetTest.

#### Documentation
TODO: maybe more in-code docs, maybe more logs to alert us when things fail.

#### Primary reviewers
@Vatyx @m-samiec @improbable-valentyn 