### PR TITLE
[UNR-2763] Add avg/min/max ping measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Enabling the Unreal GDK load balancer now creates a single query per server worker, depending on the defined load balancing strategy.
 - The `bEnableServerQBI` property has been removed, and the flag `--OverrideServerInterest` has been removed.
 - SpatialDebugger worker regions are now cuboids rather than planes, and can have their WorkerRegionVerticalScale adjusted via a setting in the SpatialDebugger.
+- SpatialPingComponent can now also report average ping measurements over a specified number of recent pings. You can specify the number of measurements recorded in `PingMeasurementsWindowSize` and get the measurement data by calling `GetAverageData`. There is also a delegate `OnRecordPing` that will be broadcast whenever a new ping measurement is recorded.
 
 ## Bug fixes:
 - Fixed a bug that caused the local API service to memory leak.

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/SpatialPingComponent.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/SpatialPingComponent.cpp
@@ -199,10 +199,13 @@ FSpatialPingAverageData USpatialPingComponent::GetAverageData() const
 	}
 	Data.WindowSize = LastPingMeasurements.Num();
 
-	Data.TotalAvg = TotalPing / TotalNum;
-	Data.TotalMin = TotalMin;
-	Data.TotalMax = TotalMax;
-	Data.TotalNum = TotalNum;
+	if (TotalNum > 0)
+	{
+		Data.TotalAvg = TotalPing / TotalNum;
+		Data.TotalMin = TotalMin;
+		Data.TotalMax = TotalMax;
+		Data.TotalNum = TotalNum;
+	}
 
 	return Data;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/SpatialPingComponent.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/SpatialPingComponent.cpp
@@ -188,7 +188,7 @@ FSpatialPingAverageData USpatialPingComponent::GetAverageData() const
 
 	if (LastPingMeasurements.Num() > 0)
 	{
-		double Total = 0.0;
+		float Total = 0.0f;
 		for (float Ping : LastPingMeasurements)
 		{
 			Total += Ping;

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/SpatialPingComponent.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/SpatialPingComponent.cpp
@@ -164,6 +164,7 @@ void USpatialPingComponent::OnRep_ReplicatedPingID()
 
 		// Calculate the round trip ping
 		RoundTripPing = static_cast<float>(FPlatformTime::Seconds() - LastSentPingTimestamp);
+		RecordPing(RoundTripPing);
 		if (RoundTripPing >= MinPingInterval)
 		{
 			// If the current ping exceeds the min interval then send a new ping immediately.
@@ -179,6 +180,48 @@ void USpatialPingComponent::OnRep_ReplicatedPingID()
 			}
 		}
 	}
