### PR TITLE
supa set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Added custom warning timeouts per RPC failure condition.
 - SpatialPingComponent can now also report average ping measurements over a specified number of recent pings. You can specify the number of measurements recorded in `PingMeasurementsWindowSize` and get the measurement data by calling `GetAverageData`. There is also a delegate `OnRecordPing` that will be broadcast whenever a new ping measurement is recorded.
 - The Spatial Output Log window now displays deployment startup errors.
+- Added `bEnableClientQueriesOnServer` (defaulted true) which makes the same queries on the server as on clients if the unreal load balancer is enabled. This is to avoid clients seeing entities the server does not if the server's interest query has not been configured correctly.
 
 ## Bug fixes:
 - Fixed a bug that caused the local API service to memory leak.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,12 +61,8 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - SpatialDebugger worker regions are now cuboids rather than planes, and can have their WorkerRegionVerticalScale adjusted via a setting in the SpatialDebugger.
 - Added custom warning timeouts per RPC failure condition.
 - SpatialPingComponent can now also report average ping measurements over a specified number of recent pings. You can specify the number of measurements recorded in `PingMeasurementsWindowSize` and get the measurement data by calling `GetAverageData`. There is also a delegate `OnRecordPing` that will be broadcast whenever a new ping measurement is recorded.
-<<<<<<< HEAD
 - The Spatial Output Log window now displays deployment startup errors.
-- Added `bEnableClientQueriesOnServer` (defaulted true) which makes the same queries on the server as on clients if the unreal load balancer is enabled. This is to avoid clients seeing entities the server does not if the server's interest query has not been configured correctly.
-=======
-- Added `bEnableClientQueriesOnServer` (defaulted false) which makes the same queries on the server as on clients. This can be enabled to avoid clients seeing entities the server does not if the server's interest query has not been configured correctly.
->>>>>>> 9abe4370... default false
+- Added `bEnableClientQueriesOnServer` (defaulted false) which makes the same queries on the server as on clients if the unreal load balancer is enabled. Enable this to avoid clients seeing entities the server does not if the server's interest query has not been configured correctly.
 
 ## Bug fixes:
 - Fixed a bug that caused the local API service to memory leak.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,8 +61,12 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - SpatialDebugger worker regions are now cuboids rather than planes, and can have their WorkerRegionVerticalScale adjusted via a setting in the SpatialDebugger.
 - Added custom warning timeouts per RPC failure condition.
 - SpatialPingComponent can now also report average ping measurements over a specified number of recent pings. You can specify the number of measurements recorded in `PingMeasurementsWindowSize` and get the measurement data by calling `GetAverageData`. There is also a delegate `OnRecordPing` that will be broadcast whenever a new ping measurement is recorded.
+<<<<<<< HEAD
 - The Spatial Output Log window now displays deployment startup errors.
 - Added `bEnableClientQueriesOnServer` (defaulted true) which makes the same queries on the server as on clients if the unreal load balancer is enabled. This is to avoid clients seeing entities the server does not if the server's interest query has not been configured correctly.
+=======
+- Added `bEnableClientQueriesOnServer` (defaulted false) which makes the same queries on the server as on clients. This can be enabled to avoid clients seeing entities the server does not if the server's interest query has not been configured correctly.
+>>>>>>> 9abe4370... default false
 
 ## Bug fixes:
 - Fixed a bug that caused the local API service to memory leak.

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -679,6 +679,11 @@ void USpatialNetDriver::OnLevelAddedToWorld(ULevel* LoadedLevel, UWorld* OwningW
 		return;
 	}
 
+	if (!IsServer())
+	{
+		return;
+	}
+
 	// If load balancing disabled but this worker is GSM authoritative then make sure
 	// we set Role_Authority on Actors in the sublevel. Also, if load balancing is
 	// enabled and lb strategy says we should have authority over a loaded level Actor

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -679,11 +679,6 @@ void USpatialNetDriver::OnLevelAddedToWorld(ULevel* LoadedLevel, UWorld* OwningW
 		return;
 	}
 
