### PR TITLE
Adding dev auth flow into SpatialNetDriver

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -235,25 +235,27 @@ void USpatialNetDriver::InitiateConnectionToSpatialOS(const FURL& URL)
 
 	// If this is the first connection try using the command line arguments to setup the config objects.
 	// If arguments can not be found we will use the regular flow of loading from the input URL.
+	FString SpatialWorkerType = GetGameInstance()->GetSpatialWorkerType().ToString();
 	if (!GameInstance->GetFirstConnectionToSpatialOSAttempted())
 	{
 		GameInstance->SetFirstConnectionToSpatialOSAttempted();
-		if (!Connection->TrySetupConnectionConfigFromCommandLine())
+		if (!Connection->TrySetupConnectionConfigFromCommandLine(SpatialWorkerType))
 		{
-			Connection->SetupConnectionConfigFromURL(URL);
+			Connection->SetupConnectionConfigFromURL(URL, SpatialWorkerType);
 		}
 	}
 	else if (URL.Host == SpatialConstants::RECONNECT_USING_COMMANDLINE_ARGUMENTS)
 	{
-		if (!Connection->TrySetupConnectionConfigFromCommandLine())
+		if (!Connection->TrySetupConnectionConfigFromCommandLine(SpatialWorkerType))
 		{
 			Connection->SetConnectionType(ESpatialConnectionType::Receptionist);
 			Connection->ReceptionistConfig.LoadDefaults();
+			Connection->ReceptionistConfig.WorkerType = SpatialWorkerType;
 		}
 	}
 	else
 	{
-		Connection->SetupConnectionConfigFromURL(URL);
+		Connection->SetupConnectionConfigFromURL(URL, SpatialWorkerType);
 	}
 
 #if WITH_EDITOR

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -204,25 +204,6 @@ USpatialGameInstance* USpatialNetDriver::GetGameInstance() const
 	return GameInstance;
 }
 
