### PR TITLE
Removing the netdriver from the spatial worker connection.

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -77,6 +77,9 @@ public:
 
 	virtual void OnOwnerUpdated(AActor* Actor);
 
+	void OnConnectionToSpatialOSSucceeded();
+	void OnConnectionToSpatialOSFailed(uint8_t ConnectionStatusCode, const FString& ErrorMessage);
+
 	void OnConnectedToSpatialOS();
 
 #if !UE_BUILD_SHIPPING

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialWorkerConnection.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialWorkerConnection.h
@@ -71,6 +71,12 @@ public:
 	FReceptionistConfig ReceptionistConfig;
 	FLocatorConfig LocatorConfig;
 
+	DECLARE_DELEGATE(OnConnectionToSpatialOSSucceededDelegate)
+	OnConnectionToSpatialOSSucceededDelegate OnConnectedCallback;
+
+	DECLARE_DELEGATE_TwoParams(OnConnectionToSpatialOSFailedDelegate, uint8_t, const FString&);
+	OnConnectionToSpatialOSFailedDelegate OnFailedToConnectCallback;
+
 	void RequestDeploymentLoginTokens();
 
 private:
@@ -85,8 +91,6 @@ private:
 	SpatialConnectionType GetConnectionType() const;
 
 	void CacheWorkerAttributes();
-
-	class USpatialNetDriver* GetSpatialNetDriverChecked() const;
 
 	// Begin FRunnable Interface
 	virtual bool Init() override;


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Need to remove all reference to the net driver from the connection. These are changes from master. Simply use a delegate on spatial worker connection that people can bind to if they want to know about successful or failing spatial connection attempts. 