### PR TITLE
Remove invalid check for outer 

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
@@ -313,8 +313,6 @@ const FClassInfo& USpatialClassInfoManager::GetOrCreateClassInfoByObject(UObject
 	}
 	else
 	{
-		check(Object->GetTypedOuter<AActor>() != nullptr);
-
 		FUnrealObjectRef ObjectRef = NetDriver->PackageMap->GetUnrealObjectRefFromObject(Object);
 
 		check(ObjectRef.IsValid());


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
This PR removes the check that assumes that a subobject will always have an outer in the `GetOrCreateClassInfoByObject` api. This is not true for game play ability tasks, as these are created in the transient package, and as a consequence these do not have an outer.

Accompanied with this PR is an engine change that makes the Gameplay ability task a spatial type by default. PR can be found here(Not setup yet)

#### Release note
REQUIRED: Add a release note to the `##Unreleased` section of CHANGELOG.md. You can find guidance for writing useful release notes [here](../SpatialGDK/Extras/internal-documentation/how-to-write-good-release-notes.md). Documentation changes are exempt from this requirement.

#### Tests
Tested in a game, still need to be validated on a vanilla GDK test gym

STRONGLY SUGGESTED: 

* Create an ability task with replicated data
* Do not mark the task as a Spatial type. 
* Use the ability and ensure that the assert is firing without the fix
* Use the ability and ensure that the assert is not firing with the fix.

#### Documentation
This PR only needs a bugfix release note

#### Primary reviewers
@mattyoung-improbable @m-samiec 