### PR TITLE
Pass --mobile flag when installing GDK for CI builds

### DIFF
--- a/SetupIncTraceLibs.bat
+++ b/SetupIncTraceLibs.bat
@@ -6,7 +6,7 @@ rem ****
 
 set NO_PAUSE=1
 set NO_SET_LOCAL=1
-call Setup.bat
+call Setup.bat %*
 
 pushd "%~dp0"
 

--- a/ci/setup-gdk.ps1
+++ b/ci/setup-gdk.ps1
@@ -12,8 +12,8 @@ Push-Location $gdk_path
     }
     $env:MSBUILD_EXE = "`"$msbuild_path`""
     if($includeTraceLibs) {
-        cmd /c SetupIncTraceLibs.bat
+        cmd /c SetupIncTraceLibs.bat --mobile
     } else {
-        cmd /c Setup.bat
+        cmd /c Setup.bat --mobile
     }
 Pop-Location


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
This change adds the ability for command line parameters to be passed through SetupIncTraceLibs.bat to Setup.bat (for example --china or --mobile). This change updates ci/setup-gdk.ps1 to pass the --mobile flag when calling Setup or SetupIncTraceLibs. It is necessary to setup the worker_sdk with --mobile in order to build Android and iOS.

Related Jira Tickets:
MBL-4
UNR-2684

This is part of a collection of changes necessary to successfully build Android versions of the Unreal GDK Example Project (GDKShooter). This change is prerequisite to other changes being merged.

#### Tests
This change was validated along with other changes in platform, unrealengine, and unrealgdkexampleproject repositories. See results of successful buildkite builds here:
https://buildkite.com/improbable/unrealgdkexampleproject-nightly/builds?branch=feature%2FMBL-9-android-ci

QA can validate the changes to SetupIncTraceLibs.bat by running it using --mobile and/or --china flags.

QA can validate the changes to setup-gdk.ps1 by running the script or any build automation which runs the script (suchs as the night unreal gdk example project build).
