### PR TITLE
Remove simulated player zip from runner on startup

### DIFF
--- a/RequireSetup
+++ b/RequireSetup
@@ -1,4 +1,4 @@
 Increment the below number whenever it is required to run Setup.bat as part of a new commit.
 Our git hooks will detect this file has been updated and automatically run Setup.bat on pull.
 
-48
+49

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Common/LinuxScripts.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Common/LinuxScripts.cs
@@ -55,6 +55,13 @@ gosu $NEW_USER ""${{SCRIPT}}"" ""$@"" >> ""/improbable/logs/${{WORKER_ID}}.log""
 
         public const string SimulatedPlayerCoordinatorShellScript =
 @"#!/bin/sh
+
+# Some clients are quite large so in order to avoid running out of disk space on the node we attempt to delete the zip
+WORKER_ZIP_DIR=""/tmp/runner_source/""
+if [ -d ""$WORKER_ZIP_DIR"" ]; then
+  rm -rf ""$WORKER_ZIP_DIR""
+fi
+
 sleep 5
 
 chmod +x WorkerCoordinator.exe


### PR DESCRIPTION
#### Description
I had to apply this fix due to running out of disk space in a test worker node with a game client that was just over 20GB (with a 11GB zip file). I'm not sure if the same applies when launching simulated player deployments (in worker nanny nodes of a separate deployment).

#### Release note
REQUIRED: Add a release note to the `##Unreleased` section of CHANGELOG.md. You can find guidance for writing useful release notes [here](../SpatialGDK/Extras/internal-documentation/how-to-write-good-release-notes.md). Documentation changes are exempt from this requirement.

#### Tests

Tested by adding a command to output disk usage on the runner before and after the remove command. Also searched simulated client logs for previously seen errors about running out of disk space and didn't find any.

#### Documentation
in-code

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.