### PR TITLE
[UNR-2735] Correctly report errors when cloud deployment fails to launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Features listed in the internal section are not ready to use but, in the spirit 
 
 ### Bug fixes:
 - Replicated references to newly created dynamic subobjects will now be resolved correctly.
+- Cloud deployment flow will now correctly report errors when a deployment fails to launch.
 
 ## [`0.8.0-preview`] - 2019-12-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Features listed in the internal section are not ready to use but, in the spirit 
 
 ### Bug fixes:
 - Replicated references to newly created dynamic subobjects will now be resolved correctly.
-- Cloud deployment flow will now correctly report errors when a deployment fails to launch.
+- Cloud deployment flow will now correctly report errors when a deployment fails to launch due to a missing assembly.
 
 ## [`0.8.0-preview`] - 2019-12-17
 

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/DeploymentLauncher/DeploymentLauncher.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/DeploymentLauncher/DeploymentLauncher.cs
@@ -189,6 +189,7 @@ namespace Improbable
                 {
                     Console.WriteLine(
                         $"Unable to launch the deployment(s). This is likely because the project '{projectName}' or assembly '{assemblyName}' doesn't exist.");
+                    return 1;
                 }
                 else
                 {

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCloudLauncher.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCloudLauncher.cpp
@@ -48,6 +48,10 @@ bool SpatialGDKCloudLaunch()
 	if (OutCode != 0)
 	{
 		UE_LOG(LogSpatialGDKEditorCloudLauncher, Error, TEXT("Cloud Launch failed with code %d: %s"), OutCode, *OutString);
+		if (!OutErr.IsEmpty())
+		{
+			UE_LOG(LogSpatialGDKEditorCloudLauncher, Error, TEXT("%s"), *OutErr);
+		}
 		bSuccess = false;
 	}
 
@@ -76,6 +80,10 @@ bool SpatialGDKCloudStop()
 	if (OutCode != 0)
 	{
 		UE_LOG(LogSpatialGDKEditorCloudLauncher, Error, TEXT("Cloud Launch failed with code %d: %s"), OutCode, *OutString);
+		if (!OutErr.IsEmpty())
+		{
+			UE_LOG(LogSpatialGDKEditorCloudLauncher, Error, TEXT("%s"), *OutErr);
+		}
 		bSuccess = false;
 	}
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
DeploymentLauncher returned 0 if it failed to launch a deployment. We also weren't printing out the error output from DeploymentLauncher if there was stuff there (e.g. if the project name is wrong which causes the deployment list command to fail).

#### Primary reviewers
@MatthewSandfordImprobable @mironec 