### PR TITLE
Set ROLE_SimulatedProxy when setting a different authority intent

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -676,6 +676,10 @@ int64 USpatialActorChannel::ReplicateActor()
 		if (NewAuthVirtualWorkerId != SpatialConstants::INVALID_VIRTUAL_WORKER_ID)
 		{
 			Sender->SendAuthorityIntentUpdate(*Actor, NewAuthVirtualWorkerId);
+
+			// If we're setting a different authority intent, preemptively changed to ROLE_SimulatedProxy 
+			Actor->Role = ROLE_SimulatedProxy;
+			Actor->RemoteRole = ROLE_Authority;
 		}
 		else
 		{


### PR DESCRIPTION
This is a safe approach to the fact that changing AuthorityIntent indicates you're about to lose authority via the enforcer and will reduce the likelihood that you try to act in an authoritative manner while SpatialOS is taking away your authority.

We're always setting Role to SimulatedProxy and RemoteRole to Authority (regardless of autonomous proxies).

This could simplify checking whether you can acquire a lock to just checking the ROLE_Authority, making UNR-2770 quite trivial. 

This would also simplify GAS ability locking in UNR-2531 which already respects ROLE_Authority.