-	if (!IsServer())
-	{
-		return;
-	}
-
 	// If load balancing disabled but this worker is GSM authoritative then make sure
 	// we set Role_Authority on Actors in the sublevel. Also, if load balancing is
 	// enabled and lb strategy says we should have authority over a loaded level Actor

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -2292,13 +2292,16 @@ USpatialActorChannel* USpatialNetDriver::CreateSpatialActorChannel(AActor* Actor
 		}
 	}
 
-	if (IsServer() && Channel != nullptr)
+	if (Channel != nullptr)
 	{
-		Channel->SetServerAuthority(StaticComponentView->HasAuthority(EntityId, SpatialConstants::POSITION_COMPONENT_ID));
-	}
-	else
-	{
-		Channel->SetClientAuthority(StaticComponentView->HasAuthority(EntityId, SpatialConstants::GetClientAuthorityComponent(GetDefault<USpatialGDKSettings>()->UseRPCRingBuffer())));
+		if (IsServer())
+		{
+			Channel->SetServerAuthority(StaticComponentView->HasAuthority(EntityId, SpatialConstants::POSITION_COMPONENT_ID));
+		}
+		else
+		{
+			Channel->SetClientAuthority(StaticComponentView->HasAuthority(EntityId, SpatialConstants::GetClientAuthorityComponent(GetDefault<USpatialGDKSettings>()->UseRPCRingBuffer())));
+		}
 	}
 
 	return Channel;

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -2292,7 +2292,7 @@ USpatialActorChannel* USpatialNetDriver::CreateSpatialActorChannel(AActor* Actor
 		}
 	}
 
