### PR TITLE
Dup functionality from DataChannel::ReplicateActor

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -464,7 +464,9 @@ int64 USpatialActorChannel::ReplicateActor()
 	else if (Actor->IsPendingKillOrUnreachable())
 	{
 		bActorIsPendingKill = true;
+#if ENGINE_MINOR_VERSION > 22
 		ActorReplicator.Reset();
+#endif
 		FString Error(FString::Printf(TEXT("ReplicateActor called with PendingKill Actor! %s"), *Describe()));
 		UE_LOG(LogNet, Log, TEXT("%s"), *Error);
 		ensureMsgf(false, TEXT("%s"), *Error);

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -449,7 +449,7 @@ int64 USpatialActorChannel::ReplicateActor()
 	const bool bReplay = ActorWorld && ActorWorld->DemoNetDriver == Connection->GetDriver();
 
 	//////////////////////////////////////////////////////////////////////////
-	// Error and stat duplication from DataChannel::ReplicateActor()
+	// Begin - error and stat duplication from DataChannel::ReplicateActor()
 	if (!bReplay)
 	{
 		GNumReplicateActorCalls++;
@@ -480,7 +480,7 @@ int64 USpatialActorChannel::ReplicateActor()
 		ensureMsgf(false, TEXT("%s"), *Error);
 		return 0;
 	}
-	// End error and stat duplication from DataChannel::ReplicateActor()
+	// End - error and stat duplication from DataChannel::ReplicateActor()
 	//////////////////////////////////////////////////////////////////////////
 
 	// Create an outgoing bunch (to satisfy some of the functions below).


### PR DESCRIPTION
#### Description
This functionality was added in 4.22, but we didn't add it to our port.
This allows USpatialActorChannel::ReplicateActor() to safely abort when encountering Actors that shouldn't be replicated etc instead of crashing.

https://improbableio.atlassian.net/browse/UNR-2849

https://github.com/improbableio/UnrealEngine/pull/346
https://github.com/improbableio/UnrealEngine/pull/347

#### Primary reviewers
@improbable-valentyn @MatthewSandfordImprobable 