### PR TITLE
Separate the Connection establishment from the Connection functionality

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
@@ -174,8 +174,10 @@ void USpatialGameInstance::HandleOnConnected()
 	SpatialWorkerId = SpatialConnectionManager->GetWorkerId();
 #if TRACE_LIB_ACTIVE
 	SpatialLatencyTracer->SetWorkerId(SpatialWorkerId);
-// 	SpatialConnection->OnEnqueueMessage.AddUObject(SpatialLatencyTracer, &USpatialLatencyTracer::OnEnqueueMessage);
-// 	SpatialConnection->OnDequeueMessage.AddUObject(SpatialLatencyTracer, &USpatialLatencyTracer::OnDequeueMessage);
+
+	USpatialWorkerConnection* WorkerConnection = SpatialConnectionManager->GetWorkerConnection();
+	WorkerConnection->OnEnqueueMessage.AddUObject(SpatialLatencyTracer, &USpatialLatencyTracer::OnEnqueueMessage);
+	WorkerConnection->OnDequeueMessage.AddUObject(SpatialLatencyTracer, &USpatialLatencyTracer::OnDequeueMessage);
 #endif
 	OnConnected.Broadcast();
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
@@ -12,7 +12,7 @@
 
 #include "EngineClasses/SpatialNetDriver.h"
 #include "EngineClasses/SpatialPendingNetGame.h"
-#include "Interop/Connection/SpatialWorkerConnection.h"
+#include "Interop/Connection/SpatialConnectionManager.h"
 #include "Interop/GlobalStateManager.h"
 #include "Interop/SpatialStaticComponentView.h"
 #include "Utils/SpatialDebugger.h"
@@ -73,20 +73,15 @@ bool USpatialGameInstance::HasSpatialNetDriver() const
 
 void USpatialGameInstance::CreateNewSpatialWorkerConnection()
 {
-	SpatialConnection = NewObject<USpatialWorkerConnection>(this);
-
-#if TRACE_LIB_ACTIVE
-	SpatialConnection->OnEnqueueMessage.AddUObject(SpatialLatencyTracer, &USpatialLatencyTracer::OnEnqueueMessage);
-	SpatialConnection->OnDequeueMessage.AddUObject(SpatialLatencyTracer, &USpatialLatencyTracer::OnDequeueMessage);
-#endif
+	SpatialConnectionManager = NewObject<USpatialConnectionManager>(this);
 }
 
 void USpatialGameInstance::DestroySpatialWorkerConnection()
 {
-	if (SpatialConnection != nullptr)
+	if (SpatialConnectionManager != nullptr)
 	{
-		SpatialConnection->DestroyConnection();
-		SpatialConnection = nullptr;
+		SpatialConnectionManager->DestroyConnection();
+		SpatialConnectionManager = nullptr;
 	}
 }
 
