### PR TITLE
robust actor and not actor receiving

### DIFF
--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -26,7 +26,7 @@ common: &common
     - "platform=windows"
     - "permission_set=builder"
     - "scaler_version=2"
-    - "queue=${CI_WINDOWS_BUILDER_QUEUE:-v4-2019-12-09-bk5051-27568394a73b2cd3}"
+    - "queue=${CI_WINDOWS_BUILDER_QUEUE:-v4-20-03-03-102720-bk8971-dd78adbb}"
   retry:
     automatic:
       - <<: *agent_transients

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialLoadBalanceEnforcer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialLoadBalanceEnforcer.cpp
@@ -28,33 +28,22 @@ void SpatialLoadBalanceEnforcer::OnAuthorityIntentComponentUpdated(const Worker_
 
 void SpatialLoadBalanceEnforcer::OnLoadBalancingComponentAdded(const Worker_AddComponentOp& Op)
 {
-	if (!(Op.data.component_id == SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID || Op.data.component_id == SpatialConstants::ENTITY_ACL_COMPONENT_ID))
-	{
-		UE_LOG(LogSpatialLoadBalanceEnforcer, Warning,
-			TEXT("Load balancer notified of add component %d for entity %lld which is not a load balancing component"),
-			Op.data.component_id, Op.entity_id);
-		return;
-	}
+	// Should only be passed auth intent or ACL.
+	check(Op.data.component_id == SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID || Op.data.component_id == SpatialConstants::ENTITY_ACL_COMPONENT_ID);
 
 	MaybeQueueAclAssignmentRequest(Op.entity_id);
 }
 
 void SpatialLoadBalanceEnforcer::OnLoadBalancingComponentRemoved(const Worker_RemoveComponentOp& Op)
 {
-	if (!(Op.component_id == SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID || Op.component_id == SpatialConstants::ENTITY_ACL_COMPONENT_ID))
-	{
-		UE_LOG(LogSpatialLoadBalanceEnforcer, Warning,
-			TEXT("Load balancer notified of remove component %d for entity %lld which is not a load balancing component"),
-			Op.component_id, Op.entity_id);
-		return;
-	}
+	// Should only be passed auth intent or ACL.
+	check(Op.component_id == SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID || Op.component_id == SpatialConstants::ENTITY_ACL_COMPONENT_ID);
 
 	if (AclAssignmentRequestIsQueued(Op.entity_id))
 	{
 		UE_LOG(LogSpatialLoadBalanceEnforcer, Warning,
 			TEXT("Component %d for entity %lld removed. Can no longer enforce the previous request for this entity."),
 			Op.component_id, Op.entity_id);
-		return;
 	}
 }
 
@@ -64,19 +53,15 @@ void SpatialLoadBalanceEnforcer::OnEntityRemoved(const Worker_RemoveEntityOp& Op
 	{
 		UE_LOG(LogSpatialLoadBalanceEnforcer, Warning,
 			TEXT("Entity %lld removed. Can no longer enforce the previous request for this entity."), Op.entity_id);
-		return;
 	}
 }
 
 void SpatialLoadBalanceEnforcer::OnAclAuthorityChanged(const Worker_AuthorityChangeOp& AuthOp)
 {
-	if (AuthOp.component_id != SpatialConstants::ENTITY_ACL_COMPONENT_ID)
-	{
-		UE_LOG(LogSpatialLoadBalanceEnforcer, Warning, TEXT("Loadbalancer informed of authority change for entity %lld that was not related to the ACL component."), AuthOp.entity_id);
-		return;
-	}
+	// This class should only be informed of ACL authority changes.
+	check(AuthOp.component_id == SpatialConstants::ENTITY_ACL_COMPONENT_ID);
 
-	if (AclAssignmentRequestIsQueued(AuthOp.entity_id) && AuthOp.authority == WORKER_AUTHORITY_NOT_AUTHORITATIVE)
+	if (AclAssignmentRequestIsQueued(AuthOp.entity_id) && AuthOp.authority != WORKER_AUTHORITY_AUTHORITATIVE)
 	{
 		UE_LOG(LogSpatialLoadBalanceEnforcer, Warning,
 			TEXT("ACL authority lost for entity %lld. Can no longer enforce the previous request for this entity."),
@@ -94,17 +79,16 @@ void SpatialLoadBalanceEnforcer::OnAclAuthorityChanged(const Worker_AuthorityCha
 //    (this worker just became responsible, so check to make sure intent and ACL agree.)
 // 3) AuthorityIntent change - Intent is authoritative on this worker but no longer assigned to this worker - ACL is authoritative on this worker.
 //    (this worker had responsibility for both and is giving up authority.)
-// Queuing an ACL assignment request may not occur if the assignment is the same as before, or if the request is already queued.
+// Queuing an ACL assignment request may not occur if the assignment is the same as before, or if the request is already queued,
+// or if we don't meet the predicate required to enforce the assignment.
 void SpatialLoadBalanceEnforcer::MaybeQueueAclAssignmentRequest(const Worker_EntityId EntityId)
 {
-	const SpatialGDK::AuthorityIntent* AuthorityIntentComponent = StaticComponentView->GetComponentData<SpatialGDK::AuthorityIntent>(EntityId);
-	if (AuthorityIntentComponent == nullptr)
+	if (!CanEnforce(EntityId))
 	{
-		// We should have checked the existence of the auth intent component before calling this function.
-		checkNoEntry();
 		return;
 	}
 
+	const SpatialGDK::AuthorityIntent* AuthorityIntentComponent = StaticComponentView->GetComponentData<SpatialGDK::AuthorityIntent>(EntityId);
 	const PhysicalWorkerName* OwningWorkerId = VirtualWorkerTranslator->GetPhysicalWorkerForVirtualWorker(AuthorityIntentComponent->VirtualWorkerId);
 	if (OwningWorkerId != nullptr &&
 		*OwningWorkerId == WorkerId &&

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialLoadBalanceEnforcer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialLoadBalanceEnforcer.cpp
@@ -171,7 +171,7 @@ TArray<SpatialLoadBalanceEnforcer::AclWriteAuthorityRequest> SpatialLoadBalanceE
 		CompletedRequests.Add(EntityId);
 	}
 
-	AclWriteAuthAssignmentRequests.RemoveAll(CompletedRequests);
+	AclWriteAuthAssignmentRequests.RemoveAll([CompletedRequests](const Worker_EntityId& EntityId) { return CompletedRequests.Contains(EntityId); });
 
 	return PendingRequests;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialLoadBalanceEnforcer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialLoadBalanceEnforcer.cpp
@@ -22,62 +22,105 @@ SpatialLoadBalanceEnforcer::SpatialLoadBalanceEnforcer(const PhysicalWorkerName&
 void SpatialLoadBalanceEnforcer::OnAuthorityIntentComponentUpdated(const Worker_ComponentUpdateOp& Op)
 {
 	check(Op.update.component_id == SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID);
-	if (StaticComponentView->HasAuthority(Op.entity_id, SpatialConstants::ENTITY_ACL_COMPONENT_ID))
-	{
-		QueueAclAssignmentRequest(Op.entity_id);
-	}
+
+	MaybeQueueAclAssignmentRequest(Op.entity_id);
 }
 
-// This is called whenever this worker becomes authoritative for the ACL component on an entity.
-// It is now this worker's responsibility to make sure that the ACL reflects the current intent,
-// which may have been received before this call.
-void SpatialLoadBalanceEnforcer::AuthorityChanged(const Worker_AuthorityChangeOp& AuthOp)
+void SpatialLoadBalanceEnforcer::OnLoadBalancingComponentAdded(const Worker_AddComponentOp& Op)
 {
-	if (AuthOp.component_id == SpatialConstants::ENTITY_ACL_COMPONENT_ID &&
-		AuthOp.authority == WORKER_AUTHORITY_AUTHORITATIVE)
+	if (!(Op.data.component_id == SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID || Op.data.component_id == SpatialConstants::ENTITY_ACL_COMPONENT_ID))
 	{
-		const SpatialGDK::AuthorityIntent* AuthorityIntentComponent = StaticComponentView->GetComponentData<SpatialGDK::AuthorityIntent>(AuthOp.entity_id);
-		if (AuthorityIntentComponent == nullptr)
-		{
-			// TODO(zoning): There are still some entities being created without an authority intent component.
-			// For example, the Unreal created worker entities don't have one. Even though those won't be able to
-			// transition, we should have the intent component on them for completeness.
-		 	UE_LOG(LogSpatialLoadBalanceEnforcer, Log, TEXT("(%s) Requested authority change for entity without AuthorityIntent component. EntityId: %lld"), *WorkerId, AuthOp.entity_id);
-			return;
-		}
+		UE_LOG(LogSpatialLoadBalanceEnforcer, Warning,
+			TEXT("Load balancer notified of add component %d for entity %lld which is not a load balancing component"),
+			Op.data.component_id, Op.entity_id);
+		return;
+	}
 
-		const PhysicalWorkerName* OwningWorkerId = VirtualWorkerTranslator->GetPhysicalWorkerForVirtualWorker(AuthorityIntentComponent->VirtualWorkerId);
-		if (OwningWorkerId != nullptr &&
-			*OwningWorkerId == WorkerId &&
-			StaticComponentView->HasAuthority(AuthOp.entity_id, SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID))
-		{
-			UE_LOG(LogSpatialLoadBalanceEnforcer, Verbose, TEXT("No need to queue newly authoritative entity %lld because this worker is already authoritative."), AuthOp.entity_id);
-			return;
-		}
-		UE_LOG(LogSpatialLoadBalanceEnforcer, Verbose, TEXT("(%s) AuthorityChanged. EntityId: %lld"), *WorkerId, AuthOp.entity_id);
-		QueueAclAssignmentRequest(AuthOp.entity_id);
+	MaybeQueueAclAssignmentRequest(Op.entity_id);
+}
+
+void SpatialLoadBalanceEnforcer::OnLoadBalancingComponentRemoved(const Worker_RemoveComponentOp& Op)
+{
+	if (!(Op.component_id == SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID || Op.component_id == SpatialConstants::ENTITY_ACL_COMPONENT_ID))
+	{
+		UE_LOG(LogSpatialLoadBalanceEnforcer, Warning,
+			TEXT("Load balancer notified of remove component %d for entity %lld which is not a load balancing component"),
+			Op.component_id, Op.entity_id);
+		return;
+	}
+
+	if (AclAssignmentRequestIsQueued(Op.entity_id))
+	{
+		UE_LOG(LogSpatialLoadBalanceEnforcer, Warning,
+			TEXT("Component %d for entity %lld removed. Can no longer enforce the previous request for this entity."),
+			Op.component_id, Op.entity_id);
+		return;
 	}
 }
 
-// QueueAclAssignmentRequest is called from three places.
+void SpatialLoadBalanceEnforcer::OnEntityRemoved(const Worker_RemoveEntityOp& Op)
+{
+	if (AclAssignmentRequestIsQueued(Op.entity_id))
+	{
+		UE_LOG(LogSpatialLoadBalanceEnforcer, Warning,
+			TEXT("Entity %lld removed. Can no longer enforce the previous request for this entity."), Op.entity_id);
+		return;
+	}
+}
+
+void SpatialLoadBalanceEnforcer::OnAclAuthorityChanged(const Worker_AuthorityChangeOp& AuthOp)
+{
+	if (AuthOp.component_id != SpatialConstants::ENTITY_ACL_COMPONENT_ID)
+	{
+		UE_LOG(LogSpatialLoadBalanceEnforcer, Warning, TEXT("Loadbalancer informed of authority change for entity %lld that was not related to the ACL component."), AuthOp.entity_id);
+		return;
+	}
+
+	if (AclAssignmentRequestIsQueued(AuthOp.entity_id) && AuthOp.authority == WORKER_AUTHORITY_NOT_AUTHORITATIVE)
+	{
+		UE_LOG(LogSpatialLoadBalanceEnforcer, Warning,
+			TEXT("ACL authority lost for entity %lld. Can no longer enforce the previous request for this entity."),
+			AuthOp.entity_id);
+		return;
+	}
+
+	MaybeQueueAclAssignmentRequest(AuthOp.entity_id);
+}
+
+// MaybeQueueAclAssignmentRequest is called from three places.
 // 1) AuthorityIntent change - Intent is not authoritative on this worker - ACL is authoritative on this worker.
 //    (another worker changed the intent, but this worker is responsible for the ACL, so update it.)
 // 2) ACL change - Intent may be anything - ACL just became authoritative on this worker.
 //    (this worker just became responsible, so check to make sure intent and ACL agree.)
 // 3) AuthorityIntent change - Intent is authoritative on this worker but no longer assigned to this worker - ACL is authoritative on this worker.
 //    (this worker had responsibility for both and is giving up authority.)
-void SpatialLoadBalanceEnforcer::QueueAclAssignmentRequest(const Worker_EntityId EntityId)
+// Queuing an ACL assignment request may not occur if the assignment is the same as before, or if the request is already queued.
+void SpatialLoadBalanceEnforcer::MaybeQueueAclAssignmentRequest(const Worker_EntityId EntityId)
 {
-	// TODO(zoning): measure the performance impact of this.
-	if (AclWriteAuthAssignmentRequests.ContainsByPredicate([EntityId](const WriteAuthAssignmentRequest& Request) { return Request.EntityId == EntityId; }))
+	const SpatialGDK::AuthorityIntent* AuthorityIntentComponent = StaticComponentView->GetComponentData<SpatialGDK::AuthorityIntent>(EntityId);
+	if (AuthorityIntentComponent == nullptr)
+	{
+		// We should have checked the existence of the auth intent component before calling this function.
+		checkNoEntry();
+		return;
+	}
+
+	const PhysicalWorkerName* OwningWorkerId = VirtualWorkerTranslator->GetPhysicalWorkerForVirtualWorker(AuthorityIntentComponent->VirtualWorkerId);
+	if (OwningWorkerId != nullptr &&
+		*OwningWorkerId == WorkerId &&
+		StaticComponentView->HasAuthority(EntityId, SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID))
+	{
+		UE_LOG(LogSpatialLoadBalanceEnforcer, Verbose, TEXT("No need to queue newly authoritative entity %lld because this worker is already authoritative."), EntityId);
+		return;
+	}
+
+	if (AclAssignmentRequestIsQueued(EntityId))
 	{
 		UE_LOG(LogSpatialLoadBalanceEnforcer, Verbose, TEXT("An ACL assignment request already exists for entity %lld on worker %s."), EntityId, *WorkerId);
+		return;
 	}
-	else
-	{
-		UE_LOG(LogSpatialLoadBalanceEnforcer, Verbose, TEXT("Queueing ACL assignment request for entity %lld on worker %s."), EntityId, *WorkerId);
-		AclWriteAuthAssignmentRequests.Add(WriteAuthAssignmentRequest(EntityId));
-	}
+
+	QueueAclAssignmentRequest(EntityId);
 }
 
 TArray<SpatialLoadBalanceEnforcer::AclWriteAuthorityRequest> SpatialLoadBalanceEnforcer::ProcessQueuedAclAssignmentRequests()
@@ -92,8 +135,7 @@ TArray<SpatialLoadBalanceEnforcer::AclWriteAuthorityRequest> SpatialLoadBalanceE
 		const SpatialGDK::AuthorityIntent* AuthorityIntentComponent = StaticComponentView->GetComponentData<SpatialGDK::AuthorityIntent>(Request.EntityId);
 		if (AuthorityIntentComponent == nullptr)
 		{
-			// TODO(zoning): Not sure whether this should be possible or not. Remove if we don't see the warning again.
-			UE_LOG(LogSpatialLoadBalanceEnforcer, Warning, TEXT("(%s) Entity without AuthIntent component will not be processed. EntityId: %lld"), *WorkerId, Request.EntityId);
+			UE_LOG(LogSpatialLoadBalanceEnforcer, Warning, TEXT("Cannot process entity as AuthIntent component has been removed since the request was queued. EntityId: %lld"), Request.EntityId);
 			CompletedRequests.Add(Request.EntityId);
 			continue;
 		}
@@ -123,13 +165,29 @@ TArray<SpatialLoadBalanceEnforcer::AclWriteAuthorityRequest> SpatialLoadBalanceE
 
 		if (StaticComponentView->HasAuthority(Request.EntityId, SpatialConstants::ENTITY_ACL_COMPONENT_ID))
 		{
-			UE_LOG(LogSpatialLoadBalanceEnforcer, Verbose, TEXT("Wrote update to the EntityACL to match the authority intent."
-				" Source worker ID: %s. Entity ID %lld. Desination worker ID: %s."), *WorkerId, Request.EntityId, **DestinationWorkerId);
-			PendingRequests.Push(AclWriteAuthorityRequest{ Request.EntityId, *DestinationWorkerId });
+			EntityAcl* Acl = StaticComponentView->GetComponentData<EntityAcl>(Request.EntityId);
+			auto* HeartbeatSets = Acl->ComponentWriteAcl.Find(SpatialConstants::HEARTBEAT_COMPONENT_ID);
+			WorkerRequirementSet ClientRequirementSet;
+			if (HeartbeatSets != nullptr)
+			{
+				// Always exactly one requirement set. This is a list only for legacy reasons.
+				ClientRequirementSet = HeartbeatSets[0];
+			}
+			TArray<Worker_ComponentId> ComponentIds;
+			Acl->ComponentWriteAcl.GetKeys(ComponentIds);
+			PendingRequests.Push(
+				AclWriteAuthorityRequest{
+					Request.EntityId,
+					*DestinationWorkerId,
+					Acl->ReadAcl,
+					ClientRequirementSet,
+					ComponentIds
+				});
+		
 		}
 		else
 		{
-			UE_LOG(LogSpatialLoadBalanceEnforcer, Log, TEXT("Failed to update the EntityACL to match the authority intent; this worker does not have authority over the EntityACL."
+			UE_LOG(LogSpatialLoadBalanceEnforcer, Log, TEXT("Failed to update the EntityACL to match the authority intent; this worker does lost authority over the EntityACL since the request was queued."
 				" Source worker ID: %s. Entity ID %lld. Desination worker ID: %s."), *WorkerId, Request.EntityId, **DestinationWorkerId);
 		}
 		CompletedRequests.Add(Request.EntityId);
@@ -138,4 +196,23 @@ TArray<SpatialLoadBalanceEnforcer::AclWriteAuthorityRequest> SpatialLoadBalanceE
 	AclWriteAuthAssignmentRequests.RemoveAll([CompletedRequests](const WriteAuthAssignmentRequest& Request) { return CompletedRequests.Contains(Request.EntityId); });
 
 	return PendingRequests;
+}
+
+void SpatialLoadBalanceEnforcer::QueueAclAssignmentRequest(const Worker_EntityId EntityId)
+{
+	UE_LOG(LogSpatialLoadBalanceEnforcer, Verbose, TEXT("Queueing ACL assignment request for entity %lld on worker %s."), EntityId, *WorkerId);
+	AclWriteAuthAssignmentRequests.Add(WriteAuthAssignmentRequest(EntityId));
+}
+
+bool SpatialLoadBalanceEnforcer::AclAssignmentRequestIsQueued(const Worker_EntityId EntityId)
+{
+	return AclWriteAuthAssignmentRequests.ContainsByPredicate([EntityId](const WriteAuthAssignmentRequest& Request) { return Request.EntityId == EntityId; });
+}
+
+bool SpatialLoadBalanceEnforcer::CanEnforce(Worker_EntityId EntityId)
+{
+	EntityAcl* Acl = StaticComponentView->GetComponentData<EntityAcl>(EntityId);
+	AuthorityIntent* AuthIntent = StaticComponentView->GetComponentData<AuthorityIntent>(EntityId);
+	// We need to be able to see the ACL and auth intent components, and be able to write to the ACL component.
+	return Acl != nullptr && AuthIntent != nullptr && StaticComponentView->HasAuthority(EntityId, SpatialConstants::ENTITY_ACL_COMPONENT_ID);
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialLoadBalanceEnforcer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialLoadBalanceEnforcer.cpp
@@ -165,9 +165,9 @@ TArray<SpatialLoadBalanceEnforcer::AclWriteAuthorityRequest> SpatialLoadBalanceE
 		{
 			EntityAcl* Acl = StaticComponentView->GetComponentData<EntityAcl>(EntityId);
 			WorkerRequirementSet ClientRequirementSet;
-			if (WorkerRequirementSet* RpcRequirmentSet = Acl->ComponentWriteAcl.Find(SpatialConstants::GetClientAuthorityComponent(GetDefault<USpatialGDKSettings>()->UseRPCRingBuffer())))
+			if (WorkerRequirementSet* RpcRequirementSet = Acl->ComponentWriteAcl.Find(SpatialConstants::GetClientAuthorityComponent(GetDefault<USpatialGDKSettings>()->UseRPCRingBuffer())))
 			{
-				ClientRequirementSet = *RpcRequirmentSet;
+				ClientRequirementSet = *RpcRequirementSet;
 			}
 			TArray<Worker_ComponentId> ComponentIds;
 			Acl->ComponentWriteAcl.GetKeys(ComponentIds);

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialLoadBalanceEnforcer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialLoadBalanceEnforcer.cpp
@@ -123,6 +123,11 @@ void SpatialLoadBalanceEnforcer::MaybeQueueAclAssignmentRequest(const Worker_Ent
 	QueueAclAssignmentRequest(EntityId);
 }
 
+bool SpatialLoadBalanceEnforcer::AclAssignmentRequestIsQueued(const Worker_EntityId EntityId) const
+{
+	return AclWriteAuthAssignmentRequests.Contains(EntityId);
+}
+
 TArray<SpatialLoadBalanceEnforcer::AclWriteAuthorityRequest> SpatialLoadBalanceEnforcer::ProcessQueuedAclAssignmentRequests()
 {
 	TArray<SpatialLoadBalanceEnforcer::AclWriteAuthorityRequest> PendingRequests;
@@ -193,11 +198,6 @@ void SpatialLoadBalanceEnforcer::QueueAclAssignmentRequest(const Worker_EntityId
 {
 	UE_LOG(LogSpatialLoadBalanceEnforcer, Verbose, TEXT("Queueing ACL assignment request for entity %lld on worker %s."), EntityId, *WorkerId);
 	AclWriteAuthAssignmentRequests.Add(EntityId);
-}
-
-bool SpatialLoadBalanceEnforcer::AclAssignmentRequestIsQueued(const Worker_EntityId EntityId) const
-{
-	return AclWriteAuthAssignmentRequests.Contains(EntityId);
 }
 
 bool SpatialLoadBalanceEnforcer::CanEnforce(Worker_EntityId EntityId) const

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialLoadBalanceEnforcer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialLoadBalanceEnforcer.cpp
@@ -171,10 +171,7 @@ TArray<SpatialLoadBalanceEnforcer::AclWriteAuthorityRequest> SpatialLoadBalanceE
 		CompletedRequests.Add(EntityId);
 	}
 
-	for (Worker_EntityId& IdToRemove : CompletedRequests)
-	{
-		AclWriteAuthAssignmentRequests.Remove(IdToRemove);
-	}
+	AclWriteAuthAssignmentRequests.RemoveAll(CompletedRequests);
 
 	return PendingRequests;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialLoadBalanceEnforcer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialLoadBalanceEnforcer.cpp
@@ -140,8 +140,8 @@ TArray<SpatialLoadBalanceEnforcer::AclWriteAuthorityRequest> SpatialLoadBalanceE
 		const SpatialGDK::AuthorityIntent* AuthorityIntentComponent = StaticComponentView->GetComponentData<SpatialGDK::AuthorityIntent>(EntityId);
 		if (AuthorityIntentComponent == nullptr)
 		{
-			// This happens if the authority intent component is removed in the same tick as a request is queued.
-			UE_LOG(LogSpatialLoadBalanceEnforcer, Warning, TEXT("Cannot process entity as AuthIntent component has been removed since the request was queued. EntityId: %lld"), EntityId);
+			// This happens if the authority intent component is removed in the same tick as a request is queued, but the request was not removed from the queue- shouldn't happen.
+			UE_LOG(LogSpatialLoadBalanceEnforcer, Error, TEXT("Cannot process entity as AuthIntent component has been removed since the request was queued. EntityId: %lld"), EntityId);
 			CompletedRequests.Add(EntityId);
 			continue;
 		}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1584,9 +1584,9 @@ void USpatialNetDriver::TickDispatch(float DeltaTime)
 		if (LoadBalanceEnforcer.IsValid())
 		{
 			SCOPE_CYCLE_COUNTER(STAT_SpatialUpdateAuthority);
-			for(const auto& Elem : LoadBalanceEnforcer->ProcessQueuedAclAssignmentRequests())
+			for(const auto& AclAssignmentRequest : LoadBalanceEnforcer->ProcessQueuedAclAssignmentRequests())
 			{
-				Sender->SetAclWriteAuthority(Elem.EntityId, Elem.OwningWorkerId, Elem.ReadAcl, Elem.ClientRequirementSet, Elem.ComponentIds);
+				Sender->SetAclWriteAuthority(AclAssignmentRequest);
 			}
 		}
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1586,7 +1586,7 @@ void USpatialNetDriver::TickDispatch(float DeltaTime)
 			SCOPE_CYCLE_COUNTER(STAT_SpatialUpdateAuthority);
 			for(const auto& Elem : LoadBalanceEnforcer->ProcessQueuedAclAssignmentRequests())
 			{
-				Sender->SetAclWriteAuthority(Elem.EntityId, Elem.OwningWorkerId);
+				Sender->SetAclWriteAuthority(Elem.EntityId, Elem.OwningWorkerId, Elem.ReadAcl, Elem.ClientRequirementSet, Elem.ComponentIds);
 			}
 		}
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -157,7 +157,7 @@ bool USpatialPackageMapClient::ResolveEntityActor(AActor* Actor, Worker_EntityId
 
 	if (GetEntityIdFromObject(Actor) != EntityId)
 	{
-		UE_LOG(LogSpatialPackageMap, Error, TEXT("ResolveEntityActor failed for Actor: %s with NetGUID: %s and passed entity ID; %lld"), *Actor->GetName(), *NetGUID.ToString(), EntityId);
+		UE_LOG(LogSpatialPackageMap, Error, TEXT("ResolveEntityActor failed for Actor: %s with NetGUID: %s and passed entity ID: %lld"), *Actor->GetName(), *NetGUID.ToString(), EntityId);
 		return false;
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -155,7 +155,7 @@ bool USpatialPackageMapClient::ResolveEntityActor(AActor* Actor, Worker_EntityId
 		NetGUID = SpatialGuidCache->AssignNewEntityActorNetGUID(Actor, EntityId);
 	}
 
-	if (GetEntityIdFromObject(Actor) == SpatialConstants::INVALID_ENTITY_ID)
+	if (GetEntityIdFromObject(Actor) != EntityId)
 	{
 		UE_LOG(LogSpatialPackageMap, Error, TEXT("ResolveEntityActor failed for Actor: %s with NetGUID: %s and passed entity ID; %lld"), *Actor->GetName(), *NetGUID.ToString(), EntityId);
 		return false;

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -157,7 +157,7 @@ bool USpatialPackageMapClient::ResolveEntityActor(AActor* Actor, Worker_EntityId
 
 	if (GetEntityIdFromObject(Actor) == SpatialConstants::INVALID_ENTITY_ID)
 	{
-		UE_LOG(LogSpatialPackageMap, Error, TEXT("ResolveEntityActor failed for Actor: %s with NetGUID: %s"), *Actor->GetName(), *NetGUID.ToString());
+		UE_LOG(LogSpatialPackageMap, Error, TEXT("ResolveEntityActor failed for Actor: %s with NetGUID: %s and passed entity ID; %lld"), *Actor->GetName(), *NetGUID.ToString(), EntityId);
 		return false;
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -370,6 +370,8 @@ void USpatialReceiver::OnAuthorityChange(const Worker_AuthorityChangeOp& Op)
 		return;
 	}
 
+	// Update this worker's view of authority. We do this here as this is when the worker is first notified of the authority change.
+	// This way systems that depend on having non-stale state can function correctly.
 	StaticComponentView->OnAuthorityChange(Op);
 
 	if (Op.component_id == SpatialConstants::ENTITY_ACL_COMPONENT_ID && LoadBalanceEnforcer != nullptr)
@@ -379,6 +381,8 @@ void USpatialReceiver::OnAuthorityChange(const Worker_AuthorityChangeOp& Op)
 
 	if (bInCriticalSection)
 	{
+		// The actor receiving flow requires authority to be handled after all components have been received, so buffer those if we
+		// are in a critical section to be handled later.
 		PendingAuthorityChanges.Add(Op);
 		return;
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -253,6 +253,11 @@ void USpatialReceiver::OnRemoveEntity(const Worker_RemoveEntityOp& Op)
 
 void USpatialReceiver::OnRemoveComponent(const Worker_RemoveComponentOp& Op)
 {
+	if (Op.component_id == SpatialConstants::UNREAL_METADATA_COMPONENT_ID)
+	{
+		RemoveActor(Op.entity_id);
+	}
+
 	if (GetDefault<USpatialGDKSettings>()->UseRPCRingBuffer() && RPCService != nullptr && Op.component_id == SpatialConstants::MULTICAST_RPCS_COMPONENT_ID)
 	{
 		// If this is a multi-cast RPC component, the RPC service should be informed to handle it.
@@ -323,12 +328,7 @@ void USpatialReceiver::ProcessRemoveComponent(const Worker_RemoveComponentOp& Op
 		return;
 	}
 
-
-	if (Op.component_id == SpatialConstants::UNREAL_METADATA_COMPONENT_ID)
-	{
-		RemoveActor(Op.entity_id);
-	}
-	else if (AActor* Actor = Cast<AActor>(PackageMap->GetObjectFromEntityId(Op.entity_id).Get()))
+	if (AActor* Actor = Cast<AActor>(PackageMap->GetObjectFromEntityId(Op.entity_id).Get()))
 	{
 		FUnrealObjectRef ObjectRef(Op.entity_id, Op.component_id);
 		if (Op.component_id == SpatialConstants::DORMANT_COMPONENT_ID)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -663,18 +663,15 @@ bool USpatialReceiver::IsReceivedEntityTornOff(Worker_EntityId EntityId)
 void USpatialReceiver::ReceiveActor(Worker_EntityId EntityId)
 {
 	SCOPE_CYCLE_COUNTER(STAT_ReceiverReceiveActor);
-	
+
 	checkf(NetDriver, TEXT("We should have a NetDriver whilst processing ops."));
 	checkf(NetDriver->GetWorld(), TEXT("We should have a World whilst processing ops."));
 
 	SpawnData* SpawnDataComp = StaticComponentView->GetComponentData<SpawnData>(EntityId);
 	UnrealMetadata* UnrealMetadataComp = StaticComponentView->GetComponentData<UnrealMetadata>(EntityId);
 
-	if (UnrealMetadataComp == nullptr)
-	{
-		// Not an Unreal entity
-		return;
-	}
+	// This function should only ever be called if we have received an unreal metadata component.
+	check(UnrealMetadataComp != nullptr);
 
 	const USpatialGDKSettings* SpatialGDKSettings = GetDefault<USpatialGDKSettings>();
 
@@ -687,8 +684,7 @@ void USpatialReceiver::ReceiveActor(Worker_EntityId EntityId)
 		return;
 	}
 
-	AActor* EntityActor = Cast<AActor>(PackageMap->GetObjectFromEntityId(EntityId));
-	if (EntityActor != nullptr)
+	if (AActor* EntityActor = Cast<AActor>(PackageMap->GetObjectFromEntityId(EntityId)))
 	{
 		UE_LOG(LogSpatialReceiver, Verbose, TEXT("%s: Entity for actor %s has been checked out on the worker which spawned it or is a singleton linked on this worker. "
 			"Entity id: %lld"), *NetDriver->Connection->GetWorkerId(), *EntityActor->GetName(), EntityId);
@@ -706,162 +702,163 @@ void USpatialReceiver::ReceiveActor(Worker_EntityId EntityId)
 		}
 
 		// If we're a singleton, apply the data, regardless of authority - JIRA: 736
-		return;
 	}
-
-	UE_LOG(LogSpatialReceiver, Verbose, TEXT("%s: Entity has been checked out on the worker which didn't spawn it. "
-		"Entity id: %lld"), *NetDriver->Connection->GetWorkerId(), EntityId);
-
-	UClass* Class = UnrealMetadataComp->GetNativeEntityClass();
-	if (Class == nullptr)
+	else
 	{
-		UE_LOG(LogSpatialReceiver, Warning, TEXT("The received actor with entity id %lld couldn't be loaded. The actor (%s) will not be spawned."),
-			EntityId, *UnrealMetadataComp->ClassPath);
-		return;
-	}
+		UE_LOG(LogSpatialReceiver, Verbose, TEXT("%s: Entity has been checked out on the worker which didn't spawn it. "
+			"Entity id: %lld"), *NetDriver->Connection->GetWorkerId(), EntityId);
 
-	// Make sure ClassInfo exists
-	const FClassInfo& ActorClassInfo = ClassInfoManager->GetOrCreateClassInfoByClass(Class);
-
-	// If the received actor is torn off, don't bother spawning it.
-	// (This is only needed due to the delay between tearoff and deleting the entity. See https://improbableio.atlassian.net/browse/UNR-841)
-	if (IsReceivedEntityTornOff(EntityId))
-	{
-		UE_LOG(LogSpatialReceiver, Verbose, TEXT("The received actor with entity id %lld was already torn off. The actor will not be spawned."), EntityId);
-		return;
-	}
-
-	EntityActor = TryGetOrCreateActor(UnrealMetadataComp, SpawnDataComp);
-
-	if (EntityActor == nullptr)
-	{
-		// This could be nullptr if:
-		// a stably named actor could not be found
-		// the Actor is a singleton that has arrived over the wire before it has been created on this worker
-		// the class couldn't be loaded
-		return;
-	}
-
-	// RemoveActor immediately if we've received the tombstone component.
-	if (NetDriver->StaticComponentView->HasComponent(EntityId, SpatialConstants::TOMBSTONE_COMPONENT_ID))
-	{
-		UE_LOG(LogSpatialReceiver, Verbose, TEXT("The received actor with entity id %lld was tombstoned. The actor will not be spawned."), EntityId);
-		// We must first Resolve the EntityId to the Actor in order for RemoveActor to succeed.
-		PackageMap->ResolveEntityActor(EntityActor, EntityId);
-		RemoveActor(EntityId);
-		return;
-	}
-
-	UNetConnection* Connection = NetDriver->GetSpatialOSNetConnection();
-
-	if (NetDriver->IsServer())
-	{
-		if (APlayerController* PlayerController = Cast<APlayerController>(EntityActor))
+		UClass* Class = UnrealMetadataComp->GetNativeEntityClass();
+		if (Class == nullptr)
 		{
-			// If entity is a PlayerController, create channel on the PlayerController's connection.
-			Connection = PlayerController->NetConnection;
+			UE_LOG(LogSpatialReceiver, Warning, TEXT("The received actor with entity id %lld couldn't be loaded. The actor (%s) will not be spawned."),
+				EntityId, *UnrealMetadataComp->ClassPath);
+			return;
 		}
-	}
 
-	if (Connection == nullptr)
-	{
-		UE_LOG(LogSpatialReceiver, Error, TEXT("Unable to find SpatialOSNetConnection! Has this worker been disconnected from SpatialOS due to a timeout?"));
-		return;
-	}
+		// Make sure ClassInfo exists
+		const FClassInfo& ActorClassInfo = ClassInfoManager->GetOrCreateClassInfoByClass(Class);
 
-	// Set up actor channel.
-	USpatialActorChannel* Channel = Cast<USpatialActorChannel>(Connection->CreateChannelByName(NAME_Actor, NetDriver->IsServer() ? EChannelCreateFlags::OpenedLocally : EChannelCreateFlags::None));
+		// If the received actor is torn off, don't bother spawning it.
+		// (This is only needed due to the delay between tearoff and deleting the entity. See https://improbableio.atlassian.net/browse/UNR-841)
+		if (IsReceivedEntityTornOff(EntityId))
+		{
+			UE_LOG(LogSpatialReceiver, Verbose, TEXT("The received actor with entity id %lld was already torn off. The actor will not be spawned."), EntityId);
+			return;
+		}
 
-	if (!Channel)
-	{
-		UE_LOG(LogSpatialReceiver, Warning, TEXT("Failed to create an actor channel when receiving entity %lld. The actor will not be spawned."), EntityId);
-		EntityActor->Destroy(true);
-		return;
-	}
+		EntityActor = TryGetOrCreateActor(UnrealMetadataComp, SpawnDataComp);
 
-	if (!PackageMap->ResolveEntityActor(EntityActor, EntityId))
-	{
-		EntityActor->Destroy(true);
-		Channel->Close(EChannelCloseReason::Destroyed);
-		return;
-	}
+		if (EntityActor == nullptr)
+		{
+			// This could be nullptr if:
+			// a stably named actor could not be found
+			// the Actor is a singleton that has arrived over the wire before it has been created on this worker
+			// the class couldn't be loaded
+			return;
+		}
+
+		// RemoveActor immediately if we've received the tombstone component.
+		if (NetDriver->StaticComponentView->HasComponent(EntityId, SpatialConstants::TOMBSTONE_COMPONENT_ID))
+		{
+			UE_LOG(LogSpatialReceiver, Verbose, TEXT("The received actor with entity id %lld was tombstoned. The actor will not be spawned."), EntityId);
+			// We must first Resolve the EntityId to the Actor in order for RemoveActor to succeed.
+			PackageMap->ResolveEntityActor(EntityActor, EntityId);
+			RemoveActor(EntityId);
+			return;
+		}
+
+		UNetConnection* Connection = NetDriver->GetSpatialOSNetConnection();
+
+		if (NetDriver->IsServer())
+		{
+			if (APlayerController* PlayerController = Cast<APlayerController>(EntityActor))
+			{
+				// If entity is a PlayerController, create channel on the PlayerController's connection.
+				Connection = PlayerController->NetConnection;
+			}
+		}
+
+		if (Connection == nullptr)
+		{
+			UE_LOG(LogSpatialReceiver, Error, TEXT("Unable to find SpatialOSNetConnection! Has this worker been disconnected from SpatialOS due to a timeout?"));
+			return;
+		}
+
+		// Set up actor channel.
+		USpatialActorChannel* Channel = Cast<USpatialActorChannel>(Connection->CreateChannelByName(NAME_Actor, NetDriver->IsServer() ? EChannelCreateFlags::OpenedLocally : EChannelCreateFlags::None));
+
+		if (!Channel)
+		{
+			UE_LOG(LogSpatialReceiver, Warning, TEXT("Failed to create an actor channel when receiving entity %lld. The actor will not be spawned."), EntityId);
+			EntityActor->Destroy(true);
+			return;
+		}
+
+		if (!PackageMap->ResolveEntityActor(EntityActor, EntityId))
+		{
+			EntityActor->Destroy(true);
+			Channel->Close(EChannelCloseReason::Destroyed);
+			return;
+		}
 
 #if ENGINE_MINOR_VERSION <= 22
-	Channel->SetChannelActor(EntityActor);
+		Channel->SetChannelActor(EntityActor);
 #else
-	Channel->SetChannelActor(EntityActor, ESetChannelActorFlags::None);
+		Channel->SetChannelActor(EntityActor, ESetChannelActorFlags::None);
 #endif
 
-	TArray<ObjectPtrRefPair> ObjectsToResolvePendingOpsFor;
+		TArray<ObjectPtrRefPair> ObjectsToResolvePendingOpsFor;
 
-	// Apply initial replicated properties.
-	// This was moved to after FinishingSpawning because components existing only in blueprints aren't added until spawning is complete
-	// Potentially we could split out the initial actor state and the initial component state
-	for (PendingAddComponentWrapper& PendingAddComponent : PendingAddComponents)
-	{
-		if (ClassInfoManager->IsGeneratedQBIMarkerComponent(PendingAddComponent.ComponentId))
+		// Apply initial replicated properties.
+		// This was moved to after FinishingSpawning because components existing only in blueprints aren't added until spawning is complete
+		// Potentially we could split out the initial actor state and the initial component state
+		for (PendingAddComponentWrapper& PendingAddComponent : PendingAddComponents)
 		{
-			continue;
+			if (ClassInfoManager->IsGeneratedQBIMarkerComponent(PendingAddComponent.ComponentId))
+			{
+				continue;
+			}
+
+			if (PendingAddComponent.EntityId == EntityId)
+			{
+				ApplyComponentDataOnActorCreation(EntityId, *PendingAddComponent.Data->ComponentData, *Channel, ActorClassInfo, ObjectsToResolvePendingOpsFor);
+			}
 		}
 
-		if (PendingAddComponent.EntityId == EntityId)
+		// Resolve things like RepNotify or RPCs after applying component data.
+		for (const ObjectPtrRefPair& ObjectToResolve : ObjectsToResolvePendingOpsFor)
 		{
-			ApplyComponentDataOnActorCreation(EntityId, *PendingAddComponent.Data->ComponentData, *Channel, ActorClassInfo, ObjectsToResolvePendingOpsFor);
-		}
-	}
-
-	// Resolve things like RepNotify or RPCs after applying component data.
-	for (const ObjectPtrRefPair& ObjectToResolve : ObjectsToResolvePendingOpsFor)
-	{
-		ResolvePendingOperations(ObjectToResolve.Key, ObjectToResolve.Value);
-	}
-
-	if (!NetDriver->IsServer())
-	{
-		// Update interest on the entity's components after receiving initial component data (so Role and RemoteRole are properly set).
-		// Don't send dynamic interest for this actor if it is otherwise handled by result types.
-		if (!SpatialGDKSettings->bEnableResultTypes)
-		{
-			Sender->SendComponentInterestForActor(Channel, EntityId, Channel->IsAuthoritativeClient());
+			ResolvePendingOperations(ObjectToResolve.Key, ObjectToResolve.Value);
 		}
 
-		// This is a bit of a hack unfortunately, among the core classes only PlayerController implements this function and it requires
-		// a player index. For now we don't support split screen, so the number is always 0.
-		if (EntityActor->IsA(APlayerController::StaticClass()))
+		if (!NetDriver->IsServer())
 		{
-			uint8 PlayerIndex = 0;
-			// FInBunch takes size in bits not bytes
-			FInBunch Bunch(NetDriver->ServerConnection, &PlayerIndex, sizeof(PlayerIndex) * 8);
-			EntityActor->OnActorChannelOpen(Bunch, NetDriver->ServerConnection);
+			// Update interest on the entity's components after receiving initial component data (so Role and RemoteRole are properly set).
+			// Don't send dynamic interest for this actor if it is otherwise handled by result types.
+			if (!SpatialGDKSettings->bEnableResultTypes)
+			{
+				Sender->SendComponentInterestForActor(Channel, EntityId, Channel->IsAuthoritativeClient());
+			}
+
+			// This is a bit of a hack unfortunately, among the core classes only PlayerController implements this function and it requires
+			// a player index. For now we don't support split screen, so the number is always 0.
+			if (EntityActor->IsA(APlayerController::StaticClass()))
+			{
+				uint8 PlayerIndex = 0;
+				// FInBunch takes size in bits not bytes
+				FInBunch Bunch(NetDriver->ServerConnection, &PlayerIndex, sizeof(PlayerIndex) * 8);
+				EntityActor->OnActorChannelOpen(Bunch, NetDriver->ServerConnection);
+			}
+			else
+			{
+				FInBunch Bunch(NetDriver->ServerConnection);
+				EntityActor->OnActorChannelOpen(Bunch, NetDriver->ServerConnection);
+			}
+
 		}
-		else
+
+		// Taken from PostNetInit
+		if (NetDriver->GetWorld()->HasBegunPlay() && !EntityActor->HasActorBegunPlay())
 		{
-			FInBunch Bunch(NetDriver->ServerConnection);
-			EntityActor->OnActorChannelOpen(Bunch, NetDriver->ServerConnection);
+			// Whenever we receive an actor over the wire, the expectation is that it is not in an authoritative
+			// state.  This is because it should already have had authoritative BeginPlay() called.  If we have
+			// authority here, we are calling BeginPlay() with authority on this actor a 2nd time, which is always incorrect.
+			check(!EntityActor->HasAuthority());
+			EntityActor->DispatchBeginPlay();
 		}
 
-	}
+		if (EntityActor->GetClass()->HasAnySpatialClassFlags(SPATIALCLASS_Singleton))
+		{
+			GlobalStateManager->RegisterSingletonChannel(EntityActor, Channel);
+		}
 
-	// Taken from PostNetInit
-	if (NetDriver->GetWorld()->HasBegunPlay() && !EntityActor->HasActorBegunPlay())
-	{
-		// Whenever we receive an actor over the wire, the expectation is that it is not in an authoritative
-		// state.  This is because it should already have had authoritative BeginPlay() called.  If we have
-		// authority here, we are calling BeginPlay() with authority on this actor a 2nd time, which is always incorrect.
-		check(!EntityActor->HasAuthority());
-		EntityActor->DispatchBeginPlay();
-	}
+		EntityActor->UpdateOverlaps();
 
-	if (EntityActor->GetClass()->HasAnySpatialClassFlags(SPATIALCLASS_Singleton))
-	{
-		GlobalStateManager->RegisterSingletonChannel(EntityActor, Channel);
-	}
-
-	EntityActor->UpdateOverlaps();
-
-	if (StaticComponentView->HasComponent(EntityId, SpatialConstants::DORMANT_COMPONENT_ID))
-	{
-		NetDriver->AddPendingDormantChannel(Channel);
+		if (StaticComponentView->HasComponent(EntityId, SpatialConstants::DORMANT_COMPONENT_ID))
+		{
+			NetDriver->AddPendingDormantChannel(Channel);
+		}
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -236,12 +236,6 @@ void USpatialReceiver::OnAddComponent(const Worker_AddComponentOp& Op)
 void USpatialReceiver::OnRemoveEntity(const Worker_RemoveEntityOp& Op)
 {
 	SCOPE_CYCLE_COUNTER(STAT_ReceiverRemoveEntity);
-	if (IsEntityWaitingForAsyncLoad(Op.entity_id))
-	{
-		// Pretend we never saw this entity.
-		EntitiesWaitingForAsyncLoad.Remove(Op.entity_id);
-		return;
-	}
 
 	if (LoadBalanceEnforcer != nullptr)
 	{
@@ -255,7 +249,15 @@ void USpatialReceiver::OnRemoveComponent(const Worker_RemoveComponentOp& Op)
 {
 	if (Op.component_id == SpatialConstants::UNREAL_METADATA_COMPONENT_ID)
 	{
-		RemoveActor(Op.entity_id);
+		if (IsEntityWaitingForAsyncLoad(Op.entity_id))
+		{
+			// Pretend we never saw this actor.
+			EntitiesWaitingForAsyncLoad.Remove(Op.entity_id);
+		}
+		else
+		{
+			RemoveActor(Op.entity_id);
+		}
 	}
 
 	if (GetDefault<USpatialGDKSettings>()->UseRPCRingBuffer() && RPCService != nullptr && Op.component_id == SpatialConstants::MULTICAST_RPCS_COMPONENT_ID)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -19,6 +19,7 @@
 #include "Interop/GlobalStateManager.h"
 #include "Interop/SpatialPlayerSpawner.h"
 #include "Interop/SpatialSender.h"
+#include "Schema/AuthorityIntent.h"
 #include "Schema/DynamicComponent.h"
 #include "Schema/RPCPayload.h"
 #include "Schema/SpawnData.h"
@@ -36,7 +37,6 @@ DEFINE_LOG_CATEGORY(LogSpatialReceiver);
 DECLARE_CYCLE_STAT(TEXT("PendingOpsOnChannel"), STAT_SpatialPendingOpsOnChannel, STATGROUP_SpatialNet);
 
 DECLARE_CYCLE_STAT(TEXT("Receiver LeaveCritSection"), STAT_ReceiverLeaveCritSection, STATGROUP_SpatialNet);
-DECLARE_CYCLE_STAT(TEXT("Receiver AddEntity"), STAT_ReceiverAddEntity, STATGROUP_SpatialNet);
 DECLARE_CYCLE_STAT(TEXT("Receiver RemoveEntity"), STAT_ReceiverRemoveEntity, STATGROUP_SpatialNet);
 DECLARE_CYCLE_STAT(TEXT("Receiver AddComponent"), STAT_ReceiverAddComponent, STATGROUP_SpatialNet);
 DECLARE_CYCLE_STAT(TEXT("Receiver ComponentUpdate"), STAT_ReceiverComponentUpdate, STATGROUP_SpatialNet);
@@ -98,7 +98,7 @@ void USpatialReceiver::LeaveCriticalSection()
 	UE_LOG(LogSpatialReceiver, Verbose, TEXT("Leaving critical section."));
 	check(bInCriticalSection);
 
-	for (Worker_EntityId& PendingAddEntity : PendingAddEntities)
+	for (Worker_EntityId& PendingAddEntity : PendingAddActors)
 	{
 		ReceiveActor(PendingAddEntity);
 		if (!IsEntityWaitingForAsyncLoad(PendingAddEntity))
@@ -114,19 +114,14 @@ void USpatialReceiver::LeaveCriticalSection()
 
 	// Mark that we've left the critical section.
 	bInCriticalSection = false;
-	PendingAddEntities.Empty();
+	PendingAddActors.Empty();
 	PendingAddComponents.Empty();
 	PendingAuthorityChanges.Empty();
 }
 
 void USpatialReceiver::OnAddEntity(const Worker_AddEntityOp& Op)
 {
-	SCOPE_CYCLE_COUNTER(STAT_ReceiverAddEntity);
 	UE_LOG(LogSpatialReceiver, Verbose, TEXT("AddEntity: %lld"), Op.entity_id);
-
-	check(bInCriticalSection);
-
-	PendingAddEntities.Emplace(Op.entity_id);
 }
 
 void USpatialReceiver::OnAddComponent(const Worker_AddComponentOp& Op)
@@ -143,14 +138,12 @@ void USpatialReceiver::OnAddComponent(const Worker_AddComponentOp& Op)
 
 	switch (Op.data.component_id)
 	{
-	case SpatialConstants::ENTITY_ACL_COMPONENT_ID:
 	case SpatialConstants::METADATA_COMPONENT_ID:
 	case SpatialConstants::POSITION_COMPONENT_ID:
 	case SpatialConstants::PERSISTENCE_COMPONENT_ID:
 	case SpatialConstants::SPAWN_DATA_COMPONENT_ID:
 	case SpatialConstants::PLAYER_SPAWNER_COMPONENT_ID:
 	case SpatialConstants::SINGLETON_COMPONENT_ID:
-	case SpatialConstants::UNREAL_METADATA_COMPONENT_ID:
 	case SpatialConstants::INTEREST_COMPONENT_ID:
 	case SpatialConstants::NOT_STREAMED_COMPONENT_ID:
 	case SpatialConstants::GSM_SHUTDOWN_COMPONENT_ID:
@@ -162,11 +155,23 @@ void USpatialReceiver::OnAddComponent(const Worker_AddComponentOp& Op)
 	case SpatialConstants::CLIENT_RPC_ENDPOINT_COMPONENT_ID_LEGACY:
 	case SpatialConstants::SERVER_RPC_ENDPOINT_COMPONENT_ID_LEGACY:
 	case SpatialConstants::SERVER_TO_SERVER_COMMAND_ENDPOINT_COMPONENT_ID:
-	case SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID:
 	case SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID:
 	case SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID:
 	case SpatialConstants::SPATIAL_DEBUGGING_COMPONENT_ID:
 		// Ignore static spatial components as they are managed by the SpatialStaticComponentView.
+		return;
+	case SpatialConstants::UNREAL_METADATA_COMPONENT_ID:
+		// The unreal metadata component is used to indicate when an actor needs to be created from the entity.
+		// This means we need to be inside a critical section, otherwise we may not have all the requisite information at the point of creating the actor.
+		check(bInCriticalSection);
+		PendingAddActors.Emplace(Op.entity_id);
+		return;
+	case SpatialConstants::ENTITY_ACL_COMPONENT_ID:
+	case SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID:
+		if (LoadBalanceEnforcer != nullptr)
+		{
+			LoadBalanceEnforcer->OnLoadBalancingComponentAdded(Op);
+		}
 		return;
 	case SpatialConstants::MULTICAST_RPCS_COMPONENT_ID:
 		// The RPC service needs to be informed when a multi-cast RPC component is added.
@@ -238,6 +243,11 @@ void USpatialReceiver::OnRemoveEntity(const Worker_RemoveEntityOp& Op)
 		return;
 	}
 
+	if (LoadBalanceEnforcer != nullptr)
+	{
+		LoadBalanceEnforcer->OnEntityRemoved(Op);
+	}
+
 	RemoveActor(Op.entity_id);
 	OnEntityRemovedDelegate.Broadcast(Op.entity_id);
 }
@@ -248,6 +258,11 @@ void USpatialReceiver::OnRemoveComponent(const Worker_RemoveComponentOp& Op)
 	{
 		// If this is a multi-cast RPC component, the RPC service should be informed to handle it.
 		RPCService->OnRemoveMulticastRPCComponentForEntity(Op.entity_id);
+	}
+
+	if ((Op.component_id == SpatialConstants::ENTITY_ACL_COMPONENT_ID || Op.component_id == SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID) && LoadBalanceEnforcer != nullptr)
+	{
+		LoadBalanceEnforcer->OnLoadBalancingComponentRemoved(Op);
 	}
 
 	// We are queuing here because if an Actor is removed from your view, remove component ops will be
@@ -309,7 +324,12 @@ void USpatialReceiver::ProcessRemoveComponent(const Worker_RemoveComponentOp& Op
 		return;
 	}
 
-	if (AActor* Actor = Cast<AActor>(PackageMap->GetObjectFromEntityId(Op.entity_id).Get()))
+
+	if (Op.component_id == SpatialConstants::UNREAL_METADATA_COMPONENT_ID)
+	{
+		RemoveActor(Op.entity_id);
+	}
+	else if (AActor* Actor = Cast<AActor>(PackageMap->GetObjectFromEntityId(Op.entity_id).Get()))
 	{
 		FUnrealObjectRef ObjectRef(Op.entity_id, Op.component_id);
 		if (Op.component_id == SpatialConstants::DORMANT_COMPONENT_ID)
@@ -348,6 +368,13 @@ void USpatialReceiver::OnAuthorityChange(const Worker_AuthorityChangeOp& Op)
 	{
 		QueueAuthorityOpForAsyncLoad(Op);
 		return;
+	}
+
+	StaticComponentView->OnAuthorityChange(Op);
+
+	if (Op.component_id == SpatialConstants::ENTITY_ACL_COMPONENT_ID && LoadBalanceEnforcer != nullptr)
+	{
+		LoadBalanceEnforcer->OnAclAuthorityChanged(Op);
 	}
 
 	if (bInCriticalSection)
@@ -395,8 +422,6 @@ void USpatialReceiver::HandlePlayerLifecycleAuthority(const Worker_AuthorityChan
 
 void USpatialReceiver::HandleActorAuthority(const Worker_AuthorityChangeOp& Op)
 {
-	StaticComponentView->OnAuthorityChange(Op);
-
 	if (GlobalStateManager->HandlesComponent(Op.component_id))
 	{
 		GlobalStateManager->AuthorityChanged(Op);
@@ -411,11 +436,6 @@ void USpatialReceiver::HandleActorAuthority(const Worker_AuthorityChangeOp& Op)
 		NetDriver->VirtualWorkerTranslationManager->AuthorityChanged(Op);
 	}
 
-	if (LoadBalanceEnforcer != nullptr)
-	{
-		LoadBalanceEnforcer->AuthorityChanged(Op);
-	}
-
 	if (NetDriver->SpatialDebugger != nullptr)
 	{
 		NetDriver->SpatialDebugger->ActorAuthorityChanged(Op);
@@ -425,6 +445,15 @@ void USpatialReceiver::HandleActorAuthority(const Worker_AuthorityChangeOp& Op)
 	if (Actor == nullptr)
 	{
 		return;
+	}
+
+	if (Op.component_id == SpatialConstants::POSITION_COMPONENT_ID)
+	{
+		NetDriver->GetActorChannelByEntityId(Op.entity_id)->OnServerAuthorityChange(Op);
+	}
+	else if (Op.component_id == SpatialConstants::GetClientAuthorityComponent(GetDefault<USpatialGDKSettings>()->UseRPCRingBuffer()))
+	{
+		NetDriver->GetActorChannelByEntityId(Op.entity_id)->OnClientAuthorityChange(Op);
 	}
 
 	if (Op.component_id == SpatialConstants::CLIENT_RPC_ENDPOINT_COMPONENT_ID_LEGACY
@@ -658,7 +687,8 @@ void USpatialReceiver::ReceiveActor(Worker_EntityId EntityId)
 		return;
 	}
 
-	if (AActor* EntityActor = Cast<AActor>(PackageMap->GetObjectFromEntityId(EntityId)))
+	AActor* EntityActor = Cast<AActor>(PackageMap->GetObjectFromEntityId(EntityId));
+	if (EntityActor != nullptr)
 	{
 		UE_LOG(LogSpatialReceiver, Verbose, TEXT("%s: Entity for actor %s has been checked out on the worker which spawned it or is a singleton linked on this worker. "
 			"Entity id: %lld"), *NetDriver->Connection->GetWorkerId(), *EntityActor->GetName(), EntityId);
@@ -676,163 +706,162 @@ void USpatialReceiver::ReceiveActor(Worker_EntityId EntityId)
 		}
 
 		// If we're a singleton, apply the data, regardless of authority - JIRA: 736
+		return;
 	}
-	else
+
+	UE_LOG(LogSpatialReceiver, Verbose, TEXT("%s: Entity has been checked out on the worker which didn't spawn it. "
+		"Entity id: %lld"), *NetDriver->Connection->GetWorkerId(), EntityId);
+
+	UClass* Class = UnrealMetadataComp->GetNativeEntityClass();
+	if (Class == nullptr)
 	{
-		UE_LOG(LogSpatialReceiver, Verbose, TEXT("%s: Entity has been checked out on the worker which didn't spawn it. "
-			"Entity id: %lld"), *NetDriver->Connection->GetWorkerId(), EntityId);
+		UE_LOG(LogSpatialReceiver, Warning, TEXT("The received actor with entity id %lld couldn't be loaded. The actor (%s) will not be spawned."),
+			EntityId, *UnrealMetadataComp->ClassPath);
+		return;
+	}
 
-		UClass* Class = UnrealMetadataComp->GetNativeEntityClass();
-		if (Class == nullptr)
+	// Make sure ClassInfo exists
+	const FClassInfo& ActorClassInfo = ClassInfoManager->GetOrCreateClassInfoByClass(Class);
+
+	// If the received actor is torn off, don't bother spawning it.
+	// (This is only needed due to the delay between tearoff and deleting the entity. See https://improbableio.atlassian.net/browse/UNR-841)
+	if (IsReceivedEntityTornOff(EntityId))
+	{
+		UE_LOG(LogSpatialReceiver, Verbose, TEXT("The received actor with entity id %lld was already torn off. The actor will not be spawned."), EntityId);
+		return;
+	}
+
+	EntityActor = TryGetOrCreateActor(UnrealMetadataComp, SpawnDataComp);
+
+	if (EntityActor == nullptr)
+	{
+		// This could be nullptr if:
+		// a stably named actor could not be found
+		// the Actor is a singleton that has arrived over the wire before it has been created on this worker
+		// the class couldn't be loaded
+		return;
+	}
+
+	// RemoveActor immediately if we've received the tombstone component.
+	if (NetDriver->StaticComponentView->HasComponent(EntityId, SpatialConstants::TOMBSTONE_COMPONENT_ID))
+	{
+		UE_LOG(LogSpatialReceiver, Verbose, TEXT("The received actor with entity id %lld was tombstoned. The actor will not be spawned."), EntityId);
+		// We must first Resolve the EntityId to the Actor in order for RemoveActor to succeed.
+		PackageMap->ResolveEntityActor(EntityActor, EntityId);
+		RemoveActor(EntityId);
+		return;
+	}
+
+	UNetConnection* Connection = NetDriver->GetSpatialOSNetConnection();
+
+	if (NetDriver->IsServer())
+	{
+		if (APlayerController* PlayerController = Cast<APlayerController>(EntityActor))
 		{
-			UE_LOG(LogSpatialReceiver, Warning, TEXT("The received actor with entity id %lld couldn't be loaded. The actor (%s) will not be spawned."),
-				EntityId, *UnrealMetadataComp->ClassPath);
-			return;
+			// If entity is a PlayerController, create channel on the PlayerController's connection.
+			Connection = PlayerController->NetConnection;
 		}
+	}
 
-		// Make sure ClassInfo exists
-		const FClassInfo& ActorClassInfo = ClassInfoManager->GetOrCreateClassInfoByClass(Class);
+	if (Connection == nullptr)
+	{
+		UE_LOG(LogSpatialReceiver, Error, TEXT("Unable to find SpatialOSNetConnection! Has this worker been disconnected from SpatialOS due to a timeout?"));
+		return;
+	}
 
-		// If the received actor is torn off, don't bother spawning it.
-		// (This is only needed due to the delay between tearoff and deleting the entity. See https://improbableio.atlassian.net/browse/UNR-841)
-		if (IsReceivedEntityTornOff(EntityId))
-		{
-			UE_LOG(LogSpatialReceiver, Verbose, TEXT("The received actor with entity id %lld was already torn off. The actor will not be spawned."), EntityId);
-			return;
-		}
+	// Set up actor channel.
+	USpatialActorChannel* Channel = Cast<USpatialActorChannel>(Connection->CreateChannelByName(NAME_Actor, NetDriver->IsServer() ? EChannelCreateFlags::OpenedLocally : EChannelCreateFlags::None));
 
-		EntityActor = TryGetOrCreateActor(UnrealMetadataComp, SpawnDataComp);
+	if (!Channel)
+	{
+		UE_LOG(LogSpatialReceiver, Warning, TEXT("Failed to create an actor channel when receiving entity %lld. The actor will not be spawned."), EntityId);
+		EntityActor->Destroy(true);
+		return;
+	}
 
-		if (EntityActor == nullptr)
-		{
-			// This could be nullptr if:
-			// a stably named actor could not be found
-			// the Actor is a singleton that has arrived over the wire before it has been created on this worker
-			// the class couldn't be loaded
-			return;
-		}
-
-		// RemoveActor immediately if we've received the tombstone component.
-		if (NetDriver->StaticComponentView->HasComponent(EntityId, SpatialConstants::TOMBSTONE_COMPONENT_ID))
-		{
-			UE_LOG(LogSpatialReceiver, Verbose, TEXT("The received actor with entity id %lld was tombstoned. The actor will not be spawned."), EntityId);
-			// We must first Resolve the EntityId to the Actor in order for RemoveActor to succeed.
-			PackageMap->ResolveEntityActor(EntityActor, EntityId);
-			RemoveActor(EntityId);
-			return;
-		}
-
-		UNetConnection* Connection = NetDriver->GetSpatialOSNetConnection();
-
-		if (NetDriver->IsServer())
-		{
-			if (APlayerController* PlayerController = Cast<APlayerController>(EntityActor))
-			{
-				// If entity is a PlayerController, create channel on the PlayerController's connection.
-				Connection = PlayerController->NetConnection;
-			}
-		}
-
-		if (Connection == nullptr)
-		{
-			UE_LOG(LogSpatialReceiver, Error, TEXT("Unable to find SpatialOSNetConnection! Has this worker been disconnected from SpatialOS due to a timeout?"));
-			return;
-		}
-
-		// Set up actor channel.
-		USpatialActorChannel* Channel = Cast<USpatialActorChannel>(Connection->CreateChannelByName(NAME_Actor, NetDriver->IsServer() ? EChannelCreateFlags::OpenedLocally : EChannelCreateFlags::None));
-
-		if (!Channel)
-		{
-			UE_LOG(LogSpatialReceiver, Warning, TEXT("Failed to create an actor channel when receiving entity %lld. The actor will not be spawned."), EntityId);
-			EntityActor->Destroy(true);
-			return;
-		}
-
-		if (!PackageMap->ResolveEntityActor(EntityActor, EntityId))
-		{
-			EntityActor->Destroy(true);
-			Channel->Close(EChannelCloseReason::Destroyed);
-			return;
-		}
+	if (!PackageMap->ResolveEntityActor(EntityActor, EntityId))
+	{
+		EntityActor->Destroy(true);
+		Channel->Close(EChannelCloseReason::Destroyed);
+		return;
+	}
 
 #if ENGINE_MINOR_VERSION <= 22
-		Channel->SetChannelActor(EntityActor);
+	Channel->SetChannelActor(EntityActor);
 #else
-		Channel->SetChannelActor(EntityActor, ESetChannelActorFlags::None);
+	Channel->SetChannelActor(EntityActor, ESetChannelActorFlags::None);
 #endif
 
-		TArray<ObjectPtrRefPair> ObjectsToResolvePendingOpsFor;
+	TArray<ObjectPtrRefPair> ObjectsToResolvePendingOpsFor;
 
-		// Apply initial replicated properties.
-		// This was moved to after FinishingSpawning because components existing only in blueprints aren't added until spawning is complete
-		// Potentially we could split out the initial actor state and the initial component state
-		for (PendingAddComponentWrapper& PendingAddComponent : PendingAddComponents)
+	// Apply initial replicated properties.
+	// This was moved to after FinishingSpawning because components existing only in blueprints aren't added until spawning is complete
+	// Potentially we could split out the initial actor state and the initial component state
+	for (PendingAddComponentWrapper& PendingAddComponent : PendingAddComponents)
+	{
+		if (ClassInfoManager->IsGeneratedQBIMarkerComponent(PendingAddComponent.ComponentId))
 		{
-			if (ClassInfoManager->IsGeneratedQBIMarkerComponent(PendingAddComponent.ComponentId))
-			{
-				continue;
-			}
-
-			if (PendingAddComponent.EntityId == EntityId)
-			{
-				ApplyComponentDataOnActorCreation(EntityId, *PendingAddComponent.Data->ComponentData, *Channel, ActorClassInfo, ObjectsToResolvePendingOpsFor);
-			}
+			continue;
 		}
 
-		// Resolve things like RepNotify or RPCs after applying component data.
-		for (const ObjectPtrRefPair& ObjectToResolve : ObjectsToResolvePendingOpsFor)
+		if (PendingAddComponent.EntityId == EntityId)
 		{
-			ResolvePendingOperations(ObjectToResolve.Key, ObjectToResolve.Value);
+			ApplyComponentDataOnActorCreation(EntityId, *PendingAddComponent.Data->ComponentData, *Channel, ActorClassInfo, ObjectsToResolvePendingOpsFor);
+		}
+	}
+
+	// Resolve things like RepNotify or RPCs after applying component data.
+	for (const ObjectPtrRefPair& ObjectToResolve : ObjectsToResolvePendingOpsFor)
+	{
+		ResolvePendingOperations(ObjectToResolve.Key, ObjectToResolve.Value);
+	}
+
+	if (!NetDriver->IsServer())
+	{
+		// Update interest on the entity's components after receiving initial component data (so Role and RemoteRole are properly set).
+		// Don't send dynamic interest for this actor if it is otherwise handled by result types.
+		if (!SpatialGDKSettings->bEnableResultTypes)
+		{
+			Sender->SendComponentInterestForActor(Channel, EntityId, Channel->IsAuthoritativeClient());
 		}
 
-		if (!NetDriver->IsServer())
+		// This is a bit of a hack unfortunately, among the core classes only PlayerController implements this function and it requires
+		// a player index. For now we don't support split screen, so the number is always 0.
+		if (EntityActor->IsA(APlayerController::StaticClass()))
 		{
-			// Update interest on the entity's components after receiving initial component data (so Role and RemoteRole are properly set).
-			// Don't send dynamic interest for this actor if it is otherwise handled by result types.
-			if (!SpatialGDKSettings->bEnableResultTypes)
-			{
-				Sender->SendComponentInterestForActor(Channel, EntityId, Channel->IsAuthoritativeClient());
-			}
-
-			// This is a bit of a hack unfortunately, among the core classes only PlayerController implements this function and it requires
-			// a player index. For now we don't support split screen, so the number is always 0.
-			if (EntityActor->IsA(APlayerController::StaticClass()))
-			{
-				uint8 PlayerIndex = 0;
-				// FInBunch takes size in bits not bytes
-				FInBunch Bunch(NetDriver->ServerConnection, &PlayerIndex, sizeof(PlayerIndex) * 8);
-				EntityActor->OnActorChannelOpen(Bunch, NetDriver->ServerConnection);
-			}
-			else
-			{
-				FInBunch Bunch(NetDriver->ServerConnection);
-				EntityActor->OnActorChannelOpen(Bunch, NetDriver->ServerConnection);
-			}
-
+			uint8 PlayerIndex = 0;
+			// FInBunch takes size in bits not bytes
+			FInBunch Bunch(NetDriver->ServerConnection, &PlayerIndex, sizeof(PlayerIndex) * 8);
+			EntityActor->OnActorChannelOpen(Bunch, NetDriver->ServerConnection);
+		}
+		else
+		{
+			FInBunch Bunch(NetDriver->ServerConnection);
+			EntityActor->OnActorChannelOpen(Bunch, NetDriver->ServerConnection);
 		}
 
-		// Taken from PostNetInit
-		if (NetDriver->GetWorld()->HasBegunPlay() && !EntityActor->HasActorBegunPlay())
-		{
-			// Whenever we receive an actor over the wire, the expectation is that it is not in an authoritative
-			// state.  This is because it should already have had authoritative BeginPlay() called.  If we have
-			// authority here, we are calling BeginPlay() with authority on this actor a 2nd time, which is always incorrect.
-			check(!EntityActor->HasAuthority());
-			EntityActor->DispatchBeginPlay();
-		}
+	}
 
-		if (EntityActor->GetClass()->HasAnySpatialClassFlags(SPATIALCLASS_Singleton))
-		{
-			GlobalStateManager->RegisterSingletonChannel(EntityActor, Channel);
-		}
+	// Taken from PostNetInit
+	if (NetDriver->GetWorld()->HasBegunPlay() && !EntityActor->HasActorBegunPlay())
+	{
+		// Whenever we receive an actor over the wire, the expectation is that it is not in an authoritative
+		// state.  This is because it should already have had authoritative BeginPlay() called.  If we have
+		// authority here, we are calling BeginPlay() with authority on this actor a 2nd time, which is always incorrect.
+		check(!EntityActor->HasAuthority());
+		EntityActor->DispatchBeginPlay();
+	}
 
-		EntityActor->UpdateOverlaps();
+	if (EntityActor->GetClass()->HasAnySpatialClassFlags(SPATIALCLASS_Singleton))
+	{
+		GlobalStateManager->RegisterSingletonChannel(EntityActor, Channel);
+	}
 
-		if (StaticComponentView->HasComponent(EntityId, SpatialConstants::DORMANT_COMPONENT_ID))
-		{
-			NetDriver->AddPendingDormantChannel(Channel);
-		}
+	EntityActor->UpdateOverlaps();
+
+	if (StaticComponentView->HasComponent(EntityId, SpatialConstants::DORMANT_COMPONENT_ID))
+	{
+		NetDriver->AddPendingDormantChannel(Channel);
 	}
 }
 
@@ -2408,7 +2437,7 @@ void USpatialReceiver::OnAsyncPackageLoaded(const FName& PackageName, UPackage* 
 			CriticalSectionSaveState CriticalSectionState(*this);
 
 			EntityWaitingForAsyncLoad AsyncLoadEntity = EntitiesWaitingForAsyncLoad.FindAndRemoveChecked(Entity);
-			PendingAddEntities.Add(Entity);
+			PendingAddActors.Add(Entity);
 			PendingAddComponents = MoveTemp(AsyncLoadEntity.InitialPendingAddComponents);
 			LeaveCriticalSection();
 
@@ -2558,10 +2587,10 @@ USpatialReceiver::CriticalSectionSaveState::CriticalSectionSaveState(USpatialRec
 {
 	if (bInCriticalSection)
 	{
-		PendingAddEntities = MoveTemp(Receiver.PendingAddEntities);
+		PendingAddActors = MoveTemp(Receiver.PendingAddActors);
 		PendingAuthorityChanges = MoveTemp(Receiver.PendingAuthorityChanges);
 		PendingAddComponents = MoveTemp(Receiver.PendingAddComponents);
-		Receiver.PendingAddEntities.Empty();
+		Receiver.PendingAddActors.Empty();
 		Receiver.PendingAuthorityChanges.Empty();
 		Receiver.PendingAddComponents.Empty();
 	}
@@ -2572,7 +2601,7 @@ USpatialReceiver::CriticalSectionSaveState::~CriticalSectionSaveState()
 {
 	if (bInCriticalSection)
 	{
-		Receiver.PendingAddEntities = MoveTemp(PendingAddEntities);
+		Receiver.PendingAddActors = MoveTemp(PendingAddActors);
 		Receiver.PendingAuthorityChanges = MoveTemp(PendingAuthorityChanges);
 		Receiver.PendingAddComponents = MoveTemp(PendingAddComponents);
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -248,7 +248,6 @@ void USpatialReceiver::OnRemoveEntity(const Worker_RemoveEntityOp& Op)
 		LoadBalanceEnforcer->OnEntityRemoved(Op);
 	}
 
-	RemoveActor(Op.entity_id);
 	OnEntityRemovedDelegate.Broadcast(Op.entity_id);
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -587,8 +587,6 @@ void USpatialSender::SetAclWriteAuthority(const SpatialLoadBalanceEnforcer::AclW
 			continue;
 		}
 
-		WorkerRequirementSet RequirementSet;
-
 		if (ComponentId == SpatialConstants::ENTITY_ACL_COMPONENT_ID)
 		{
 			NewAcl.ComponentWriteAcl.Add(ComponentId, { SpatialConstants::LoadBalancerAttributeSet });

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -591,11 +591,11 @@ void USpatialSender::SetAclWriteAuthority(const SpatialLoadBalanceEnforcer::AclW
 
 		if (ComponentId == SpatialConstants::ENTITY_ACL_COMPONENT_ID)
 		{
-			NewAcl.ComponentWriteAcl.Add(ComponentId, { LoadBalancerAttributeSet });
+			NewAcl.ComponentWriteAcl.Add(ComponentId, { SpatialConstants::LoadBalancerAttributeSet });
 			continue;
 		}
 	
-		NewAcl.Add(ComponentId, { OwningServerWorkerAttributeSet });
+		NewAcl.ComponentWriteAcl.Add(ComponentId, { OwningServerWorkerAttributeSet });
 	}
 
 	UE_LOG(LogSpatialLoadBalanceEnforcer, Log, TEXT("(%s) Setting Acl WriteAuth for entity %lld to %s"), *NetDriver->Connection->GetWorkerId(), Request.EntityId, *Request.OwningWorkerId);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -586,7 +586,7 @@ void USpatialSender::SetAclWriteAuthority(const SpatialLoadBalanceEnforcer::AclW
 
 		if (ComponentId == SpatialConstants::ENTITY_ACL_COMPONENT_ID)
 		{
-			NewAcl.ComponentWriteAcl.Add(ComponentId, { SpatialConstants::LoadBalancerAttributeSet });
+			NewAcl.ComponentWriteAcl.Add(ComponentId, { SpatialConstants::GetLoadBalancerAttributeSet(GetDefault<USpatialGDKSettings>()->LoadBalancingWorkerType.WorkerTypeName) });
 			continue;
 		}
 	

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -559,11 +559,8 @@ void USpatialSender::SendAuthorityIntentUpdate(const AActor& Actor, VirtualWorke
 	FWorkerComponentUpdate Update = AuthorityIntentComponent->CreateAuthorityIntentUpdate();
 	Connection->SendComponentUpdate(EntityId, &Update);
 
-	if (NetDriver->StaticComponentView->HasAuthority(EntityId, SpatialConstants::ENTITY_ACL_COMPONENT_ID))
-	{
-		// Also notify the enforcer directly on the worker that sends the component update, as the update will short circuit
-		NetDriver->LoadBalanceEnforcer->MaybeQueueAclAssignmentRequest(EntityId);
-	}
+	// Also notify the enforcer directly on the worker that sends the component update, as the update will short circuit
+	NetDriver->LoadBalanceEnforcer->MaybeQueueAclAssignmentRequest(EntityId);
 }
 
 void USpatialSender::SetAclWriteAuthority(const SpatialLoadBalanceEnforcer::AclWriteAuthorityRequest& Request)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -593,7 +593,7 @@ void USpatialSender::SetAclWriteAuthority(const SpatialLoadBalanceEnforcer::AclW
 		NewAcl.ComponentWriteAcl.Add(ComponentId, { OwningServerWorkerAttributeSet });
 	}
 
-	UE_LOG(LogSpatialLoadBalanceEnforcer, Log, TEXT("(%s) Setting Acl WriteAuth for entity %lld to %s"), *NetDriver->Connection->GetWorkerId(), Request.EntityId, *Request.OwningWorkerId);
+	UE_LOG(LogSpatialLoadBalanceEnforcer, Verbose, TEXT("(%s) Setting Acl WriteAuth for entity %lld to %s"), *NetDriver->Connection->GetWorkerId(), Request.EntityId, *Request.OwningWorkerId);
 
 	FWorkerComponentUpdate Update = NewAcl.CreateEntityAclUpdate();
 	NetDriver->Connection->SendComponentUpdate(Request.EntityId, &Update);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStaticComponentView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStaticComponentView.cpp
@@ -30,7 +30,6 @@ Worker_Authority USpatialStaticComponentView::GetAuthority(Worker_EntityId Entit
 	return WORKER_AUTHORITY_NOT_AUTHORITATIVE;
 }
 
-// TODO UNR-640 - Need to fix for authority loss imminent
 bool USpatialStaticComponentView::HasAuthority(Worker_EntityId EntityId, Worker_ComponentId ComponentId) const
 {
 	return GetAuthority(EntityId, ComponentId) == WORKER_AUTHORITY_AUTHORITATIVE;

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -71,9 +71,9 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 	const USpatialGDKSettings* SpatialSettings = GetDefault<USpatialGDKSettings>();
 	if (SpatialSettings->bEnableUnrealLoadBalancer)
 	{
-		AnyServerRequirementSet.Add(SpatialConstants::LoadBalancerAttributeSet);
-		AnyServerOrClientRequirementSet.Add(SpatialConstants::LoadBalancerAttributeSet);
-		AnyServerOrOwningClientRequirementSet.Add(SpatialConstants::LoadBalancerAttributeSet);
+		AnyServerRequirementSet.Add(SpatialConstants::GetLoadBalancerAttributeSet(SpatialSettings->LoadBalancingWorkerType.WorkerTypeName));
+		AnyServerOrClientRequirementSet.Add(SpatialConstants::GetLoadBalancerAttributeSet(SpatialSettings->LoadBalancingWorkerType.WorkerTypeName));
+		AnyServerOrOwningClientRequirementSet.Add(SpatialConstants::GetLoadBalancerAttributeSet(SpatialSettings->LoadBalancingWorkerType.WorkerTypeName));
 
 		const UAbstractLBStrategy* LBStrategy = NetDriver->LoadBalanceStrategy;
 		check(LBStrategy != nullptr);
@@ -133,8 +133,7 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 
 	if (SpatialSettings->bEnableUnrealLoadBalancer)
 	{
-		const WorkerAttributeSet ACLAttributeSet = { SpatialConstants::LoadBalancerAttributeSet };
-		const WorkerRequirementSet ACLRequirementSet = { ACLAttributeSet };
+		const WorkerRequirementSet ACLRequirementSet = { SpatialConstants::GetLoadBalancerAttributeSet(SpatialSettings->LoadBalancingWorkerType.WorkerTypeName) };
 		ComponentWriteAcl.Add(SpatialConstants::ENTITY_ACL_COMPONENT_ID, ACLRequirementSet);
 		ComponentWriteAcl.Add(SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID, AuthoritativeWorkerRequirementSet);
 	}
@@ -423,9 +422,8 @@ TArray<FWorkerComponentData> EntityFactory::CreateTombstoneEntityComponents(AAct
 	const USpatialGDKSettings* SpatialSettings = GetDefault<USpatialGDKSettings>();
 	if (SpatialSettings->bEnableUnrealLoadBalancer)
 	{
-		const WorkerAttributeSet ZoningAttributeSet = { SpatialConstants::LoadBalancerAttributeSet };
-		AnyServerRequirementSet.Add(ZoningAttributeSet);
-		AnyServerOrClientRequirementSet.Add(ZoningAttributeSet);
+		AnyServerRequirementSet.Add(SpatialConstants::GetLoadBalancerAttributeSet(SpatialSettings->LoadBalancingWorkerType.WorkerTypeName));
+		AnyServerOrClientRequirementSet.Add(SpatialConstants::GetLoadBalancerAttributeSet(SpatialSettings->LoadBalancingWorkerType.WorkerTypeName));
 	}
 
 	WorkerRequirementSet ReadAcl;

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -67,14 +67,13 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 	WorkerAttributeSet WorkerAttributeOrSpecificWorker{ Info.WorkerType.ToString() };
 	VirtualWorkerId IntendedVirtualWorkerId = SpatialConstants::INVALID_VIRTUAL_WORKER_ID;
 
-	// Add Zoning Attribute if we are using the load balancer.
+	// Add Load Balancer Attribute if we are using the load balancer.
 	const USpatialGDKSettings* SpatialSettings = GetDefault<USpatialGDKSettings>();
 	if (SpatialSettings->bEnableUnrealLoadBalancer)
 	{
-		WorkerAttributeSet ZoningAttributeSet = { SpatialConstants::ZoningAttribute };
-		AnyServerRequirementSet.Add(ZoningAttributeSet);
-		AnyServerOrClientRequirementSet.Add(ZoningAttributeSet);
-		AnyServerOrOwningClientRequirementSet.Add(ZoningAttributeSet);
+		AnyServerRequirementSet.Add(SpatialConstants::LoadBalancerAttributeSet);
+		AnyServerOrClientRequirementSet.Add(SpatialConstants::LoadBalancerAttributeSet);
+		AnyServerOrOwningClientRequirementSet.Add(SpatialConstants::LoadBalancerAttributeSet);
 
 		const UAbstractLBStrategy* LBStrategy = NetDriver->LoadBalanceStrategy;
 		check(LBStrategy != nullptr);
@@ -134,7 +133,7 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 
 	if (SpatialSettings->bEnableUnrealLoadBalancer)
 	{
-		const WorkerAttributeSet ACLAttributeSet = { SpatialConstants::ZoningAttribute };
+		const WorkerAttributeSet ACLAttributeSet = { SpatialConstants::LoadBalancerAttributeSet };
 		const WorkerRequirementSet ACLRequirementSet = { ACLAttributeSet };
 		ComponentWriteAcl.Add(SpatialConstants::ENTITY_ACL_COMPONENT_ID, ACLRequirementSet);
 		ComponentWriteAcl.Add(SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID, AuthoritativeWorkerRequirementSet);
@@ -424,7 +423,7 @@ TArray<FWorkerComponentData> EntityFactory::CreateTombstoneEntityComponents(AAct
 	const USpatialGDKSettings* SpatialSettings = GetDefault<USpatialGDKSettings>();
 	if (SpatialSettings->bEnableUnrealLoadBalancer)
 	{
-		const WorkerAttributeSet ZoningAttributeSet = { SpatialConstants::ZoningAttribute };
+		const WorkerAttributeSet ZoningAttributeSet = { SpatialConstants::LoadBalancerAttributeSet };
 		AnyServerRequirementSet.Add(ZoningAttributeSet);
 		AnyServerOrClientRequirementSet.Add(ZoningAttributeSet);
 	}

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -164,7 +164,32 @@ public:
 	// Indicates whether this client worker has "ownership" (authority over Client endpoint) over the entity corresponding to this channel.
 	inline bool IsAuthoritativeClient() const
 	{
-		return bIsAuthClient;
+		if (GetDefault<USpatialGDKSettings>()->bEnableResultTypes)
+		{
+			return bIsAuthClient;
+		}
+
+		// If we aren't using result types, we have to actually look at the ACL to see if we should be authoritative or not to guess if we are going to receive authority
+		// in order to send dynamic interest overrides correctly for this client. If we don't do this there's a good chance we will see that there is no server RPC endpoint
+		// on this entity when we try to send any RPCs immediately after checking out the entity, which can lead to inconsistent state.
+		const TArray<FString>& WorkerAttributes = NetDriver->Connection->GetWorkerAttributes();
+		if (const SpatialGDK::EntityAcl* EntityACL = NetDriver->StaticComponentView->GetComponentData<SpatialGDK::EntityAcl>(EntityId))
+		{
+			if (const WorkerRequirementSet* WorkerRequirementsSet = EntityACL->ComponentWriteAcl.Find(SpatialConstants::GetClientAuthorityComponent(GetDefault<USpatialGDKSettings>()->UseRPCRingBuffer()))) {
+				for (const WorkerAttributeSet& AttributeSet : *WorkerRequirementsSet)
+				{
+					for (const FString& Attribute : AttributeSet)
+					{
+						if (WorkerAttributes.Contains(Attribute))
+						{
+							return true;
+						}
+					}
+				}
+			}
+		}
+	
+		return false;
 	}
 
 	inline void OnServerAuthorityChange(const Worker_AuthorityChangeOp& Op)

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -155,10 +155,10 @@ public:
 		return NetDriver->StaticComponentView->HasAuthority(EntityId, SpatialConstants::GetClientAuthorityComponent(GetDefault<USpatialGDKSettings>()->UseRPCRingBuffer()));
 	}
 
-	inline void OnClientAuthorityChange(Worker_AuthorityChangeOp Op)
+	inline void OnClientAuthorityChange(const Worker_AuthorityChangeOp& Op)
 	{
 		check(Op.component_id == SpatialConstants::GetClientAuthorityComponent(GetDefault<USpatialGDKSettings>()->UseRPCRingBuffer()));
-		bIsAuthClient = Op.authority == WORKER_AUTHORITY_AUTHORITATIVE ? true : false;
+		bIsAuthClient = Op.authority == WORKER_AUTHORITY_AUTHORITATIVE;
 	}
 
 	// Indicates whether this client worker has "ownership" (authority over Client endpoint) over the entity corresponding to this channel.
@@ -167,10 +167,10 @@ public:
 		return bIsAuthClient;
 	}
 
-	inline void OnServerAuthorityChange(Worker_AuthorityChangeOp Op)
+	inline void OnServerAuthorityChange(const Worker_AuthorityChangeOp& Op)
 	{
 		check(Op.component_id == SpatialConstants::POSITION_COMPONENT_ID);
-		bIsAuthServer = Op.authority == WORKER_AUTHORITY_AUTHORITATIVE ? true : false;
+		bIsAuthServer = Op.authority == WORKER_AUTHORITY_AUTHORITATIVE;
 	}
 
 	inline bool IsAuthoritativeServer() const

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialLoadBalanceEnforcer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialLoadBalanceEnforcer.h
@@ -19,19 +19,30 @@ public:
 	struct AclWriteAuthorityRequest
 	{
 		Worker_EntityId EntityId = 0;
-		FString OwningWorkerId;
+		PhysicalWorkerName OwningWorkerId;
+		WorkerRequirementSet ReadAcl;
+		WorkerRequirementSet ClientRequirementSet;
+		TArray<Worker_ComponentId> ComponentIds;
 	};
 
 	SpatialLoadBalanceEnforcer(const PhysicalWorkerName& InWorkerId, const USpatialStaticComponentView* InStaticComponentView, const SpatialVirtualWorkerTranslator* InVirtualWorkerTranslator);
 
-	void AuthorityChanged(const Worker_AuthorityChangeOp& AuthOp);
-	void QueueAclAssignmentRequest(const Worker_EntityId EntityId);
 
 	void OnAuthorityIntentComponentUpdated(const Worker_ComponentUpdateOp& Op);
+	void OnLoadBalancingComponentAdded(const Worker_AddComponentOp& Op);
+	void OnLoadBalancingComponentRemoved(const Worker_RemoveComponentOp& Op);
+	void OnEntityRemoved(const Worker_RemoveEntityOp& Op);
+	void OnAclAuthorityChanged(const Worker_AuthorityChangeOp& AuthOp);
+
+	void MaybeQueueAclAssignmentRequest(const Worker_EntityId EntityId);
 
 	TArray<AclWriteAuthorityRequest> ProcessQueuedAclAssignmentRequests();
 
 private:
+
+	void QueueAclAssignmentRequest(const Worker_EntityId EntityId);
+	bool AclAssignmentRequestIsQueued(const Worker_EntityId EntityId);
+	bool CanEnforce(Worker_EntityId EntityId);
 
 	const PhysicalWorkerName WorkerId;
 	TWeakObjectPtr<const USpatialStaticComponentView> StaticComponentView;

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialLoadBalanceEnforcer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialLoadBalanceEnforcer.h
@@ -41,22 +41,12 @@ public:
 private:
 
 	void QueueAclAssignmentRequest(const Worker_EntityId EntityId);
-	bool AclAssignmentRequestIsQueued(const Worker_EntityId EntityId);
-	bool CanEnforce(Worker_EntityId EntityId);
+	bool AclAssignmentRequestIsQueued(const Worker_EntityId EntityId) const;
+	bool CanEnforce(Worker_EntityId EntityId) const;
 
 	const PhysicalWorkerName WorkerId;
 	TWeakObjectPtr<const USpatialStaticComponentView> StaticComponentView;
 	const SpatialVirtualWorkerTranslator* VirtualWorkerTranslator;
 
-	struct WriteAuthAssignmentRequest
-	{
-		WriteAuthAssignmentRequest(Worker_EntityId InputEntityId)
-			: EntityId(InputEntityId)
-			, ProcessAttempts(0)
-		{}
-		Worker_EntityId EntityId;
-		int32 ProcessAttempts;
-	};
-
-	TArray<WriteAuthAssignmentRequest> AclWriteAuthAssignmentRequests;
+	TSet<Worker_EntityId> AclWriteAuthAssignmentRequests;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialLoadBalanceEnforcer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialLoadBalanceEnforcer.h
@@ -35,13 +35,14 @@ public:
 	void OnAclAuthorityChanged(const Worker_AuthorityChangeOp& AuthOp);
 
 	void MaybeQueueAclAssignmentRequest(const Worker_EntityId EntityId);
+	// Visible for testing
+	bool AclAssignmentRequestIsQueued(const Worker_EntityId EntityId) const;
 
 	TArray<AclWriteAuthorityRequest> ProcessQueuedAclAssignmentRequests();
 
 private:
 
 	void QueueAclAssignmentRequest(const Worker_EntityId EntityId);
-	bool AclAssignmentRequestIsQueued(const Worker_EntityId EntityId) const;
 	bool CanEnforce(Worker_EntityId EntityId) const;
 
 	const PhysicalWorkerName WorkerId;

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialLoadBalanceEnforcer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialLoadBalanceEnforcer.h
@@ -48,5 +48,5 @@ private:
 	TWeakObjectPtr<const USpatialStaticComponentView> StaticComponentView;
 	const SpatialVirtualWorkerTranslator* VirtualWorkerTranslator;
 
-	TSet<Worker_EntityId> AclWriteAuthAssignmentRequests;
+	TArray<Worker_EntityId> AclWriteAuthAssignmentRequests;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -93,7 +93,6 @@ public:
 	void MoveMappedObjectToUnmapped(const FUnrealObjectRef&);
 
 private:
-
 	void EnterCriticalSection();
 	void LeaveCriticalSection();
 
@@ -187,14 +186,12 @@ private:
 	// END TODO
 
 public:
-
 	TMap<TPair<Worker_EntityId_Key, Worker_ComponentId>, TSharedRef<FPendingSubobjectAttachment>> PendingEntitySubobjectDelegations;
 
 	FOnEntityAddedDelegate OnEntityAddedDelegate;
 	FOnEntityRemovedDelegate OnEntityRemovedDelegate;
 
 private:
-
 	UPROPERTY()
 	USpatialNetDriver* NetDriver;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -178,7 +178,7 @@ private:
 		USpatialReceiver& Receiver;
 
 		bool bInCriticalSection;
-		TArray<Worker_EntityId> PendingAddEntities;
+		TArray<Worker_EntityId> PendingAddActors;
 		TArray<Worker_AuthorityChangeOp> PendingAuthorityChanges;
 		TArray<PendingAddComponentWrapper> PendingAddComponents;
 	};
@@ -194,6 +194,7 @@ public:
 	FOnEntityRemovedDelegate OnEntityRemovedDelegate;
 
 private:
+
 	UPROPERTY()
 	USpatialNetDriver* NetDriver;
 
@@ -228,7 +229,7 @@ private:
 	FRPCContainer IncomingRPCs{ ERPCQueueType::Receive };
 
 	bool bInCriticalSection;
-	TArray<Worker_EntityId> PendingAddEntities;
+	TArray<Worker_EntityId> PendingAddActors;
 	TArray<Worker_AuthorityChangeOp> PendingAuthorityChanges;
 	TArray<PendingAddComponentWrapper> PendingAddComponents;
 	TArray<Worker_RemoveComponentOp> QueuedRemoveComponentOps;

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -75,7 +75,7 @@ public:
 	void SendComponentInterestForSubobject(const FClassInfo& Info, Worker_EntityId EntityId, bool bNetOwned);
 	void SendPositionUpdate(Worker_EntityId EntityId, const FVector& Location);
 	void SendAuthorityIntentUpdate(const AActor& Actor, VirtualWorkerId NewAuthoritativeVirtualWorkerId);
-	void SetAclWriteAuthority(const Worker_EntityId EntityId, const FString& DestinationWorkerId);
+	void SetAclWriteAuthority(const Worker_EntityId EntityId, const FString& DestinationWorkerId, const WorkerRequirementSet& ReadAcl, const WorkerRequirementSet& ClientRequirementSet, const TArray<Worker_ComponentId>& ComponentIds);
 	FRPCErrorInfo SendRPC(const FPendingRPCParams& Params);
 	ERPCResult SendRPCInternal(UObject* TargetObject, UFunction* Function, const SpatialGDK::RPCPayload& Payload);
 	void SendCommandResponse(Worker_RequestId RequestId, Worker_CommandResponse& Response);

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 
+#include "EngineClasses/SpatialLoadBalanceEnforcer.h"
 #include "EngineClasses/SpatialNetBitWriter.h"
 #include "Interop/SpatialClassInfoManager.h"
 #include "Interop/SpatialRPCService.h"
@@ -75,7 +76,7 @@ public:
 	void SendComponentInterestForSubobject(const FClassInfo& Info, Worker_EntityId EntityId, bool bNetOwned);
 	void SendPositionUpdate(Worker_EntityId EntityId, const FVector& Location);
 	void SendAuthorityIntentUpdate(const AActor& Actor, VirtualWorkerId NewAuthoritativeVirtualWorkerId);
-	void SetAclWriteAuthority(const Worker_EntityId EntityId, const FString& DestinationWorkerId, const WorkerRequirementSet& ReadAcl, const WorkerRequirementSet& ClientRequirementSet, const TArray<Worker_ComponentId>& ComponentIds);
+	void SetAclWriteAuthority(const SpatialLoadBalanceEnforcer::AclWriteAuthorityRequest& Request);
 	FRPCErrorInfo SendRPC(const FPendingRPCParams& Params);
 	ERPCResult SendRPCInternal(UObject* TargetObject, UFunction* Function, const SpatialGDK::RPCPayload& Payload);
 	void SendCommandResponse(Worker_RequestId RequestId, Worker_CommandResponse& Response);

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -6,7 +6,6 @@
 #include "Schema/UnrealObjectRef.h"
 #include "SpatialCommonTypes.h"
 #include "UObject/Script.h"
-#include "Utils/SpatialActorGroupManager.h"
 
 #include <WorkerSDK/improbable/c_schema.h>
 #include <WorkerSDK/improbable/c_worker.h>

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -42,225 +42,225 @@ enum ESchemaComponentType : int32
 namespace SpatialConstants
 {
 
-inline FString RPCTypeToString(ERPCType RPCType)
-{
-	switch (RPCType)
+	inline FString RPCTypeToString(ERPCType RPCType)
 	{
-	case ERPCType::ClientReliable:
-		return TEXT("Client, Reliable");
-	case ERPCType::ClientUnreliable:
-		return TEXT("Client, Unreliable");
-	case ERPCType::ServerReliable:
-		return TEXT("Server, Reliable");
-	case ERPCType::ServerUnreliable:
-		return TEXT("Server, Unreliable");
-	case ERPCType::NetMulticast:
-		return TEXT("Multicast");
-	case ERPCType::CrossServer:
-		return TEXT("CrossServer");
+		switch (RPCType)
+		{
+		case ERPCType::ClientReliable:
+			return TEXT("Client, Reliable");
+		case ERPCType::ClientUnreliable:
+			return TEXT("Client, Unreliable");
+		case ERPCType::ServerReliable:
+			return TEXT("Server, Reliable");
+		case ERPCType::ServerUnreliable:
+			return TEXT("Server, Unreliable");
+		case ERPCType::NetMulticast:
+			return TEXT("Multicast");
+		case ERPCType::CrossServer:
+			return TEXT("CrossServer");
+		}
+
+		checkNoEntry();
+		return FString();
 	}
 
-	checkNoEntry();
-	return FString();
-}
+	enum EntityIds
+	{
+		INVALID_ENTITY_ID = 0,
+		INITIAL_SPAWNER_ENTITY_ID = 1,
+		INITIAL_GLOBAL_STATE_MANAGER_ENTITY_ID = 2,
+		INITIAL_VIRTUAL_WORKER_TRANSLATOR_ENTITY_ID = 3,
+		FIRST_AVAILABLE_ENTITY_ID = 4,
+	};
 
-enum EntityIds
-{
-	INVALID_ENTITY_ID = 0,
-	INITIAL_SPAWNER_ENTITY_ID = 1,
-	INITIAL_GLOBAL_STATE_MANAGER_ENTITY_ID = 2,
-	INITIAL_VIRTUAL_WORKER_TRANSLATOR_ENTITY_ID = 3,
-	FIRST_AVAILABLE_ENTITY_ID = 4,
-};
+	const Worker_ComponentId INVALID_COMPONENT_ID = 0;
 
-const Worker_ComponentId INVALID_COMPONENT_ID							= 0;
+	const Worker_ComponentId ENTITY_ACL_COMPONENT_ID = 50;
+	const Worker_ComponentId METADATA_COMPONENT_ID = 53;
+	const Worker_ComponentId POSITION_COMPONENT_ID = 54;
+	const Worker_ComponentId PERSISTENCE_COMPONENT_ID = 55;
+	const Worker_ComponentId INTEREST_COMPONENT_ID = 58;
+	// This is a component on per-worker system entities.
+	const Worker_ComponentId WORKER_COMPONENT_ID = 60;
 
-const Worker_ComponentId ENTITY_ACL_COMPONENT_ID						= 50;
-const Worker_ComponentId METADATA_COMPONENT_ID							= 53;
-const Worker_ComponentId POSITION_COMPONENT_ID							= 54;
-const Worker_ComponentId PERSISTENCE_COMPONENT_ID						= 55;
-const Worker_ComponentId INTEREST_COMPONENT_ID							= 58;
-// This is a component on per-worker system entities.
-const Worker_ComponentId WORKER_COMPONENT_ID							= 60;
+	const Worker_ComponentId MAX_RESERVED_SPATIAL_SYSTEM_COMPONENT_ID = 100;
 
-const Worker_ComponentId MAX_RESERVED_SPATIAL_SYSTEM_COMPONENT_ID		= 100;
+	const Worker_ComponentId SPAWN_DATA_COMPONENT_ID = 9999;
+	const Worker_ComponentId PLAYER_SPAWNER_COMPONENT_ID = 9998;
+	const Worker_ComponentId SINGLETON_COMPONENT_ID = 9997;
+	const Worker_ComponentId UNREAL_METADATA_COMPONENT_ID = 9996;
+	const Worker_ComponentId SINGLETON_MANAGER_COMPONENT_ID = 9995;
+	const Worker_ComponentId DEPLOYMENT_MAP_COMPONENT_ID = 9994;
+	const Worker_ComponentId STARTUP_ACTOR_MANAGER_COMPONENT_ID = 9993;
+	const Worker_ComponentId GSM_SHUTDOWN_COMPONENT_ID = 9992;
+	const Worker_ComponentId HEARTBEAT_COMPONENT_ID = 9991;
+	// Marking the event-based RPC components as legacy while the ring buffer
+	// implementation is under a feature flag.
+	const Worker_ComponentId CLIENT_RPC_ENDPOINT_COMPONENT_ID_LEGACY = 9990;
+	const Worker_ComponentId SERVER_RPC_ENDPOINT_COMPONENT_ID_LEGACY = 9989;
+	const Worker_ComponentId NETMULTICAST_RPCS_COMPONENT_ID_LEGACY = 9987;
 
-const Worker_ComponentId SPAWN_DATA_COMPONENT_ID						= 9999;
-const Worker_ComponentId PLAYER_SPAWNER_COMPONENT_ID					= 9998;
-const Worker_ComponentId SINGLETON_COMPONENT_ID							= 9997;
-const Worker_ComponentId UNREAL_METADATA_COMPONENT_ID					= 9996;
-const Worker_ComponentId SINGLETON_MANAGER_COMPONENT_ID					= 9995;
-const Worker_ComponentId DEPLOYMENT_MAP_COMPONENT_ID					= 9994;
-const Worker_ComponentId STARTUP_ACTOR_MANAGER_COMPONENT_ID			    = 9993;
-const Worker_ComponentId GSM_SHUTDOWN_COMPONENT_ID						= 9992;
-const Worker_ComponentId HEARTBEAT_COMPONENT_ID							= 9991;
-// Marking the event-based RPC components as legacy while the ring buffer
-// implementation is under a feature flag.
-const Worker_ComponentId CLIENT_RPC_ENDPOINT_COMPONENT_ID_LEGACY		= 9990;
-const Worker_ComponentId SERVER_RPC_ENDPOINT_COMPONENT_ID_LEGACY		= 9989;
-const Worker_ComponentId NETMULTICAST_RPCS_COMPONENT_ID_LEGACY			= 9987;
+	const Worker_ComponentId NOT_STREAMED_COMPONENT_ID = 9986;
+	const Worker_ComponentId RPCS_ON_ENTITY_CREATION_ID = 9985;
+	const Worker_ComponentId DEBUG_METRICS_COMPONENT_ID = 9984;
+	const Worker_ComponentId ALWAYS_RELEVANT_COMPONENT_ID = 9983;
+	const Worker_ComponentId TOMBSTONE_COMPONENT_ID = 9982;
+	const Worker_ComponentId DORMANT_COMPONENT_ID = 9981;
+	const Worker_ComponentId AUTHORITY_INTENT_COMPONENT_ID = 9980;
+	const Worker_ComponentId VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID = 9979;
 
-const Worker_ComponentId NOT_STREAMED_COMPONENT_ID						= 9986;
-const Worker_ComponentId RPCS_ON_ENTITY_CREATION_ID						= 9985;
-const Worker_ComponentId DEBUG_METRICS_COMPONENT_ID						= 9984;
-const Worker_ComponentId ALWAYS_RELEVANT_COMPONENT_ID					= 9983;
-const Worker_ComponentId TOMBSTONE_COMPONENT_ID                         = 9982;
-const Worker_ComponentId DORMANT_COMPONENT_ID							= 9981;
-const Worker_ComponentId AUTHORITY_INTENT_COMPONENT_ID                  = 9980;
-const Worker_ComponentId VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID        = 9979;
+	const Worker_ComponentId CLIENT_ENDPOINT_COMPONENT_ID = 9978;
+	const Worker_ComponentId SERVER_ENDPOINT_COMPONENT_ID = 9977;
+	const Worker_ComponentId MULTICAST_RPCS_COMPONENT_ID = 9976;
+	const Worker_ComponentId SPATIAL_DEBUGGING_COMPONENT_ID = 9975;
+	const Worker_ComponentId SERVER_WORKER_COMPONENT_ID = 9974;
+	const Worker_ComponentId SERVER_TO_SERVER_COMMAND_ENDPOINT_COMPONENT_ID = 9973;
 
-const Worker_ComponentId CLIENT_ENDPOINT_COMPONENT_ID					= 9978;
-const Worker_ComponentId SERVER_ENDPOINT_COMPONENT_ID					= 9977;
-const Worker_ComponentId MULTICAST_RPCS_COMPONENT_ID					= 9976;
-const Worker_ComponentId SPATIAL_DEBUGGING_COMPONENT_ID					= 9975;
-const Worker_ComponentId SERVER_WORKER_COMPONENT_ID						= 9974;
-const Worker_ComponentId SERVER_TO_SERVER_COMMAND_ENDPOINT_COMPONENT_ID = 9973;
+	const Worker_ComponentId STARTING_GENERATED_COMPONENT_ID = 10000;
 
-const Worker_ComponentId STARTING_GENERATED_COMPONENT_ID				= 10000;
+	const Schema_FieldId SINGLETON_MANAGER_SINGLETON_NAME_TO_ENTITY_ID = 1;
 
-const Schema_FieldId SINGLETON_MANAGER_SINGLETON_NAME_TO_ENTITY_ID		= 1;
+	const Schema_FieldId DEPLOYMENT_MAP_MAP_URL_ID = 1;
+	const Schema_FieldId DEPLOYMENT_MAP_ACCEPTING_PLAYERS_ID = 2;
+	const Schema_FieldId DEPLOYMENT_MAP_SESSION_ID = 3;
+	const Schema_FieldId DEPLOYMENT_MAP_SCHEMA_HASH = 4;
 
-const Schema_FieldId DEPLOYMENT_MAP_MAP_URL_ID							= 1;
-const Schema_FieldId DEPLOYMENT_MAP_ACCEPTING_PLAYERS_ID				= 2;
-const Schema_FieldId DEPLOYMENT_MAP_SESSION_ID							= 3;
-const Schema_FieldId DEPLOYMENT_MAP_SCHEMA_HASH							= 4;
+	const Schema_FieldId STARTUP_ACTOR_MANAGER_CAN_BEGIN_PLAY_ID = 1;
 
-const Schema_FieldId STARTUP_ACTOR_MANAGER_CAN_BEGIN_PLAY_ID			= 1;
+	const Schema_FieldId ACTOR_COMPONENT_REPLICATES_ID = 1;
+	const Schema_FieldId ACTOR_TEAROFF_ID = 3;
 
-const Schema_FieldId ACTOR_COMPONENT_REPLICATES_ID                      = 1;
-const Schema_FieldId ACTOR_TEAROFF_ID									= 3;
+	const Schema_FieldId HEARTBEAT_EVENT_ID = 1;
+	const Schema_FieldId HEARTBEAT_CLIENT_HAS_QUIT_ID = 1;
 
-const Schema_FieldId HEARTBEAT_EVENT_ID                                 = 1;
-const Schema_FieldId HEARTBEAT_CLIENT_HAS_QUIT_ID						= 1;
+	const Schema_FieldId SHUTDOWN_MULTI_PROCESS_REQUEST_ID = 1;
+	const Schema_FieldId SHUTDOWN_ADDITIONAL_SERVERS_EVENT_ID = 1;
 
-const Schema_FieldId SHUTDOWN_MULTI_PROCESS_REQUEST_ID					= 1;
-const Schema_FieldId SHUTDOWN_ADDITIONAL_SERVERS_EVENT_ID				= 1;
+	const Schema_FieldId CLEAR_RPCS_ON_ENTITY_CREATION = 1;
 
-const Schema_FieldId CLEAR_RPCS_ON_ENTITY_CREATION						= 1;
+	// DebugMetrics command IDs
+	const Schema_FieldId DEBUG_METRICS_START_RPC_METRICS_ID = 1;
+	const Schema_FieldId DEBUG_METRICS_STOP_RPC_METRICS_ID = 2;
+	const Schema_FieldId DEBUG_METRICS_MODIFY_SETTINGS_ID = 3;
 
-// DebugMetrics command IDs
-const Schema_FieldId DEBUG_METRICS_START_RPC_METRICS_ID					= 1;
-const Schema_FieldId DEBUG_METRICS_STOP_RPC_METRICS_ID					= 2;
-const Schema_FieldId DEBUG_METRICS_MODIFY_SETTINGS_ID					= 3;
+	// ModifySettingPayload Field IDs
+	const Schema_FieldId MODIFY_SETTING_PAYLOAD_NAME_ID = 1;
+	const Schema_FieldId MODIFY_SETTING_PAYLOAD_VALUE_ID = 2;
 
-// ModifySettingPayload Field IDs
-const Schema_FieldId MODIFY_SETTING_PAYLOAD_NAME_ID						= 1;
-const Schema_FieldId MODIFY_SETTING_PAYLOAD_VALUE_ID					= 2;
+	// UnrealObjectRef Field IDs
+	const Schema_FieldId UNREAL_OBJECT_REF_ENTITY_ID = 1;
+	const Schema_FieldId UNREAL_OBJECT_REF_OFFSET_ID = 2;
+	const Schema_FieldId UNREAL_OBJECT_REF_PATH_ID = 3;
+	const Schema_FieldId UNREAL_OBJECT_REF_NO_LOAD_ON_CLIENT_ID = 4;
+	const Schema_FieldId UNREAL_OBJECT_REF_OUTER_ID = 5;
+	const Schema_FieldId UNREAL_OBJECT_REF_USE_SINGLETON_CLASS_PATH_ID = 6;
 
-// UnrealObjectRef Field IDs
-const Schema_FieldId UNREAL_OBJECT_REF_ENTITY_ID						= 1;
-const Schema_FieldId UNREAL_OBJECT_REF_OFFSET_ID						= 2;
-const Schema_FieldId UNREAL_OBJECT_REF_PATH_ID							= 3;
-const Schema_FieldId UNREAL_OBJECT_REF_NO_LOAD_ON_CLIENT_ID				= 4;
-const Schema_FieldId UNREAL_OBJECT_REF_OUTER_ID							= 5;
-const Schema_FieldId UNREAL_OBJECT_REF_USE_SINGLETON_CLASS_PATH_ID		= 6;
+	// UnrealRPCPayload Field IDs
+	const Schema_FieldId UNREAL_RPC_PAYLOAD_OFFSET_ID = 1;
+	const Schema_FieldId UNREAL_RPC_PAYLOAD_RPC_INDEX_ID = 2;
+	const Schema_FieldId UNREAL_RPC_PAYLOAD_RPC_PAYLOAD_ID = 3;
+	const Schema_FieldId UNREAL_RPC_PAYLOAD_TRACE_ID = 4;
+	// UnrealPackedRPCPayload additional Field ID
+	const Schema_FieldId UNREAL_PACKED_RPC_PAYLOAD_ENTITY_ID = 5;
 
-// UnrealRPCPayload Field IDs
-const Schema_FieldId UNREAL_RPC_PAYLOAD_OFFSET_ID						= 1;
-const Schema_FieldId UNREAL_RPC_PAYLOAD_RPC_INDEX_ID					= 2;
-const Schema_FieldId UNREAL_RPC_PAYLOAD_RPC_PAYLOAD_ID					= 3;
-const Schema_FieldId UNREAL_RPC_PAYLOAD_TRACE_ID						= 4;
-// UnrealPackedRPCPayload additional Field ID
-const Schema_FieldId UNREAL_PACKED_RPC_PAYLOAD_ENTITY_ID				= 5;
+	const Schema_FieldId UNREAL_RPC_TRACE_ID = 1;
+	const Schema_FieldId UNREAL_RPC_SPAN_ID = 2;
 
-const Schema_FieldId UNREAL_RPC_TRACE_ID								= 1;
-const Schema_FieldId UNREAL_RPC_SPAN_ID									= 2;
+	// Unreal(Client|Server|Multicast)RPCEndpoint Field IDs
+	const Schema_FieldId UNREAL_RPC_ENDPOINT_READY_ID = 1;
+	const Schema_FieldId UNREAL_RPC_ENDPOINT_EVENT_ID = 1;
+	const Schema_FieldId UNREAL_RPC_ENDPOINT_PACKED_EVENT_ID = 2;
+	const Schema_FieldId UNREAL_RPC_ENDPOINT_COMMAND_ID = 1;
 
-// Unreal(Client|Server|Multicast)RPCEndpoint Field IDs
-const Schema_FieldId UNREAL_RPC_ENDPOINT_READY_ID 						= 1;
-const Schema_FieldId UNREAL_RPC_ENDPOINT_EVENT_ID						= 1;
-const Schema_FieldId UNREAL_RPC_ENDPOINT_PACKED_EVENT_ID				= 2;
-const Schema_FieldId UNREAL_RPC_ENDPOINT_COMMAND_ID						= 1;
+	const Schema_FieldId PLAYER_SPAWNER_SPAWN_PLAYER_COMMAND_ID = 1;
 
-const Schema_FieldId PLAYER_SPAWNER_SPAWN_PLAYER_COMMAND_ID = 1;
+	// AuthorityIntent codes and Field IDs.
+	const Schema_FieldId AUTHORITY_INTENT_VIRTUAL_WORKER_ID = 1;
 
-// AuthorityIntent codes and Field IDs.
-const Schema_FieldId AUTHORITY_INTENT_VIRTUAL_WORKER_ID					= 1;
+	// VirtualWorkerTranslation Field IDs.
+	const Schema_FieldId VIRTUAL_WORKER_TRANSLATION_MAPPING_ID = 1;
+	const Schema_FieldId MAPPING_VIRTUAL_WORKER_ID = 1;
+	const Schema_FieldId MAPPING_PHYSICAL_WORKER_NAME = 2;
+	const PhysicalWorkerName TRANSLATOR_UNSET_PHYSICAL_NAME = FString("UnsetWorkerName");
 
-// VirtualWorkerTranslation Field IDs.
-const Schema_FieldId VIRTUAL_WORKER_TRANSLATION_MAPPING_ID				= 1;
-const Schema_FieldId MAPPING_VIRTUAL_WORKER_ID							= 1;
-const Schema_FieldId MAPPING_PHYSICAL_WORKER_NAME						= 2;
-const PhysicalWorkerName TRANSLATOR_UNSET_PHYSICAL_NAME = FString("UnsetWorkerName");
+	// WorkerEntity Field IDs.
+	const Schema_FieldId WORKER_ID_ID = 1;
+	const Schema_FieldId WORKER_TYPE_ID = 2;
 
-// WorkerEntity Field IDs.
-const Schema_FieldId WORKER_ID_ID										= 1;
-const Schema_FieldId WORKER_TYPE_ID										= 2;
+	// SpatialDebugger Field IDs.
+	const Schema_FieldId SPATIAL_DEBUGGING_AUTHORITATIVE_VIRTUAL_WORKER_ID = 1;
+	const Schema_FieldId SPATIAL_DEBUGGING_AUTHORITATIVE_COLOR = 2;
+	const Schema_FieldId SPATIAL_DEBUGGING_INTENT_VIRTUAL_WORKER_ID = 3;
+	const Schema_FieldId SPATIAL_DEBUGGING_INTENT_COLOR = 4;
+	const Schema_FieldId SPATIAL_DEBUGGING_IS_LOCKED = 5;
 
-// SpatialDebugger Field IDs.
-const Schema_FieldId SPATIAL_DEBUGGING_AUTHORITATIVE_VIRTUAL_WORKER_ID   = 1;
-const Schema_FieldId SPATIAL_DEBUGGING_AUTHORITATIVE_COLOR               = 2;
-const Schema_FieldId SPATIAL_DEBUGGING_INTENT_VIRTUAL_WORKER_ID          = 3;
-const Schema_FieldId SPATIAL_DEBUGGING_INTENT_COLOR                      = 4;
-const Schema_FieldId SPATIAL_DEBUGGING_IS_LOCKED                         = 5;
+	// ServerWorker Field IDs.
+	const Schema_FieldId SERVER_WORKER_NAME_ID = 1;
+	const Schema_FieldId SERVER_WORKER_READY_TO_BEGIN_PLAY_ID = 2;
 
-// ServerWorker Field IDs.
-const Schema_FieldId SERVER_WORKER_NAME_ID								 = 1;
-const Schema_FieldId SERVER_WORKER_READY_TO_BEGIN_PLAY_ID				 = 2;
+	// Reserved entity IDs expire in 5 minutes, we will refresh them every 3 minutes to be safe.
+	const float ENTITY_RANGE_EXPIRATION_INTERVAL_SECONDS = 180.0f;
 
-// Reserved entity IDs expire in 5 minutes, we will refresh them every 3 minutes to be safe.
-const float ENTITY_RANGE_EXPIRATION_INTERVAL_SECONDS = 180.0f;
+	const float FIRST_COMMAND_RETRY_WAIT_SECONDS = 0.2f;
+	const uint32 MAX_NUMBER_COMMAND_ATTEMPTS = 5u;
 
-const float FIRST_COMMAND_RETRY_WAIT_SECONDS = 0.2f;
-const uint32 MAX_NUMBER_COMMAND_ATTEMPTS = 5u;
+	const FName DefaultActorGroup = FName(TEXT("Default"));
 
-const FName DefaultActorGroup = FName(TEXT("Default"));
+	const VirtualWorkerId INVALID_VIRTUAL_WORKER_ID = 0;
+	const ActorLockToken INVALID_ACTOR_LOCK_TOKEN = 0;
+	const FString INVALID_WORKER_NAME = TEXT("");
 
-const VirtualWorkerId INVALID_VIRTUAL_WORKER_ID = 0;
-const ActorLockToken INVALID_ACTOR_LOCK_TOKEN = 0;
-const FString INVALID_WORKER_NAME = TEXT("");
+	const WorkerAttributeSet UnrealServerAttributeSet = TArray<FString>{ DefaultServerWorkerType.ToString() };
+	const WorkerAttributeSet UnrealClientAttributeSet = TArray<FString>{ DefaultClientWorkerType.ToString() };
 
-const WorkerAttributeSet UnrealServerAttributeSet = TArray<FString>{DefaultServerWorkerType.ToString()};
-const WorkerAttributeSet UnrealClientAttributeSet = TArray<FString>{DefaultClientWorkerType.ToString()};
+	const WorkerRequirementSet UnrealServerPermission{ {UnrealServerAttributeSet} };
+	const WorkerRequirementSet UnrealClientPermission{ {UnrealClientAttributeSet} };
+	const WorkerRequirementSet ClientOrServerPermission{ {UnrealClientAttributeSet, UnrealServerAttributeSet} };
 
-const WorkerRequirementSet UnrealServerPermission{ {UnrealServerAttributeSet} };
-const WorkerRequirementSet UnrealClientPermission{ {UnrealClientAttributeSet} };
-const WorkerRequirementSet ClientOrServerPermission{ {UnrealClientAttributeSet, UnrealServerAttributeSet} };
+	const FString ClientsStayConnectedURLOption = TEXT("clientsStayConnected");
+	const FString SpatialSessionIdURLOption = TEXT("spatialSessionId=");
 
-const FString ClientsStayConnectedURLOption = TEXT("clientsStayConnected");
-const FString SpatialSessionIdURLOption = TEXT("spatialSessionId=");
+	const FString LOCATOR_HOST = TEXT("locator.improbable.io");
+	const FString LOCATOR_HOST_CN = TEXT("locator.spatialoschina.com");
+	const uint16 LOCATOR_PORT = 443;
 
-const FString LOCATOR_HOST    = TEXT("locator.improbable.io");
-const FString LOCATOR_HOST_CN = TEXT("locator.spatialoschina.com");
-const uint16 LOCATOR_PORT     = 443;
+	const FString AssemblyPattern = TEXT("^[a-zA-Z0-9_.-]{5,64}$");
+	const FString ProjectPattern = TEXT("^[a-z0-9_]{3,32}$");
+	const FString DeploymentPattern = TEXT("^[a-z0-9_]{2,32}$");
 
-const FString AssemblyPattern   = TEXT("^[a-zA-Z0-9_.-]{5,64}$");
-const FString ProjectPattern    = TEXT("^[a-z0-9_]{3,32}$");
-const FString DeploymentPattern = TEXT("^[a-z0-9_]{2,32}$");
+	inline float GetCommandRetryWaitTimeSeconds(uint32 NumAttempts)
+	{
+		// Double the time to wait on each failure.
+		uint32 WaitTimeExponentialFactor = 1u << (NumAttempts - 1);
+		return FIRST_COMMAND_RETRY_WAIT_SECONDS * WaitTimeExponentialFactor;
+	}
 
-inline float GetCommandRetryWaitTimeSeconds(uint32 NumAttempts)
-{
-	// Double the time to wait on each failure.
-	uint32 WaitTimeExponentialFactor = 1u << (NumAttempts - 1);
-	return FIRST_COMMAND_RETRY_WAIT_SECONDS * WaitTimeExponentialFactor;
-}
+	const FString LOCAL_HOST = TEXT("127.0.0.1");
+	const uint16  DEFAULT_PORT = 7777;
 
-const FString LOCAL_HOST   = TEXT("127.0.0.1");
-const uint16  DEFAULT_PORT = 7777;
+	const float ENTITY_QUERY_RETRY_WAIT_SECONDS = 3.0f;
 
-const float ENTITY_QUERY_RETRY_WAIT_SECONDS = 3.0f;
+	const Worker_ComponentId MIN_EXTERNAL_SCHEMA_ID = 1000;
+	const Worker_ComponentId MAX_EXTERNAL_SCHEMA_ID = 2000;
 
-const Worker_ComponentId MIN_EXTERNAL_SCHEMA_ID = 1000;
-const Worker_ComponentId MAX_EXTERNAL_SCHEMA_ID = 2000;
+	const FString SPATIALOS_METRICS_DYNAMIC_FPS = TEXT("Dynamic.FPS");
 
-const FString SPATIALOS_METRICS_DYNAMIC_FPS = TEXT("Dynamic.FPS");
+	// URL that can be used to reconnect using the command line arguments.
+	const FString RECONNECT_USING_COMMANDLINE_ARGUMENTS = TEXT("0.0.0.0");
+	const FString URL_LOGIN_OPTION = TEXT("login=");
+	const FString URL_PLAYER_IDENTITY_OPTION = TEXT("playeridentity=");
+	const FString URL_DEV_AUTH_TOKEN_OPTION = TEXT("devauthtoken=");
+	const FString URL_TARGET_DEPLOYMENT_OPTION = TEXT("deployment=");
+	const FString URL_PLAYER_ID_OPTION = TEXT("playerid=");
+	const FString URL_DISPLAY_NAME_OPTION = TEXT("displayname=");
+	const FString URL_METADATA_OPTION = TEXT("metadata=");
 
-// URL that can be used to reconnect using the command line arguments.
-const FString RECONNECT_USING_COMMANDLINE_ARGUMENTS = TEXT("0.0.0.0");
-const FString URL_LOGIN_OPTION = TEXT("login=");
-const FString URL_PLAYER_IDENTITY_OPTION = TEXT("playeridentity=");
-const FString URL_DEV_AUTH_TOKEN_OPTION = TEXT("devauthtoken=");
-const FString URL_TARGET_DEPLOYMENT_OPTION = TEXT("deployment=");
-const FString URL_PLAYER_ID_OPTION = TEXT("playerid=");
-const FString URL_DISPLAY_NAME_OPTION = TEXT("displayname=");
-const FString URL_METADATA_OPTION = TEXT("metadata=");
+	const FString DEVELOPMENT_AUTH_PLAYER_ID = TEXT("Player Id");
 
-const FString DEVELOPMENT_AUTH_PLAYER_ID = TEXT("Player Id");
+	const FString SCHEMA_DATABASE_FILE_PATH = TEXT("Spatial/SchemaDatabase");
+	const FString SCHEMA_DATABASE_ASSET_PATH = TEXT("/Game/Spatial/SchemaDatabase");
 
-const FString SCHEMA_DATABASE_FILE_PATH  = TEXT("Spatial/SchemaDatabase");
-const FString SCHEMA_DATABASE_ASSET_PATH = TEXT("/Game/Spatial/SchemaDatabase");
-
-const FString ZoningAttribute = DefaultServerWorkerType.ToString();
+	const WorkerAttributeSet LoadBalancerAttributeSet = { DefaultServerWorkerType.ToString() };
 
 // A list of components clients require on top of any generated data components in order to handle non-authoritative actors correctly.
 const TArray<Worker_ComponentId> REQUIRED_COMPONENTS_FOR_NON_AUTH_CLIENT_INTEREST = TArray<Worker_ComponentId>

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -42,225 +42,225 @@ enum ESchemaComponentType : int32
 namespace SpatialConstants
 {
 
-	inline FString RPCTypeToString(ERPCType RPCType)
+inline FString RPCTypeToString(ERPCType RPCType)
+{
+	switch (RPCType)
 	{
-		switch (RPCType)
-		{
-		case ERPCType::ClientReliable:
-			return TEXT("Client, Reliable");
-		case ERPCType::ClientUnreliable:
-			return TEXT("Client, Unreliable");
-		case ERPCType::ServerReliable:
-			return TEXT("Server, Reliable");
-		case ERPCType::ServerUnreliable:
-			return TEXT("Server, Unreliable");
-		case ERPCType::NetMulticast:
-			return TEXT("Multicast");
-		case ERPCType::CrossServer:
-			return TEXT("CrossServer");
-		}
-
-		checkNoEntry();
-		return FString();
+	case ERPCType::ClientReliable:
+		return TEXT("Client, Reliable");
+	case ERPCType::ClientUnreliable:
+		return TEXT("Client, Unreliable");
+	case ERPCType::ServerReliable:
+		return TEXT("Server, Reliable");
+	case ERPCType::ServerUnreliable:
+		return TEXT("Server, Unreliable");
+	case ERPCType::NetMulticast:
+		return TEXT("Multicast");
+	case ERPCType::CrossServer:
+		return TEXT("CrossServer");
 	}
 
-	enum EntityIds
-	{
-		INVALID_ENTITY_ID = 0,
-		INITIAL_SPAWNER_ENTITY_ID = 1,
-		INITIAL_GLOBAL_STATE_MANAGER_ENTITY_ID = 2,
-		INITIAL_VIRTUAL_WORKER_TRANSLATOR_ENTITY_ID = 3,
-		FIRST_AVAILABLE_ENTITY_ID = 4,
-	};
+	checkNoEntry();
+	return FString();
+}
 
-	const Worker_ComponentId INVALID_COMPONENT_ID = 0;
+enum EntityIds
+{
+	INVALID_ENTITY_ID = 0,
+	INITIAL_SPAWNER_ENTITY_ID = 1,
+	INITIAL_GLOBAL_STATE_MANAGER_ENTITY_ID = 2,
+	INITIAL_VIRTUAL_WORKER_TRANSLATOR_ENTITY_ID = 3,
+	FIRST_AVAILABLE_ENTITY_ID = 4,
+};
 
-	const Worker_ComponentId ENTITY_ACL_COMPONENT_ID = 50;
-	const Worker_ComponentId METADATA_COMPONENT_ID = 53;
-	const Worker_ComponentId POSITION_COMPONENT_ID = 54;
-	const Worker_ComponentId PERSISTENCE_COMPONENT_ID = 55;
-	const Worker_ComponentId INTEREST_COMPONENT_ID = 58;
-	// This is a component on per-worker system entities.
-	const Worker_ComponentId WORKER_COMPONENT_ID = 60;
+const Worker_ComponentId INVALID_COMPONENT_ID = 0;
 
-	const Worker_ComponentId MAX_RESERVED_SPATIAL_SYSTEM_COMPONENT_ID = 100;
+const Worker_ComponentId ENTITY_ACL_COMPONENT_ID = 50;
+const Worker_ComponentId METADATA_COMPONENT_ID = 53;
+const Worker_ComponentId POSITION_COMPONENT_ID = 54;
+const Worker_ComponentId PERSISTENCE_COMPONENT_ID = 55;
+const Worker_ComponentId INTEREST_COMPONENT_ID = 58;
+// This is a component on per-worker system entities.
+const Worker_ComponentId WORKER_COMPONENT_ID = 60;
 
-	const Worker_ComponentId SPAWN_DATA_COMPONENT_ID = 9999;
-	const Worker_ComponentId PLAYER_SPAWNER_COMPONENT_ID = 9998;
-	const Worker_ComponentId SINGLETON_COMPONENT_ID = 9997;
-	const Worker_ComponentId UNREAL_METADATA_COMPONENT_ID = 9996;
-	const Worker_ComponentId SINGLETON_MANAGER_COMPONENT_ID = 9995;
-	const Worker_ComponentId DEPLOYMENT_MAP_COMPONENT_ID = 9994;
-	const Worker_ComponentId STARTUP_ACTOR_MANAGER_COMPONENT_ID = 9993;
-	const Worker_ComponentId GSM_SHUTDOWN_COMPONENT_ID = 9992;
-	const Worker_ComponentId HEARTBEAT_COMPONENT_ID = 9991;
-	// Marking the event-based RPC components as legacy while the ring buffer
-	// implementation is under a feature flag.
-	const Worker_ComponentId CLIENT_RPC_ENDPOINT_COMPONENT_ID_LEGACY = 9990;
-	const Worker_ComponentId SERVER_RPC_ENDPOINT_COMPONENT_ID_LEGACY = 9989;
-	const Worker_ComponentId NETMULTICAST_RPCS_COMPONENT_ID_LEGACY = 9987;
+const Worker_ComponentId MAX_RESERVED_SPATIAL_SYSTEM_COMPONENT_ID = 100;
 
-	const Worker_ComponentId NOT_STREAMED_COMPONENT_ID = 9986;
-	const Worker_ComponentId RPCS_ON_ENTITY_CREATION_ID = 9985;
-	const Worker_ComponentId DEBUG_METRICS_COMPONENT_ID = 9984;
-	const Worker_ComponentId ALWAYS_RELEVANT_COMPONENT_ID = 9983;
-	const Worker_ComponentId TOMBSTONE_COMPONENT_ID = 9982;
-	const Worker_ComponentId DORMANT_COMPONENT_ID = 9981;
-	const Worker_ComponentId AUTHORITY_INTENT_COMPONENT_ID = 9980;
-	const Worker_ComponentId VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID = 9979;
+const Worker_ComponentId SPAWN_DATA_COMPONENT_ID = 9999;
+const Worker_ComponentId PLAYER_SPAWNER_COMPONENT_ID = 9998;
+const Worker_ComponentId SINGLETON_COMPONENT_ID = 9997;
+const Worker_ComponentId UNREAL_METADATA_COMPONENT_ID = 9996;
+const Worker_ComponentId SINGLETON_MANAGER_COMPONENT_ID = 9995;
+const Worker_ComponentId DEPLOYMENT_MAP_COMPONENT_ID = 9994;
+const Worker_ComponentId STARTUP_ACTOR_MANAGER_COMPONENT_ID = 9993;
+const Worker_ComponentId GSM_SHUTDOWN_COMPONENT_ID = 9992;
+const Worker_ComponentId HEARTBEAT_COMPONENT_ID = 9991;
+// Marking the event-based RPC components as legacy while the ring buffer
+// implementation is under a feature flag.
+const Worker_ComponentId CLIENT_RPC_ENDPOINT_COMPONENT_ID_LEGACY = 9990;
+const Worker_ComponentId SERVER_RPC_ENDPOINT_COMPONENT_ID_LEGACY = 9989;
+const Worker_ComponentId NETMULTICAST_RPCS_COMPONENT_ID_LEGACY = 9987;
 
-	const Worker_ComponentId CLIENT_ENDPOINT_COMPONENT_ID = 9978;
-	const Worker_ComponentId SERVER_ENDPOINT_COMPONENT_ID = 9977;
-	const Worker_ComponentId MULTICAST_RPCS_COMPONENT_ID = 9976;
-	const Worker_ComponentId SPATIAL_DEBUGGING_COMPONENT_ID = 9975;
-	const Worker_ComponentId SERVER_WORKER_COMPONENT_ID = 9974;
-	const Worker_ComponentId SERVER_TO_SERVER_COMMAND_ENDPOINT_COMPONENT_ID = 9973;
+const Worker_ComponentId NOT_STREAMED_COMPONENT_ID = 9986;
+const Worker_ComponentId RPCS_ON_ENTITY_CREATION_ID = 9985;
+const Worker_ComponentId DEBUG_METRICS_COMPONENT_ID = 9984;
+const Worker_ComponentId ALWAYS_RELEVANT_COMPONENT_ID = 9983;
+const Worker_ComponentId TOMBSTONE_COMPONENT_ID = 9982;
+const Worker_ComponentId DORMANT_COMPONENT_ID = 9981;
+const Worker_ComponentId AUTHORITY_INTENT_COMPONENT_ID = 9980;
+const Worker_ComponentId VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID = 9979;
 
-	const Worker_ComponentId STARTING_GENERATED_COMPONENT_ID = 10000;
+const Worker_ComponentId CLIENT_ENDPOINT_COMPONENT_ID = 9978;
+const Worker_ComponentId SERVER_ENDPOINT_COMPONENT_ID = 9977;
+const Worker_ComponentId MULTICAST_RPCS_COMPONENT_ID = 9976;
+const Worker_ComponentId SPATIAL_DEBUGGING_COMPONENT_ID = 9975;
+const Worker_ComponentId SERVER_WORKER_COMPONENT_ID = 9974;
+const Worker_ComponentId SERVER_TO_SERVER_COMMAND_ENDPOINT_COMPONENT_ID = 9973;
 
-	const Schema_FieldId SINGLETON_MANAGER_SINGLETON_NAME_TO_ENTITY_ID = 1;
+const Worker_ComponentId STARTING_GENERATED_COMPONENT_ID = 10000;
 
-	const Schema_FieldId DEPLOYMENT_MAP_MAP_URL_ID = 1;
-	const Schema_FieldId DEPLOYMENT_MAP_ACCEPTING_PLAYERS_ID = 2;
-	const Schema_FieldId DEPLOYMENT_MAP_SESSION_ID = 3;
-	const Schema_FieldId DEPLOYMENT_MAP_SCHEMA_HASH = 4;
+const Schema_FieldId SINGLETON_MANAGER_SINGLETON_NAME_TO_ENTITY_ID = 1;
 
-	const Schema_FieldId STARTUP_ACTOR_MANAGER_CAN_BEGIN_PLAY_ID = 1;
+const Schema_FieldId DEPLOYMENT_MAP_MAP_URL_ID = 1;
+const Schema_FieldId DEPLOYMENT_MAP_ACCEPTING_PLAYERS_ID = 2;
+const Schema_FieldId DEPLOYMENT_MAP_SESSION_ID = 3;
+const Schema_FieldId DEPLOYMENT_MAP_SCHEMA_HASH = 4;
 
-	const Schema_FieldId ACTOR_COMPONENT_REPLICATES_ID = 1;
-	const Schema_FieldId ACTOR_TEAROFF_ID = 3;
+const Schema_FieldId STARTUP_ACTOR_MANAGER_CAN_BEGIN_PLAY_ID = 1;
 
-	const Schema_FieldId HEARTBEAT_EVENT_ID = 1;
-	const Schema_FieldId HEARTBEAT_CLIENT_HAS_QUIT_ID = 1;
+const Schema_FieldId ACTOR_COMPONENT_REPLICATES_ID = 1;
+const Schema_FieldId ACTOR_TEAROFF_ID = 3;
 
-	const Schema_FieldId SHUTDOWN_MULTI_PROCESS_REQUEST_ID = 1;
-	const Schema_FieldId SHUTDOWN_ADDITIONAL_SERVERS_EVENT_ID = 1;
+const Schema_FieldId HEARTBEAT_EVENT_ID = 1;
+const Schema_FieldId HEARTBEAT_CLIENT_HAS_QUIT_ID = 1;
 
-	const Schema_FieldId CLEAR_RPCS_ON_ENTITY_CREATION = 1;
+const Schema_FieldId SHUTDOWN_MULTI_PROCESS_REQUEST_ID = 1;
+const Schema_FieldId SHUTDOWN_ADDITIONAL_SERVERS_EVENT_ID = 1;
 
-	// DebugMetrics command IDs
-	const Schema_FieldId DEBUG_METRICS_START_RPC_METRICS_ID = 1;
-	const Schema_FieldId DEBUG_METRICS_STOP_RPC_METRICS_ID = 2;
-	const Schema_FieldId DEBUG_METRICS_MODIFY_SETTINGS_ID = 3;
+const Schema_FieldId CLEAR_RPCS_ON_ENTITY_CREATION = 1;
 
-	// ModifySettingPayload Field IDs
-	const Schema_FieldId MODIFY_SETTING_PAYLOAD_NAME_ID = 1;
-	const Schema_FieldId MODIFY_SETTING_PAYLOAD_VALUE_ID = 2;
+// DebugMetrics command IDs
+const Schema_FieldId DEBUG_METRICS_START_RPC_METRICS_ID = 1;
+const Schema_FieldId DEBUG_METRICS_STOP_RPC_METRICS_ID = 2;
+const Schema_FieldId DEBUG_METRICS_MODIFY_SETTINGS_ID = 3;
 
-	// UnrealObjectRef Field IDs
-	const Schema_FieldId UNREAL_OBJECT_REF_ENTITY_ID = 1;
-	const Schema_FieldId UNREAL_OBJECT_REF_OFFSET_ID = 2;
-	const Schema_FieldId UNREAL_OBJECT_REF_PATH_ID = 3;
-	const Schema_FieldId UNREAL_OBJECT_REF_NO_LOAD_ON_CLIENT_ID = 4;
-	const Schema_FieldId UNREAL_OBJECT_REF_OUTER_ID = 5;
-	const Schema_FieldId UNREAL_OBJECT_REF_USE_SINGLETON_CLASS_PATH_ID = 6;
+// ModifySettingPayload Field IDs
+const Schema_FieldId MODIFY_SETTING_PAYLOAD_NAME_ID = 1;
+const Schema_FieldId MODIFY_SETTING_PAYLOAD_VALUE_ID = 2;
 
-	// UnrealRPCPayload Field IDs
-	const Schema_FieldId UNREAL_RPC_PAYLOAD_OFFSET_ID = 1;
-	const Schema_FieldId UNREAL_RPC_PAYLOAD_RPC_INDEX_ID = 2;
-	const Schema_FieldId UNREAL_RPC_PAYLOAD_RPC_PAYLOAD_ID = 3;
-	const Schema_FieldId UNREAL_RPC_PAYLOAD_TRACE_ID = 4;
-	// UnrealPackedRPCPayload additional Field ID
-	const Schema_FieldId UNREAL_PACKED_RPC_PAYLOAD_ENTITY_ID = 5;
+// UnrealObjectRef Field IDs
+const Schema_FieldId UNREAL_OBJECT_REF_ENTITY_ID = 1;
+const Schema_FieldId UNREAL_OBJECT_REF_OFFSET_ID = 2;
+const Schema_FieldId UNREAL_OBJECT_REF_PATH_ID = 3;
+const Schema_FieldId UNREAL_OBJECT_REF_NO_LOAD_ON_CLIENT_ID = 4;
+const Schema_FieldId UNREAL_OBJECT_REF_OUTER_ID = 5;
+const Schema_FieldId UNREAL_OBJECT_REF_USE_SINGLETON_CLASS_PATH_ID = 6;
 
-	const Schema_FieldId UNREAL_RPC_TRACE_ID = 1;
-	const Schema_FieldId UNREAL_RPC_SPAN_ID = 2;
+// UnrealRPCPayload Field IDs
+const Schema_FieldId UNREAL_RPC_PAYLOAD_OFFSET_ID = 1;
+const Schema_FieldId UNREAL_RPC_PAYLOAD_RPC_INDEX_ID = 2;
+const Schema_FieldId UNREAL_RPC_PAYLOAD_RPC_PAYLOAD_ID = 3;
+const Schema_FieldId UNREAL_RPC_PAYLOAD_TRACE_ID = 4;
+// UnrealPackedRPCPayload additional Field ID
+const Schema_FieldId UNREAL_PACKED_RPC_PAYLOAD_ENTITY_ID = 5;
 
-	// Unreal(Client|Server|Multicast)RPCEndpoint Field IDs
-	const Schema_FieldId UNREAL_RPC_ENDPOINT_READY_ID = 1;
-	const Schema_FieldId UNREAL_RPC_ENDPOINT_EVENT_ID = 1;
-	const Schema_FieldId UNREAL_RPC_ENDPOINT_PACKED_EVENT_ID = 2;
-	const Schema_FieldId UNREAL_RPC_ENDPOINT_COMMAND_ID = 1;
+const Schema_FieldId UNREAL_RPC_TRACE_ID = 1;
+const Schema_FieldId UNREAL_RPC_SPAN_ID = 2;
 
-	const Schema_FieldId PLAYER_SPAWNER_SPAWN_PLAYER_COMMAND_ID = 1;
+// Unreal(Client|Server|Multicast)RPCEndpoint Field IDs
+const Schema_FieldId UNREAL_RPC_ENDPOINT_READY_ID = 1;
+const Schema_FieldId UNREAL_RPC_ENDPOINT_EVENT_ID = 1;
+const Schema_FieldId UNREAL_RPC_ENDPOINT_PACKED_EVENT_ID = 2;
+const Schema_FieldId UNREAL_RPC_ENDPOINT_COMMAND_ID = 1;
 
-	// AuthorityIntent codes and Field IDs.
-	const Schema_FieldId AUTHORITY_INTENT_VIRTUAL_WORKER_ID = 1;
+const Schema_FieldId PLAYER_SPAWNER_SPAWN_PLAYER_COMMAND_ID = 1;
 
-	// VirtualWorkerTranslation Field IDs.
-	const Schema_FieldId VIRTUAL_WORKER_TRANSLATION_MAPPING_ID = 1;
-	const Schema_FieldId MAPPING_VIRTUAL_WORKER_ID = 1;
-	const Schema_FieldId MAPPING_PHYSICAL_WORKER_NAME = 2;
-	const PhysicalWorkerName TRANSLATOR_UNSET_PHYSICAL_NAME = FString("UnsetWorkerName");
+// AuthorityIntent codes and Field IDs.
+const Schema_FieldId AUTHORITY_INTENT_VIRTUAL_WORKER_ID = 1;
 
-	// WorkerEntity Field IDs.
-	const Schema_FieldId WORKER_ID_ID = 1;
-	const Schema_FieldId WORKER_TYPE_ID = 2;
+// VirtualWorkerTranslation Field IDs.
+const Schema_FieldId VIRTUAL_WORKER_TRANSLATION_MAPPING_ID = 1;
+const Schema_FieldId MAPPING_VIRTUAL_WORKER_ID = 1;
+const Schema_FieldId MAPPING_PHYSICAL_WORKER_NAME = 2;
+const PhysicalWorkerName TRANSLATOR_UNSET_PHYSICAL_NAME = FString("UnsetWorkerName");
 
-	// SpatialDebugger Field IDs.
-	const Schema_FieldId SPATIAL_DEBUGGING_AUTHORITATIVE_VIRTUAL_WORKER_ID = 1;
-	const Schema_FieldId SPATIAL_DEBUGGING_AUTHORITATIVE_COLOR = 2;
-	const Schema_FieldId SPATIAL_DEBUGGING_INTENT_VIRTUAL_WORKER_ID = 3;
-	const Schema_FieldId SPATIAL_DEBUGGING_INTENT_COLOR = 4;
-	const Schema_FieldId SPATIAL_DEBUGGING_IS_LOCKED = 5;
+// WorkerEntity Field IDs.
+const Schema_FieldId WORKER_ID_ID = 1;
+const Schema_FieldId WORKER_TYPE_ID = 2;
 
-	// ServerWorker Field IDs.
-	const Schema_FieldId SERVER_WORKER_NAME_ID = 1;
-	const Schema_FieldId SERVER_WORKER_READY_TO_BEGIN_PLAY_ID = 2;
+// SpatialDebugger Field IDs.
+const Schema_FieldId SPATIAL_DEBUGGING_AUTHORITATIVE_VIRTUAL_WORKER_ID = 1;
+const Schema_FieldId SPATIAL_DEBUGGING_AUTHORITATIVE_COLOR = 2;
+const Schema_FieldId SPATIAL_DEBUGGING_INTENT_VIRTUAL_WORKER_ID = 3;
+const Schema_FieldId SPATIAL_DEBUGGING_INTENT_COLOR = 4;
+const Schema_FieldId SPATIAL_DEBUGGING_IS_LOCKED = 5;
 
-	// Reserved entity IDs expire in 5 minutes, we will refresh them every 3 minutes to be safe.
-	const float ENTITY_RANGE_EXPIRATION_INTERVAL_SECONDS = 180.0f;
+// ServerWorker Field IDs.
+const Schema_FieldId SERVER_WORKER_NAME_ID = 1;
+const Schema_FieldId SERVER_WORKER_READY_TO_BEGIN_PLAY_ID = 2;
 
-	const float FIRST_COMMAND_RETRY_WAIT_SECONDS = 0.2f;
-	const uint32 MAX_NUMBER_COMMAND_ATTEMPTS = 5u;
+// Reserved entity IDs expire in 5 minutes, we will refresh them every 3 minutes to be safe.
+const float ENTITY_RANGE_EXPIRATION_INTERVAL_SECONDS = 180.0f;
 
-	const FName DefaultActorGroup = FName(TEXT("Default"));
+const float FIRST_COMMAND_RETRY_WAIT_SECONDS = 0.2f;
+const uint32 MAX_NUMBER_COMMAND_ATTEMPTS = 5u;
 
-	const VirtualWorkerId INVALID_VIRTUAL_WORKER_ID = 0;
-	const ActorLockToken INVALID_ACTOR_LOCK_TOKEN = 0;
-	const FString INVALID_WORKER_NAME = TEXT("");
+const FName DefaultActorGroup = FName(TEXT("Default"));
 
-	const WorkerAttributeSet UnrealServerAttributeSet = TArray<FString>{ DefaultServerWorkerType.ToString() };
-	const WorkerAttributeSet UnrealClientAttributeSet = TArray<FString>{ DefaultClientWorkerType.ToString() };
+const VirtualWorkerId INVALID_VIRTUAL_WORKER_ID = 0;
+const ActorLockToken INVALID_ACTOR_LOCK_TOKEN = 0;
+const FString INVALID_WORKER_NAME = TEXT("");
 
-	const WorkerRequirementSet UnrealServerPermission{ {UnrealServerAttributeSet} };
-	const WorkerRequirementSet UnrealClientPermission{ {UnrealClientAttributeSet} };
-	const WorkerRequirementSet ClientOrServerPermission{ {UnrealClientAttributeSet, UnrealServerAttributeSet} };
+const WorkerAttributeSet UnrealServerAttributeSet = TArray<FString>{ DefaultServerWorkerType.ToString() };
+const WorkerAttributeSet UnrealClientAttributeSet = TArray<FString>{ DefaultClientWorkerType.ToString() };
 
-	const FString ClientsStayConnectedURLOption = TEXT("clientsStayConnected");
-	const FString SpatialSessionIdURLOption = TEXT("spatialSessionId=");
+const WorkerRequirementSet UnrealServerPermission{ {UnrealServerAttributeSet} };
+const WorkerRequirementSet UnrealClientPermission{ {UnrealClientAttributeSet} };
+const WorkerRequirementSet ClientOrServerPermission{ {UnrealClientAttributeSet, UnrealServerAttributeSet} };
 
-	const FString LOCATOR_HOST = TEXT("locator.improbable.io");
-	const FString LOCATOR_HOST_CN = TEXT("locator.spatialoschina.com");
-	const uint16 LOCATOR_PORT = 443;
+const FString ClientsStayConnectedURLOption = TEXT("clientsStayConnected");
+const FString SpatialSessionIdURLOption = TEXT("spatialSessionId=");
 
-	const FString AssemblyPattern = TEXT("^[a-zA-Z0-9_.-]{5,64}$");
-	const FString ProjectPattern = TEXT("^[a-z0-9_]{3,32}$");
-	const FString DeploymentPattern = TEXT("^[a-z0-9_]{2,32}$");
+const FString LOCATOR_HOST = TEXT("locator.improbable.io");
+const FString LOCATOR_HOST_CN = TEXT("locator.spatialoschina.com");
+const uint16 LOCATOR_PORT = 443;
 
-	inline float GetCommandRetryWaitTimeSeconds(uint32 NumAttempts)
-	{
-		// Double the time to wait on each failure.
-		uint32 WaitTimeExponentialFactor = 1u << (NumAttempts - 1);
-		return FIRST_COMMAND_RETRY_WAIT_SECONDS * WaitTimeExponentialFactor;
-	}
+const FString AssemblyPattern = TEXT("^[a-zA-Z0-9_.-]{5,64}$");
+const FString ProjectPattern = TEXT("^[a-z0-9_]{3,32}$");
+const FString DeploymentPattern = TEXT("^[a-z0-9_]{2,32}$");
 
-	const FString LOCAL_HOST = TEXT("127.0.0.1");
-	const uint16  DEFAULT_PORT = 7777;
+inline float GetCommandRetryWaitTimeSeconds(uint32 NumAttempts)
+{
+	// Double the time to wait on each failure.
+	uint32 WaitTimeExponentialFactor = 1u << (NumAttempts - 1);
+	return FIRST_COMMAND_RETRY_WAIT_SECONDS * WaitTimeExponentialFactor;
+}
 
-	const float ENTITY_QUERY_RETRY_WAIT_SECONDS = 3.0f;
+const FString LOCAL_HOST = TEXT("127.0.0.1");
+const uint16  DEFAULT_PORT = 7777;
 
-	const Worker_ComponentId MIN_EXTERNAL_SCHEMA_ID = 1000;
-	const Worker_ComponentId MAX_EXTERNAL_SCHEMA_ID = 2000;
+const float ENTITY_QUERY_RETRY_WAIT_SECONDS = 3.0f;
 
-	const FString SPATIALOS_METRICS_DYNAMIC_FPS = TEXT("Dynamic.FPS");
+const Worker_ComponentId MIN_EXTERNAL_SCHEMA_ID = 1000;
+const Worker_ComponentId MAX_EXTERNAL_SCHEMA_ID = 2000;
 
-	// URL that can be used to reconnect using the command line arguments.
-	const FString RECONNECT_USING_COMMANDLINE_ARGUMENTS = TEXT("0.0.0.0");
-	const FString URL_LOGIN_OPTION = TEXT("login=");
-	const FString URL_PLAYER_IDENTITY_OPTION = TEXT("playeridentity=");
-	const FString URL_DEV_AUTH_TOKEN_OPTION = TEXT("devauthtoken=");
-	const FString URL_TARGET_DEPLOYMENT_OPTION = TEXT("deployment=");
-	const FString URL_PLAYER_ID_OPTION = TEXT("playerid=");
-	const FString URL_DISPLAY_NAME_OPTION = TEXT("displayname=");
-	const FString URL_METADATA_OPTION = TEXT("metadata=");
+const FString SPATIALOS_METRICS_DYNAMIC_FPS = TEXT("Dynamic.FPS");
 
-	const FString DEVELOPMENT_AUTH_PLAYER_ID = TEXT("Player Id");
+// URL that can be used to reconnect using the command line arguments.
+const FString RECONNECT_USING_COMMANDLINE_ARGUMENTS = TEXT("0.0.0.0");
+const FString URL_LOGIN_OPTION = TEXT("login=");
+const FString URL_PLAYER_IDENTITY_OPTION = TEXT("playeridentity=");
+const FString URL_DEV_AUTH_TOKEN_OPTION = TEXT("devauthtoken=");
+const FString URL_TARGET_DEPLOYMENT_OPTION = TEXT("deployment=");
+const FString URL_PLAYER_ID_OPTION = TEXT("playerid=");
+const FString URL_DISPLAY_NAME_OPTION = TEXT("displayname=");
+const FString URL_METADATA_OPTION = TEXT("metadata=");
 
-	const FString SCHEMA_DATABASE_FILE_PATH = TEXT("Spatial/SchemaDatabase");
-	const FString SCHEMA_DATABASE_ASSET_PATH = TEXT("/Game/Spatial/SchemaDatabase");
+const FString DEVELOPMENT_AUTH_PLAYER_ID = TEXT("Player Id");
 
-	const WorkerAttributeSet LoadBalancerAttributeSet = { DefaultServerWorkerType.ToString() };
+const FString SCHEMA_DATABASE_FILE_PATH = TEXT("Spatial/SchemaDatabase");
+const FString SCHEMA_DATABASE_ASSET_PATH = TEXT("/Game/Spatial/SchemaDatabase");
+
+const WorkerAttributeSet LoadBalancerAttributeSet = { DefaultServerWorkerType.ToString() };
 
 // A list of components clients require on top of any generated data components in order to handle non-authoritative actors correctly.
 const TArray<Worker_ComponentId> REQUIRED_COMPONENTS_FOR_NON_AUTH_CLIENT_INTEREST = TArray<Worker_ComponentId>

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -312,8 +312,7 @@ const TArray<Worker_ComponentId> REQUIRED_COMPONENTS_FOR_NON_AUTH_SERVER_INTERES
 	GSM_SHUTDOWN_COMPONENT_ID,
 
 	// Unreal load balancing components
-	VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID,
-	AUTHORITY_INTENT_COMPONENT_ID
+	VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID
 };
 
 // A list of components servers require on entities they are authoritative over on top of the components already checked out by the interest query.

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -6,6 +6,7 @@
 #include "Schema/UnrealObjectRef.h"
 #include "SpatialCommonTypes.h"
 #include "UObject/Script.h"
+#include "Utils/SpatialActorGroupManager.h"
 
 #include <WorkerSDK/improbable/c_schema.h>
 #include <WorkerSDK/improbable/c_worker.h>
@@ -260,8 +261,6 @@ const FString DEVELOPMENT_AUTH_PLAYER_ID = TEXT("Player Id");
 const FString SCHEMA_DATABASE_FILE_PATH  = TEXT("Spatial/SchemaDatabase");
 const FString SCHEMA_DATABASE_ASSET_PATH = TEXT("/Game/Spatial/SchemaDatabase");
 
-const WorkerAttributeSet LoadBalancerAttributeSet = { DefaultServerWorkerType.ToString() };
-
 // A list of components clients require on top of any generated data components in order to handle non-authoritative actors correctly.
 const TArray<Worker_ComponentId> REQUIRED_COMPONENTS_FOR_NON_AUTH_CLIENT_INTEREST = TArray<Worker_ComponentId>
 {
@@ -357,6 +356,15 @@ inline Worker_ComponentId RPCTypeToWorkerComponentIdLegacy(ERPCType RPCType)
 inline Worker_ComponentId GetClientAuthorityComponent(bool bUsingRingBuffers)
 {
 	return bUsingRingBuffers ? CLIENT_ENDPOINT_COMPONENT_ID : CLIENT_RPC_ENDPOINT_COMPONENT_ID_LEGACY;
+}
+
+inline WorkerAttributeSet GetLoadBalancerAttributeSet(FName LoadBalancingWorkerType)
+{
+	if (LoadBalancingWorkerType == "")
+	{
+		return { DefaultServerWorkerType.ToString() };
+	}
+	return { LoadBalancingWorkerType.ToString() };
 }
 
 } // ::SpatialConstants

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -260,7 +260,7 @@ const FString DEVELOPMENT_AUTH_PLAYER_ID = TEXT("Player Id");
 const FString SCHEMA_DATABASE_FILE_PATH  = TEXT("Spatial/SchemaDatabase");
 const FString SCHEMA_DATABASE_ASSET_PATH = TEXT("/Game/Spatial/SchemaDatabase");
 
-const FString LoadBalancerAttributeSet = { DefaultServerWorkerType.ToString() };
+const WorkerAttributeSet LoadBalancerAttributeSet = { DefaultServerWorkerType.ToString() };
 
 // A list of components clients require on top of any generated data components in order to handle non-authoritative actors correctly.
 const TArray<Worker_ComponentId> REQUIRED_COMPONENTS_FOR_NON_AUTH_CLIENT_INTEREST = TArray<Worker_ComponentId>

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -42,225 +42,225 @@ enum ESchemaComponentType : int32
 namespace SpatialConstants
 {
 
-inline FString RPCTypeToString(ERPCType RPCType)
-{
-	switch (RPCType)
+	inline FString RPCTypeToString(ERPCType RPCType)
 	{
-	case ERPCType::ClientReliable:
-		return TEXT("Client, Reliable");
-	case ERPCType::ClientUnreliable:
-		return TEXT("Client, Unreliable");
-	case ERPCType::ServerReliable:
-		return TEXT("Server, Reliable");
-	case ERPCType::ServerUnreliable:
-		return TEXT("Server, Unreliable");
-	case ERPCType::NetMulticast:
-		return TEXT("Multicast");
-	case ERPCType::CrossServer:
-		return TEXT("CrossServer");
+		switch (RPCType)
+		{
+		case ERPCType::ClientReliable:
+			return TEXT("Client, Reliable");
+		case ERPCType::ClientUnreliable:
+			return TEXT("Client, Unreliable");
+		case ERPCType::ServerReliable:
+			return TEXT("Server, Reliable");
+		case ERPCType::ServerUnreliable:
+			return TEXT("Server, Unreliable");
+		case ERPCType::NetMulticast:
+			return TEXT("Multicast");
+		case ERPCType::CrossServer:
+			return TEXT("CrossServer");
+		}
+
+		checkNoEntry();
+		return FString();
 	}
 
-	checkNoEntry();
-	return FString();
-}
+	enum EntityIds
+	{
+		INVALID_ENTITY_ID = 0,
+		INITIAL_SPAWNER_ENTITY_ID = 1,
+		INITIAL_GLOBAL_STATE_MANAGER_ENTITY_ID = 2,
+		INITIAL_VIRTUAL_WORKER_TRANSLATOR_ENTITY_ID = 3,
+		FIRST_AVAILABLE_ENTITY_ID = 4,
+	};
 
-enum EntityIds
-{
-	INVALID_ENTITY_ID = 0,
-	INITIAL_SPAWNER_ENTITY_ID = 1,
-	INITIAL_GLOBAL_STATE_MANAGER_ENTITY_ID = 2,
-	INITIAL_VIRTUAL_WORKER_TRANSLATOR_ENTITY_ID = 3,
-	FIRST_AVAILABLE_ENTITY_ID = 4,
-};
+	const Worker_ComponentId INVALID_COMPONENT_ID = 0;
 
-const Worker_ComponentId INVALID_COMPONENT_ID = 0;
+	const Worker_ComponentId ENTITY_ACL_COMPONENT_ID = 50;
+	const Worker_ComponentId METADATA_COMPONENT_ID = 53;
+	const Worker_ComponentId POSITION_COMPONENT_ID = 54;
+	const Worker_ComponentId PERSISTENCE_COMPONENT_ID = 55;
+	const Worker_ComponentId INTEREST_COMPONENT_ID = 58;
+	// This is a component on per-worker system entities.
+	const Worker_ComponentId WORKER_COMPONENT_ID = 60;
 
-const Worker_ComponentId ENTITY_ACL_COMPONENT_ID = 50;
-const Worker_ComponentId METADATA_COMPONENT_ID = 53;
-const Worker_ComponentId POSITION_COMPONENT_ID = 54;
-const Worker_ComponentId PERSISTENCE_COMPONENT_ID = 55;
-const Worker_ComponentId INTEREST_COMPONENT_ID = 58;
-// This is a component on per-worker system entities.
-const Worker_ComponentId WORKER_COMPONENT_ID = 60;
+	const Worker_ComponentId MAX_RESERVED_SPATIAL_SYSTEM_COMPONENT_ID = 100;
 
-const Worker_ComponentId MAX_RESERVED_SPATIAL_SYSTEM_COMPONENT_ID = 100;
+	const Worker_ComponentId SPAWN_DATA_COMPONENT_ID = 9999;
+	const Worker_ComponentId PLAYER_SPAWNER_COMPONENT_ID = 9998;
+	const Worker_ComponentId SINGLETON_COMPONENT_ID = 9997;
+	const Worker_ComponentId UNREAL_METADATA_COMPONENT_ID = 9996;
+	const Worker_ComponentId SINGLETON_MANAGER_COMPONENT_ID = 9995;
+	const Worker_ComponentId DEPLOYMENT_MAP_COMPONENT_ID = 9994;
+	const Worker_ComponentId STARTUP_ACTOR_MANAGER_COMPONENT_ID = 9993;
+	const Worker_ComponentId GSM_SHUTDOWN_COMPONENT_ID = 9992;
+	const Worker_ComponentId HEARTBEAT_COMPONENT_ID = 9991;
+	// Marking the event-based RPC components as legacy while the ring buffer
+	// implementation is under a feature flag.
+	const Worker_ComponentId CLIENT_RPC_ENDPOINT_COMPONENT_ID_LEGACY = 9990;
+	const Worker_ComponentId SERVER_RPC_ENDPOINT_COMPONENT_ID_LEGACY = 9989;
+	const Worker_ComponentId NETMULTICAST_RPCS_COMPONENT_ID_LEGACY = 9987;
 
-const Worker_ComponentId SPAWN_DATA_COMPONENT_ID = 9999;
-const Worker_ComponentId PLAYER_SPAWNER_COMPONENT_ID = 9998;
-const Worker_ComponentId SINGLETON_COMPONENT_ID = 9997;
-const Worker_ComponentId UNREAL_METADATA_COMPONENT_ID = 9996;
-const Worker_ComponentId SINGLETON_MANAGER_COMPONENT_ID = 9995;
-const Worker_ComponentId DEPLOYMENT_MAP_COMPONENT_ID = 9994;
-const Worker_ComponentId STARTUP_ACTOR_MANAGER_COMPONENT_ID = 9993;
-const Worker_ComponentId GSM_SHUTDOWN_COMPONENT_ID = 9992;
-const Worker_ComponentId HEARTBEAT_COMPONENT_ID = 9991;
-// Marking the event-based RPC components as legacy while the ring buffer
-// implementation is under a feature flag.
-const Worker_ComponentId CLIENT_RPC_ENDPOINT_COMPONENT_ID_LEGACY = 9990;
-const Worker_ComponentId SERVER_RPC_ENDPOINT_COMPONENT_ID_LEGACY = 9989;
-const Worker_ComponentId NETMULTICAST_RPCS_COMPONENT_ID_LEGACY = 9987;
+	const Worker_ComponentId NOT_STREAMED_COMPONENT_ID = 9986;
+	const Worker_ComponentId RPCS_ON_ENTITY_CREATION_ID = 9985;
+	const Worker_ComponentId DEBUG_METRICS_COMPONENT_ID = 9984;
+	const Worker_ComponentId ALWAYS_RELEVANT_COMPONENT_ID = 9983;
+	const Worker_ComponentId TOMBSTONE_COMPONENT_ID = 9982;
+	const Worker_ComponentId DORMANT_COMPONENT_ID = 9981;
+	const Worker_ComponentId AUTHORITY_INTENT_COMPONENT_ID = 9980;
+	const Worker_ComponentId VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID = 9979;
 
-const Worker_ComponentId NOT_STREAMED_COMPONENT_ID = 9986;
-const Worker_ComponentId RPCS_ON_ENTITY_CREATION_ID = 9985;
-const Worker_ComponentId DEBUG_METRICS_COMPONENT_ID = 9984;
-const Worker_ComponentId ALWAYS_RELEVANT_COMPONENT_ID = 9983;
-const Worker_ComponentId TOMBSTONE_COMPONENT_ID = 9982;
-const Worker_ComponentId DORMANT_COMPONENT_ID = 9981;
-const Worker_ComponentId AUTHORITY_INTENT_COMPONENT_ID = 9980;
-const Worker_ComponentId VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID = 9979;
+	const Worker_ComponentId CLIENT_ENDPOINT_COMPONENT_ID = 9978;
+	const Worker_ComponentId SERVER_ENDPOINT_COMPONENT_ID = 9977;
+	const Worker_ComponentId MULTICAST_RPCS_COMPONENT_ID = 9976;
+	const Worker_ComponentId SPATIAL_DEBUGGING_COMPONENT_ID = 9975;
+	const Worker_ComponentId SERVER_WORKER_COMPONENT_ID = 9974;
+	const Worker_ComponentId SERVER_TO_SERVER_COMMAND_ENDPOINT_COMPONENT_ID = 9973;
 
-const Worker_ComponentId CLIENT_ENDPOINT_COMPONENT_ID = 9978;
-const Worker_ComponentId SERVER_ENDPOINT_COMPONENT_ID = 9977;
-const Worker_ComponentId MULTICAST_RPCS_COMPONENT_ID = 9976;
-const Worker_ComponentId SPATIAL_DEBUGGING_COMPONENT_ID = 9975;
-const Worker_ComponentId SERVER_WORKER_COMPONENT_ID = 9974;
-const Worker_ComponentId SERVER_TO_SERVER_COMMAND_ENDPOINT_COMPONENT_ID = 9973;
+	const Worker_ComponentId STARTING_GENERATED_COMPONENT_ID = 10000;
 
-const Worker_ComponentId STARTING_GENERATED_COMPONENT_ID = 10000;
+	const Schema_FieldId SINGLETON_MANAGER_SINGLETON_NAME_TO_ENTITY_ID = 1;
 
-const Schema_FieldId SINGLETON_MANAGER_SINGLETON_NAME_TO_ENTITY_ID = 1;
+	const Schema_FieldId DEPLOYMENT_MAP_MAP_URL_ID = 1;
+	const Schema_FieldId DEPLOYMENT_MAP_ACCEPTING_PLAYERS_ID = 2;
+	const Schema_FieldId DEPLOYMENT_MAP_SESSION_ID = 3;
+	const Schema_FieldId DEPLOYMENT_MAP_SCHEMA_HASH = 4;
 
-const Schema_FieldId DEPLOYMENT_MAP_MAP_URL_ID = 1;
-const Schema_FieldId DEPLOYMENT_MAP_ACCEPTING_PLAYERS_ID = 2;
-const Schema_FieldId DEPLOYMENT_MAP_SESSION_ID = 3;
-const Schema_FieldId DEPLOYMENT_MAP_SCHEMA_HASH = 4;
+	const Schema_FieldId STARTUP_ACTOR_MANAGER_CAN_BEGIN_PLAY_ID = 1;
 
-const Schema_FieldId STARTUP_ACTOR_MANAGER_CAN_BEGIN_PLAY_ID = 1;
+	const Schema_FieldId ACTOR_COMPONENT_REPLICATES_ID = 1;
+	const Schema_FieldId ACTOR_TEAROFF_ID = 3;
 
-const Schema_FieldId ACTOR_COMPONENT_REPLICATES_ID = 1;
-const Schema_FieldId ACTOR_TEAROFF_ID = 3;
+	const Schema_FieldId HEARTBEAT_EVENT_ID = 1;
+	const Schema_FieldId HEARTBEAT_CLIENT_HAS_QUIT_ID = 1;
 
-const Schema_FieldId HEARTBEAT_EVENT_ID = 1;
-const Schema_FieldId HEARTBEAT_CLIENT_HAS_QUIT_ID = 1;
+	const Schema_FieldId SHUTDOWN_MULTI_PROCESS_REQUEST_ID = 1;
+	const Schema_FieldId SHUTDOWN_ADDITIONAL_SERVERS_EVENT_ID = 1;
 
-const Schema_FieldId SHUTDOWN_MULTI_PROCESS_REQUEST_ID = 1;
-const Schema_FieldId SHUTDOWN_ADDITIONAL_SERVERS_EVENT_ID = 1;
+	const Schema_FieldId CLEAR_RPCS_ON_ENTITY_CREATION = 1;
 
-const Schema_FieldId CLEAR_RPCS_ON_ENTITY_CREATION = 1;
+	// DebugMetrics command IDs
+	const Schema_FieldId DEBUG_METRICS_START_RPC_METRICS_ID = 1;
+	const Schema_FieldId DEBUG_METRICS_STOP_RPC_METRICS_ID = 2;
+	const Schema_FieldId DEBUG_METRICS_MODIFY_SETTINGS_ID = 3;
 
-// DebugMetrics command IDs
-const Schema_FieldId DEBUG_METRICS_START_RPC_METRICS_ID = 1;
-const Schema_FieldId DEBUG_METRICS_STOP_RPC_METRICS_ID = 2;
-const Schema_FieldId DEBUG_METRICS_MODIFY_SETTINGS_ID = 3;
+	// ModifySettingPayload Field IDs
+	const Schema_FieldId MODIFY_SETTING_PAYLOAD_NAME_ID = 1;
+	const Schema_FieldId MODIFY_SETTING_PAYLOAD_VALUE_ID = 2;
 
-// ModifySettingPayload Field IDs
-const Schema_FieldId MODIFY_SETTING_PAYLOAD_NAME_ID = 1;
-const Schema_FieldId MODIFY_SETTING_PAYLOAD_VALUE_ID = 2;
+	// UnrealObjectRef Field IDs
+	const Schema_FieldId UNREAL_OBJECT_REF_ENTITY_ID = 1;
+	const Schema_FieldId UNREAL_OBJECT_REF_OFFSET_ID = 2;
+	const Schema_FieldId UNREAL_OBJECT_REF_PATH_ID = 3;
+	const Schema_FieldId UNREAL_OBJECT_REF_NO_LOAD_ON_CLIENT_ID = 4;
+	const Schema_FieldId UNREAL_OBJECT_REF_OUTER_ID = 5;
+	const Schema_FieldId UNREAL_OBJECT_REF_USE_SINGLETON_CLASS_PATH_ID = 6;
 
-// UnrealObjectRef Field IDs
-const Schema_FieldId UNREAL_OBJECT_REF_ENTITY_ID = 1;
-const Schema_FieldId UNREAL_OBJECT_REF_OFFSET_ID = 2;
-const Schema_FieldId UNREAL_OBJECT_REF_PATH_ID = 3;
-const Schema_FieldId UNREAL_OBJECT_REF_NO_LOAD_ON_CLIENT_ID = 4;
-const Schema_FieldId UNREAL_OBJECT_REF_OUTER_ID = 5;
-const Schema_FieldId UNREAL_OBJECT_REF_USE_SINGLETON_CLASS_PATH_ID = 6;
+	// UnrealRPCPayload Field IDs
+	const Schema_FieldId UNREAL_RPC_PAYLOAD_OFFSET_ID = 1;
+	const Schema_FieldId UNREAL_RPC_PAYLOAD_RPC_INDEX_ID = 2;
+	const Schema_FieldId UNREAL_RPC_PAYLOAD_RPC_PAYLOAD_ID = 3;
+	const Schema_FieldId UNREAL_RPC_PAYLOAD_TRACE_ID = 4;
+	// UnrealPackedRPCPayload additional Field ID
+	const Schema_FieldId UNREAL_PACKED_RPC_PAYLOAD_ENTITY_ID = 5;
 
-// UnrealRPCPayload Field IDs
-const Schema_FieldId UNREAL_RPC_PAYLOAD_OFFSET_ID = 1;
-const Schema_FieldId UNREAL_RPC_PAYLOAD_RPC_INDEX_ID = 2;
-const Schema_FieldId UNREAL_RPC_PAYLOAD_RPC_PAYLOAD_ID = 3;
-const Schema_FieldId UNREAL_RPC_PAYLOAD_TRACE_ID = 4;
-// UnrealPackedRPCPayload additional Field ID
-const Schema_FieldId UNREAL_PACKED_RPC_PAYLOAD_ENTITY_ID = 5;
+	const Schema_FieldId UNREAL_RPC_TRACE_ID = 1;
+	const Schema_FieldId UNREAL_RPC_SPAN_ID = 2;
 
-const Schema_FieldId UNREAL_RPC_TRACE_ID = 1;
-const Schema_FieldId UNREAL_RPC_SPAN_ID = 2;
+	// Unreal(Client|Server|Multicast)RPCEndpoint Field IDs
+	const Schema_FieldId UNREAL_RPC_ENDPOINT_READY_ID = 1;
+	const Schema_FieldId UNREAL_RPC_ENDPOINT_EVENT_ID = 1;
+	const Schema_FieldId UNREAL_RPC_ENDPOINT_PACKED_EVENT_ID = 2;
+	const Schema_FieldId UNREAL_RPC_ENDPOINT_COMMAND_ID = 1;
 
-// Unreal(Client|Server|Multicast)RPCEndpoint Field IDs
-const Schema_FieldId UNREAL_RPC_ENDPOINT_READY_ID = 1;
-const Schema_FieldId UNREAL_RPC_ENDPOINT_EVENT_ID = 1;
-const Schema_FieldId UNREAL_RPC_ENDPOINT_PACKED_EVENT_ID = 2;
-const Schema_FieldId UNREAL_RPC_ENDPOINT_COMMAND_ID = 1;
+	const Schema_FieldId PLAYER_SPAWNER_SPAWN_PLAYER_COMMAND_ID = 1;
 
-const Schema_FieldId PLAYER_SPAWNER_SPAWN_PLAYER_COMMAND_ID = 1;
+	// AuthorityIntent codes and Field IDs.
+	const Schema_FieldId AUTHORITY_INTENT_VIRTUAL_WORKER_ID = 1;
 
-// AuthorityIntent codes and Field IDs.
-const Schema_FieldId AUTHORITY_INTENT_VIRTUAL_WORKER_ID = 1;
+	// VirtualWorkerTranslation Field IDs.
+	const Schema_FieldId VIRTUAL_WORKER_TRANSLATION_MAPPING_ID = 1;
+	const Schema_FieldId MAPPING_VIRTUAL_WORKER_ID = 1;
+	const Schema_FieldId MAPPING_PHYSICAL_WORKER_NAME = 2;
+	const PhysicalWorkerName TRANSLATOR_UNSET_PHYSICAL_NAME = FString("UnsetWorkerName");
 
-// VirtualWorkerTranslation Field IDs.
-const Schema_FieldId VIRTUAL_WORKER_TRANSLATION_MAPPING_ID = 1;
-const Schema_FieldId MAPPING_VIRTUAL_WORKER_ID = 1;
-const Schema_FieldId MAPPING_PHYSICAL_WORKER_NAME = 2;
-const PhysicalWorkerName TRANSLATOR_UNSET_PHYSICAL_NAME = FString("UnsetWorkerName");
+	// WorkerEntity Field IDs.
+	const Schema_FieldId WORKER_ID_ID = 1;
+	const Schema_FieldId WORKER_TYPE_ID = 2;
 
-// WorkerEntity Field IDs.
-const Schema_FieldId WORKER_ID_ID = 1;
-const Schema_FieldId WORKER_TYPE_ID = 2;
+	// SpatialDebugger Field IDs.
+	const Schema_FieldId SPATIAL_DEBUGGING_AUTHORITATIVE_VIRTUAL_WORKER_ID = 1;
+	const Schema_FieldId SPATIAL_DEBUGGING_AUTHORITATIVE_COLOR = 2;
+	const Schema_FieldId SPATIAL_DEBUGGING_INTENT_VIRTUAL_WORKER_ID = 3;
+	const Schema_FieldId SPATIAL_DEBUGGING_INTENT_COLOR = 4;
+	const Schema_FieldId SPATIAL_DEBUGGING_IS_LOCKED = 5;
 
-// SpatialDebugger Field IDs.
-const Schema_FieldId SPATIAL_DEBUGGING_AUTHORITATIVE_VIRTUAL_WORKER_ID = 1;
-const Schema_FieldId SPATIAL_DEBUGGING_AUTHORITATIVE_COLOR = 2;
-const Schema_FieldId SPATIAL_DEBUGGING_INTENT_VIRTUAL_WORKER_ID = 3;
-const Schema_FieldId SPATIAL_DEBUGGING_INTENT_COLOR = 4;
-const Schema_FieldId SPATIAL_DEBUGGING_IS_LOCKED = 5;
+	// ServerWorker Field IDs.
+	const Schema_FieldId SERVER_WORKER_NAME_ID = 1;
+	const Schema_FieldId SERVER_WORKER_READY_TO_BEGIN_PLAY_ID = 2;
 
-// ServerWorker Field IDs.
-const Schema_FieldId SERVER_WORKER_NAME_ID = 1;
-const Schema_FieldId SERVER_WORKER_READY_TO_BEGIN_PLAY_ID = 2;
+	// Reserved entity IDs expire in 5 minutes, we will refresh them every 3 minutes to be safe.
+	const float ENTITY_RANGE_EXPIRATION_INTERVAL_SECONDS = 180.0f;
 
-// Reserved entity IDs expire in 5 minutes, we will refresh them every 3 minutes to be safe.
-const float ENTITY_RANGE_EXPIRATION_INTERVAL_SECONDS = 180.0f;
+	const float FIRST_COMMAND_RETRY_WAIT_SECONDS = 0.2f;
+	const uint32 MAX_NUMBER_COMMAND_ATTEMPTS = 5u;
 
-const float FIRST_COMMAND_RETRY_WAIT_SECONDS = 0.2f;
-const uint32 MAX_NUMBER_COMMAND_ATTEMPTS = 5u;
+	const FName DefaultActorGroup = FName(TEXT("Default"));
 
-const FName DefaultActorGroup = FName(TEXT("Default"));
+	const VirtualWorkerId INVALID_VIRTUAL_WORKER_ID = 0;
+	const ActorLockToken INVALID_ACTOR_LOCK_TOKEN = 0;
+	const FString INVALID_WORKER_NAME = TEXT("");
 
-const VirtualWorkerId INVALID_VIRTUAL_WORKER_ID = 0;
-const ActorLockToken INVALID_ACTOR_LOCK_TOKEN = 0;
-const FString INVALID_WORKER_NAME = TEXT("");
+	const WorkerAttributeSet UnrealServerAttributeSet = TArray<FString>{ DefaultServerWorkerType.ToString() };
+	const WorkerAttributeSet UnrealClientAttributeSet = TArray<FString>{ DefaultClientWorkerType.ToString() };
 
-const WorkerAttributeSet UnrealServerAttributeSet = TArray<FString>{ DefaultServerWorkerType.ToString() };
-const WorkerAttributeSet UnrealClientAttributeSet = TArray<FString>{ DefaultClientWorkerType.ToString() };
+	const WorkerRequirementSet UnrealServerPermission{ {UnrealServerAttributeSet} };
+	const WorkerRequirementSet UnrealClientPermission{ {UnrealClientAttributeSet} };
+	const WorkerRequirementSet ClientOrServerPermission{ {UnrealClientAttributeSet, UnrealServerAttributeSet} };
 
-const WorkerRequirementSet UnrealServerPermission{ {UnrealServerAttributeSet} };
-const WorkerRequirementSet UnrealClientPermission{ {UnrealClientAttributeSet} };
-const WorkerRequirementSet ClientOrServerPermission{ {UnrealClientAttributeSet, UnrealServerAttributeSet} };
+	const FString ClientsStayConnectedURLOption = TEXT("clientsStayConnected");
+	const FString SpatialSessionIdURLOption = TEXT("spatialSessionId=");
 
-const FString ClientsStayConnectedURLOption = TEXT("clientsStayConnected");
-const FString SpatialSessionIdURLOption = TEXT("spatialSessionId=");
+	const FString LOCATOR_HOST = TEXT("locator.improbable.io");
+	const FString LOCATOR_HOST_CN = TEXT("locator.spatialoschina.com");
+	const uint16 LOCATOR_PORT = 443;
 
-const FString LOCATOR_HOST = TEXT("locator.improbable.io");
-const FString LOCATOR_HOST_CN = TEXT("locator.spatialoschina.com");
-const uint16 LOCATOR_PORT = 443;
+	const FString AssemblyPattern = TEXT("^[a-zA-Z0-9_.-]{5,64}$");
+	const FString ProjectPattern = TEXT("^[a-z0-9_]{3,32}$");
+	const FString DeploymentPattern = TEXT("^[a-z0-9_]{2,32}$");
 
-const FString AssemblyPattern = TEXT("^[a-zA-Z0-9_.-]{5,64}$");
-const FString ProjectPattern = TEXT("^[a-z0-9_]{3,32}$");
-const FString DeploymentPattern = TEXT("^[a-z0-9_]{2,32}$");
+	inline float GetCommandRetryWaitTimeSeconds(uint32 NumAttempts)
+	{
+		// Double the time to wait on each failure.
+		uint32 WaitTimeExponentialFactor = 1u << (NumAttempts - 1);
+		return FIRST_COMMAND_RETRY_WAIT_SECONDS * WaitTimeExponentialFactor;
+	}
 
-inline float GetCommandRetryWaitTimeSeconds(uint32 NumAttempts)
-{
-	// Double the time to wait on each failure.
-	uint32 WaitTimeExponentialFactor = 1u << (NumAttempts - 1);
-	return FIRST_COMMAND_RETRY_WAIT_SECONDS * WaitTimeExponentialFactor;
-}
+	const FString LOCAL_HOST = TEXT("127.0.0.1");
+	const uint16  DEFAULT_PORT = 7777;
 
-const FString LOCAL_HOST = TEXT("127.0.0.1");
-const uint16  DEFAULT_PORT = 7777;
+	const float ENTITY_QUERY_RETRY_WAIT_SECONDS = 3.0f;
 
-const float ENTITY_QUERY_RETRY_WAIT_SECONDS = 3.0f;
+	const Worker_ComponentId MIN_EXTERNAL_SCHEMA_ID = 1000;
+	const Worker_ComponentId MAX_EXTERNAL_SCHEMA_ID = 2000;
 
-const Worker_ComponentId MIN_EXTERNAL_SCHEMA_ID = 1000;
-const Worker_ComponentId MAX_EXTERNAL_SCHEMA_ID = 2000;
+	const FString SPATIALOS_METRICS_DYNAMIC_FPS = TEXT("Dynamic.FPS");
 
-const FString SPATIALOS_METRICS_DYNAMIC_FPS = TEXT("Dynamic.FPS");
+	// URL that can be used to reconnect using the command line arguments.
+	const FString RECONNECT_USING_COMMANDLINE_ARGUMENTS = TEXT("0.0.0.0");
+	const FString URL_LOGIN_OPTION = TEXT("login=");
+	const FString URL_PLAYER_IDENTITY_OPTION = TEXT("playeridentity=");
+	const FString URL_DEV_AUTH_TOKEN_OPTION = TEXT("devauthtoken=");
+	const FString URL_TARGET_DEPLOYMENT_OPTION = TEXT("deployment=");
+	const FString URL_PLAYER_ID_OPTION = TEXT("playerid=");
+	const FString URL_DISPLAY_NAME_OPTION = TEXT("displayname=");
+	const FString URL_METADATA_OPTION = TEXT("metadata=");
 
-// URL that can be used to reconnect using the command line arguments.
-const FString RECONNECT_USING_COMMANDLINE_ARGUMENTS = TEXT("0.0.0.0");
-const FString URL_LOGIN_OPTION = TEXT("login=");
-const FString URL_PLAYER_IDENTITY_OPTION = TEXT("playeridentity=");
-const FString URL_DEV_AUTH_TOKEN_OPTION = TEXT("devauthtoken=");
-const FString URL_TARGET_DEPLOYMENT_OPTION = TEXT("deployment=");
-const FString URL_PLAYER_ID_OPTION = TEXT("playerid=");
-const FString URL_DISPLAY_NAME_OPTION = TEXT("displayname=");
-const FString URL_METADATA_OPTION = TEXT("metadata=");
+	const FString DEVELOPMENT_AUTH_PLAYER_ID = TEXT("Player Id");
 
-const FString DEVELOPMENT_AUTH_PLAYER_ID = TEXT("Player Id");
+	const FString SCHEMA_DATABASE_FILE_PATH = TEXT("Spatial/SchemaDatabase");
+	const FString SCHEMA_DATABASE_ASSET_PATH = TEXT("/Game/Spatial/SchemaDatabase");
 
-const FString SCHEMA_DATABASE_FILE_PATH = TEXT("Spatial/SchemaDatabase");
-const FString SCHEMA_DATABASE_ASSET_PATH = TEXT("/Game/Spatial/SchemaDatabase");
-
-const WorkerAttributeSet LoadBalancerAttributeSet = { DefaultServerWorkerType.ToString() };
+	const FString LoadBalancerAttributeSet = { DefaultServerWorkerType.ToString() };
 
 // A list of components clients require on top of any generated data components in order to handle non-authoritative actors correctly.
 const TArray<Worker_ComponentId> REQUIRED_COMPONENTS_FOR_NON_AUTH_CLIENT_INTEREST = TArray<Worker_ComponentId>
@@ -312,7 +312,7 @@ const TArray<Worker_ComponentId> REQUIRED_COMPONENTS_FOR_NON_AUTH_SERVER_INTERES
 	GSM_SHUTDOWN_COMPONENT_ID,
 
 	// Unreal load balancing components
-	VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID
+	VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID,
 };
 
 // A list of components servers require on entities they are authoritative over on top of the components already checked out by the interest query.

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -42,225 +42,225 @@ enum ESchemaComponentType : int32
 namespace SpatialConstants
 {
 
-	inline FString RPCTypeToString(ERPCType RPCType)
+inline FString RPCTypeToString(ERPCType RPCType)
+{
+	switch (RPCType)
 	{
-		switch (RPCType)
-		{
-		case ERPCType::ClientReliable:
-			return TEXT("Client, Reliable");
-		case ERPCType::ClientUnreliable:
-			return TEXT("Client, Unreliable");
-		case ERPCType::ServerReliable:
-			return TEXT("Server, Reliable");
-		case ERPCType::ServerUnreliable:
-			return TEXT("Server, Unreliable");
-		case ERPCType::NetMulticast:
-			return TEXT("Multicast");
-		case ERPCType::CrossServer:
-			return TEXT("CrossServer");
-		}
-
-		checkNoEntry();
-		return FString();
+	case ERPCType::ClientReliable:
+		return TEXT("Client, Reliable");
+	case ERPCType::ClientUnreliable:
+		return TEXT("Client, Unreliable");
+	case ERPCType::ServerReliable:
+		return TEXT("Server, Reliable");
+	case ERPCType::ServerUnreliable:
+		return TEXT("Server, Unreliable");
+	case ERPCType::NetMulticast:
+		return TEXT("Multicast");
+	case ERPCType::CrossServer:
+		return TEXT("CrossServer");
 	}
 
-	enum EntityIds
-	{
-		INVALID_ENTITY_ID = 0,
-		INITIAL_SPAWNER_ENTITY_ID = 1,
-		INITIAL_GLOBAL_STATE_MANAGER_ENTITY_ID = 2,
-		INITIAL_VIRTUAL_WORKER_TRANSLATOR_ENTITY_ID = 3,
-		FIRST_AVAILABLE_ENTITY_ID = 4,
-	};
+	checkNoEntry();
+	return FString();
+}
 
-	const Worker_ComponentId INVALID_COMPONENT_ID = 0;
+enum EntityIds
+{
+	INVALID_ENTITY_ID = 0,
+	INITIAL_SPAWNER_ENTITY_ID = 1,
+	INITIAL_GLOBAL_STATE_MANAGER_ENTITY_ID = 2,
+	INITIAL_VIRTUAL_WORKER_TRANSLATOR_ENTITY_ID = 3,
+	FIRST_AVAILABLE_ENTITY_ID = 4,
+};
 
-	const Worker_ComponentId ENTITY_ACL_COMPONENT_ID = 50;
-	const Worker_ComponentId METADATA_COMPONENT_ID = 53;
-	const Worker_ComponentId POSITION_COMPONENT_ID = 54;
-	const Worker_ComponentId PERSISTENCE_COMPONENT_ID = 55;
-	const Worker_ComponentId INTEREST_COMPONENT_ID = 58;
-	// This is a component on per-worker system entities.
-	const Worker_ComponentId WORKER_COMPONENT_ID = 60;
+const Worker_ComponentId INVALID_COMPONENT_ID							= 0;
 
-	const Worker_ComponentId MAX_RESERVED_SPATIAL_SYSTEM_COMPONENT_ID = 100;
+const Worker_ComponentId ENTITY_ACL_COMPONENT_ID						= 50;
+const Worker_ComponentId METADATA_COMPONENT_ID							= 53;
+const Worker_ComponentId POSITION_COMPONENT_ID							= 54;
+const Worker_ComponentId PERSISTENCE_COMPONENT_ID						= 55;
+const Worker_ComponentId INTEREST_COMPONENT_ID							= 58;
+// This is a component on per-worker system entities.
+const Worker_ComponentId WORKER_COMPONENT_ID							= 60;
 
-	const Worker_ComponentId SPAWN_DATA_COMPONENT_ID = 9999;
-	const Worker_ComponentId PLAYER_SPAWNER_COMPONENT_ID = 9998;
-	const Worker_ComponentId SINGLETON_COMPONENT_ID = 9997;
-	const Worker_ComponentId UNREAL_METADATA_COMPONENT_ID = 9996;
-	const Worker_ComponentId SINGLETON_MANAGER_COMPONENT_ID = 9995;
-	const Worker_ComponentId DEPLOYMENT_MAP_COMPONENT_ID = 9994;
-	const Worker_ComponentId STARTUP_ACTOR_MANAGER_COMPONENT_ID = 9993;
-	const Worker_ComponentId GSM_SHUTDOWN_COMPONENT_ID = 9992;
-	const Worker_ComponentId HEARTBEAT_COMPONENT_ID = 9991;
-	// Marking the event-based RPC components as legacy while the ring buffer
-	// implementation is under a feature flag.
-	const Worker_ComponentId CLIENT_RPC_ENDPOINT_COMPONENT_ID_LEGACY = 9990;
-	const Worker_ComponentId SERVER_RPC_ENDPOINT_COMPONENT_ID_LEGACY = 9989;
-	const Worker_ComponentId NETMULTICAST_RPCS_COMPONENT_ID_LEGACY = 9987;
+const Worker_ComponentId MAX_RESERVED_SPATIAL_SYSTEM_COMPONENT_ID		= 100;
 
-	const Worker_ComponentId NOT_STREAMED_COMPONENT_ID = 9986;
-	const Worker_ComponentId RPCS_ON_ENTITY_CREATION_ID = 9985;
-	const Worker_ComponentId DEBUG_METRICS_COMPONENT_ID = 9984;
-	const Worker_ComponentId ALWAYS_RELEVANT_COMPONENT_ID = 9983;
-	const Worker_ComponentId TOMBSTONE_COMPONENT_ID = 9982;
-	const Worker_ComponentId DORMANT_COMPONENT_ID = 9981;
-	const Worker_ComponentId AUTHORITY_INTENT_COMPONENT_ID = 9980;
-	const Worker_ComponentId VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID = 9979;
+const Worker_ComponentId SPAWN_DATA_COMPONENT_ID						= 9999;
+const Worker_ComponentId PLAYER_SPAWNER_COMPONENT_ID					= 9998;
+const Worker_ComponentId SINGLETON_COMPONENT_ID							= 9997;
+const Worker_ComponentId UNREAL_METADATA_COMPONENT_ID					= 9996;
+const Worker_ComponentId SINGLETON_MANAGER_COMPONENT_ID					= 9995;
+const Worker_ComponentId DEPLOYMENT_MAP_COMPONENT_ID					= 9994;
+const Worker_ComponentId STARTUP_ACTOR_MANAGER_COMPONENT_ID			    = 9993;
+const Worker_ComponentId GSM_SHUTDOWN_COMPONENT_ID						= 9992;
+const Worker_ComponentId HEARTBEAT_COMPONENT_ID							= 9991;
+// Marking the event-based RPC components as legacy while the ring buffer
+// implementation is under a feature flag.
+const Worker_ComponentId CLIENT_RPC_ENDPOINT_COMPONENT_ID_LEGACY		= 9990;
+const Worker_ComponentId SERVER_RPC_ENDPOINT_COMPONENT_ID_LEGACY		= 9989;
+const Worker_ComponentId NETMULTICAST_RPCS_COMPONENT_ID_LEGACY			= 9987;
 
-	const Worker_ComponentId CLIENT_ENDPOINT_COMPONENT_ID = 9978;
-	const Worker_ComponentId SERVER_ENDPOINT_COMPONENT_ID = 9977;
-	const Worker_ComponentId MULTICAST_RPCS_COMPONENT_ID = 9976;
-	const Worker_ComponentId SPATIAL_DEBUGGING_COMPONENT_ID = 9975;
-	const Worker_ComponentId SERVER_WORKER_COMPONENT_ID = 9974;
-	const Worker_ComponentId SERVER_TO_SERVER_COMMAND_ENDPOINT_COMPONENT_ID = 9973;
+const Worker_ComponentId NOT_STREAMED_COMPONENT_ID						= 9986;
+const Worker_ComponentId RPCS_ON_ENTITY_CREATION_ID						= 9985;
+const Worker_ComponentId DEBUG_METRICS_COMPONENT_ID						= 9984;
+const Worker_ComponentId ALWAYS_RELEVANT_COMPONENT_ID					= 9983;
+const Worker_ComponentId TOMBSTONE_COMPONENT_ID                         = 9982;
+const Worker_ComponentId DORMANT_COMPONENT_ID							= 9981;
+const Worker_ComponentId AUTHORITY_INTENT_COMPONENT_ID                  = 9980;
+const Worker_ComponentId VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID        = 9979;
 
-	const Worker_ComponentId STARTING_GENERATED_COMPONENT_ID = 10000;
+const Worker_ComponentId CLIENT_ENDPOINT_COMPONENT_ID					= 9978;
+const Worker_ComponentId SERVER_ENDPOINT_COMPONENT_ID					= 9977;
+const Worker_ComponentId MULTICAST_RPCS_COMPONENT_ID					= 9976;
+const Worker_ComponentId SPATIAL_DEBUGGING_COMPONENT_ID					= 9975;
+const Worker_ComponentId SERVER_WORKER_COMPONENT_ID						= 9974;
+const Worker_ComponentId SERVER_TO_SERVER_COMMAND_ENDPOINT_COMPONENT_ID = 9973;
 
-	const Schema_FieldId SINGLETON_MANAGER_SINGLETON_NAME_TO_ENTITY_ID = 1;
+const Worker_ComponentId STARTING_GENERATED_COMPONENT_ID				= 10000;
 
-	const Schema_FieldId DEPLOYMENT_MAP_MAP_URL_ID = 1;
-	const Schema_FieldId DEPLOYMENT_MAP_ACCEPTING_PLAYERS_ID = 2;
-	const Schema_FieldId DEPLOYMENT_MAP_SESSION_ID = 3;
-	const Schema_FieldId DEPLOYMENT_MAP_SCHEMA_HASH = 4;
+const Schema_FieldId SINGLETON_MANAGER_SINGLETON_NAME_TO_ENTITY_ID		= 1;
 
-	const Schema_FieldId STARTUP_ACTOR_MANAGER_CAN_BEGIN_PLAY_ID = 1;
+const Schema_FieldId DEPLOYMENT_MAP_MAP_URL_ID							= 1;
+const Schema_FieldId DEPLOYMENT_MAP_ACCEPTING_PLAYERS_ID				= 2;
+const Schema_FieldId DEPLOYMENT_MAP_SESSION_ID							= 3;
+const Schema_FieldId DEPLOYMENT_MAP_SCHEMA_HASH							= 4;
 
-	const Schema_FieldId ACTOR_COMPONENT_REPLICATES_ID = 1;
-	const Schema_FieldId ACTOR_TEAROFF_ID = 3;
+const Schema_FieldId STARTUP_ACTOR_MANAGER_CAN_BEGIN_PLAY_ID			= 1;
 
-	const Schema_FieldId HEARTBEAT_EVENT_ID = 1;
-	const Schema_FieldId HEARTBEAT_CLIENT_HAS_QUIT_ID = 1;
+const Schema_FieldId ACTOR_COMPONENT_REPLICATES_ID                      = 1;
+const Schema_FieldId ACTOR_TEAROFF_ID									= 3;
 
-	const Schema_FieldId SHUTDOWN_MULTI_PROCESS_REQUEST_ID = 1;
-	const Schema_FieldId SHUTDOWN_ADDITIONAL_SERVERS_EVENT_ID = 1;
+const Schema_FieldId HEARTBEAT_EVENT_ID                                 = 1;
+const Schema_FieldId HEARTBEAT_CLIENT_HAS_QUIT_ID						= 1;
 
-	const Schema_FieldId CLEAR_RPCS_ON_ENTITY_CREATION = 1;
+const Schema_FieldId SHUTDOWN_MULTI_PROCESS_REQUEST_ID					= 1;
+const Schema_FieldId SHUTDOWN_ADDITIONAL_SERVERS_EVENT_ID				= 1;
 
-	// DebugMetrics command IDs
-	const Schema_FieldId DEBUG_METRICS_START_RPC_METRICS_ID = 1;
-	const Schema_FieldId DEBUG_METRICS_STOP_RPC_METRICS_ID = 2;
-	const Schema_FieldId DEBUG_METRICS_MODIFY_SETTINGS_ID = 3;
+const Schema_FieldId CLEAR_RPCS_ON_ENTITY_CREATION						= 1;
 
-	// ModifySettingPayload Field IDs
-	const Schema_FieldId MODIFY_SETTING_PAYLOAD_NAME_ID = 1;
-	const Schema_FieldId MODIFY_SETTING_PAYLOAD_VALUE_ID = 2;
+// DebugMetrics command IDs
+const Schema_FieldId DEBUG_METRICS_START_RPC_METRICS_ID					= 1;
+const Schema_FieldId DEBUG_METRICS_STOP_RPC_METRICS_ID					= 2;
+const Schema_FieldId DEBUG_METRICS_MODIFY_SETTINGS_ID					= 3;
 
-	// UnrealObjectRef Field IDs
-	const Schema_FieldId UNREAL_OBJECT_REF_ENTITY_ID = 1;
-	const Schema_FieldId UNREAL_OBJECT_REF_OFFSET_ID = 2;
-	const Schema_FieldId UNREAL_OBJECT_REF_PATH_ID = 3;
-	const Schema_FieldId UNREAL_OBJECT_REF_NO_LOAD_ON_CLIENT_ID = 4;
-	const Schema_FieldId UNREAL_OBJECT_REF_OUTER_ID = 5;
-	const Schema_FieldId UNREAL_OBJECT_REF_USE_SINGLETON_CLASS_PATH_ID = 6;
+// ModifySettingPayload Field IDs
+const Schema_FieldId MODIFY_SETTING_PAYLOAD_NAME_ID						= 1;
+const Schema_FieldId MODIFY_SETTING_PAYLOAD_VALUE_ID					= 2;
 
-	// UnrealRPCPayload Field IDs
-	const Schema_FieldId UNREAL_RPC_PAYLOAD_OFFSET_ID = 1;
-	const Schema_FieldId UNREAL_RPC_PAYLOAD_RPC_INDEX_ID = 2;
-	const Schema_FieldId UNREAL_RPC_PAYLOAD_RPC_PAYLOAD_ID = 3;
-	const Schema_FieldId UNREAL_RPC_PAYLOAD_TRACE_ID = 4;
-	// UnrealPackedRPCPayload additional Field ID
-	const Schema_FieldId UNREAL_PACKED_RPC_PAYLOAD_ENTITY_ID = 5;
+// UnrealObjectRef Field IDs
+const Schema_FieldId UNREAL_OBJECT_REF_ENTITY_ID						= 1;
+const Schema_FieldId UNREAL_OBJECT_REF_OFFSET_ID						= 2;
+const Schema_FieldId UNREAL_OBJECT_REF_PATH_ID							= 3;
+const Schema_FieldId UNREAL_OBJECT_REF_NO_LOAD_ON_CLIENT_ID				= 4;
+const Schema_FieldId UNREAL_OBJECT_REF_OUTER_ID							= 5;
+const Schema_FieldId UNREAL_OBJECT_REF_USE_SINGLETON_CLASS_PATH_ID		= 6;
 
-	const Schema_FieldId UNREAL_RPC_TRACE_ID = 1;
-	const Schema_FieldId UNREAL_RPC_SPAN_ID = 2;
+// UnrealRPCPayload Field IDs
+const Schema_FieldId UNREAL_RPC_PAYLOAD_OFFSET_ID						= 1;
+const Schema_FieldId UNREAL_RPC_PAYLOAD_RPC_INDEX_ID					= 2;
+const Schema_FieldId UNREAL_RPC_PAYLOAD_RPC_PAYLOAD_ID					= 3;
+const Schema_FieldId UNREAL_RPC_PAYLOAD_TRACE_ID						= 4;
+// UnrealPackedRPCPayload additional Field ID
+const Schema_FieldId UNREAL_PACKED_RPC_PAYLOAD_ENTITY_ID				= 5;
 
-	// Unreal(Client|Server|Multicast)RPCEndpoint Field IDs
-	const Schema_FieldId UNREAL_RPC_ENDPOINT_READY_ID = 1;
-	const Schema_FieldId UNREAL_RPC_ENDPOINT_EVENT_ID = 1;
-	const Schema_FieldId UNREAL_RPC_ENDPOINT_PACKED_EVENT_ID = 2;
-	const Schema_FieldId UNREAL_RPC_ENDPOINT_COMMAND_ID = 1;
+const Schema_FieldId UNREAL_RPC_TRACE_ID								= 1;
+const Schema_FieldId UNREAL_RPC_SPAN_ID									= 2;
 
-	const Schema_FieldId PLAYER_SPAWNER_SPAWN_PLAYER_COMMAND_ID = 1;
+// Unreal(Client|Server|Multicast)RPCEndpoint Field IDs
+const Schema_FieldId UNREAL_RPC_ENDPOINT_READY_ID 						= 1;
+const Schema_FieldId UNREAL_RPC_ENDPOINT_EVENT_ID						= 1;
+const Schema_FieldId UNREAL_RPC_ENDPOINT_PACKED_EVENT_ID				= 2;
+const Schema_FieldId UNREAL_RPC_ENDPOINT_COMMAND_ID						= 1;
 
-	// AuthorityIntent codes and Field IDs.
-	const Schema_FieldId AUTHORITY_INTENT_VIRTUAL_WORKER_ID = 1;
+const Schema_FieldId PLAYER_SPAWNER_SPAWN_PLAYER_COMMAND_ID = 1;
 
-	// VirtualWorkerTranslation Field IDs.
-	const Schema_FieldId VIRTUAL_WORKER_TRANSLATION_MAPPING_ID = 1;
-	const Schema_FieldId MAPPING_VIRTUAL_WORKER_ID = 1;
-	const Schema_FieldId MAPPING_PHYSICAL_WORKER_NAME = 2;
-	const PhysicalWorkerName TRANSLATOR_UNSET_PHYSICAL_NAME = FString("UnsetWorkerName");
+// AuthorityIntent codes and Field IDs.
+const Schema_FieldId AUTHORITY_INTENT_VIRTUAL_WORKER_ID					= 1;
 
-	// WorkerEntity Field IDs.
-	const Schema_FieldId WORKER_ID_ID = 1;
-	const Schema_FieldId WORKER_TYPE_ID = 2;
+// VirtualWorkerTranslation Field IDs.
+const Schema_FieldId VIRTUAL_WORKER_TRANSLATION_MAPPING_ID				= 1;
+const Schema_FieldId MAPPING_VIRTUAL_WORKER_ID							= 1;
+const Schema_FieldId MAPPING_PHYSICAL_WORKER_NAME						= 2;
+const PhysicalWorkerName TRANSLATOR_UNSET_PHYSICAL_NAME = FString("UnsetWorkerName");
 
-	// SpatialDebugger Field IDs.
-	const Schema_FieldId SPATIAL_DEBUGGING_AUTHORITATIVE_VIRTUAL_WORKER_ID = 1;
-	const Schema_FieldId SPATIAL_DEBUGGING_AUTHORITATIVE_COLOR = 2;
-	const Schema_FieldId SPATIAL_DEBUGGING_INTENT_VIRTUAL_WORKER_ID = 3;
-	const Schema_FieldId SPATIAL_DEBUGGING_INTENT_COLOR = 4;
-	const Schema_FieldId SPATIAL_DEBUGGING_IS_LOCKED = 5;
+// WorkerEntity Field IDs.
+const Schema_FieldId WORKER_ID_ID										= 1;
+const Schema_FieldId WORKER_TYPE_ID										= 2;
 
-	// ServerWorker Field IDs.
-	const Schema_FieldId SERVER_WORKER_NAME_ID = 1;
-	const Schema_FieldId SERVER_WORKER_READY_TO_BEGIN_PLAY_ID = 2;
+// SpatialDebugger Field IDs.
+const Schema_FieldId SPATIAL_DEBUGGING_AUTHORITATIVE_VIRTUAL_WORKER_ID   = 1;
+const Schema_FieldId SPATIAL_DEBUGGING_AUTHORITATIVE_COLOR               = 2;
+const Schema_FieldId SPATIAL_DEBUGGING_INTENT_VIRTUAL_WORKER_ID          = 3;
+const Schema_FieldId SPATIAL_DEBUGGING_INTENT_COLOR                      = 4;
+const Schema_FieldId SPATIAL_DEBUGGING_IS_LOCKED                         = 5;
 
-	// Reserved entity IDs expire in 5 minutes, we will refresh them every 3 minutes to be safe.
-	const float ENTITY_RANGE_EXPIRATION_INTERVAL_SECONDS = 180.0f;
+// ServerWorker Field IDs.
+const Schema_FieldId SERVER_WORKER_NAME_ID								 = 1;
+const Schema_FieldId SERVER_WORKER_READY_TO_BEGIN_PLAY_ID				 = 2;
 
-	const float FIRST_COMMAND_RETRY_WAIT_SECONDS = 0.2f;
-	const uint32 MAX_NUMBER_COMMAND_ATTEMPTS = 5u;
+// Reserved entity IDs expire in 5 minutes, we will refresh them every 3 minutes to be safe.
+const float ENTITY_RANGE_EXPIRATION_INTERVAL_SECONDS = 180.0f;
 
-	const FName DefaultActorGroup = FName(TEXT("Default"));
+const float FIRST_COMMAND_RETRY_WAIT_SECONDS = 0.2f;
+const uint32 MAX_NUMBER_COMMAND_ATTEMPTS = 5u;
 
-	const VirtualWorkerId INVALID_VIRTUAL_WORKER_ID = 0;
-	const ActorLockToken INVALID_ACTOR_LOCK_TOKEN = 0;
-	const FString INVALID_WORKER_NAME = TEXT("");
+const FName DefaultActorGroup = FName(TEXT("Default"));
 
-	const WorkerAttributeSet UnrealServerAttributeSet = TArray<FString>{ DefaultServerWorkerType.ToString() };
-	const WorkerAttributeSet UnrealClientAttributeSet = TArray<FString>{ DefaultClientWorkerType.ToString() };
+const VirtualWorkerId INVALID_VIRTUAL_WORKER_ID = 0;
+const ActorLockToken INVALID_ACTOR_LOCK_TOKEN = 0;
+const FString INVALID_WORKER_NAME = TEXT("");
 
-	const WorkerRequirementSet UnrealServerPermission{ {UnrealServerAttributeSet} };
-	const WorkerRequirementSet UnrealClientPermission{ {UnrealClientAttributeSet} };
-	const WorkerRequirementSet ClientOrServerPermission{ {UnrealClientAttributeSet, UnrealServerAttributeSet} };
+const WorkerAttributeSet UnrealServerAttributeSet = TArray<FString>{DefaultServerWorkerType.ToString()};
+const WorkerAttributeSet UnrealClientAttributeSet = TArray<FString>{DefaultClientWorkerType.ToString()};
 
-	const FString ClientsStayConnectedURLOption = TEXT("clientsStayConnected");
-	const FString SpatialSessionIdURLOption = TEXT("spatialSessionId=");
+const WorkerRequirementSet UnrealServerPermission{ {UnrealServerAttributeSet} };
+const WorkerRequirementSet UnrealClientPermission{ {UnrealClientAttributeSet} };
+const WorkerRequirementSet ClientOrServerPermission{ {UnrealClientAttributeSet, UnrealServerAttributeSet} };
 
-	const FString LOCATOR_HOST = TEXT("locator.improbable.io");
-	const FString LOCATOR_HOST_CN = TEXT("locator.spatialoschina.com");
-	const uint16 LOCATOR_PORT = 443;
+const FString ClientsStayConnectedURLOption = TEXT("clientsStayConnected");
+const FString SpatialSessionIdURLOption = TEXT("spatialSessionId=");
 
-	const FString AssemblyPattern = TEXT("^[a-zA-Z0-9_.-]{5,64}$");
-	const FString ProjectPattern = TEXT("^[a-z0-9_]{3,32}$");
-	const FString DeploymentPattern = TEXT("^[a-z0-9_]{2,32}$");
+const FString LOCATOR_HOST    = TEXT("locator.improbable.io");
+const FString LOCATOR_HOST_CN = TEXT("locator.spatialoschina.com");
+const uint16 LOCATOR_PORT     = 443;
 
-	inline float GetCommandRetryWaitTimeSeconds(uint32 NumAttempts)
-	{
-		// Double the time to wait on each failure.
-		uint32 WaitTimeExponentialFactor = 1u << (NumAttempts - 1);
-		return FIRST_COMMAND_RETRY_WAIT_SECONDS * WaitTimeExponentialFactor;
-	}
+const FString AssemblyPattern   = TEXT("^[a-zA-Z0-9_.-]{5,64}$");
+const FString ProjectPattern    = TEXT("^[a-z0-9_]{3,32}$");
+const FString DeploymentPattern = TEXT("^[a-z0-9_]{2,32}$");
 
-	const FString LOCAL_HOST = TEXT("127.0.0.1");
-	const uint16  DEFAULT_PORT = 7777;
+inline float GetCommandRetryWaitTimeSeconds(uint32 NumAttempts)
+{
+	// Double the time to wait on each failure.
+	uint32 WaitTimeExponentialFactor = 1u << (NumAttempts - 1);
+	return FIRST_COMMAND_RETRY_WAIT_SECONDS * WaitTimeExponentialFactor;
+}
 
-	const float ENTITY_QUERY_RETRY_WAIT_SECONDS = 3.0f;
+const FString LOCAL_HOST   = TEXT("127.0.0.1");
+const uint16  DEFAULT_PORT = 7777;
 
-	const Worker_ComponentId MIN_EXTERNAL_SCHEMA_ID = 1000;
-	const Worker_ComponentId MAX_EXTERNAL_SCHEMA_ID = 2000;
+const float ENTITY_QUERY_RETRY_WAIT_SECONDS = 3.0f;
 
-	const FString SPATIALOS_METRICS_DYNAMIC_FPS = TEXT("Dynamic.FPS");
+const Worker_ComponentId MIN_EXTERNAL_SCHEMA_ID = 1000;
+const Worker_ComponentId MAX_EXTERNAL_SCHEMA_ID = 2000;
 
-	// URL that can be used to reconnect using the command line arguments.
-	const FString RECONNECT_USING_COMMANDLINE_ARGUMENTS = TEXT("0.0.0.0");
-	const FString URL_LOGIN_OPTION = TEXT("login=");
-	const FString URL_PLAYER_IDENTITY_OPTION = TEXT("playeridentity=");
-	const FString URL_DEV_AUTH_TOKEN_OPTION = TEXT("devauthtoken=");
-	const FString URL_TARGET_DEPLOYMENT_OPTION = TEXT("deployment=");
-	const FString URL_PLAYER_ID_OPTION = TEXT("playerid=");
-	const FString URL_DISPLAY_NAME_OPTION = TEXT("displayname=");
-	const FString URL_METADATA_OPTION = TEXT("metadata=");
+const FString SPATIALOS_METRICS_DYNAMIC_FPS = TEXT("Dynamic.FPS");
 
-	const FString DEVELOPMENT_AUTH_PLAYER_ID = TEXT("Player Id");
+// URL that can be used to reconnect using the command line arguments.
+const FString RECONNECT_USING_COMMANDLINE_ARGUMENTS = TEXT("0.0.0.0");
+const FString URL_LOGIN_OPTION = TEXT("login=");
+const FString URL_PLAYER_IDENTITY_OPTION = TEXT("playeridentity=");
+const FString URL_DEV_AUTH_TOKEN_OPTION = TEXT("devauthtoken=");
+const FString URL_TARGET_DEPLOYMENT_OPTION = TEXT("deployment=");
+const FString URL_PLAYER_ID_OPTION = TEXT("playerid=");
+const FString URL_DISPLAY_NAME_OPTION = TEXT("displayname=");
+const FString URL_METADATA_OPTION = TEXT("metadata=");
 
-	const FString SCHEMA_DATABASE_FILE_PATH = TEXT("Spatial/SchemaDatabase");
-	const FString SCHEMA_DATABASE_ASSET_PATH = TEXT("/Game/Spatial/SchemaDatabase");
+const FString DEVELOPMENT_AUTH_PLAYER_ID = TEXT("Player Id");
 
-	const FString LoadBalancerAttributeSet = { DefaultServerWorkerType.ToString() };
+const FString SCHEMA_DATABASE_FILE_PATH  = TEXT("Spatial/SchemaDatabase");
+const FString SCHEMA_DATABASE_ASSET_PATH = TEXT("/Game/Spatial/SchemaDatabase");
+
+const FString LoadBalancerAttributeSet = { DefaultServerWorkerType.ToString() };
 
 // A list of components clients require on top of any generated data components in order to handle non-authoritative actors correctly.
 const TArray<Worker_ComponentId> REQUIRED_COMPONENTS_FOR_NON_AUTH_CLIENT_INTEREST = TArray<Worker_ComponentId>
@@ -312,7 +312,7 @@ const TArray<Worker_ComponentId> REQUIRED_COMPONENTS_FOR_NON_AUTH_SERVER_INTERES
 	GSM_SHUTDOWN_COMPONENT_ID,
 
 	// Unreal load balancing components
-	VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID,
+	VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID
 };
 
 // A list of components servers require on entities they are authoritative over on top of the components already checked out by the interest query.

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalanceEnforcer/SpatialLoadBalanceEnforcerTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalanceEnforcer/SpatialLoadBalanceEnforcerTest.cpp
@@ -255,3 +255,144 @@ LOADBALANCEENFORCER_TEST(GIVEN_authority_change_when_authoritative_over_authorit
 
 	return true;
 }
+
+LOADBALANCEENFORCER_TEST(GIVEN_acl_authority_loss_WHEN_request_is_queued_THEN_return_no_acl_assignment_requests)
+{
+	TUniquePtr<SpatialVirtualWorkerTranslator> VirtualWorkerTranslator = CreateVirtualWorkerTranslator();
+
+	// Set up the world in such a way that we can enforce the authority, and we are not already the authoritative worker so should try and assign authority.
+	USpatialStaticComponentView* StaticComponentView = NewObject<USpatialStaticComponentView>();
+	AddEntityToStaticComponentView(*StaticComponentView, EntityIdOne, VirtualWorkerOne, WORKER_AUTHORITY_NOT_AUTHORITATIVE);
+
+	TUniquePtr<SpatialLoadBalanceEnforcer> LoadBalanceEnforcer = MakeUnique<SpatialLoadBalanceEnforcer>(ValidWorkerOne, StaticComponentView, VirtualWorkerTranslator.Get());
+
+	Worker_AuthorityChangeOp AuthOp;
+	AuthOp.entity_id = EntityIdOne;
+	AuthOp.authority = WORKER_AUTHORITY_AUTHORITATIVE;
+	AuthOp.component_id = SpatialConstants::ENTITY_ACL_COMPONENT_ID;
+
+	LoadBalanceEnforcer->OnAclAuthorityChanged(AuthOp);
+
+	// At this point, we expect there to be a queued request.
+	TestTrue("Assignment request is queued", LoadBalanceEnforcer->AclAssignmentRequestIsQueued(EntityIdOne));
+
+	AuthOp.authority = WORKER_AUTHORITY_NOT_AUTHORITATIVE;
+
+	LoadBalanceEnforcer->OnAclAuthorityChanged(AuthOp);
+
+	// Now we should have dropped that request.
+
+	TArray<SpatialLoadBalanceEnforcer::AclWriteAuthorityRequest> ACLRequests = LoadBalanceEnforcer->ProcessQueuedAclAssignmentRequests();
+
+	bool bSuccess = ACLRequests.Num() == 0;
+	TestTrue("LoadBalanceEnforcer returned expected ACL assignment results", bSuccess);
+
+	return true;
+}
+
+LOADBALANCEENFORCER_TEST(GIVEN_entity_removal_WHEN_request_is_queued_THEN_return_no_acl_assignment_requests)
+{
+	TUniquePtr<SpatialVirtualWorkerTranslator> VirtualWorkerTranslator = CreateVirtualWorkerTranslator();
+
+	// Set up the world in such a way that we can enforce the authority, and we are not already the authoritative worker so should try and assign authority.
+	USpatialStaticComponentView* StaticComponentView = NewObject<USpatialStaticComponentView>();
+	AddEntityToStaticComponentView(*StaticComponentView, EntityIdOne, VirtualWorkerOne, WORKER_AUTHORITY_NOT_AUTHORITATIVE);
+
+	TUniquePtr<SpatialLoadBalanceEnforcer> LoadBalanceEnforcer = MakeUnique<SpatialLoadBalanceEnforcer>(ValidWorkerOne, StaticComponentView, VirtualWorkerTranslator.Get());
+
+	Worker_AuthorityChangeOp AuthOp;
+	AuthOp.entity_id = EntityIdOne;
+	AuthOp.authority = WORKER_AUTHORITY_AUTHORITATIVE;
+	AuthOp.component_id = SpatialConstants::ENTITY_ACL_COMPONENT_ID;
+
+	LoadBalanceEnforcer->OnAclAuthorityChanged(AuthOp);
+
+	// At this point, we expect there to be a queued request.
+	TestTrue("Assignment request is queued", LoadBalanceEnforcer->AclAssignmentRequestIsQueued(EntityIdOne));
+
+	Worker_RemoveEntityOp EntityOp;
+	EntityOp.entity_id = EntityIdOne;
+
+	LoadBalanceEnforcer->OnEntityRemoved(EntityOp);
+
+	// Now we should have dropped that request.
+
+	TArray<SpatialLoadBalanceEnforcer::AclWriteAuthorityRequest> ACLRequests = LoadBalanceEnforcer->ProcessQueuedAclAssignmentRequests();
+
+	bool bSuccess = ACLRequests.Num() == 0;
+	TestTrue("LoadBalanceEnforcer returned expected ACL assignment results", bSuccess);
+
+	return true;
+}
+
+LOADBALANCEENFORCER_TEST(GIVEN_authority_intent_component_removal_WHEN_request_is_queued_THEN_return_no_acl_assignment_requests)
+{
+	TUniquePtr<SpatialVirtualWorkerTranslator> VirtualWorkerTranslator = CreateVirtualWorkerTranslator();
+
+	// Set up the world in such a way that we can enforce the authority, and we are not already the authoritative worker so should try and assign authority.
+	USpatialStaticComponentView* StaticComponentView = NewObject<USpatialStaticComponentView>();
+	AddEntityToStaticComponentView(*StaticComponentView, EntityIdOne, VirtualWorkerOne, WORKER_AUTHORITY_NOT_AUTHORITATIVE);
+
+	TUniquePtr<SpatialLoadBalanceEnforcer> LoadBalanceEnforcer = MakeUnique<SpatialLoadBalanceEnforcer>(ValidWorkerOne, StaticComponentView, VirtualWorkerTranslator.Get());
+
+	Worker_AuthorityChangeOp AuthOp;
+	AuthOp.entity_id = EntityIdOne;
+	AuthOp.authority = WORKER_AUTHORITY_AUTHORITATIVE;
+	AuthOp.component_id = SpatialConstants::ENTITY_ACL_COMPONENT_ID;
+
+	LoadBalanceEnforcer->OnAclAuthorityChanged(AuthOp);
+
+	// At this point, we expect there to be a queued request.
+	TestTrue("Assignment request is queued", LoadBalanceEnforcer->AclAssignmentRequestIsQueued(EntityIdOne));
+
+	Worker_RemoveComponentOp ComponentOp;
+	ComponentOp.entity_id = EntityIdOne;
+	ComponentOp.component_id = SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID;
+
+	LoadBalanceEnforcer->OnLoadBalancingComponentRemoved(ComponentOp);
+
+	// Now we should have dropped that request.
+
+	TArray<SpatialLoadBalanceEnforcer::AclWriteAuthorityRequest> ACLRequests = LoadBalanceEnforcer->ProcessQueuedAclAssignmentRequests();
+
+	bool bSuccess = ACLRequests.Num() == 0;
+	TestTrue("LoadBalanceEnforcer returned expected ACL assignment results", bSuccess);
+
+	return true;
+}
+
+LOADBALANCEENFORCER_TEST(GIVEN_acl_component_removal_WHEN_request_is_queued_THEN_return_no_acl_assignment_requests)
+{
+	TUniquePtr<SpatialVirtualWorkerTranslator> VirtualWorkerTranslator = CreateVirtualWorkerTranslator();
+
+	// Set up the world in such a way that we can enforce the authority, and we are not already the authoritative worker so should try and assign authority.
+	USpatialStaticComponentView* StaticComponentView = NewObject<USpatialStaticComponentView>();
+	AddEntityToStaticComponentView(*StaticComponentView, EntityIdOne, VirtualWorkerOne, WORKER_AUTHORITY_NOT_AUTHORITATIVE);
+
+	TUniquePtr<SpatialLoadBalanceEnforcer> LoadBalanceEnforcer = MakeUnique<SpatialLoadBalanceEnforcer>(ValidWorkerOne, StaticComponentView, VirtualWorkerTranslator.Get());
+
+	Worker_AuthorityChangeOp AuthOp;
+	AuthOp.entity_id = EntityIdOne;
+	AuthOp.authority = WORKER_AUTHORITY_AUTHORITATIVE;
+	AuthOp.component_id = SpatialConstants::ENTITY_ACL_COMPONENT_ID;
+
+	LoadBalanceEnforcer->OnAclAuthorityChanged(AuthOp);
+
+	// At this point, we expect there to be a queued request.
+	TestTrue("Assignment request is queued", LoadBalanceEnforcer->AclAssignmentRequestIsQueued(EntityIdOne));
+
+	Worker_RemoveComponentOp ComponentOp;
+	ComponentOp.entity_id = EntityIdOne;
+	ComponentOp.component_id = SpatialConstants::ENTITY_ACL_COMPONENT_ID;
+
+	LoadBalanceEnforcer->OnLoadBalancingComponentRemoved(ComponentOp);
+
+	// Now we should have dropped that request.
+
+	TArray<SpatialLoadBalanceEnforcer::AclWriteAuthorityRequest> ACLRequests = LoadBalanceEnforcer->ProcessQueuedAclAssignmentRequests();
+
+	bool bSuccess = ACLRequests.Num() == 0;
+	TestTrue("LoadBalanceEnforcer returned expected ACL assignment results", bSuccess);
+
+	return true;
+}

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalanceEnforcer/SpatialLoadBalanceEnforcerTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalanceEnforcer/SpatialLoadBalanceEnforcerTest.cpp
@@ -25,8 +25,8 @@ PhysicalWorkerName ValidWorkerTwo = TEXT("ValidWorkerTwo");
 VirtualWorkerId VirtualWorkerOne = 1;
 VirtualWorkerId VirtualWorkerTwo = 2;
 
-Worker_EntityId EntityIdOne = 0;
-Worker_EntityId EntityIdTwo = 1;
+Worker_EntityId EntityIdOne = 1;
+Worker_EntityId EntityIdTwo = 2;
 
 void AddEntityToStaticComponentView(USpatialStaticComponentView& StaticComponentView,
 	const Worker_EntityId EntityId, VirtualWorkerId Id, Worker_Authority AuthorityIntentAuthority)
@@ -45,70 +45,27 @@ void AddEntityToStaticComponentView(USpatialStaticComponentView& StaticComponent
 	}
 }
 
-void InitialiseVirtualWorkerTranslator(SpatialVirtualWorkerTranslator* VirtualWorkerTranslator, bool bAddDefaultWorkerMapping)
+void InitialiseVirtualWorkerTranslator(SpatialVirtualWorkerTranslator* VirtualWorkerTranslator)
 {
 	Schema_Object* DataObject = TestingSchemaHelpers::CreateTranslationComponentDataFields();
-	if (bAddDefaultWorkerMapping)
-	{
-		TestingSchemaHelpers::AddTranslationComponentDataMapping(DataObject, 1, ValidWorkerOne);
-		TestingSchemaHelpers::AddTranslationComponentDataMapping(DataObject, 2, ValidWorkerTwo);
-	}
+
+	TestingSchemaHelpers::AddTranslationComponentDataMapping(DataObject, 1, ValidWorkerOne);
+	TestingSchemaHelpers::AddTranslationComponentDataMapping(DataObject, 2, ValidWorkerTwo);
+
 	VirtualWorkerTranslator->ApplyVirtualWorkerManagerData(DataObject);
 }
 
-TUniquePtr<SpatialVirtualWorkerTranslator> CreateVirtualWorkerTranslator(bool bAddDefaultWorkerMapping = true)
+TUniquePtr<SpatialVirtualWorkerTranslator> CreateVirtualWorkerTranslator()
 {
 	ULBStrategyStub* LoadBalanceStrategy = NewObject<ULBStrategyStub>();
 	TUniquePtr<SpatialVirtualWorkerTranslator> VirtualWorkerTranslator = MakeUnique<SpatialVirtualWorkerTranslator>(LoadBalanceStrategy, ValidWorkerOne);
 
-	InitialiseVirtualWorkerTranslator(VirtualWorkerTranslator.Get(), bAddDefaultWorkerMapping);
+	InitialiseVirtualWorkerTranslator(VirtualWorkerTranslator.Get());
 
 	return VirtualWorkerTranslator;
 }
 
 } // anonymous namespace
-
-LOADBALANCEENFORCER_TEST(GIVEN_load_balance_enforcer_with_no_mapping_WHEN_asked_for_acl_assignments_THEN_return_no_acl_assignment_requests)
-{
-	// This will create a virtual worker translator with no virtual to physical workerId mapping.
-	// This mean the load balance enforcer will not be able to find the physical workerId from entities AuthorityIntent components and therefore fail to produce ACL requests.
-	TUniquePtr<SpatialVirtualWorkerTranslator>  VirtualWorkerTranslator = CreateVirtualWorkerTranslator(false /*bAddDefaultWorkerMapping*/);
-
-	USpatialStaticComponentView* StaticComponentView = NewObject<USpatialStaticComponentView>();
-	AddEntityToStaticComponentView(*StaticComponentView, EntityIdOne, VirtualWorkerOne, WORKER_AUTHORITY_AUTHORITATIVE);
-	AddEntityToStaticComponentView(*StaticComponentView, EntityIdTwo, VirtualWorkerTwo, WORKER_AUTHORITY_AUTHORITATIVE);
-
-	TUniquePtr<SpatialLoadBalanceEnforcer> LoadBalanceEnforcer = MakeUnique<SpatialLoadBalanceEnforcer>(ValidWorkerOne, StaticComponentView, VirtualWorkerTranslator.Get());
-
-	LoadBalanceEnforcer->QueueAclAssignmentRequest(EntityIdOne);
-	LoadBalanceEnforcer->QueueAclAssignmentRequest(EntityIdTwo);
-
-	TArray<SpatialLoadBalanceEnforcer::AclWriteAuthorityRequest> ACLRequests = LoadBalanceEnforcer->ProcessQueuedAclAssignmentRequests();
-
-	bool bSuccess = ACLRequests.Num() == 0;
-
-	// Now add a mapping to the VirtualWorkerTranslator and retry getting the ACL requests.
-	InitialiseVirtualWorkerTranslator(VirtualWorkerTranslator.Get(), true /*bAddDefaultWorkerMapping*/);
-
-	ACLRequests.Empty();
-	ACLRequests = LoadBalanceEnforcer->ProcessQueuedAclAssignmentRequests();
-
-	if (ACLRequests.Num() == 2)
-	{
-		bSuccess &= ACLRequests[0].EntityId == EntityIdOne;
-		bSuccess &= ACLRequests[0].OwningWorkerId == ValidWorkerOne;
-		bSuccess &= ACLRequests[1].EntityId == EntityIdTwo;
-		bSuccess &= ACLRequests[1].OwningWorkerId == ValidWorkerTwo;
-	}
-	else
-	{
-		bSuccess = false;
-	}
-
-	TestTrue("LoadBalanceEnforcer returned expected ACL assignment results", bSuccess);
-
-	return true;
-}
 
 LOADBALANCEENFORCER_TEST(GIVEN_a_static_component_view_with_no_data_WHEN_asking_load_balance_enforcer_for_acl_assignments_THEN_return_no_acl_assignment_requests)
 {
@@ -120,49 +77,16 @@ LOADBALANCEENFORCER_TEST(GIVEN_a_static_component_view_with_no_data_WHEN_asking_
 
 	TUniquePtr<SpatialLoadBalanceEnforcer> LoadBalanceEnforcer = MakeUnique<SpatialLoadBalanceEnforcer>(ValidWorkerOne, StaticComponentView, VirtualWorkerTranslator.Get());
 
-	LoadBalanceEnforcer->QueueAclAssignmentRequest(EntityIdOne);
-	LoadBalanceEnforcer->QueueAclAssignmentRequest(EntityIdTwo);
+	LoadBalanceEnforcer->MaybeQueueAclAssignmentRequest(EntityIdOne);
+	LoadBalanceEnforcer->MaybeQueueAclAssignmentRequest(EntityIdTwo);
 
 	TArray<SpatialLoadBalanceEnforcer::AclWriteAuthorityRequest> ACLRequests = LoadBalanceEnforcer->ProcessQueuedAclAssignmentRequests();
 
 	bool bSuccess = ACLRequests.Num() == 0;
 
 	// Now add components to the StaticComponentView and retry getting the ACL requests.
-	AddEntityToStaticComponentView(*StaticComponentView, EntityIdOne, VirtualWorkerOne, WORKER_AUTHORITY_AUTHORITATIVE);
-	AddEntityToStaticComponentView(*StaticComponentView, EntityIdTwo, VirtualWorkerTwo, WORKER_AUTHORITY_AUTHORITATIVE);
-
-	ACLRequests.Empty();
-	ACLRequests = LoadBalanceEnforcer->ProcessQueuedAclAssignmentRequests();
-
-	bSuccess &= ACLRequests.Num() == 0;
-
-	TestTrue("LoadBalanceEnforcer returned expected ACL assignment results", bSuccess);
-
-	return true;
-}
-
-LOADBALANCEENFORCER_TEST(GIVEN_a_static_component_view_with_uninitialised_authority_intent_component_WHEN_asking_load_balance_enforcer_for_acl_assignments_THEN_return_no_acl_assignment_requests)
-{
-	TUniquePtr<SpatialVirtualWorkerTranslator>  VirtualWorkerTranslator = CreateVirtualWorkerTranslator();
-
-	// Here we create a static component view and add entities to it but do not assign the AuthorityIntent virtual worker id.
-	// This means that the load balance enforcer will not be able to find the physical worker id associated with an entity and therefore fail to produce ACL requests.
-	USpatialStaticComponentView* StaticComponentView = NewObject<USpatialStaticComponentView>();
-	AddEntityToStaticComponentView(*StaticComponentView, EntityIdOne, SpatialConstants::INVALID_VIRTUAL_WORKER_ID, WORKER_AUTHORITY_AUTHORITATIVE);
-	AddEntityToStaticComponentView(*StaticComponentView, EntityIdTwo, SpatialConstants::INVALID_VIRTUAL_WORKER_ID, WORKER_AUTHORITY_AUTHORITATIVE);
-
-	TUniquePtr<SpatialLoadBalanceEnforcer> LoadBalanceEnforcer = MakeUnique<SpatialLoadBalanceEnforcer>(ValidWorkerOne, StaticComponentView, VirtualWorkerTranslator.Get());
-
-	LoadBalanceEnforcer->QueueAclAssignmentRequest(EntityIdOne);
-	LoadBalanceEnforcer->QueueAclAssignmentRequest(EntityIdTwo);
-
-	TArray<SpatialLoadBalanceEnforcer::AclWriteAuthorityRequest> ACLRequests = LoadBalanceEnforcer->ProcessQueuedAclAssignmentRequests();
-
-	bool bSuccess = ACLRequests.Num() == 0;
-
-	// Now set authority intent component virtual worker id and retry getting the ACL requests.
-	StaticComponentView->GetComponentData<SpatialGDK::AuthorityIntent>(EntityIdOne)->VirtualWorkerId = VirtualWorkerOne;
-	StaticComponentView->GetComponentData<SpatialGDK::AuthorityIntent>(EntityIdTwo)->VirtualWorkerId = VirtualWorkerTwo;
+	AddEntityToStaticComponentView(*StaticComponentView, EntityIdOne, VirtualWorkerOne, WORKER_AUTHORITY_NOT_AUTHORITATIVE);
+	AddEntityToStaticComponentView(*StaticComponentView, EntityIdTwo, VirtualWorkerTwo, WORKER_AUTHORITY_NOT_AUTHORITATIVE);
 
 	ACLRequests.Empty();
 	ACLRequests = LoadBalanceEnforcer->ProcessQueuedAclAssignmentRequests();
@@ -179,13 +103,13 @@ LOADBALANCEENFORCER_TEST(GIVEN_load_balance_enforcer_with_valid_mapping_WHEN_ask
 	TUniquePtr<SpatialVirtualWorkerTranslator>  VirtualWorkerTranslator = CreateVirtualWorkerTranslator();
 
 	USpatialStaticComponentView* StaticComponentView = NewObject<USpatialStaticComponentView>();
-	AddEntityToStaticComponentView(*StaticComponentView, EntityIdOne, VirtualWorkerOne, WORKER_AUTHORITY_AUTHORITATIVE);
-	AddEntityToStaticComponentView(*StaticComponentView, EntityIdTwo, VirtualWorkerTwo, WORKER_AUTHORITY_AUTHORITATIVE);
+	AddEntityToStaticComponentView(*StaticComponentView, EntityIdOne, VirtualWorkerOne, WORKER_AUTHORITY_NOT_AUTHORITATIVE);
+	AddEntityToStaticComponentView(*StaticComponentView, EntityIdTwo, VirtualWorkerTwo, WORKER_AUTHORITY_NOT_AUTHORITATIVE);
 
 	TUniquePtr<SpatialLoadBalanceEnforcer> LoadBalanceEnforcer = MakeUnique<SpatialLoadBalanceEnforcer>(ValidWorkerOne, StaticComponentView, VirtualWorkerTranslator.Get());
 
-	LoadBalanceEnforcer->QueueAclAssignmentRequest(EntityIdOne);
-	LoadBalanceEnforcer->QueueAclAssignmentRequest(EntityIdTwo);
+	LoadBalanceEnforcer->MaybeQueueAclAssignmentRequest(EntityIdOne);
+	LoadBalanceEnforcer->MaybeQueueAclAssignmentRequest(EntityIdTwo);
 
 	TArray<SpatialLoadBalanceEnforcer::AclWriteAuthorityRequest> ACLRequests = LoadBalanceEnforcer->ProcessQueuedAclAssignmentRequests();
 
@@ -212,12 +136,12 @@ LOADBALANCEENFORCER_TEST(GIVEN_load_balance_enforcer_with_valid_mapping_WHEN_que
 	TUniquePtr<SpatialVirtualWorkerTranslator>  VirtualWorkerTranslator = CreateVirtualWorkerTranslator();
 
 	USpatialStaticComponentView* StaticComponentView = NewObject<USpatialStaticComponentView>();
-	AddEntityToStaticComponentView(*StaticComponentView, EntityIdOne, VirtualWorkerOne, WORKER_AUTHORITY_AUTHORITATIVE);
+	AddEntityToStaticComponentView(*StaticComponentView, EntityIdOne, VirtualWorkerOne, WORKER_AUTHORITY_NOT_AUTHORITATIVE);
 
 	TUniquePtr<SpatialLoadBalanceEnforcer> LoadBalanceEnforcer = MakeUnique<SpatialLoadBalanceEnforcer>(ValidWorkerOne, StaticComponentView, VirtualWorkerTranslator.Get());
 
-	LoadBalanceEnforcer->QueueAclAssignmentRequest(EntityIdOne);
-	LoadBalanceEnforcer->QueueAclAssignmentRequest(EntityIdOne);
+	LoadBalanceEnforcer->MaybeQueueAclAssignmentRequest(EntityIdOne);
+	LoadBalanceEnforcer->MaybeQueueAclAssignmentRequest(EntityIdOne);
 
 	TArray<SpatialLoadBalanceEnforcer::AclWriteAuthorityRequest> ACLRequests = LoadBalanceEnforcer->ProcessQueuedAclAssignmentRequests();
 
@@ -242,7 +166,7 @@ LOADBALANCEENFORCER_TEST(GIVEN_authority_intent_change_op_WHEN_we_inform_load_ba
 	TUniquePtr<SpatialVirtualWorkerTranslator> VirtualWorkerTranslator = CreateVirtualWorkerTranslator();
 
 	USpatialStaticComponentView* StaticComponentView = NewObject<USpatialStaticComponentView>();
-	AddEntityToStaticComponentView(*StaticComponentView, EntityIdOne, VirtualWorkerOne, WORKER_AUTHORITY_AUTHORITATIVE);
+	AddEntityToStaticComponentView(*StaticComponentView, EntityIdOne, VirtualWorkerOne, WORKER_AUTHORITY_NOT_AUTHORITATIVE);
 
 	TUniquePtr<SpatialLoadBalanceEnforcer> LoadBalanceEnforcer = MakeUnique<SpatialLoadBalanceEnforcer>(ValidWorkerOne, StaticComponentView, VirtualWorkerTranslator.Get());
 
@@ -274,8 +198,8 @@ LOADBALANCEENFORCER_TEST(GIVEN_authority_change_when_not_authoritative_over_auth
 {
 	TUniquePtr<SpatialVirtualWorkerTranslator>  VirtualWorkerTranslator = CreateVirtualWorkerTranslator();
 
-	// The important part of this test is that the work does not already have authority over the AuthorityIntent component.
-		// In this case, we the load balance enforcer needs to create an ACL request.
+	// The important part of this test is that the worker does not already have authority over the AuthorityIntent component.
+	// In this case, we expect the load balance enforcer to create an ACL request.
 	USpatialStaticComponentView* StaticComponentView = NewObject<USpatialStaticComponentView>();
 	AddEntityToStaticComponentView(*StaticComponentView, EntityIdOne, VirtualWorkerOne, WORKER_AUTHORITY_NOT_AUTHORITATIVE);
 
@@ -286,7 +210,7 @@ LOADBALANCEENFORCER_TEST(GIVEN_authority_change_when_not_authoritative_over_auth
 	UpdateOp.authority = WORKER_AUTHORITY_AUTHORITATIVE;
 	UpdateOp.component_id = SpatialConstants::ENTITY_ACL_COMPONENT_ID;
 
-	LoadBalanceEnforcer->AuthorityChanged(UpdateOp);
+	LoadBalanceEnforcer->OnAclAuthorityChanged(UpdateOp);
 
 	TArray<SpatialLoadBalanceEnforcer::AclWriteAuthorityRequest> ACLRequests = LoadBalanceEnforcer->ProcessQueuedAclAssignmentRequests();
 
@@ -310,8 +234,8 @@ LOADBALANCEENFORCER_TEST(GIVEN_authority_change_when_authoritative_over_authorit
 {
 	TUniquePtr<SpatialVirtualWorkerTranslator> VirtualWorkerTranslator = CreateVirtualWorkerTranslator();
 
-	// The important part of this test is that the work does already have authority over the AuthorityIntent component.
-	// In this case, we the load balance enforcer does not need to create an ACL request.
+	// The important part of this test is that the worker does already have authority over the AuthorityIntent component.
+	// In this case, we expect the load balance enforcer not to create an ACL request.
 	USpatialStaticComponentView* StaticComponentView = NewObject<USpatialStaticComponentView>();
 	AddEntityToStaticComponentView(*StaticComponentView, EntityIdOne, VirtualWorkerOne, WORKER_AUTHORITY_AUTHORITATIVE);
 
@@ -322,7 +246,7 @@ LOADBALANCEENFORCER_TEST(GIVEN_authority_change_when_authoritative_over_authorit
 	UpdateOp.authority = WORKER_AUTHORITY_AUTHORITATIVE;
 	UpdateOp.component_id = SpatialConstants::ENTITY_ACL_COMPONENT_ID;
 
-	LoadBalanceEnforcer->AuthorityChanged(UpdateOp);
+	LoadBalanceEnforcer->OnAclAuthorityChanged(UpdateOp);
 
 	TArray<SpatialLoadBalanceEnforcer::AclWriteAuthorityRequest> ACLRequests = LoadBalanceEnforcer->ProcessQueuedAclAssignmentRequests();
 

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalanceEnforcer/SpatialLoadBalanceEnforcerTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalanceEnforcer/SpatialLoadBalanceEnforcerTest.cpp
@@ -49,8 +49,8 @@ void InitialiseVirtualWorkerTranslator(SpatialVirtualWorkerTranslator* VirtualWo
 {
 	Schema_Object* DataObject = TestingSchemaHelpers::CreateTranslationComponentDataFields();
 
-	TestingSchemaHelpers::AddTranslationComponentDataMapping(DataObject, 1, ValidWorkerOne);
-	TestingSchemaHelpers::AddTranslationComponentDataMapping(DataObject, 2, ValidWorkerTwo);
+	TestingSchemaHelpers::AddTranslationComponentDataMapping(DataObject, VirtualWorkerOne, ValidWorkerOne);
+	TestingSchemaHelpers::AddTranslationComponentDataMapping(DataObject, VirtualWorkerTwo, ValidWorkerTwo);
 
 	VirtualWorkerTranslator->ApplyVirtualWorkerManagerData(DataObject);
 }

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalanceEnforcer/SpatialLoadBalanceEnforcerTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalanceEnforcer/SpatialLoadBalanceEnforcerTest.cpp
@@ -45,22 +45,17 @@ void AddEntityToStaticComponentView(USpatialStaticComponentView& StaticComponent
 	}
 }
 
-void InitialiseVirtualWorkerTranslator(SpatialVirtualWorkerTranslator* VirtualWorkerTranslator)
+TUniquePtr<SpatialVirtualWorkerTranslator> CreateVirtualWorkerTranslator()
 {
+	ULBStrategyStub* LoadBalanceStrategy = NewObject<ULBStrategyStub>();
+	TUniquePtr<SpatialVirtualWorkerTranslator> VirtualWorkerTranslator = MakeUnique<SpatialVirtualWorkerTranslator>(LoadBalanceStrategy, ValidWorkerOne);
+
 	Schema_Object* DataObject = TestingSchemaHelpers::CreateTranslationComponentDataFields();
 
 	TestingSchemaHelpers::AddTranslationComponentDataMapping(DataObject, VirtualWorkerOne, ValidWorkerOne);
 	TestingSchemaHelpers::AddTranslationComponentDataMapping(DataObject, VirtualWorkerTwo, ValidWorkerTwo);
 
 	VirtualWorkerTranslator->ApplyVirtualWorkerManagerData(DataObject);
-}
-
-TUniquePtr<SpatialVirtualWorkerTranslator> CreateVirtualWorkerTranslator()
-{
-	ULBStrategyStub* LoadBalanceStrategy = NewObject<ULBStrategyStub>();
-	TUniquePtr<SpatialVirtualWorkerTranslator> VirtualWorkerTranslator = MakeUnique<SpatialVirtualWorkerTranslator>(LoadBalanceStrategy, ValidWorkerOne);
-
-	InitialiseVirtualWorkerTranslator(VirtualWorkerTranslator.Get());
 
 	return VirtualWorkerTranslator;
 }

--- a/ci/gdk_build.template.steps.yaml
+++ b/ci/gdk_build.template.steps.yaml
@@ -13,7 +13,7 @@ common: &common
     - "platform=windows"
     - "permission_set=builder"
     - "scaler_version=2"
-    - "queue=${CI_WINDOWS_BUILDER_QUEUE:-v4-2019-12-09-bk5051-27568394a73b2cd3}" ## revert to new queue once windows baking issues have been resolved...
+    - "queue=${CI_WINDOWS_BUILDER_QUEUE:-v4-20-03-03-102720-bk8971-dd78adbb}"
     - "boot_disk_size_gb=500"
   retry:
     automatic:


### PR DESCRIPTION
#### Description
Actors should only be spawned from an entity at the end of a critical section if we see the unreal metadata component. Otherwise it is _only_ a load balancing entity, and should be treated as such. Entities can dynamically match the definition of each type of entity depending on the authority over the ACL component and the presence of the unreal metadata component.

#### Tests
Handover gym
EDIT: Now with added unit tests!

#### Primary reviewers
@m-samiec @samiwh 