### PR TITLE
UNR-3000 Spatial Output shows startup errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - SpatialDebugger worker regions are now cuboids rather than planes, and can have their WorkerRegionVerticalScale adjusted via a setting in the SpatialDebugger.
 - Added custom warning timeouts per RPC failure condition.
 - SpatialPingComponent can now also report average ping measurements over a specified number of recent pings. You can specify the number of measurements recorded in `PingMeasurementsWindowSize` and get the measurement data by calling `GetAverageData`. There is also a delegate `OnRecordPing` that will be broadcast whenever a new ping measurement is recorded.
+- The Spatial Output Log window now displays deployment startup errors.
 
 ## Bug fixes:
 - Fixed a bug that caused the local API service to memory leak.

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -25,7 +25,7 @@ DEFINE_LOG_CATEGORY(LogSpatialDeploymentManager);
 
 #define LOCTEXT_NAMESPACE "FLocalDeploymentManager"
 
-static const FString SpatialServiceVersion(TEXT("20200120.115350.8d6b779c82"));
+static const FString SpatialServiceVersion(TEXT("20200121.174928.6ae1ccd1b7"));
 
 namespace
 {
@@ -356,7 +356,7 @@ bool FLocalDeploymentManager::FinishLocalDeployment(FString LaunchConfig, FStrin
 		}
 		else
 		{
-			UE_LOG(LogSpatialDeploymentManager, Error, TEXT("Local deployment creation failed. Deployment status: %s"), *DeploymentStatus);
+			UE_LOG(LogSpatialDeploymentManager, Error, TEXT("Local deployment creation failed. Deployment status: %s. Please check the 'Spatial Output' window for more details."), *DeploymentStatus);
 		}
 	}
 	else

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SSpatialOutputLog.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SSpatialOutputLog.cpp
@@ -257,7 +257,6 @@ void SSpatialOutputLog::StartPollTimer(const FString& LogFilePath)
 
 void SSpatialOutputLog::FormatAndPrintRawErrorLine(const FString& LogLine)
 {
-	// If this line could not be matched then it's most likely an error with a stack trace. Attempt to use the ErrorLine formatter.
 	const FRegexPattern ErrorPattern = FRegexPattern(TEXT("level=(.*) msg=(.*) code=(.*) code_string=(.*) error=(.*) stack=(.*)"));
 	FRegexMatcher ErrorMatcher(ErrorPattern, LogLine);
 
@@ -274,9 +273,7 @@ void SSpatialOutputLog::FormatAndPrintRawErrorLine(const FString& LogLine)
 	FString ErrorMessage = ErrorMatcher.GetCaptureGroup(5);
 	FString Stack = ErrorMatcher.GetCaptureGroup(6);
 
-	// TODO: Build a single cohesive log message out of this mess
-
-	// The stack message comes with partially escaped characters.
+	// The stack message comes with double escaped characters.
 	Stack = Stack.ReplaceEscapedCharWithChar();
 
 	// Format the log message to be easy to read.
@@ -284,6 +281,7 @@ void SSpatialOutputLog::FormatAndPrintRawErrorLine(const FString& LogLine)
 
 	ELogVerbosity::Type LogVerbosity = ELogVerbosity::Error;
 
+	// There are currently no logger names included in the errors from Spatial Service and so we always give it this LogCategory.
 	FString LogCategory = TEXT("SpatialService");
 
 	// Serialization must be done on the game thread.
@@ -301,6 +299,7 @@ void SSpatialOutputLog::FormatAndPrintRawLogLine(const FString& LogLine)
 
 	if (!LogMatcher.FindNext())
 	{
+		// If this line could not be matched then it's most likely an error with a stack trace. Attempt to use the ErrorLine formatter.
 		FormatAndPrintRawErrorLine(LogLine);
 		return;
 	}

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SSpatialOutputLog.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SSpatialOutputLog.cpp
@@ -279,15 +279,10 @@ void SSpatialOutputLog::FormatAndPrintRawErrorLine(const FString& LogLine)
 	// Format the log message to be easy to read.
 	FString LogMessage = FString::Printf(TEXT("%s \n Code: %s \n Code String: %s \n Error: %s \n Stack: %s"), *Message, *ErrorCode, *ErrorCodeString, *ErrorMessage, *Stack);
 
-	ELogVerbosity::Type LogVerbosity = ELogVerbosity::Error;
-
-	// There are currently no logger names included in the errors from Spatial Service and so we always give it this LogCategory.
-	FString LogCategory = TEXT("SpatialService");
-
 	// Serialization must be done on the game thread.
-	AsyncTask(ENamedThreads::GameThread, [this, LogMessage, LogVerbosity, LogCategory]
+	AsyncTask(ENamedThreads::GameThread, [this, LogMessage]
 	{
-		Serialize(*LogMessage, LogVerbosity, FName(*LogCategory));
+		Serialize(*LogMessage, ELogVerbosity::Error, FName(TEXT("SpatialService")));
 	});
 }
 
@@ -299,7 +294,7 @@ void SSpatialOutputLog::FormatAndPrintRawLogLine(const FString& LogLine)
 
 	if (!LogMatcher.FindNext())
 	{
-		// If this line could not be matched then it's most likely an error with a stack trace. Attempt to use the ErrorLine formatter.
+		// If this log line did not match the log line regex then it is an error line which is parsed differently.
 		FormatAndPrintRawErrorLine(LogLine);
 		return;
 	}

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SSpatialOutputLog.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SSpatialOutputLog.cpp
@@ -103,8 +103,12 @@ void SSpatialOutputLog::StartUpLogDirectoryWatcher(const FString& LogDirectory)
 			// Watch the log directory for changes.
 			if (!FPaths::DirectoryExists(LogDirectory))
 			{
-				UE_LOG(LogSpatialOutputLog, Error, TEXT("Local deployment log directory does not exist!"));
-				return;
+				UE_LOG(LogSpatialOutputLog, Log, TEXT("Spatial local deployment log directory '%s' does not exist. Attempting to create it."), *LogDirectory);
+				if (!FPlatformFileManager::Get().GetPlatformFile().CreateDirectoryTree(*LogDirectory))
+				{
+					UE_LOG(LogSpatialOutputLog, Error, TEXT("Could not create the spatial local deployment log directory. The Spatial Output window will not function."));
+					return;
+				}
 			}
 
 			LogDirectoryChangedDelegate = IDirectoryWatcher::FDirectoryChanged::CreateRaw(this, &SSpatialOutputLog::OnLogDirectoryChanged);

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SSpatialOutputLog.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SSpatialOutputLog.h
@@ -42,6 +42,7 @@ private:
 	void CloseLogReader();
 
 	void FormatAndPrintRawLogLine(const FString& LogLine);
+	void FormatAndPrintRawErrorLine(const FString& LogLine);
 
 	void StartUpLogDirectoryWatcher(const FString& LogDirectory);
 	void ShutdownLogDirectoryWatcher(const FString& LogDirectory);


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
PR adds the ability to read runtime errors that come from the Spatial Service.
We parse the error and do some minor formatting to present it to the user in the Spatial Output. 
Before these errors would not be printed to the `launch.log` or displayed to the user and so the user would need tribal knowledge of how to get their Spatial Service logs. The user would simply see `Local deployment startup failed! Deployment status: STOPPED` with no additional information.

What is shown to the user in the case of startup failure:
![image](https://user-images.githubusercontent.com/31517089/76091598-c5c59100-5fb5-11ea-8756-fd4d74c9a830.png)

![image](https://user-images.githubusercontent.com/31517089/76091602-cbbb7200-5fb5-11ea-9a6e-de685a2a8880.png)

#### Release note
Feature: The Spatial Output Log window now displays deployment startup errors.

#### Tests
Made the startup failure 

#### Primary reviewers
@mironec @m-samiec 