@@ -176,9 +171,11 @@ void USpatialGameInstance::Init()
 void USpatialGameInstance::HandleOnConnected()
 {
 	UE_LOG(LogSpatialGameInstance, Log, TEXT("Successfully connected to SpatialOS"));
-	SpatialWorkerId = SpatialConnection->GetWorkerId();
+	SpatialWorkerId = SpatialConnectionManager->GetWorkerId();
 #if TRACE_LIB_ACTIVE
 	SpatialLatencyTracer->SetWorkerId(SpatialWorkerId);
+// 	SpatialConnection->OnEnqueueMessage.AddUObject(SpatialLatencyTracer, &USpatialLatencyTracer::OnEnqueueMessage);
+// 	SpatialConnection->OnDequeueMessage.AddUObject(SpatialLatencyTracer, &USpatialLatencyTracer::OnDequeueMessage);
 #endif
 	OnConnected.Broadcast();
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialLoadBalanceEnforcer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialLoadBalanceEnforcer.cpp
@@ -24,15 +24,7 @@ void SpatialLoadBalanceEnforcer::OnAuthorityIntentComponentUpdated(const Worker_
 	check(Op.update.component_id == SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID);
 	if (StaticComponentView->HasAuthority(Op.entity_id, SpatialConstants::ENTITY_ACL_COMPONENT_ID))
 	{
-		const SpatialGDK::AuthorityIntent* AuthorityIntentComponent = StaticComponentView->GetComponentData<SpatialGDK::AuthorityIntent>(Op.entity_id);
-		if (AuthorityIntentComponent != nullptr) {
-			UE_LOG(LogSpatialLoadBalanceEnforcer, Verbose, TEXT("(%s) OnAuthorityIntentComponentUpdated. EntityId: %lld. VirtualWorkerId: %d."), *WorkerId, Op.entity_id, AuthorityIntentComponent->VirtualWorkerId);
-			QueueAclAssignmentRequest(Op.entity_id);
-		}
-		else
-		{
-			UE_LOG(LogSpatialLoadBalanceEnforcer, Warning, TEXT("EntityId: %lld. Authority intent componet in update is null."), Op.entity_id);
-		}
+		QueueAclAssignmentRequest(Op.entity_id);
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
@@ -171,7 +171,7 @@ void USpatialNetConnection::SetHeartbeatEventTimer()
 			Schema_AddObject(EventsObject, SpatialConstants::HEARTBEAT_EVENT_ID);
 
 			USpatialWorkerConnection* WorkerConnection = Cast<USpatialNetDriver>(Connection->Driver)->Connection;
-			if (WorkerConnection->IsConnected())
+			if (WorkerConnection != nullptr)
 			{
 				WorkerConnection->SendComponentUpdate(Connection->PlayerControllerEntity, &ComponentUpdate);
 			}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -22,6 +22,7 @@
 #include "EngineClasses/SpatialPackageMapClient.h"
 #include "EngineClasses/SpatialPendingNetGame.h"
 #include "EngineClasses/SpatialWorldSettings.h"
+#include "Interop/Connection/SpatialConnectionManager.h"
 #include "Interop/Connection/SpatialWorkerConnection.h"
 #include "Interop/GlobalStateManager.h"
 #include "Interop/SpatialClassInfoManager.h"
@@ -237,9 +238,9 @@ void USpatialNetDriver::InitiateConnectionToSpatialOS(const FURL& URL)
 		UE_LOG(LogSpatialOSNetDriver, Log, TEXT("Getting existing connection, not creating a new one"));
 	}
 
-	Connection = GameInstance->GetSpatialWorkerConnection();
-	Connection->OnConnectedCallback.BindUObject(this, &USpatialNetDriver::OnConnectionToSpatialOSSucceeded);
-	Connection->OnFailedToConnectCallback.BindUObject(this, &USpatialNetDriver::OnConnectionToSpatialOSFailed);
+	ConnectionManager = GameInstance->GetSpatialConnectionManager();
+	ConnectionManager->OnConnectedCallback.BindUObject(this, &USpatialNetDriver::OnConnectionToSpatialOSSucceeded);
+	ConnectionManager->OnFailedToConnectCallback.BindUObject(this, &USpatialNetDriver::OnConnectionToSpatialOSFailed);
 
 	// If this is the first connection try using the command line arguments to setup the config objects.
 	// If arguments can not be found we will use the regular flow of loading from the input URL.
@@ -247,34 +248,37 @@ void USpatialNetDriver::InitiateConnectionToSpatialOS(const FURL& URL)
 	if (!GameInstance->GetFirstConnectionToSpatialOSAttempted())
 	{
 		GameInstance->SetFirstConnectionToSpatialOSAttempted();
-		if (!Connection->TrySetupConnectionConfigFromCommandLine(SpatialWorkerType))
+		if (!ConnectionManager->TrySetupConnectionConfigFromCommandLine(SpatialWorkerType))
 		{
-			Connection->SetupConnectionConfigFromURL(URL, SpatialWorkerType);
+			ConnectionManager->SetupConnectionConfigFromURL(URL, SpatialWorkerType);
 		}
 	}
 	else if (URL.Host == SpatialConstants::RECONNECT_USING_COMMANDLINE_ARGUMENTS)
 	{
-		if (!Connection->TrySetupConnectionConfigFromCommandLine(SpatialWorkerType))
+		if (!ConnectionManager->TrySetupConnectionConfigFromCommandLine(SpatialWorkerType))
 		{
-			Connection->SetConnectionType(ESpatialConnectionType::Receptionist);
-			Connection->ReceptionistConfig.LoadDefaults();
-			Connection->ReceptionistConfig.WorkerType = SpatialWorkerType;
+			ConnectionManager->SetConnectionType(ESpatialConnectionType::Receptionist);
+			ConnectionManager->ReceptionistConfig.LoadDefaults();
+			ConnectionManager->ReceptionistConfig.WorkerType = SpatialWorkerType;
 		}
 	}
 	else
 	{
-		Connection->SetupConnectionConfigFromURL(URL, SpatialWorkerType);
+		ConnectionManager->SetupConnectionConfigFromURL(URL, SpatialWorkerType);
 	}
 
 #if WITH_EDITOR
-	Connection->Connect(bConnectAsClient, PlayInEditorID);
+	ConnectionManager->Connect(bConnectAsClient, PlayInEditorID);
 #else
-	Connection->Connect(bConnectAsClient, 0);
+	ConnectionManager->Connect(bConnectAsClient, 0);
 #endif
 }
 
 void USpatialNetDriver::OnConnectionToSpatialOSSucceeded()
 {
+	Connection = ConnectionManager->GetWorkerConnection();
+	check(Connection);
+
 	// If we're the server, we will spawn the special Spatial connection that will route all updates to SpatialOS.
 	// There may be more than one of these connections in the future for different replication conditions.
 	if (!bConnectAsClient)
@@ -1545,10 +1549,7 @@ void USpatialNetDriver::TickDispatch(float DeltaTime)
 		const USpatialGDKSettings* SpatialGDKSettings = GetDefault<USpatialGDKSettings>();
 		if (SpatialGDKSettings->bRunSpatialWorkerConnectionOnGameThread)
 		{
-			if (Connection->IsConnected())
-			{
-				Connection->QueueLatestOpList();
-			}
+			Connection->QueueLatestOpList();
 		}
 
 		TArray<Worker_OpList*> OpLists = Connection->GetOpList();
@@ -1747,7 +1748,7 @@ void USpatialNetDriver::TickFlush(float DeltaTime)
 
 	if (SpatialGDKSettings->bRunSpatialWorkerConnectionOnGameThread)
 	{
-		if (Connection != nullptr && Connection->IsConnected())
+		if (Connection != nullptr)
 		{
 			Connection->ProcessOutgoingMessages();
 		}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslator.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslator.cpp
@@ -22,7 +22,7 @@ const PhysicalWorkerName* SpatialVirtualWorkerTranslator::GetPhysicalWorkerForVi
 
 void SpatialVirtualWorkerTranslator::ApplyVirtualWorkerManagerData(Schema_Object* ComponentObject)
 {
-    UE_LOG(LogSpatialVirtualWorkerTranslator, Log, TEXT("ApplyVirtualWorkerManagerData"));
+    UE_LOG(LogSpatialVirtualWorkerTranslator, Log, TEXT("(%d) ApplyVirtualWorkerManagerData"), LocalVirtualWorkerId);
 
 	// The translation schema is a list of Mappings, where each entry has a virtual and physical worker ID. 
 	ApplyMappingFromSchema(ComponentObject);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
@@ -1,0 +1,458 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "Interop/Connection/SpatialConnectionManager.h"
+#if WITH_EDITOR
+#include "Interop/Connection/EditorWorkerController.h"
+#endif
+
+#include "Async/Async.h"
+#include "Improbable/SpatialEngineConstants.h"
+#include "Misc/Paths.h"
+
+#include "Interop/Connection/SpatialWorkerConnection.h"
+#include "SpatialGDKSettings.h"
+#include "Utils/ErrorCodeRemapping.h"
+
+DEFINE_LOG_CATEGORY(LogSpatialConnectionManager);
+
+using namespace SpatialGDK;
+
+struct ConfigureConnection
+{
+	ConfigureConnection(const FConnectionConfig& InConfig, const bool bConnectAsClient)
+		: Config(InConfig)
+		, Params()
+		, WorkerType(*Config.WorkerType)
+		, ProtocolLogPrefix(*FormatProtocolPrefix())
+	{
+		Params = Worker_DefaultConnectionParameters();
+
+		Params.worker_type = WorkerType.Get();
+
+		Params.enable_protocol_logging_at_startup = Config.EnableProtocolLoggingAtStartup;
+		Params.protocol_logging.log_prefix = ProtocolLogPrefix.Get();
+
+		Params.component_vtable_count = 0;
+		Params.default_component_vtable = &DefaultVtable;
+
+		Params.network.connection_type = Config.LinkProtocol;
+		Params.network.use_external_ip = Config.UseExternalIp;
+		Params.network.modular_tcp.multiplex_level = Config.TcpMultiplexLevel;
+		if (Config.TcpNoDelay)
+		{
+			Params.network.modular_tcp.downstream_tcp.flush_delay_millis = 0;
+			Params.network.modular_tcp.upstream_tcp.flush_delay_millis = 0;
+		}
+
+		// We want the bridge to worker messages to be compressed; not the worker to bridge messages.
+		Params.network.modular_kcp.upstream_compression = nullptr;
+		Params.network.modular_kcp.downstream_compression = &EnableCompressionParams;
+
+		Params.network.modular_kcp.upstream_kcp.flush_interval_millis = Config.UdpUpstreamIntervalMS;
+		Params.network.modular_kcp.downstream_kcp.flush_interval_millis = Config.UdpDownstreamIntervalMS;
+
+#if WITH_EDITOR
+		Params.network.modular_tcp.downstream_heartbeat = &HeartbeatParams;
+		Params.network.modular_tcp.upstream_heartbeat = &HeartbeatParams;
+		Params.network.modular_kcp.downstream_heartbeat = &HeartbeatParams;
+		Params.network.modular_kcp.upstream_heartbeat = &HeartbeatParams;
+#endif
+
+		if (!bConnectAsClient && GetDefault<USpatialGDKSettings>()->bUseSecureServerConnection)
+		{
+			Params.network.modular_kcp.security_type = WORKER_NETWORK_SECURITY_TYPE_TLS;
+			Params.network.modular_tcp.security_type = WORKER_NETWORK_SECURITY_TYPE_TLS;
+		}
+		else if (bConnectAsClient && GetDefault<USpatialGDKSettings>()->bUseSecureClientConnection)
+		{
+			Params.network.modular_kcp.security_type = WORKER_NETWORK_SECURITY_TYPE_TLS;
+			Params.network.modular_tcp.security_type = WORKER_NETWORK_SECURITY_TYPE_TLS;
+		}
+		else
+		{
+			Params.network.modular_kcp.security_type = WORKER_NETWORK_SECURITY_TYPE_INSECURE;
+			Params.network.modular_tcp.security_type = WORKER_NETWORK_SECURITY_TYPE_INSECURE;
+		}
+
+		Params.enable_dynamic_components = true;
+	}
+
+	FString FormatProtocolPrefix() const
+	{
+		FString FinalProtocolLoggingPrefix = FPaths::ConvertRelativePathToFull(FPaths::ProjectLogDir());
+		if (!Config.ProtocolLoggingPrefix.IsEmpty())
+		{
+			FinalProtocolLoggingPrefix += Config.ProtocolLoggingPrefix;
+		}
+		else
+		{
+			FinalProtocolLoggingPrefix += Config.WorkerId;
+		}
+		return FinalProtocolLoggingPrefix;
+	}
+
+	const FConnectionConfig& Config;
+	Worker_ConnectionParameters Params;
+	FTCHARToUTF8 WorkerType;
+	FTCHARToUTF8 ProtocolLogPrefix;
+	Worker_ComponentVtable DefaultVtable{};
+	Worker_CompressionParameters EnableCompressionParams{};
+
+#if WITH_EDITOR
+	Worker_HeartbeatParameters HeartbeatParams{ WORKER_DEFAULTS_HEARTBEAT_INTERVAL_MILLIS, MAX_int64 };
+#endif
+};
+
+void USpatialConnectionManager::FinishDestroy()
+{
+	UE_LOG(LogSpatialConnectionManager, Log, TEXT("Destorying SpatialConnectionManager."));
+
+	DestroyConnection();
+
+	Super::FinishDestroy();
+}
+
+void USpatialConnectionManager::DestroyConnection()
+{
+	if (WorkerLocator)
+	{
+		AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [WorkerLocator = WorkerLocator]
+		{
+			Worker_Locator_Destroy(WorkerLocator);
+		});
+
+		WorkerLocator = nullptr;
+	}
+
+	if (WorkerConnection != nullptr)
+	{
+		WorkerConnection->DestroyConnection();
+		WorkerConnection = nullptr;
+	}
+
+	bIsConnected = false;
+}
+
+void USpatialConnectionManager::Connect(bool bInitAsClient, uint32 PlayInEditorID)
+{
+	if (bIsConnected)
+	{
+		check(bInitAsClient == bConnectAsClient);
+		AsyncTask(ENamedThreads::GameThread, [WeakThis = TWeakObjectPtr<USpatialConnectionManager>(this)]
+			{
+				if (WeakThis.IsValid())
+				{
+					WeakThis->OnConnectionSuccess();
+				}
+				else
+				{
+					UE_LOG(LogSpatialConnectionManager, Error, TEXT("SpatialConnectionManager is not valid but was already connected."));
+				}
+			});
+		return;
+	}
+
+	bConnectAsClient = bInitAsClient;
+
+	const USpatialGDKSettings* SpatialGDKSettings = GetDefault<USpatialGDKSettings>();
+	if (SpatialGDKSettings->bUseDevelopmentAuthenticationFlow && bInitAsClient)
+	{
+		DevAuthConfig.Deployment = SpatialGDKSettings->DevelopmentDeploymentToConnect;
+		DevAuthConfig.WorkerType = SpatialConstants::DefaultClientWorkerType.ToString();
+		DevAuthConfig.UseExternalIp = true;
+		StartDevelopmentAuth(SpatialGDKSettings->DevelopmentAuthenticationToken);
+		return;
+	}
+
+	switch (GetConnectionType())
+	{
+	case ESpatialConnectionType::Receptionist:
+		ConnectToReceptionist(PlayInEditorID);
+		break;
+	case ESpatialConnectionType::Locator:
+		ConnectToLocator(&LocatorConfig);
+		break;
+	case ESpatialConnectionType::DevAuthFlow:
+		StartDevelopmentAuth(DevAuthConfig.DevelopmentAuthToken);
+		break;
+	}
+}
+
+void USpatialConnectionManager::OnLoginTokens(void* UserData, const Worker_Alpha_LoginTokensResponse* LoginTokens)
+{
+	if (LoginTokens->status.code != WORKER_CONNECTION_STATUS_CODE_SUCCESS)
+	{
+		UE_LOG(LogSpatialWorkerConnection, Error, TEXT("Failed to get login token, StatusCode: %d, Error: %s"), LoginTokens->status.code, UTF8_TO_TCHAR(LoginTokens->status.detail));
+		return;
+	}
+
+	if (LoginTokens->login_token_count == 0)
+	{
+		UE_LOG(LogSpatialWorkerConnection, Warning, TEXT("No deployment found to connect to. Did you add the 'dev_login' tag to the deployment you want to connect to?"));
+		return;
+	}
+
+	UE_LOG(LogSpatialWorkerConnection, Verbose, TEXT("Successfully received LoginTokens, Count: %d"), LoginTokens->login_token_count);
+	USpatialConnectionManager* ConnectionManager = static_cast<USpatialConnectionManager*>(UserData);
+	ConnectionManager->ProcessLoginTokensResponse(LoginTokens);
+}
+
+void USpatialConnectionManager::ProcessLoginTokensResponse(const Worker_Alpha_LoginTokensResponse* LoginTokens)
+{
+	// If LoginTokenResCallback is callable and returns true, return early.
+	if (LoginTokenResCallback && LoginTokenResCallback(LoginTokens))
+	{
+		return;
+	}
+
+	const FString& DeploymentToConnect = DevAuthConfig.Deployment;
+	// If not set, use the first deployment. It can change every query if you have multiple items available, because the order is not guaranteed.
+	if (DeploymentToConnect.IsEmpty())
+	{
+		DevAuthConfig.LoginToken = FString(LoginTokens->login_tokens[0].login_token);
+	}
+	else
+	{
+		for (uint32 i = 0; i < LoginTokens->login_token_count; i++)
+		{
+			FString DeploymentName = FString(LoginTokens->login_tokens[i].deployment_name);
+			if (DeploymentToConnect.Compare(DeploymentName) == 0)
+			{
+				DevAuthConfig.LoginToken = FString(LoginTokens->login_tokens[i].login_token);
+				break;
+			}
+		}
+	}
+	ConnectToLocator(&DevAuthConfig);
+}
+
+void USpatialConnectionManager::RequestDeploymentLoginTokens()
+{
+	Worker_Alpha_LoginTokensRequest LTParams{};
+	FTCHARToUTF8 PlayerIdentityToken(*DevAuthConfig.PlayerIdentityToken);
+	LTParams.player_identity_token = PlayerIdentityToken.Get();
+	FTCHARToUTF8 WorkerType(*DevAuthConfig.WorkerType);
+	LTParams.worker_type = WorkerType.Get();
+	LTParams.use_insecure_connection = false;
+
+	if (Worker_Alpha_LoginTokensResponseFuture* LTFuture = Worker_Alpha_CreateDevelopmentLoginTokensAsync(TCHAR_TO_UTF8(*DevAuthConfig.LocatorHost), SpatialConstants::LOCATOR_PORT, &LTParams))
+	{
+		Worker_Alpha_LoginTokensResponseFuture_Get(LTFuture, nullptr, this, &USpatialConnectionManager::OnLoginTokens);
+	}
+}
+
+void USpatialConnectionManager::OnPlayerIdentityToken(void* UserData, const Worker_Alpha_PlayerIdentityTokenResponse* PIToken)
+{
+	if (PIToken->status.code != WORKER_CONNECTION_STATUS_CODE_SUCCESS)
+	{
+		UE_LOG(LogSpatialWorkerConnection, Error, TEXT("Failed to get PlayerIdentityToken, StatusCode: %d, Error: %s"), PIToken->status.code, UTF8_TO_TCHAR(PIToken->status.detail));
+		return;
+	}
+
+	UE_LOG(LogSpatialWorkerConnection, Log, TEXT("Successfully received PIToken: %s"), UTF8_TO_TCHAR(PIToken->player_identity_token));
+	USpatialConnectionManager* ConnectionManager = static_cast<USpatialConnectionManager*>(UserData);
+	ConnectionManager->DevAuthConfig.PlayerIdentityToken = UTF8_TO_TCHAR(PIToken->player_identity_token);
+
+	ConnectionManager->RequestDeploymentLoginTokens();
+}
+
+void USpatialConnectionManager::StartDevelopmentAuth(const FString& DevAuthToken)
+{
+	FTCHARToUTF8 DAToken(*DevAuthToken);
+	FTCHARToUTF8 PlayerId(*DevAuthConfig.PlayerId);
+	FTCHARToUTF8 DisplayName(*DevAuthConfig.DisplayName);
+	FTCHARToUTF8 MetaData(*DevAuthConfig.MetaData);
+
+	Worker_Alpha_PlayerIdentityTokenRequest PITParams{};
+	PITParams.development_authentication_token = DAToken.Get();
+	PITParams.player_id = PlayerId.Get();
+	PITParams.display_name = DisplayName.Get();
+	PITParams.metadata = MetaData.Get();
+	PITParams.use_insecure_connection = false;
+
+	if (Worker_Alpha_PlayerIdentityTokenResponseFuture* PITFuture = Worker_Alpha_CreateDevelopmentPlayerIdentityTokenAsync(TCHAR_TO_UTF8(*DevAuthConfig.LocatorHost), SpatialConstants::LOCATOR_PORT, &PITParams))
+	{
+		Worker_Alpha_PlayerIdentityTokenResponseFuture_Get(PITFuture, nullptr, this, &USpatialConnectionManager::OnPlayerIdentityToken);
+	}
+}
+
+void USpatialConnectionManager::ConnectToReceptionist(uint32 PlayInEditorID)
+{
+#if WITH_EDITOR
+	SpatialGDKServices::InitWorkers(bConnectAsClient, PlayInEditorID, ReceptionistConfig.WorkerId);
+#endif
+
+	ReceptionistConfig.PreConnectInit(bConnectAsClient);
+
+	ConfigureConnection ConnectionConfig(ReceptionistConfig, bConnectAsClient);
+
+	Worker_ConnectionFuture* ConnectionFuture = Worker_ConnectAsync(
+		TCHAR_TO_UTF8(*ReceptionistConfig.GetReceptionistHost()), ReceptionistConfig.ReceptionistPort,
+		TCHAR_TO_UTF8(*ReceptionistConfig.WorkerId), &ConnectionConfig.Params);
+
+	FinishConnecting(ConnectionFuture);
+}
+
+void USpatialConnectionManager::ConnectToLocator(FLocatorConfig* InLocatorConfig)
+{
+	if (InLocatorConfig == nullptr)
+	{
+		UE_LOG(LogSpatialWorkerConnection, Error, TEXT("Trying to connect to locator with invalid locator config"));
+		return;
+	}
+
+	InLocatorConfig->PreConnectInit(bConnectAsClient);
+
+	ConfigureConnection ConnectionConfig(*InLocatorConfig, bConnectAsClient);
+
+	FTCHARToUTF8 PlayerIdentityTokenCStr(*InLocatorConfig->PlayerIdentityToken);
+	FTCHARToUTF8 LoginTokenCStr(*InLocatorConfig->LoginToken);
+
+	Worker_LocatorParameters LocatorParams = {};
+	FString ProjectName;
+	FParse::Value(FCommandLine::Get(), TEXT("projectName"), ProjectName);
+	LocatorParams.project_name = TCHAR_TO_UTF8(*ProjectName);
+	LocatorParams.credentials_type = Worker_LocatorCredentialsTypes::WORKER_LOCATOR_PLAYER_IDENTITY_CREDENTIALS;
+	LocatorParams.player_identity.player_identity_token = PlayerIdentityTokenCStr.Get();
+	LocatorParams.player_identity.login_token = LoginTokenCStr.Get();
+
+	// Connect to the locator on the default port(0 will choose the default)
+	WorkerLocator = Worker_Locator_Create(TCHAR_TO_UTF8(*InLocatorConfig->LocatorHost), SpatialConstants::LOCATOR_PORT, &LocatorParams);
+
+	Worker_ConnectionFuture* ConnectionFuture = Worker_Locator_ConnectAsync(WorkerLocator, &ConnectionConfig.Params);
+
+	FinishConnecting(ConnectionFuture);
+}
+
+void USpatialConnectionManager::FinishConnecting(Worker_ConnectionFuture* ConnectionFuture)
+{
+	TWeakObjectPtr<USpatialConnectionManager> WeakSpatialConnectionManager(this);
+
+	AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [ConnectionFuture, WeakSpatialConnectionManager]
+	{
+		Worker_Connection* NewCAPIWorkerConnection = Worker_ConnectionFuture_Get(ConnectionFuture, nullptr);
+		Worker_ConnectionFuture_Destroy(ConnectionFuture);
+
+		AsyncTask(ENamedThreads::GameThread, [WeakSpatialConnectionManager, NewCAPIWorkerConnection]
+		{
+			USpatialConnectionManager* SpatialConnectionManager = WeakSpatialConnectionManager.Get();
+
+			if (Worker_Connection_IsConnected(NewCAPIWorkerConnection))
+			{
+				SpatialConnectionManager->WorkerConnection = NewObject<USpatialWorkerConnection>();
+				SpatialConnectionManager->WorkerConnection->SetConection(NewCAPIWorkerConnection);
+				SpatialConnectionManager->OnConnectionSuccess();
+			}
+			else
+			{
+				uint8_t ConnectionStatusCode = Worker_Connection_GetConnectionStatusCode(NewCAPIWorkerConnection);
+				const FString ErrorMessage(UTF8_TO_TCHAR(Worker_Connection_GetConnectionStatusDetailString(NewCAPIWorkerConnection)));
+
+				// TODO: Try to reconnect - UNR-576
+				SpatialConnectionManager->OnConnectionFailure(ConnectionStatusCode, ErrorMessage);
+			}
+		});
+	});
+}
+
+ESpatialConnectionType USpatialConnectionManager::GetConnectionType() const
+{
+	return ConnectionType;
+}
+
+void USpatialConnectionManager::SetConnectionType(ESpatialConnectionType InConnectionType)
+{
+	// The locator config may not have been initialized
+	check(!(InConnectionType == ESpatialConnectionType::Locator && LocatorConfig.LocatorHost.IsEmpty()))
+
+	ConnectionType = InConnectionType;
+}
+
+bool USpatialConnectionManager::TrySetupConnectionConfigFromCommandLine(const FString& SpatialWorkerType)
+{
+	bool bSuccessfullyLoaded = LocatorConfig.TryLoadCommandLineArgs();
+	if (bSuccessfullyLoaded)
+	{
+		SetConnectionType(ESpatialConnectionType::Locator);
+		LocatorConfig.WorkerType = SpatialWorkerType;
+	}
+	else
+	{
+		bSuccessfullyLoaded = DevAuthConfig.TryLoadCommandLineArgs();
+		if (bSuccessfullyLoaded)
+		{
+			SetConnectionType(ESpatialConnectionType::DevAuthFlow);
+			DevAuthConfig.WorkerType = SpatialWorkerType;
+		}
+		else
+		{
+			bSuccessfullyLoaded = ReceptionistConfig.TryLoadCommandLineArgs();
+			SetConnectionType(ESpatialConnectionType::Receptionist);
+			ReceptionistConfig.WorkerType = SpatialWorkerType;
+		}
+	}
+
+	return bSuccessfullyLoaded;
+}
+
+void USpatialConnectionManager::SetupConnectionConfigFromURL(const FURL& URL, const FString& SpatialWorkerType)
+{
+	if (URL.Host == SpatialConstants::LOCATOR_HOST && URL.HasOption(TEXT("locator")))
+	{
+		SetConnectionType(ESpatialConnectionType::Locator);
+		// TODO: UNR-2811 We might add a feature whereby we get the locator host from the URL option.
+		FParse::Value(FCommandLine::Get(), TEXT("locatorHost"), LocatorConfig.LocatorHost);
+		LocatorConfig.PlayerIdentityToken = URL.GetOption(*SpatialConstants::URL_PLAYER_IDENTITY_OPTION, TEXT(""));
+		LocatorConfig.LoginToken = URL.GetOption(*SpatialConstants::URL_LOGIN_OPTION, TEXT(""));
+		LocatorConfig.WorkerType = SpatialWorkerType;
+	}
+	else if (URL.Host == SpatialConstants::LOCATOR_HOST && URL.HasOption(TEXT("devauth")))
+	{
+		SetConnectionType(ESpatialConnectionType::DevAuthFlow);
+		// TODO: UNR-2811 Also set the locator host of DevAuthConfig from URL.
+		FParse::Value(FCommandLine::Get(), TEXT("locatorHost"), DevAuthConfig.LocatorHost);
+		DevAuthConfig.DevelopmentAuthToken = URL.GetOption(*SpatialConstants::URL_DEV_AUTH_TOKEN_OPTION, TEXT(""));
+		DevAuthConfig.Deployment = URL.GetOption(*SpatialConstants::URL_TARGET_DEPLOYMENT_OPTION, TEXT(""));
+		DevAuthConfig.PlayerId = URL.GetOption(*SpatialConstants::URL_PLAYER_ID_OPTION, *SpatialConstants::DEVELOPMENT_AUTH_PLAYER_ID);
+		DevAuthConfig.DisplayName = URL.GetOption(*SpatialConstants::URL_DISPLAY_NAME_OPTION, TEXT(""));
+		DevAuthConfig.MetaData = URL.GetOption(*SpatialConstants::URL_METADATA_OPTION, TEXT(""));
+		DevAuthConfig.WorkerType = SpatialWorkerType;
+	}
+	else
+	{
+		SetConnectionType(ESpatialConnectionType::Receptionist);
+		ReceptionistConfig.SetReceptionistHost(URL.Host);
+		ReceptionistConfig.WorkerType = SpatialWorkerType;
+
+		const TCHAR* UseExternalIpForBridge = TEXT("useExternalIpForBridge");
+		if (URL.HasOption(UseExternalIpForBridge))
+		{
+			FString UseExternalIpOption = URL.GetOption(UseExternalIpForBridge, TEXT(""));
+			ReceptionistConfig.UseExternalIp = !UseExternalIpOption.Equals(TEXT("false"), ESearchCase::IgnoreCase);
+		}
+	}
+}
+
+PhysicalWorkerName USpatialConnectionManager::GetWorkerId() const
+{
+	return WorkerConnection->GetWorkerId();
+}
+
+const TArray<FString>& USpatialConnectionManager::GetWorkerAttributes() const
+{
+	return WorkerConnection->GetWorkerAttributes();
+}
+
+void USpatialConnectionManager::OnConnectionSuccess()
+{
+	bIsConnected = true;
+
+	OnConnectedCallback.ExecuteIfBound();
+}
+
+void USpatialConnectionManager::OnConnectionFailure(uint8_t ConnectionStatusCode, const FString& ErrorMessage)
+{
+	bIsConnected = false;
+
+	OnFailedToConnectCallback.ExecuteIfBound(ConnectionStatusCode, ErrorMessage);
+}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
@@ -1,109 +1,32 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
 #include "Interop/Connection/SpatialWorkerConnection.h"
-#if WITH_EDITOR
-#include "Interop/Connection/EditorWorkerController.h"
-#endif
 
 #include "Async/Async.h"
-#include "Improbable/SpatialEngineConstants.h" 
-#include "Misc/Paths.h"
-
 #include "SpatialGDKSettings.h"
-#include "Utils/ErrorCodeRemapping.h"
 
 DEFINE_LOG_CATEGORY(LogSpatialWorkerConnection);
 
 using namespace SpatialGDK;
 
-struct ConfigureConnection
+void USpatialWorkerConnection::SetConection(Worker_Connection* WorkerConnectionIn)
 {
-	ConfigureConnection(const FConnectionConfig& InConfig, const bool bConnectAsClient)
-		: Config(InConfig)
-		, Params()
-		, WorkerType(*Config.WorkerType)
-		, ProtocolLogPrefix(*FormatProtocolPrefix())
+	WorkerConnection = WorkerConnectionIn;
+
+	CacheWorkerAttributes();
+	if (WorkerConnectionIn != nullptr && Worker_Connection_IsConnected(WorkerConnectionIn))
 	{
-		Params = Worker_DefaultConnectionParameters();
-
-		Params.worker_type = WorkerType.Get();
-
-		Params.enable_protocol_logging_at_startup = Config.EnableProtocolLoggingAtStartup;
-		Params.protocol_logging.log_prefix = ProtocolLogPrefix.Get();
-
-		Params.component_vtable_count = 0;
-		Params.default_component_vtable = &DefaultVtable;
-
-		Params.network.connection_type = Config.LinkProtocol;
-		Params.network.use_external_ip = Config.UseExternalIp;
-		Params.network.modular_tcp.multiplex_level = Config.TcpMultiplexLevel;
-		if (Config.TcpNoDelay)
+		if (OpsProcessingThread == nullptr)
 		{
-			Params.network.modular_tcp.downstream_tcp.flush_delay_millis = 0;
-			Params.network.modular_tcp.upstream_tcp.flush_delay_millis = 0;
+			InitializeOpsProcessingThread();
 		}
-
-		// We want the bridge to worker messages to be compressed; not the worker to bridge messages.
-		Params.network.modular_kcp.upstream_compression = nullptr;
-		Params.network.modular_kcp.downstream_compression = &EnableCompressionParams;
-
-		Params.network.modular_kcp.upstream_kcp.flush_interval_millis = Config.UdpUpstreamIntervalMS;
-		Params.network.modular_kcp.downstream_kcp.flush_interval_millis = Config.UdpDownstreamIntervalMS;
-
-#if WITH_EDITOR
-		Params.network.modular_tcp.downstream_heartbeat = &HeartbeatParams;
-		Params.network.modular_tcp.upstream_heartbeat = &HeartbeatParams;
-		Params.network.modular_kcp.downstream_heartbeat = &HeartbeatParams;
-		Params.network.modular_kcp.upstream_heartbeat = &HeartbeatParams;
-#endif
-		
-		if (!bConnectAsClient && GetDefault<USpatialGDKSettings>()->bUseSecureServerConnection)
-		{
-			Params.network.modular_kcp.security_type = WORKER_NETWORK_SECURITY_TYPE_TLS;
-			Params.network.modular_tcp.security_type = WORKER_NETWORK_SECURITY_TYPE_TLS;
-		}
-		else if (bConnectAsClient && GetDefault<USpatialGDKSettings>()->bUseSecureClientConnection)
-		{
-			Params.network.modular_kcp.security_type = WORKER_NETWORK_SECURITY_TYPE_TLS;
-			Params.network.modular_tcp.security_type = WORKER_NETWORK_SECURITY_TYPE_TLS;
-		}
-		else
-		{
-			Params.network.modular_kcp.security_type = WORKER_NETWORK_SECURITY_TYPE_INSECURE;
-			Params.network.modular_tcp.security_type = WORKER_NETWORK_SECURITY_TYPE_INSECURE;
-		}
-
-		Params.enable_dynamic_components = true;
 	}
-
-	FString FormatProtocolPrefix() const
-	{
-		FString FinalProtocolLoggingPrefix = FPaths::ConvertRelativePathToFull(FPaths::ProjectLogDir());
-		if (!Config.ProtocolLoggingPrefix.IsEmpty())
-		{
-			FinalProtocolLoggingPrefix += Config.ProtocolLoggingPrefix;
-		}
-		else
-		{
-			FinalProtocolLoggingPrefix += Config.WorkerId;
-		}
-		return FinalProtocolLoggingPrefix;
-	}
-
-	const FConnectionConfig& Config;
-	Worker_ConnectionParameters Params;
-	FTCHARToUTF8 WorkerType;
-	FTCHARToUTF8 ProtocolLogPrefix;
-	Worker_ComponentVtable DefaultVtable{};
-	Worker_CompressionParameters EnableCompressionParams{};
-
-#if WITH_EDITOR
-	Worker_HeartbeatParameters HeartbeatParams{ WORKER_DEFAULTS_HEARTBEAT_INTERVAL_MILLIS, MAX_int64 };
-#endif
-};
+}
 
 void USpatialWorkerConnection::FinishDestroy()
 {
+	UE_LOG(LogSpatialWorkerConnection, Log, TEXT("Destorying SpatialWorkerconnection."));
+
 	DestroyConnection();
 
 	Super::FinishDestroy();
@@ -128,322 +51,8 @@ void USpatialWorkerConnection::DestroyConnection()
 		WorkerConnection = nullptr;
 	}
 
-	if (WorkerLocator)
-	{
-		AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [WorkerLocator = WorkerLocator]
-		{
-			Worker_Locator_Destroy(WorkerLocator);
-		});
-
-		WorkerLocator = nullptr;
-	}
-
-	bIsConnected = false;
 	NextRequestId = 0;
 	KeepRunning.AtomicSet(true);
