### PR TITLE
Remove 0.6.5 from CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased-`x.y.z`] - 2020-xx-xx
 
-## [`0.8.1-preview`] - 2020-xx-xx
-### Adapted from 0.6.5
+## [`0.8.1-preview`] - 2020-05-12
 ### Features:
-Features listed in the internal section are not ready to use but, in the spirit of open development, we detail every change we make to the GDK.
 - **SpatialOS GDK for Unreal** > **Editor Settings** > **Region Settings** has been moved to **SpatialOS GDK for Unreal** > **Runtime Settings** > **Region Settings**.
 - Local deployments can now be launched in China, when the **Region where services are located** is set to `CN`.
 - Updated the version of the local API service used by the UnrealGDK.
@@ -130,12 +128,6 @@ Features listed in the internal section are not ready to use but, in the spirit 
 - Muticast RPCs that are sent shortly after an actor is created are now correctly processed by all clients.
 - When replicating an actor, the owner's Spatial position will no longer be used if it isn't replicated.
 - Fixed a crash upon checking out an actor with a deleted static subobject.
-
-## [`0.6.5`] - 2020-01-13
-### Internal:
-Features listed in the internal section are not ready to use but, in the spirit of open development, we detail every change we make to the GDK.
-- **SpatialOS GDK for Unreal** > **Editor Settings** > **Region Settings** has been moved to **SpatialOS GDK for Unreal** > **Runtime Settings** > **Region Settings**.
-- Local deployments can now be launched in China, when the **Region where services are located** is set to `CN`.
 
 ## [`0.6.4`] - 2019-12-13
 ### Bug fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [`0.8.1-preview`] - 2020-05-12
 ### Features:
 - **SpatialOS GDK for Unreal** > **Editor Settings** > **Region Settings** has been moved to **SpatialOS GDK for Unreal** > **Runtime Settings** > **Region Settings**.
-- Local deployments can now be launched in China, when the **Region where services are located** is set to `CN`.
+- You can now choose which SpatialOS service region you want to use by adjusting the**Region where services are located** setting. You must use the service region that you're geographically located in.
+- Deployments can now be launched in China, when the **Region where services are located** is set to `CN`.
 - Updated the version of the local API service used by the UnrealGDK.
 - The Spatial output log will now be open by default.
 


### PR DESCRIPTION
#### Description
* Removes 0.6.5 from the CHANGELOG as we decided not to ship that patch release.
* Adds a speculative ship date for 0.8.1-preview.
* Clarifies CN region settings. 