### PR TITLE
[UNR-2964][MS] Ensure spatial commands are run with correct environment arg.

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -75,8 +75,9 @@ void FSpatialGDKEditorToolbarModule::StartupModule()
 
 	FSpatialGDKServicesModule& GDKServices = FModuleManager::GetModuleChecked<FSpatialGDKServicesModule>("SpatialGDKServices");
 	LocalDeploymentManager = GDKServices.GetLocalDeploymentManager();
+	LocalDeploymentManager->PreInit(GetDefault<USpatialGDKSettings>()->IsRunningInChina());
+
 	LocalDeploymentManager->SetAutoDeploy(SpatialGDKEditorSettings->bAutoStartLocalDeployment);
-	LocalDeploymentManager->SetInChina(GetDefault<USpatialGDKSettings>()->IsRunningInChina());
 
 	// Bind the play button delegate to starting a local spatial deployment.
 	if (!UEditorEngine::TryStartSpatialDeployment.IsBound() && SpatialGDKEditorSettings->bAutoStartLocalDeployment)

--- a/SpatialGDK/Source/SpatialGDKServices/Private/Interop/Connection/EditorWorkerController.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/Interop/Connection/EditorWorkerController.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 #include "Interop/Connection/EditorWorkerController.h"
 
+#include "SpatialCommandUtils.h"
 #include "SpatialGDKServicesPrivate.h"
 
 #include "Editor.h"
@@ -73,9 +74,8 @@ struct EditorWorkerController
 				"--existing_worker_id %s "
 				"--replacing_worker_id %s"), *ServicePort, *OldWorker, *NewWorker);
 		uint32 ProcessID = 0;
