### PR TITLE
GV-230: Fix SetupInTraceLibs.bat to call Setup.bat from the correct directory

### DIFF
--- a/SetupIncTraceLibs.bat
+++ b/SetupIncTraceLibs.bat
@@ -6,9 +6,10 @@ rem ****
 
 set NO_PAUSE=1
 set NO_SET_LOCAL=1
-call Setup.bat
 
 pushd "%~dp0"
+
+call Setup.bat
 
 call :MarkStartOfBlock "%~0"
 


### PR DESCRIPTION
If the script is started from a directory different than its own, it fails because it can't find Setup.bat
