### PR TITLE
Fix int8 -> bool compile error in VS2019

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/SpatialDebugging.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/SpatialDebugging.h
@@ -42,7 +42,7 @@ struct SpatialDebugging : Component
 		AuthoritativeColor = FColor(Schema_GetUint32(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_AUTHORITATIVE_COLOR));
 		IntentVirtualWorkerId = Schema_GetUint32(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_INTENT_VIRTUAL_WORKER_ID);
 		IntentColor = FColor(Schema_GetUint32(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_INTENT_COLOR));
-		IsLocked = Schema_GetBool(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_IS_LOCKED);
+		IsLocked = Schema_GetBool(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_IS_LOCKED) != 0;
 	}
 
 	Worker_ComponentData CreateSpatialDebuggingData()
@@ -85,7 +85,7 @@ struct SpatialDebugging : Component
 		AuthoritativeColor = FColor(Schema_GetUint32(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_AUTHORITATIVE_COLOR));
 		IntentVirtualWorkerId = Schema_GetUint32(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_INTENT_VIRTUAL_WORKER_ID);
 		IntentColor = FColor(Schema_GetUint32(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_INTENT_COLOR));
-		IsLocked = Schema_GetBool(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_IS_LOCKED);
+		IsLocked = Schema_GetBool(ComponentObject, SpatialConstants::SPATIAL_DEBUGGING_IS_LOCKED) != 0;
 	}
 
 	// Id of the Unreal server worker which is authoritative for the entity.


### PR DESCRIPTION
#### Description
VS2019 doesn't like the loss of information when going from an int8 to bool. This fixes our usage of this.

#### Release note
Not required, should have worked from the get-go.

#### Tests
N/A

#### Documentation
N/A

#### Primary reviewers
@joshuahuburn 