### PR TITLE
[UNR-2896] Move the initialization for Spatial connection into a separate function

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
@@ -95,7 +95,7 @@ FGameInstancePIEResult USpatialGameInstance::StartPlayInEditorGameInstance(ULoca
 }
 #endif
 
-void USpatialGameInstance::StartGameInstance()
+void USpatialGameInstance::TryConnectToSpatial()
 {
 	if (HasSpatialNetDriver())
 	{
@@ -121,6 +121,11 @@ void USpatialGameInstance::StartGameInstance()
 			}
 		}
 	}
+}
+
+void USpatialGameInstance::StartGameInstance()
+{
+	TryConnectToSpatial();
 
 	Super::StartGameInstance();
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialGameInstance.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialGameInstance.h
@@ -23,6 +23,9 @@ public:
 #if WITH_EDITOR
 	virtual FGameInstancePIEResult StartPlayInEditorGameInstance(ULocalPlayer* LocalPlayer, const FGameInstancePIEParameters& Params) override;
 #endif
+	// Initializes the Spatial connection if Spatial networking is enabled, otherwise does nothing.
+	void TryConnectToSpatial();
+
 	virtual void StartGameInstance() override;
 
 	//~ Begin UObject Interface


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Move the logic that creates a Spatial connection out of `StartGameInstance` so that the game's GameInstance has an alternative to calling `Super::StartGameInstance` (e.g. when it doesn't want the logic inside `UGameInstance::StartGameInstance`)

#### Primary reviewers
@mironec @mattyoung-improbable 