### PR TITLE
Create log directory if it doesn't exist for the spatial output

### DIFF
--- a/SpatialGDK/Source/SpatialGDKServices/Private/SSpatialOutputLog.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SSpatialOutputLog.cpp
@@ -103,8 +103,12 @@ void SSpatialOutputLog::StartUpLogDirectoryWatcher(const FString& LogDirectory)
 			// Watch the log directory for changes.
 			if (!FPaths::DirectoryExists(LogDirectory))
 			{
-				UE_LOG(LogSpatialOutputLog, Error, TEXT("Local deployment log directory does not exist!"));
-				return;
+				UE_LOG(LogSpatialOutputLog, Log, TEXT("Spatial local deployment log directory '%s' does not exist. Attempting to create it."), *LogDirectory);
+				if (!FPlatformFileManager::Get().GetPlatformFile().CreateDirectoryTree(*LogDirectory))
+				{
+					UE_LOG(LogSpatialOutputLog, Error, TEXT("Could not create the spatial local deployment log directory. The Spatial Output window will not function."));
+					return;
+				}
 			}
 
 			LogDirectoryChangedDelegate = IDirectoryWatcher::FDirectoryChanged::CreateRaw(this, &SSpatialOutputLog::OnLogDirectoryChanged);

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SSpatialOutputLog.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SSpatialOutputLog.cpp
@@ -103,7 +103,7 @@ void SSpatialOutputLog::StartUpLogDirectoryWatcher(const FString& LogDirectory)
 			// Watch the log directory for changes.
 			if (!FPaths::DirectoryExists(LogDirectory))
 			{
-				UE_LOG(LogSpatialOutputLog, Log, TEXT("Spatial local deployment log directory '%s' does not exist. Attempting to create it."), *LogDirectory);
+				UE_LOG(LogSpatialOutputLog, Log, TEXT("Spatial local deployment log directory '%s' does not exist. Will create it."), *LogDirectory);
 				if (!FPlatformFileManager::Get().GetPlatformFile().CreateDirectoryTree(*LogDirectory))
 				{
 					UE_LOG(LogSpatialOutputLog, Error, TEXT("Could not create the spatial local deployment log directory. The Spatial Output window will not function."));


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
If you have never ran a local deployment the Spatial Output creation would error on attempting to set up a Directory Watcher. This PR simply attempts to create that log directory if it does not exist. This has became an issue since Spatial Output is now enabled by default.

#### Release note
Transient bug fix

#### Tests
Deleted `spatial/logs/localdeployment` folder. Started editor. No error. Spatial Output worked when creating deployment.

How can this be verified by QA?
Delete `spatial/logs/localdeployment` folder. Start editor. No error. Spatial Output works when creating deployment.

#### Primary reviewers
@mironec @mattyoung-improbable 