### PR TITLE
[UNR-2887] Fix: Dynamic subobjects attached near actor creation would not be able to replicate their properties

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -358,7 +358,7 @@ void USpatialReceiver::HandleActorAuthority(const Worker_AuthorityChangeOp& Op)
 		// TODO UNR-955 - Remove this once batch reservation of EntityIds are in.
 		if (Op.authority == WORKER_AUTHORITY_AUTHORITATIVE)
 		{
-			Sender->ProcessUpdatesQueuedUntilAuthority(Op.entity_id);
+			Sender->ProcessUpdatesQueuedUntilAuthority(Op.entity_id, Op.component_id);
 		}
 
 		// If we became authoritative over the position component. set our role to be ROLE_Authority
@@ -538,7 +538,7 @@ void USpatialReceiver::ReceiveActor(Worker_EntityId EntityId)
 	if (AActor* EntityActor = Cast<AActor>(PackageMap->GetObjectFromEntityId(EntityId)))
 	{
 		UE_LOG(LogSpatialReceiver, Log, TEXT("Entity for actor %s has been checked out on the worker which spawned it or is a singleton linked on this worker. "
-			"Entity id: $lld"), *EntityActor->GetName(), EntityId);
+			"Entity id: %lld"), *EntityActor->GetName(), EntityId);
 
 		// Assume SimulatedProxy until we've been delegated Authority
 		bool bAuthority = StaticComponentView->GetAuthority(EntityId, Position::ComponentId) == WORKER_AUTHORITY_AUTHORITATIVE;

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -292,20 +292,20 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 					// This is a failure but there is already a log inside TryResolveNewDynamicSubbojectAndGetClassInfo
 					continue;
 				}
-
-				ForAllSchemaComponentTypes([&](ESchemaComponentType Type)
-				{
-					if (SubobjectInfo->SchemaComponents[Type] != SpatialConstants::INVALID_COMPONENT_ID)
-					{
-						ComponentWriteAcl.Add(SubobjectInfo->SchemaComponents[Type], AuthoritativeWorkerRequirementSet);
-					}
-				});
 			}
 
 			const FClassInfo& SubobjectInfo = ClassInfoManager->GetOrCreateClassInfoByObject(Subobject);
 
 			FRepChangeState SubobjectRepChanges = Channel->CreateInitialRepChangeState(Subobject);
 			FHandoverChangeState SubobjectHandoverChanges = Channel->CreateInitialHandoverChangeState(SubobjectInfo);
+
+			ForAllSchemaComponentTypes([&](ESchemaComponentType Type)
+			{
+				if (SubobjectInfo.SchemaComponents[Type] != SpatialConstants::INVALID_COMPONENT_ID)
+				{
+					ComponentWriteAcl.FindOrAdd(SubobjectInfo.SchemaComponents[Type]) = AuthoritativeWorkerRequirementSet;
+				}
+			});
 
 			TArray<Worker_ComponentData> ActorSubobjectDatas = DataFactory.CreateComponentDatas(Subobject, SubobjectInfo, SubobjectRepChanges, SubobjectHandoverChanges);
 			ComponentDatas.Append(ActorSubobjectDatas);
@@ -539,15 +539,22 @@ void USpatialSender::SendComponentUpdates(UObject* Object, const FClassInfo& Inf
 }
 
 // Apply (and clean up) any updates queued, due to being sent previously when they didn't have authority.
-void USpatialSender::ProcessUpdatesQueuedUntilAuthority(Worker_EntityId EntityId)
+void USpatialSender::ProcessUpdatesQueuedUntilAuthority(Worker_EntityId EntityId, Worker_ComponentId ComponentId)
 {
 	if (TArray<Worker_ComponentUpdate>* UpdatesQueuedUntilAuthority = UpdatesQueuedUntilAuthorityMap.Find(EntityId))
 	{
-		for (Worker_ComponentUpdate& Update : *UpdatesQueuedUntilAuthority)
+		for (auto It = UpdatesQueuedUntilAuthority->CreateIterator(); It; It++)
 		{
-			Connection->SendComponentUpdate(EntityId, &Update);
+			if (ComponentId == It->component_id)
+			{
+				Connection->SendComponentUpdate(EntityId, &(*It));
+				It.RemoveCurrent();
+			}
 		}
-		UpdatesQueuedUntilAuthorityMap.Remove(EntityId);
+		if (UpdatesQueuedUntilAuthority->Num() == 0)
+		{
+			UpdatesQueuedUntilAuthorityMap.Remove(EntityId);
+		}
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -303,7 +303,7 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel)
 			{
 				if (SubobjectInfo.SchemaComponents[Type] != SpatialConstants::INVALID_COMPONENT_ID)
 				{
-					ComponentWriteAcl.FindOrAdd(SubobjectInfo.SchemaComponents[Type]) = AuthoritativeWorkerRequirementSet;
+					ComponentWriteAcl.Add(SubobjectInfo.SchemaComponents[Type], AuthoritativeWorkerRequirementSet);
 				}
 			});
 
