### PR TITLE
Restored a check for if the connection should be used from the game t…

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
@@ -340,7 +340,7 @@ void USpatialConnectionManager::FinishConnecting(Worker_ConnectionFuture* Connec
 			if (Worker_Connection_IsConnected(NewCAPIWorkerConnection))
 			{
 				SpatialConnectionManager->WorkerConnection = NewObject<USpatialWorkerConnection>();
-				SpatialConnectionManager->WorkerConnection->SetConection(NewCAPIWorkerConnection);
+				SpatialConnectionManager->WorkerConnection->SetConnection(NewCAPIWorkerConnection);
 				SpatialConnectionManager->OnConnectionSuccess();
 			}
 			else

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
@@ -9,12 +9,14 @@ DEFINE_LOG_CATEGORY(LogSpatialWorkerConnection);
 
 using namespace SpatialGDK;
 
-void USpatialWorkerConnection::SetConection(Worker_Connection* WorkerConnectionIn)
+void USpatialWorkerConnection::SetConnection(Worker_Connection* WorkerConnectionIn)
 {
 	WorkerConnection = WorkerConnectionIn;
 
 	CacheWorkerAttributes();
-	if (WorkerConnectionIn != nullptr && Worker_Connection_IsConnected(WorkerConnectionIn))
+
+	const USpatialGDKSettings* SpatialGDKSettings = GetDefault<USpatialGDKSettings>();    
+	if (!SpatialGDKSettings->bRunSpatialWorkerConnectionOnGameThread)  
 	{
 		if (OpsProcessingThread == nullptr)
 		{

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialWorkerConnection.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialWorkerConnection.h
@@ -24,7 +24,7 @@ class SPATIALGDK_API USpatialWorkerConnection : public UObject, public FRunnable
 	GENERATED_BODY()
 
 public:
-	void SetConection(Worker_Connection* WorkerConnectionIn);
+	void SetConnection(Worker_Connection* WorkerConnectionIn);
 	virtual void FinishDestroy() override;
 	void DestroyConnection();
 


### PR DESCRIPTION
#### Description
Fixed a bug where we forgot to check if the connection should be used from the game thread or not.

The fact that it can be used from multiple threads implies that we should probably not have the connection manager own the connection; that has not been dealt with here in favour of getting this fix in quickly.