### PR TITLE
expose colors to blueprints

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
@@ -9,6 +9,7 @@
 #include "Kismet/KismetSystemLibrary.h"
 #include "SpatialConstants.h"
 #include "SpatialGDKSettings.h"
+#include "Utils/InspectionColors.h"
 #include "Utils/SpatialActorGroupManager.h"
 
 DEFINE_LOG_CATEGORY(LogSpatial);
@@ -68,6 +69,11 @@ TArray<FDistanceFrequencyPair> USpatialStatics::GetNCDDistanceRatios()
 float USpatialStatics::GetFullFrequencyNetCullDistanceRatio()
 {
 	return GetDefault<USpatialGDKSettings>()->FullFrequencyNetCullDistanceRatio;
+}
+
+FColor USpatialStatics::GetInspectorColorForWorkerName(const FString& WorkerName)
+{
+	return SpatialGDK::GetColorForWorkerName(WorkerName);
 }
 
 bool USpatialStatics::IsSpatialOffloadingEnabled()

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/InspectionColors.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/InspectionColors.h
@@ -6,7 +6,6 @@
 #include "Math/Color.h"
 
 // Mimicking Inspector V2 coloring from platform/js/console/src/inspector-v2/styles/colors.ts
-
 namespace SpatialGDK
 {
 	// Argument expected in the form: UnrealWorker1a2s3d4f...

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/InspectionColors.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/InspectionColors.h
@@ -6,6 +6,7 @@
 #include "Math/Color.h"
 
 // Mimicking Inspector V2 coloring from platform/js/console/src/inspector-v2/styles/colors.ts
+
 namespace SpatialGDK
 {
 	// Argument expected in the form: UnrealWorker1a2s3d4f...

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialStatics.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialStatics.h
@@ -101,6 +101,13 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "SpatialOS")
 	static float GetFullFrequencyNetCullDistanceRatio();
 
+	/**
+	 * Returns the inspector colour for the given worker name.
+	 * Argument expected in the form: UnrealWorker1a2s3d4f...
+	 */
+	UFUNCTION(BlueprintCallable, Category = "SpatialOS")
+	static FColor GetInspectorColorForWorkerName(const FString& WorkerName);
+
 private:
 
 	static SpatialActorGroupManager* GetActorGroupManager(const UObject* WorldContext);


### PR DESCRIPTION
#### Description
Exposes the get inspection color function to blueprints- required for a server to server RPC visualisation in a test gym which will follow this PR

#### Tests
The test gym works, you can see the colors

#### Primary reviewers
@alastairdglennie 