### PR TITLE
[UNR-2842] Have a more explicit error message when pulling load balancing strategy from world settings

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -411,7 +411,14 @@ void USpatialNetDriver::CreateAndInitializeLoadBalancingClasses()
 	{
 		if (WorldSettings == nullptr || WorldSettings->LoadBalanceStrategy == nullptr)
 		{
-			UE_LOG(LogSpatialOSNetDriver, Error, TEXT("If EnableUnrealLoadBalancer is set, there must be a LoadBalancing strategy set. Using a 1x1 grid."));
+			if (WorldSettings == nullptr)
+			{
+				UE_LOG(LogSpatialOSNetDriver, Error, TEXT("If EnableUnrealLoadBalancer is set, WorldSettings should inherit from SpatialWorldSettings to get the load balancing strategy. Using a 1x1 grid."));
+			}
+			else
+			{
+				UE_LOG(LogSpatialOSNetDriver, Error, TEXT("If EnableUnrealLoadBalancer is set, there must be a LoadBalancing strategy set. Using a 1x1 grid."));
+			}
 			LoadBalanceStrategy = NewObject<UGridBasedLBStrategy>(this);
 		}
 		else


### PR DESCRIPTION
#### Description
Have more explicit message about pulling load balancer configuration from SpatialWorldSettings

Relates to engine PRs : 
https://github.com/improbableio/UnrealEngine/pull/339
https://github.com/improbableio/UnrealEngine/pull/340

#### Release note

#### Tests

#### Documentation

#### Primary reviewers