### PR TITLE
Change FindChecked call by code that would not crash in release

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -173,13 +173,16 @@ void FSpatialObjectRepState::UpdateRefToRepStateMap(FObjectToRepStateMap& RepSta
 	{
 		if (!LocalReferencedObj.Contains(Ref))
 		{
-			TSet<FChannelObjectPair>& RepStatesWithRef = RepStateMap.FindChecked(Ref);
+			TSet<FChannelObjectPair>* RepStatesWithRef = RepStateMap.Find(Ref);
 
-			RepStatesWithRef.Remove(ThisObj);
-
-			if (RepStatesWithRef.Num() == 0)
+			if (ensure(RepStatesWithRef))
 			{
-				RepStateMap.Remove(Ref);
+				RepStatesWithRef->Remove(ThisObj);
+
+				if (RepStatesWithRef->Num() == 0)
+				{
+					RepStateMap.Remove(Ref);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
#### Description

The changed code could cause a null pointer exception in release. It may have happened in a Scavenger playtest in a case when both maps would have been desynchronized (the cause of the desync has been corrected).
The new code is safer in release while still catching error in test.