### PR TITLE
Adding a mobile settings section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A warning is shown if a cloud deployment is launched with the `manual_worker_connection_only` flag set to true
 - Server travel supported for single server game worlds. Does not currently support zoning or off-loading.
 - Enabled the SpatialOS toolbar for MacOS.
-- Added a menu item to push additional arguments for iOS devices.
 - Improved workflow around schema generation issues and launching local builds. A warning will now show if attempting to run a local deployment after a schema error.
 - DeploymentLauncher can parse a .pb.json launch configuration.
 - DeploymentLauncher can launch a Simulated Player deployment independently from the target deployment.
@@ -49,8 +48,9 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Introduced experimental feature flag `bEnableResultTypes`, defaulting false. Flip this to true for Interest queries to only include the set of components required to run. Should give bandwidth savings depending on your game. 
 - Moved Dev Auth settings from runtime settings to editor settings.
 - Added the option to use the development authentication flow using the command line.
-- Added a button to generate the Development Authentication Token inside the Unreal Editor. To use it, navigate to **SpatialOS GDK for Unreal** > **Editor Settings** > **Cloud Connection**.
+- Added a button to generate the Development Authentication Token inside the Unreal Editor. To use it, navigate to **Edit** > **Project Setting** > **SpatialOS GDK for Unreal** > **Editor Settings** > **Cloud Connection**.
 - The Spatial output log will now be open by default.
+- Added a new settings section allowing you to configure the launch arguments when running a a client on a mobile device. To use it, navigate to **Edit** > **Project Setting** > **SpatialOS GDK for Unreal** > **Editor Settings** > **Mobile**.
 
 ## Bug fixes:
 - Fixed a bug that caused the local API service to memory leak.

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
@@ -213,7 +213,7 @@ FReply FSpatialGDKEditorLayoutDetails::PrepareAndroidApplication()
 
 	const FString ProjectName = FApp::GetProjectName();
 	const FString AndroidCommandLineFile = FString::Printf(TEXT("/mnt/sdcard/UE4Game/%s/UE4CommandLine.txt"), *ProjectName);
-	const FString AdbArguments = FString::Printf(TEXT("push %s %s"), *OutCommandLineArgsFile, *AndroidCommandLineFile);
+	const FString AdbArguments = FString::Printf(TEXT("push \"%s\" \"%s\""), *OutCommandLineArgsFile, *AndroidCommandLineFile);
 	FString AdbExe = FPaths::ConvertRelativePathToFull(FPaths::Combine(AndroidHome, TEXT("platform-tools/adb")));
 
 #if PLATFORM_WINDOWS

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
@@ -5,13 +5,16 @@
 #include "DetailLayoutBuilder.h"
 #include "DetailWidgetRow.h"
 #include "DetailCategoryBuilder.h"
+#include "HAL/PlatformFilemanager.h"
+#include "IOSRuntimeSettings.h"
+#include "Misc/App.h"
+#include "Misc/FileHelper.h"
+#include "Misc/MessageDialog.h"
+#include "Serialization/JsonSerializer.h"
 #include "SpatialGDKEditorSettings.h"
 #include "SpatialGDKServicesConstants.h"
 #include "SpatialGDKServicesModule.h"
-#include "Serialization/JsonSerializer.h"
 #include "Widgets/Text/STextBlock.h"
-#include "Misc/MessageDialog.h"
-
 #include "Widgets/Input/SButton.h"
 
 DEFINE_LOG_CATEGORY(LogSpatialGDKEditorLayoutDetails);