-}
-
-void USpatialWorkerConnection::Connect(bool bInitAsClient, uint32 PlayInEditorID)
-{
-	if (bIsConnected)
-	{
-		check(bInitAsClient == bConnectAsClient);
-		AsyncTask(ENamedThreads::GameThread, [WeakThis = TWeakObjectPtr<USpatialWorkerConnection>(this)]
-			{
-				if (WeakThis.IsValid())
-				{
-					WeakThis->OnConnectionSuccess();
-				}
-				else
-				{
-					UE_LOG(LogSpatialWorkerConnection, Error, TEXT("SpatialWorkerConnection is not valid but was already connected."));
-				}
-			});
-		return;
-	}
-
-	bConnectAsClient = bInitAsClient;
-
-	const USpatialGDKSettings* SpatialGDKSettings = GetDefault<USpatialGDKSettings>();
-	if (SpatialGDKSettings->bUseDevelopmentAuthenticationFlow && bInitAsClient)
-	{
-		DevAuthConfig.Deployment = SpatialGDKSettings->DevelopmentDeploymentToConnect;
-		DevAuthConfig.WorkerType = SpatialConstants::DefaultClientWorkerType.ToString();
-		DevAuthConfig.UseExternalIp = true;
-		StartDevelopmentAuth(SpatialGDKSettings->DevelopmentAuthenticationToken);
-		return;
-	}
-
-	switch (GetConnectionType())
-	{
-	case ESpatialConnectionType::Receptionist:
-		ConnectToReceptionist(PlayInEditorID);
-		break;
-	case ESpatialConnectionType::Locator:
-		ConnectToLocator(&LocatorConfig);
-		break;
-	case ESpatialConnectionType::DevAuthFlow:
-		StartDevelopmentAuth(DevAuthConfig.DevelopmentAuthToken);
-		break;
-	}
-}
-
-void USpatialWorkerConnection::OnLoginTokens(void* UserData, const Worker_Alpha_LoginTokensResponse* LoginTokens)
-{
-	if (LoginTokens->status.code != WORKER_CONNECTION_STATUS_CODE_SUCCESS)
-	{
-		UE_LOG(LogSpatialWorkerConnection, Error, TEXT("Failed to get login token, StatusCode: %d, Error: %s"), LoginTokens->status.code, UTF8_TO_TCHAR(LoginTokens->status.detail));
-		return;
-	}
-
-	if (LoginTokens->login_token_count == 0)
-	{
-		UE_LOG(LogSpatialWorkerConnection, Warning, TEXT("No deployment found to connect to. Did you add the 'dev_login' tag to the deployment you want to connect to?"));
-		return;
-	}
-
-	UE_LOG(LogSpatialWorkerConnection, Verbose, TEXT("Successfully received LoginTokens, Count: %d"), LoginTokens->login_token_count);
-	USpatialWorkerConnection* Connection = static_cast<USpatialWorkerConnection*>(UserData);
-	Connection->ProcessLoginTokensResponse(LoginTokens);
-}
-
-void USpatialWorkerConnection::ProcessLoginTokensResponse(const Worker_Alpha_LoginTokensResponse* LoginTokens)
-{
-	// If LoginTokenResCallback is callable and returns true, return early.
-	if (LoginTokenResCallback && LoginTokenResCallback(LoginTokens))
-	{
-		return;
-	}
-	
-	const FString& DeploymentToConnect = DevAuthConfig.Deployment;
-	// If not set, use the first deployment. It can change every query if you have multiple items available, because the order is not guaranteed.
-	if (DeploymentToConnect.IsEmpty())
-	{
-		DevAuthConfig.LoginToken = FString(LoginTokens->login_tokens[0].login_token);
-	}
-	else
-	{
-		for (uint32 i = 0; i < LoginTokens->login_token_count; i++)
-		{
-			FString DeploymentName = FString(LoginTokens->login_tokens[i].deployment_name);
-			if (DeploymentToConnect.Compare(DeploymentName) == 0)
-			{
-				DevAuthConfig.LoginToken = FString(LoginTokens->login_tokens[i].login_token);
-				break;
-			}
-		}
-	}
-	ConnectToLocator(&  DevAuthConfig);
-}
-
-void USpatialWorkerConnection::RequestDeploymentLoginTokens()
-{
-	Worker_Alpha_LoginTokensRequest LTParams{};
-	FTCHARToUTF8 PlayerIdentityToken(*DevAuthConfig.PlayerIdentityToken);
-	LTParams.player_identity_token = PlayerIdentityToken.Get();
-	FTCHARToUTF8 WorkerType(*DevAuthConfig.WorkerType);
-	LTParams.worker_type = WorkerType.Get();
-	LTParams.use_insecure_connection = false;
-	
-	if (Worker_Alpha_LoginTokensResponseFuture* LTFuture = Worker_Alpha_CreateDevelopmentLoginTokensAsync(TCHAR_TO_UTF8(*DevAuthConfig.LocatorHost), SpatialConstants::LOCATOR_PORT, &LTParams))
-	{
-		Worker_Alpha_LoginTokensResponseFuture_Get(LTFuture, nullptr, this, &USpatialWorkerConnection::OnLoginTokens);
-	}
-}
-
-void USpatialWorkerConnection::OnPlayerIdentityToken(void* UserData, const Worker_Alpha_PlayerIdentityTokenResponse* PIToken)
-{
-	if (PIToken->status.code != WORKER_CONNECTION_STATUS_CODE_SUCCESS)
-	{
-		UE_LOG(LogSpatialWorkerConnection, Error, TEXT("Failed to get PlayerIdentityToken, StatusCode: %d, Error: %s"), PIToken->status.code, UTF8_TO_TCHAR(PIToken->status.detail));
-		return;
-	}
-
-	UE_LOG(LogSpatialWorkerConnection, Log, TEXT("Successfully received PIToken: %s"), UTF8_TO_TCHAR(PIToken->player_identity_token));
-	USpatialWorkerConnection* Connection = static_cast<USpatialWorkerConnection*>(UserData);
-	Connection->DevAuthConfig.PlayerIdentityToken = UTF8_TO_TCHAR(PIToken->player_identity_token);
-	
-	Connection->RequestDeploymentLoginTokens();
-}
-
-void USpatialWorkerConnection::StartDevelopmentAuth(const FString& DevAuthToken)
-{
-	FTCHARToUTF8 DAToken(*DevAuthToken);
-	FTCHARToUTF8 PlayerId(*DevAuthConfig.PlayerId);
-	FTCHARToUTF8 DisplayName(*DevAuthConfig.DisplayName);
-	FTCHARToUTF8 MetaData(*DevAuthConfig.MetaData);
-
-	Worker_Alpha_PlayerIdentityTokenRequest PITParams{};
-	PITParams.development_authentication_token = DAToken.Get();
-	PITParams.player_id = PlayerId.Get();
-	PITParams.display_name = DisplayName.Get();
-	PITParams.metadata = MetaData.Get();
-	PITParams.use_insecure_connection = false;
-
-	if (Worker_Alpha_PlayerIdentityTokenResponseFuture* PITFuture = Worker_Alpha_CreateDevelopmentPlayerIdentityTokenAsync(TCHAR_TO_UTF8(*DevAuthConfig.LocatorHost), SpatialConstants::LOCATOR_PORT, &PITParams))
-	{
-		Worker_Alpha_PlayerIdentityTokenResponseFuture_Get(PITFuture, nullptr, this, &USpatialWorkerConnection::OnPlayerIdentityToken);
-	}
-}
-
-void USpatialWorkerConnection::ConnectToReceptionist(uint32 PlayInEditorID)
-{
-#if WITH_EDITOR
-	SpatialGDKServices::InitWorkers(bConnectAsClient, PlayInEditorID, ReceptionistConfig.WorkerId);
-#endif
-
-	ReceptionistConfig.PreConnectInit(bConnectAsClient);
-
-	ConfigureConnection ConnectionConfig(ReceptionistConfig, bConnectAsClient);
-
-	Worker_ConnectionFuture* ConnectionFuture = Worker_ConnectAsync(
-		TCHAR_TO_UTF8(*ReceptionistConfig.GetReceptionistHost()), ReceptionistConfig.ReceptionistPort,
-		TCHAR_TO_UTF8(*ReceptionistConfig.WorkerId), &ConnectionConfig.Params);
-
-	FinishConnecting(ConnectionFuture);
-}
-
-void USpatialWorkerConnection::ConnectToLocator(FLocatorConfig* InLocatorConfig)
-{
-	if (InLocatorConfig == nullptr)
-	{
-		UE_LOG(LogSpatialWorkerConnection, Error, TEXT("Trying to connect to locator with invalid locator config"));
-		return;
-	}
-
-	InLocatorConfig->PreConnectInit(bConnectAsClient);
-
-	ConfigureConnection ConnectionConfig(*InLocatorConfig, bConnectAsClient);
-
-	FTCHARToUTF8 PlayerIdentityTokenCStr(*InLocatorConfig->PlayerIdentityToken);
-	FTCHARToUTF8 LoginTokenCStr(*InLocatorConfig->LoginToken);
-
-	Worker_LocatorParameters LocatorParams = {};
-	FString ProjectName;
-	FParse::Value(FCommandLine::Get(), TEXT("projectName"), ProjectName);
-	LocatorParams.project_name = TCHAR_TO_UTF8(*ProjectName);
-	LocatorParams.credentials_type = Worker_LocatorCredentialsTypes::WORKER_LOCATOR_PLAYER_IDENTITY_CREDENTIALS;
-	LocatorParams.player_identity.player_identity_token = PlayerIdentityTokenCStr.Get();
-	LocatorParams.player_identity.login_token = LoginTokenCStr.Get();
-
-	// Connect to the locator on the default port(0 will choose the default)
-	WorkerLocator = Worker_Locator_Create(TCHAR_TO_UTF8(*InLocatorConfig->LocatorHost), SpatialConstants::LOCATOR_PORT, &LocatorParams);
-
-	Worker_ConnectionFuture* ConnectionFuture = Worker_Locator_ConnectAsync(WorkerLocator, &ConnectionConfig.Params);
-
-	FinishConnecting(ConnectionFuture);
-}
-
-void USpatialWorkerConnection::FinishConnecting(Worker_ConnectionFuture* ConnectionFuture)
-{
-	TWeakObjectPtr<USpatialWorkerConnection> WeakSpatialWorkerConnection(this);
-
-	AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [ConnectionFuture, WeakSpatialWorkerConnection]
-	{
-		Worker_Connection* NewCAPIWorkerConnection = Worker_ConnectionFuture_Get(ConnectionFuture, nullptr);
-		Worker_ConnectionFuture_Destroy(ConnectionFuture);
-
-		AsyncTask(ENamedThreads::GameThread, [WeakSpatialWorkerConnection, NewCAPIWorkerConnection]
-		{
-			USpatialWorkerConnection* SpatialWorkerConnection = WeakSpatialWorkerConnection.Get();
-
-			if (SpatialWorkerConnection == nullptr)
-			{
-				return;
-			}
-
-			SpatialWorkerConnection->WorkerConnection = NewCAPIWorkerConnection;
-
-			if (Worker_Connection_IsConnected(NewCAPIWorkerConnection))
-			{
-				SpatialWorkerConnection->CacheWorkerAttributes();
-				SpatialWorkerConnection->OnConnectionSuccess();
-			}
-			else
-			{
-				// TODO: Try to reconnect - UNR-576
-				SpatialWorkerConnection->OnConnectionFailure();
-			}
-		});
-	});
-}
-
-ESpatialConnectionType USpatialWorkerConnection::GetConnectionType() const
-{
-	return ConnectionType;
-}
-
-void USpatialWorkerConnection::SetConnectionType(ESpatialConnectionType InConnectionType)
-{
-	// The locator config may not have been initialized
-	check(!(InConnectionType == ESpatialConnectionType::Locator && LocatorConfig.LocatorHost.IsEmpty()))
-
-	ConnectionType = InConnectionType;
-}
-
-bool USpatialWorkerConnection::TrySetupConnectionConfigFromCommandLine(const FString& SpatialWorkerType)
-{
-	bool bSuccessfullyLoaded = LocatorConfig.TryLoadCommandLineArgs();
-	if (bSuccessfullyLoaded)
-	{
-		SetConnectionType(ESpatialConnectionType::Locator);
-		LocatorConfig.WorkerType = SpatialWorkerType;
-	}
-	else
-	{
-		bSuccessfullyLoaded = DevAuthConfig.TryLoadCommandLineArgs();
-		if (bSuccessfullyLoaded)
-		{
-			SetConnectionType(ESpatialConnectionType::DevAuthFlow);
-			DevAuthConfig.WorkerType = SpatialWorkerType;
-		}
-		else
-		{
-			bSuccessfullyLoaded = ReceptionistConfig.TryLoadCommandLineArgs();
-			SetConnectionType(ESpatialConnectionType::Receptionist);
-			ReceptionistConfig.WorkerType = SpatialWorkerType;
-		}
-	}
-
-	return bSuccessfullyLoaded;
-}
-
-void USpatialWorkerConnection::SetupConnectionConfigFromURL(const FURL& URL, const FString& SpatialWorkerType)
-{
-	if (URL.Host == SpatialConstants::LOCATOR_HOST && URL.HasOption(TEXT("locator")))
-	{
-		SetConnectionType(ESpatialConnectionType::Locator);
-		// TODO: UNR-2811 We might add a feature whereby we get the locator host from the URL option.
-		FParse::Value(FCommandLine::Get(), TEXT("locatorHost"), LocatorConfig.LocatorHost);
-		LocatorConfig.PlayerIdentityToken = URL.GetOption(*SpatialConstants::URL_PLAYER_IDENTITY_OPTION, TEXT(""));
-		LocatorConfig.LoginToken = URL.GetOption(*SpatialConstants::URL_LOGIN_OPTION, TEXT(""));
-		LocatorConfig.WorkerType = SpatialWorkerType;
-	}
-	else if (URL.Host == SpatialConstants::LOCATOR_HOST && URL.HasOption(TEXT("devauth")))
-	{
-		SetConnectionType(ESpatialConnectionType::DevAuthFlow);
-		// TODO: UNR-2811 Also set the locator host of DevAuthConfig from URL.
-		FParse::Value(FCommandLine::Get(), TEXT("locatorHost"), DevAuthConfig.LocatorHost);
-		DevAuthConfig.DevelopmentAuthToken = URL.GetOption(*SpatialConstants::URL_DEV_AUTH_TOKEN_OPTION, TEXT(""));
-		DevAuthConfig.Deployment = URL.GetOption(*SpatialConstants::URL_TARGET_DEPLOYMENT_OPTION, TEXT(""));
-		DevAuthConfig.PlayerId = URL.GetOption(*SpatialConstants::URL_PLAYER_ID_OPTION, *SpatialConstants::DEVELOPMENT_AUTH_PLAYER_ID);
-		DevAuthConfig.DisplayName = URL.GetOption(*SpatialConstants::URL_DISPLAY_NAME_OPTION, TEXT(""));
-		DevAuthConfig.MetaData = URL.GetOption(*SpatialConstants::URL_METADATA_OPTION, TEXT(""));
-		DevAuthConfig.WorkerType = SpatialWorkerType;
-	}
-	else
-	{
-		SetConnectionType(ESpatialConnectionType::Receptionist);
-		ReceptionistConfig.SetReceptionistHost(URL.Host);
-		ReceptionistConfig.WorkerType = SpatialWorkerType;
-
-		const TCHAR* UseExternalIpForBridge = TEXT("useExternalIpForBridge");
-		if (URL.HasOption(UseExternalIpForBridge))
-		{
-			FString UseExternalIpOption = URL.GetOption(UseExternalIpForBridge, TEXT(""));
-			ReceptionistConfig.UseExternalIp = !UseExternalIpOption.Equals(TEXT("false"), ESearchCase::IgnoreCase);
-		}
-	}
 }
 
 TArray<Worker_OpList*> USpatialWorkerConnection::GetOpList()