-
-void USpatialNetDriver::StartSetupConnectionConfigFromCommandLine(bool& bOutSuccessfullyLoaded, bool& bOutUseReceptionist)
-{
-	USpatialGameInstance* GameInstance = GetGameInstance();
-
-	FString CommandLineLocatorHost;
-	FParse::Value(FCommandLine::Get(), TEXT("locatorHost"), CommandLineLocatorHost);
-	if (!CommandLineLocatorHost.IsEmpty())
-	{
-		bOutSuccessfullyLoaded = Connection->LocatorConfig.TryLoadCommandLineArgs();
-		bOutUseReceptionist = false;
-	}
-	else
-	{
-		bOutSuccessfullyLoaded = Connection->ReceptionistConfig.TryLoadCommandLineArgs();
-		bOutUseReceptionist = true;
-	}
-}
-
 void USpatialNetDriver::InitiateConnectionToSpatialOS(const FURL& URL)
 {
 	USpatialGameInstance* GameInstance = GetGameInstance();
@@ -252,47 +233,28 @@ void USpatialNetDriver::InitiateConnectionToSpatialOS(const FURL& URL)
 	Connection->OnConnectedCallback.BindUObject(this, &USpatialNetDriver::OnConnectionToSpatialOSSucceeded);
 	Connection->OnFailedToConnectCallback.BindUObject(this, &USpatialNetDriver::OnConnectionToSpatialOSFailed);
 
-	bool bUseReceptionist = true;
-	bool bShouldLoadFromURL = true;
-
 	// If this is the first connection try using the command line arguments to setup the config objects.
 	// If arguments can not be found we will use the regular flow of loading from the input URL.
 	if (!GameInstance->GetFirstConnectionToSpatialOSAttempted())
 	{
-		bool bSuccessfullyLoadedFromCommandLine;
-		StartSetupConnectionConfigFromCommandLine(bSuccessfullyLoadedFromCommandLine, bUseReceptionist);
-		bShouldLoadFromURL = !bSuccessfullyLoadedFromCommandLine;
 		GameInstance->SetFirstConnectionToSpatialOSAttempted();
+		if (!Connection->TrySetupConnectionConfigFromCommandLine())
+		{
+			Connection->SetupConnectionConfigFromURL(URL);
+		}
 	}
 	else if (URL.Host == SpatialConstants::RECONNECT_USING_COMMANDLINE_ARGUMENTS)
 	{
-		bool bSuccessfullyLoadedFromCommandLine;
-		StartSetupConnectionConfigFromCommandLine(bSuccessfullyLoadedFromCommandLine, bUseReceptionist);
-
-		if (!bSuccessfullyLoadedFromCommandLine)
+		if (!Connection->TrySetupConnectionConfigFromCommandLine())
 		{
-			if (bUseReceptionist)
-			{
-				Connection->ReceptionistConfig.LoadDefaults();
-			}
-			else
-			{
-				Connection->LocatorConfig.LoadDefaults();
-			}
+			Connection->SetConnectionType(ESpatialConnectionType::Receptionist);
+			Connection->ReceptionistConfig.LoadDefaults();
 		}
-
-		// Setting bShouldLoadFromURL to false is important here because if we fail to load command line args,
-		// we do not want to set the ReceptionistConfig URL to SpatialConstants::RECONNECT_USING_COMMANDLINE_ARGUMENTS.
-		bShouldLoadFromURL = false;
 	}
-
-	if (bShouldLoadFromURL)
+	else
 	{
-		Connection->StartSetupConnectionConfigFromURL(URL, bUseReceptionist);
+		Connection->SetupConnectionConfigFromURL(URL);
 	}
-
-	const FString& WorkerType = GameInstance->GetSpatialWorkerType().ToString();
-	Connection->FinishSetupConnectionConfig(URL, bUseReceptionist, WorkerType);
 
 #if WITH_EDITOR
 	Connection->Connect(bConnectAsClient, PlayInEditorID);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
@@ -163,6 +163,8 @@ void USpatialWorkerConnection::Connect(bool bInitAsClient, uint32 PlayInEditorID
 	case ESpatialConnectionType::Locator:
 		ConnectToLocator();
 		break;
+	case ESpatialConnectionType::DevAuthFlow:
+		StartDevelopmentAuth(DevAuthConfig.DevelopmentAuthToken);
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
@@ -334,61 +334,59 @@ void USpatialWorkerConnection::SetConnectionType(ESpatialConnectionType InConnec
 	ConnectionType = InConnectionType;
 }
 
-bool USpatialNetDriver::TrySetupConnectionConfigFromCommandLine()
+bool USpatialWorkerConnection::TrySetupConnectionConfigFromCommandLine(const FString& SpatialWorkerType)
 {
-	FString WorkerType = GetGameInstance()->GetSpatialWorkerType().ToString();
-	bool bSuccessfullyLoaded = Connection->LocatorConfig.TryLoadCommandLineArgs();
+	bool bSuccessfullyLoaded = LocatorConfig.TryLoadCommandLineArgs();
 	if (bSuccessfullyLoaded)
 	{
-		Connection->SetConnectionType(ESpatialConnectionType::Locator);
-		Connection->LocatorConfig.WorkerType = WorkerType;
+		SetConnectionType(ESpatialConnectionType::Locator);
+		LocatorConfig.WorkerType = SpatialWorkerType;
 	}
 	else
 	{
-		bSuccessfullyLoaded = Connection->DevAuthConfig.TryLoadCommandLineArgs();
+		bSuccessfullyLoaded = DevAuthConfig.TryLoadCommandLineArgs();
 		if (bSuccessfullyLoaded)
 		{
-			Connection->SetConnectionType(ESpatialConnectionType::DevAuthFlow);
-			Connection->DevAuthConfig.WorkerType = WorkerType;
+			SetConnectionType(ESpatialConnectionType::DevAuthFlow);
+			DevAuthConfig.WorkerType = SpatialWorkerType;
 		}
 		else
 		{
-			bSuccessfullyLoaded = Connection->ReceptionistConfig.TryLoadCommandLineArgs();
-			Connection->SetConnectionType(ESpatialConnectionType::Receptionist);
-			Connection->ReceptionistConfig.WorkerType = WorkerType;
+			bSuccessfullyLoaded = ReceptionistConfig.TryLoadCommandLineArgs();
+			SetConnectionType(ESpatialConnectionType::Receptionist);
+			ReceptionistConfig.WorkerType = SpatialWorkerType;
 		}
 	}
 
 	return bSuccessfullyLoaded;
 }
 
-void USpatialNetDriver::SetupConnectionConfigFromURL(const FURL& URL)
+void USpatialWorkerConnection::SetupConnectionConfigFromURL(const FURL& URL, const FString& SpatialWorkerType)
 {
-	FString WorkerType = GetGameInstance()->GetSpatialWorkerType().ToString();
 	if (URL.Host == SpatialConstants::LOCATOR_HOST && URL.HasOption(TEXT("locator")))
 	{
-		Connection->SetConnectionType(ESpatialConnectionType::Locator);
-		Connection->LocatorConfig.PlayerIdentityToken = URL.GetOption(*SpatialConstants::URL_PLAYER_IDENTITY_OPTION, TEXT(""));
-		Connection->LocatorConfig.LoginToken = URL.GetOption(*SpatialConstants::URL_LOGIN_OPTION, TEXT(""));
-		Connection->LocatorConfig.WorkerType = WorkerType;
+		SetConnectionType(ESpatialConnectionType::Locator);
+		LocatorConfig.PlayerIdentityToken = URL.GetOption(*SpatialConstants::URL_PLAYER_IDENTITY_OPTION, TEXT(""));
+		LocatorConfig.LoginToken = URL.GetOption(*SpatialConstants::URL_LOGIN_OPTION, TEXT(""));
+		LocatorConfig.WorkerType = SpatialWorkerType;
 	}
 	else if (URL.Host == SpatialConstants::LOCATOR_HOST && URL.HasOption(TEXT("devauth")))
 	{
-		Connection->SetConnectionType(ESpatialConnectionType::DevAuthFlow);
-		Connection->DevAuthConfig.DevelopmentAuthToken = URL.GetOption(*SpatialConstants::URL_DEV_AUTH_OPTION, TEXT(""));
-		Connection->DevAuthConfig.WorkerType = WorkerType;
+		SetConnectionType(ESpatialConnectionType::DevAuthFlow);
+		DevAuthConfig.DevelopmentAuthToken = URL.GetOption(*SpatialConstants::URL_DEV_AUTH_OPTION, TEXT(""));
+		DevAuthConfig.WorkerType = SpatialWorkerType;
 	}
 	else
 	{
-		Connection->SetConnectionType(ESpatialConnectionType::Receptionist);
-		Connection->ReceptionistConfig.SetReceptionistHost(URL.Host);
-		Connection->ReceptionistConfig.WorkerType = WorkerType;
+		SetConnectionType(ESpatialConnectionType::Receptionist);
+		ReceptionistConfig.SetReceptionistHost(URL.Host);
+		ReceptionistConfig.WorkerType = SpatialWorkerType;
 
 		const TCHAR* UseExternalIpForBridge = TEXT("useExternalIpForBridge");
 		if (URL.HasOption(UseExternalIpForBridge))
 		{
 			FString UseExternalIpOption = URL.GetOption(UseExternalIpForBridge, TEXT(""));
-			Connection->ReceptionistConfig.UseExternalIp = !UseExternalIpOption.Equals(TEXT("false"), ESearchCase::IgnoreCase);
+			ReceptionistConfig.UseExternalIp = !UseExternalIpOption.Equals(TEXT("false"), ESearchCase::IgnoreCase);
 		}
 	}
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -269,8 +269,6 @@ private:
 	TArray<Worker_EntityId> TombstonedEntities;
 #endif
 
-	void StartSetupConnectionConfigFromCommandLine(bool& bOutSuccessfullyLoaded, bool& bOutUseReceptionist);
-
 	void MakePlayerSpawnRequest();
 
 	FUnrealObjectRef GetCurrentPlayerControllerRef();

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
@@ -30,11 +30,6 @@ struct FConnectionConfig
 		FParse::Bool(CommandLine, TEXT("enableProtocolLogging"), EnableProtocolLoggingAtStartup);
 		FParse::Value(CommandLine, TEXT("protocolLoggingPrefix"), ProtocolLoggingPrefix);
         
-#if PLATFORM_IOS || PLATFORM_ANDROID
-		// On a mobile platform, you can only be a client worker, and therefore use the external IP.
-		WorkerType = SpatialConstants::DefaultClientWorkerType.ToString();
-		UseExternalIp = true;
-#endif
 		FString LinkProtocolString;
 		FParse::Value(CommandLine, TEXT("linkProtocol"), LinkProtocolString);
 		if (LinkProtocolString == TEXT("Tcp"))
@@ -120,6 +115,35 @@ public:
 	FString LocatorHost;
 	FString PlayerIdentityToken;
 	FString LoginToken;
+};
+
+class FDevAuthConfig : public FConnectionConfig
+{
+public:
+	FDevAuthConfig()
+	{
+		LoadDefaults();
+	}
+
+	void LoadDefaults()
+	{
+		UseExternalIp = true;
+		LocatorHost = SpatialConstants::LOCATOR_HOST;
+	}
+
+	bool TryLoadCommandLineArgs()
+	{
+		bool bSuccess = true;
+		const TCHAR* CommandLine = FCommandLine::Get();
+		bSuccess &= FParse::Value(CommandLine, TEXT("locatorHost"), LocatorHost);
+		bSuccess &= FParse::Value(CommandLine, TEXT("devAuthToken"), DevelopmentAuthToken);
+		FParse::Value(CommandLine, TEXT("deployment"), Deployment); // this is optional
+		return bSuccess;
+	}
+
+	FString LocatorHost;
+	FString DevelopmentAuthToken;
+	FString Deployment;
 };
 
 class FReceptionistConfig : public FConnectionConfig

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
@@ -106,7 +106,7 @@ public:
 	{
 		bool bSuccess = true;
 		const TCHAR* CommandLine = FCommandLine::Get();
-		bSuccess &= FParse::Value(CommandLine, TEXT("locatorHost"), LocatorHost);
+		FParse::Value(CommandLine, TEXT("locatorHost"), LocatorHost);
 		bSuccess &= FParse::Value(CommandLine, TEXT("playerIdentityToken"), PlayerIdentityToken);
 		bSuccess &= FParse::Value(CommandLine, TEXT("loginToken"), LoginToken);
 		return bSuccess;
@@ -135,9 +135,9 @@ public:
 	{
 		bool bSuccess = true;
 		const TCHAR* CommandLine = FCommandLine::Get();
-		bSuccess &= FParse::Value(CommandLine, TEXT("locatorHost"), LocatorHost);
-		bSuccess &= FParse::Value(CommandLine, TEXT("devAuthToken"), DevelopmentAuthToken);
-		FParse::Value(CommandLine, TEXT("deployment"), Deployment); // this is optional
+		FParse::Value(CommandLine, TEXT("locatorHost"), LocatorHost);
+		FParse::Value(CommandLine, TEXT("deployment"), Deployment);
+		bSuccess = FParse::Value(CommandLine, TEXT("devAuthToken"), DevelopmentAuthToken);
 		return bSuccess;
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialWorkerConnection.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialWorkerConnection.h
@@ -76,8 +76,8 @@ public:
 	DECLARE_DELEGATE_TwoParams(OnConnectionToSpatialOSFailedDelegate, uint8_t, const FString&);
 	OnConnectionToSpatialOSFailedDelegate OnFailedToConnectCallback;
 
-	void StartSetupConnectionConfigFromURL(const FURL& URL, bool& bOutUseReceptionist);
-	void FinishSetupConnectionConfig(const FURL& URL, bool bUseReceptionist, const FString& SpatialWorkerType);
+	bool TrySetupConnectionConfigFromCommandLine();
+	void SetupConnectionConfigFromURL(const FURL& URL);
 
 private:
 	void ConnectToReceptionist(uint32 PlayInEditorID);

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialWorkerConnection.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialWorkerConnection.h
@@ -78,8 +78,8 @@ public:
 	DECLARE_DELEGATE_TwoParams(OnConnectionToSpatialOSFailedDelegate, uint8_t, const FString&);
 	OnConnectionToSpatialOSFailedDelegate OnFailedToConnectCallback;
 
-	bool TrySetupConnectionConfigFromCommandLine();
-	void SetupConnectionConfigFromURL(const FURL& URL);
+	bool TrySetupConnectionConfigFromCommandLine(const FString& SpatialWorkerType);
+	void SetupConnectionConfigFromURL(const FURL& URL, const FString& SpatialWorkerType);
 
 private:
 	void ConnectToReceptionist(uint32 PlayInEditorID);

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialWorkerConnection.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialWorkerConnection.h
@@ -62,6 +62,7 @@ public:
 
 	void SetConnectionType(ESpatialConnectionType InConnectionType);
 
+	// TODO: UNR-2753
 	FReceptionistConfig ReceptionistConfig;
 	FLocatorConfig LocatorConfig;
 	FDevAuthConfig DevAuthConfig;

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialWorkerConnection.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialWorkerConnection.h
@@ -24,7 +24,8 @@ enum class ESpatialConnectionType
 {
 	Receptionist,
 	LegacyLocator,
-	Locator
+	Locator,
+	DevAuthFlow
 };
 
 UCLASS()
@@ -63,6 +64,7 @@ public:
 
 	FReceptionistConfig ReceptionistConfig;
 	FLocatorConfig LocatorConfig;
+	FDevAuthConfig DevAuthConfig;
 
 	DECLARE_MULTICAST_DELEGATE_OneParam(FOnEnqueueMessage, const SpatialGDK::FOutgoingMessage*);
 	FOnEnqueueMessage OnEnqueueMessage;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -242,6 +242,7 @@ const FString SPATIALOS_METRICS_DYNAMIC_FPS = TEXT("Dynamic.FPS");
 const FString RECONNECT_USING_COMMANDLINE_ARGUMENTS = TEXT("0.0.0.0");
 const FString URL_LOGIN_OPTION = TEXT("login=");
 const FString URL_PLAYER_IDENTITY_OPTION = TEXT("playeridentity=");
+const FString URL_DEV_AUTH_OPTION = TEXT("devauth=");
 
 const FString DEVELOPMENT_AUTH_PLAYER_ID = TEXT("Player Id");
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Some of the work I've been doing to add the dev auth flow properly into the GDK.
It also refactors the flow a bit by making it a bit simpler and isolating the construction of the different connection configs into one method instead of starting to construct it in one and finish constructing it in the other.

PR can be read in commit order.

#### Release note
REQUIRED: Add a release note to the `##Unreleased` section of CHANGELOG.md. You can find guidance for writing useful release notes [here](../SpatialGDK/Extras/internal-documentation/how-to-write-good-release-notes.md). Documentation changes are exempt from this requirement.

#### Tests
Have been manually testing the different flows. Seems to work so far

#### Documentation
will add documentation for the dev auth flow later

#### Primary reviewers
@improbable-valentyn @m-samiec @MatthewSandfordImprobable 