@@ -23,26 +26,53 @@ TSharedRef<IDetailCustomization> FSpatialGDKEditorLayoutDetails::MakeInstance()
 
 void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& DetailBuilder)
 {
-	IDetailCategoryBuilder& CustomCategory = DetailBuilder.EditCategory("Cloud Connection");
-	CustomCategory.AddCustomRow(FText::FromString("Generate Development Authentication Token"))
+	IDetailCategoryBuilder& CloudConnectionCategory = DetailBuilder.EditCategory("Cloud Connection");
+	CloudConnectionCategory.AddCustomRow(FText::FromString("Generate Development Authentication Token"))
 		.ValueContent()
 		.VAlign(VAlign_Center)
-		.MaxDesiredWidth(250)
+		.MinDesiredWidth(250)
 		[
 			SNew(SButton)
 			.VAlign(VAlign_Center)
-			.OnClicked(this, &FSpatialGDKEditorLayoutDetails::ClickedOnButton)
+			.OnClicked(this, &FSpatialGDKEditorLayoutDetails::GenerateDevAuthToken)
 			.Content()
 			[
 				SNew(STextBlock).Text(FText::FromString("Generate Dev Auth Token"))
 			]
 		];
+
+	IDetailCategoryBuilder& MobileCategory = DetailBuilder.EditCategory("Mobile");
+	MobileCategory.AddCustomRow(FText::FromString("Push SpatialOS settings to Android device"))
+		.ValueContent()
+		.VAlign(VAlign_Center)
+		.MinDesiredWidth(250)
+		[
+			SNew(SButton)
+			.VAlign(VAlign_Center)
+		.OnClicked(this, &FSpatialGDKEditorLayoutDetails::PrepareAndroidApplication)
+		.Content()
+		[
+			SNew(STextBlock).Text(FText::FromString("Push SpatialOS settings to Android device"))
+		]
+		];
+
+	MobileCategory.AddCustomRow(FText::FromString("Push SpatialOS settings to iOS device"))
+		.ValueContent()
+		.VAlign(VAlign_Center)
+		.MinDesiredWidth(250)
+		[
+			SNew(SButton)
+			.VAlign(VAlign_Center)
+		.OnClicked(this, &FSpatialGDKEditorLayoutDetails::PrepareIOSApplication)
+		.Content()
+		[
+			SNew(STextBlock).Text(FText::FromString("Push SpatialOS settings to iOS device"))
+		]
+		];
 }
 
-FReply FSpatialGDKEditorLayoutDetails::ClickedOnButton()
+FReply FSpatialGDKEditorLayoutDetails::GenerateDevAuthToken()
 {
-
-
 	FString CreateDevAuthTokenResult;
 	int32 ExitCode;
 	FSpatialGDKServicesModule::ExecuteAndReadOutput(SpatialGDKServicesConstants::SpatialExe, TEXT("project auth dev-auth-token create --description=\"Unreal GDK Token\" --json_output"), SpatialGDKServicesConstants::SpatialOSDirectory, CreateDevAuthTokenResult, ExitCode);
@@ -51,7 +81,7 @@ FReply FSpatialGDKEditorLayoutDetails::ClickedOnButton()
 	{
 		UE_LOG(LogSpatialGDKEditorLayoutDetails, Warning, TEXT("Unable to generate a development authentication token. Result: %s"), *CreateDevAuthTokenResult);
 		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to generate a development authentication token. Result: %s"), *CreateDevAuthTokenResult)));
-		return FReply::Handled();
+		return FReply::Unhandled();
 	};
 
 	FString AuthResult;
@@ -68,7 +98,7 @@ FReply FSpatialGDKEditorLayoutDetails::ClickedOnButton()
 	{
 		UE_LOG(LogSpatialGDKEditorLayoutDetails, Warning, TEXT("Unable to parse the received development authentication token. Result: %s"), *DevAuthTokenResult);
 		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to parse the received development authentication token. Result: %s"), *DevAuthTokenResult)));
-		return FReply::Handled();
+		return FReply::Unhandled();
 	}
 
 	TSharedPtr<FJsonObject> JsonDataObject = JsonRootObject->GetObjectField("json_data");
@@ -81,5 +111,130 @@ FReply FSpatialGDKEditorLayoutDetails::ClickedOnButton()
 		SpatialGDKEditorSettings->SetRuntimeDevelopmentAuthenticationToken();
 	}
 
