### PR TITLE
[UNR-2872] Fix crash on dangling pointer

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1735,6 +1735,7 @@ void USpatialReceiver::ApplyComponentUpdate(const Worker_ComponentUpdate& Compon
 	ComponentReader Reader(NetDriver, RepStateHelper.GetRefMap());
 	bool bOutReferencesChanged = false;
 	Reader.ApplyComponentUpdate(ComponentUpdate, TargetObject, Channel, bIsHandover, bOutReferencesChanged);
+	RepStateHelper.Update(*this, Channel, TargetObject, bOutReferencesChanged);
 
 	// This is a temporary workaround, see UNR-841:
 	// If the update includes tearoff, close the channel and clean up the entity.
@@ -1748,8 +1749,6 @@ void USpatialReceiver::ApplyComponentUpdate(const Worker_ComponentUpdate& Compon
 			Channel.ConditionalCleanUp(false, EChannelCloseReason::TearOff);
 		}
 	}
-
-	RepStateHelper.Update(*this, Channel, TargetObject, bOutReferencesChanged);
 }
 
 ERPCResult USpatialReceiver::ApplyRPCInternal(UObject* TargetObject, UFunction* Function, const RPCPayload& Payload, const FString& SenderWorkerId, bool bApplyWithUnresolvedRefs /* = false */)


### PR DESCRIPTION
#### Description
The RepStateUpdateHelper keeps a reference to a TMap entry. In USpatialReceiver::ApplyComponentUpdate, there is a case where if a specific flag has been set, we cleanup the channel. This caused the referenced TMap to be cleared, leaving a dangling pointer which was accessed later in RepStateUpdateHelper::Update
The fix moves the call to update before the channel has an opportunity to be cleaned-up.

#### Tests
The crash was 100% reproducible in the Shooter Game
