### PR TITLE
Remove overzealous assert

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -489,7 +489,6 @@ void USpatialReceiver::HandleActorAuthority(const Worker_AuthorityChangeOp& Op)
 						// The following check will return false on non-authoritative servers if the Pawn hasn't been received yet.
 						if (APawn* PawnFromPlayerState = PlayerState->GetPawn())
 						{
-							check(PlayerState->bIsABot || PawnFromPlayerState->IsPlayerControlled());
 							if (PawnFromPlayerState->IsPlayerControlled())
 							{
 								PawnFromPlayerState->RemoteRole = ROLE_AutonomousProxy;


### PR DESCRIPTION
Quick drive by to remove an overzealous assert I added a while back. IsPlayerControlled checks whether the Pawn's internal PlayerState member is set. That member is set in OnRep_PlayerState, so if we receive the PlayerState actor before the PlayerState property of the pawn is replicated, the assert would fire. Pawn::SetPlayerState catches the replication and sets the pawn's role.