### PR TITLE
Adding a Generate Dev Auth Token Button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Introduced experimental feature flag `bEnableResultTypes`, defaulting false. Flip this to true for Interest queries to only include the set of components required to run. Should give bandwidth savings depending on your game. 
 - Moved Dev Auth settings from runtime settings to editor settings.
 - Added the option to use the development authentication flow using the command line.
-- Added a button to generate the Development Authentication Token inside the Unreal Editor.
+- Added a button to generate the Development Authentication Token inside the Unreal Editor. To use it, navigate to **SpatialOS GDK for Unreal** > **Editor Settings** > **Cloud Connection**.
 
 ## Bug fixes:
 - Fixed a bug that caused the local API service to memory leak.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Introduced experimental feature flag `bEnableResultTypes`, defaulting false. Flip this to true for Interest queries to only include the set of components required to run. Should give bandwidth savings depending on your game. 
 - Moved Dev Auth settings from runtime settings to editor settings.
 - Added the option to use the development authentication flow using the command line.
+- Added a button to generate the Development Authentication Token inside the Unreal Editor.
 
 ## Bug fixes:
 - Fixed a bug that caused the local API service to memory leak.

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
@@ -71,6 +71,7 @@ FReply FSpatialGDKEditorLayoutDetails::ClickedOnButton()
 	{
 		SpatialGDKEditorSettings->DevelopmentAuthenticationToken = TokenSecret;
 		SpatialGDKEditorSettings->SaveConfig();
+		SpatialGDKEditorSettings->SetRuntimeDevelopmentAuthenticationToken();
 	}
 
 	return FReply::Handled();

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
@@ -10,6 +10,8 @@
 #include "SpatialGDKServicesModule.h"
 #include "Serialization/JsonSerializer.h"
 #include "Widgets/Text/STextBlock.h"
+#include "Misc/MessageDialog.h"
+
 #include "Widgets/Input/SButton.h"
 
 DEFINE_LOG_CATEGORY(LogSpatialGDKEditorLayoutDetails);
@@ -39,13 +41,17 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 
 FReply FSpatialGDKEditorLayoutDetails::ClickedOnButton()
 {
+
+
 	FString CreateDevAuthTokenResult;
 	int32 ExitCode;
 	FSpatialGDKServicesModule::ExecuteAndReadOutput(SpatialGDKServicesConstants::SpatialExe, TEXT("project auth dev-auth-token create --description=\"Unreal GDK Token\" --json_output"), SpatialGDKServicesConstants::SpatialOSDirectory, CreateDevAuthTokenResult, ExitCode);
 
 	if (ExitCode != 0)
 	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Warning, TEXT("Unable to generate a development authentication token. %s"), *CreateDevAuthTokenResult);
+		UE_LOG(LogSpatialGDKEditorLayoutDetails, Warning, TEXT("Unable to generate a development authentication token. Result: %s"), *CreateDevAuthTokenResult);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to generate a development authentication token. Result: %s"), *CreateDevAuthTokenResult)));
+		return FReply::Handled();
 	};
 
 	FString AuthResult;
@@ -60,7 +66,8 @@ FReply FSpatialGDKEditorLayoutDetails::ClickedOnButton()
 	TSharedPtr<FJsonObject> JsonRootObject;
 	if (!(FJsonSerializer::Deserialize(JsonReader, JsonRootObject) && JsonRootObject.IsValid()))
 	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Warning, TEXT("Unable to parse the received development authentication token. %s"), *DevAuthTokenResult);
