### PR TITLE
[UNR-2950][MS] Fix when generating schema, we need to delete the old …

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -536,6 +536,15 @@ void CopyWellKnownSchemaFiles(const FString& GDKSchemaCopyDir, const FString& Co
 		}
 	}
 
+	// Delete the existing schema files. This ensures there are no conflicts between schema files.
+	TArray<FString> FoundFiles;
+	PlatformFile.FindFiles(FoundFiles, *GDKSchemaCopyDir, TEXT("schema"));
+
+	for (FString& File : FoundFiles)
+	{
+		PlatformFile.DeleteFile(*File);
+	}
+
 	if (!PlatformFile.DirectoryExists(*CoreSDKSchemaCopyDir))
 	{
 		if (!PlatformFile.CreateDirectoryTree(*CoreSDKSchemaCopyDir))


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
When we change versions, after regenerating schema we can run into errors. 
This is due to the fact that we copy all files from "SpatialGDK\Extras\schema" into the projects "spatial\schema\unreal\gdk" folder but do not remove the old files. Generally this isn't a problem as all files just get overwritten but certain GDK changes will have files mismatches which can cause silent and also obvious errors. 

#### Primary reviewers
@mironec 