### PR TITLE
[UNR-2184] Copy Portal part of Urls so you can specify the spawn poin…

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -518,6 +518,7 @@ void USpatialNetDriver::OnGSMQuerySuccess()
 			FURL RedirectURL = FURL(&LastURL, *DeploymentMapURL, (ETravelType)WorldContext.TravelType);
 			RedirectURL.Host = LastURL.Host;
 			RedirectURL.Port = LastURL.Port;
+			RedirectURL.Portal = LastURL.Portal;
 
 			// Usually the LastURL options are added to the RedirectURL in the FURL constructor.
 			// However this is not the case when TravelType = TRAVEL_Absolute so we must do it explicitly here.

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialPlayerSpawner.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialPlayerSpawner.cpp
@@ -183,6 +183,7 @@ void USpatialPlayerSpawner::ObtainPlayerParams(FURL& LoginURL, FUniqueNetIdRepl&
 		{
 			LoginURL.AddOption(*Op);
 		}
+		LoginURL.Portal = WorldContext->LastURL.Portal;
 
 		// Send the player unique Id at login
 		OutUniqueId = LocalPlayer->GetPreferredUniqueNetId();


### PR DESCRIPTION
-------

#### Description
UE4 can specify a "Portal" on a FURL.  When the player is spawning, it will look for spawn points with this value specified, so you can have people go to a certain spawn point when first joining the game, etc.

Previous to this change we were not copying the Portal value around, so it was impossible to use this system to send players to the correct spawn points.

#### Release note
You can now use the Portal field on FURLs when joining a deployment to specify which player start you want to select.

#### Tests
These changes came from another project that has been running them for several months.

#### Documentation
Release notes. 
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.