+		UE_LOG(LogSpatialGDKEditorLayoutDetails, Warning, TEXT("Unable to parse the received development authentication token. Result: %s"), *DevAuthTokenResult);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to parse the received development authentication token. Result: %s"), *DevAuthTokenResult)));
 		return FReply::Handled();
 	}
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
@@ -1,0 +1,77 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "SpatialGDKEditorLayoutDetails.h"
+
+#include "DetailLayoutBuilder.h"
+#include "DetailWidgetRow.h"
+#include "DetailCategoryBuilder.h"
+#include "SpatialGDKEditorSettings.h"
+#include "SpatialGDKServicesConstants.h"
+#include "SpatialGDKServicesModule.h"
+#include "Serialization/JsonSerializer.h"
+#include "Widgets/Text/STextBlock.h"
+#include "Widgets/Input/SButton.h"
+
+DEFINE_LOG_CATEGORY(LogSpatialGDKEditorLayoutDetails);
+
+TSharedRef<IDetailCustomization> FSpatialGDKEditorLayoutDetails::MakeInstance()
+{
+	return MakeShareable(new FSpatialGDKEditorLayoutDetails);
+}
+
+void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& DetailBuilder)
+{
+	IDetailCategoryBuilder& CustomCategory = DetailBuilder.EditCategory("Cloud Connection");
+	CustomCategory.AddCustomRow(FText::FromString("Generate Development Authentication Token"))
+		.ValueContent()
+		.VAlign(VAlign_Center)
+		.MaxDesiredWidth(250)
+		[
+			SNew(SButton)
+			.VAlign(VAlign_Center)
+			.OnClicked(this, &FSpatialGDKEditorLayoutDetails::ClickedOnButton)
+			.Content()
+			[
+				SNew(STextBlock).Text(FText::FromString("Generate Dev Auth Token"))
+			]
+		];
+}
+
+FReply FSpatialGDKEditorLayoutDetails::ClickedOnButton()
+{
+	FString CreateDevAuthTokenResult;
+	int32 ExitCode;
+	FSpatialGDKServicesModule::ExecuteAndReadOutput(SpatialGDKServicesConstants::SpatialExe, TEXT("project auth dev-auth-token create --description=\"Unreal GDK Token\" --json_output"), SpatialGDKServicesConstants::SpatialOSDirectory, CreateDevAuthTokenResult, ExitCode);
+
+	if (ExitCode != 0)
+	{
+		UE_LOG(LogSpatialGDKEditorLayoutDetails, Warning, TEXT("Unable to generate a development authentication token. %s"), *CreateDevAuthTokenResult);
+	};
+
+	FString AuthResult;
+	FString DevAuthTokenResult;
+	if (!CreateDevAuthTokenResult.Split(TEXT("\n"), &AuthResult, &DevAuthTokenResult) || DevAuthTokenResult.IsEmpty())
+	{
+		// This is necessary because depending on whether you are already authenticated against spatial, it will either return two json structs or one.
+		DevAuthTokenResult = CreateDevAuthTokenResult;
+	}
+
+	TSharedRef<TJsonReader<TCHAR>> JsonReader = TJsonReaderFactory<TCHAR>::Create(DevAuthTokenResult);
+	TSharedPtr<FJsonObject> JsonRootObject;
+	if (!(FJsonSerializer::Deserialize(JsonReader, JsonRootObject) && JsonRootObject.IsValid()))
+	{
+		UE_LOG(LogSpatialGDKEditorLayoutDetails, Warning, TEXT("Unable to parse the received development authentication token. %s"), *DevAuthTokenResult);
+		return FReply::Handled();
+	}
+
+	TSharedPtr<FJsonObject> JsonDataObject = JsonRootObject->GetObjectField("json_data");
+	FString TokenSecret = JsonDataObject->GetStringField("token_secret");
+
+	if (USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetMutableDefault<USpatialGDKEditorSettings>())
+	{
+		SpatialGDKEditorSettings->DevelopmentAuthenticationToken = TokenSecret;
+		SpatialGDKEditorSettings->SaveConfig();
+	}
+
+	return FReply::Handled();
+}

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -4,6 +4,7 @@
 
 #include "SpatialGDKSettings.h"
 #include "SpatialGDKEditorSettings.h"
+#include "SpatialGDKEditorLayoutDetails.h"
 
 #include "ISettingsModule.h"
 #include "ISettingsContainer.h"
@@ -58,6 +59,7 @@ void FSpatialGDKEditorModule::RegisterSettings()
 
 	FPropertyEditorModule& PropertyModule = FModuleManager::LoadModuleChecked<FPropertyEditorModule>("PropertyEditor");
 	PropertyModule.RegisterCustomPropertyTypeLayout("WorkerType", FOnGetPropertyTypeCustomizationInstance::CreateStatic(&FWorkerTypeCustomization::MakeInstance));
+	PropertyModule.RegisterCustomClassLayout(USpatialGDKEditorSettings::StaticClass()->GetFName(), FOnGetDetailCustomizationInstance::CreateStatic(&FSpatialGDKEditorLayoutDetails::MakeInstance));
 }
 
 void FSpatialGDKEditorModule::UnregisterSettings()

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
@@ -1,0 +1,19 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "IDetailCustomization.h"
+#include "Input/Reply.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKEditorLayoutDetails, Log, All);
+
+class FSpatialGDKEditorLayoutDetails : public IDetailCustomization
+{
+private:
+	FReply ClickedOnButton();
+
+public:
+	static TSharedRef<IDetailCustomization> MakeInstance();
+	virtual void CustomizeDetails(IDetailLayoutBuilder& DetailBuilder) override;
+};

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -241,7 +241,6 @@ private:
 
 	/** Set DAT in runtime settings. */
 	void SetRuntimeUseDevelopmentAuthenticationFlow();
-	void SetRuntimeDevelopmentAuthenticationToken();
 	void SetRuntimeDevelopmentDeploymentToConnect();
 
 	/** Set WorkerTypesToLaunch in level editor play settings. */
@@ -487,4 +486,6 @@ public:
 	}
 
 	bool IsDeploymentConfigurationValid() const;
+
+	void SetRuntimeDevelopmentAuthenticationToken();
 };


### PR DESCRIPTION
#### Description
Adds a button to the Spatial GDK Editor Settings to generate the dev auth token directly inside the Unreal Editor. 

![devauthtokenbutton](https://user-images.githubusercontent.com/31853332/73543383-c014e280-442e-11ea-80d3-2597339b6443.PNG)

#### Release note
added it

#### Tests
Tested the button both when being authenticated against SpatialOS and when not

#### Documentation
no documentation yet

