### PR TITLE
[UNR-2978][MS] Added warning on deploying SimPlayers without it being built on your machine.

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -423,6 +423,11 @@ public:
 		return FPaths::Combine(SpatialGDKServicesConstants::SpatialOSDirectory, TEXT("schema/unreal/generated/"));
 	}
 
+	FORCEINLINE FString GetBuiltWorkerFolder() const
+	{
+		return FPaths::Combine(SpatialGDKServicesConstants::SpatialOSDirectory, TEXT("build/assembly/worker/"));
+	}
+
 	FORCEINLINE FString GetSpatialOSCommandLineLaunchFlags() const
 	{
 		FString CommandLineLaunchFlags = TEXT("");

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -9,6 +9,8 @@
 #include "Framework/Application/SlateApplication.h"
 #include "Framework/MultiBox/MultiBoxBuilder.h"
 #include "Framework/Notifications/NotificationManager.h"
+#include "HAL/PlatformFilemanager.h"
+#include "Misc/MessageDialog.h"
 #include "Runtime/Launch/Resources/Version.h"
 #include "SpatialCommandUtils.h"
 #include "SpatialGDKSettings.h"
@@ -562,6 +564,20 @@ FReply SSpatialGDKSimulatedPlayerDeployment::OnLaunchClicked()
 		}
 
 		return FReply::Handled();
+	}
+
+	if (SpatialGDKSettings->IsSimulatedPlayersEnabled())
+	{
+		IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
+		FString BuiltWorkerFolder = GetDefault<USpatialGDKEditorSettings>()->GetBuiltWorkerFolder();
+		FString SimPlayersFileName = TEXT("UnrealSimulatedPlayer@Linux.zip");
+		FString SimPlayerFilePath = FPaths::Combine(BuiltWorkerFolder, SimPlayersFileName);
+
+		if (!PlatformFile.FileExists(*SimPlayerFilePath))
+		{
+			FString MissingSimPlayerBuildText = FString::Printf(TEXT("Warning: Detected that %s is missing. To launch a successful SimPlayer deployment ensure that SimPlayers is built and uploaded."), *SimPlayersFileName);
+			FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(MissingSimPlayerBuildText));
+		}
 	}
 
 	if (ToolbarPtr)

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -570,12 +570,12 @@ FReply SSpatialGDKSimulatedPlayerDeployment::OnLaunchClicked()
 	{
 		IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
 		FString BuiltWorkerFolder = GetDefault<USpatialGDKEditorSettings>()->GetBuiltWorkerFolder();
-		FString SimPlayersFileName = TEXT("UnrealSimulatedPlayer@Linux.zip");
-		FString SimPlayerFilePath = FPaths::Combine(BuiltWorkerFolder, SimPlayersFileName);
+		FString BuiltSimPlayersName = TEXT("UnrealSimulatedPlayer@Linux.zip");
+		FString BuiltSimPlayerPath = FPaths::Combine(BuiltWorkerFolder, BuiltSimPlayersName);
 
-		if (!PlatformFile.FileExists(*SimPlayerFilePath))
+		if (!PlatformFile.FileExists(*BuiltSimPlayerPath))
 		{
-			FString MissingSimPlayerBuildText = FString::Printf(TEXT("Warning: Detected that %s is missing. To launch a successful SimPlayer deployment ensure that SimPlayers is built and uploaded."), *SimPlayersFileName);
+			FString MissingSimPlayerBuildText = FString::Printf(TEXT("Warning: Detected that %s is missing. To launch a successful SimPlayer deployment ensure that SimPlayers is built and uploaded."), *BuiltSimPlayersName);
 			FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(MissingSimPlayerBuildText));
 		}
 	}


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

I will be modifying BuildWorker.bat in our projects to remove the building of SimPlayers. This reflects what we say in the docs (that BuildWorker does not build SimPlayers).

https://github.com/spatialos/UnrealGDKExampleProject/pull/104
https://github.com/spatialos/UnrealGDKTestGyms/pull/42