### PR TITLE
Make the Dev Auth Config more configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Added support for Android.
 - Introduced experimental feature flag `bEnableResultTypes`, defaulting false. Flip this to true for Interest queries to only include the set of components required to run. Should give bandwidth savings depending on your game. 
 - Moved Dev Auth settings from runtime settings to editor settings.
+- Added the option to use the development authentication flow using the command line.
 
 ## Bug fixes:
 - Fixed a bug that caused the local API service to memory leak.

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
@@ -234,12 +234,10 @@ void USpatialWorkerConnection::OnPlayerIdentityToken(void* UserData, const Worke
 void USpatialWorkerConnection::StartDevelopmentAuth(const FString& DevAuthToken)
 {
 	Worker_Alpha_PlayerIdentityTokenRequest PITParams{};
-	FTCHARToUTF8 DAToken(*DevAuthToken);
-	FTCHARToUTF8 PlayerId(*SpatialConstants::DEVELOPMENT_AUTH_PLAYER_ID);
-	PITParams.development_authentication_token = DAToken.Get();
-	PITParams.player_id = PlayerId.Get();
-	PITParams.display_name = "";
-	PITParams.metadata = "";
+	PITParams.development_authentication_token = TCHAR_TO_UTF8(*DevAuthToken);
+	PITParams.player_id = TCHAR_TO_UTF8(*DevAuthConfig.PlayerId);
+	PITParams.display_name = TCHAR_TO_UTF8(*DevAuthConfig.DisplayName);
+	PITParams.metadata = TCHAR_TO_UTF8(*DevAuthConfig.MetaData);
 	PITParams.use_insecure_connection = false;
 
 	if (Worker_Alpha_PlayerIdentityTokenResponseFuture* PITFuture = Worker_Alpha_CreateDevelopmentPlayerIdentityTokenAsync(TCHAR_TO_UTF8(*DevAuthConfig.LocatorHost), SpatialConstants::LOCATOR_PORT, &PITParams))

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
@@ -233,11 +233,16 @@ void USpatialWorkerConnection::OnPlayerIdentityToken(void* UserData, const Worke
 
 void USpatialWorkerConnection::StartDevelopmentAuth(const FString& DevAuthToken)
 {
+	FTCHARToUTF8 DAToken(*DevAuthToken);
+	FTCHARToUTF8 PlayerId(*DevAuthConfig.PlayerId);
+	FTCHARToUTF8 DisplayName(*DevAuthConfig.DisplayName);
+	FTCHARToUTF8 MetaData(*DevAuthConfig.MetaData);
+
 	Worker_Alpha_PlayerIdentityTokenRequest PITParams{};
-	PITParams.development_authentication_token = TCHAR_TO_UTF8(*DevAuthToken);
-	PITParams.player_id = TCHAR_TO_UTF8(*DevAuthConfig.PlayerId);
-	PITParams.display_name = TCHAR_TO_UTF8(*DevAuthConfig.DisplayName);
-	PITParams.metadata = TCHAR_TO_UTF8(*DevAuthConfig.MetaData);
+	PITParams.development_authentication_token = DAToken.Get();
+	PITParams.player_id = PlayerId.Get();
+	PITParams.display_name = DisplayName.Get();
+	PITParams.metadata = MetaData.Get();
 	PITParams.use_insecure_connection = false;
 
 	if (Worker_Alpha_PlayerIdentityTokenResponseFuture* PITFuture = Worker_Alpha_CreateDevelopmentPlayerIdentityTokenAsync(TCHAR_TO_UTF8(*DevAuthConfig.LocatorHost), SpatialConstants::LOCATOR_PORT, &PITParams))

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
@@ -129,6 +129,7 @@ public:
 	{
 		UseExternalIp = true;
 		LocatorHost = SpatialConstants::LOCATOR_HOST;
+		PlayerId = SpatialConstants::DEVELOPMENT_AUTH_PLAYER_ID;
 	}
 
 	bool TryLoadCommandLineArgs()
@@ -137,12 +138,18 @@ public:
 		const TCHAR* CommandLine = FCommandLine::Get();
 		FParse::Value(CommandLine, TEXT("locatorHost"), LocatorHost);
 		FParse::Value(CommandLine, TEXT("deployment"), Deployment);
+		FParse::Value(CommandLine, TEXT("playerId"), PlayerId);
+		FParse::Value(CommandLine, TEXT("displayName"), DisplayName);
+		FParse::Value(CommandLine, TEXT("metaData"), MetaData);
 		bSuccess = FParse::Value(CommandLine, TEXT("devAuthToken"), DevelopmentAuthToken);
 		return bSuccess;
 	}
 
 	FString DevelopmentAuthToken;
 	FString Deployment;
+	FString PlayerId;
+	FString DisplayName;
+	FString MetaData;
 };
 
 class FReceptionistConfig : public FConnectionConfig

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
@@ -128,8 +128,16 @@ public:
 	void LoadDefaults()
 	{
 		UseExternalIp = true;
-		LocatorHost = SpatialConstants::LOCATOR_HOST;
 		PlayerId = SpatialConstants::DEVELOPMENT_AUTH_PLAYER_ID;
+
+		if (GetDefault<USpatialGDKSettings>()->IsRunningInChina())
+		{
+			LocatorHost = SpatialConstants::LOCATOR_HOST_CN;
+		}
+		else
+		{
+			LocatorHost = SpatialConstants::LOCATOR_HOST;
+		}
 	}
 
 	bool TryLoadCommandLineArgs()


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Making it possible to parse in command line arguments for player id, display name and metadata.

#### Release note
added a changelog entry (for this and the last dev auth PR)

#### Tests
still need to test it

#### Documentation
documentation will happen with UNR-2757

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.