### PR TITLE
[UNR-1954] Use System entity for connection cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Fixed an issue where newly created subobjects would have empty state when RepNotify was called for a property pointing to that subobject.
 - Fixed an issue where deleted, initially dormant startup actors would still be present on other workers.
 - Force activation of RPC ring buffer when load balancing is enabled, to allow RPC handover when authority changes
+- Fixed a race where a client leaving the deployment could leave its actor behind on the server, to be cleaned up after a long timeout.
 
 ### External contributors:
 @DW-Sebastien

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
@@ -30,7 +30,6 @@ USpatialNetConnection::USpatialNetConnection(const FObjectInitializer& ObjectIni
 void USpatialNetConnection::BeginDestroy()
 {
 	DisableHeartbeat();
-	
 	Super::BeginDestroy();
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
@@ -38,7 +38,7 @@ void USpatialNetConnection::CleanUp()
 {
 	if (USpatialNetDriver* SpatialNetDriver = Cast<USpatialNetDriver>(Driver))
 	{
-		SpatialNetDriver->CleanUpConnection(this);
+		SpatialNetDriver->CleanUpClientConnection(this);
 	}
 
 	Super::CleanUp();

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
@@ -36,7 +36,10 @@ void USpatialNetConnection::BeginDestroy()
 
 void USpatialNetConnection::CleanUp()
 {
-	Cast<USpatialNetDriver>(Driver)->CleanUpConnection(this);
+	if (USpatialNetDriver* SpatialNetDriver = Cast<USpatialNetDriver>(Driver))
+	{
+		SpatialNetDriver->CleanUpConnection(this);
+	}
 
 	Super::CleanUp();
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
@@ -30,8 +30,15 @@ USpatialNetConnection::USpatialNetConnection(const FObjectInitializer& ObjectIni
 void USpatialNetConnection::BeginDestroy()
 {
 	DisableHeartbeat();
-
+	
 	Super::BeginDestroy();
+}
+
+void USpatialNetConnection::CleanUp()
+{
+	Cast<USpatialNetDriver>(Driver)->CleanUpConnection(this);
+
+	Super::CleanUp();
 }
 
 void USpatialNetConnection::InitBase(UNetDriver* InDriver, class FSocket* InSocket, const FURL& InURL, EConnectionState InState, int32 InMaxPacket /*= 0*/, int32 InPacketOverhead /*= 0*/)

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
@@ -38,7 +38,10 @@ void USpatialNetConnection::CleanUp()
 {
 	if (USpatialNetDriver* SpatialNetDriver = Cast<USpatialNetDriver>(Driver))
 	{
-		SpatialNetDriver->CleanUpConnection(this);
+		if (!WorkerAttribute.IsEmpty())
+		{
+			SpatialNetDriver->CleanUpConnection(this);
+		}
 	}
 
 	Super::CleanUp();

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
@@ -30,6 +30,7 @@ USpatialNetConnection::USpatialNetConnection(const FObjectInitializer& ObjectIni
 void USpatialNetConnection::BeginDestroy()
 {
 	DisableHeartbeat();
+	
 	Super::BeginDestroy();
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
@@ -38,10 +38,7 @@ void USpatialNetConnection::CleanUp()
 {
 	if (USpatialNetDriver* SpatialNetDriver = Cast<USpatialNetDriver>(Driver))
 	{
-		if (!WorkerAttribute.IsEmpty())
-		{
-			SpatialNetDriver->CleanUpConnection(this);
-		}
+		SpatialNetDriver->CleanUpConnection(this);
 	}
 
 	Super::CleanUp();

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1828,7 +1828,7 @@ bool USpatialNetDriver::CreateSpatialNetConnection(const FURL& InUrl, const FUni
 	check(WorkerAttributeOption);
 	SpatialConnection->WorkerAttribute = FString(WorkerAttributeOption).Mid(1); // Trim off the = at the beginning.
 
-	
+	// Register workerId and its connection.
 	if(TOptional<FString> WorkerId = ExtractWorkerIDFromAttribute(SpatialConnection->WorkerAttribute))
 	{
 		UE_LOG(LogSpatialOSNetDriver, Log, TEXT("Worker %s 's NetConnection created."), *WorkerId.GetValue());

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1784,7 +1784,7 @@ namespace
 {
 	TOptional<FString> ExtractWorkerIDFromAttribute(const FString& WorkerAttribute)
 	{
-		const FString WorkerIdAttr = "workerId:";
+		const FString WorkerIdAttr = TEXT("workerId:");
 		int32 AttrOffset = WorkerAttribute.Find(WorkerIdAttr);
 
 		if (AttrOffset < 0)
@@ -1829,11 +1829,10 @@ bool USpatialNetDriver::CreateSpatialNetConnection(const FURL& InUrl, const FUni
 	SpatialConnection->WorkerAttribute = FString(WorkerAttributeOption).Mid(1); // Trim off the = at the beginning.
 
 	// Register workerId and its connection.
-	if(TOptional<FString> WorkerId = ExtractWorkerIDFromAttribute(SpatialConnection->WorkerAttribute))
+	if (TOptional<FString> WorkerId = ExtractWorkerIDFromAttribute(SpatialConnection->WorkerAttribute))
 	{
 		UE_LOG(LogSpatialOSNetDriver, Verbose, TEXT("Worker %s 's NetConnection created."), *WorkerId.GetValue());
 
-		//check(WorkerConnections.Find(WorkerId) == nullptr);
 		WorkerConnections.Add(WorkerId.GetValue(), SpatialConnection);
 	}
 
@@ -1868,19 +1867,22 @@ bool USpatialNetDriver::CreateSpatialNetConnection(const FURL& InUrl, const FUni
 	return true;
 }
 
-void USpatialNetDriver::CleanUpConnection(USpatialNetConnection* ConnectionCleanedUp)
+void USpatialNetDriver::CleanUpClientConnection(USpatialNetConnection* ConnectionCleanedUp)
 {
-	if (TOptional<FString> WorkerId = ExtractWorkerIDFromAttribute(*ConnectionCleanedUp->WorkerAttribute))
+	if (!ConnectionCleanedUp->WorkerAttribute.IsEmpty())
 	{
-		WorkerConnections.Remove(WorkerId.GetValue());
+		if (TOptional<FString> WorkerId = ExtractWorkerIDFromAttribute(*ConnectionCleanedUp->WorkerAttribute))
+		{
+			WorkerConnections.Remove(WorkerId.GetValue());
+		}
 	}
 }
 
-TWeakObjectPtr<USpatialNetConnection> USpatialNetDriver::FindWorkerConnectionFromWorkerId(const FString& WorkerId)
+TWeakObjectPtr<USpatialNetConnection> USpatialNetDriver::FindClientConnectionFromWorkerId(const FString& WorkerId)
 {
-	if (TWeakObjectPtr<USpatialNetConnection>* PlayerConnectionPtr = WorkerConnections.Find(WorkerId))
+	if (TWeakObjectPtr<USpatialNetConnection>* ClientConnectionPtr = WorkerConnections.Find(WorkerId))
 	{
-		return *PlayerConnectionPtr;
+		return *ClientConnectionPtr;
 	}
 
 	return {};

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1789,7 +1789,7 @@ namespace
 
 		if (AttrOffset < 0)
 		{
-			UE_LOG(LogSpatialOSNetDriver, Log, TEXT("Error : Worker attribute does not contain workerId : %s"), *WorkerAttribute);
+			UE_LOG(LogSpatialOSNetDriver, Error, TEXT("Error : Worker attribute does not contain workerId : %s"), *WorkerAttribute);
 			return {};
 		}
 		
@@ -1831,7 +1831,7 @@ bool USpatialNetDriver::CreateSpatialNetConnection(const FURL& InUrl, const FUni
 	// Register workerId and its connection.
 	if(TOptional<FString> WorkerId = ExtractWorkerIDFromAttribute(SpatialConnection->WorkerAttribute))
 	{
-		UE_LOG(LogSpatialOSNetDriver, Log, TEXT("Worker %s 's NetConnection created."), *WorkerId.GetValue());
+		UE_LOG(LogSpatialOSNetDriver, Verbose, TEXT("Worker %s 's NetConnection created."), *WorkerId.GetValue());
 
 		//check(WorkerConnections.Find(WorkerId) == nullptr);
 		WorkerConnections.Add(WorkerId.GetValue(), SpatialConnection);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -177,7 +177,7 @@ void USpatialReceiver::OnAddComponent(const Worker_AddComponentOp& Op)
 		{
 			// Register system identity for a worker connection, to know when a player has disconnected.
 			Worker* WorkerData = StaticComponentView->GetComponentData<Worker>(Op.entity_id);
-			WorkerConnectionEntity.Add(Op.entity_id, WorkerData->WorkerId);
+			WorkerConnectionEntities.Add(Op.entity_id, WorkerData->WorkerId);
 			UE_LOG(LogSpatialReceiver, Verbose, TEXT("Worker %s 's system identity was checked out."), *WorkerData->WorkerId);
 		}
 		return;
@@ -254,7 +254,8 @@ void USpatialReceiver::OnRemoveEntity(const Worker_RemoveEntityOp& Op)
 
 	if (NetDriver->IsServer())
 	{
-		if (FString* WorkerName = WorkerConnectionEntity.Find(Op.entity_id))
+		// Check to see if we are removing a system entity for a worker connection. If so clean up the ClientConnection to delete any and all actors for this connection's controller.
+		if (FString* WorkerName = WorkerConnectionEntities.Find(Op.entity_id))
 		{
 			TWeakObjectPtr<USpatialNetConnection> ClientConnectionPtr = NetDriver->FindClientConnectionFromWorkerId(*WorkerName);
 			if (USpatialNetConnection* ClientConnection = ClientConnectionPtr.Get())
@@ -270,7 +271,7 @@ void USpatialReceiver::OnRemoveEntity(const Worker_RemoveEntityOp& Op)
 					}
 				}
 			}
-			WorkerConnectionEntity.Remove(Op.entity_id);
+			WorkerConnectionEntities.Remove(Op.entity_id);
 		}
 	}
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -267,8 +267,7 @@ void USpatialReceiver::OnRemoveEntity(const Worker_RemoveEntityOp& Op)
 					if (AuthorityPlayerControllerConnectionMap.Find(PCEntity))
 					{
 						UE_LOG(LogSpatialReceiver, Verbose, TEXT("Worker %s disconnected after its system identity was removed."), *(*WorkerName));
-						ClientConnection->CleanUp();
-						AuthorityPlayerControllerConnectionMap.Remove(PCEntity);
+						CloseClientConnection(ClientConnection, PCEntity);
 					}
 				}
 			}
@@ -2399,9 +2398,14 @@ void USpatialReceiver::OnHeartbeatComponentUpdate(const Worker_ComponentUpdateOp
 		GetBoolFromSchema(FieldsObject, SpatialConstants::HEARTBEAT_CLIENT_HAS_QUIT_ID))
 	{
 		// Client has disconnected, let's clean up their connection.
-		NetConnection->CleanUp();
-		AuthorityPlayerControllerConnectionMap.Remove(Op.entity_id);
+		CloseClientConnection(NetConnection, Op.entity_id);
 	}
+}
+
+void USpatialReceiver::CloseClientConnection(USpatialNetConnection* ClientConnection, Worker_EntityId PlayerControllerEntityId)
+{
+	ClientConnection->CleanUp();
+	AuthorityPlayerControllerConnectionMap.Remove(PlayerControllerEntityId);
 }
 
 void USpatialReceiver::PeriodicallyProcessIncomingRPCs()

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -172,6 +172,7 @@ void USpatialReceiver::OnAddComponent(const Worker_AddComponentOp& Op)
 		{
 			LoadBalanceEnforcer->OnLoadBalancingComponentAdded(Op);
 		}
+		return;
 	case SpatialConstants::WORKER_COMPONENT_ID:
 		if(NetDriver->IsServer())
 		{

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -173,12 +173,13 @@ void USpatialReceiver::OnAddComponent(const Worker_AddComponentOp& Op)
 			LoadBalanceEnforcer->OnLoadBalancingComponentAdded(Op);
 		}
 	case SpatialConstants::WORKER_COMPONENT_ID:
-	{
-		// Register system identity for a worker connection, to know when a player has disconnected.
-		Worker* WorkerData = StaticComponentView->GetComponentData<Worker>(Op.entity_id);
-		WorkerConnectionEntity.Add(Op.entity_id, WorkerData->WorkerId);
-		UE_LOG(LogSpatialReceiver, Verbose, TEXT("Worker %s 's system identity was checked out."), *WorkerData->WorkerId);
-	}
+		if(NetDriver->IsServer())
+		{
+			// Register system identity for a worker connection, to know when a player has disconnected.
+			Worker* WorkerData = StaticComponentView->GetComponentData<Worker>(Op.entity_id);
+			WorkerConnectionEntity.Add(Op.entity_id, WorkerData->WorkerId);
+			UE_LOG(LogSpatialReceiver, Verbose, TEXT("Worker %s 's system identity was checked out."), *WorkerData->WorkerId);
+		}
 		return;
 	case SpatialConstants::MULTICAST_RPCS_COMPONENT_ID:
 		// The RPC service needs to be informed when a multi-cast RPC component is added.
@@ -255,16 +256,16 @@ void USpatialReceiver::OnRemoveEntity(const Worker_RemoveEntityOp& Op)
 	{
 		if (FString* WorkerName = WorkerConnectionEntity.Find(Op.entity_id))
 		{
-			TWeakObjectPtr<USpatialNetConnection> PlayerConnectionPtr = NetDriver->FindWorkerConnectionFromWorkerId(*WorkerName);
-			if (USpatialNetConnection* PlayerConnection = PlayerConnectionPtr.Get())
+			TWeakObjectPtr<USpatialNetConnection> ClientConnectionPtr = NetDriver->FindClientConnectionFromWorkerId(*WorkerName);
+			if (USpatialNetConnection* ClientConnection = ClientConnectionPtr.Get())
 			{
-				if (APlayerController* Controller = PlayerConnection->GetPlayerController(nullptr))
+				if (APlayerController* Controller = ClientConnection->GetPlayerController(/*InWorld*/ nullptr))
 				{
 					Worker_EntityId PCEntity = PackageMap->GetEntityIdFromObject(Controller);
 					if (AuthorityPlayerControllerConnectionMap.Find(PCEntity))
 					{
 						UE_LOG(LogSpatialReceiver, Verbose, TEXT("Worker %s disconnected after its system identity was removed."), *(*WorkerName));
-						PlayerConnection->CleanUp();
+						ClientConnection->CleanUp();
 						AuthorityPlayerControllerConnectionMap.Remove(PCEntity);
 					}
 				}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStaticComponentView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStaticComponentView.cpp
@@ -62,6 +62,9 @@ void USpatialStaticComponentView::OnAddComponent(const Worker_AddComponentOp& Op
 	case SpatialConstants::PERSISTENCE_COMPONENT_ID:
 		Data = MakeUnique<SpatialGDK::Persistence>(Op.data);
 		break;
+	case SpatialConstants::WORKER_COMPONENT_ID:
+		Data = MakeUnique<SpatialGDK::Worker>(Op.data);
+		break;
 	case SpatialConstants::SPAWN_DATA_COMPONENT_ID:
 		Data = MakeUnique<SpatialGDK::SpawnData>(Op.data);
 		break;

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -318,6 +318,20 @@ Interest InterestFactory::CreateServerWorkerInterest(const UAbstractLBStrategy* 
 
 	ServerQuery.Constraint = Constraint;
 	AddComponentQueryPairToInterestComponent(ServerInterest, SpatialConstants::POSITION_COMPONENT_ID, ServerQuery);
+
+
+	// Add another query to get the worker system entities.
+	// It allows us to know when a client has disconnected.
+	// TODO : Migrate the LoadBalancer to use the checked-out worker components instead of making a query ?
+
+	ServerQuery = Query();
+	if (SpatialGDKSettings->bEnableResultTypes)
+	{
+		ServerQuery.ResultComponentId.Add(SpatialConstants::WORKER_COMPONENT_ID);
+	}
+	ServerQuery.Constraint.ComponentConstraint = SpatialConstants::WORKER_COMPONENT_ID;
+	AddComponentQueryPairToInterestComponent(ServerInterest, SpatialConstants::POSITION_COMPONENT_ID, ServerQuery);
+
 	return ServerInterest;
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -319,10 +319,9 @@ Interest InterestFactory::CreateServerWorkerInterest(const UAbstractLBStrategy* 
 	ServerQuery.Constraint = Constraint;
 	AddComponentQueryPairToInterestComponent(ServerInterest, SpatialConstants::POSITION_COMPONENT_ID, ServerQuery);
 
-
 	// Add another query to get the worker system entities.
 	// It allows us to know when a client has disconnected.
-	// TODO : Migrate the LoadBalancer to use the checked-out worker components instead of making a query ?
+	// TODO UNR-3042 : Migrate the VirtualWorkerTranslationManager to use the checked-out worker components instead of making a query.
 
 	ServerQuery = Query();
 	if (!SpatialGDKSettings->bEnableResultTypes)

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -325,7 +325,11 @@ Interest InterestFactory::CreateServerWorkerInterest(const UAbstractLBStrategy* 
 	// TODO : Migrate the LoadBalancer to use the checked-out worker components instead of making a query ?
 
 	ServerQuery = Query();
-	if (SpatialGDKSettings->bEnableResultTypes)
+	if (!SpatialGDKSettings->bEnableResultTypes)
+	{
+		ServerQuery.FullSnapshotResult = true;
+	}
+	else
 	{
 		ServerQuery.ResultComponentId.Add(SpatialConstants::WORKER_COMPONENT_ID);
 	}

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetConnection.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetConnection.h
@@ -44,6 +44,7 @@ public:
 	virtual FString LowLevelGetRemoteAddress(bool bAppendPort = false) override { return TEXT(""); }
 	virtual FString LowLevelDescribe() override { return TEXT(""); }
 	virtual FString RemoteAddressToString() override { return TEXT(""); }
+	virtual void CleanUp() override;
 	///////
 	// End NetConnection Interface
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -120,6 +120,8 @@ public:
 
 	void SetSpatialMetricsDisplay(ASpatialMetricsDisplay* InSpatialMetricsDisplay);
 	void SetSpatialDebugger(ASpatialDebugger* InSpatialDebugger);
+	TWeakObjectPtr<USpatialNetConnection> FindWorkerConnectionFromWorkerId(const FString& WorkerId);
+	void CleanUpConnection(USpatialNetConnection* ConnectionCleanedUp);
 
 	UPROPERTY()
 	USpatialWorkerConnection* Connection;
@@ -190,6 +192,8 @@ private:
 	TArray<Worker_OpList*> QueuedStartupOpLists;
 	TSet<Worker_EntityId_Key> DormantEntities;
 	TSet<TWeakObjectPtr<USpatialActorChannel>> PendingDormantChannels;
+
+	TMap<FString, TWeakObjectPtr<USpatialNetConnection>> WorkerConnections;
 
 	FTimerManager TimerManager;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -120,8 +120,8 @@ public:
 
 	void SetSpatialMetricsDisplay(ASpatialMetricsDisplay* InSpatialMetricsDisplay);
 	void SetSpatialDebugger(ASpatialDebugger* InSpatialDebugger);
-	TWeakObjectPtr<USpatialNetConnection> FindWorkerConnectionFromWorkerId(const FString& WorkerId);
-	void CleanUpConnection(USpatialNetConnection* ConnectionCleanedUp);
+	TWeakObjectPtr<USpatialNetConnection> FindClientConnectionFromWorkerId(const FString& WorkerId);
+	void CleanUpClientConnection(USpatialNetConnection* ClientConnection);
 
 	UPROPERTY()
 	USpatialWorkerConnection* Connection;

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -143,7 +143,7 @@ private:
 	AActor* FindSingletonActor(UClass* SingletonClass);
 
 	void OnHeartbeatComponentUpdate(const Worker_ComponentUpdateOp& Op);
-	void CloseClientConnection(USpatialNetConnection* Client, Worker_EntityId);
+	void CloseClientConnection(USpatialNetConnection* ClientConnection, Worker_EntityId PlayerControllerEntityId);
 
 	void PeriodicallyProcessIncomingRPCs();
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -143,6 +143,7 @@ private:
 	AActor* FindSingletonActor(UClass* SingletonClass);
 
 	void OnHeartbeatComponentUpdate(const Worker_ComponentUpdateOp& Op);
+	void CloseClientConnection(USpatialNetConnection* Client, Worker_EntityId);
 
 	void PeriodicallyProcessIncomingRPCs();
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -244,6 +244,7 @@ private:
 	TMap<Worker_EntityId_Key, TWeakObjectPtr<USpatialNetConnection>> AuthorityPlayerControllerConnectionMap;
 
 	TMap<TPair<Worker_EntityId_Key, Worker_ComponentId>, PendingAddComponentWrapper> PendingDynamicSubobjectComponents;
+	TMap<Worker_EntityId_Key, FString> WorkerConnectionEntity;
 
 	// TODO: Refactor into a separate class so we can add automated tests for this. UNR-2649
 	struct EntityWaitingForAsyncLoad

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -244,7 +244,7 @@ private:
 	TMap<Worker_EntityId_Key, TWeakObjectPtr<USpatialNetConnection>> AuthorityPlayerControllerConnectionMap;
 
 	TMap<TPair<Worker_EntityId_Key, Worker_ComponentId>, PendingAddComponentWrapper> PendingDynamicSubobjectComponents;
-	TMap<Worker_EntityId_Key, FString> WorkerConnectionEntity;
+	TMap<Worker_EntityId_Key, FString> WorkerConnectionEntities;
 
 	// TODO: Refactor into a separate class so we can add automated tests for this. UNR-2649
 	struct EntityWaitingForAsyncLoad

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -82,6 +82,7 @@ const Worker_ComponentId PERSISTENCE_COMPONENT_ID						= 55;
 const Worker_ComponentId INTEREST_COMPONENT_ID							= 58;
 // This is a component on per-worker system entities.
 const Worker_ComponentId WORKER_COMPONENT_ID							= 60;
+const Worker_ComponentId PLAYERIDENTITY_COMPONENT_ID			= 61;
 
 const Worker_ComponentId MAX_RESERVED_SPATIAL_SYSTEM_COMPONENT_ID		= 100;
 


### PR DESCRIPTION
#### Description
A player leaving a deployment can leave its actor behind on the server. It happens because a player leaving is detected through an update to the Heartbeat component. This update could be skipped because the network stack has several background threads, which are not necessarily flushed in case of disconnection.
Another way to detect a disconnection would be to catch the disappearance of the entity associated to a client worker.
Several things need to happen : 
1) Server worker need to be interested in worker system entities.
2) Worker components need to be read.
3) USpatialNetConnection need to be associated to their corresponding system entity (this is loosely done by matching workerId)

(also include a driveby fix for cleanup code which asks for object references after the world has been removed from the net driver)

#### Release note

#### Tests
Tested by going through portals in NWX, which travels between deployments.
Testing this properly would require a simple way to spin up a server, and having a client connect and disconnect several times, since the issue was a race.

#### Documentation

#### Primary reviewers