@@ -543,15 +543,15 @@ void USpatialSender::ProcessUpdatesQueuedUntilAuthority(Worker_EntityId EntityId
 {
 	if (TArray<Worker_ComponentUpdate>* UpdatesQueuedUntilAuthority = UpdatesQueuedUntilAuthorityMap.Find(EntityId))
 	{
-		for (int32 Num = 0; Num < UpdatesQueuedUntilAuthority->Num(); Num++)
+		for (auto It = UpdatesQueuedUntilAuthority->CreateIterator(); It; It++)
 		{
-			if (ComponentId == (*UpdatesQueuedUntilAuthority)[Num].component_id)
+			if (ComponentId == It->component_id)
 			{
-				Connection->SendComponentUpdate(EntityId, &(*UpdatesQueuedUntilAuthority)[Num]);
-				UpdatesQueuedUntilAuthority->RemoveAtSwap(Num);
-				Num--;
+				Connection->SendComponentUpdate(EntityId, &(*It));
+				It.RemoveCurrent();
 			}
 		}
+
 		if (UpdatesQueuedUntilAuthority->Num() == 0)
 		{
 			UpdatesQueuedUntilAuthorityMap.Remove(EntityId);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -543,12 +543,13 @@ void USpatialSender::ProcessUpdatesQueuedUntilAuthority(Worker_EntityId EntityId
 {
 	if (TArray<Worker_ComponentUpdate>* UpdatesQueuedUntilAuthority = UpdatesQueuedUntilAuthorityMap.Find(EntityId))
 	{
-		for (auto It = UpdatesQueuedUntilAuthority->CreateIterator(); It; It++)
+		for (int32 Num = 0; Num < UpdatesQueuedUntilAuthority->Num(); Num++)
 		{
-			if (ComponentId == It->component_id)
+			if (ComponentId == (*UpdatesQueuedUntilAuthority)[Num].component_id)
 			{
-				Connection->SendComponentUpdate(EntityId, &(*It));
-				It.RemoveCurrent();
+				Connection->SendComponentUpdate(EntityId, &(*UpdatesQueuedUntilAuthority)[Num]);
+				UpdatesQueuedUntilAuthority->RemoveAtSwap(Num);
+				Num--;
 			}
 		}
 		if (UpdatesQueuedUntilAuthority->Num() == 0)

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -102,7 +102,7 @@ public:
 	void UpdateInterestComponent(AActor* Actor);
 
 	void ProcessOrQueueOutgoingRPC(const FUnrealObjectRef& InTargetObjectRef, SpatialGDK::RPCPayload&& InPayload);
-	void ProcessUpdatesQueuedUntilAuthority(Worker_EntityId EntityId);
+	void ProcessUpdatesQueuedUntilAuthority(Worker_EntityId EntityId, Worker_ComponentId ComponentId);
 
 	void FlushPackedRPCs();
 


### PR DESCRIPTION
#### Description
Previously, if trying to create and attach a dynamic subobject to an actor near its creation point, the fields of the dynamic component would not replicate properly after initial creation.
The reason for this was that we were not setting component write ACLs properly for these subobjects. This was due to the change made earlier, to resolve dynamic components earlier, which caused the code trying to check if the subobject is dynamically attached to think it was not dynamically attached, since it has already been resolved. This is fixed by decoupling the writing of ACLs from the resolution of the dynamic object in `SpatialSender::CreateEntity`.

Also a drive-by fix for $lld spam in logs.
Also a drive-by fix for authority queuing not checking which component we got authority over and potentially firing component updates for objects we did not have authority over.

#### Release note
This actually worked prior to the previous fix to dynamic subobjects (also in this RC), so I think no release note is necessary.

#### Tests
Augmented dynamic component tests: https://github.com/improbable/UnrealGDKEngineNetTest/pull/8.

#### Documentation
N/A

#### Primary reviewers
@improbable-valentyn @Vatyx