-		FProcHandle ProcHandle = FPlatformProcess::CreateProc(
-			*(CmdExecutable), *CmdArgs, false, true, true, &ProcessID, 2 /*PriorityModifier*/,
-			nullptr, nullptr, nullptr);
+		FProcHandle ProcHandle = SpatialCommandUtils::CreateSpatialProcess(CmdArgs, false, true, true, &ProcessID, 2 /*PriorityModifier*/,
+				nullptr, nullptr, nullptr, false);
 
 		return ProcHandle;
 	}

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
@@ -8,7 +8,7 @@ DEFINE_LOG_CATEGORY(LogSpatialCommandUtils);
 namespace
 {
 	FString ChinaEnvironmentArgument = TEXT(" --environment=cn-production");
-}
+} // anonymous namespace
 
 void SpatialCommandUtils::ExecuteSpatialCommandAndReadOutput(FString Arguments, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode, bool bIsRunningInChina)
 {

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
@@ -1,17 +1,49 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
 #include "SpatialCommandUtils.h"
+#include "SpatialGDKServicesModule.h"
 
 DEFINE_LOG_CATEGORY(LogSpatialCommandUtils);
 
-bool SpatialCommandUtils::AttemptSpatialAuth(bool IsRunningInChina)
+namespace
 {
-	FString SpatialInfoArgs = IsRunningInChina ? TEXT("auth login --environment=cn-production") : TEXT("auth login");
+	FString ChinaEnvironmentArgument = TEXT(" --environment=cn-production");
+}
+
+void SpatialCommandUtils::ExecuteSpatialCommandAndReadOutput(FString Arguments, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode, bool bIsRunningInChina)
+{
+	if (bIsRunningInChina)
+	{
+		Arguments += ChinaEnvironmentArgument;
+	}
+
+	FSpatialGDKServicesModule::ExecuteAndReadOutput(*FSpatialGDKServicesModule::GetSpatialExe(), Arguments, DirectoryToRun, OutResult, OutExitCode);
+}
+
+void SpatialCommandUtils::ExecuteSpatialCommand(FString Arguments, int32* OutExitCode, FString* OutStdOut, FString* OutStdEr, bool bIsRunningInChina)
+{
+	if (bIsRunningInChina)
+	{
+		Arguments += ChinaEnvironmentArgument;
+	}
+	FPlatformProcess::ExecProcess(*FSpatialGDKServicesModule::GetSpatialExe(), *Arguments, OutExitCode, OutStdOut, OutStdEr);
+}
+
+FProcHandle SpatialCommandUtils::CreateSpatialProcess(FString Arguments, bool bLaunchDetached, bool bLaunchHidden, bool bLaunchReallyHidden, uint32* OutProcessID, int32 PriorityModifier, const TCHAR* OptionalWorkingDirectory, void* PipeWriteChild, void * PipeReadChild, bool bIsRunningInChina)
+{
+	if (bIsRunningInChina)
+	{
+		Arguments += ChinaEnvironmentArgument;
+	}
+	return FPlatformProcess::CreateProc(*FSpatialGDKServicesModule::GetSpatialExe(), *Arguments, bLaunchDetached, bLaunchHidden, bLaunchReallyHidden, OutProcessID, PriorityModifier, OptionalWorkingDirectory, PipeWriteChild, PipeReadChild);
+}
+
+bool SpatialCommandUtils::AttemptSpatialAuth(bool bIsRunningInChina)
+{
 	FString SpatialInfoResult;
 	FString StdErr;
 	int32 ExitCode;
-
-	FPlatformProcess::ExecProcess(*FString(TEXT("spatial")), *SpatialInfoArgs, &ExitCode, &SpatialInfoResult, &StdErr);
+	ExecuteSpatialCommand(TEXT("auth login"), &ExitCode, &SpatialInfoResult, &StdErr, bIsRunningInChina);
 
 	bool bSuccess = ExitCode == 0;
 	if (!bSuccess)

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialGDKServicesModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialGDKServicesModule.cpp
@@ -8,6 +8,7 @@
 #include "Framework/Application/SlateApplication.h"
 #include "Framework/Docking/TabManager.h"
 #include "Misc/FileHelper.h"
+#include "SpatialCommandUtils.h"
 #include "SSpatialOutputLog.h"
 #include "Serialization/JsonReader.h"
 #include "Serialization/JsonSerializer.h"
@@ -88,11 +89,11 @@ const FString& FSpatialGDKServicesModule::GetSpatialExe()
 	return SpatialExe;
 }
 
-bool FSpatialGDKServicesModule::SpatialPreRunChecks()
+bool FSpatialGDKServicesModule::SpatialPreRunChecks(bool bIsInChina)
 {
 	FString SpatialExistenceCheckResult;
 	int32 ExitCode;
-	ExecuteAndReadOutput(GetSpatialExe(), TEXT("version"), GetSpatialOSDirectory(), SpatialExistenceCheckResult, ExitCode);
+	SpatialCommandUtils::ExecuteSpatialCommandAndReadOutput(TEXT("version"), GetSpatialOSDirectory(), SpatialExistenceCheckResult, ExitCode, bIsInChina);
 
 	if (ExitCode != 0)
 	{

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalDeploymentManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalDeploymentManager.h
@@ -17,6 +17,9 @@ class FLocalDeploymentManager
 public:
 	FLocalDeploymentManager();
 
+	// Needs to be ran after SetInChina is called.
+	void SPATIALGDKSERVICES_API PreInit(bool IsInChina);
+
 	void SPATIALGDKSERVICES_API Init(FString RuntimeIPToExpose);
 
 	void SPATIALGDKSERVICES_API SetInChina(bool IsInChina);

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
@@ -10,5 +10,11 @@ class SpatialCommandUtils
 {
 public:
 
-	SPATIALGDKSERVICES_API static bool AttemptSpatialAuth(bool IsRunningInChina);
+	SPATIALGDKSERVICES_API static void ExecuteSpatialCommandAndReadOutput(FString Arguments, const FString& DirectoryToRun, FString& OutResult, int32& ExitCode, bool bIsRunningInChina);
+
+	SPATIALGDKSERVICES_API static void ExecuteSpatialCommand(FString Arguments, int32* OutReturnCode, FString* OutStdOut, FString* OutStdEr, bool bIsRunningInChina);
+
+	SPATIALGDKSERVICES_API static FProcHandle CreateSpatialProcess(FString Arguments, bool bLaunchDetached, bool bLaunchHidden, bool bLaunchReallyHidden, uint32* OutProcessID, int32 PriorityModifier, const TCHAR* OptionalWorkingDirectory, void* PipeWriteChild, void * PipeReadChild, bool bIsRunningInChina);
+
+	SPATIALGDKSERVICES_API static bool AttemptSpatialAuth(bool bIsRunningInChina);
 };

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesModule.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesModule.h
@@ -24,7 +24,7 @@ public:
 	static FString GetSpatialGDKPluginDirectory(const FString& AppendPath = TEXT(""));
 	static const FString& GetSpotExe();
 	static const FString& GetSpatialExe();
-	static bool SpatialPreRunChecks();
+	static bool SpatialPreRunChecks(bool bIsInChina);
 
 	FORCEINLINE static FString GetProjectName()
 	{

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKServices/LocalDeploymentManager/LocalDeploymentManagerTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKServices/LocalDeploymentManager/LocalDeploymentManagerTest.cpp
@@ -3,6 +3,7 @@
 #include "TestDefinitions.h"
 
 #include "LocalDeploymentManager.h"
+#include "SpatialCommandUtils.h"
 #include "SpatialGDKDefaultLaunchConfigGenerator.h"
 #include "SpatialGDKDefaultWorkerJsonGenerator.h"
 #include "SpatialGDKEditorSettings.h"
@@ -35,8 +36,7 @@ namespace
 		FString BuildConfigArgs = TEXT("worker build build-config");
 		FString WorkerBuildConfigResult;
 		int32 ExitCode;
-		const FString SpatialExe(TEXT("spatial.exe"));
-		FSpatialGDKServicesModule::ExecuteAndReadOutput(SpatialExe, BuildConfigArgs, FSpatialGDKServicesModule::GetSpatialOSDirectory(), WorkerBuildConfigResult, ExitCode);
+		SpatialCommandUtils::ExecuteSpatialCommandAndReadOutput(BuildConfigArgs, FSpatialGDKServicesModule::GetSpatialOSDirectory(), WorkerBuildConfigResult, ExitCode, false);
 
 		const int32 ExitCodeSuccess = 0;
 		return (ExitCode == ExitCodeSuccess);


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
This aids in fixing an issue where the editor has not yet fully opened but we make a call to spatial that does not call the environment arg correctly for China. 