+	return FReply::Handled();
+}
+
+bool FSpatialGDKEditorLayoutDetails::TryConstructMobileCommandLineArgumentsFile(FString& CommandLineArgsFile)
+{
+	UE_LOG(LogSpatialGDKEditorLayoutDetails, Warning, TEXT("Pushing to iOS device..."));
+	const USpatialGDKEditorSettings* SpatialGDKSettings = GetDefault<USpatialGDKEditorSettings>();
+	const FString ProjectName = FApp::GetProjectName();
+
+	// The project path is based on this: https://github.com/improbableio/UnrealEngine/blob/4.22-SpatialOSUnrealGDK-release/Engine/Source/Programs/AutomationTool/AutomationUtils/DeploymentContext.cs#L408
+	const FString IOSProjectPath = FString::Printf(TEXT("../../../%s/%s.uproject"), *ProjectName, *ProjectName);
+	FString TravelUrl;
+	FString SpatialOSCommandLineArgs = FString::Printf(TEXT("-workerType %s"), *(SpatialGDKSettings->MobileWorkerType));
+	if (SpatialGDKSettings->bMobileConnectToLocalDeployment)
+	{
+		TravelUrl = SpatialGDKSettings->MobileRuntimeIP;
+	}
+	else
+	{
+		TravelUrl = TEXT("connect.to.spatialos");
+
+		if (SpatialGDKSettings->DevelopmentAuthenticationToken.IsEmpty())
+		{
+			FReply GeneratedToken = GenerateDevAuthToken();
+			if (!GeneratedToken.IsEventHandled())
+			{
+				return false;
+			}
+		}
+
+		SpatialOSCommandLineArgs += FString::Printf(TEXT(" +devauthToken %s"), *(SpatialGDKSettings->DevelopmentAuthenticationToken));
+		if (!SpatialGDKSettings->DevelopmentDeploymentToConnect.IsEmpty())
+		{
+			SpatialOSCommandLineArgs += FString::Printf(TEXT(" +deployment %s"), *(SpatialGDKSettings->DevelopmentDeploymentToConnect));
+		}
+	}
+
+	const FString FinalCommandLineArgs = FString::Printf(TEXT("%s %s %s %s"), *IOSProjectPath, *TravelUrl, *SpatialOSCommandLineArgs, *(SpatialGDKSettings->MobileExtraCommandLineArgs));
+	CommandLineArgsFile = FPaths::ConvertRelativePathToFull(FPaths::Combine(*FPaths::ProjectLogDir(), TEXT("ue4commandline.txt")));
+
+	if (!FFileHelper::SaveStringToFile(FinalCommandLineArgs, *CommandLineArgsFile, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM))
+	{
+		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Failed to write command line args to file: %s"), *CommandLineArgsFile);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Failed to write command line args to file: %s"), *CommandLineArgsFile)));
+		return false;
+	}
+
+	return true;
+}
+
+bool FSpatialGDKEditorLayoutDetails::TryPushCommandLineArgs(const FString Executable, const FString ExeArguments, const FString CommandLineArgsFile)
+{
+	FString OutCommandLineArgsFile;
+	FString ExeOutput;
+	FString StdErr;
+	int32 ExitCode;
+
+	FPlatformProcess::ExecProcess(*Executable, *ExeArguments, &ExitCode, &ExeOutput, &StdErr);
+	if (ExitCode != 0)
+	{
+		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Failed to update the mobile client. %s %s"), *ExeOutput, *StdErr);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Failed to update the mobile client. See the Output log for more information.")));
+		return false;
+	}
+
+	UE_LOG(LogSpatialGDKEditorLayoutDetails, Log, TEXT("Successfully stored command line args on device: %s"), *ExeOutput);
+	IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
+	if (!PlatformFile.DeleteFile(*CommandLineArgsFile))
+	{
+		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Failed to delete file %s"), *CommandLineArgsFile);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Failed to delete file %s"), *CommandLineArgsFile)));
+	}
+
+	return true;
+}
+
+FReply FSpatialGDKEditorLayoutDetails::PrepareAndroidApplication()
+{
+	FString AndroidHome = FPlatformMisc::GetEnvironmentVariable(TEXT("ANDROID_HOME"));
+	if (AndroidHome.IsEmpty())
+	{
+		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Environment variable ANDROID_HOME is not set. Please make sure to configure this."));
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Environment variable ANDROID_HOME is not set. Please make sure to configure this.")));
+		return FReply::Unhandled();
+	}
+
+	FString OutCommandLineArgsFile;
+
+	if (!TryConstructMobileCommandLineArgumentsFile(OutCommandLineArgsFile))
+	{
+		return FReply::Unhandled();
+	}
+
+	const FString ProjectName = FApp::GetProjectName();
+	const FString AndroidCommandLineFile = FString::Printf(TEXT("/mnt/sdcard/UE4Game/%s/UE4CommandLine.txt"), *ProjectName);
+	const FString AdbArguments = FString::Printf(TEXT("push %s %s"), *OutCommandLineArgsFile, *AndroidCommandLineFile);
+	FString AdbExe = FPaths::ConvertRelativePathToFull(FPaths::Combine(AndroidHome, TEXT("platform-tools/adb")));
+
+#if PLATFORM_WINDOWS
+	AdbExe = FString::Printf(TEXT("%s.exe"), *AdbExe);
+#endif
+
+	TryPushCommandLineArgs(AdbExe, AdbArguments, OutCommandLineArgsFile);
+	return FReply::Handled();
+}
+
+FReply FSpatialGDKEditorLayoutDetails::PrepareIOSApplication()
+{
+	const UIOSRuntimeSettings* IOSRuntimeSettings = GetDefault<UIOSRuntimeSettings>();
+	FString OutCommandLineArgsFile;
+
+	if (!TryConstructMobileCommandLineArgumentsFile(OutCommandLineArgsFile))
+	{
+		return FReply::Unhandled();
+	}
+
+	FString Executable = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/DotNET/IOS/deploymentserver.exe")));
+	FString DeploymentServerArguments = FString::Printf(TEXT("copyfile -bundle \"%s\" -file \"%s\" -file \"/Documents/ue4commandline.txt\""), *(IOSRuntimeSettings->BundleIdentifier), *OutCommandLineArgsFile);
+
+#if PLATFORM_MAC
+	DeploymentServerArguments = FString::Printf(TEXT("%s %s"), *Executable, *DeploymentServerArguments);
+	Executable = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/ThirdParty/Mono/Mac/bin/mono")));
+#endif
+
+	TryPushCommandLineArgs(Executable, DeploymentServerArguments, OutCommandLineArgsFile);
 	return FReply::Handled();
 }

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
@@ -101,6 +101,7 @@ FReply FSpatialGDKEditorLayoutDetails::GenerateDevAuthToken()
 		return FReply::Unhandled();
 	}
 
