### PR TITLE
[CHINF-886][MS] Fixing a crash caused by the merge into release related to the jira issue.

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -251,7 +251,11 @@ void USpatialNetDriver::InitiateConnectionToSpatialOS(const FURL& URL)
 		}
 	}
 
-	Connection->Connect(bConnectAsClient);
+#if WITH_EDITOR
+	Connection->Connect(bConnectAsClient, PlayInEditorID);
+#else
+	Connection->Connect(bConnectAsClient, 0);
+#endif
 }
 
 void USpatialNetDriver::OnConnectedToSpatialOS()

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
@@ -68,7 +68,7 @@ void USpatialWorkerConnection::DestroyConnection()
 	KeepRunning.AtomicSet(true);
 }
 
-void USpatialWorkerConnection::Connect(bool bInitAsClient)
+void USpatialWorkerConnection::Connect(bool bInitAsClient, uint32 PlayInEditorID)
 {
 	if (bIsConnected)
 	{
@@ -88,7 +88,7 @@ void USpatialWorkerConnection::Connect(bool bInitAsClient)
 	switch (GetConnectionType())
 	{
 	case SpatialConnectionType::Receptionist:
-		ConnectToReceptionist(bInitAsClient);
+		ConnectToReceptionist(bInitAsClient, PlayInEditorID);
 		break;
 	case SpatialConnectionType::Locator:
 		ConnectToLocator();
@@ -191,7 +191,7 @@ void USpatialWorkerConnection::StartDevelopmentAuth(FString DevAuthToken)
 	}
 }
 
-void USpatialWorkerConnection::ConnectToReceptionist(bool bConnectAsClient)
+void USpatialWorkerConnection::ConnectToReceptionist(bool bConnectAsClient, uint32 PlayInEditorID)
 {
 	if (ReceptionistConfig.WorkerType.IsEmpty())
 	{
@@ -200,7 +200,7 @@ void USpatialWorkerConnection::ConnectToReceptionist(bool bConnectAsClient)
 	}
 
 #if WITH_EDITOR
-	SpatialGDKServices::InitWorkers(bConnectAsClient, GetSpatialNetDriverChecked()->PlayInEditorID, ReceptionistConfig.WorkerId);
+	SpatialGDKServices::InitWorkers(bConnectAsClient, PlayInEditorID, ReceptionistConfig.WorkerId);
 #endif
 
 	if (ReceptionistConfig.WorkerId.IsEmpty())

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialWorkerConnection.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialWorkerConnection.h
@@ -45,7 +45,7 @@ public:
     /// @param Callback - callback function.
 	void RegisterOnLoginTokensCallback(const LoginTokenResponseCallback& Callback) {LoginTokenResCallback = Callback;}
 
-	void Connect(bool bConnectAsClient, uint32 PlayInEditorI);
+	void Connect(bool bConnectAsClient, uint32 PlayInEditorID);
 
 	FORCEINLINE bool IsConnected() { return bIsConnected; }
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialWorkerConnection.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialWorkerConnection.h
@@ -45,7 +45,7 @@ public:
     /// @param Callback - callback function.
 	void RegisterOnLoginTokensCallback(const LoginTokenResponseCallback& Callback) {LoginTokenResCallback = Callback;}
 
-	void Connect(bool bConnectAsClient);
+	void Connect(bool bConnectAsClient, uint32 PlayInEditorI);
 
 	FORCEINLINE bool IsConnected() { return bIsConnected; }
 
@@ -74,7 +74,7 @@ public:
 	void RequestDeploymentLoginTokens();
 
 private:
-	void ConnectToReceptionist(bool bConnectAsClient);
+	void ConnectToReceptionist(bool bConnectAsClient, uint32 PlayInEditorID);
 	void ConnectToLocator();
 	void FinishConnecting(Worker_ConnectionFuture* ConnectionFuture);
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Previously we got the PlayInEditorID inside ConnectToReceptionist by trying to get the NetDriver and take it off that. Issue with that is that the Example project was making the SpatialWorkerConnection->Connect call before PendingNetGame was set resulting in a crash.

USpatialNetDriver* USpatialWorkerConnection::GetSpatialNetDriverChecked() const
{
	UNetDriver* NetDriver = GameInstance->GetWorld()->GetNetDriver();

	// On the client, the world might not be completely set up.
	// in this case we can use the PendingNetGame to get the NetDriver
	if (NetDriver == nullptr)
	{
		NetDriver = GameInstance->GetWorldContext()->**PendingNetGame**->GetNetDriver();
	}

	USpatialNetDriver* SpatialNetDriver = Cast<USpatialNetDriver>(NetDriver);
	checkf(SpatialNetDriver, TEXT("SpatialNetDriver was invalid while accessing SpatialNetDriver!"));
	return SpatialNetDriver;
}