### PR TITLE
[UNR-2372] Do not reset shadow data for the entire object on every update

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/SpatialPingComponent.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/SpatialPingComponent.cpp
@@ -64,7 +64,7 @@ void USpatialPingComponent::SetPingEnabled(bool bSetEnabled)
 	}
 
 	// Only execute on owning local client.
-	if (!OwningController->HasAuthority())
+	if (OwningController->IsNetMode(NM_Client) && OwningController->GetLocalRole() == ROLE_AutonomousProxy)
 	{
 		if (bSetEnabled && !bIsPingEnabled)
 		{

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -1092,11 +1092,6 @@ FObjectReplicator* USpatialActorChannel::PreReceiveSpatialUpdate(UObject* Target
 
 	FObjectReplicator& Replicator = FindOrCreateReplicator(TargetObject).Get();
 	TargetObject->PreNetReceive();
-#if ENGINE_MINOR_VERSION <= 22
-	ResetShadowData(*Replicator.RepLayout, Replicator.RepState->StaticBuffer, TargetObject);
-#else
-	ResetShadowData(*Replicator.RepLayout, Replicator.RepState->GetReceivingRepState()->StaticBuffer, TargetObject);
-#endif
 
 	return &Replicator;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
@@ -187,6 +187,12 @@ void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject&
 
 			uint8* Data = (uint8*)&Object + SwappedCmd.Offset;
 
+			// Native does this anytime it receives anything, but we probably only have to do so when receiving repnotify properties
+			if (Parent.Property->HasAnyPropertyFlags(CPF_RepNotify))
+			{
+				Cmd.Property->CopySingleValue((FRepShadowDataBuffer)(RepState->StaticBuffer.GetData()) + SwappedCmd.ShadowOffset, Data);
+			}
+
 			if (Cmd.Type == ERepLayoutCmdType::DynamicArray)
 			{
 				UArrayProperty* ArrayProperty = Cast<UArrayProperty>(Cmd.Property);

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
@@ -192,7 +192,6 @@ void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject&
 			{
 #if ENGINE_MINOR_VERSION <= 22
 				FRepStateStaticBuffer& ShadowData = RepState->StaticBuffer;
-				
 #else
 				FRepStateStaticBuffer& ShadowData = RepState->GetReceivingRepState()->StaticBuffer;
 #endif

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
@@ -187,8 +187,8 @@ void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject&
 
 			uint8* Data = (uint8*)&Object + SwappedCmd.Offset;
 
-			// Native does this anytime it receives anything, but we probably only have to do so when receiving repnotify properties
-			if (Parent.Property->HasAnyPropertyFlags(CPF_RepNotify))
+			// Native also does a check for RepNotifies != nullptr, but we cannot use it here, this should be equivalent
+			if (Parent.RepNotifyNumParams != INDEX_NONE)
 			{
 				#if ENGINE_MINOR_VERSION <= 22
 					Cmd.Property->CopySingleValue(RepState->StaticBuffer.GetData() + SwappedCmd.ShadowOffset, Data);

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
@@ -197,23 +197,23 @@ void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject&
 
 				uint8* Data = (uint8*)&Object + SwappedCmd.Offset;
 
-                // If the property has RepNotifies, update with local data and possibly initialize the shadow data
-                if (Parent.Property->HasAnyPropertyFlags(CPF_RepNotify))
-                {
+				// If the property has RepNotifies, update with local data and possibly initialize the shadow data
+				if (Parent.Property->HasAnyPropertyFlags(CPF_RepNotify))
+				{
 #if ENGINE_MINOR_VERSION <= 22
-                    FRepStateStaticBuffer& ShadowData = RepState->StaticBuffer;
+					FRepStateStaticBuffer& ShadowData = RepState->StaticBuffer;
 #else
-                    FRepStateStaticBuffer& ShadowData = RepState->GetReceivingRepState()->StaticBuffer;
+					FRepStateStaticBuffer& ShadowData = RepState->GetReceivingRepState()->StaticBuffer;
 #endif
-                    if (ShadowData.Num() == 0)
-                    {
-                        Channel.ResetShadowData(*Replicator->RepLayout.Get(), ShadowData, &Object);
-                    }
-                    else
-                    {
-                        Cmd.Property->CopySingleValue(ShadowData.GetData() + SwappedCmd.ShadowOffset, Data);
-                    }
-                }
+					if (ShadowData.Num() == 0)
+					{
+						Channel.ResetShadowData(*Replicator->RepLayout.Get(), ShadowData, &Object);
+					}
+					else
+					{
+						Cmd.Property->CopySingleValue(ShadowData.GetData() + SwappedCmd.ShadowOffset, Data);
+					}
+				}
 
 				if (Cmd.Type == ERepLayoutCmdType::DynamicArray)
 				{

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
@@ -187,8 +187,8 @@ void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject&
 
 			uint8* Data = (uint8*)&Object + SwappedCmd.Offset;
 
-			// Native also does a check for RepNotifies != nullptr, but we cannot use it here, this should be equivalent
-			if (Parent.RepNotifyNumParams != INDEX_NONE)
+			// If the property has RepNotifies, update with local data and possibly initialize the shadow data
+			if (Parent.Property->HasAnyPropertyFlags(CPF_RepNotify))
 			{
 #if ENGINE_MINOR_VERSION <= 22
 				FRepStateStaticBuffer& ShadowData = RepState->StaticBuffer;

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
@@ -190,7 +190,15 @@ void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject&
 			// Native does this anytime it receives anything, but we probably only have to do so when receiving repnotify properties
 			if (Parent.Property->HasAnyPropertyFlags(CPF_RepNotify))
 			{
-				Cmd.Property->CopySingleValue((FRepShadowDataBuffer)(RepState->StaticBuffer.GetData()) + SwappedCmd.ShadowOffset, Data);
+				#if ENGINE_MINOR_VERSION <= 22
+					Cmd.Property->CopySingleValue(RepState->StaticBuffer.GetData() + SwappedCmd.ShadowOffset, Data);
+				#else
+					if (RepState->GetReceivingRepState()->StaticBuffer.Num() == 0)
+					{
+						Channel.ResetShadowData(*Replicator->RepLayout.Get(), RepState->GetReceivingRepState()->StaticBuffer, &Object);
+					}
+					Cmd.Property->CopySingleValue(RepState->GetReceivingRepState()->StaticBuffer.GetData() + SwappedCmd.ShadowOffset, Data);
+				#endif
 			}
 
 			if (Cmd.Type == ERepLayoutCmdType::DynamicArray)

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
@@ -190,18 +190,20 @@ void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject&
 			// Native also does a check for RepNotifies != nullptr, but we cannot use it here, this should be equivalent
 			if (Parent.RepNotifyNumParams != INDEX_NONE)
 			{
-				#if ENGINE_MINOR_VERSION <= 22
+#if ENGINE_MINOR_VERSION <= 22
+				FRepStateStaticBuffer& ShadowData = RepState->StaticBuffer;
+				
+#else
+				FRepStateStaticBuffer& ShadowData = RepState->GetReceivingRepState()->StaticBuffer;
+#endif
+				if (ShadowData.Num() == 0)
+				{
+					Channel.ResetShadowData(*Replicator->RepLayout.Get(), ShadowData, &Object);
+				}
+				else
+				{
 					Cmd.Property->CopySingleValue(RepState->StaticBuffer.GetData() + SwappedCmd.ShadowOffset, Data);
-				#else
-					if (RepState->GetReceivingRepState()->StaticBuffer.Num() == 0)
-					{
-						Channel.ResetShadowData(*Replicator->RepLayout.Get(), RepState->GetReceivingRepState()->StaticBuffer, &Object);
-					}
-					else
-					{
-						Cmd.Property->CopySingleValue(RepState->GetReceivingRepState()->StaticBuffer.GetData() + SwappedCmd.ShadowOffset, Data);
-					}
-				#endif
+				}
 			}
 
 			if (Cmd.Type == ERepLayoutCmdType::DynamicArray)

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
@@ -197,7 +197,10 @@ void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject&
 					{
 						Channel.ResetShadowData(*Replicator->RepLayout.Get(), RepState->GetReceivingRepState()->StaticBuffer, &Object);
 					}
-					Cmd.Property->CopySingleValue(RepState->GetReceivingRepState()->StaticBuffer.GetData() + SwappedCmd.ShadowOffset, Data);
+					else
+					{
+						Cmd.Property->CopySingleValue(RepState->GetReceivingRepState()->StaticBuffer.GetData() + SwappedCmd.ShadowOffset, Data);
+					}
 				#endif
 			}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
@@ -201,7 +201,7 @@ void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject&
 				}
 				else
 				{
-					Cmd.Property->CopySingleValue(RepState->StaticBuffer.GetData() + SwappedCmd.ShadowOffset, Data);
+					Cmd.Property->CopySingleValue(ShadowData.GetData() + SwappedCmd.ShadowOffset, Data);
 				}
 			}
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -256,6 +256,8 @@ public:
 	// Call when a subobject is deleted to unmap its references and cleanup its cached informations.
 	void OnSubobjectDeleted(const FUnrealObjectRef& ObjectRef, UObject* Object);
 
+	static void ResetShadowData(FRepLayout& RepLayout, FRepStateStaticBuffer& StaticBuffer, UObject* TargetObject);
+
 protected:
 	// Begin UChannel interface
 	virtual bool CleanUp(const bool bForDestroy, EChannelCloseReason CloseReason) override;
@@ -273,8 +275,6 @@ private:
 	
 	void UpdateEntityACLToNewOwner();
 	void UpdateInterestBucketComponentId();
-
-	static void ResetShadowData(FRepLayout& RepLayout, FRepStateStaticBuffer& StaticBuffer, UObject* TargetObject);
 
 public:
 	// If this actor channel is responsible for creating a new entity, this will be set to true once the entity creation request is issued.


### PR DESCRIPTION
#### Description
We previously reset the entire object's shadow data in `USpatialActorChannel::PreReceiveSpatialUpdate`. This was mostly wasted effort. With this change, we only reset the shadow data for the updated property.

This should keep parity with Unreal, as the worrisome scenario was this:
1) Let's say replicated X starts at 1 on both the server and client
2) Client changes X locally to 10
3) Server changes X locally to 10
4) Client receives replicated X from the server, but it's the same as the local value so a RepNotify wouldn't be fired on spatial
It turns out, this RepNotify also won't fire on native, because native copies the current value of the property to the shadow data before receiving the property from the wire.

#### Release note
Do we need one? It's an optimisation.

#### Tests
Added a new automated test for RepNotifies in the test project - https://github.com/improbable/UnrealGDKEngineNetTest/pull/8

We may have to do a larger playtest.

#### Documentation
None, maybe some should be present

#### Primary reviewers
@improbable-valentyn 