+}
+
+FSpatialPingAverageData USpatialPingComponent::GetAverageData() const
+{
+	FSpatialPingAverageData Data = {};
+
+	if (LastPingMeasurements.Num() > 0)
+	{
+		double Total = 0.0;
+		for (float Ping : LastPingMeasurements)
+		{
+			Total += Ping;
+		}
+		Data.LastMeasurementsWindowAvg = Total / LastPingMeasurements.Num();
+		Data.LastMeasurementsWindowMin = FMath::Min(LastPingMeasurements);
+		Data.LastMeasurementsWindowMax = FMath::Max(LastPingMeasurements);
+	}
+	Data.WindowSize = LastPingMeasurements.Num();
+
+	Data.TotalAvg = TotalPing / TotalNum;
+	Data.TotalMin = TotalMin;
+	Data.TotalMax = TotalMax;
+	Data.TotalNum = TotalNum;
+
+	return Data;
+}
+
+void USpatialPingComponent::RecordPing(float Ping)
+{
+	LastPingMeasurements.Add(Ping);
+	if (LastPingMeasurements.Num() > PingMeasurementsWindowSize)
+	{
+		LastPingMeasurements.RemoveAt(0);
+	}
+
+	TotalPing += Ping;
+	TotalNum++;
+
+	TotalMin = FMath::Min(TotalMin, Ping);
+	TotalMax = FMath::Max(TotalMax, Ping);
+
+	OnRecordPing.Broadcast(Ping);
 }
 
 bool USpatialPingComponent::SendServerWorkerPingID_Validate(uint16 PingID)

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/SpatialPingComponent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/SpatialPingComponent.h
@@ -9,6 +9,32 @@
 
 DECLARE_LOG_CATEGORY_EXTERN(LogSpatialPingComponent, Log, All);
 
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnRecordPing, float, Ping);
+
+USTRUCT(BlueprintType)
+struct FSpatialPingAverageData
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintReadWrite, Category = SpatialPing)
+	float LastMeasurementsWindowAvg;
+	UPROPERTY(BlueprintReadWrite, Category = SpatialPing)
+	float LastMeasurementsWindowMin;
+	UPROPERTY(BlueprintReadWrite, Category = SpatialPing)
+	float LastMeasurementsWindowMax;
+	UPROPERTY(BlueprintReadWrite, Category = SpatialPing)
+	int WindowSize;
+
+	UPROPERTY(BlueprintReadWrite, Category = SpatialPing)
+	float TotalAvg;
+	UPROPERTY(BlueprintReadWrite, Category = SpatialPing)
+	float TotalMin;
+	UPROPERTY(BlueprintReadWrite, Category = SpatialPing)
+	float TotalMax;
+	UPROPERTY(BlueprintReadWrite, Category = SpatialPing)
+	int TotalNum;
+};
+
 /*
  Offers a configurable means of measuring round-trip latency in SpatialOS deployments.
  This component should be attached to a player controller.
@@ -31,6 +57,10 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = SpatialPing)
 	float TimeoutLimit = 4.0f;
 
+	// The number of ping measurements recorded for the rolling average.
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = SpatialPing)
+	int PingMeasurementsWindowSize = 20;
+
 	virtual void BeginPlay() override;
 	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
@@ -45,6 +75,14 @@ public:
 	// Returns the latest raw round-trip ping value in seconds.
 	UFUNCTION(BlueprintCallable, Category = "SpatialGDK|Ping")
 	float GetPing() const;
+
+	// Returns the average, min, and max values for the last PingMeasurementsWindowSize measurements as well as the total average, min, and max.
+	UFUNCTION(BlueprintCallable, Category = "SpatialGDK|Ping")
+	FSpatialPingAverageData GetAverageData() const;
+
+	// Multicast delegate that will be broadcast whenever a new ping measurement is recorded.
+	UPROPERTY(BlueprintAssignable, Category = "SpatialGDK|Ping")
+	FOnRecordPing OnRecordPing;
 
 private:
 	float RoundTripPing;
@@ -79,4 +117,13 @@ private:
 
 	UFUNCTION(Server, Unreliable, WithValidation)
 	virtual void SendServerWorkerPingID(uint16 PingID);
+
+	void RecordPing(float Ping);
+
+	TArray<float> LastPingMeasurements;
+
+	double TotalPing = 0.0;
+	float TotalMin = 1.0f;
+	float TotalMax = 0.0f;
+	int TotalNum = 0;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/SpatialPingComponent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/SpatialPingComponent.h
@@ -122,7 +122,7 @@ private:
 
 	TArray<float> LastPingMeasurements;
 
-	double TotalPing = 0.0;
+	float TotalPing = 0.0f;
 	float TotalMin = 1.0f;
 	float TotalMax = 0.0f;
 	int TotalNum = 0;


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
SpatialPingComponent can now also report average ping measurements over a specified number of recent pings. You can specify the number of measurements recorded in `PingMeasurementsWindowSize` and get the measurement data by calling `GetAverageData`. There is also a delegate `OnRecordPing` that will be broadcast whenever a new ping measurement is recorded.

#### Tests
Added a UI to display these measurements in LatencyGym:
https://github.com/spatialos/UnrealGDKTestGyms/pull/47

#### Primary reviewers
@m-samiec @improbable-danny 