### PR TITLE
Ability to delete initially dormant startup actors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Track properties containing references to replicated actors, in order to resolve them again if the actor they reference moves out and back into relevance.
 - Fix problem where PIE sessions sometimes fail to start due to missing schema for SpatialDebugger blueprint.
 - Fixed an issue where newly created subobjects would have empty state when RepNotify was called for a property pointing to that subobject.
+- Fixed an issue where deleted, initially dormant startup actors would still be present on other workers.
 
 ### External contributors:
 @DW-Sebastien

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -1100,7 +1100,7 @@ void USpatialActorChannel::OnCreateEntityResponse(const Worker_CreateEntityRespo
 
 	// True if the entity is in the worker's view.
 	// If this is the case then we know the entity was created and do not need to retry if the request timed-out.
-	const bool bEntityIsInView = NetDriver->StaticComponentView->HasComponent(Position::ComponentId, GetEntityId());
+	const bool bEntityIsInView = NetDriver->StaticComponentView->HasComponent(SpatialGDK::Position::ComponentId, GetEntityId());
 
 	switch (static_cast<Worker_StatusCode>(Op.status_code))
 	{
@@ -1169,7 +1169,7 @@ void USpatialActorChannel::UpdateSpatialPosition()
 
 	// Check that the Actor has moved sufficiently far to be updated
 	const float SpatialPositionThresholdSquared = FMath::Square(GetDefault<USpatialGDKSettings>()->PositionDistanceThreshold);
-	FVector ActorSpatialPosition = GetActorSpatialPosition(Actor);
+	FVector ActorSpatialPosition = SpatialGDK::GetActorSpatialPosition(Actor);
 	if (FVector::DistSquared(ActorSpatialPosition, LastPositionSinceUpdate) < SpatialPositionThresholdSquared)
 	{
 		return;

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -49,11 +49,11 @@
 #include "SpatialGDKServicesModule.h"
 #endif
 
+using SpatialGDK::ComponentFactory;
 using SpatialGDK::FindFirstOpOfType;
 using SpatialGDK::FindFirstOpOfTypeForComponent;
 using SpatialGDK::InterestFactory;
 using SpatialGDK::RPCPayload;
-using SpatialGDK::ComponentFactory;
 
 DEFINE_LOG_CATEGORY(LogSpatialOSNetDriver);
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -830,10 +830,8 @@ void USpatialNetDriver::NotifyActorDestroyed(AActor* ThisActor, bool IsSeamlessT
 				UE_LOG(LogSpatialOSNetDriver, Log, TEXT("Creating a tombstone entity for initially dormant statup actor. "
 					"Actor: %s."), *ThisActor->GetName());
 				Sender->CreateTombstoneEntity(ThisActor);
-				return;
 			}
-
-			if (IsDormantEntity(EntityId) && ThisActor->HasAuthority())
+			else if (IsDormantEntity(EntityId) && ThisActor->HasAuthority())
 			{
 				// Deliberately don't unregister the dormant entity, but let it get cleaned up in the entity remove op process
 				if (!StaticComponentView->HasAuthority(EntityId, SpatialGDK::Position::ComponentId))

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -49,6 +49,12 @@
 #include "SpatialGDKServicesModule.h"
 #endif
 
+using SpatialGDK::FindFirstOpOfType;
+using SpatialGDK::FindFirstOpOfTypeForComponent;
+using SpatialGDK::InterestFactory;
+using SpatialGDK::RPCPayload;
+using SpatialGDK::ComponentFactory;
+
 DEFINE_LOG_CATEGORY(LogSpatialOSNetDriver);
 
 DECLARE_CYCLE_STAT(TEXT("ServerReplicateActors"), STAT_SpatialServerReplicateActors, STATGROUP_SpatialNet);

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -813,6 +813,31 @@ void USpatialNetDriver::NotifyActorDestroyed(AActor* ThisActor, bool IsSeamlessT
 
 	if (bIsServer)
 	{
+		// Check if this is a dormant entity, and if so retire the entity
+		if (PackageMap != nullptr)
+		{
+			const Worker_EntityId EntityId = PackageMap->GetEntityIdFromObject(ThisActor);
+
+			// If the actor is an initially dormant startup actor that has not been replicated.
+			if (EntityId == SpatialConstants::INVALID_ENTITY_ID && ThisActor->IsNetStartupActor())
+			{
+				UE_LOG(LogSpatialOSNetDriver, Log, TEXT("Creating a tombstone entity for initially dormant statup actor. "
+					"Actor: %s."), *ThisActor->GetName());
+				Sender->CreateTombstoneEntity(ThisActor);
+				return;
+			}
+
+			if (IsDormantEntity(EntityId) && ThisActor->HasAuthority())
+			{
+				// Deliberately don't unregister the dormant entity, but let it get cleaned up in the entity remove op process
+				if (!StaticComponentView->HasAuthority(EntityId, SpatialGDK::Position::ComponentId))
+				{
+					UE_LOG(LogSpatialOSNetDriver, Warning, TEXT("Retiring dormant entity that we don't have spatial authority over [%lld][%s]"), EntityId, *ThisActor->GetName());
+				}
+				Sender->RetireEntity(EntityId);
+			}
+		}
+
 		for (int32 i = ClientConnections.Num() - 1; i >= 0; i--)
 		{
 			UNetConnection* ClientConnection = ClientConnections[i];
@@ -831,21 +856,6 @@ void USpatialNetDriver::NotifyActorDestroyed(AActor* ThisActor, bool IsSeamlessT
 
 			// Remove it from any dormancy lists
 			ClientConnection->DormantReplicatorMap.Remove(ThisActor);
-		}
-
-		// Check if this is a dormant entity, and if so retire the entity
-		if (PackageMap != nullptr)
-		{
-			Worker_EntityId EntityId = PackageMap->GetEntityIdFromObject(ThisActor);
-			if (IsDormantEntity(EntityId) && ThisActor->HasAuthority())
-			{
-				// Deliberately don't unregister the dormant entity, but let it get cleaned up in the entity remove op process
-				if (!StaticComponentView->HasAuthority(EntityId, SpatialGDK::Position::ComponentId))
-				{
-					UE_LOG(LogSpatialOSNetDriver, Warning, TEXT("Retiring dormant entity that we don't have spatial authority over [%lld][%s]"), EntityId, *ThisActor->GetName());
-				}
-				Sender->RetireEntity(EntityId);
-			}
 		}
 	}
 
@@ -1638,26 +1648,14 @@ void USpatialNetDriver::TickFlush(float DeltaTime)
 	// Super::TickFlush() will not call ReplicateActors() because Spatial connections have InternalAck set to true.
 	// In our case, our Spatial actor interop is triggered through ReplicateActors() so we want to call it regardless.
 
-#if USE_SERVER_PERF_COUNTERS
-	double ServerReplicateActorsTimeMs = 0.0f;
-#endif // USE_SERVER_PERF_COUNTERS
-
-  const USpatialGDKSettings* SpatialGDKSettings = GetDefault<USpatialGDKSettings>();
+	const USpatialGDKSettings* SpatialGDKSettings = GetDefault<USpatialGDKSettings>();
 
 	if (IsServer() && GetSpatialOSNetConnection() != nullptr && PackageMap->IsEntityPoolReady() && bIsReadyToStart)
 	{
 		// Update all clients.
 #if WITH_SERVER_CODE
 
-#if USE_SERVER_PERF_COUNTERS
-		double ServerReplicateActorsTimeStart = FPlatformTime::Seconds();
-#endif // USE_SERVER_PERF_COUNTERS
-
 		int32 Updated = ServerReplicateActors(DeltaTime);
-
-#if USE_SERVER_PERF_COUNTERS
-		ServerReplicateActorsTimeMs = (FPlatformTime::Seconds() - ServerReplicateActorsTimeStart) * 1000.0;
-#endif // USE_SERVER_PERF_COUNTERS
 
 		static int32 LastUpdateCount = 0;
 		// Only log the zero replicated actors once after replicating an actor

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -827,7 +827,7 @@ void USpatialReceiver::RemoveActor(Worker_EntityId EntityId)
 {
 	TWeakObjectPtr<UObject> WeakActor = PackageMap->GetObjectFromEntityId(EntityId);
 
-	// Actor has been destroyed already. Clean up surrounding bookkeeping.
+	// Actor has not been resolved yet or has already been destroyed. Clean up surrounding bookkeeping.
 	if (!WeakActor.IsValid())
 	{
 		DestroyActor(nullptr, EntityId);
@@ -1931,17 +1931,17 @@ void USpatialReceiver::AddPendingReliableRPC(Worker_RequestId RequestId, TShared
 
 void USpatialReceiver::AddEntityQueryDelegate(Worker_RequestId RequestId, EntityQueryDelegate Delegate)
 {
-	EntityQueryDelegates.Add(RequestId, Delegate);
+	EntityQueryDelegates.Add(RequestId, MoveTemp(Delegate));
 }
 
 void USpatialReceiver::AddReserveEntityIdsDelegate(Worker_RequestId RequestId, ReserveEntityIDsDelegate Delegate)
 {
-	ReserveEntityIDsDelegates.Add(RequestId, Delegate);
+	ReserveEntityIDsDelegates.Add(RequestId, MoveTemp(Delegate));
 }
 
-void USpatialReceiver::AddCreateEntityDelegate(Worker_RequestId RequestId, const CreateEntityDelegate& Delegate)
+void USpatialReceiver::AddCreateEntityDelegate(Worker_RequestId RequestId, CreateEntityDelegate Delegate)
 {
-	CreateEntityDelegates.Add(RequestId, Delegate);
+	CreateEntityDelegates.Emplace(RequestId, MoveTemp(Delegate));
 }
 
 TWeakObjectPtr<USpatialActorChannel> USpatialReceiver::PopPendingActorRequest(Worker_RequestId RequestId)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1941,7 +1941,7 @@ void USpatialReceiver::AddReserveEntityIdsDelegate(Worker_RequestId RequestId, R
 
 void USpatialReceiver::AddCreateEntityDelegate(Worker_RequestId RequestId, CreateEntityDelegate Delegate)
 {
-	CreateEntityDelegates.Emplace(RequestId, MoveTemp(Delegate));
+	CreateEntityDelegates.Add(RequestId, MoveTemp(Delegate));
 }
 
 TWeakObjectPtr<USpatialActorChannel> USpatialReceiver::PopPendingActorRequest(Worker_RequestId RequestId)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -251,14 +251,14 @@ bool USpatialSender::ValidateOrExit_IsSupportedClass(const FString& PathName)
 	return ClassInfoManager->ValidateOrExit_IsSupportedClass(RemappedPathName);
 }
 
-void USpatialSender::EntityComponentsDeleter::operator()(TArray<Worker_ComponentData>* Components) const noexcept
+void USpatialSender::EntityComponentsDeleter::operator()(TArray<FWorkerComponentData>* Components) const noexcept
 {
 	if (Components == nullptr)
 	{
 		return;
 	}
 
-	for (Worker_ComponentData Component : *Components)
+	for (FWorkerComponentData Component : *Components)
 	{
 		Schema_DestroyComponentData(Component.schema_type);
 	}
@@ -266,11 +266,11 @@ void USpatialSender::EntityComponentsDeleter::operator()(TArray<Worker_Component
 	delete Components;
 }
 
-TArray<Worker_ComponentData> USpatialSender::CopyEntityComponentData(const EntityComponents& EntityComponents)
+TArray<FWorkerComponentData> USpatialSender::CopyEntityComponentData(const EntityComponents& EntityComponents)
 {
-	TArray<Worker_ComponentData> Copy;
+	TArray<FWorkerComponentData> Copy;
 	Copy.Reserve(EntityComponents->Num());
-	for (const Worker_ComponentData& Component : *EntityComponents)
+	for (const FWorkerComponentData& Component : *EntityComponents)
 	{
 		Copy.Emplace(Worker_ComponentData{
 			Component.reserved,
@@ -1173,7 +1173,7 @@ void USpatialSender::CreateTombstoneEntity(AActor* Actor)
 	GEngine->NetworkRemapPath(NetDriver, TempPath, false /*bIsReading*/);
 	const TSchemaOption<FUnrealObjectRef> StablyNamedObjectRef = FUnrealObjectRef(0, 0, TempPath, OuterObjectRef, true);
 
-	EntityComponents Components(new TArray<Worker_ComponentData>);
+	EntityComponents Components(new TArray<FWorkerComponentData>);
 	Components->Add(Position(Coordinates::FromFVector(GetActorSpatialPosition(Actor))).CreatePositionData());
 	Components->Add(Metadata(Class->GetName()).CreateMetadataData());
 	Components->Add(UnrealMetadata(StablyNamedObjectRef, GetOwnerWorkerAttribute(Actor), Class->GetPathName(), true).CreateUnrealMetadataData());

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -255,6 +255,8 @@ void USpatialSender::DeleteEntityComponentData(TArray<FWorkerComponentData>& Ent
 	{
 		Schema_DestroyComponentData(Component.schema_type);
 	}
+
+	EntityComponents.Empty();
 }
 
 TArray<FWorkerComponentData> USpatialSender::CopyEntityComponentData(const TArray<FWorkerComponentData>& EntityComponents)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -16,12 +16,9 @@
 #include "Net/NetworkProfiler.h"
 #include "Schema/AuthorityIntent.h"
 #include "Schema/ClientRPCEndpointLegacy.h"
-#include "Schema/Heartbeat.h"
 #include "Schema/Interest.h"
 #include "Schema/RPCPayload.h"
 #include "Schema/ServerRPCEndpointLegacy.h"
-#include "Schema/Singleton.h"
-#include "Schema/SpawnData.h"
 #include "Schema/StandardLibrary.h"
 #include "Schema/Tombstone.h"
 #include "Schema/UnrealMetadata.h"
@@ -29,7 +26,6 @@
 #include "Utils/SpatialActorGroupManager.h"
 #include "Utils/ComponentFactory.h"
 #include "Utils/EntityFactory.h"
-#include "Utils/InspectionColors.h"
 #include "Utils/InterestFactory.h"
 #include "Utils/RepLayoutUtils.h"
 #include "Utils/SpatialActorUtils.h"
@@ -280,7 +276,7 @@ TArray<Worker_ComponentData> USpatialSender::CopyEntityComponentData(const Entit
 			Component.reserved,
 			Component.component_id,
 			Schema_CopyComponentData(Component.schema_type),
-			nullptr
+			nullptr 
 		});
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -14,6 +14,7 @@
 #include "Schema/Singleton.h"
 #include "Schema/SpatialDebugging.h"
 #include "Schema/SpawnData.h"
+#include "Schema/Tombstone.h"
 #include "Utils/ComponentFactory.h"
 #include "Utils/InspectionColors.h"
 #include "Utils/InterestFactory.h"
@@ -21,7 +22,6 @@
 #include "Utils/SpatialDebugger.h"
 
 #include "Engine.h"
-#include "Schema/Tombstone.h"
 
 namespace SpatialGDK
 {

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -21,6 +21,7 @@
 #include "Utils/SpatialDebugger.h"
 
 #include "Engine.h"
+#include "Schema/Tombstone.h"
 
 namespace SpatialGDK
 {
@@ -378,4 +379,70 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
  
 	return ComponentDatas;
 }
+
+TArray<FWorkerComponentData> EntityFactory::CreateTombstoneEntityComponents(AActor* Actor)
+{
+	check(Actor->IsNetStartupActor());
+
+	const UClass* Class = Actor->GetClass();
+
+	// Construct an ACL for a read-only entity.
+	WorkerRequirementSet AnyServerRequirementSet;
+	WorkerRequirementSet AnyServerOrClientRequirementSet = { SpatialConstants::UnrealClientAttributeSet };
+
+	for (const FName& WorkerType : GetDefault<USpatialGDKSettings>()->ServerWorkerTypes)
+	{
+		WorkerAttributeSet ServerWorkerAttributeSet = { WorkerType.ToString() };
+
+		AnyServerRequirementSet.Add(ServerWorkerAttributeSet);
+		AnyServerOrClientRequirementSet.Add(ServerWorkerAttributeSet);
+	}
+
+	// Add Zoning Attribute if we are using the load balancer.
+	const USpatialGDKSettings* SpatialSettings = GetDefault<USpatialGDKSettings>();
+	if (SpatialSettings->bEnableUnrealLoadBalancer)
+	{
+		const WorkerAttributeSet ZoningAttributeSet = { SpatialConstants::ZoningAttribute };
+		AnyServerRequirementSet.Add(ZoningAttributeSet);
+		AnyServerOrClientRequirementSet.Add(ZoningAttributeSet);
+	}
+
+	WorkerRequirementSet ReadAcl;
+	if (Class->HasAnySpatialClassFlags(SPATIALCLASS_ServerOnly))
+	{
+		ReadAcl = AnyServerRequirementSet;
+	}
+	else
+	{
+		ReadAcl = AnyServerOrClientRequirementSet;
+	}
+
+	// Get a stable object ref.
+	FUnrealObjectRef OuterObjectRef = PackageMap->GetUnrealObjectRefFromObject(Actor->GetOuter());
+	if (OuterObjectRef == FUnrealObjectRef::UNRESOLVED_OBJECT_REF)
+	{
+		const FNetworkGUID NetGUID = PackageMap->ResolveStablyNamedObject(Actor->GetOuter());
+		OuterObjectRef = PackageMap->GetUnrealObjectRefFromNetGUID(NetGUID);
+	}
+
+	// No path in SpatialOS should contain a PIE prefix.
+	FString TempPath = Actor->GetFName().ToString();
+	GEngine->NetworkRemapPath(NetDriver, TempPath, false /*bIsReading*/);
+	const TSchemaOption<FUnrealObjectRef> StablyNamedObjectRef = FUnrealObjectRef(0, 0, TempPath, OuterObjectRef, true);
+
+	TArray<FWorkerComponentData> Components;
+	Components.Add(Position(Coordinates::FromFVector(GetActorSpatialPosition(Actor))).CreatePositionData());
+	Components.Add(Metadata(Class->GetName()).CreateMetadataData());
+	Components.Add(UnrealMetadata(StablyNamedObjectRef, GetOwnerWorkerAttribute(Actor), Class->GetPathName(), true).CreateUnrealMetadataData());
+	Components.Add(Tombstone().CreateData());
+	Components.Add(EntityAcl(ReadAcl, WriteAclMap()).CreateEntityAclData());
+
+	if (!Class->HasAnySpatialClassFlags(SPATIALCLASS_NotPersistent))
+	{
+		Components.Add(Persistence().CreatePersistenceData());
+	}
+
+	return Components;
 }
+
+}  // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialOSDispatcherInterface.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialOSDispatcherInterface.h
@@ -41,5 +41,5 @@ public:
 	virtual void AddPendingReliableRPC(Worker_RequestId RequestId, TSharedRef<struct FReliableRPCForRetry> ReliableRPC) PURE_VIRTUAL(SpatialOSDispatcherInterface::AddPendingReliableRPC, return;);
 	virtual void AddEntityQueryDelegate(Worker_RequestId RequestId, EntityQueryDelegate Delegate) PURE_VIRTUAL(SpatialOSDispatcherInterface::AddEntityQueryDelegate, return;);
 	virtual void AddReserveEntityIdsDelegate(Worker_RequestId RequestId, ReserveEntityIDsDelegate Delegate) PURE_VIRTUAL(SpatialOSDispatcherInterface::AddReserveEntityIdsDelegate, return;);
-	virtual void AddCreateEntityDelegate(Worker_RequestId RequestId, const CreateEntityDelegate& Delegate) PURE_VIRTUAL(SpatialOSDispatcherInterface::AddCreateEntityDelegate, return;);
+	virtual void AddCreateEntityDelegate(Worker_RequestId RequestId, CreateEntityDelegate Delegate) PURE_VIRTUAL(SpatialOSDispatcherInterface::AddCreateEntityDelegate, return;);
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -75,7 +75,7 @@ public:
 
 	virtual void AddEntityQueryDelegate(Worker_RequestId RequestId, EntityQueryDelegate Delegate) override;
 	virtual void AddReserveEntityIdsDelegate(Worker_RequestId RequestId, ReserveEntityIDsDelegate Delegate) override;
-	virtual void AddCreateEntityDelegate(Worker_RequestId RequestId, const CreateEntityDelegate& Delegate) override;
+	virtual void AddCreateEntityDelegate(Worker_RequestId RequestId, CreateEntityDelegate Delegate) override;
 
 	virtual void OnEntityQueryResponse(const Worker_EntityQueryResponseOp& Op) override;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -88,7 +88,7 @@ public:
 	void SendCreateEntityRequest(USpatialActorChannel* Channel);
 	void RetireEntity(const Worker_EntityId EntityId);
 
-	/** Creates an entity containing just a tombstone component and the minimal data to resolve an actor. */
+	// Creates an entity containing just a tombstone component and the minimal data to resolve an actor.
 	void CreateTombstoneEntity(AActor* Actor);
 
 	void SendRequestToClearRPCsOnEntityCreation(Worker_EntityId EntityId);
@@ -125,19 +125,13 @@ public:
 	bool ValidateOrExit_IsSupportedClass(const FString& PathName);
 
 private:
-	struct EntityComponentsDeleter
-	{
-		void operator()(TArray<FWorkerComponentData>* Components) const noexcept;
-	};
-
-	using EntityComponents = TUniquePtr<TArray<FWorkerComponentData>, EntityComponentsDeleter>;
-
 	// Create a copy of an array of components. Deep copies all Schema_ComponentData.
-	static TArray<FWorkerComponentData> CopyEntityComponentData(const EntityComponents& EntityComponents);
+	static TArray<FWorkerComponentData> CopyEntityComponentData(const TArray<FWorkerComponentData>& EntityComponents);
+	// Create a copy of an array of components. Deep copies all Schema_ComponentData.
+	static void DeleteEntityComponentData(TArray<FWorkerComponentData>& EntityComponents);
 
 	// Create an entity given a set of components and an ID. Retries with the same component data and entity ID on timeout.
-	// Requires that EntitiesBeingCreatedWithRetries contains the component data with the key of EntityId.
-	void CreateEntityWithRetries(Worker_EntityId EntityId, FString EntityName);
+	void CreateEntityWithRetries(Worker_EntityId EntityId, FString EntityName, TArray<FWorkerComponentData> Components);
 
 	// Actor Lifecycle
 	Worker_RequestId CreateEntity(USpatialActorChannel* Channel);
@@ -177,10 +171,6 @@ private:
 
 	UPROPERTY()
 	USpatialClassInfoManager* ClassInfoManager;
-
-	// Stores the component data of entities being created for which we need to persist the component data between retries.
-	// We can not have the response delegates own the data as they must be copyable.
-	TMap<Worker_EntityId_Key, EntityComponents> EntitiesBeingCreatedWithRetries;
 
 	SpatialActorGroupManager* ActorGroupManager;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -127,13 +127,13 @@ public:
 private:
 	struct EntityComponentsDeleter
 	{
-		void operator()(TArray<Worker_ComponentData>* Components) const noexcept;
+		void operator()(TArray<FWorkerComponentData>* Components) const noexcept;
 	};
 
-	using EntityComponents = TUniquePtr<TArray<Worker_ComponentData>, EntityComponentsDeleter>;
+	using EntityComponents = TUniquePtr<TArray<FWorkerComponentData>, EntityComponentsDeleter>;
 
 	// Create a copy of an array of components. Deep copies all Schema_ComponentData.
-	static TArray<Worker_ComponentData> CopyEntityComponentData(const EntityComponents& EntityComponents);
+	static TArray<FWorkerComponentData> CopyEntityComponentData(const EntityComponents& EntityComponents);
 
 	// Create an entity given a set of components and an ID. Retries with the same component data and entity ID on timeout.
 	// Requires that EntitiesBeingCreatedWithRetries contains the component data with the key of EntityId.

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -17,8 +17,6 @@
 
 #include "SpatialSender.generated.h"
 
-using namespace SpatialGDK;
-
 DECLARE_LOG_CATEGORY_EXTERN(LogSpatialSender, Log, All);
 
 class USpatialActorChannel;
@@ -59,7 +57,7 @@ struct FPendingRPC
 // TODO: Clear TMap entries when USpatialActorChannel gets deleted - UNR:100
 // care for actor getting deleted before actor channel
 using FChannelObjectPair = TPair<TWeakObjectPtr<USpatialActorChannel>, TWeakObjectPtr<UObject>>;
-using FRPCsOnEntityCreationMap = TMap<TWeakObjectPtr<const UObject>, RPCsOnEntityCreation>;
+using FRPCsOnEntityCreationMap = TMap<TWeakObjectPtr<const UObject>, SpatialGDK::RPCsOnEntityCreation>;
 using FUpdatesQueuedUntilAuthority = TMap<Worker_EntityId_Key, TArray<FWorkerComponentUpdate>>;
 using FChannelsToUpdatePosition = TSet<TWeakObjectPtr<USpatialActorChannel>>;
 
@@ -79,7 +77,7 @@ public:
 	void SendAuthorityIntentUpdate(const AActor& Actor, VirtualWorkerId NewAuthoritativeVirtualWorkerId);
 	void SetAclWriteAuthority(const Worker_EntityId EntityId, const FString& DestinationWorkerId);
 	FRPCErrorInfo SendRPC(const FPendingRPCParams& Params);
-	ERPCResult SendRPCInternal(UObject* TargetObject, UFunction* Function, const RPCPayload& Payload);
+	ERPCResult SendRPCInternal(UObject* TargetObject, UFunction* Function, const SpatialGDK::RPCPayload& Payload);
 	void SendCommandResponse(Worker_RequestId RequestId, Worker_CommandResponse& Response);
 	void SendEmptyCommandResponse(Worker_ComponentId ComponentId, Schema_FieldId CommandIndex, Worker_RequestId RequestId);
 	void SendCommandFailure(Worker_RequestId RequestId, const FString& Message);
@@ -116,7 +114,7 @@ public:
 
 	void FlushRPCService();
 
-	RPCPayload CreateRPCPayloadFromParams(UObject* TargetObject, const FUnrealObjectRef& TargetObjectRef, UFunction* Function, void* Params);
+	SpatialGDK::RPCPayload CreateRPCPayloadFromParams(UObject* TargetObject, const FUnrealObjectRef& TargetObjectRef, UFunction* Function, void* Params);
 	void GainAuthorityThenAddComponent(USpatialActorChannel* Channel, UObject* Object, const FClassInfo* Info);
 
 	// Creates an entity authoritative on this server worker, ensuring it will be able to receive updates for the GSM.
@@ -150,16 +148,16 @@ private:
 	// RPC Construction
 	FSpatialNetBitWriter PackRPCDataToSpatialNetBitWriter(UFunction* Function, void* Parameters) const;
 
-	Worker_CommandRequest CreateRPCCommandRequest(UObject* TargetObject, const RPCPayload& Payload, Worker_ComponentId ComponentId, Schema_FieldId CommandIndex, Worker_EntityId& OutEntityId);
+	Worker_CommandRequest CreateRPCCommandRequest(UObject* TargetObject, const SpatialGDK::RPCPayload& Payload, Worker_ComponentId ComponentId, Schema_FieldId CommandIndex, Worker_EntityId& OutEntityId);
 	Worker_CommandRequest CreateRetryRPCCommandRequest(const FReliableRPCForRetry& RPC, uint32 TargetObjectOffset);
-	Worker_ComponentUpdate CreateRPCEventUpdate(UObject* TargetObject, const RPCPayload& Payload, Worker_ComponentId ComponentId, Schema_FieldId EventIndext);
-	ERPCResult AddPendingRPC(UObject* TargetObject, UFunction* Function, const RPCPayload& Payload, Worker_ComponentId ComponentId, Schema_FieldId RPCIndext);
+	Worker_ComponentUpdate CreateRPCEventUpdate(UObject* TargetObject, const SpatialGDK::RPCPayload& Payload, Worker_ComponentId ComponentId, Schema_FieldId EventIndext);
+	ERPCResult AddPendingRPC(UObject* TargetObject, UFunction* Function, const SpatialGDK::RPCPayload& Payload, Worker_ComponentId ComponentId, Schema_FieldId RPCIndext);
 
 	TArray<Worker_InterestOverride> CreateComponentInterestForActor(USpatialActorChannel* Channel, bool bIsNetOwned);
 
 	// RPC Tracking
 #if !UE_BUILD_SHIPPING
-	void TrackRPC(AActor* Actor, UFunction* Function, const RPCPayload& Payload, const ERPCType RPCType);
+	void TrackRPC(AActor* Actor, UFunction* Function, const SpatialGDK::RPCPayload& Payload, const ERPCType RPCType);
 #endif
 private:
 	UPROPERTY()

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/EntityFactory.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/EntityFactory.h
@@ -7,6 +7,7 @@
 #include <WorkerSDK/improbable/c_schema.h>
 #include <WorkerSDK/improbable/c_worker.h>
 
+class AActor;
 class USpatialActorChannel;
 class USpatialNetDriver;
 class USpatialPackageMap;
@@ -26,6 +27,7 @@ public:
 	EntityFactory(USpatialNetDriver* InNetDriver, USpatialPackageMapClient* InPackageMap, USpatialClassInfoManager* InClassInfoManager, SpatialRPCService* InRPCService);
  
 	TArray<FWorkerComponentData> CreateEntityComponents(USpatialActorChannel* Channel, FRPCsOnEntityCreationMap& OutgoingOnCreateEntityRPCs);
+	TArray<FWorkerComponentData> CreateTombstoneEntityComponents(AActor* Actor);
  
 private:
 	USpatialNetDriver* NetDriver;
@@ -33,4 +35,4 @@ private:
 	USpatialClassInfoManager* ClassInfoManager;
 	SpatialRPCService* RPCService;
 };
-}
+}  // namepsace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/EntityFactory.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/EntityFactory.h
@@ -2,9 +2,8 @@
  
 #pragma once
  
-#include "Core.h"
- 
 #include "SpatialCommonTypes.h"
+
 #include <WorkerSDK/improbable/c_schema.h>
 #include <WorkerSDK/improbable/c_worker.h>
 

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/SpatialOSDispatcherInterface/SpatialOSDispatcherSpy.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/SpatialOSDispatcherInterface/SpatialOSDispatcherSpy.cpp
@@ -67,7 +67,7 @@ void SpatialOSDispatcherSpy::AddEntityQueryDelegate(Worker_RequestId RequestId, 
 void SpatialOSDispatcherSpy::AddReserveEntityIdsDelegate(Worker_RequestId RequestId, ReserveEntityIDsDelegate Delegate)
 {}
 
-void SpatialOSDispatcherSpy::AddCreateEntityDelegate(Worker_RequestId RequestId, const CreateEntityDelegate& Delegate)
+void SpatialOSDispatcherSpy::AddCreateEntityDelegate(Worker_RequestId RequestId, CreateEntityDelegate Delegate)
 {}
 
 void SpatialOSDispatcherSpy::OnEntityQueryResponse(const Worker_EntityQueryResponseOp& Op)

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/SpatialOSDispatcherInterface/SpatialOSDispatcherSpy.h
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/SpatialOSDispatcherInterface/SpatialOSDispatcherSpy.h
@@ -43,7 +43,7 @@ public:
 
 	virtual void AddEntityQueryDelegate(Worker_RequestId RequestId, EntityQueryDelegate Delegate) override;
 	virtual void AddReserveEntityIdsDelegate(Worker_RequestId RequestId, ReserveEntityIDsDelegate Delegate) override;
-	virtual void AddCreateEntityDelegate(Worker_RequestId RequestId, const CreateEntityDelegate& Delegate) override;
+	virtual void AddCreateEntityDelegate(Worker_RequestId RequestId, CreateEntityDelegate Delegate) override;
 
 	virtual void OnEntityQueryResponse(const Worker_EntityQueryResponseOp& Op) override;
 


### PR DESCRIPTION
#### Description
READ IN COMMIT ORDER FOR THE BEST OF TIMES

Adds the ability to delete initially dormant startup actors. When such an actor is deleted a tombstone entity is created containing a minimum number of components. In order to be able to retry creating these entities we have to store the component data in the sender and copy it for each attempt.

Currently ownership is denoted by a unique pointer with a custom deleter. Likely improvements to this would be to have an RAII type for worker components rather than just on the array however this seemed like the larger change in this PR.

#### Release note
Fixed an issue where deleted, initially dormant startup actors would still be present on other workers.

#### Tests
Test gym 

#### Documentation
Release note.

#### Primary reviewers
@m-samiec 