+	// We need a pointer to a shared pointer due to how the JSON API works.
 	const TSharedPtr<FJsonObject>* JsonDataObject;
 	if (JsonRootObject->TryGetObjectField("json_data", JsonDataObject))
 	{

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
@@ -12,11 +12,11 @@ class FSpatialGDKEditorLayoutDetails : public IDetailCustomization
 {
 private:
 	bool TryConstructMobileCommandLineArgumentsFile(FString& CommandLineArgsFile);
-	bool TryPushCommandLineArgs(const FString& Executable, const FString& ExeArguments, const FString& CommandLineArgsFile);
+	bool TryPushCommandLineArgsToDevice(const FString& Executable, const FString& ExeArguments, const FString& CommandLineArgsFile);
 
 	FReply GenerateDevAuthToken();
-	FReply PrepareIOSApplication();
-	FReply PrepareAndroidApplication();
+	FReply PushCommandLineArgsToIOSDevice();
+	FReply PushCommandLineArgsToAndroidDevice();
 
 public:
 	static TSharedRef<IDetailCustomization> MakeInstance();

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
@@ -12,7 +12,7 @@ class FSpatialGDKEditorLayoutDetails : public IDetailCustomization
 {
 private:
 	bool TryConstructMobileCommandLineArgumentsFile(FString& CommandLineArgsFile);
-	bool TryPushCommandLineArgs(const FString Executable, const FString ExeArguments, const FString CommandLineArgsFile);
+	bool TryPushCommandLineArgs(const FString& Executable, const FString& ExeArguments, const FString& CommandLineArgsFile);
 
 	FReply GenerateDevAuthToken();
 	FReply PrepareIOSApplication();

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
@@ -11,7 +11,12 @@ DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKEditorLayoutDetails, Log, All);
 class FSpatialGDKEditorLayoutDetails : public IDetailCustomization
 {
 private:
-	FReply ClickedOnButton();
+	bool TryConstructMobileCommandLineArgumentsFile(FString& CommandLineArgsFile);
+	bool TryPushCommandLineArgs(const FString Executable, const FString ExeArguments, const FString CommandLineArgsFile);
+
+	FReply GenerateDevAuthToken();
+	FReply PrepareIOSApplication();
+	FReply PrepareAndroidApplication();
 
 public:
 	static TSharedRef<IDetailCustomization> MakeInstance();

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -345,6 +345,19 @@ private:
 	static bool IsManualWorkerConnectionSet(const FString& LaunchConfigPath);
 
 public:
+	UPROPERTY(EditAnywhere, config, Category = "Mobile", meta = (DisplayName = "Connect to a local deployment"))
+		bool bMobileConnectToLocalDeployment;
+
+	UPROPERTY(EditAnywhere, config, Category = "Mobile", meta = (DisplayName = "Mobile Client Worker Type"))
+		FString MobileWorkerType = SpatialConstants::DefaultClientWorkerType.ToString();
+
+	UPROPERTY(EditAnywhere, config, Category = "Mobile", meta = (EditCondition = "bMobileConnectToLocalDeployment", DisplayName = "Runtime IP to local deployment"))
+		FString MobileRuntimeIP;
+
+	UPROPERTY(EditAnywhere, config, Category = "Mobile", meta = (DisplayName = "Extra Command Line Arguments"))
+		FString MobileExtraCommandLineArgs;
+
+public:
 	/** If you have selected **Auto-generate launch configuration file**, you can change the default options in the file from the drop-down menu. */
 	UPROPERTY(EditAnywhere, config, Category = "Launch", meta = (EditCondition = "bGenerateDefaultLaunchConfig", DisplayName = "Launch configuration file options"))
 	FSpatialLaunchConfigDescription LaunchConfigDesc;

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -346,16 +346,16 @@ private:
 
 public:
 	UPROPERTY(EditAnywhere, config, Category = "Mobile", meta = (DisplayName = "Connect to a local deployment"))
-		bool bMobileConnectToLocalDeployment;
-
-	UPROPERTY(EditAnywhere, config, Category = "Mobile", meta = (DisplayName = "Mobile Client Worker Type"))
-		FString MobileWorkerType = SpatialConstants::DefaultClientWorkerType.ToString();
+	bool bMobileConnectToLocalDeployment;
 
 	UPROPERTY(EditAnywhere, config, Category = "Mobile", meta = (EditCondition = "bMobileConnectToLocalDeployment", DisplayName = "Runtime IP to local deployment"))
-		FString MobileRuntimeIP;
+	FString MobileRuntimeIP;
+
+	UPROPERTY(EditAnywhere, config, Category = "Mobile", meta = (DisplayName = "Mobile Client Worker Type"))
+	FString MobileWorkerType = SpatialConstants::DefaultClientWorkerType.ToString();
 
 	UPROPERTY(EditAnywhere, config, Category = "Mobile", meta = (DisplayName = "Extra Command Line Arguments"))
-		FString MobileExtraCommandLineArgs;
+	FString MobileExtraCommandLineArgs;
 
 public:
 	/** If you have selected **Auto-generate launch configuration file**, you can change the default options in the file from the drop-down menu. */

--- a/SpatialGDK/Source/SpatialGDKEditor/SpatialGDKEditor.Build.cs
+++ b/SpatialGDK/Source/SpatialGDKEditor/SpatialGDKEditor.Build.cs
@@ -7,16 +7,17 @@ public class SpatialGDKEditor : ModuleRules
 	public SpatialGDKEditor(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        bFasterWithoutUnity = true;
+		bFasterWithoutUnity = true;
 
-        PrivateDependencyModuleNames.AddRange(
+		PrivateDependencyModuleNames.AddRange(
 			new string[] {
 				"Core",
 				"CoreUObject",
 				"EditorStyle",
 				"Engine",
  				"EngineSettings",
-				"Json",
+ 				"IOSRuntimeSettings",
+ 				"Json",
 				"PropertyEditor",
 				"Slate",
 				"SlateCore",
@@ -24,7 +25,7 @@ public class SpatialGDKEditor : ModuleRules
 				"SpatialGDKServices",
 				"UnrealEd",
 				"GameplayAbilities"
-            });
+			});
 
 		PrivateIncludePaths.AddRange(
 			new string[]

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -229,13 +229,6 @@ void FSpatialGDKEditorToolbarModule::MapActions(TSharedPtr<class FUICommandList>
 		FCanExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StopSpatialServiceCanExecute),
 		FIsActionChecked(),
 		FIsActionButtonVisible::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StopSpatialServiceIsVisible));
-
-	InPluginCommands->MapAction(
-		FSpatialGDKEditorToolbarCommands::Get().UpdateIOSClient,
-		FExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::UpdateIOSClient),
-		FCanExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::UpdateIOSClientIsVisible),
-		FIsActionChecked(),
-		FIsActionButtonVisible::CreateRaw(this, &FSpatialGDKEditorToolbarModule::UpdateIOSClientIsVisible));
 }
 
 void FSpatialGDKEditorToolbarModule::SetupToolbar(TSharedPtr<class FUICommandList> InPluginCommands)
