### PR TITLE
Exposing dev auth fields as URL options

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
@@ -389,7 +389,11 @@ void USpatialWorkerConnection::SetupConnectionConfigFromURL(const FURL& URL, con
 		SetConnectionType(ESpatialConnectionType::DevAuthFlow);
 		// TODO: UNR-2811 Also set the locator host of DevAuthConfig from URL.
 		FParse::Value(FCommandLine::Get(), TEXT("locatorHost"), DevAuthConfig.LocatorHost);
-		DevAuthConfig.DevelopmentAuthToken = URL.GetOption(*SpatialConstants::URL_DEV_AUTH_OPTION, TEXT(""));
+		DevAuthConfig.DevelopmentAuthToken = URL.GetOption(*SpatialConstants::URL_DEV_AUTH_TOKEN_OPTION, TEXT(""));
+		DevAuthConfig.Deployment = URL.GetOption(*SpatialConstants::URL_TARGET_DEPLOYMENT_OPTION, TEXT(""));
+		DevAuthConfig.PlayerId = URL.GetOption(*SpatialConstants::URL_PLAYER_ID_OPTION, *SpatialConstants::DEVELOPMENT_AUTH_PLAYER_ID);
+		DevAuthConfig.DisplayName = URL.GetOption(*SpatialConstants::URL_DISPLAY_NAME_OPTION, TEXT(""));
+		DevAuthConfig.MetaData = URL.GetOption(*SpatialConstants::URL_METADATA_OPTION, TEXT(""));
 		DevAuthConfig.WorkerType = SpatialWorkerType;
 	}
 	else

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -242,7 +242,11 @@ const FString SPATIALOS_METRICS_DYNAMIC_FPS = TEXT("Dynamic.FPS");
 const FString RECONNECT_USING_COMMANDLINE_ARGUMENTS = TEXT("0.0.0.0");
 const FString URL_LOGIN_OPTION = TEXT("login=");
 const FString URL_PLAYER_IDENTITY_OPTION = TEXT("playeridentity=");
-const FString URL_DEV_AUTH_OPTION = TEXT("devauth=");
+const FString URL_DEV_AUTH_TOKEN_OPTION = TEXT("devauthtoken=");
+const FString URL_TARGET_DEPLOYMENT_OPTION = TEXT("deployment=");
+const FString URL_PLAYER_ID_OPTION = TEXT("playerid=");
+const FString URL_DISPLAY_NAME_OPTION = TEXT("displayname=");
+const FString URL_METADATA_OPTION = TEXT("metadata=");
 
 const FString DEVELOPMENT_AUTH_PLAYER_ID = TEXT("Player Id");
 


### PR DESCRIPTION
#### Description
Exposing all the different fields that can be set for the dev auth flow for when using Map URL only instead of command line args.