### PR TITLE
Feature/UNR-2589 latency tracking

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
@@ -36,7 +36,6 @@ namespace
 	};
 
 	UEStream Stream;
-	FString MessagePrefix;
 
 #if TRACE_LIB_ACTIVE
 	improbable::trace::SpanContext ReadSpanContext(const void* TraceBytes, const void* SpanBytes)
@@ -76,11 +75,16 @@ void USpatialLatencyTracer::RegisterProject(UObject* WorldContextObject, const F
 #endif // TRACE_LIB_ACTIVE
 }
 
-void USpatialLatencyTracer::SetMessagePrefix(const FString& NewMessagePrefix)
+bool USpatialLatencyTracer::SetMessagePrefix(UObject* WorldContextObject, const FString& NewMessagePrefix)
 {
 #if TRACE_LIB_ACTIVE
-	MessagePrefix = NewMessagePrefix;
+	USpatialLatencyTracer* tracer = GetTracer(WorldContextObject);
+	if (tracer != NULL) {
+		tracer->MessagePrefix = NewMessagePrefix;
+		return true;
+	}
 #endif // TRACE_LIB_ACTIVE
+	return false;
 }
 
 bool USpatialLatencyTracer::BeginLatencyTrace(UObject* WorldContextObject, const FString& TraceDesc, FSpatialLatencyPayload& OutLatencyPayload)

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
@@ -78,8 +78,7 @@ void USpatialLatencyTracer::RegisterProject(UObject* WorldContextObject, const F
 bool USpatialLatencyTracer::SetMessagePrefix(UObject* WorldContextObject, const FString& NewMessagePrefix)
 {
 #if TRACE_LIB_ACTIVE
-	USpatialLatencyTracer* Tracer = GetTracer(WorldContextObject);
-	if (Tracer != NULL)
+	if (USpatialLatencyTracer* Tracer = GetTracer(WorldContextObject))
 	{
 		Tracer->MessagePrefix = NewMessagePrefix;
 		return true;

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
@@ -78,9 +78,10 @@ void USpatialLatencyTracer::RegisterProject(UObject* WorldContextObject, const F
 bool USpatialLatencyTracer::SetMessagePrefix(UObject* WorldContextObject, const FString& NewMessagePrefix)
 {
 #if TRACE_LIB_ACTIVE
-	USpatialLatencyTracer* tracer = GetTracer(WorldContextObject);
-	if (tracer != NULL) {
-		tracer->MessagePrefix = NewMessagePrefix;
+	USpatialLatencyTracer* Tracer = GetTracer(WorldContextObject);
+	if (Tracer != NULL)
+	{
+		Tracer->MessagePrefix = NewMessagePrefix;
 		return true;
 	}
 #endif // TRACE_LIB_ACTIVE

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
@@ -56,6 +56,7 @@ USpatialLatencyTracer::USpatialLatencyTracer()
 #if TRACE_LIB_ACTIVE
 	ActiveTraceKey = InvalidTraceKey;
 	ResetWorkerId();
+	MessagePrefix = "";
 #endif
 }
 
@@ -70,6 +71,13 @@ void USpatialLatencyTracer::RegisterProject(UObject* WorldContextObject, const F
 	std::cerr.rdbuf(&Stream);
 
 	StdoutExporter::Register();
+#endif // TRACE_LIB_ACTIVE
+}
+
+void USpatialLatencyTracer::SetMessagePrefix(const FString& NewMessagePrefix)
+{
+#if TRACE_LIB_ACTIVE
+	MessagePrefix = NewMessagePrefix;
 #endif // TRACE_LIB_ACTIVE
 }
 
@@ -583,7 +591,7 @@ void USpatialLatencyTracer::WriteKeyFrameToTrace(const TraceSpan* Trace, const F
 
 FString USpatialLatencyTracer::FormatMessage(const FString& Message) const
 {
-	return FString::Printf(TEXT("(%s) : %s"), *WorkerId.Left(18), *Message);
+	return FString::Printf(TEXT("%s(%s) : %s"), *MessagePrefix, *WorkerId.Left(18), *Message);
 }
 
 #endif // TRACE_LIB_ACTIVE

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
@@ -36,6 +36,7 @@ namespace
 	};
 
 	UEStream Stream;
+	FString MessagePrefix;
 
 #if TRACE_LIB_ACTIVE
 	improbable::trace::SpanContext ReadSpanContext(const void* TraceBytes, const void* SpanBytes)
@@ -177,8 +178,6 @@ USpatialLatencyTracer* USpatialLatencyTracer::GetTracer(UObject* WorldContextObj
 }
 
 #if TRACE_LIB_ACTIVE
-FString USpatialLatencyTracer::MessagePrefix = TEXT("");
-
 bool USpatialLatencyTracer::IsValidKey(const TraceKey Key)
 {
 	FScopeLock Lock(&Mutex);

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
@@ -51,6 +51,8 @@ namespace
 #endif
 }  // anonymous namespace
 
+const TraceKey USpatialLatencyTracer::InvalidTraceKey = -1;
+
 USpatialLatencyTracer::USpatialLatencyTracer()
 {
 #if TRACE_LIB_ACTIVE
@@ -175,6 +177,8 @@ USpatialLatencyTracer* USpatialLatencyTracer::GetTracer(UObject* WorldContextObj
 }
 
 #if TRACE_LIB_ACTIVE
+FString USpatialLatencyTracer::MessagePrefix = TEXT("");
+
 bool USpatialLatencyTracer::IsValidKey(const TraceKey Key)
 {
 	FScopeLock Lock(&Mutex);

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
@@ -56,7 +56,6 @@ USpatialLatencyTracer::USpatialLatencyTracer()
 #if TRACE_LIB_ACTIVE
 	ActiveTraceKey = InvalidTraceKey;
 	ResetWorkerId();
-	MessagePrefix = "";
 #endif
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
@@ -51,8 +51,6 @@ namespace
 #endif
 }  // anonymous namespace
 
-const TraceKey USpatialLatencyTracer::InvalidTraceKey = -1;
-
 USpatialLatencyTracer::USpatialLatencyTracer()
 {
 #if TRACE_LIB_ACTIVE

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracer.h
@@ -73,7 +73,7 @@ public:
 
 	// Set a prefix to be used for all span names. No whitespace is generated (e.g. "prefix(WorkerID) Actual Message Here").
 	UFUNCTION(BlueprintCallable, Category = "SpatialOS", meta = (WorldContext = "WorldContextObject"))
-	void SetMessagePrefix(const FString& NewMessagePrefix);
+	static void SetMessagePrefix(const FString& NewMessagePrefix);
 
 	// Start a latency trace. This will start the latency timer and attach it to a specific RPC.
 	UFUNCTION(BlueprintCallable, Category = "SpatialOS", meta = (WorldContext = "WorldContextObject"))
@@ -160,7 +160,7 @@ private:
 	void ClearTrackingInformation();
 
 	FString WorkerId;
-	FString MessagePrefix;
+	static FString MessagePrefix;
 
 	// This is used to track if there is an active trace within a currently processing network call. The user is
 	// able to hook into this active trace, and `continue` it to another network relevant call. If so, the

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracer.h
@@ -159,8 +159,6 @@ private:
 
 	void ClearTrackingInformation();
 
-	// GetTracer may return null during startup, so store MessagePrefix statically to ensure success of SetMessagePrefix
-	static FString MessagePrefix;
 	FString WorkerId;
 
 	// This is used to track if there is an active trace within a currently processing network call. The user is

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracer.h
@@ -71,6 +71,11 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "SpatialOS", meta = (WorldContext = "WorldContextObject"))
 	static void RegisterProject(UObject* WorldContextObject, const FString& ProjectId);
 
+	// Set a prefix to be used for all span names. No whitespace is generated (e.g. "prefix(WorkerID) Actual Message Here").
+	UFUNCTION(BlueprintCallable, Category = "SpatialOS", meta = (WorldContext = "WorldContextObject"))
+	void SetMessagePrefix(const FString& NewMessagePrefix);
+
+	// Start a latency trace. This will start the latency timer and attach it to a specific RPC.
 	UFUNCTION(BlueprintCallable, Category = "SpatialOS", meta = (WorldContext = "WorldContextObject"))
 	static bool BeginLatencyTrace(UObject* WorldContextObject, const FString& TraceDesc, FSpatialLatencyPayload& OutLatencyPayload);
 
@@ -155,6 +160,7 @@ private:
 	void ClearTrackingInformation();
 
 	FString WorkerId;
+	FString MessagePrefix;
 
 	// This is used to track if there is an active trace within a currently processing network call. The user is
 	// able to hook into this active trace, and `continue` it to another network relevant call. If so, the

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracer.h
@@ -159,8 +159,9 @@ private:
 
 	void ClearTrackingInformation();
 
-	FString WorkerId;
+	// GetTracer may return null during startup, so store MessagePrefix statically to ensure success of SetMessagePrefix
 	static FString MessagePrefix;
+	FString WorkerId;
 
 	// This is used to track if there is an active trace within a currently processing network call. The user is
 	// able to hook into this active trace, and `continue` it to another network relevant call. If so, the

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracer.h
@@ -73,7 +73,7 @@ public:
 
 	// Set a prefix to be used for all span names. Resulting uploaded span names are of the format "PREFIX(WORKER_ID) : USER_SPECIFIED_NAME".
 	UFUNCTION(BlueprintCallable, Category = "SpatialOS", meta = (WorldContext = "WorldContextObject"))
-	static void SetMessagePrefix(const FString& NewMessagePrefix);
+	static bool SetMessagePrefix(UObject* WorldContextObject, const FString& NewMessagePrefix);
 
 	// Start a latency trace. This will start the latency timer and attach it to a specific RPC.
 	UFUNCTION(BlueprintCallable, Category = "SpatialOS", meta = (WorldContext = "WorldContextObject"))
@@ -160,6 +160,7 @@ private:
 	void ClearTrackingInformation();
 
 	FString WorkerId;
+	FString MessagePrefix;
 
 	// This is used to track if there is an active trace within a currently processing network call. The user is
 	// able to hook into this active trace, and `continue` it to another network relevant call. If so, the

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracer.h
@@ -71,7 +71,7 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "SpatialOS", meta = (WorldContext = "WorldContextObject"))
 	static void RegisterProject(UObject* WorldContextObject, const FString& ProjectId);
 
-	// Set a prefix to be used for all span names. No whitespace is generated (e.g. "prefix(WorkerID) Actual Message Here").
+	// Set a prefix to be used for all span names. Resulting uploaded span names are of the format "PREFIX(WORKER_ID) : USER_SPECIFIED_NAME".
 	UFUNCTION(BlueprintCallable, Category = "SpatialOS", meta = (WorldContext = "WorldContextObject"))
 	static void SetMessagePrefix(const FString& NewMessagePrefix);
 

--- a/ci/setup-gdk.ps1
+++ b/ci/setup-gdk.ps1
@@ -10,5 +10,5 @@ Push-Location $gdk_path
         $env:NO_PAUSE = 1
     }
     $env:MSBUILD_EXE = "`"$msbuild_path`""
-    cmd /c Setup.bat
+    cmd /c SetupIncTraceLibs.bat
 Pop-Location

--- a/ci/setup-gdk.ps1
+++ b/ci/setup-gdk.ps1
@@ -2,7 +2,8 @@
 # This script is used directly as part of the UnrealGDKExampleProject CI, so providing default values may be strictly necessary
 param (
     [string] $gdk_path = "$gdk_home",
-    [string] $msbuild_path = "$((Get-Item 'Env:programfiles(x86)').Value)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin\MSBuild.exe" ## Location of MSBuild.exe on the build agent, as it only has the build tools, not the full visual studio
+    [string] $msbuild_path = "$((Get-Item 'Env:programfiles(x86)').Value)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin\MSBuild.exe", ## Location of MSBuild.exe on the build agent, as it only has the build tools, not the full visual studio
+    [switch] $includeTraceLibs
 )
 
 Push-Location $gdk_path
@@ -10,5 +11,9 @@ Push-Location $gdk_path
         $env:NO_PAUSE = 1
     }
     $env:MSBUILD_EXE = "`"$msbuild_path`""
-    cmd /c SetupIncTraceLibs.bat
+    if($includeTraceLibs) {
+        cmd /c SetupIncTraceLibs.bat
+    } else {
+        cmd /c Setup.bat
+    }
 Pop-Location


### PR DESCRIPTION
#### Context
This PR is part of an effort to produce, aggregate, upload and display NFR latency metrics.
The following 4 PR's constitute the required code repo changes for this goal:
* Nfr-Benchmark-Pipeline: https://github.com/improbable/nfr-benchmark-pipeline/pull/88
* UnrealGDKTestGyms: https://github.com/spatialos/UnrealGDKTestGyms/pull/23
* UnrealGDK: https://github.com/spatialos/UnrealGDK/pull/1717
* ShooterGameBuildkite: https://github.com/improbable/ShooterGameBuildKite/pull/22

#### Description of Changes
These changes add a static function to the existing latency tracing code that allows to easily set the prefixes of trace names. This facilitates the use of the new latency tracing scenario, aa users are expected to specify a trace prefix (because all traces are uploaded to the same project by default). This PR also makes sure that the trace library is fetched and built when the GDK is downloaded during CI.

#### Release note
These changes are not public facing, so no release note has been added.

#### Tests
A build that makes use of all four changed repositories has been kicked off at https://buildkite.com/improbable/shootergamebuildkite-sg-perf-test/builds/675. All NFR scenarios complete succesfully.

#### Documentation
In-code commentary has been provided.
Full documentation for the new latency tracing scenario has been provided in the Nfr Runner PR.

#### Primary reviewers
@spatialos/develop-unrea @improbable-danny @m-samiec @michelefabris 