-	if (IsServer())
+	if (IsServer() && Channel != nullptr)
 	{
 		Channel->SetServerAuthority(StaticComponentView->HasAuthority(EntityId, SpatialConstants::POSITION_COMPONENT_ID));
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -83,6 +83,7 @@ USpatialGDKSettings::USpatialGDKSettings(const FObjectInitializer& ObjectInitial
 	, bUseSecureClientConnection(false)
 	, bUseSecureServerConnection(false)
 	, bUseDevelopmentAuthenticationFlow(false)
+	, bEnableClientQueriesOnServer(true)
 {
 	DefaultReceptionistHost = SpatialConstants::LOCAL_HOST;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -82,7 +82,7 @@ USpatialGDKSettings::USpatialGDKSettings(const FObjectInitializer& ObjectInitial
 	, FullFrequencyNetCullDistanceRatio(1.0f)
 	, bUseSecureClientConnection(false)
 	, bUseSecureServerConnection(false)
-	, bEnableClientQueriesOnServer(true)
+	, bEnableClientQueriesOnServer(false)
 	, bUseDevelopmentAuthenticationFlow(false)
 {
 	DefaultReceptionistHost = SpatialConstants::LOCAL_HOST;

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -82,8 +82,8 @@ USpatialGDKSettings::USpatialGDKSettings(const FObjectInitializer& ObjectInitial
 	, FullFrequencyNetCullDistanceRatio(1.0f)
 	, bUseSecureClientConnection(false)
 	, bUseSecureServerConnection(false)
-	, bUseDevelopmentAuthenticationFlow(false)
 	, bEnableClientQueriesOnServer(true)
+	, bUseDevelopmentAuthenticationFlow(false)
 {
 	DefaultReceptionistHost = SpatialConstants::LOCAL_HOST;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -439,13 +439,16 @@ void InterestFactory::AddSystemQuery(Interest& OutInterest, const QueryConstrain
 
 	AddComponentQueryPairToInterestComponent(OutInterest, SpatialConstants::GetClientAuthorityComponent(Settings->UseRPCRingBuffer()), SystemQuery);
 
-	// Add the spatial constraint to the server as well to make sure the server sees the same as the client.
+	// Add the spatial and always interested constraint to the server as well to make sure the server sees the same as the client.
 	// The always relevant constraint is added as part of the server worker query, so leave that out here.
 	// Servers also don't need to be level constrained.
 	if (Settings->bEnableClientQueriesOnServer)
 	{
 		Query ServerSystemQuery;
-		ServerSystemQuery.Constraint = CheckoutRadiusConstraint;
+		QueryConstraint ServerSystemConstraint;
+		ServerSystemConstraint.OrConstraint.Add(CheckoutRadiusConstraint);
+		ServerSystemConstraint.OrConstraint.Add(AlwaysInterestedConstraint);
+		ServerSystemQuery.Constraint = ServerSystemConstraint;
 
 		SetResultType(ServerSystemQuery, ServerNonAuthInterestResultType);
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -449,7 +449,7 @@ void InterestFactory::AddSystemQuery(Interest& OutInterest, const QueryConstrain
 	// Add the spatial constraint to the server as well to make sure the server sees the same as the client.
 	// The always relevant and always interested are added as part of the server worker query, so leave that here.
 	// Servers also don't need to be level constrained.
-	if (Settings->bEnableUnrealLoadBalancer && Settings->bEnableClientQueriesOnServer)
+	if (Settings->bEnableClientQueriesOnServer)
 	{
 		Query ServerSystemQuery;
 		ServerSystemQuery.Constraint = CheckoutRadiusConstraint;
@@ -503,7 +503,7 @@ void InterestFactory::AddUserDefinedQueries(Interest& OutInterest, const AActor*
 		// Add the user interest to the server as well if load balancing is enabled and the client queries on server flag is flipped
 		// Need to check if load balancing is enabled otherwise there is not chance the client could see and entity the server can't,
 		// which is what the client queries on server flag is to avoid.
-		if (Settings->bEnableUnrealLoadBalancer && Settings->bEnableClientQueriesOnServer)
+		if (Settings->bEnableClientQueriesOnServer)
 		{
 			Query ServerUserQuery;
 			ServerUserQuery.Constraint = UserConstraint;
@@ -594,7 +594,7 @@ void InterestFactory::AddNetCullDistanceFrequencyQueries(Interest& OutInterest, 
 		AddComponentQueryPairToInterestComponent(OutInterest, SpatialConstants::GetClientAuthorityComponent(Settings->UseRPCRingBuffer()), NewQuery);
 
 		// Add the queries to the server as well to ensure that all entities checked out on the client will be present on the server.
-		if (Settings->bEnableUnrealLoadBalancer && Settings->bEnableClientQueriesOnServer)
+		if (Settings->bEnableClientQueriesOnServer)
 		{
 			Query ServerQuery;
 			ServerQuery.Constraint = CheckoutRadiusConstraintFrequencyPair.Constraint;

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -325,14 +325,7 @@ Interest InterestFactory::CreateServerWorkerInterest(const UAbstractLBStrategy* 
 	// TODO UNR-3042 : Migrate the VirtualWorkerTranslationManager to use the checked-out worker components instead of making a query.
 
 	ServerQuery = Query();
-	if (!SpatialGDKSettings->bEnableResultTypes)
-	{
-		ServerQuery.FullSnapshotResult = true;
-	}
-	else
-	{
-		ServerQuery.ResultComponentId.Add(SpatialConstants::WORKER_COMPONENT_ID);
-	}
+	SetResultType(ServerQuery, ResultType{ SpatialConstants::WORKER_COMPONENT_ID });
 	ServerQuery.Constraint.ComponentConstraint = SpatialConstants::WORKER_COMPONENT_ID;
 	AddComponentQueryPairToInterestComponent(ServerInterest, SpatialConstants::POSITION_COMPONENT_ID, ServerQuery);
 
@@ -447,7 +440,7 @@ void InterestFactory::AddSystemQuery(Interest& OutInterest, const QueryConstrain
 	AddComponentQueryPairToInterestComponent(OutInterest, SpatialConstants::GetClientAuthorityComponent(Settings->UseRPCRingBuffer()), SystemQuery);
 
 	// Add the spatial constraint to the server as well to make sure the server sees the same as the client.
-	// The always relevant and always interested are added as part of the server worker query, so leave that here.
+	// The always relevant constraint is added as part of the server worker query, so leave that out here.
 	// Servers also don't need to be level constrained.
 	if (Settings->bEnableClientQueriesOnServer)
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -432,12 +432,12 @@ void InterestFactory::AddSystemQuery(Interest& OutInterest, const QueryConstrain
 	SystemAndLevelConstraint.AndConstraint.Add(SystemDefinedConstraints);
 	SystemAndLevelConstraint.AndConstraint.Add(LevelConstraint);
 
-	Query SystemQuery;
-	SystemQuery.Constraint = SystemAndLevelConstraint;
+	Query ClientSystemQuery;
+	ClientSystemQuery.Constraint = SystemAndLevelConstraint;
 
-	SetResultType(SystemQuery, ClientNonAuthInterestResultType);
+	SetResultType(ClientSystemQuery, ClientNonAuthInterestResultType);
 
-	AddComponentQueryPairToInterestComponent(OutInterest, SpatialConstants::GetClientAuthorityComponent(Settings->UseRPCRingBuffer()), SystemQuery);
+	AddComponentQueryPairToInterestComponent(OutInterest, SpatialConstants::GetClientAuthorityComponent(Settings->UseRPCRingBuffer()), ClientSystemQuery);
 
 	// Add the spatial and always interested constraint to the server as well to make sure the server sees the same as the client.
 	// The always relevant constraint is added as part of the server worker query, so leave that out here.

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -37,7 +37,7 @@ static QueryConstraint ClientCheckoutRadiusConstraint;
 
 // Cache the result types of queries.
 static ResultType ClientNonAuthInterestResultType;
-static ResultType ClientAuthInterestResultType ;
+static ResultType ClientAuthInterestResultType;
 static ResultType ServerNonAuthInterestResultType;
 static ResultType ServerAuthInterestResultType;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -325,6 +325,12 @@ public:
 	UPROPERTY(EditAnywhere, Config, Category = "Connection")
 	bool bUseSecureServerConnection;
 
+	/**
+	 * Enable to ensure server workers always express interest such that any server is interested in a super set of
+	 * client interest. This will cause servers to make most of the same queries as their delegated client queries.
+	 * Intended to be used in development before interest in your game has been optimised to ensure correct functionality.
+	 */
+
 public:
 	// UI Hidden settings passed through from SpatialGDKEditorSettings
 	bool bUseDevelopmentAuthenticationFlow;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -328,8 +328,10 @@ public:
 	/**
 	 * Enable to ensure server workers always express interest such that any server is interested in a super set of
 	 * client interest. This will cause servers to make most of the same queries as their delegated client queries.
-	 * Intended to be used in development before interest in your game has been optimised to ensure correct functionality.
+	 * Intended to be used in development before interest due to the LB strategy ensures correct functionality.
 	 */
+	UPROPERTY(EditAnywhere, Config, Category = "Interest")
+	bool bEnableClientQueriesOnServer;
 
 public:
 	// UI Hidden settings passed through from SpatialGDKEditorSettings

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/InterestFactory.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/InterestFactory.h
@@ -16,6 +16,8 @@ DECLARE_LOG_CATEGORY_EXTERN(LogInterestFactory, Log, All);
 
 namespace SpatialGDK
 {
+using ResultType = TArray<Worker_ComponentId>;
+
 class SPATIALGDK_API InterestFactory
 {
 public:
@@ -36,10 +38,10 @@ private:
 	static QueryConstraint CreateNetCullDistanceConstraintWithFrequency(USpatialClassInfoManager* ClassInfoManager);
 
 	// Builds the result types of necessary components for clients
-	static TArray<Worker_ComponentId> CreateClientNonAuthInterestResultType(USpatialClassInfoManager* ClassInfoManager);
-	static TArray<Worker_ComponentId> CreateClientAuthInterestResultType(USpatialClassInfoManager* ClassInfoManager);
-	static TArray<Worker_ComponentId> CreateServerNonAuthInterestResultType(USpatialClassInfoManager* ClassInfoManager);
-	static TArray<Worker_ComponentId> CreateServerAuthInterestResultType(USpatialClassInfoManager* ClassInfoManager);
+	static ResultType CreateClientNonAuthInterestResultType(USpatialClassInfoManager* ClassInfoManager);
+	static ResultType CreateClientAuthInterestResultType(USpatialClassInfoManager* ClassInfoManager);
+	static ResultType CreateServerNonAuthInterestResultType(USpatialClassInfoManager* ClassInfoManager);
+	static ResultType CreateServerAuthInterestResultType(USpatialClassInfoManager* ClassInfoManager);
 
 	Interest CreateInterest() const;
 
@@ -50,16 +52,16 @@ private:
 	// The components servers need to see on entities they have authority over that they don't already see through authority.
 	void AddServerSelfInterest(Interest& OutInterest) const;
 
+	// Add the checkout radius, always relevant, or always interested query.
+	void AddSystemQuery(Interest& OutInterest, const QueryConstraint& LevelConstraint) const;
+
 	void AddUserDefinedQueries(Interest& OutInterest, const AActor* InActor, const QueryConstraint& LevelConstraint) const;
 	FrequencyToConstraintsMap GetUserDefinedFrequencyToConstraintsMap(const AActor* InActor) const;
 	void GetActorUserDefinedQueryConstraints(const AActor* InActor, FrequencyToConstraintsMap& OutFrequencyToConstraints, bool bRecurseChildren) const;
 
-	TArray<Query> GetNetCullDistanceFrequencyQueries(const QueryConstraint& LevelConstraint) const;
+	void AddNetCullDistanceFrequencyQueries(Interest& OutInterest, const QueryConstraint& LevelConstraint) const;
 
 	static void AddComponentQueryPairToInterestComponent(Interest& OutInterest, const Worker_ComponentId ComponentId, const Query& QueryToAdd);
-
-	// Checkout Constraint OR AlwaysInterested OR AlwaysRelevant Constraint
-	QueryConstraint CreateSystemDefinedConstraints() const;
 
 	// System Defined Constraints
 	QueryConstraint CreateCheckoutRadiusConstraints() const;
@@ -70,6 +72,9 @@ private:
 	QueryConstraint CreateLevelConstraints() const;	
 
 	void AddObjectToConstraint(UObjectPropertyBase* Property, uint8* Data, QueryConstraint& OutConstraint) const;
+
+	// If the result types flag is flipped, set the specified result type.
+	static void SetResultType(Query& OutQuery, const ResultType& InResultType);
 
 	AActor* Actor;
 	const FClassInfo& Info;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/InterestFactory.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/InterestFactory.h
@@ -43,8 +43,6 @@ private:
 
 	Interest CreateInterest() const;
 
-	// Only uses Defined Constraint
-	void AddActorInterest(Interest& OutInterest) const;
 	// Defined Constraint AND Level Constraint
 	void AddPlayerControllerActorInterest(Interest& OutInterest) const;
 	// The components clients need to see on entities they are have authority over that they don't already see through authority.
@@ -52,7 +50,7 @@ private:
 	// The components servers need to see on entities they have authority over that they don't already see through authority.
 	void AddServerSelfInterest(Interest& OutInterest) const;
 
-	TArray<Query> GetUserDefinedQueries(const AActor* InActor, const QueryConstraint& LevelConstraint) const;
+	void AddUserDefinedQueries(Interest& OutInterest, const AActor* InActor, const QueryConstraint& LevelConstraint) const;
 	FrequencyToConstraintsMap GetUserDefinedFrequencyToConstraintsMap(const AActor* InActor) const;
 	void GetActorUserDefinedQueryConstraints(const AActor* InActor, FrequencyToConstraintsMap& OutFrequencyToConstraints, bool bRecurseChildren) const;
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Server now makes a super set of the queries made by clients to ensure they always have the same entities checked out as any of their clients. Hidden behind a new flag which defaults true.

Also refactors the interest factory a bit to make the ever-more-complicated flow of building the interest component a little easier to follow, as this change also complicates it further. 

Includes bugfix for the no channel exists PR because it turns out it might not exist even just after the point we create it. Who would have guessed

#### Release note
Added `bEnableClientQueriesOnServer` (defaulted false) which makes the same queries on the server as on clients if the unreal load balancer is enabled. This can be enabled to avoid clients seeing entities the server does not if the server's interest query has not been configured correctly.

#### Documentation
Comments

#### Primary reviewers
@m-samiec @MatthewSandfordImprobable 