### PR TITLE
Bugfix/fix worker startup race

### DIFF
--- a/RequireSetup
+++ b/RequireSetup
@@ -1,4 +1,4 @@
 Increment the below number whenever it is required to run Setup.bat as part of a new commit.
 Our git hooks will detect this file has been updated and automatically run Setup.bat on pull.
 
-49
+50

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Common/LinuxScripts.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Common/LinuxScripts.cs
@@ -15,7 +15,7 @@ LOG_FILE=$2
 shift 2
 
 # 2>/dev/null silences errors by redirecting stderr to the null device. This is done to prevent errors when a machine attempts to add the same user more than once.
-mkdir -p /improbable/logs/UnrealWorker
+mkdir -p /improbable/logs/UnrealWorker/
 useradd $NEW_USER -m -d /improbable/logs/UnrealWorker 2>/dev/null
 chown -R $NEW_USER:$NEW_USER $(pwd) 2>/dev/null
 chmod -R o+rw /improbable/logs 2>/dev/null

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Common/LinuxScripts.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Common/LinuxScripts.cs
@@ -15,7 +15,7 @@ LOG_FILE=$2
 shift 2
 
 # 2>/dev/null silences errors by redirecting stderr to the null device. This is done to prevent errors when a machine attempts to add the same user more than once.
-mkdir -p /improbable/logs/UnrealWorker/
+mkdir -p /improbable/logs/UnrealWorker/Logs
 useradd $NEW_USER -m -d /improbable/logs/UnrealWorker/Logs 2>/dev/null
 chown -R $NEW_USER:$NEW_USER $(pwd) 2>/dev/null
 chmod -R o+rw /improbable/logs 2>/dev/null

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Common/LinuxScripts.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Common/LinuxScripts.cs
@@ -15,8 +15,8 @@ LOG_FILE=$2
 shift 2
 
 # 2>/dev/null silences errors by redirecting stderr to the null device. This is done to prevent errors when a machine attempts to add the same user more than once.
-mkdir -p /improbable/logs/UnrealWorker/Logs
-useradd $NEW_USER -m -d /improbable/logs/UnrealWorker/Logs 2>/dev/null
+mkdir -p /improbable/logs/UnrealWorker
+useradd $NEW_USER -m -d /improbable/logs/UnrealWorker 2>/dev/null
 chown -R $NEW_USER:$NEW_USER $(pwd) 2>/dev/null
 chmod -R o+rw /improbable/logs 2>/dev/null
 


### PR DESCRIPTION
#### Description
Fix a race when starting multiple workers at once where two workers during their `useradd` command would race to construct the USER_DIR. When a worker failed to create the user, it'll then fail to run the Unreal binary. This was done by setting the USER_DIR directly to `logs/UnrealWorker/` which is where the logs were being output anyway.

#### Tests
Ran a cloud deployment with multiple workers and they all started up.

#### Primary reviewers
@ShivamMistry @ianbillett @joshuahuburn 