@@ -276,7 +269,6 @@ void FSpatialGDKEditorToolbarModule::AddMenuExtension(FMenuBuilder& Builder)
 #endif
 		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().StartSpatialService);
 		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().StopSpatialService);
-		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().UpdateIOSClient);
 	}
 	Builder.EndSection();
 }
@@ -772,12 +764,6 @@ bool FSpatialGDKEditorToolbarModule::StopSpatialServiceCanExecute() const
 	return !LocalDeploymentManager->IsServiceStopping();
 }
 
-bool FSpatialGDKEditorToolbarModule::UpdateIOSClientIsVisible() const
-{
-	FProjectStatus ProjectStatus;
-	return IProjectManager::Get().QueryStatusForCurrentProject(ProjectStatus) && ProjectStatus.IsTargetPlatformSupported("IOS");
-}
-
 void FSpatialGDKEditorToolbarModule::OnPropertyChanged(UObject* ObjectBeingModified, FPropertyChangedEvent& PropertyChangedEvent)
 {
 	if (USpatialGDKEditorSettings* Settings = Cast<USpatialGDKEditorSettings>(ObjectBeingModified))
@@ -914,54 +900,6 @@ FString FSpatialGDKEditorToolbarModule::GetOptionalExposedRuntimeIP() const
 	{
 		return TEXT("");
 	}
-}
-
-void FSpatialGDKEditorToolbarModule::UpdateIOSClient() const
-{
-	const USpatialGDKEditorSettings* SpatialGDKSettings = GetDefault<USpatialGDKEditorSettings>();
-	const UIOSRuntimeSettings* IOSRuntimeSettings = GetDefault<UIOSRuntimeSettings>();
-	const FString ProjectName = FApp::GetProjectName();
-
-	// The project path is based on this: https://github.com/improbableio/UnrealEngine/blob/4.22-SpatialOSUnrealGDK-release/Engine/Source/Programs/AutomationTool/AutomationUtils/DeploymentContext.cs#L408
-	const FString CommandLineArgs = FString::Printf(TEXT( "../../../%s/%s.uproject %s -game -log -workerType %s"), *ProjectName, *ProjectName, *(SpatialGDKSettings->ExposedRuntimeIP), *SpatialConstants::DefaultClientWorkerType.ToString());
-	const FString CommandLineArgsFile = FPaths::Combine(*FPaths::ProjectLogDir(), TEXT("ue4commandline.txt"));
-
-	if(!FFileHelper::SaveStringToFile(CommandLineArgs, *CommandLineArgsFile, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM))
-	{
-		UE_LOG(LogSpatialGDKEditorToolbar, Error, TEXT("UpdateIOSClient: Failed to write command line args to file: %s"), *CommandLineArgsFile);
-		return;
-	}
-
-	FString DeploymentServerExe = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/DotNET/IOS/deploymentserver.exe")));
-	FString DeploymentServerArguments = FString::Printf(TEXT("copyfile -bundle \"%s\" -file \"%s\" -file \"/Documents/ue4commandline.txt\""), *(IOSRuntimeSettings->BundleIdentifier), *CommandLineArgsFile);
-	FString DeploymentServerOutput;
-	FString StdErr;
-	int32 ExitCode;
-
-#if PLATFORM_WINDOWS
-	FPlatformProcess::ExecProcess(*DeploymentServerExe, *DeploymentServerArguments, &ExitCode, &DeploymentServerOutput, &StdErr);
-#elif PLATFORM_MAC
-	FString MonoExe = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/ThirdParty/Mono/Mac/bin/mono")));
-	DeploymentServerArguments = FString::Printf(TEXT("%s %s"), *DeploymentServerExe, *DeploymentServerArguments);
-	FPlatformProcess::ExecProcess(*MonoExe, *DeploymentServerArguments, &ExitCode, &DeploymentServerOutput, &StdErr);
-#endif
-
-	UE_LOG(LogSpatialGDKEditorToolbar, Warning, TEXT("Output: %s. Args: %s %s"), *DeploymentServerOutput, *DeploymentServerExe, *DeploymentServerArguments);
-
-	if (ExitCode != 0)
-	{
-		UE_LOG(LogSpatialGDKEditorToolbar, Error, TEXT("Failed to update the iOS client."));
-		return;
-	}
-
-	IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
-	if (!PlatformFile.DeleteFile(*CommandLineArgsFile))
-	{
-		UE_LOG(LogSpatialGDKEditorToolbar, Error, TEXT("Failed to delete file %s"), *CommandLineArgsFile);
-		return;
-	}
-
-	UE_LOG(LogSpatialGDKEditorToolbar, Verbose, TEXT("Successfully stored command line args on device: %s"), *DeploymentServerOutput);
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarCommands.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarCommands.cpp
@@ -16,7 +16,6 @@ void FSpatialGDKEditorToolbarCommands::RegisterCommands()
 	UI_COMMAND(OpenSimulatedPlayerConfigurationWindowAction, "Deploy", "Opens a configuration menu for cloud deployments.", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(StartSpatialService, "Start Service", "Starts the Spatial service daemon.", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(StopSpatialService, "Stop Service", "Stops the Spatial service daemon.", EUserInterfaceActionType::Button, FInputGesture());
-	UI_COMMAND(UpdateIOSClient, "Update iOS app", "Updates your mobile app on your device with the correct runtime ip.", EUserInterfaceActionType::Button, FInputGesture());
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -75,8 +75,6 @@ private:
 	bool StopSpatialServiceIsVisible() const;
 	bool StopSpatialServiceCanExecute() const;
 
-	bool UpdateIOSClientIsVisible() const;
-
 	void LaunchInspectorWebpageButtonClicked();
 	void CreateSnapshotButtonClicked();
 	void SchemaGenerateButtonClicked();
@@ -106,8 +104,6 @@ private:
 	bool IsSchemaGenerated() const;
 
 	FString GetOptionalExposedRuntimeIP() const;
-
-	void UpdateIOSClient() const;
 
 	static void ShowCompileLog();
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbarCommands.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbarCommands.h
@@ -32,5 +32,4 @@ public:
 
 	TSharedPtr<FUICommandInfo> StartSpatialService;
 	TSharedPtr<FUICommandInfo> StopSpatialService;
-	TSharedPtr<FUICommandInfo> UpdateIOSClient;
 };


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Adding a section in the Editor Settings that allows you to configure the command line arguments needed to connect your mobile device to a SpatialOS deployment.

can be read in commit order

![mobilesettings](https://user-images.githubusercontent.com/31853332/74045149-2d42ed80-49c4-11ea-9398-7dd5db1c97a1.PNG)

#### Release note
added

#### Tests

- [x] Test pushing to iOS device on Windows & able to connect to a local deployment
- [x] Test pushing to iOS device on Windows & able to connect to a cloud deployment
- [x] Test pushing to Android device on Windows & able to connect to a local deployment
- [x] Test pushing to Android device on Windows & able to connect to a cloud deployment
- [x] Test pushing to iOS device on MacOS & able to connect to a local deployment
- [x] Test pushing to iOS device on MacOS & able to connect to a cloud deployment
- [x] Test pushing to Android device on MacOS & able to connect to a local deployment
- [x] Test pushing to Android device on MacOS & able to connect to a cloud deployment

#### Documentation
Will be written after merging this PR

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.

