### PR TITLE
UNR-2926 Fix lock icon on spatial debugger

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -702,26 +702,40 @@ int64 USpatialActorChannel::ReplicateActor()
 	if (SpatialGDKSettings->bEnableUnrealLoadBalancer &&
 		NetDriver->StaticComponentView->HasAuthority(EntityId, SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID))
 	{
-		if (!NetDriver->LoadBalanceStrategy->ShouldHaveAuthority(*Actor) && !NetDriver->LockingPolicy->IsLocked(Actor))
+		// We use an additional bool to keep track of whether we've called IsLocked. This is because 1) we don't
+		// want to call it twice in both the main load-balancing flow and when sending a debugger update and 2)
+		// for efficiency, we want to wait to until ShouldHaveAuthority is called before we try calling IsLocked
+		// on the main load-balancing flow.
+		bool bCalledIsLocked = false;
+		bool bIsLocked = false;
+		if (!NetDriver->LoadBalanceStrategy->ShouldHaveAuthority(*Actor))
 		{
-			const VirtualWorkerId NewAuthVirtualWorkerId = NetDriver->LoadBalanceStrategy->WhoShouldHaveAuthority(*Actor);
-			if (NewAuthVirtualWorkerId != SpatialConstants::INVALID_VIRTUAL_WORKER_ID)
+			bIsLocked = NetDriver->LockingPolicy->IsLocked(Actor);
+			bCalledIsLocked = true;
+			if (!bIsLocked)
 			{
-				Sender->SendAuthorityIntentUpdate(*Actor, NewAuthVirtualWorkerId);
+				const VirtualWorkerId NewAuthVirtualWorkerId = NetDriver->LoadBalanceStrategy->WhoShouldHaveAuthority(*Actor);
+				if (NewAuthVirtualWorkerId != SpatialConstants::INVALID_VIRTUAL_WORKER_ID)
+				{
+					Sender->SendAuthorityIntentUpdate(*Actor, NewAuthVirtualWorkerId);
 
-				// If we're setting a different authority intent, preemptively changed to ROLE_SimulatedProxy 
-				Actor->Role = ROLE_SimulatedProxy;
-				Actor->RemoteRole = ROLE_Authority;
-			}
-			else
-			{
-				UE_LOG(LogSpatialActorChannel, Error, TEXT("Load Balancing Strategy returned invalid virtual worker for actor %s"), *Actor->GetName());
+					// If we're setting a different authority intent, preemptively changed to ROLE_SimulatedProxy 
+					Actor->Role = ROLE_SimulatedProxy;
+					Actor->RemoteRole = ROLE_Authority;
+				}
+				else
+				{
+					UE_LOG(LogSpatialActorChannel, Error, TEXT("Load Balancing Strategy returned invalid virtual worker for actor %s"), *Actor->GetName());
+				}
 			}
 		}
 
 		if (SpatialGDK::SpatialDebugging* DebuggingInfo = NetDriver->StaticComponentView->GetComponentData<SpatialGDK::SpatialDebugging>(EntityId))
 		{
-			bool bIsLocked = NetDriver->LockingPolicy->IsLocked(Actor);
+			if (!bCalledIsLocked)
+			{
+				bIsLocked = NetDriver->LockingPolicy->IsLocked(Actor);
+			}
 			if (DebuggingInfo->IsLocked != bIsLocked)
 			{
 				DebuggingInfo->IsLocked = bIsLocked;

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -22,6 +22,7 @@
 #include "Interop/SpatialSender.h"
 #include "LoadBalancing/AbstractLBStrategy.h"
 #include "Schema/ClientRPCEndpointLegacy.h"
+#include "Schema/SpatialDebugging.h"
 #include "Schema/ServerRPCEndpointLegacy.h"
 #include "SpatialConstants.h"
 #include "SpatialGDKSettings.h"
@@ -696,25 +697,39 @@ int64 USpatialActorChannel::ReplicateActor()
 		}
 	}
 
-	if (SpatialGDKSettings->bEnableUnrealLoadBalancer &&
+	if (SpatialGDKSettings->bEnableUnrealLoadBalancer)
+	{
+		const bool bActorIsLocked = NetDriver->LockingPolicy->IsLocked(Actor);
+
 		// TODO: the 'bWroteSomethingImportant' check causes problems for actors that need to transition in groups (ex. Character, PlayerController, PlayerState),
 		// so disabling it for now.  Figure out a way to deal with this to recover the perf lost by calling ShouldChangeAuthority() frequently. [UNR-2387]
-		NetDriver->StaticComponentView->HasAuthority(EntityId, SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID) &&
-		!NetDriver->LoadBalanceStrategy->ShouldHaveAuthority(*Actor) &&
-		!NetDriver->LockingPolicy->IsLocked(Actor))
-	{
-		const VirtualWorkerId NewAuthVirtualWorkerId = NetDriver->LoadBalanceStrategy->WhoShouldHaveAuthority(*Actor);
-		if (NewAuthVirtualWorkerId != SpatialConstants::INVALID_VIRTUAL_WORKER_ID)
+		if (NetDriver->StaticComponentView->HasAuthority(EntityId, SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID) &&
+			!bActorIsLocked &&
+			!NetDriver->LoadBalanceStrategy->ShouldHaveAuthority(*Actor))
 		{
-			Sender->SendAuthorityIntentUpdate(*Actor, NewAuthVirtualWorkerId);
+			const VirtualWorkerId NewAuthVirtualWorkerId = NetDriver->LoadBalanceStrategy->WhoShouldHaveAuthority(*Actor);
+			if (NewAuthVirtualWorkerId != SpatialConstants::INVALID_VIRTUAL_WORKER_ID)
+			{
+				Sender->SendAuthorityIntentUpdate(*Actor, NewAuthVirtualWorkerId);
 
-			// If we're setting a different authority intent, preemptively changed to ROLE_SimulatedProxy 
-			Actor->Role = ROLE_SimulatedProxy;
-			Actor->RemoteRole = ROLE_Authority;
+				// If we're setting a different authority intent, preemptively changed to ROLE_SimulatedProxy 
+				Actor->Role = ROLE_SimulatedProxy;
+				Actor->RemoteRole = ROLE_Authority;
+			}
+			else
+			{
+				UE_LOG(LogSpatialActorChannel, Error, TEXT("Load Balancing Strategy returned invalid virtual worker for actor %s"), *Actor->GetName());
+			}
 		}
-		else
+
+		if (SpatialGDK::SpatialDebugging* DebuggingInfo = NetDriver->StaticComponentView->GetComponentData<SpatialGDK::SpatialDebugging>(EntityId))
 		{
-			UE_LOG(LogSpatialActorChannel, Error, TEXT("Load Balancing Strategy returned invalid virtual worker for actor %s"), *Actor->GetName());
+			if (bActorIsLocked != DebuggingInfo->IsLocked)
+			{
+				DebuggingInfo->IsLocked = bActorIsLocked;
+				FWorkerComponentUpdate DebuggingUpdate = DebuggingInfo->CreateSpatialDebuggingUpdate();
+				NetDriver->Connection->SendComponentUpdate(EntityId, &DebuggingUpdate);
+			}
 		}
 	}
 #if USE_NETWORK_PROFILER 


### PR DESCRIPTION
#### Description
The SpatialDebugger overhead lock icon currently doesn't work. The SpatialDebugging SpatialOS component property IsLocked was never being set by the authoritative server so never displayed.

It does now:

![lock-icon-works](https://user-images.githubusercontent.com/9222722/74670641-81f31f00-51a1-11ea-93a2-e64171ae1b09.gif)

#### How can this be verified by QA?
Follow the instructions for the LockingGym and above the same behaviour as the gif.

#### Primary reviewers
@jennifer-at-improbable-io 