### PR TITLE
server qbi that CAN'T be turned off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - With the `--OverrideResultTypes` flag flipped, servers will no longer check out server RPC components on actors they do not own. This should give a bandwidth saving to server workers in offloaded and zoned games.
 - The `InstallGDK` scripts now `git clone` the correct version of the `UnrealGDK` and `UnrealGDKExampleProject` for the `UnrealEngine` branch you have checked out. They read `UnrealGDKVersion.txt` & `UnrealGDKExampleProjectVersion.txt` to determine what the correct branches are.
 - Unreal Engine `4.24.3` is now supported. You can find the `4.24.3` version of our engine fork [here](https://github.com/improbableio/UnrealEngine/tree/4.24-SpatialOSUnrealGDK).
-- Enabling server QBI now creates a single query per server worker, depending on the defined load balancing strategy.
+- Enabling the Unreal GDK load balancer now creates a single query per server worker, depending on the defined load balancing strategy.
 
 ## Bug fixes:
 - Fixed a bug that caused the local API service to memory leak.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - The `InstallGDK` scripts now `git clone` the correct version of the `UnrealGDK` and `UnrealGDKExampleProject` for the `UnrealEngine` branch you have checked out. They read `UnrealGDKVersion.txt` & `UnrealGDKExampleProjectVersion.txt` to determine what the correct branches are.
 - Unreal Engine `4.24.3` is now supported. You can find the `4.24.3` version of our engine fork [here](https://github.com/improbableio/UnrealEngine/tree/4.24-SpatialOSUnrealGDK).
 - Enabling the Unreal GDK load balancer now creates a single query per server worker, depending on the defined load balancing strategy.
-- The flag `--OverrideServerInterest` has been removed.
+- The `bEnableServerQBI` property has been removed, and the flag `--OverrideServerInterest` has been removed.
 
 ## Bug fixes:
 - Fixed a bug that caused the local API service to memory leak.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - The `InstallGDK` scripts now `git clone` the correct version of the `UnrealGDK` and `UnrealGDKExampleProject` for the `UnrealEngine` branch you have checked out. They read `UnrealGDKVersion.txt` & `UnrealGDKExampleProjectVersion.txt` to determine what the correct branches are.
 - Unreal Engine `4.24.3` is now supported. You can find the `4.24.3` version of our engine fork [here](https://github.com/improbableio/UnrealEngine/tree/4.24-SpatialOSUnrealGDK).
 - Enabling the Unreal GDK load balancer now creates a single query per server worker, depending on the defined load balancing strategy.
+- The flag `--OverrideServerInterest` has been removed.
 
 ## Bug fixes:
 - Fixed a bug that caused the local API service to memory leak.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - With the `--OverrideResultTypes` flag flipped, servers will no longer check out server RPC components on actors they do not own. This should give a bandwidth saving to server workers in offloaded and zoned games.
 - The `InstallGDK` scripts now `git clone` the correct version of the `UnrealGDK` and `UnrealGDKExampleProject` for the `UnrealEngine` branch you have checked out. They read `UnrealGDKVersion.txt` & `UnrealGDKExampleProjectVersion.txt` to determine what the correct branches are.
 - Unreal Engine `4.24.3` is now supported. You can find the `4.24.3` version of our engine fork [here](https://github.com/improbableio/UnrealEngine/tree/4.24-SpatialOSUnrealGDK).
+- Enabling server QBI now creates a single query per server worker, depending on the defined load balancing strategy.
 
 ## Bug fixes:
 - Fixed a bug that caused the local API service to memory leak.

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -2261,7 +2261,7 @@ void USpatialNetDriver::HandleStartupOpQueueing(const TArray<Worker_OpList*>& In
 			if (GetDefault<USpatialGDKSettings>()->bEnableUnrealLoadBalancer)
 			{
 				// We know at this point that we have all the information to set the worker's interest query.
-				Sender->UpdateWorkerEntityInterestAndPosition();
+				Sender->UpdateServerWorkerEntityInterestAndPosition();
 			}
 
 			// We've found and dispatched all ops we need for startup,

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -431,7 +431,7 @@ void USpatialNetDriver::CreateAndInitializeLoadBalancingClasses()
 		{
 			LoadBalanceStrategy = NewObject<UAbstractLBStrategy>(this, WorldSettings->LoadBalanceStrategy);
 		}
-		LoadBalanceStrategy->Init(this);
+		LoadBalanceStrategy->Init();
 	}
 
 	VirtualWorkerTranslator = MakeUnique<SpatialVirtualWorkerTranslator>(LoadBalanceStrategy, Connection->GetWorkerId());
@@ -2259,7 +2259,7 @@ void USpatialNetDriver::HandleStartupOpQueueing(const TArray<Worker_OpList*>& In
 		if (bIsReadyToStart)
 		{
 			// We know at this point that we have all the information to set the worker's interest query.
-			Sender->SendServerWorkerEntityInterestUpdate();
+			Sender->UpdateWorkerEntityInterestAndPosition();
 
 			// We've found and dispatched all ops we need for startup,
 			// trigger BeginPlay() on the GSM and process the queued ops.

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -2258,6 +2258,9 @@ void USpatialNetDriver::HandleStartupOpQueueing(const TArray<Worker_OpList*>& In
 
 		if (bIsReadyToStart)
 		{
+			// We know at this point that we have all the information to set the worker's interest query.
+			Sender->SendServerWorkerEntityInterestUpdate();
+
 			// We've found and dispatched all ops we need for startup,
 			// trigger BeginPlay() on the GSM and process the queued ops.
 			// Note that FindAndDispatchStartupOps() will have notified the Dispatcher

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -2258,8 +2258,11 @@ void USpatialNetDriver::HandleStartupOpQueueing(const TArray<Worker_OpList*>& In
 
 		if (bIsReadyToStart)
 		{
-			// We know at this point that we have all the information to set the worker's interest query.
-			Sender->UpdateWorkerEntityInterestAndPosition();
+			if (GetDefault<USpatialGDKSettings>()->bEnableUnrealLoadBalancer)
+			{
+				// We know at this point that we have all the information to set the worker's interest query.
+				Sender->UpdateWorkerEntityInterestAndPosition();
+			}
 
 			// We've found and dispatched all ops we need for startup,
 			// trigger BeginPlay() on the GSM and process the queued ops.

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -209,7 +209,6 @@ void USpatialReceiver::OnAddComponent(const Worker_AddComponentOp& Op)
 		{
 			Schema_Object* ComponentObject = Schema_GetComponentDataFields(Op.data.schema_type);
 			NetDriver->VirtualWorkerTranslator->ApplyVirtualWorkerManagerData(ComponentObject);
-			Sender->SendServerWorkerEntityInterestUpdate();
 		}
 		return;
 	}
@@ -1431,7 +1430,6 @@ void USpatialReceiver::OnComponentUpdate(const Worker_ComponentUpdateOp& Op)
 		{
 			Schema_Object* ComponentObject = Schema_GetComponentUpdateFields(Op.update.schema_type);
 			NetDriver->VirtualWorkerTranslator->ApplyVirtualWorkerManagerData(ComponentObject);
-			Sender->SendServerWorkerEntityInterestUpdate();
 		}
 		return;
 	case SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID:

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -209,6 +209,7 @@ void USpatialReceiver::OnAddComponent(const Worker_AddComponentOp& Op)
 		{
 			Schema_Object* ComponentObject = Schema_GetComponentDataFields(Op.data.schema_type);
 			NetDriver->VirtualWorkerTranslator->ApplyVirtualWorkerManagerData(ComponentObject);
+			Sender->SendServerWorkerEntityInterestUpdate();
 		}
 		return;
 	}
@@ -1430,6 +1431,7 @@ void USpatialReceiver::OnComponentUpdate(const Worker_ComponentUpdateOp& Op)
 		{
 			Schema_Object* ComponentObject = Schema_GetComponentUpdateFields(Op.update.schema_type);
 			NetDriver->VirtualWorkerTranslator->ApplyVirtualWorkerManagerData(ComponentObject);
+			Sender->SendServerWorkerEntityInterestUpdate();
 		}
 		return;
 	case SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID:

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -205,7 +205,7 @@ void USpatialSender::CreateServerWorkerEntity(int AttemptCounter)
 		{
 			Sender->NetDriver->WorkerEntityId = Op.entity_id;
 			Sender->NetDriver->GlobalStateManager->TrySendWorkerReadyToBeginPlay();
-			Worker_ComponentUpdate InterestUpdate = InterestFactory::CreateServerWorkerInterest(*Sender->NetDriver).CreateInterestUpdate();
+			FWorkerComponentUpdate InterestUpdate = InterestFactory::CreateServerWorkerInterest(*Sender->NetDriver).CreateInterestUpdate();
 			Sender->Connection->SendComponentUpdate(Sender->NetDriver->WorkerEntityId, &InterestUpdate);
 			
 			return;
@@ -320,7 +320,7 @@ void USpatialSender::SendServerWorkerEntityInterestUpdate()
 		// Can't set interest yet
 		return;
 	}
-	Worker_ComponentUpdate InterestUpdate = InterestFactory::CreateServerWorkerInterest(*NetDriver).CreateInterestUpdate();
+	FWorkerComponentUpdate InterestUpdate = InterestFactory::CreateServerWorkerInterest(*NetDriver).CreateInterestUpdate();
 	Connection->SendComponentUpdate(NetDriver->WorkerEntityId, &InterestUpdate);
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -188,7 +188,7 @@ void USpatialSender::CreateServerWorkerEntity(int AttemptCounter)
 	Components.Add(EntityAcl(WorkerIdPermission, ComponentWriteAcl).CreateEntityAclData());
 	Components.Add(ServerWorker(Connection->GetWorkerId(), false).CreateServerWorkerData());
 	check(NetDriver != nullptr);
-	Components.Add(InterestFactory::CreateServerWorkerInterest(*NetDriver).CreateInterestData());
+	Components.Add(InterestFactory::CreateServerWorkerInterest(NetDriver->LoadBalanceStrategy).CreateInterestData());
 
 	const Worker_RequestId RequestId = Connection->SendCreateEntityRequest(MoveTemp(Components), nullptr);
 
@@ -321,12 +321,12 @@ void USpatialSender::UpdateWorkerEntityInterestAndPosition()
 	}
 
 	// Update the interest. If it's ready, also adds interest according to the load balancing strategy.
-	FWorkerComponentUpdate InterestUpdate = InterestFactory::CreateServerWorkerInterest(*NetDriver).CreateInterestUpdate();
+	FWorkerComponentUpdate InterestUpdate = InterestFactory::CreateServerWorkerInterest(NetDriver->LoadBalanceStrategy).CreateInterestUpdate();
 	Connection->SendComponentUpdate(NetDriver->WorkerEntityId, &InterestUpdate);
 
 	if (NetDriver->LoadBalanceStrategy->IsReady())
 	{
-		// Also update the position of thew worker entity to the centre of the load balancing region.
+		// Also update the position of the worker entity to the centre of the load balancing region.
 		SendPositionUpdate(NetDriver->WorkerEntityId, NetDriver->LoadBalanceStrategy->GetWorkerEntityPosition());
 	}
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -320,11 +320,11 @@ void USpatialSender::UpdateServerWorkerEntityInterestAndPosition()
 		return;
 	}
 
-	// Update the interest. If it's ready, also adds interest according to the load balancing strategy.
+	// Update the interest. If it's ready and not null, also adds interest according to the load balancing strategy.
 	FWorkerComponentUpdate InterestUpdate = InterestFactory::CreateServerWorkerInterest(NetDriver->LoadBalanceStrategy).CreateInterestUpdate();
 	Connection->SendComponentUpdate(NetDriver->WorkerEntityId, &InterestUpdate);
 
-	if (NetDriver->LoadBalanceStrategy->IsReady())
+	if (NetDriver->LoadBalanceStrategy != nullptr && NetDriver->LoadBalanceStrategy->IsReady())
 	{
 		// Also update the position of the worker entity to the centre of the load balancing region.
 		SendPositionUpdate(NetDriver->WorkerEntityId, NetDriver->LoadBalanceStrategy->GetWorkerEntityPosition());

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -186,8 +186,9 @@ void USpatialSender::CreateServerWorkerEntity(int AttemptCounter)
 	Components.Add(Position().CreatePositionData());
 	Components.Add(Metadata(FString::Format(TEXT("WorkerEntity:{0}"), { Connection->GetWorkerId() })).CreateMetadataData());
 	Components.Add(EntityAcl(WorkerIdPermission, ComponentWriteAcl).CreateEntityAclData());
-	Components.Add(InterestFactory::CreateServerWorkerInterest().CreateInterestData());
 	Components.Add(ServerWorker(Connection->GetWorkerId(), false).CreateServerWorkerData());
+	check(NetDriver != nullptr);
+	Components.Add(InterestFactory::CreateServerWorkerInterest(*NetDriver).CreateInterestData());
 
 	const Worker_RequestId RequestId = Connection->SendCreateEntityRequest(MoveTemp(Components), nullptr);
 
@@ -204,6 +205,9 @@ void USpatialSender::CreateServerWorkerEntity(int AttemptCounter)
 		{
 			Sender->NetDriver->WorkerEntityId = Op.entity_id;
 			Sender->NetDriver->GlobalStateManager->TrySendWorkerReadyToBeginPlay();
+			Worker_ComponentUpdate InterestUpdate = InterestFactory::CreateServerWorkerInterest(*Sender->NetDriver).CreateInterestUpdate();
+			Sender->Connection->SendComponentUpdate(Sender->NetDriver->WorkerEntityId, &InterestUpdate);
+			
 			return;
 		}
 
@@ -284,7 +288,7 @@ void USpatialSender::CreateEntityWithRetries(Worker_EntityId EntityId, FString E
 
 	Delegate.BindLambda([this, EntityId, Name = MoveTemp(EntityName), Components = MoveTemp(EntityComponents)](const Worker_CreateEntityResponseOp& Op) mutable
 	{
-		switch(Op.status_code)
+		switch (Op.status_code)
 		{
 		case WORKER_STATUS_CODE_SUCCESS:
 			UE_LOG(LogSpatialSender, Log, TEXT("Created entity. "
@@ -294,7 +298,7 @@ void USpatialSender::CreateEntityWithRetries(Worker_EntityId EntityId, FString E
 		case WORKER_STATUS_CODE_TIMEOUT:
 			UE_LOG(LogSpatialSender, Log, TEXT("Timed out creating entity. Retrying. "
 				"Entity name: %s, entity id: %lld"), *Name, EntityId);
-			CreateEntityWithRetries(EntityId,  MoveTemp(Name), MoveTemp(Components));
+			CreateEntityWithRetries(EntityId, MoveTemp(Name), MoveTemp(Components));
 			break;
 		default:
 			UE_LOG(LogSpatialSender, Log, TEXT("Failed to create entity. It might already be created. Not retrying. "
@@ -305,6 +309,19 @@ void USpatialSender::CreateEntityWithRetries(Worker_EntityId EntityId, FString E
 	});
 
 	Receiver->AddCreateEntityDelegate(RequestId, MoveTemp(Delegate));
+}
+
+void USpatialSender::SendServerWorkerEntityInterestUpdate()
+{
+	check(Connection != nullptr);
+	check(NetDriver != nullptr);
+	if (NetDriver->WorkerEntityId == SpatialConstants::INVALID_ENTITY_ID)
+	{
+		// Can't set interest yet
+		return;
+	}
+	Worker_ComponentUpdate InterestUpdate = InterestFactory::CreateServerWorkerInterest(*NetDriver).CreateInterestUpdate();
+	Connection->SendComponentUpdate(NetDriver->WorkerEntityId, &InterestUpdate);
 }
 
 void USpatialSender::SendComponentUpdates(UObject* Object, const FClassInfo& Info, USpatialActorChannel* Channel, const FRepChangeState* RepChanges, const FHandoverChangeState* HandoverChanges)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -188,6 +188,8 @@ void USpatialSender::CreateServerWorkerEntity(int AttemptCounter)
 	Components.Add(EntityAcl(WorkerIdPermission, ComponentWriteAcl).CreateEntityAclData());
 	Components.Add(ServerWorker(Connection->GetWorkerId(), false).CreateServerWorkerData());
 	check(NetDriver != nullptr);
+	// It is unlikely the load balance strategy would be set up at this point, but we call this function again later when it is ready in order
+	// to set the interest of the server worker according to the strategy.
 	Components.Add(InterestFactory::CreateServerWorkerInterest(NetDriver->LoadBalanceStrategy).CreateInterestData());
 
 	const Worker_RequestId RequestId = Connection->SendCreateEntityRequest(MoveTemp(Components), nullptr);
@@ -205,8 +207,6 @@ void USpatialSender::CreateServerWorkerEntity(int AttemptCounter)
 		{
 			Sender->NetDriver->WorkerEntityId = Op.entity_id;
 			Sender->NetDriver->GlobalStateManager->TrySendWorkerReadyToBeginPlay();
-			Sender->UpdateServerWorkerEntityInterestAndPosition();
-			
 			return;
 		}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -205,8 +205,7 @@ void USpatialSender::CreateServerWorkerEntity(int AttemptCounter)
 		{
 			Sender->NetDriver->WorkerEntityId = Op.entity_id;
 			Sender->NetDriver->GlobalStateManager->TrySendWorkerReadyToBeginPlay();
-			FWorkerComponentUpdate InterestUpdate = InterestFactory::CreateServerWorkerInterest(*Sender->NetDriver).CreateInterestUpdate();
-			Sender->Connection->SendComponentUpdate(Sender->NetDriver->WorkerEntityId, &InterestUpdate);
+			Sender->SendServerWorkerEntityInterestUpdate();
 			
 			return;
 		}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -205,7 +205,7 @@ void USpatialSender::CreateServerWorkerEntity(int AttemptCounter)
 		{
 			Sender->NetDriver->WorkerEntityId = Op.entity_id;
 			Sender->NetDriver->GlobalStateManager->TrySendWorkerReadyToBeginPlay();
-			Sender->UpdateWorkerEntityInterestAndPosition();
+			Sender->UpdateServerWorkerEntityInterestAndPosition();
 			
 			return;
 		}
@@ -310,7 +310,7 @@ void USpatialSender::CreateEntityWithRetries(Worker_EntityId EntityId, FString E
 	Receiver->AddCreateEntityDelegate(RequestId, MoveTemp(Delegate));
 }
 
-void USpatialSender::UpdateWorkerEntityInterestAndPosition()
+void USpatialSender::UpdateServerWorkerEntityInterestAndPosition()
 {
 	check(Connection != nullptr);
 	check(NetDriver != nullptr);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -320,12 +320,15 @@ void USpatialSender::UpdateWorkerEntityInterestAndPosition()
 		return;
 	}
 
-	// Update the interest according to the load balancing strategy.
+	// Update the interest. If it's ready, also adds interest according to the load balancing strategy.
 	FWorkerComponentUpdate InterestUpdate = InterestFactory::CreateServerWorkerInterest(*NetDriver).CreateInterestUpdate();
 	Connection->SendComponentUpdate(NetDriver->WorkerEntityId, &InterestUpdate);
 
-	// Also update the position of thew worker entity to the centre of the load balancing region.
-
+	if (NetDriver->LoadBalanceStrategy->IsReady())
+	{
+		// Also update the position of thew worker entity to the centre of the load balancing region.
+		SendPositionUpdate(NetDriver->WorkerEntityId, NetDriver->LoadBalanceStrategy->GetWorkerEntityPosition());
+	}
 }
 
 void USpatialSender::SendComponentUpdates(UObject* Object, const FClassInfo& Info, USpatialActorChannel* Channel, const FRepChangeState* RepChanges, const FHandoverChangeState* HandoverChanges)

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
@@ -105,7 +105,6 @@ SpatialGDK::QueryConstraint UGridBasedLBStrategy::GetWorkerInterestQueryConstrai
 {
 	// For a grid-based strategy, the interest area is the cell that the worker is authoritative over plus some border region.
 	check(IsReady());
-	check(Rows * Cols > 0);
 
 	const FBox2D Interest2D = WorkerCells[LocalVirtualWorkerId - 1].ExpandBy(InterestBorder);
 	const FVector Min = FVector{ Interest2D.Min.X, Interest2D.Min.Y, -FLT_MAX };

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
@@ -19,9 +19,9 @@ UGridBasedLBStrategy::UGridBasedLBStrategy()
 {
 }
 
-void UGridBasedLBStrategy::Init(const USpatialNetDriver* InNetDriver)
+void UGridBasedLBStrategy::Init()
 {
-	Super::Init(InNetDriver);
+	Super::Init();
 
 	UE_LOG(LogGridBasedLBStrategy, Log, TEXT("GridBasedLBStrategy initialized with Rows = %d and Cols = %d."), Rows, Cols);
 

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
@@ -108,14 +108,6 @@ SpatialGDK::QueryConstraint UGridBasedLBStrategy::GetWorkerInterestQueryConstrai
 	check(InterestBorder >= 0);
 	check(Rows * Cols > 0);
 
-	// If there is only one worker, this special cases to a "true" constraint (Component constraint for the position component).
-	if (Rows * Cols == 1)
-	{
-		SpatialGDK::QueryConstraint TrueConstraint;
-		TrueConstraint.ComponentConstraint = SpatialConstants::POSITION_COMPONENT_ID;
-		return TrueConstraint;
-	}
-
 	const FBox2D Interest2D = WorkerCells[LocalVirtualWorkerId - 1].ExpandBy(InterestBorder);
 	const FVector Min = FVector{ Interest2D.Min.X, Interest2D.Min.Y, -FLT_MAX };
 	const FVector Max = FVector{ Interest2D.Max.X, Interest2D.Max.Y, FLT_MAX };

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
@@ -105,7 +105,6 @@ SpatialGDK::QueryConstraint UGridBasedLBStrategy::GetWorkerInterestQueryConstrai
 {
 	// For a grid-based strategy, the interest area is the cell that the worker is authoritative over plus some border region.
 	check(IsReady());
-	check(InterestBorder >= 0);
 	check(Rows * Cols > 0);
 
 	const FBox2D Interest2D = WorkerCells[LocalVirtualWorkerId - 1].ExpandBy(InterestBorder);

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
@@ -3,6 +3,7 @@
 #include "LoadBalancing/GridBasedLBStrategy.h"
 
 #include "EngineClasses/SpatialNetDriver.h"
+#include "Schema/Interest.h"
 #include "Utils/SpatialActorUtils.h"
 
 #include "Templates/Tuple.h"
@@ -15,6 +16,7 @@ UGridBasedLBStrategy::UGridBasedLBStrategy()
 	, Cols(1)
 	, WorldWidth(10000.f)
 	, WorldHeight(10000.f)
+	, InterestBorder(0.f)
 {
 }
 
@@ -98,6 +100,27 @@ VirtualWorkerId UGridBasedLBStrategy::WhoShouldHaveAuthority(const AActor& Actor
 	}
 
 	return SpatialConstants::INVALID_VIRTUAL_WORKER_ID;
+}
+
+void UGridBasedLBStrategy::CreateWorkerInterestQueries(TArray<SpatialGDK::Query>& OutQueries) const
+{
+	// For a grid-based strategy, the interest area is the cell that the worker is authoritative over plus some border region.
+	// If there is only a single server, then there is no need to create interest since the worker has authority over the entire world (in principle, at least).
+	check(IsReady());
+	check(InterestBorder >= 0);
+	if (Rows * Cols > 0)
+	{
+		const FBox2D Interest2D = WorkerCells[LocalVirtualWorkerId - 1].ExpandBy(InterestBorder);
+		const FVector Min = FVector{ Interest2D.Min.X, Interest2D.Min.Y, FLT_MIN };
+		const FVector Max = FVector{ Interest2D.Max.X, Interest2D.Max.Y, FLT_MAX };
+		const FBox Interest3D = FBox{ Min, Max };
+		SpatialGDK::QueryConstraint Constraint;
+		Constraint.BoxConstraint = SpatialGDK::BoxConstraint{ SpatialGDK::Coordinates::FromFVector(Interest3D.GetCenter()), SpatialGDK::EdgeLength::FromFVector(2 * Interest3D.GetExtent()) };
+		SpatialGDK::Query Query;
+		Query.Constraint = Constraint;
+		Query.FullSnapshotResult = true;
+		OutQueries.Add(Query);
+	}
 }
 
 bool UGridBasedLBStrategy::IsInside(const FBox2D& Box, const FVector2D& Location)

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
@@ -117,7 +117,7 @@ SpatialGDK::QueryConstraint UGridBasedLBStrategy::GetWorkerInterestQueryConstrai
 	}
 
 	const FBox2D Interest2D = WorkerCells[LocalVirtualWorkerId - 1].ExpandBy(InterestBorder);
-	const FVector Min = FVector{ Interest2D.Min.X, Interest2D.Min.Y, FLT_MIN };
+	const FVector Min = FVector{ Interest2D.Min.X, Interest2D.Min.Y, -FLT_MAX };
 	const FVector Max = FVector{ Interest2D.Max.X, Interest2D.Max.Y, FLT_MAX };
 	const FBox Interest3D = FBox{ Min, Max };
 	SpatialGDK::QueryConstraint Constraint;

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
@@ -125,6 +125,13 @@ SpatialGDK::QueryConstraint UGridBasedLBStrategy::GetWorkerInterestQueryConstrai
 	return Constraint;
 }
 
+FVector UGridBasedLBStrategy::GetWorkerEntityPosition() const
+{
+	check(IsReady());
+	const FVector2D Centre = WorkerCells[LocalVirtualWorkerId - 1].GetCenter();
+	return FVector{ Centre.X, Centre.Y, 0.f };
+}
+
 bool UGridBasedLBStrategy::IsInside(const FBox2D& Box, const FVector2D& Location)
 {
 	return Location.X >= Box.Min.X && Location.Y >= Box.Min.Y

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -56,7 +56,6 @@ USpatialGDKSettings::USpatialGDKSettings(const FObjectInitializer& ObjectInitial
 	, bUseFrameTimeAsLoad(false)
 	, bBatchSpatialPositionUpdates(false)
 	, MaxDynamicallyAttachedSubobjectsPerClass(3)
-	, bEnableServerQBI(true)
 	, bEnableResultTypes(false)
 	, bPackRPCs(false)
 	, ServicesRegion(EServicesRegion::Default)
@@ -94,7 +93,6 @@ void USpatialGDKSettings::PostInitProperties()
 	// Check any command line overrides for using QBI, Offloading (after reading the config value):
 	const TCHAR* CommandLine = FCommandLine::Get();
 	CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideSpatialOffloading"), TEXT("Offloading"), bEnableOffloading);
-	CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideServerInterest"), TEXT("Server interest"), bEnableServerQBI);
 	CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideHandover"), TEXT("Handover"), bEnableHandover);
 	CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideLoadBalancer"), TEXT("Load balancer"), bEnableUnrealLoadBalancer);
 	CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideRPCRingBuffers"), TEXT("RPC ring buffers"), bUseRPCRingBuffers);
@@ -108,10 +106,6 @@ void USpatialGDKSettings::PostInitProperties()
 
 	if (bEnableUnrealLoadBalancer)
 	{
-		if (bEnableServerQBI == false)
-		{
-			UE_LOG(LogSpatialGDKSettings, Warning, TEXT("Unreal load balancing is enabled, but server interest is disabled."));
-		}
 		if (bEnableHandover == false)
 		{
 			UE_LOG(LogSpatialGDKSettings, Warning, TEXT("Unreal load balancing is enabled, but handover is disabled."));

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -2,18 +2,18 @@
 
 #include "Utils/InterestFactory.h"
 
-#include "Engine/World.h"
-#include "Engine/Classes/GameFramework/Actor.h"
-#include "GameFramework/PlayerController.h"
-#include "UObject/UObjectIterator.h"
-#include "Utils/CheckoutRadiusConstraintUtils.h"
-
 #include "EngineClasses/Components/ActorInterestComponent.h"
 #include "EngineClasses/SpatialNetConnection.h"
 #include "EngineClasses/SpatialNetDriver.h"
 #include "EngineClasses/SpatialPackageMapClient.h"
+#include "LoadBalancing/AbstractLBStrategy.h"
 #include "SpatialGDKSettings.h"
 #include "SpatialConstants.h"
+#include "Utils/CheckoutRadiusConstraintUtils.h"
+
+#include "Engine/World.h"
+#include "Engine/Classes/GameFramework/Actor.h"
+#include "GameFramework/PlayerController.h"
 #include "UObject/UObjectIterator.h"
 
 DEFINE_LOG_CATEGORY(LogInterestFactory);

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -12,6 +12,7 @@
 #include "EngineClasses/SpatialNetConnection.h"
 #include "EngineClasses/SpatialNetDriver.h"
 #include "EngineClasses/SpatialPackageMapClient.h"
+#include "LoadBalancing/AbstractLBStrategy.h"
 #include "SpatialGDKSettings.h"
 #include "SpatialConstants.h"
 #include "UObject/UObjectIterator.h"

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -261,10 +261,6 @@ Worker_ComponentUpdate InterestFactory::CreateInterestUpdate() const
 Interest InterestFactory::CreateServerWorkerInterest(const UAbstractLBStrategy* LBStrategy)
 {
 	const USpatialGDKSettings* SpatialGDKSettings = GetDefault<USpatialGDKSettings>();
-	if (SpatialGDKSettings->bEnableServerQBI)
-	{
-		UE_LOG(LogInterestFactory, Warning, TEXT("For performance reasons, it's recommended to disable server QBI"));
-	}
 
 	Interest ServerInterest;
 	ComponentInterest ServerComponentInterest;

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -313,8 +313,7 @@ Interest InterestFactory::CreateServerWorkerInterest(const USpatialNetDriver& Ne
 			{
 				QueryConstraint LoadBalancerConstraint = LoadBalancer->GetWorkerInterestQueryConstraint();
 
-				Constraint.OrConstraint.Empty();
-				Constraint.OrConstraint.Add(AlwaysRelevantConstraint);
+				// This makes the assumption that the always relevant constraint is an or constraint in order to flatten the constraint.
 				Constraint.OrConstraint.Add(LoadBalancerConstraint);
 			}
 		}
@@ -336,19 +335,14 @@ Interest InterestFactory::CreateInterest() const
 		AddPlayerControllerActorInterest(ResultInterest);
 	}
 
-	if (Actor->GetNetConnection() != nullptr && Settings->bEnableResultTypes)
-	{
-		// Clients need to see owner only and server RPC components on entities they have authority over
-		AddClientSelfInterest(ResultInterest);
-	}
-
-	if (Settings->bEnableServerQBI)
-	{
-		return Interest{};
-	}
-
 	if (Settings->bEnableResultTypes)
 	{
+		if (Actor->GetNetConnection() != nullptr)
+		{
+			// Clients need to see owner only and server RPC components on entities they have authority over
+			AddClientSelfInterest(ResultInterest);
+		}
+
 		// Every actor needs a self query for the server to the client RPC endpoint
 		AddServerSelfInterest(ResultInterest);
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -277,7 +277,7 @@ Interest InterestFactory::CreateServerWorkerInterest(const UAbstractLBStrategy* 
 		ServerQuery.FullSnapshotResult = true;
 	}
 
-	if (!SpatialGDKSettings->bEnableServerQBI && SpatialGDKSettings->bEnableOffloading)
+	if (SpatialGDKSettings->bEnableOffloading)
 	{
 		// In offloading scenarios, hijack the server worker entity to ensure each server has interest in all entities
 		Constraint.ComponentConstraint = SpatialConstants::POSITION_COMPONENT_ID;
@@ -297,7 +297,7 @@ Interest InterestFactory::CreateServerWorkerInterest(const UAbstractLBStrategy* 
 
 	// If we aren't using the load balancer, there is no need for further interest as we are either offloading or single server,
 	// so will checkout everything we care about through authority.
-	if (SpatialGDKSettings->bEnableUnrealLoadBalancer && SpatialGDKSettings->bEnableServerQBI)
+	if (SpatialGDKSettings->bEnableUnrealLoadBalancer)
 	{
 		if (LBStrategy != nullptr)
 		{

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -312,8 +312,12 @@ Interest InterestFactory::CreateServerWorkerInterest(const UAbstractLBStrategy* 
 			{
 				QueryConstraint LoadBalancerConstraint = LBStrategy->GetWorkerInterestQueryConstraint();
 
-				// This makes the assumption that the always relevant constraint is an or constraint in order to flatten the constraint.
-				Constraint.OrConstraint.Add(LoadBalancerConstraint);
+				// Rather than adding the load balancer constraint at the end, reorder the constraints to have the large spatial
+				// constraint at the front. This is more likely to be efficient.
+				QueryConstraint NewConstraint;
+				NewConstraint.OrConstraint.Add(LoadBalancerConstraint);
+				NewConstraint.OrConstraint.Add(AlwaysRelevantConstraint);
+				Constraint = NewConstraint;
 			}
 		}
 	}

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -120,7 +120,7 @@ public:
 
 	// Creates an entity authoritative on this server worker, ensuring it will be able to receive updates for the GSM.
 	void CreateServerWorkerEntity(int AttemptCounter = 1);
-	void SendServerWorkerEntityInterestUpdate();
+	void UpdateWorkerEntityInterestAndPosition();
 
 	void ClearPendingRPCs(const Worker_EntityId EntityId);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -120,7 +120,7 @@ public:
 
 	// Creates an entity authoritative on this server worker, ensuring it will be able to receive updates for the GSM.
 	void CreateServerWorkerEntity(int AttemptCounter = 1);
-	void UpdateWorkerEntityInterestAndPosition();
+	void UpdateServerWorkerEntityInterestAndPosition();
 
 	void ClearPendingRPCs(const Worker_EntityId EntityId);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -120,6 +120,7 @@ public:
 
 	// Creates an entity authoritative on this server worker, ensuring it will be able to receive updates for the GSM.
 	void CreateServerWorkerEntity(int AttemptCounter = 1);
+	void SendServerWorkerEntityInterestUpdate();
 
 	void ClearPendingRPCs(const Worker_EntityId EntityId);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLBStrategy.h
@@ -39,7 +39,7 @@ class SPATIALGDK_API UAbstractLBStrategy : public UObject
 public:
 	UAbstractLBStrategy();
 
-	virtual void Init(const USpatialNetDriver* InNetDriver) {}
+	virtual void Init() {}
 
 	bool IsReady() const { return LocalVirtualWorkerId != SpatialConstants::INVALID_VIRTUAL_WORKER_ID; }
 
@@ -51,9 +51,14 @@ public:
 	virtual VirtualWorkerId WhoShouldHaveAuthority(const AActor& Actor) const PURE_VIRTUAL(UAbstractLBStrategy::WhoShouldHaveAuthority, return SpatialConstants::INVALID_VIRTUAL_WORKER_ID;)
 
 	/**
-	* Create the query constraints required by this worker based on the load balancing strategy used.
+	* Get the query constraints required by this worker based on the load balancing strategy used.
 	*/
 	virtual SpatialGDK::QueryConstraint GetWorkerInterestQueryConstraint() const PURE_VIRTUAL(UAbstractLBStrategy::GetWorkerInterestQueryConstraint, return {};)
+
+	/**
+	* Get a logical worker entity position for this strategy. For example, the centre of a grid square in a grid-based strategy. Optional- otherwise returns the origin.
+	*/
+	virtual FVector GetWorkerEntityPosition() const { return FVector::ZeroVector; }
 
 protected:
 

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLBStrategy.h
@@ -10,6 +10,11 @@
 
 #include "AbstractLBStrategy.generated.h"
 
+namespace SpatialGDK
+{
+	struct Query;
+}
+class USpatialClassInfoManager;
 class USpatialNetDriver;
 
 /**
@@ -43,6 +48,11 @@ public:
 
 	virtual bool ShouldHaveAuthority(const AActor& Actor) const { return false; }
 	virtual VirtualWorkerId WhoShouldHaveAuthority(const AActor& Actor) const PURE_VIRTUAL(UAbstractLBStrategy::WhoShouldHaveAuthority, return SpatialConstants::INVALID_VIRTUAL_WORKER_ID;)
+
+	/**
+		* Add any interest queries required by this worker based on the load balancing strategy used.
+		*/
+	virtual void CreateWorkerInterestQueries(TArray<SpatialGDK::Query>& OutQueries) const PURE_VIRTUAL(UAbstractLBStrategy::CreateWorkerInterestQueries, )
 
 protected:
 

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLBStrategy.h
@@ -6,6 +6,7 @@
 #include "SpatialConstants.h"
 
 #include "CoreMinimal.h"
+#include "Schema/Interest.h"
 #include "UObject/NoExportTypes.h"
 
 #include "AbstractLBStrategy.generated.h"
@@ -50,9 +51,9 @@ public:
 	virtual VirtualWorkerId WhoShouldHaveAuthority(const AActor& Actor) const PURE_VIRTUAL(UAbstractLBStrategy::WhoShouldHaveAuthority, return SpatialConstants::INVALID_VIRTUAL_WORKER_ID;)
 
 	/**
-		* Add any interest queries required by this worker based on the load balancing strategy used.
-		*/
-	virtual void CreateWorkerInterestQueries(TArray<SpatialGDK::Query>& OutQueries) const PURE_VIRTUAL(UAbstractLBStrategy::CreateWorkerInterestQueries, )
+	* Create the query constraints required by this worker based on the load balancing strategy used.
+	*/
+	virtual SpatialGDK::QueryConstraint GetWorkerInterestQueryConstraint() const PURE_VIRTUAL(UAbstractLBStrategy::GetWorkerInterestQueryConstraint, return {};)
 
 protected:
 

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLBStrategy.h
@@ -11,13 +11,6 @@
 
 #include "AbstractLBStrategy.generated.h"
 
-namespace SpatialGDK
-{
-	struct Query;
-}
-class USpatialClassInfoManager;
-class USpatialNetDriver;
-
 /**
  * This class can be used to define a load balancing strategy.
  * At runtime, all unreal workers will:

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/GridBasedLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/GridBasedLBStrategy.h
@@ -45,6 +45,8 @@ public:
 	virtual VirtualWorkerId WhoShouldHaveAuthority(const AActor& Actor) const override;
 
 	virtual SpatialGDK::QueryConstraint GetWorkerInterestQueryConstraint() const override;
+
+	virtual FVector GetWorkerEntityPosition() const override;
 /* End UAbstractLBStrategy Interface */
 
 	LBStrategyRegions GetLBStrategyRegions() const;

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/GridBasedLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/GridBasedLBStrategy.h
@@ -7,6 +7,7 @@
 #include "CoreMinimal.h"
 #include "Math/Box2D.h"
 #include "Math/Vector2D.h"
+#include "Schema/Interest.h"
 
 #include "GridBasedLBStrategy.generated.h"
 
@@ -43,7 +44,7 @@ public:
 	virtual bool ShouldHaveAuthority(const AActor& Actor) const override;
 	virtual VirtualWorkerId WhoShouldHaveAuthority(const AActor& Actor) const override;
 
-	virtual void CreateWorkerInterestQueries(TArray<SpatialGDK::Query>& OutQueries) const override;
+	virtual SpatialGDK::QueryConstraint GetWorkerInterestQueryConstraint() const override;
 /* End UAbstractLBStrategy Interface */
 
 	LBStrategyRegions GetLBStrategyRegions() const;

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/GridBasedLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/GridBasedLBStrategy.h
@@ -37,7 +37,7 @@ public:
 	using LBStrategyRegions = TArray<TPair<VirtualWorkerId, FBox2D>>;
 
 /* UAbstractLBStrategy Interface */
-	virtual void Init(const USpatialNetDriver* InNetDriver) override;
+	virtual void Init() override;
 
 	virtual TSet<VirtualWorkerId> GetVirtualWorkerIds() const override;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/GridBasedLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/GridBasedLBStrategy.h
@@ -7,7 +7,6 @@
 #include "CoreMinimal.h"
 #include "Math/Box2D.h"
 #include "Math/Vector2D.h"
-#include "Schema/Interest.h"
 
 #include "GridBasedLBStrategy.generated.h"
 

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/GridBasedLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/GridBasedLBStrategy.h
@@ -42,6 +42,8 @@ public:
 
 	virtual bool ShouldHaveAuthority(const AActor& Actor) const override;
 	virtual VirtualWorkerId WhoShouldHaveAuthority(const AActor& Actor) const override;
+
+	virtual void CreateWorkerInterestQueries(TArray<SpatialGDK::Query>& OutQueries) const override;
 /* End UAbstractLBStrategy Interface */
 
 	LBStrategyRegions GetLBStrategyRegions() const;
@@ -58,6 +60,9 @@ protected:
 
 	UPROPERTY(EditDefaultsOnly, meta = (ClampMin = "1"), Category = "Grid Based Load Balancing")
 	float WorldHeight;
+
+	UPROPERTY(EditDefaultsOnly, meta = (ClampMin = "0"), Category = "Grid Based Load Balancing")
+	float InterestBorder;
 
 private:
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/StandardLibrary.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/StandardLibrary.h
@@ -42,6 +42,11 @@ struct Coordinates
 
 		return Location;
 	}
+
+	inline bool operator!=(const Coordinates& Right) const
+	{
+		return X != Right.X || Y != Right.Y || Z != Right.Z;
+	}
 };
 
 static const Coordinates DeploymentOrigin{ 0, 0, 0 };

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -189,11 +189,6 @@ public:
 	UPROPERTY(EditAnywhere, config, Category = "Schema Generation", meta = (DisplayName = "Maximum Dynamically Attached Subobjects Per Class"))
 	uint32 MaxDynamicallyAttachedSubobjectsPerClass;
 
-	/** EXPERIMENTAL - This is a stop-gap until we can better define server interest on system entities.
-	Disabling this is not supported in a zoned-worker environment*/
-	UPROPERTY(config)
-	bool bEnableServerQBI;
-
 	/** EXPERIMENTAL - Adds granular result types for queries.
 	Granular here means specifically the required Unreal components for spawning other actors and all data type components.
 	Needs testing thoroughly before making default. May be replaced by component set result types instead. */

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/InterestFactory.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/InterestFactory.h
@@ -54,9 +54,6 @@ private:
 	void GetActorUserDefinedQueries(const AActor* InActor, const QueryConstraint& LevelConstraints, TArray<SpatialGDK::Query>& OutQueries, bool bRecurseChildren) const;
 	TArray<Query> GetUserDefinedQueries(const QueryConstraint& LevelConstraints) const;
 
-	// Defined Constraint AND Level Constraint
-	Interest CreateActorInterest() const;
-
 	static void AddComponentQueryPairToInterestComponent(Interest& OutInterest, const Worker_ComponentId ComponentId, const Query& QueryToAdd);
 
 	// Checkout Constraint OR AlwaysInterested OR AlwaysRelevant Constraint

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/InterestFactory.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/InterestFactory.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "Interop/SpatialClassInfoManager.h"
+#include "LoadBalancing/AbstractLBStrategy.h"
 #include "Schema/Interest.h"
 
 #include <WorkerSDK/improbable/c_worker.h>
@@ -25,7 +26,7 @@ public:
 	Worker_ComponentData CreateInterestData() const;
 	Worker_ComponentUpdate CreateInterestUpdate() const;
 
-	static Interest CreateServerWorkerInterest(const USpatialNetDriver& NetDriver);
+	static Interest CreateServerWorkerInterest(const UAbstractLBStrategy* LBStrategy);
 
 private:
 	// Build the checkout radius constraints for client workers

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/InterestFactory.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/InterestFactory.h
@@ -25,7 +25,7 @@ public:
 	Worker_ComponentData CreateInterestData() const;
 	Worker_ComponentUpdate CreateInterestUpdate() const;
 
-	static Interest CreateServerWorkerInterest();
+	static Interest CreateServerWorkerInterest(const USpatialNetDriver& NetDriver);
 
 private:
 	// Build the checkout radius constraints for client workers
@@ -53,6 +53,9 @@ private:
 
 	void GetActorUserDefinedQueries(const AActor* InActor, const QueryConstraint& LevelConstraints, TArray<SpatialGDK::Query>& OutQueries, bool bRecurseChildren) const;
 	TArray<Query> GetUserDefinedQueries(const QueryConstraint& LevelConstraints) const;
+
+	// Defined Constraint AND Level Constraint
+	Interest CreateActorInterest() const;
 
 	static void AddComponentQueryPairToInterestComponent(Interest& OutInterest, const Worker_ComponentId ComponentId, const Query& QueryToAdd);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/InterestFactory.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/InterestFactory.h
@@ -3,11 +3,11 @@
 #pragma once
 
 #include "Interop/SpatialClassInfoManager.h"
-#include "LoadBalancing/AbstractLBStrategy.h"
 #include "Schema/Interest.h"
 
 #include <WorkerSDK/improbable/c_worker.h>
 
+class UAbstractLBStrategy;
 class USpatialClassInfoManager;
 class USpatialPackageMapClient;
 class AActor;

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/GridBasedLBStrategyTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/GridBasedLBStrategyTest.cpp
@@ -1,5 +1,10 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
+#include "LoadBalancing/GridBasedLBStrategy.h"
+#include "Schema/StandardLibrary.h"
+#include "SpatialConstants.h"
+#include "TestGridBasedLBStrategy.h"
+
 #include "CoreMinimal.h"
 #include "Engine/Engine.h"
 #include "Engine/World.h"
@@ -8,11 +13,6 @@
 #include "Tests/AutomationCommon.h"
 #include "Tests/AutomationEditorCommon.h"
 #include "Tests/TestDefinitions.h"
-
-#include "LoadBalancing/GridBasedLBStrategy.h"
-#include "Schema/StandardLibrary.h"
-#include "SpatialConstants.h"
-#include "TestGridBasedLBStrategy.h"
 
 #define GRIDBASEDLBSTRATEGY_TEST(TestName) \
 	GDK_TEST(Core, UGridBasedLBStrategy, TestName)

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/GridBasedLBStrategyTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/GridBasedLBStrategyTest.cpp
@@ -3,15 +3,16 @@
 #include "CoreMinimal.h"
 #include "Engine/Engine.h"
 #include "Engine/World.h"
-#include "LoadBalancing/GridBasedLBStrategy.h"
 #include "GameFramework/DefaultPawn.h"
 #include "GameFramework/GameStateBase.h"
-#include "Schema/StandardLibrary.h"
-#include "SpatialConstants.h"
-#include "Tests/TestDefinitions.h"
-#include "TestGridBasedLBStrategy.h"
 #include "Tests/AutomationCommon.h"
 #include "Tests/AutomationEditorCommon.h"
+#include "Tests/TestDefinitions.h"
+
+#include "LoadBalancing/GridBasedLBStrategy.h"
+#include "Schema/StandardLibrary.h"
+#include "SpatialConstants.h"
+#include "TestGridBasedLBStrategy.h"
 
 #define GRIDBASEDLBSTRATEGY_TEST(TestName) \
 	GDK_TEST(Core, UGridBasedLBStrategy, TestName)

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/GridBasedLBStrategyTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/GridBasedLBStrategyTest.cpp
@@ -56,7 +56,7 @@ DEFINE_LATENT_AUTOMATION_COMMAND_FIVE_PARAMETER(FCreateStrategy, uint32, Rows, u
 bool FCreateStrategy::Update()
 {
 	Strat = UTestGridBasedLBStrategy::Create(Rows, Cols, WorldWidth, WorldHeight);
-	Strat->Init(nullptr);
+	Strat->Init();
 
 	TSet<uint32> VirtualWorkerIds = Strat->GetVirtualWorkerIds();
 	Strat->SetLocalVirtualWorkerId(VirtualWorkerIds.Array()[LocalWorkerIdIndex]);
@@ -168,7 +168,7 @@ bool FCheckVirtualWorkersMatch::Update()
 GRIDBASEDLBSTRATEGY_TEST(GIVEN_2_rows_3_cols_WHEN_get_virtual_worker_ids_is_called_THEN_it_returns_6_ids)
 {
 	Strat = UTestGridBasedLBStrategy::Create(2, 3, 10000.f, 10000.f);
-	Strat->Init(nullptr);
+	Strat->Init();
 
 	TSet<uint32> VirtualWorkerIds = Strat->GetVirtualWorkerIds();
 	TestEqual("Number of Virtual Workers", VirtualWorkerIds.Num(), 6);
@@ -179,7 +179,7 @@ GRIDBASEDLBSTRATEGY_TEST(GIVEN_2_rows_3_cols_WHEN_get_virtual_worker_ids_is_call
 GRIDBASEDLBSTRATEGY_TEST(GIVEN_a_grid_WHEN_get_virtual_worker_ids_THEN_all_worker_ids_are_valid)
 {
 	Strat = UTestGridBasedLBStrategy::Create(5, 10, 10000.f, 10000.f);
-	Strat->Init(nullptr);
+	Strat->Init();
 
 	TSet<uint32> VirtualWorkerIds = Strat->GetVirtualWorkerIds();
 	for (uint32 VirtualWorkerId : VirtualWorkerIds)
@@ -193,7 +193,7 @@ GRIDBASEDLBSTRATEGY_TEST(GIVEN_a_grid_WHEN_get_virtual_worker_ids_THEN_all_worke
 GRIDBASEDLBSTRATEGY_TEST(GIVEN_grid_is_not_ready_WHEN_local_virtual_worker_id_is_set_THEN_is_ready)
 {
 	Strat = UTestGridBasedLBStrategy::Create(1, 1, 10000.f, 10000.f);
-	Strat->Init(nullptr);
+	Strat->Init();
 
 	TestFalse("IsReady Before LocalVirtualWorkerId Set", Strat->IsReady());
 
@@ -207,7 +207,7 @@ GRIDBASEDLBSTRATEGY_TEST(GIVEN_grid_is_not_ready_WHEN_local_virtual_worker_id_is
 GRIDBASEDLBSTRATEGY_TEST(GIVEN_four_cells_WHEN_get_worker_interest_for_virtual_worker_THEN_returns_correct_constraint)
 {
 	Strat = UTestGridBasedLBStrategy::Create(2, 2, 10000.f, 10000.f, 1000.0f);
-	Strat->Init(nullptr);
+	Strat->Init();
 
 	// Take the top right corner, as then all our testing numbers can be positive.
 	Strat->SetLocalVirtualWorkerId(4);
@@ -234,7 +234,7 @@ GRIDBASEDLBSTRATEGY_TEST(GIVEN_four_cells_WHEN_get_worker_interest_for_virtual_w
 GRIDBASEDLBSTRATEGY_TEST(GIVEN_one_cell_WHEN_get_worker_interest_for_virtual_worker_THEN_returns_special_case_true_constraint)
 {
 	Strat = UTestGridBasedLBStrategy::Create(1, 1, 10000.f, 10000.f, 1000.0f);
-	Strat->Init(nullptr);
+	Strat->Init();
 
 	Strat->SetLocalVirtualWorkerId(1);
 

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/GridBasedLBStrategyTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/GridBasedLBStrategyTest.cpp
@@ -247,6 +247,23 @@ GRIDBASEDLBSTRATEGY_TEST(GIVEN_one_cell_WHEN_get_worker_interest_for_virtual_wor
 	return true;
 }
 
+GRIDBASEDLBSTRATEGY_TEST(GIVEN_four_cells_WHEN_get_worker_entity_position_for_virtual_worker_THEN_returns_correct_position)
+{
+	Strat = UTestGridBasedLBStrategy::Create(2, 2, 10000.f, 10000.f, 1000.0f);
+	Strat->Init();
+
+	// Take the top right corner, as then all our testing numbers can be positive.
+	Strat->SetLocalVirtualWorkerId(4);
+
+	FVector WorkerPosition = Strat->GetWorkerEntityPosition();
+
+	FVector TestPosition = FVector{ 2500.0f, 2500.0f, 0.0f };
+
+	TestEqual("Worker entity position is as expected", WorkerPosition, TestPosition);
+
+	return true;
+}
+
 }  // anonymous namespace
 
 GRIDBASEDLBSTRATEGY_TEST(GIVEN_a_single_cell_and_valid_local_id_WHEN_should_relinquish_called_THEN_returns_false)

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/GridBasedLBStrategyTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/GridBasedLBStrategyTest.cpp
@@ -232,21 +232,6 @@ GRIDBASEDLBSTRATEGY_TEST(GIVEN_four_cells_WHEN_get_worker_interest_for_virtual_w
 	return true;
 }
 
-GRIDBASEDLBSTRATEGY_TEST(GIVEN_one_cell_WHEN_get_worker_interest_for_virtual_worker_THEN_returns_special_case_true_constraint)
-{
-	Strat = UTestGridBasedLBStrategy::Create(1, 1, 10000.f, 10000.f, 1000.0f);
-	Strat->Init();
-
-	Strat->SetLocalVirtualWorkerId(1);
-
-	SpatialGDK::QueryConstraint StratConstraint = Strat->GetWorkerInterestQueryConstraint();
-
-	TestTrue("Constraint is a component constraint", StratConstraint.ComponentConstraint.IsSet());
-	TestTrue("Constraint is for the position component", StratConstraint.ComponentConstraint.GetValue() == SpatialConstants::POSITION_COMPONENT_ID);
-
-	return true;
-}
-
 GRIDBASEDLBSTRATEGY_TEST(GIVEN_four_cells_WHEN_get_worker_entity_position_for_virtual_worker_THEN_returns_correct_position)
 {
 	Strat = UTestGridBasedLBStrategy::Create(2, 2, 10000.f, 10000.f, 1000.0f);

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/TestGridBasedLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/TestGridBasedLBStrategy.cpp
@@ -2,19 +2,6 @@
 
 #include "TestGridBasedLBStrategy.h"
 
-UGridBasedLBStrategy* UTestGridBasedLBStrategy::Create(uint32 InRows, uint32 InCols, float WorldWidth, float WorldHeight)
-{
-	UTestGridBasedLBStrategy* Strat = NewObject<UTestGridBasedLBStrategy>();
-
-	Strat->Rows = InRows;
-	Strat->Cols = InCols;
-
-	Strat->WorldWidth = WorldWidth;
-	Strat->WorldHeight = WorldHeight;
-
-	return Strat;
-}
-
 UGridBasedLBStrategy* UTestGridBasedLBStrategy::Create(uint32 InRows, uint32 InCols, float WorldWidth, float WorldHeight, float InterestBorder)
 {
 	UTestGridBasedLBStrategy* Strat = NewObject<UTestGridBasedLBStrategy>();

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/TestGridBasedLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/TestGridBasedLBStrategy.cpp
@@ -14,3 +14,18 @@ UGridBasedLBStrategy* UTestGridBasedLBStrategy::Create(uint32 InRows, uint32 InC
 
 	return Strat;
 }
+
+UGridBasedLBStrategy* UTestGridBasedLBStrategy::Create(uint32 InRows, uint32 InCols, float WorldWidth, float WorldHeight, float InterestBorder)
+{
+	UTestGridBasedLBStrategy* Strat = NewObject<UTestGridBasedLBStrategy>();
+
+	Strat->Rows = InRows;
+	Strat->Cols = InCols;
+
+	Strat->WorldWidth = WorldWidth;
+	Strat->WorldHeight = WorldHeight;
+
+	Strat->InterestBorder = InterestBorder;
+
+	return Strat;
+}

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/TestGridBasedLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/TestGridBasedLBStrategy.h
@@ -17,5 +17,5 @@ class SPATIALGDKTESTS_API UTestGridBasedLBStrategy : public UGridBasedLBStrategy
 public:
 
 	static UGridBasedLBStrategy* Create(uint32 Rows, uint32 Cols, float WorldWidth, float WorldHeight);
-
+	static UGridBasedLBStrategy* Create(uint32 Rows, uint32 Cols, float WorldWidth, float WorldHeight, float InterestBorder);
 };

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/TestGridBasedLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/TestGridBasedLBStrategy.h
@@ -16,6 +16,5 @@ class SPATIALGDKTESTS_API UTestGridBasedLBStrategy : public UGridBasedLBStrategy
 
 public:
 
-	static UGridBasedLBStrategy* Create(uint32 Rows, uint32 Cols, float WorldWidth, float WorldHeight);
-	static UGridBasedLBStrategy* Create(uint32 Rows, uint32 Cols, float WorldWidth, float WorldHeight, float InterestBorder);
+	static UGridBasedLBStrategy* Create(uint32 Rows, uint32 Cols, float WorldWidth, float WorldHeight, float InterestBorder = 0.0f);
 };


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Server QBI now makes workers express a single interest query. This query is defined by the load balancing strategy. Also moves the worker entity position based on the LB strategy. 

Added sane interest for grid LB based on @yumnuska's changes. 

#### Release note
Enabling the Unreal GDK load balancer now creates a single query per server worker, depending on the defined load balancing strategy.

#### Tests

Unit tests for the grid LB interest

cross server RPC gym depends on this after https://github.com/spatialos/UnrealGDKTestGyms/pull/45 is merged

#### Documentation
In code comments

#### Primary reviewers
@m-samiec @alastairdglennie 