### PR TITLE
Fix coordinates in GridBasedLBStrategy

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
@@ -35,28 +35,30 @@ void UGridBasedLBStrategy::Init(const USpatialNetDriver* InNetDriver)
 	const float ColumnWidth = WorldWidth / Cols;
 	const float RowHeight = WorldHeight / Rows;
 
-	float XMin = WorldWidthMin;
-	float YMin = WorldHeightMin;
+	// We would like the inspector's representation of the load balancing strategy to match our intuition.
+	// +x is forward, so rows are perpendicular to the x-axis and columns are perpendicular to the y-axis.
+	float XMin = WorldHeightMin;
+	float YMin = WorldWidthMin;
 	float XMax, YMax;
 
 	for (uint32 Col = 0; Col < Cols; ++Col)
 	{
-		XMax = XMin + ColumnWidth;
+		YMax = YMin + ColumnWidth;
 
 		for (uint32 Row = 0; Row < Rows; ++Row)
 		{
-			YMax = YMin + RowHeight;
+			XMax = XMin + RowHeight;
 
 			FVector2D Min(XMin, YMin);
 			FVector2D Max(XMax, YMax);
 			FBox2D Cell(Min, Max);
 			WorkerCells.Add(Cell);
 
-			YMin = YMax;
+			XMin = XMax;
 		}
 
-		YMin = WorldHeightMin;
-		XMin = XMax;
+		XMin = WorldHeightMin;
+		YMin = YMax;
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/GridBasedLBStrategyTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/GridBasedLBStrategyTest.cpp
@@ -243,7 +243,7 @@ GRIDBASEDLBSTRATEGY_TEST(GIVEN_moving_actor_WHEN_actor_crosses_boundary_THEN_sho
 {
 	AutomationOpenMap("/Engine/Maps/Entry");
 
-	ADD_LATENT_AUTOMATION_COMMAND(FCreateStrategy(1, 2, 10000.f, 10000.f, 0));
+	ADD_LATENT_AUTOMATION_COMMAND(FCreateStrategy(2, 1, 10000.f, 10000.f, 0));
 	ADD_LATENT_AUTOMATION_COMMAND(FWaitForWorld());
 	ADD_LATENT_AUTOMATION_COMMAND(FSpawnActorAtLocation("Actor1", FVector(-2.f, 0.f, 0.f)));
 	ADD_LATENT_AUTOMATION_COMMAND(FWaitForActor("Actor1"));
@@ -278,7 +278,7 @@ GRIDBASEDLBSTRATEGY_TEST(GIVEN_two_cells_WHEN_actor_in_one_cell_THEN_strategy_re
 	AutomationOpenMap("/Engine/Maps/Entry");
 
 	ADD_LATENT_AUTOMATION_COMMAND(FWaitForWorld());
-	ADD_LATENT_AUTOMATION_COMMAND(FSpawnActorAtLocation("Actor1", FVector(-2500.f, 0.f, 0.f)));
+	ADD_LATENT_AUTOMATION_COMMAND(FSpawnActorAtLocation("Actor1", FVector(0.f, -2500.f, 0.f)));
 	ADD_LATENT_AUTOMATION_COMMAND(FWaitForActor("Actor1"));
 	ADD_LATENT_AUTOMATION_COMMAND(FCreateStrategy(1, 2, 10000.f, 10000.f, 0));
 	ADD_LATENT_AUTOMATION_COMMAND(FCheckShouldRelinquishAuthority(this, "Actor1", false));


### PR DESCRIPTION
I noticed that the v2 inspector was showing odd results for which worker had auth for an actor when using a 2-row strategy for the runtime and gdk together. Before this change, I would see this:

![image](https://user-images.githubusercontent.com/27557/75187939-6a1f1c00-5708-11ea-8291-27327593d7ac.png)

with these changes, I see this:

![image](https://user-images.githubusercontent.com/27557/75187956-773c0b00-5708-11ea-8a2b-f65cfc0ae925.png)
