### PR TITLE
Spawn actor entities with component authority based on lb strat if zo…

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -80,7 +80,9 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 		IntendedVirtualWorkerId = NetDriver->LoadBalanceStrategy->WhoShouldHaveAuthority(*Actor);
 		if (IntendedVirtualWorkerId == SpatialConstants::INVALID_VIRTUAL_WORKER_ID)
 		{
-			UE_LOG(LogEntityFactory, Error, TEXT("Load balancing strategy provided invalid virtual worker ID to spawn actor with. Actor: %s"), *Actor->GetName());
+			UE_LOG(LogEntityFactory, Error, TEXT("Load balancing strategy provided invalid virtual worker ID to spawn Actor. Actor: %s"), *Actor->GetName());
+			// We'll just default to spawning with intent set to this worker's virtual worker ID
+			IntendedVirtualWorkerId = NetDriver->VirtualWorkerTranslator->GetLocalVirtualWorkerId()
 		}
 		else
 		{

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -82,7 +82,7 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 		{
 			UE_LOG(LogEntityFactory, Error, TEXT("Load balancing strategy provided invalid virtual worker ID to spawn Actor. Actor: %s"), *Actor->GetName());
 			// We'll just default to spawning with intent set to this worker's virtual worker ID
-			IntendedVirtualWorkerId = NetDriver->VirtualWorkerTranslator->GetLocalVirtualWorkerId()
+			IntendedVirtualWorkerId = NetDriver->VirtualWorkerTranslator->GetLocalVirtualWorkerId();
 		}
 		else
 		{

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/EntityFactory.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/EntityFactory.h
@@ -7,6 +7,8 @@
 #include <WorkerSDK/improbable/c_schema.h>
 #include <WorkerSDK/improbable/c_worker.h>
 
+DECLARE_LOG_CATEGORY_EXTERN(LogEntityFactory, Log, All);
+
 class AActor;
 class USpatialActorChannel;
 class USpatialNetDriver;


### PR DESCRIPTION
### Description
When spawning Actor entities with load balancing enabled, we can skip an auth reassignment by directly assigning EntityACL write mapping and authority intent

**Before: Actor entities are spawned with UnrealWorker attribute then immediately after authority intent is set correctly and enforcer moves it (each Cube has OnAuthorityGained called twice)**

![image](https://user-images.githubusercontent.com/9222722/74048156-937e3f00-49c9-11ea-823e-8d4e44a88e5d.png)

**After: Actor entity EntityACLs are set to the lb strategized worker on spawn, so there's no need to immediately load balance on spawn (each Cube has OnAuthorityGained called once)**

![image](https://user-images.githubusercontent.com/9222722/74048217-b27cd100-49c9-11ea-8e8e-428c1e2ef772.png)

