### PR TITLE
[UNR-2736] Don't construct shadow data every time when receiving update

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -1325,8 +1325,6 @@ void USpatialActorChannel::ResetShadowData(FRepLayout& RepLayout, FRepStateStati
 #if ENGINE_MINOR_VERSION <= 22
 		RepLayout.InitShadowData(StaticBuffer, TargetObject->GetClass(), reinterpret_cast<uint8*>(TargetObject));
 #else
-		// TODO: UNR-2372 - Investigate not resetting the ShadowData.
-		StaticBuffer.Buffer.Empty();
 		RepLayout.InitRepStateStaticBuffer(StaticBuffer, reinterpret_cast<const uint8*>(TargetObject));
 #endif
 	}

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -274,6 +274,8 @@ private:
 	void UpdateEntityACLToNewOwner();
 	void UpdateInterestBucketComponentId();
 
+	static void ResetShadowData(FRepLayout& RepLayout, FRepStateStaticBuffer& StaticBuffer, UObject* TargetObject);
+
 public:
 	// If this actor channel is responsible for creating a new entity, this will be set to true once the entity creation request is issued.
 	bool bCreatedEntity;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/EngineVersionCheck.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/EngineVersionCheck.h
@@ -7,7 +7,7 @@
 // GDK Version to be updated with SPATIAL_ENGINE_VERSION
 // when breaking changes are made to the engine that requires
 // changes to the GDK to remain compatible
-#define SPATIAL_GDK_VERSION 13
+#define SPATIAL_GDK_VERSION 14
 
 // Check if GDK is compatible with the current version of Unreal Engine
 // SPATIAL_ENGINE_VERSION is incremented in engine when breaking changes

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/EngineVersionCheck.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/EngineVersionCheck.h
@@ -7,7 +7,7 @@
 // GDK Version to be updated with SPATIAL_ENGINE_VERSION
 // when breaking changes are made to the engine that requires
 // changes to the GDK to remain compatible
-#define SPATIAL_GDK_VERSION 14
+#define SPATIAL_GDK_VERSION 13
 
 // Check if GDK is compatible with the current version of Unreal Engine
 // SPATIAL_ENGINE_VERSION is incremented in engine when breaking changes


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
We used to call `InitShadowData` in 4.22 and `InitRepStateStaticBuffer` in 4.23 every time before applying replicated state, which constructed the properties in shadow data and allocated memory for TArrays etc.

Corresponding engine PRs:
4.23 https://github.com/improbableio/UnrealEngine/pull/341
4.22 https://github.com/improbableio/UnrealEngine/pull/343

#### Primary reviewers
@mattyoung-improbable @mironec 