### PR TITLE
Feature/unr 2012 fix registering singletons crash

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -850,7 +850,7 @@ void USpatialNetDriver::NotifyActorDestroyed(AActor* ThisActor, bool IsSeamlessT
 			}
 
 			// If the actor is an initially dormant startup actor that has not been replicated.
-			if (EntityId == SpatialConstants::INVALID_ENTITY_ID && ThisActor->IsNetStartupActor() && ThisActor->HasAuthority())
+			if (EntityId == SpatialConstants::INVALID_ENTITY_ID && ThisActor->IsNetStartupActor() && ThisActor->GetIsReplicated() && ThisActor->HasAuthority())
 			{
 				UE_LOG(LogSpatialOSNetDriver, Log, TEXT("Creating a tombstone entity for initially dormant statup actor. "
 					"Actor: %s."), *ThisActor->GetName());

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -824,6 +824,11 @@ void USpatialNetDriver::NotifyActorDestroyed(AActor* ThisActor, bool IsSeamlessT
 
 	const bool bIsServer = ServerConnection == nullptr;
 
+	if (ThisActor->GetClass()->HasAnySpatialClassFlags(SPATIALCLASS_Singleton))
+	{
+		SingletonActorChannels.Remove(ThisActor->GetClass()->GetPathName());
+	}
+
 	if (bIsServer)
 	{
 		// Check if this is a dormant entity, and if so retire the entity
@@ -832,7 +837,7 @@ void USpatialNetDriver::NotifyActorDestroyed(AActor* ThisActor, bool IsSeamlessT
 			const Worker_EntityId EntityId = PackageMap->GetEntityIdFromObject(ThisActor);
 
 			// If the actor is an initially dormant startup actor that has not been replicated.
-			if (EntityId == SpatialConstants::INVALID_ENTITY_ID && ThisActor->IsNetStartupActor() && GlobalStateManager->HasAuthority())
+			if (EntityId == SpatialConstants::INVALID_ENTITY_ID && ThisActor->IsNetStartupActor() && ThisActor->HasAuthority())
 			{
 				UE_LOG(LogSpatialOSNetDriver, Log, TEXT("Creating a tombstone entity for initially dormant statup actor. "
 					"Actor: %s."), *ThisActor->GetName());

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -824,9 +824,10 @@ void USpatialNetDriver::NotifyActorDestroyed(AActor* ThisActor, bool IsSeamlessT
 
 	const bool bIsServer = ServerConnection == nullptr;
 
+	// Remove the record of destroyed singletons.
 	if (ThisActor->GetClass()->HasAnySpatialClassFlags(SPATIALCLASS_Singleton))
 	{
-		SingletonActorChannels.Remove(ThisActor->GetClass()->GetPathName());
+		GlobalStateManager->RemoveSingletonInstance(ThisActor);
 	}
 
 	if (bIsServer)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
@@ -232,7 +232,7 @@ void UGlobalStateManager::LinkExistingSingletonActor(const UClass* SingletonActo
 		return;
 	}
 
-	TPair<AActor*, USpatialActorChannel*>* ActorChannelPair = NetDriver->SingletonActorChannels.Find(SingletonActorClass->GetPathName());
+	TPair<AActor*, USpatialActorChannel*>* ActorChannelPair = SingletonClassPathToActorChannels.Find(SingletonActorClass->GetPathName());
 	if (ActorChannelPair == nullptr)
 	{
 		// Dynamically spawn singleton actor if we have queued up data - ala USpatialReceiver::ReceiveActor - JIRA: 735
@@ -309,7 +309,7 @@ USpatialActorChannel* UGlobalStateManager::AddSingleton(AActor* SingletonActor)
 
 	UClass* SingletonActorClass = SingletonActor->GetClass();
 
-	TPair<AActor*, USpatialActorChannel*>& ActorChannelPair = NetDriver->SingletonActorChannels.FindOrAdd(SingletonActorClass->GetPathName());
+	TPair<AActor*, USpatialActorChannel*>& ActorChannelPair = SingletonClassPathToActorChannels.FindOrAdd(SingletonActorClass->GetPathName());
 	USpatialActorChannel*& Channel = ActorChannelPair.Value;
 	check(ActorChannelPair.Key == nullptr || ActorChannelPair.Key == SingletonActor);
 	ActorChannelPair.Key = SingletonActor;
@@ -357,9 +357,16 @@ USpatialActorChannel* UGlobalStateManager::AddSingleton(AActor* SingletonActor)
 	return Channel;
 }
 
+void UGlobalStateManager::RemoveSingletonInstance(const AActor* SingletonActor)
+{
+	check(SingletonActor->GetClass()->HasAnySpatialClassFlags(SPATIALCLASS_Singleton));
+
+	SingletonClassPathToActorChannels.Remove(SingletonActor->GetClass()->GetPathName());
+}
+
 void UGlobalStateManager::RegisterSingletonChannel(AActor* SingletonActor, USpatialActorChannel* SingletonChannel)
 {
-	TPair<AActor*, USpatialActorChannel*>& ActorChannelPair = NetDriver->SingletonActorChannels.FindOrAdd(SingletonActor->GetClass()->GetPathName());
+	TPair<AActor*, USpatialActorChannel*>& ActorChannelPair = SingletonClassPathToActorChannels.FindOrAdd(SingletonActor->GetClass()->GetPathName());
 
 	check(ActorChannelPair.Key == nullptr || ActorChannelPair.Key == SingletonActor);
 	check(ActorChannelPair.Value == nullptr || ActorChannelPair.Value == SingletonChannel);
@@ -370,7 +377,7 @@ void UGlobalStateManager::RegisterSingletonChannel(AActor* SingletonActor, USpat
 
 void UGlobalStateManager::ExecuteInitialSingletonActorReplication()
 {
-	for (auto& ClassToActorChannel : NetDriver->SingletonActorChannels)
+	for (auto& ClassToActorChannel : SingletonClassPathToActorChannels)
 	{
 		auto& ActorChannelPair = ClassToActorChannel.Value;
 		AddSingleton(ActorChannelPair.Key);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
@@ -232,7 +232,7 @@ void UGlobalStateManager::LinkExistingSingletonActor(const UClass* SingletonActo
 		return;
 	}
 
-	TPair<AActor*, USpatialActorChannel*>* ActorChannelPair = NetDriver->SingletonActorChannels.Find(SingletonActorClass);
+	TPair<AActor*, USpatialActorChannel*>* ActorChannelPair = NetDriver->SingletonActorChannels.Find(SingletonActorClass->GetPathName());
 	if (ActorChannelPair == nullptr)
 	{
 		// Dynamically spawn singleton actor if we have queued up data - ala USpatialReceiver::ReceiveActor - JIRA: 735
@@ -309,7 +309,7 @@ USpatialActorChannel* UGlobalStateManager::AddSingleton(AActor* SingletonActor)
 
 	UClass* SingletonActorClass = SingletonActor->GetClass();
 
-	TPair<AActor*, USpatialActorChannel*>& ActorChannelPair = NetDriver->SingletonActorChannels.FindOrAdd(SingletonActorClass);
+	TPair<AActor*, USpatialActorChannel*>& ActorChannelPair = NetDriver->SingletonActorChannels.FindOrAdd(SingletonActorClass->GetPathName());
 	USpatialActorChannel*& Channel = ActorChannelPair.Value;
 	check(ActorChannelPair.Key == nullptr || ActorChannelPair.Key == SingletonActor);
 	ActorChannelPair.Key = SingletonActor;
@@ -359,7 +359,7 @@ USpatialActorChannel* UGlobalStateManager::AddSingleton(AActor* SingletonActor)
 
 void UGlobalStateManager::RegisterSingletonChannel(AActor* SingletonActor, USpatialActorChannel* SingletonChannel)
 {
-	TPair<AActor*, USpatialActorChannel*>& ActorChannelPair = NetDriver->SingletonActorChannels.FindOrAdd(SingletonActor->GetClass());
+	TPair<AActor*, USpatialActorChannel*>& ActorChannelPair = NetDriver->SingletonActorChannels.FindOrAdd(SingletonActor->GetClass()->GetPathName());
 
 	check(ActorChannelPair.Key == nullptr || ActorChannelPair.Key == SingletonActor);
 	check(ActorChannelPair.Value == nullptr || ActorChannelPair.Value == SingletonChannel);

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -156,8 +156,6 @@ public:
 
 	Worker_EntityId WorkerEntityId = SpatialConstants::INVALID_ENTITY_ID;
 
-	TMap<FString, TPair<AActor*, USpatialActorChannel*>> SingletonActorChannels;
-
 	// If this worker is authoritative over the translation, the manager will be instantiated.
 	TUniquePtr<SpatialVirtualWorkerTranslationManager> VirtualWorkerTranslationManager;
 	void InitializeVirtualWorkerTranslationManager();

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -156,7 +156,7 @@ public:
 
 	Worker_EntityId WorkerEntityId = SpatialConstants::INVALID_ENTITY_ID;
 
-	TMap<UClass*, TPair<AActor*, USpatialActorChannel*>> SingletonActorChannels;
+	TMap<FString, TPair<AActor*, USpatialActorChannel*>> SingletonActorChannels;
 
 	// If this worker is authoritative over the translation, the manager will be instantiated.
 	TUniquePtr<SpatialVirtualWorkerTranslationManager> VirtualWorkerTranslationManager;

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/GlobalStateManager.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/GlobalStateManager.h
@@ -75,6 +75,7 @@ public:
 
 	USpatialActorChannel* AddSingleton(AActor* SingletonActor);
 	void RegisterSingletonChannel(AActor* SingletonActor, USpatialActorChannel* SingletonChannel);
+	void RemoveSingletonInstance(const AActor* SingletonActor);
 
 	Worker_EntityId GlobalStateManagerEntityId;
 
@@ -126,4 +127,6 @@ private:
 	USpatialReceiver* Receiver;
 
 	FDelegateHandle PrePIEEndedHandle;
+
+	TMap<FString, TPair<AActor*, USpatialActorChannel*>> SingletonClassPathToActorChannels;
 };

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
@@ -10,8 +10,10 @@
 #include "Utils/SchemaDatabase.h"
 
 #include "CoreMinimal.h"
+#include "GeneralProjectSettings.h"
 #include "HAL/PlatformFilemanager.h"
 #include "Misc/FileHelper.h"
+#include "Misc/PackageName.h"
 
 #define LOCTEXT_NAMESPACE "SpatialGDKEDitorSchemaGeneratorTest"
 


### PR DESCRIPTION
#### Description
Fix a crash on when loading and unloading levels from world composition on the client.
Changes the UClass* key to an FString path name and removes destroyed actors from the singleton channel map.

Also moved the map to the gsm class as it's the only place that uses it. Hopefully makes it slightly easier to pull singleton stuff out into it's own class later. Done in commit order.
First commit is a driveby, second is the main change, third is the optional change to the map location.

#### Tests
Gym

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.