@@ -553,34 +162,6 @@ void USpatialWorkerConnection::CacheWorkerAttributes()
 	for (uint32 Index = 0; Index < Attributes->attribute_count; ++Index)
 	{
 		CachedWorkerAttributes.Add(UTF8_TO_TCHAR(Attributes->attributes[Index]));
-	}
-}
-
-void USpatialWorkerConnection::OnConnectionSuccess()
-{
-	bIsConnected = true;
-
-	const USpatialGDKSettings* SpatialGDKSettings = GetDefault<USpatialGDKSettings>();
-	if (!SpatialGDKSettings->bRunSpatialWorkerConnectionOnGameThread)
-	{
-		if (OpsProcessingThread == nullptr)
-		{
-			InitializeOpsProcessingThread();
-		}
-	}
-
-	OnConnectedCallback.ExecuteIfBound();
-}
-
-void USpatialWorkerConnection::OnConnectionFailure()
-{
-	bIsConnected = false;
-
-	if (WorkerConnection != nullptr)
-	{
-		uint8_t ConnectionStatusCode = Worker_Connection_GetConnectionStatusCode(WorkerConnection);
-		const FString ErrorMessage(UTF8_TO_TCHAR(Worker_Connection_GetConnectionStatusDetailString(WorkerConnection)));
-		OnFailedToConnectCallback.ExecuteIfBound(ConnectionStatusCode, ErrorMessage);
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialOutputDevice.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialOutputDevice.cpp
@@ -30,7 +30,7 @@ void FSpatialOutputDevice::Serialize(const TCHAR* InData, ELogVerbosity::Type Ve
 		return;
 	}
 
-	if (bLogToSpatial && Connection->IsConnected())
+	if (bLogToSpatial && Connection != nullptr)
 	{
 #if WITH_EDITOR
 		if (GPlayInEditorID != PIEIndex)

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialGameInstance.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialGameInstance.h
@@ -8,7 +8,7 @@
 #include "SpatialGameInstance.generated.h"
 
 class USpatialLatencyTracer;
-class USpatialWorkerConnection;
+class USpatialConnectionManager;
 class UGlobalStateManager;
 class USpatialStaticComponentView;
 
@@ -42,7 +42,7 @@ public:
 	// Destroying the SpatialWorkerConnection disconnects us from SpatialOS.
 	void DestroySpatialWorkerConnection();
 
-	FORCEINLINE USpatialWorkerConnection* GetSpatialWorkerConnection() { return SpatialConnection; }
+	FORCEINLINE USpatialConnectionManager* GetSpatialConnectionManager() { return SpatialConnectionManager; }
 	FORCEINLINE USpatialLatencyTracer* GetSpatialLatencyTracer() { return SpatialLatencyTracer; }
 	FORCEINLINE UGlobalStateManager* GetGlobalStateManager() { return GlobalStateManager; };
 	FORCEINLINE USpatialStaticComponentView* GetStaticComponentView() { return StaticComponentView; };
@@ -66,7 +66,7 @@ protected:
 private:
 	// SpatialConnection is stored here for persistence between map travels.
 	UPROPERTY()
-	USpatialWorkerConnection* SpatialConnection;
+	USpatialConnectionManager* SpatialConnectionManager;
 
 	bool bFirstConnectionToSpatialOSAttempted = false;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -30,6 +30,7 @@ class UEntityPool;
 class UGlobalStateManager;
 class USpatialActorChannel;
 class USpatialClassInfoManager;
+class USpatialConnectionManager;
 class USpatialGameInstance;
 class USpatialMetrics;
 class USpatialNetConnection;
@@ -123,6 +124,8 @@ public:
 
 	UPROPERTY()
 	USpatialWorkerConnection* Connection;
+	UPROPERTY()
+	USpatialConnectionManager* ConnectionManager;
 	UPROPERTY()
 	USpatialSender* Sender;
 	UPROPERTY()

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialConnectionManager.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialConnectionManager.h
@@ -1,0 +1,92 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "Interop/Connection/SpatialOSWorkerInterface.h"
+#include "Interop/Connection/ConnectionConfig.h"
+#include "SpatialCommonTypes.h"
+#include "SpatialGDKSettings.h"
+
+#include "SpatialConnectionManager.generated.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogSpatialConnectionManager, Log, All);
+
+class USpatialWorkerConnection;
+
+enum class ESpatialConnectionType
+{
+	Receptionist,
+	LegacyLocator,
+	Locator,
+	DevAuthFlow
+};
+
+UCLASS()
+class SPATIALGDK_API USpatialConnectionManager : public UObject
+{
+	GENERATED_BODY()
+
+public:
+	virtual void FinishDestroy() override;
+	void DestroyConnection();
+	
+	using LoginTokenResponseCallback = TFunction<bool(const Worker_Alpha_LoginTokensResponse*)>;
+    
+    /// Register a callback using this function.
+    /// It will be triggered when receiving login tokens using the development authentication flow inside SpatialWorkerConnection.
+    /// @param Callback - callback function.
+	void RegisterOnLoginTokensCallback(const LoginTokenResponseCallback& Callback) {LoginTokenResCallback = Callback;}
+
+	void Connect(bool bConnectAsClient, uint32 PlayInEditorID);
+
+	FORCEINLINE bool IsConnected() { return bIsConnected; }
+
+	PhysicalWorkerName GetWorkerId() const;
+	const TArray<FString>& GetWorkerAttributes() const;
+
+	void SetConnectionType(ESpatialConnectionType InConnectionType);
+
+	// TODO: UNR-2753
+	FReceptionistConfig ReceptionistConfig;
+	FLocatorConfig LocatorConfig;
+	FDevAuthConfig DevAuthConfig;
+
+	DECLARE_DELEGATE(OnConnectionToSpatialOSSucceededDelegate)
+	OnConnectionToSpatialOSSucceededDelegate OnConnectedCallback;
+
+	DECLARE_DELEGATE_TwoParams(OnConnectionToSpatialOSFailedDelegate, uint8_t, const FString&);
+	OnConnectionToSpatialOSFailedDelegate OnFailedToConnectCallback;
+
+	bool TrySetupConnectionConfigFromCommandLine(const FString& SpatialWorkerType);
+	void SetupConnectionConfigFromURL(const FURL& URL, const FString& SpatialWorkerType);
+
+	USpatialWorkerConnection* GetWorkerConnection() { return WorkerConnection; }
+
+private:
+	void ConnectToReceptionist(uint32 PlayInEditorID);
+	void ConnectToLocator(FLocatorConfig* InLocatorConfig);
+	void FinishConnecting(Worker_ConnectionFuture* ConnectionFuture);
+
+	void OnConnectionSuccess();
+	void OnConnectionFailure(uint8_t ConnectionStatusCode, const FString& ErrorMessage);
+
+	ESpatialConnectionType GetConnectionType() const;
+
+	void StartDevelopmentAuth(const FString& DevAuthToken);
+	void RequestDeploymentLoginTokens();
+	static void OnPlayerIdentityToken(void* UserData, const Worker_Alpha_PlayerIdentityTokenResponse* PIToken);
+	static void OnLoginTokens(void* UserData, const Worker_Alpha_LoginTokensResponse* LoginTokens);
+	void ProcessLoginTokensResponse(const Worker_Alpha_LoginTokensResponse* LoginTokens);
+
+private:
+	UPROPERTY()
+	USpatialWorkerConnection* WorkerConnection;
+
+	Worker_Locator* WorkerLocator;
+
+	bool bIsConnected;
+	bool bConnectAsClient = false;
+
+	ESpatialConnectionType ConnectionType = ESpatialConnectionType::Receptionist;
+	LoginTokenResponseCallback LoginTokenResCallback;
+};


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description

This should have no functional change, it is just reoganization.

The existing SpatialWorkerConnection used to both be responsible for negotiating the connection with SpatialOS and also responsible for communicating data down that connection. This change separates the functionality into the SpatialConnectionManager (which creates the connection) and the SpatialWorkerConnection (which now just pipes data across the connection).

#### Release note
REQUIRED: Add a release note to the `##Unreleased` section of CHANGELOG.md. You can find guidance for writing useful release notes [here](../SpatialGDK/Extras/internal-documentation/how-to-write-good-release-notes.md). Documentation changes are exempt from this requirement.

#### Tests
How did you test these changes prior to submitting this pull request?
What automated tests are included in this PR?

STRONGLY SUGGESTED: How can this be verified by QA?

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.