### PR TITLE
[UNR-2796] Enhance deployment startup report

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -233,7 +233,7 @@ bool USpatialGDKEditorSettings::IsManualWorkerConnectionSet(const FString& Launc
 {
 	TSharedPtr<FJsonValue> LaunchConfigJson;
 	{
-		FArchive* ConfigFile = IFileManager::Get().CreateFileReader(*LaunchConfigPath);
+		TUniquePtr<FArchive> ConfigFile(IFileManager::Get().CreateFileReader(*LaunchConfigPath));
 
 		if (!ConfigFile)
 		{
@@ -241,12 +241,9 @@ bool USpatialGDKEditorSettings::IsManualWorkerConnectionSet(const FString& Launc
 			return false;
 		}
 
-		TSharedRef<TJsonReader<char>> JsonReader = TJsonReader<char>::Create(ConfigFile);
+		TSharedRef<TJsonReader<char>> JsonReader = TJsonReader<char>::Create(ConfigFile.Get());
 
 		FJsonSerializer::Deserialize(*JsonReader, LaunchConfigJson);
-
-		delete ConfigFile;
-		ConfigFile = nullptr;
 	}
 
 	const TSharedPtr<FJsonObject>* LaunchConfigJsonRootObject;

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -342,7 +342,7 @@ private:
 	static bool IsProjectNameValid(const FString& Name);
 	static bool IsDeploymentNameValid(const FString& Name);
 	static bool IsRegionCodeValid(const ERegionCode::Type RegionCode);
-	static bool IsManualWorkerConnectionSet(const FString& LaunchConfigPath);
+	static bool IsManualWorkerConnectionSet(const FString& LaunchConfigPath, TArray<FString>& OutWorkersManuallyLaunched);
 
 public:
 	UPROPERTY(EditAnywhere, config, Category = "Mobile", meta = (DisplayName = "Connect to a local deployment"))


### PR DESCRIPTION
#### Description
Given a configuration where some workers would need to be manually started, the Cloud Deployment launcher reports that the deployment won't start any worker.
The message reported has been changed to tell which workers won't be started by parsing the configuration file.

#### Release note

#### Tests
Launching Cloud Deploy in the example project, with the one_worker.json config file should report that the DeploymentManager worker needs to be manually started.

#### Documentation