### PR TITLE
[UNR-2859] Multi-worker dynamic components using component presence

### DIFF
--- a/SpatialGDK/Extras/schema/component_presence.schema
+++ b/SpatialGDK/Extras/schema/component_presence.schema
@@ -1,0 +1,14 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+package unreal;
+
+// The ComponentPresence component should be present on all entities that 
+// should be load-balanced. This contains a single property which is the 
+// list of component IDs that the game server should be authoritative over
+// in order to be correctly simulating the entity. This should be useful in
+// future for deducing entity completeness without critical sections but is 
+// used currently just found enabling dynamic components in a multi-worker
+// environment.
+component ComponentPresence {
+    id = 9972;
+    list<uint32> actor_component_list = 1;
+}

--- a/SpatialGDK/Extras/schema/component_presence.schema
+++ b/SpatialGDK/Extras/schema/component_presence.schema
@@ -6,7 +6,7 @@ package unreal;
 // list of component IDs that the game server should be authoritative over
 // in order to be correctly simulating the entity. This should be useful in
 // future for deducing entity completeness without critical sections but is 
-// used currently just found enabling dynamic components in a multi-worker
+// used currently just for enabling dynamic components in a multi-worker
 // environment.
 component ComponentPresence {
     id = 9972;

--- a/SpatialGDK/Extras/schema/component_presence.schema
+++ b/SpatialGDK/Extras/schema/component_presence.schema
@@ -3,11 +3,10 @@ package unreal;
 
 // The ComponentPresence component should be present on all entities that 
 // should be load-balanced. This contains a single property which is the 
-// list of component IDs that the game server should be authoritative over
-// in order to be correctly simulating the entity. This should be useful in
-// future for deducing entity completeness without critical sections but is 
-// used currently just for enabling dynamic components in a multi-worker
-// environment.
+// list of component IDs that are present on the entity. Currently, this 
+// is used for enabling dynamic components in a multi-worker environment,
+// and should be useful in future for deducing entity completeness without
+// critical sections.
 component ComponentPresence {
     id = 9972;
     list<uint32> actor_component_list = 1;

--- a/SpatialGDK/Extras/schema/component_presence.schema
+++ b/SpatialGDK/Extras/schema/component_presence.schema
@@ -9,5 +9,5 @@ package unreal;
 // critical sections.
 component ComponentPresence {
     id = 9972;
-    list<uint32> actor_component_list = 1;
+    list<uint32> component_list = 1;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -699,7 +699,7 @@ int64 USpatialActorChannel::ReplicateActor()
 				{
 					OnSubobjectDeleted(ObjectRef, RepComp.Key());
 
-					Sender->SendRemoveComponent(EntityId, NetDriver->ClassInfoManager->GetClassInfoByComponentId(ObjectRef.Offset));
+					Sender->SendRemoveComponentForClassInfo(EntityId, NetDriver->ClassInfoManager->GetClassInfoByComponentId(ObjectRef.Offset));
 				}
 
 				RepComp.Value()->CleanUp();
@@ -791,7 +791,7 @@ void USpatialActorChannel::DynamicallyAttachSubobject(UObject* Object)
 	// Check to see if we already have authority over the subobject to be added
 	if (NetDriver->StaticComponentView->HasAuthority(EntityId, Info->SchemaComponents[SCHEMA_Data]))
 	{
-		Sender->SendAddComponent(this, Object, *Info, ReplicationBytesWritten);
+		Sender->SendAddComponentForSubobject(this, Object, *Info, ReplicationBytesWritten);
 	}
 	else
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialLoadBalanceEnforcer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialLoadBalanceEnforcer.cpp
@@ -23,7 +23,6 @@ SpatialLoadBalanceEnforcer::SpatialLoadBalanceEnforcer(const PhysicalWorkerName&
 
 void SpatialLoadBalanceEnforcer::OnLoadBalancingComponentAdded(const Worker_AddComponentOp& Op)
 {
-	// Should only be passed auth intent, ACL or component presence.
 	check(HandlesComponent(Op.data.component_id));
 
 	MaybeQueueAclAssignmentRequest(Op.entity_id);
@@ -31,7 +30,6 @@ void SpatialLoadBalanceEnforcer::OnLoadBalancingComponentAdded(const Worker_AddC
 
 void SpatialLoadBalanceEnforcer::OnLoadBalancingComponentUpdated(const Worker_ComponentUpdateOp& Op)
 {
-	// Should only be passed auth intent or component presence.
 	check(HandlesComponent(Op.update.component_id));
 
 	MaybeQueueAclAssignmentRequest(Op.entity_id);
@@ -39,7 +37,6 @@ void SpatialLoadBalanceEnforcer::OnLoadBalancingComponentUpdated(const Worker_Co
 
 void SpatialLoadBalanceEnforcer::OnLoadBalancingComponentRemoved(const Worker_RemoveComponentOp& Op)
 {
-	// Should only be passed auth intent, component presence, or ACL.
 	check(HandlesComponent(Op.component_id));
 
 	if (AclAssignmentRequestIsQueued(Op.entity_id))

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialLoadBalanceEnforcer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialLoadBalanceEnforcer.cpp
@@ -181,7 +181,7 @@ TArray<SpatialLoadBalanceEnforcer::AclWriteAuthorityRequest> SpatialLoadBalanceE
 			TArray<Worker_ComponentId> ComponentIds;
 			Acl->ComponentWriteAcl.GetKeys(ComponentIds);
 			// Ensure that every component ID in ComponentPresence is set in the write ACL.
-			for (const auto& RequiredComponentId : ComponentPresenceComponent->ActorComponentList)
+			for (const auto& RequiredComponentId : ComponentPresenceComponent->ComponentList)
 			{
 				ComponentIds.AddUnique(RequiredComponentId);
 			}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -2247,7 +2247,7 @@ void USpatialNetDriver::RefreshActorDormancy(AActor* Actor, bool bMakeDormant)
 			Worker_AddComponentOp AddComponentOp{};
 			AddComponentOp.entity_id = EntityId;
 			AddComponentOp.data = ComponentFactory::CreateEmptyComponentData(SpatialConstants::DORMANT_COMPONENT_ID);
-			Sender->TrySendAddComponent(AddComponentOp.entity_id, { AddComponentOp.data });
+			Sender->SendAddComponents(AddComponentOp.entity_id, { AddComponentOp.data });
 			StaticComponentView->OnAddComponent(AddComponentOp);
 		}
 	}
@@ -2258,7 +2258,7 @@ void USpatialNetDriver::RefreshActorDormancy(AActor* Actor, bool bMakeDormant)
 			Worker_RemoveComponentOp RemoveComponentOp{};
 			RemoveComponentOp.entity_id = EntityId;
 			RemoveComponentOp.component_id = SpatialConstants::DORMANT_COMPONENT_ID;
-			Sender->SendRemoveComponentForComponentId(EntityId, SpatialConstants::DORMANT_COMPONENT_ID);
+			Sender->SendRemoveComponent(EntityId, SpatialConstants::DORMANT_COMPONENT_ID);
 			StaticComponentView->OnRemoveComponent(RemoveComponentOp);
 		}
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -2247,8 +2247,8 @@ void USpatialNetDriver::RefreshActorDormancy(AActor* Actor, bool bMakeDormant)
 			Worker_AddComponentOp AddComponentOp{};
 			AddComponentOp.entity_id = EntityId;
 			AddComponentOp.data = ComponentFactory::CreateEmptyComponentData(SpatialConstants::DORMANT_COMPONENT_ID);
-			FWorkerComponentData Data{ AddComponentOp.data };
-			Connection->SendAddComponent(AddComponentOp.entity_id, &Data);
+			TArray<FWorkerComponentData> Data = { AddComponentOp.data };
+			Sender->SendAddComponentForComponentData(AddComponentOp.entity_id, Data);
 			StaticComponentView->OnAddComponent(AddComponentOp);
 		}
 	}
@@ -2259,7 +2259,7 @@ void USpatialNetDriver::RefreshActorDormancy(AActor* Actor, bool bMakeDormant)
 			Worker_RemoveComponentOp RemoveComponentOp{};
 			RemoveComponentOp.entity_id = EntityId;
 			RemoveComponentOp.component_id = SpatialConstants::DORMANT_COMPONENT_ID;
-			Connection->SendRemoveComponent(EntityId, SpatialConstants::DORMANT_COMPONENT_ID);
+			Sender->SendRemoveComponentForComponentId(EntityId, SpatialConstants::DORMANT_COMPONENT_ID);
 			StaticComponentView->OnRemoveComponent(RemoveComponentOp);
 		}
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -2258,7 +2258,7 @@ void USpatialNetDriver::RefreshActorDormancy(AActor* Actor, bool bMakeDormant)
 			Worker_RemoveComponentOp RemoveComponentOp{};
 			RemoveComponentOp.entity_id = EntityId;
 			RemoveComponentOp.component_id = SpatialConstants::DORMANT_COMPONENT_ID;
-			Sender->SendRemoveComponent(EntityId, { SpatialConstants::DORMANT_COMPONENT_ID });
+			Sender->SendRemoveComponents(EntityId, { SpatialConstants::DORMANT_COMPONENT_ID });
 			StaticComponentView->OnRemoveComponent(RemoveComponentOp);
 		}
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -2258,7 +2258,7 @@ void USpatialNetDriver::RefreshActorDormancy(AActor* Actor, bool bMakeDormant)
 			Worker_RemoveComponentOp RemoveComponentOp{};
 			RemoveComponentOp.entity_id = EntityId;
 			RemoveComponentOp.component_id = SpatialConstants::DORMANT_COMPONENT_ID;
-			Sender->SendRemoveComponent(EntityId, SpatialConstants::DORMANT_COMPONENT_ID);
+			Sender->SendRemoveComponent(EntityId, { SpatialConstants::DORMANT_COMPONENT_ID });
 			StaticComponentView->OnRemoveComponent(RemoveComponentOp);
 		}
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -2247,8 +2247,7 @@ void USpatialNetDriver::RefreshActorDormancy(AActor* Actor, bool bMakeDormant)
 			Worker_AddComponentOp AddComponentOp{};
 			AddComponentOp.entity_id = EntityId;
 			AddComponentOp.data = ComponentFactory::CreateEmptyComponentData(SpatialConstants::DORMANT_COMPONENT_ID);
-			TArray<FWorkerComponentData> Data = { AddComponentOp.data };
-			Sender->SendAddComponentForComponentData(AddComponentOp.entity_id, Data);
+			Sender->TrySendAddComponent(AddComponentOp.entity_id, { AddComponentOp.data });
 			StaticComponentView->OnAddComponent(AddComponentOp);
 		}
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -168,6 +168,7 @@ void USpatialReceiver::OnAddComponent(const Worker_AddComponentOp& Op)
 		return;
 	case SpatialConstants::ENTITY_ACL_COMPONENT_ID:
 	case SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID:
+	case SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID:
 		if (LoadBalanceEnforcer != nullptr)
 		{
 			LoadBalanceEnforcer->OnLoadBalancingComponentAdded(Op);
@@ -297,7 +298,7 @@ void USpatialReceiver::OnRemoveComponent(const Worker_RemoveComponentOp& Op)
 		RPCService->OnRemoveMulticastRPCComponentForEntity(Op.entity_id);
 	}
 
-	if ((Op.component_id == SpatialConstants::ENTITY_ACL_COMPONENT_ID || Op.component_id == SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID) && LoadBalanceEnforcer != nullptr)
+	if (LoadBalanceEnforcer != nullptr && LoadBalanceEnforcer->HandlesComponent(Op.component_id))
 	{
 		LoadBalanceEnforcer->OnLoadBalancingComponentRemoved(Op);
 	}
@@ -1468,9 +1469,10 @@ void USpatialReceiver::OnComponentUpdate(const Worker_ComponentUpdateOp& Op)
 		HandleRPCLegacy(Op);
 		return;
 	case SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID:
+	case SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID:
 		if (NetDriver->IsServer() && (LoadBalanceEnforcer != nullptr))
 		{
-			LoadBalanceEnforcer->OnAuthorityIntentComponentUpdated(Op);
+			LoadBalanceEnforcer->OnLoadBalancingComponentUpdated(Op);
 		}
 		return;
 	case SpatialConstants::VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID:

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -612,7 +612,7 @@ void USpatialReceiver::HandleActorAuthority(const Worker_AuthorityChangeOp& Op)
 				{
 					// TODO: UNR-664 - We should track the bytes sent here and factor them into channel saturation.
 					uint32 BytesWritten = 0;
-					Sender->SendAddComponent(PendingSubobjectAttachment.Channel, Object, *PendingSubobjectAttachment.Info, BytesWritten);
+					Sender->SendAddComponentForSubobject(PendingSubobjectAttachment.Channel, Object, *PendingSubobjectAttachment.Info, BytesWritten);
 				}
 			}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1470,7 +1470,7 @@ void USpatialReceiver::OnComponentUpdate(const Worker_ComponentUpdateOp& Op)
 		return;
 	case SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID:
 	case SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID:
-		if (NetDriver->IsServer() && (LoadBalanceEnforcer != nullptr))
+		if (LoadBalanceEnforcer != nullptr)
 		{
 			LoadBalanceEnforcer->OnLoadBalancingComponentUpdated(Op);
 		}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -640,31 +640,31 @@ void USpatialSender::SetAclWriteAuthority(const SpatialLoadBalanceEnforcer::AclW
 
 	const WorkerAttributeSet OwningServerWorkerAttributeSet = { WriteWorkerId };
 
-	EntityAcl NewAcl = StaticComponentView->GetComponentData<EntityAcl>(Request.EntityId);
+	EntityAcl* NewAcl = StaticComponentView->GetComponentData<EntityAcl>(Request.EntityId);
 
-	NewAcl.ReadAcl = Request.ReadAcl;
+	NewAcl->ReadAcl = Request.ReadAcl;
 
 	for (const Worker_ComponentId& ComponentId : Request.ComponentIds)
 	{
 		if (ComponentId == SpatialConstants::HEARTBEAT_COMPONENT_ID
 			|| ComponentId == SpatialConstants::GetClientAuthorityComponent(GetDefault<USpatialGDKSettings>()->UseRPCRingBuffer()))
 		{
-			NewAcl.ComponentWriteAcl.Add(ComponentId, Request.ClientRequirementSet);
+			NewAcl->ComponentWriteAcl.Add(ComponentId, Request.ClientRequirementSet);
 			continue;
 		}
 
 		if (ComponentId == SpatialConstants::ENTITY_ACL_COMPONENT_ID)
 		{
-			NewAcl.ComponentWriteAcl.Add(ComponentId, { SpatialConstants::GetLoadBalancerAttributeSet(GetDefault<USpatialGDKSettings>()->LoadBalancingWorkerType.WorkerTypeName) });
+			NewAcl->ComponentWriteAcl.Add(ComponentId, { SpatialConstants::GetLoadBalancerAttributeSet(GetDefault<USpatialGDKSettings>()->LoadBalancingWorkerType.WorkerTypeName) });
 			continue;
 		}
 	
-		NewAcl.ComponentWriteAcl.Add(ComponentId, { OwningServerWorkerAttributeSet });
+		NewAcl->ComponentWriteAcl.Add(ComponentId, { OwningServerWorkerAttributeSet });
 	}
 
 	UE_LOG(LogSpatialLoadBalanceEnforcer, Verbose, TEXT("(%s) Setting Acl WriteAuth for entity %lld to %s"), *NetDriver->Connection->GetWorkerId(), Request.EntityId, *Request.OwningWorkerId);
 
-	FWorkerComponentUpdate Update = NewAcl.CreateEntityAclUpdate();
+	FWorkerComponentUpdate Update = NewAcl->CreateEntityAclUpdate();
 	NetDriver->Connection->SendComponentUpdate(Request.EntityId, &Update);
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -81,6 +81,8 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel, uin
 	// If the Actor was loaded rather than dynamically spawned, associate it with its owning sublevel.
 	ComponentDatas.Add(CreateLevelComponentData(Channel->Actor));
 
+	ComponentDatas.Add(ComponentPresence::CreateComponentPresenceData(EntityFactory::GetComponentPresenceList(ComponentDatas)));
+
 	Worker_EntityId EntityId = Channel->GetEntityId();
 	Worker_RequestId CreateEntityRequestId = Connection->SendCreateEntityRequest(MoveTemp(ComponentDatas), &EntityId);
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -153,7 +153,6 @@ void USpatialSender::GainAuthorityThenAddComponent(USpatialActorChannel* Channel
 
 	// We collect component IDs related to the dynamic subobject being added to gain authority over.
 	TArray<Worker_ComponentId> NewComponentIds;
-	NewComponentIds.SetNum(SCHEMA_Count);
 	ForAllSchemaComponentTypes([&](ESchemaComponentType Type)
 	{
 		Worker_ComponentId ComponentId = Info->SchemaComponents[Type];

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -162,7 +162,7 @@ void USpatialSender::GainAuthorityThenAddComponent(USpatialActorChannel* Channel
 		ComponentPresence* ComponentPresenceData = StaticComponentView->GetComponentData<ComponentPresence>(EntityId);
 		for (auto& NewComponentId : NewComponentIds)
 		{
-			ComponentPresenceData->ActorComponentList.AddUnique(NewComponentId);
+			ComponentPresenceData->ComponentList.AddUnique(NewComponentId);
 		}
 
 		FWorkerComponentUpdate Update = ComponentPresenceData->CreateComponentPresenceUpdate();
@@ -205,7 +205,7 @@ void USpatialSender::SendRemoveComponent(Worker_EntityId EntityId, const FClassI
 		check(StaticComponentView->HasAuthority(EntityId, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID));
 
 		ComponentPresence* ComponentPresenceData = StaticComponentView->GetComponentData<ComponentPresence>(EntityId);
-		TArray<Worker_ComponentId>* ActorComponentList = &ComponentPresenceData->ActorComponentList;
+		TArray<Worker_ComponentId>* ActorComponentList = &ComponentPresenceData->ComponentList;
 		for (auto RequiredComponentIt = ActorComponentList->CreateIterator(); RequiredComponentIt; RequiredComponentIt++)
 		{
 			if (ComponentsToRemove.Contains(*RequiredComponentIt))

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -192,15 +192,13 @@ void USpatialSender::GainAuthorityThenAddComponent(USpatialActorChannel* Channel
 
 	// Update the ComponentPresence component with the new component IDs. If this worker does not have EntityACL
 	// authority, this component is used to inform the enforcer of the component IDs to add to the EntityACL.
-	{
-		check(StaticComponentView->HasAuthority(EntityId, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID));
+	check(StaticComponentView->HasAuthority(EntityId, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID));
 
-		ComponentPresence* ComponentPresenceData = StaticComponentView->GetComponentData<ComponentPresence>(EntityId);
-		ComponentPresenceData->AddComponentIds(NewComponentIds);
+	ComponentPresence* ComponentPresenceData = StaticComponentView->GetComponentData<ComponentPresence>(EntityId);
+	ComponentPresenceData->AddComponentIds(NewComponentIds);
 
-		FWorkerComponentUpdate Update = ComponentPresenceData->CreateComponentPresenceUpdate();
-		Connection->SendComponentUpdate(Channel->GetEntityId(), &Update);
-	}
+	FWorkerComponentUpdate Update = ComponentPresenceData->CreateComponentPresenceUpdate();
+	Connection->SendComponentUpdate(Channel->GetEntityId(), &Update);
 }
 
 void USpatialSender::SendRemoveComponentForClassInfo(Worker_EntityId EntityId, const FClassInfo& Info)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -152,10 +152,13 @@ void USpatialSender::GainAuthorityThenAddComponent(USpatialActorChannel* Channel
 		}
 	});
 
-	// If the load balancer is enabled and we're not EntityACL authoritative, we need to use the ComponentPresence
-	// component to inform the enforcer worker with the list of component IDs to gain authority over.
-	if (GetDefault<USpatialGDKSettings>()->bEnableUnrealLoadBalancer && !StaticComponentView->HasAuthority(EntityId, SpatialConstants::ENTITY_ACL_COMPONENT_ID))
+	// If the load balancer is enabled and we're not EntityACL authoritative, we need to update the ComponentPresence
+	// component with the new component IDs. If this worker does not have EntityACL authority, this is used to inform
+	// the enforcer of the component IDs to add to the EntityACL.
+	if (GetDefault<USpatialGDKSettings>()->bEnableUnrealLoadBalancer)
 	{
+		check(StaticComponentView->HasAuthority(EntityId, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID));
+
 		ComponentPresence* ComponentPresenceData = StaticComponentView->GetComponentData<ComponentPresence>(EntityId);
 		for (auto& NewComponentId : NewComponentIds)
 		{
@@ -165,8 +168,9 @@ void USpatialSender::GainAuthorityThenAddComponent(USpatialActorChannel* Channel
 		FWorkerComponentUpdate Update = ComponentPresenceData->CreateComponentPresenceUpdate();
 		Connection->SendComponentUpdate(Channel->GetEntityId(), &Update);
 	}
-	// Otherwise, we're EntityACL authoritative, and we can directly update the component IDs to gain authority over.
-	else
+
+	// If this worker is EntityACL authoritative, we can directly update the component IDs to gain authority over.
+	if (StaticComponentView->HasAuthority(EntityId, SpatialConstants::ENTITY_ACL_COMPONENT_ID))
 	{
 		const FClassInfo& ActorInfo = ClassInfoManager->GetOrCreateClassInfoByClass(Channel->Actor->GetClass());
 		const WorkerAttributeSet WorkerAttribute{ ActorInfo.WorkerType.ToString() };
@@ -198,6 +202,8 @@ void USpatialSender::SendRemoveComponent(Worker_EntityId EntityId, const FClassI
 	// If load-balancing is enabled, we need to update the ComponentPresence ID list.
 	if (GetDefault<USpatialGDKSettings>()->bEnableUnrealLoadBalancer)
 	{
+		check(StaticComponentView->HasAuthority(EntityId, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID));
+
 		ComponentPresence* ComponentPresenceData = StaticComponentView->GetComponentData<ComponentPresence>(EntityId);
 		TArray<Worker_ComponentId>* ActorComponentList = &ComponentPresenceData->ActorComponentList;
 		for (auto RequiredComponentIt = ActorComponentList->CreateIterator(); RequiredComponentIt; RequiredComponentIt++)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -214,16 +214,14 @@ void USpatialSender::SendRemoveComponentForClassInfo(Worker_EntityId EntityId, c
 	}
 
 	// Update ComponentPresence.
-	{
-		check(StaticComponentView->HasAuthority(EntityId, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID));
+	check(StaticComponentView->HasAuthority(EntityId, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID));
 
-		ComponentPresence* ComponentPresenceData = StaticComponentView->GetComponentData<ComponentPresence>(EntityId);
-		const bool bRemovedComponents = ComponentPresenceData->RemoveComponentIds(ComponentsToRemove);
-		if (bRemovedComponents)
-		{
-			FWorkerComponentUpdate Update = ComponentPresenceData->CreateComponentPresenceUpdate();
-			Connection->SendComponentUpdate(EntityId, &Update);
-		}
+	ComponentPresence* ComponentPresenceData = StaticComponentView->GetComponentData<ComponentPresence>(EntityId);
+	const bool bRemovedComponents = ComponentPresenceData->RemoveComponentIds(ComponentsToRemove);
+	if (bRemovedComponents)
+	{
+		FWorkerComponentUpdate Update = ComponentPresenceData->CreateComponentPresenceUpdate();
+		Connection->SendComponentUpdate(EntityId, &Update);
 	}
 
 	PackageMap->RemoveSubobject(FUnrealObjectRef(EntityId, Info.SchemaComponents[SCHEMA_Data]));

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStaticComponentView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStaticComponentView.cpp
@@ -6,6 +6,7 @@
 #include "Schema/ClientEndpoint.h"
 #include "Schema/ClientRPCEndpointLegacy.h"
 #include "Schema/Component.h"
+#include "Schema/ComponentPresence.h"
 #include "Schema/Heartbeat.h"
 #include "Schema/Interest.h"
 #include "Schema/MulticastRPCs.h"
@@ -104,6 +105,9 @@ void USpatialStaticComponentView::OnAddComponent(const Worker_AddComponentOp& Op
 	case SpatialConstants::SPATIAL_DEBUGGING_COMPONENT_ID:
 		Data = MakeUnique<SpatialGDK::SpatialDebugging>(Op.data);
 		break;
+	case SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID:
+		Data = MakeUnique<SpatialGDK::ComponentPresence>(Op.data);
+		break;
 	default:
 		// Component is not hand written, but we still want to know the existence of it on this entity.
 		Data = nullptr;
@@ -157,6 +161,9 @@ void USpatialStaticComponentView::OnComponentUpdate(const Worker_ComponentUpdate
 		break;
 	case SpatialConstants::SPATIAL_DEBUGGING_COMPONENT_ID:
 		Component = GetComponentData<SpatialGDK::SpatialDebugging>(Op.entity_id);
+		break;
+	case SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID:
+		Component = GetComponentData<SpatialGDK::ComponentPresence>(Op.entity_id);
 		break;
 	default:
 		return;

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -413,11 +413,12 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 
 		// Populate the ComponentPresence component with the list of initially present component IDs.
 		TArray<Worker_ComponentId> ComponentPresenceList;
-		ComponentPresenceList.Init(ComponentDatas.Num());
+		ComponentPresenceList.SetNum(ComponentDatas.Num() + 1);
 		for (int i = 0; i < ComponentDatas.Num(); i++)
 		{
 			ComponentPresenceList[i] = ComponentDatas[i].component_id;
 		}
+		ComponentPresenceList[ComponentDatas.Num()] = ComponentPresence::ComponentId;
 		ComponentDatas.Add(ComponentPresence::CreateComponentPresenceData(ComponentPresenceList));
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -411,9 +411,13 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 	{
 		ComponentWriteAcl.Add(ComponentPresence::ComponentId, AuthoritativeWorkerRequirementSet);
 
-		// Populate the ComponentPresence component with the list of initially assigned component IDs.
+		// Populate the ComponentPresence component with the list of initially present component IDs.
 		TArray<Worker_ComponentId> ComponentPresenceList;
-		ComponentWriteAcl.GenerateKeyArray(ComponentPresenceList);
+		ComponentPresenceList.Init(ComponentData.Num());
+		for (int i = 0; i < ComponentDatas.Num(); i++)
+		{
+			ComponentPresenceList[i] = ComponentDatas[i].component_id;
+		}
 		ComponentDatas.Add(ComponentPresence::CreateComponentPresenceData(ComponentPresenceList));
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -413,7 +413,7 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 
 		// Populate the ComponentPresence component with the list of initially present component IDs.
 		TArray<Worker_ComponentId> ComponentPresenceList;
-		ComponentPresenceList.Init(ComponentData.Num());
+		ComponentPresenceList.Init(ComponentDatas.Num());
 		for (int i = 0; i < ComponentDatas.Num(); i++)
 		{
 			ComponentPresenceList[i] = ComponentDatas[i].component_id;

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -9,6 +9,7 @@
 #include "Interop/SpatialRPCService.h"
 #include "LoadBalancing/AbstractLBStrategy.h"
 #include "Schema/AuthorityIntent.h"
+#include "Schema/ComponentPresence.h"
 #include "Schema/Heartbeat.h"
 #include "Schema/ClientRPCEndpointLegacy.h"
 #include "Schema/ServerRPCEndpointLegacy.h"
@@ -403,6 +404,17 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 		ComponentDatas.Add(SubobjectHandoverData);
 
 		ComponentWriteAcl.Add(SubobjectInfo.SchemaComponents[SCHEMA_Handover], AuthoritativeWorkerRequirementSet);
+	}
+
+	// Add ComponentPresence to the entity.
+	if (SpatialSettings->bEnableUnrealLoadBalancer)
+	{
+		ComponentWriteAcl.Add(ComponentPresence::ComponentId, AuthoritativeWorkerRequirementSet);
+
+		// Populate the ComponentPresence component with the list of initially assigned component IDs.
+		TArray<Worker_ComponentId> ComponentPresenceList;
+		ComponentWriteAcl.GenerateKeyArray(ComponentPresenceList);
+		ComponentDatas.Add(ComponentPresence::CreateComponentPresenceData(ComponentPresenceList));
 	}
 
 	ComponentDatas.Add(EntityAcl(ReadAcl, ComponentWriteAcl).CreateEntityAclData());

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -410,8 +410,6 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 
 	ComponentDatas.Add(EntityAcl(ReadAcl, ComponentWriteAcl).CreateEntityAclData());
 
-	ComponentDatas.Add(ComponentPresence::CreateComponentPresenceData(EntityFactory::GetComponentPresenceList(ComponentDatas)));
-
 	return ComponentDatas;
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -243,7 +243,7 @@ void InterestFactory::AddServerSelfInterest(Interest& OutInterest, const Worker_
 	// Add a query for the load balancing worker (whoever is delegated the ACL) to read the authority intent
 	Query LoadBalanceQuery;
 	LoadBalanceQuery.Constraint.EntityIdConstraint = EntityId;
-	LoadBalanceQuery.ResultComponentIds = ResultType{ SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID };
+	LoadBalanceQuery.ResultComponentIds = ResultType{ SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID };
 	AddComponentQueryPairToInterestComponent(OutInterest, SpatialConstants::ENTITY_ACL_COMPONENT_ID, LoadBalanceQuery);
 }
 
@@ -331,7 +331,7 @@ void InterestFactory::AddUserDefinedQueries(Interest& OutInterest, const AActor*
 		// queries are for their players to check out more actors than they normally would, so use the client non auth result type,
 		// which includes all components required for a client to see non-authoritative actors.
 		SetResultType(UserQuery, ClientNonAuthInterestResultType);
-		
+
 		AddComponentQueryPairToInterestComponent(OutInterest, SpatialConstants::GetClientAuthorityComponent(Settings->UseRPCRingBuffer()), UserQuery);
 
 		// Add the user interest to the server as well if load balancing is enabled and the client queries on server flag is flipped

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
@@ -291,8 +291,7 @@ void ASpatialDebugger::ActorAuthorityChanged(const Worker_AuthorityChangeOp& Aut
 		{
 			// Some entities won't have debug info, so create it now.
 			SpatialDebugging NewDebuggingInfo(LocalVirtualWorkerId, LocalVirtualWorkerColor, SpatialConstants::INVALID_VIRTUAL_WORKER_ID, InvalidServerTintColor, false);
-			TArray<FWorkerComponentData> DebuggingData = { NewDebuggingInfo.CreateSpatialDebuggingData() };
-			NetDriver->Sender->SendAddComponentForComponentData(AuthOp.entity_id, DebuggingData);
+			NetDriver->Sender->TrySendAddComponent(AuthOp.entity_id, { NewDebuggingInfo.CreateSpatialDebuggingData() });
 			return;
 		}
 		else

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
@@ -291,7 +291,7 @@ void ASpatialDebugger::ActorAuthorityChanged(const Worker_AuthorityChangeOp& Aut
 		{
 			// Some entities won't have debug info, so create it now.
 			SpatialDebugging NewDebuggingInfo(LocalVirtualWorkerId, LocalVirtualWorkerColor, SpatialConstants::INVALID_VIRTUAL_WORKER_ID, InvalidServerTintColor, false);
-			NetDriver->Sender->TrySendAddComponent(AuthOp.entity_id, { NewDebuggingInfo.CreateSpatialDebuggingData() });
+			NetDriver->Sender->SendAddComponents(AuthOp.entity_id, { NewDebuggingInfo.CreateSpatialDebuggingData() });
 			return;
 		}
 		else

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
@@ -4,6 +4,7 @@
 
 #include "EngineClasses/SpatialNetDriver.h"
 #include "Interop/SpatialReceiver.h"
+#include "Interop/SpatialSender.h"
 #include "Interop/SpatialStaticComponentView.h"
 #include "LoadBalancing/WorkerRegion.h"
 #include "Schema/AuthorityIntent.h"
@@ -290,8 +291,8 @@ void ASpatialDebugger::ActorAuthorityChanged(const Worker_AuthorityChangeOp& Aut
 		{
 			// Some entities won't have debug info, so create it now.
 			SpatialDebugging NewDebuggingInfo(LocalVirtualWorkerId, LocalVirtualWorkerColor, SpatialConstants::INVALID_VIRTUAL_WORKER_ID, InvalidServerTintColor, false);
-			FWorkerComponentData DebuggingData = NewDebuggingInfo.CreateSpatialDebuggingData();
-			NetDriver->Connection->SendAddComponent(AuthOp.entity_id, &DebuggingData);
+			TArray<FWorkerComponentData> DebuggingData = { NewDebuggingInfo.CreateSpatialDebuggingData() };
+			NetDriver->Sender->SendAddComponentForComponentData(AuthOp.entity_id, DebuggingData);
 			return;
 		}
 		else

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialLoadBalanceEnforcer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialLoadBalanceEnforcer.h
@@ -27,9 +27,10 @@ public:
 
 	SpatialLoadBalanceEnforcer(const PhysicalWorkerName& InWorkerId, const USpatialStaticComponentView* InStaticComponentView, const SpatialVirtualWorkerTranslator* InVirtualWorkerTranslator);
 
+	bool HandlesComponent(Worker_ComponentId ComponentId) const;
 
-	void OnAuthorityIntentComponentUpdated(const Worker_ComponentUpdateOp& Op);
 	void OnLoadBalancingComponentAdded(const Worker_AddComponentOp& Op);
+	void OnLoadBalancingComponentUpdated(const Worker_ComponentUpdateOp& Op);
 	void OnLoadBalancingComponentRemoved(const Worker_RemoveComponentOp& Op);
 	void OnEntityRemoved(const Worker_RemoveEntityOp& Op);
 	void OnAclAuthorityChanged(const Worker_AuthorityChangeOp& AuthOp);
@@ -41,7 +42,6 @@ public:
 	TArray<AclWriteAuthorityRequest> ProcessQueuedAclAssignmentRequests();
 
 private:
-
 	void QueueAclAssignmentRequest(const Worker_EntityId EntityId);
 	bool CanEnforce(Worker_EntityId EntityId) const;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -83,7 +83,7 @@ public:
 	void SendEmptyCommandResponse(Worker_ComponentId ComponentId, Schema_FieldId CommandIndex, Worker_RequestId RequestId);
 	void SendCommandFailure(Worker_RequestId RequestId, const FString& Message);
 	void SendAddComponentForSubobject(USpatialActorChannel* Channel, UObject* Subobject, const FClassInfo& Info, uint32& OutBytesWritten);
-	void SendAddComponentForComponentData(Worker_EntityId EntityId, TArray<FWorkerComponentData>& ComponentDatas);
+	void TrySendAddComponent(Worker_EntityId EntityId, TArray<FWorkerComponentData> ComponentDatas);
 	void SendRemoveComponentForClassInfo(Worker_EntityId EntityId, const FClassInfo& Info);
 	void SendRemoveComponentForComponentId(Worker_EntityId EntityId, Worker_ComponentId ComponentId);
 	void SendInterestBucketComponentChange(const Worker_EntityId EntityId, const Worker_ComponentId OldComponent, const Worker_ComponentId NewComponent);

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -85,7 +85,7 @@ public:
 	void SendAddComponentForSubobject(USpatialActorChannel* Channel, UObject* Subobject, const FClassInfo& Info, uint32& OutBytesWritten);
 	void SendAddComponents(Worker_EntityId EntityId, TArray<FWorkerComponentData> ComponentDatas);
 	void SendRemoveComponentForClassInfo(Worker_EntityId EntityId, const FClassInfo& Info);
-	void SendRemoveComponent(Worker_EntityId EntityId, Worker_ComponentId ComponentId);
+	void SendRemoveComponents(Worker_EntityId EntityId, TArray<Worker_ComponentId> ComponentIds);
 	void SendInterestBucketComponentChange(const Worker_EntityId EntityId, const Worker_ComponentId OldComponent, const Worker_ComponentId NewComponent);
 
 	void SendCreateEntityRequest(USpatialActorChannel* Channel, uint32& OutBytesWritten);

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -83,9 +83,9 @@ public:
 	void SendEmptyCommandResponse(Worker_ComponentId ComponentId, Schema_FieldId CommandIndex, Worker_RequestId RequestId);
 	void SendCommandFailure(Worker_RequestId RequestId, const FString& Message);
 	void SendAddComponentForSubobject(USpatialActorChannel* Channel, UObject* Subobject, const FClassInfo& Info, uint32& OutBytesWritten);
-	void TrySendAddComponent(Worker_EntityId EntityId, TArray<FWorkerComponentData> ComponentDatas);
+	void SendAddComponents(Worker_EntityId EntityId, TArray<FWorkerComponentData> ComponentDatas);
 	void SendRemoveComponentForClassInfo(Worker_EntityId EntityId, const FClassInfo& Info);
-	void SendRemoveComponentForComponentId(Worker_EntityId EntityId, Worker_ComponentId ComponentId);
+	void SendRemoveComponent(Worker_EntityId EntityId, Worker_ComponentId ComponentId);
 	void SendInterestBucketComponentChange(const Worker_EntityId EntityId, const Worker_ComponentId OldComponent, const Worker_ComponentId NewComponent);
 
 	void SendCreateEntityRequest(USpatialActorChannel* Channel, uint32& OutBytesWritten);

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -82,8 +82,10 @@ public:
 	void SendCommandResponse(Worker_RequestId RequestId, Worker_CommandResponse& Response);
 	void SendEmptyCommandResponse(Worker_ComponentId ComponentId, Schema_FieldId CommandIndex, Worker_RequestId RequestId);
 	void SendCommandFailure(Worker_RequestId RequestId, const FString& Message);
-	void SendAddComponent(USpatialActorChannel* Channel, UObject* Subobject, const FClassInfo& Info, uint32& OutBytesWritten);
-	void SendRemoveComponent(Worker_EntityId EntityId, const FClassInfo& Info);
+	void SendAddComponentForSubobject(USpatialActorChannel* Channel, UObject* Subobject, const FClassInfo& Info, uint32& OutBytesWritten);
+	void SendAddComponentForComponentData(Worker_EntityId EntityId, TArray<FWorkerComponentData>& ComponentDatas);
+	void SendRemoveComponentForClassInfo(Worker_EntityId EntityId, const FClassInfo& Info);
+	void SendRemoveComponentForComponentId(Worker_EntityId EntityId, Worker_ComponentId ComponentId);
 	void SendInterestBucketComponentChange(const Worker_EntityId EntityId, const Worker_ComponentId OldComponent, const Worker_ComponentId NewComponent);
 
 	void SendCreateEntityRequest(USpatialActorChannel* Channel, uint32& OutBytesWritten);

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/ComponentPresence.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/ComponentPresence.h
@@ -1,0 +1,86 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "Schema/Component.h"
+#include "SpatialCommonTypes.h"
+#include "Utils/SchemaUtils.h"
+
+#include <WorkerSDK/improbable/c_schema.h>
+
+namespace SpatialGDK
+{
+
+struct ComponentPresence : Component
+	{
+	static const Worker_ComponentId ComponentId = SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID;
+
+	ComponentPresence() = default;
+
+	ComponentPresence(TArray<Worker_ComponentId> InActorComponentList)
+		: ActorComponentList(InActorComponentList)
+	{}
+
+	ComponentPresence(const Worker_ComponentData& Data)
+	{
+		Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
+		CopyListFromComponentObject(ComponentObject);
+	}
+
+	Worker_ComponentData CreateComponentPresenceData()
+	{
+		return CreateComponentPresenceData(ActorComponentList);
+	}
+
+	static Worker_ComponentData CreateComponentPresenceData(const TArray<Worker_ComponentId>& ActorComponentList)
+	{
+		Worker_ComponentData Data = {};
+		Data.component_id = ComponentId;
+		Data.schema_type = Schema_CreateComponentData();
+		Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
+
+		for (int32 i = 0; i < ActorComponentList.Num(); ++i)
+		{
+			Schema_AddUint32(ComponentObject, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_LIST_ID, ActorComponentList[i]);
+		}
+
+		return Data;
+	}
+
+	Worker_ComponentUpdate CreateComponentPresenceUpdate()
+	{
+		return CreateComponentPresenceUpdate(ActorComponentList);
+	}
+
+	static Worker_ComponentUpdate CreateComponentPresenceUpdate(const TArray<Worker_ComponentId>& ActorComponentList)
+	{
+		Worker_ComponentUpdate Update = {};
+		Update.component_id = ComponentId;
+		Update.schema_type = Schema_CreateComponentUpdate();
+		Schema_Object* ComponentObject = Schema_GetComponentUpdateFields(Update.schema_type);
+
+		Schema_AddUint32List(ComponentObject, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_LIST_ID,
+			ActorComponentList.GetData(), ActorComponentList.Num());
+
+		return Update;
+	}
+
+	void ApplyComponentUpdate(const Worker_ComponentUpdate& Update)
+	{
+		Schema_Object* ComponentObject = Schema_GetComponentUpdateFields(Update.schema_type);
+		CopyListFromComponentObject(ComponentObject);
+	}
+
+	void CopyListFromComponentObject(Schema_Object* ComponentObject)
+	{
+		ActorComponentList.SetNum(Schema_GetUint32Count(ComponentObject, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_LIST_ID), true);
+		Schema_GetUint32List(ComponentObject, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_LIST_ID, ActorComponentList.GetData());
+	}
+
+	// List of component IDs on a SpatialOS entity representing an Actor that a worker simulating
+	// should have authority over.
+	TArray<Worker_ComponentId> ActorComponentList;
+};
+
+} // namespace SpatialGDK
+

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/ComponentPresence.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/ComponentPresence.h
@@ -4,7 +4,10 @@
 
 #include "Schema/Component.h"
 #include "SpatialCommonTypes.h"
+#include "SpatialConstants.h"
 #include "Utils/SchemaUtils.h"
+
+#include "Containers/Array.h"
 
 #include <WorkerSDK/improbable/c_schema.h>
 
@@ -12,7 +15,7 @@ namespace SpatialGDK
 {
 
 struct ComponentPresence : Component
-	{
+{
 	static const Worker_ComponentId ComponentId = SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID;
 
 	ComponentPresence() = default;

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/ComponentPresence.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/ComponentPresence.h
@@ -75,7 +75,7 @@ struct ComponentPresence : Component
 		Schema_GetUint32List(ComponentObject, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_LIST_ID, ComponentList.GetData());
 	}
 
-	bool AddComponentDataIds(const TArray<FWorkerComponentData>& ComponentDatas)
+	void AddComponentDataIds(const TArray<FWorkerComponentData>& ComponentDatas)
 	{
 		TArray<Worker_ComponentId> ComponentIds;
 		ComponentIds.SetNum(ComponentDatas.Num());
@@ -84,34 +84,23 @@ struct ComponentPresence : Component
 			ComponentIds.Add(ComponentData.component_id);
 		}
 
-		return AddComponentIds(ComponentIds);
+		AddComponentIds(ComponentIds);
 	}
 
-	bool AddComponentIds(const TArray<Worker_ComponentId>& ComponentsToAdd)
+	void AddComponentIds(const TArray<Worker_ComponentId>& ComponentsToAdd)
 	{
-		const int32 OldPresentComponentCount = ComponentList.Num();
-
 		for (auto& NewComponentId : ComponentsToAdd)
 		{
 			ComponentList.AddUnique(NewComponentId);
 		}
-
-		return OldPresentComponentCount != ComponentList.Num();
 	}
 
-	bool RemoveComponentIds(const TArray<Worker_ComponentId>& ComponentsToRemove)
+	void RemoveComponentIds(const TArray<Worker_ComponentId>& ComponentsToRemove)
 	{
-		const int32 OldPresentComponentCount = ComponentList.Num();
-
-		for (auto RequiredComponentIt = ComponentList.CreateIterator(); RequiredComponentIt; RequiredComponentIt++)
+		ComponentList.RemoveAll([&](Worker_ComponentId PresentComponent)
 		{
-			if (ComponentsToRemove.Contains(*RequiredComponentIt))
-			{
-				RequiredComponentIt.RemoveCurrent();
-			}
-		}
-
-		return OldPresentComponentCount != ComponentList.Num();
+			return ComponentsToRemove.Contains(PresentComponent);
+		});
 	}
 
 	// List of component IDs that exist on an entity.

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/ComponentPresence.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/ComponentPresence.h
@@ -75,6 +75,45 @@ struct ComponentPresence : Component
 		Schema_GetUint32List(ComponentObject, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_LIST_ID, ComponentList.GetData());
 	}
 
+	bool AddComponentDataIds(const TArray<FWorkerComponentData>& ComponentDatas)
+	{
+		TArray<Worker_ComponentId> ComponentIds;
+		ComponentIds.SetNum(ComponentDatas.Num());
+		for (const FWorkerComponentData& ComponentData : ComponentDatas)
+		{
+			ComponentIds.Add(ComponentData.component_id);
+		}
+
+		return AddComponentIds(ComponentIds);
+	}
+
+	bool AddComponentIds(const TArray<Worker_ComponentId>& ComponentsToAdd)
+	{
+		const int32 OldPresentComponentCount = ComponentList.Num();
+
+		for (auto& NewComponentId : ComponentsToAdd)
+		{
+			ComponentList.AddUnique(NewComponentId);
+		}
+
+		return OldPresentComponentCount != ComponentList.Num();
+	}
+
+	bool RemoveComponentIds(const TArray<Worker_ComponentId>& ComponentsToRemove)
+	{
+		const int32 OldPresentComponentCount = ComponentList.Num();
+
+		for (auto RequiredComponentIt = ComponentList.CreateIterator(); RequiredComponentIt; RequiredComponentIt++)
+		{
+			if (ComponentsToRemove.Contains(*RequiredComponentIt))
+			{
+				RequiredComponentIt.RemoveCurrent();
+			}
+		}
+
+		return OldPresentComponentCount != ComponentList.Num();
+	}
+
 	// List of component IDs that exist on an entity.
 	TArray<Worker_ComponentId> ComponentList;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/ComponentPresence.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/ComponentPresence.h
@@ -20,8 +20,8 @@ struct ComponentPresence : Component
 
 	ComponentPresence() = default;
 
-	ComponentPresence(TArray<Worker_ComponentId> InActorComponentList)
-		: ComponentList(InActorComponentList)
+	ComponentPresence(TArray<Worker_ComponentId>&& InActorComponentList)
+		: ComponentList(MoveTemp(InActorComponentList))
 	{}
 
 	ComponentPresence(const Worker_ComponentData& Data)
@@ -42,9 +42,9 @@ struct ComponentPresence : Component
 		Data.schema_type = Schema_CreateComponentData();
 		Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
 
-		for (const Worker_ComponentId& ComponentId : ComponentList)
+		for (const Worker_ComponentId& InComponentId : ComponentList)
 		{
-			Schema_AddUint32(ComponentObject, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_LIST_ID, ComponentId);
+			Schema_AddUint32(ComponentObject, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_LIST_ID, InComponentId);
 		}
 
 		return Data;

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/ComponentPresence.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/ComponentPresence.h
@@ -80,10 +80,9 @@ struct ComponentPresence : Component
 		Schema_GetUint32List(ComponentObject, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_LIST_ID, ActorComponentList.GetData());
 	}
 
-	// List of component IDs on a SpatialOS entity representing an Actor that a worker simulating
+	// List of component IDs on a SpatialOS entity representing an Actor that a simulating worker 
 	// should have authority over.
 	TArray<Worker_ComponentId> ActorComponentList;
 };
 
 } // namespace SpatialGDK
-

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/ComponentPresence.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/ComponentPresence.h
@@ -42,9 +42,9 @@ struct ComponentPresence : Component
 		Data.schema_type = Schema_CreateComponentData();
 		Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
 
-		for (int32 i = 0; i < ComponentList.Num(); ++i)
+		for (const Worker_ComponentId& ComponentId : ComponentList)
 		{
-			Schema_AddUint32(ComponentObject, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_LIST_ID, ComponentList[i]);
+			Schema_AddUint32(ComponentObject, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_LIST_ID, ComponentId);
 		}
 
 		return Data;
@@ -89,7 +89,7 @@ struct ComponentPresence : Component
 
 	void AddComponentIds(const TArray<Worker_ComponentId>& ComponentsToAdd)
 	{
-		for (auto& NewComponentId : ComponentsToAdd)
+		for (const Worker_ComponentId& NewComponentId : ComponentsToAdd)
 		{
 			ComponentList.AddUnique(NewComponentId);
 		}

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/ComponentPresence.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/ComponentPresence.h
@@ -21,7 +21,7 @@ struct ComponentPresence : Component
 	ComponentPresence() = default;
 
 	ComponentPresence(TArray<Worker_ComponentId> InActorComponentList)
-		: ActorComponentList(InActorComponentList)
+		: ComponentList(InActorComponentList)
 	{}
 
 	ComponentPresence(const Worker_ComponentData& Data)
@@ -32,19 +32,19 @@ struct ComponentPresence : Component
 
 	Worker_ComponentData CreateComponentPresenceData()
 	{
-		return CreateComponentPresenceData(ActorComponentList);
+		return CreateComponentPresenceData(ComponentList);
 	}
 
-	static Worker_ComponentData CreateComponentPresenceData(const TArray<Worker_ComponentId>& ActorComponentList)
+	static Worker_ComponentData CreateComponentPresenceData(const TArray<Worker_ComponentId>& ComponentList)
 	{
 		Worker_ComponentData Data = {};
 		Data.component_id = ComponentId;
 		Data.schema_type = Schema_CreateComponentData();
 		Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
 
-		for (int32 i = 0; i < ActorComponentList.Num(); ++i)
+		for (int32 i = 0; i < ComponentList.Num(); ++i)
 		{
-			Schema_AddUint32(ComponentObject, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_LIST_ID, ActorComponentList[i]);
+			Schema_AddUint32(ComponentObject, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_LIST_ID, ComponentList[i]);
 		}
 
 		return Data;
@@ -58,7 +58,7 @@ struct ComponentPresence : Component
 		Schema_Object* ComponentObject = Schema_GetComponentUpdateFields(Update.schema_type);
 
 		Schema_AddUint32List(ComponentObject, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_LIST_ID,
-			ActorComponentList.GetData(), ActorComponentList.Num());
+			ComponentList.GetData(), ComponentList.Num());
 
 		return Update;
 	}
@@ -71,13 +71,12 @@ struct ComponentPresence : Component
 
 	void CopyListFromComponentObject(Schema_Object* ComponentObject)
 	{
-		ActorComponentList.SetNum(Schema_GetUint32Count(ComponentObject, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_LIST_ID), true);
-		Schema_GetUint32List(ComponentObject, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_LIST_ID, ActorComponentList.GetData());
+		ComponentList.SetNum(Schema_GetUint32Count(ComponentObject, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_LIST_ID), true);
+		Schema_GetUint32List(ComponentObject, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_LIST_ID, ComponentList.GetData());
 	}
 
-	// List of component IDs on a SpatialOS entity representing an Actor that a simulating worker 
-	// should have authority over.
-	TArray<Worker_ComponentId> ActorComponentList;
+	// List of component IDs that exist on an entity.
+	TArray<Worker_ComponentId> ComponentList;
 };
 
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/ComponentPresence.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/ComponentPresence.h
@@ -52,11 +52,6 @@ struct ComponentPresence : Component
 
 	Worker_ComponentUpdate CreateComponentPresenceUpdate()
 	{
-		return CreateComponentPresenceUpdate(ActorComponentList);
-	}
-
-	static Worker_ComponentUpdate CreateComponentPresenceUpdate(const TArray<Worker_ComponentId>& ActorComponentList)
-	{
 		Worker_ComponentUpdate Update = {};
 		Update.component_id = ComponentId;
 		Update.schema_type = Schema_CreateComponentUpdate();

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/ComponentPresence.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/ComponentPresence.h
@@ -78,9 +78,12 @@ struct ComponentPresence : Component
 	void AddComponentDataIds(const TArray<FWorkerComponentData>& ComponentDatas)
 	{
 		TArray<Worker_ComponentId> ComponentIds;
-		ComponentIds.SetNum(ComponentDatas.Num());
 		for (const FWorkerComponentData& ComponentData : ComponentDatas)
 		{
+			if (ComponentData.component_id == 0)
+			{
+				UE_LOG(LogTemp, Warning, TEXT("Unknoasdfasdfao KCP."));
+			}
 			ComponentIds.Add(ComponentData.component_id);
 		}
 

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -116,6 +116,7 @@ const Worker_ComponentId MULTICAST_RPCS_COMPONENT_ID					= 9976;
 const Worker_ComponentId SPATIAL_DEBUGGING_COMPONENT_ID					= 9975;
 const Worker_ComponentId SERVER_WORKER_COMPONENT_ID						= 9974;
 const Worker_ComponentId SERVER_TO_SERVER_COMMAND_ENDPOINT_COMPONENT_ID = 9973;
+const Worker_ComponentId COMPONENT_PRESENCE_COMPONENT_ID				= 9972;
 
 const Worker_ComponentId STARTING_GENERATED_COMPONENT_ID				= 10000;
 
@@ -212,6 +213,9 @@ const Schema_FieldId FORWARD_SPAWN_PLAYER_START_ACTOR_ID				 = 1;
 const Schema_FieldId FORWARD_SPAWN_PLAYER_DATA_ID						 = 2;
 const Schema_FieldId FORWARD_SPAWN_PLAYER_CLIENT_WORKER_ID				 = 3;
 const Schema_FieldId FORWARD_SPAWN_PLAYER_RESPONSE_SUCCESS_ID			 = 1;
+
+// ComponentPresence Field IDs.
+const Schema_FieldId COMPONENT_PRESENCE_COMPONENT_LIST_ID				 = 1;
 
 // Reserved entity IDs expire in 5 minutes, we will refresh them every 3 minutes to be safe.
 const float ENTITY_RANGE_EXPIRATION_INTERVAL_SECONDS = 180.0f;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/EntityFactory.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/EntityFactory.h
@@ -32,7 +32,9 @@ public:
  
 	TArray<FWorkerComponentData> CreateEntityComponents(USpatialActorChannel* Channel, FRPCsOnEntityCreationMap& OutgoingOnCreateEntityRPCs, uint32& OutBytesWritten);
 	TArray<FWorkerComponentData> CreateTombstoneEntityComponents(AActor* Actor);
- 
+
+	static TArray<Worker_ComponentId> GetComponentPresenceList(const TArray<FWorkerComponentData>& ComponentDatas);
+
 private:
 	USpatialNetDriver* NetDriver;
 	USpatialPackageMapClient* PackageMap;

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SnapshotGenerator/SpatialGDKEditorSnapshotGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SnapshotGenerator/SpatialGDKEditorSnapshotGenerator.cpp
@@ -155,7 +155,7 @@ bool CreateGlobalStateManager(Worker_SnapshotOutputStream* OutputStream)
 	Components.Add(CreateGSMShutdownData());
 	Components.Add(CreateStartupActorManagerData());
 	Components.Add(EntityAcl(CreateReadACLForAlwaysRelevantEntities(), ComponentWriteAcl).CreateEntityAclData());
-	Components.Add(ComponentPresence::CreateComponentPresenceData(EntityFactory::GetComponentPresenceList(Components)));
+	Components.Add(ComponentPresence(EntityFactory::GetComponentPresenceList(Components)).CreateComponentPresenceData());
 
 	GSM.component_count = Components.Num();
 	GSM.components = Components.GetData();

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SnapshotGenerator/SpatialGDKEditorSnapshotGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SnapshotGenerator/SpatialGDKEditorSnapshotGenerator.cpp
@@ -144,9 +144,6 @@ bool CreateGlobalStateManager(Worker_SnapshotOutputStream* OutputStream)
 	ComponentWriteAcl.Add(SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
 	ComponentWriteAcl.Add(SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
 
-	TArray<Worker_ComponentId> PresentComponentIds;
-	ComponentWriteAcl.GenerateKeyArray(PresentComponentIds);
-
 	Components.Add(Position(DeploymentOrigin).CreatePositionData());
 	Components.Add(Metadata(TEXT("GlobalStateManager")).CreateMetadataData());
 	Components.Add(Persistence().CreatePersistenceData());

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SnapshotGenerator/SpatialGDKEditorSnapshotGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SnapshotGenerator/SpatialGDKEditorSnapshotGenerator.cpp
@@ -12,6 +12,7 @@
 #include "SpatialConstants.h"
 #include "SpatialGDKEditorSettings.h"
 #include "SpatialGDKSettings.h"
+#include "Utils/EntityFactory.h"
 #include "Utils/ComponentFactory.h"
 #include "Utils/RepDataUtils.h"
 #include "Utils/RepLayoutUtils.h"
@@ -130,7 +131,7 @@ bool CreateGlobalStateManager(Worker_SnapshotOutputStream* OutputStream)
 	Worker_Entity GSM;
 	GSM.entity_id = SpatialConstants::INITIAL_GLOBAL_STATE_MANAGER_ENTITY_ID;
 
-	TArray<Worker_ComponentData> Components;
+	TArray<FWorkerComponentData> Components;
 
 	WriteAclMap ComponentWriteAcl;
 	ComponentWriteAcl.Add(SpatialConstants::POSITION_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
@@ -152,16 +153,7 @@ bool CreateGlobalStateManager(Worker_SnapshotOutputStream* OutputStream)
 	Components.Add(CreateGSMShutdownData());
 	Components.Add(CreateStartupActorManagerData());
 	Components.Add(EntityAcl(CreateReadACLForAlwaysRelevantEntities(), ComponentWriteAcl).CreateEntityAclData());
-
-	TArray<Worker_ComponentId> ComponentPresenceList;
-	ComponentPresenceList.SetNum(Components.Num() + 1);
-	for (int i = 0; i < Components.Num(); i++)
-	{
-		ComponentPresenceList[i] = Components[i].component_id;
-	}
-	ComponentPresenceList[Components.Num()] = ComponentPresence::ComponentId;
-
-	Components.Add(ComponentPresence::CreateComponentPresenceData(ComponentPresenceList));
+	Components.Add(ComponentPresence::CreateComponentPresenceData(EntityFactory::GetComponentPresenceList(Components)));
 
 	GSM.component_count = Components.Num();
 	GSM.components = Components.GetData();

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SnapshotGenerator/SpatialGDKEditorSnapshotGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SnapshotGenerator/SpatialGDKEditorSnapshotGenerator.cpp
@@ -40,7 +40,7 @@ bool CreateSpawnerEntity(Worker_SnapshotOutputStream* OutputStream)
 	PlayerSpawnerData.component_id = SpatialConstants::PLAYER_SPAWNER_COMPONENT_ID;
 	PlayerSpawnerData.schema_type = Schema_CreateComponentData();
 
-	TArray<Worker_ComponentData> Components;
+	TArray<FWorkerComponentData> Components;
 
 	WriteAclMap ComponentWriteAcl;
 	ComponentWriteAcl.Add(SpatialConstants::POSITION_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
@@ -49,12 +49,14 @@ bool CreateSpawnerEntity(Worker_SnapshotOutputStream* OutputStream)
 	ComponentWriteAcl.Add(SpatialConstants::ENTITY_ACL_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
 	ComponentWriteAcl.Add(SpatialConstants::PLAYER_SPAWNER_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
 	ComponentWriteAcl.Add(SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
+	ComponentWriteAcl.Add(SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
 
 	Components.Add(Position(DeploymentOrigin).CreatePositionData());
 	Components.Add(Metadata(TEXT("SpatialSpawner")).CreateMetadataData());
 	Components.Add(Persistence().CreatePersistenceData());
 	Components.Add(EntityAcl(SpatialConstants::ClientOrServerPermission, ComponentWriteAcl).CreateEntityAclData());
 	Components.Add(PlayerSpawnerData);
+	Components.Add(ComponentPresence(EntityFactory::GetComponentPresenceList(Components)).CreateComponentPresenceData());
 
 	SpawnerEntity.component_count = Components.Num();
 	SpawnerEntity.components = Components.GetData();
@@ -175,7 +177,7 @@ bool CreateVirtualWorkerTranslator(Worker_SnapshotOutputStream* OutputStream)
 	Worker_Entity VirtualWorkerTranslator;
 	VirtualWorkerTranslator.entity_id = SpatialConstants::INITIAL_VIRTUAL_WORKER_TRANSLATOR_ENTITY_ID;
 
-	TArray<Worker_ComponentData> Components;
+	TArray<FWorkerComponentData> Components;
 
 	WriteAclMap ComponentWriteAcl;
 	ComponentWriteAcl.Add(SpatialConstants::POSITION_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
@@ -183,12 +185,14 @@ bool CreateVirtualWorkerTranslator(Worker_SnapshotOutputStream* OutputStream)
 	ComponentWriteAcl.Add(SpatialConstants::PERSISTENCE_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
 	ComponentWriteAcl.Add(SpatialConstants::ENTITY_ACL_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
 	ComponentWriteAcl.Add(SpatialConstants::VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
+	ComponentWriteAcl.Add(SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
 
 	Components.Add(Position(DeploymentOrigin).CreatePositionData());
 	Components.Add(Metadata(TEXT("VirtualWorkerTranslator")).CreateMetadataData());
 	Components.Add(Persistence().CreatePersistenceData());
 	Components.Add(CreateVirtualWorkerTranslatorData());
 	Components.Add(EntityAcl(CreateReadACLForAlwaysRelevantEntities(), ComponentWriteAcl).CreateEntityAclData());
+	Components.Add(ComponentPresence(EntityFactory::GetComponentPresenceList(Components)).CreateComponentPresenceData());
 
 	VirtualWorkerTranslator.component_count = Components.Num();
 	VirtualWorkerTranslator.components = Components.GetData();

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SnapshotGenerator/SpatialGDKEditorSnapshotGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SnapshotGenerator/SpatialGDKEditorSnapshotGenerator.cpp
@@ -4,6 +4,7 @@
 
 #include "Engine/LevelScriptActor.h"
 #include "Interop/SpatialClassInfoManager.h"
+#include "Schema/ComponentPresence.h"
 #include "Schema/Interest.h"
 #include "Schema/SpawnData.h"
 #include "Schema/StandardLibrary.h"
@@ -141,6 +142,10 @@ bool CreateGlobalStateManager(Worker_SnapshotOutputStream* OutputStream)
 	ComponentWriteAcl.Add(SpatialConstants::GSM_SHUTDOWN_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
 	ComponentWriteAcl.Add(SpatialConstants::STARTUP_ACTOR_MANAGER_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
 	ComponentWriteAcl.Add(SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
+	ComponentWriteAcl.Add(SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
+
+	TArray<Worker_ComponentId> PresentComponentIds;
+	ComponentWriteAcl.GenerateKeyArray(PresentComponentIds);
 
 	Components.Add(Position(DeploymentOrigin).CreatePositionData());
 	Components.Add(Metadata(TEXT("GlobalStateManager")).CreateMetadataData());
@@ -150,6 +155,7 @@ bool CreateGlobalStateManager(Worker_SnapshotOutputStream* OutputStream)
 	Components.Add(CreateGSMShutdownData());
 	Components.Add(CreateStartupActorManagerData());
 	Components.Add(EntityAcl(CreateReadACLForAlwaysRelevantEntities(), ComponentWriteAcl).CreateEntityAclData());
+	Components.Add(ComponentPresence(PresentComponentIds).CreateComponentPresenceData());
 
 	GSM.component_count = Components.Num();
 	GSM.components = Components.GetData();

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SnapshotGenerator/SpatialGDKEditorSnapshotGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SnapshotGenerator/SpatialGDKEditorSnapshotGenerator.cpp
@@ -155,7 +155,16 @@ bool CreateGlobalStateManager(Worker_SnapshotOutputStream* OutputStream)
 	Components.Add(CreateGSMShutdownData());
 	Components.Add(CreateStartupActorManagerData());
 	Components.Add(EntityAcl(CreateReadACLForAlwaysRelevantEntities(), ComponentWriteAcl).CreateEntityAclData());
-	Components.Add(ComponentPresence(PresentComponentIds).CreateComponentPresenceData());
+
+	TArray<Worker_ComponentId> ComponentPresenceList;
+	ComponentPresenceList.SetNum(Components.Num() + 1);
+	for (int i = 0; i < Components.Num(); i++)
+	{
+		ComponentPresenceList[i] = Components[i].component_id;
+	}
+	ComponentPresenceList[Components.Num()] = ComponentPresence::ComponentId;
+
+	Components.Add(ComponentPresence::CreateComponentPresenceData(ComponentPresenceList));
 
 	GSM.component_count = Components.Num();
 	GSM.components = Components.GetData();

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalanceEnforcer/SpatialLoadBalanceEnforcerTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalanceEnforcer/SpatialLoadBalanceEnforcerTest.cpp
@@ -39,6 +39,10 @@ void AddEntityToStaticComponentView(USpatialStaticComponentView& StaticComponent
 		EntityId, SpatialConstants::ENTITY_ACL_COMPONENT_ID,
 		WORKER_AUTHORITY_AUTHORITATIVE);
 
+	TestingComponentViewHelpers::AddEntityComponentToStaticComponentView(StaticComponentView,
+		EntityId, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID,
+		AuthorityIntentAuthority);
+
 	if (Id != SpatialConstants::INVALID_VIRTUAL_WORKER_ID)
 	{
 		StaticComponentView.GetComponentData<SpatialGDK::AuthorityIntent>(EntityId)->VirtualWorkerId = Id;
@@ -169,7 +173,7 @@ LOADBALANCEENFORCER_TEST(GIVEN_authority_intent_change_op_WHEN_we_inform_load_ba
 	UpdateOp.entity_id = EntityIdOne;
 	UpdateOp.update.component_id = SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID;
 
-	LoadBalanceEnforcer->OnAuthorityIntentComponentUpdated(UpdateOp);
+	LoadBalanceEnforcer->OnLoadBalancingComponentUpdated(UpdateOp);
 
 	TArray<SpatialLoadBalanceEnforcer::AclWriteAuthorityRequest> ACLRequests = LoadBalanceEnforcer->ProcessQueuedAclAssignmentRequests();
 

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalanceEnforcer/SpatialLoadBalanceEnforcerTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalanceEnforcer/SpatialLoadBalanceEnforcerTest.cpp
@@ -395,3 +395,87 @@ LOADBALANCEENFORCER_TEST(GIVEN_acl_component_removal_WHEN_request_is_queued_THEN
 
 	return true;
 }
+
+LOADBALANCEENFORCER_TEST(GIVEN_component_presence_change_op_WHEN_we_inform_load_balance_enforcer_THEN_queue_authority_request)
+{
+	TUniquePtr<SpatialVirtualWorkerTranslator> VirtualWorkerTranslator = CreateVirtualWorkerTranslator();
+
+	USpatialStaticComponentView* StaticComponentView = NewObject<USpatialStaticComponentView>();
+	AddEntityToStaticComponentView(*StaticComponentView, EntityIdOne, VirtualWorkerOne, WORKER_AUTHORITY_NOT_AUTHORITATIVE);
+
+	TUniquePtr<SpatialLoadBalanceEnforcer> LoadBalanceEnforcer = MakeUnique<SpatialLoadBalanceEnforcer>(ValidWorkerOne, StaticComponentView, VirtualWorkerTranslator.Get());
+
+	// Choose some explicit component IDs to add to our ComponentPresence component.
+	Worker_ComponentId TestComponentIdOne = 123;
+	Worker_ComponentId TestComponentIdTwo = 456;
+	TArray<Worker_ComponentId> PresentComponentIds{ TestComponentIdOne, TestComponentIdTwo };
+
+	// Create a ComponentPresence component update op with the required components.
+	Worker_ComponentUpdateOp UpdateOp;
+	UpdateOp.entity_id = EntityIdOne;
+	UpdateOp.update.component_id = SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID;
+	UpdateOp.update.schema_type = Schema_CreateComponentUpdate();
+	Schema_Object* UpdateFields = Schema_GetComponentUpdateFields(UpdateOp.update.schema_type);
+	Schema_AddUint32List(UpdateFields, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_LIST_ID, PresentComponentIds.GetData(), PresentComponentIds.Num());
+
+	// Pass the ComponentPresence update to the enforcer to queue an ACL assignment.
+	LoadBalanceEnforcer->OnLoadBalancingComponentUpdated(UpdateOp);
+
+	// Pass the update op to the StaticComponentView so that they can be read when the ACL assigment is processed.
+	StaticComponentView->OnComponentUpdate(UpdateOp);
+
+	TArray<SpatialLoadBalanceEnforcer::AclWriteAuthorityRequest> ACLRequests = LoadBalanceEnforcer->ProcessQueuedAclAssignmentRequests();
+
+	bool bSuccess = true;
+	if (ACLRequests.Num() == 1)
+	{
+		bSuccess &= ACLRequests[0].EntityId == EntityIdOne;
+		bSuccess &= ACLRequests[0].OwningWorkerId == ValidWorkerOne;
+		bSuccess &= ACLRequests[0].ComponentIds.Contains(TestComponentIdOne);
+		bSuccess &= ACLRequests[0].ComponentIds.Contains(TestComponentIdTwo);
+	}
+	else
+	{
+		bSuccess = false;
+	}
+
+	TestTrue("LoadBalanceEnforcer returned expected ACL assignment results", bSuccess);
+
+	return true;
+}
+
+LOADBALANCEENFORCER_TEST(GIVEN_component_presence_component_removal_WHEN_request_is_queued_THEN_return_no_acl_assignment_requests)
+{
+	TUniquePtr<SpatialVirtualWorkerTranslator> VirtualWorkerTranslator = CreateVirtualWorkerTranslator();
+
+	// Set up the world in such a way that we can enforce the authority, and we are not already the authoritative worker so should try and assign authority.
+	USpatialStaticComponentView* StaticComponentView = NewObject<USpatialStaticComponentView>();
+	AddEntityToStaticComponentView(*StaticComponentView, EntityIdOne, VirtualWorkerOne, WORKER_AUTHORITY_NOT_AUTHORITATIVE);
+
+	TUniquePtr<SpatialLoadBalanceEnforcer> LoadBalanceEnforcer = MakeUnique<SpatialLoadBalanceEnforcer>(ValidWorkerOne, StaticComponentView, VirtualWorkerTranslator.Get());
+
+	Worker_AuthorityChangeOp AuthOp;
+	AuthOp.entity_id = EntityIdOne;
+	AuthOp.authority = WORKER_AUTHORITY_AUTHORITATIVE;
+	AuthOp.component_id = SpatialConstants::ENTITY_ACL_COMPONENT_ID;
+
+	LoadBalanceEnforcer->OnAclAuthorityChanged(AuthOp);
+
+	// At this point, we expect there to be a queued request.
+	TestTrue("Assignment request is queued", LoadBalanceEnforcer->AclAssignmentRequestIsQueued(EntityIdOne));
+
+	Worker_RemoveComponentOp ComponentOp;
+	ComponentOp.entity_id = EntityIdOne;
+	ComponentOp.component_id = SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID;
+
+	LoadBalanceEnforcer->OnLoadBalancingComponentRemoved(ComponentOp);
+
+	// Now we should have dropped that request.
+
+	TArray<SpatialLoadBalanceEnforcer::AclWriteAuthorityRequest> ACLRequests = LoadBalanceEnforcer->ProcessQueuedAclAssignmentRequests();
+
+	bool bSuccess = ACLRequests.Num() == 0;
+	TestTrue("LoadBalanceEnforcer returned expected ACL assignment results", bSuccess);
+
+	return true;
+}

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalanceEnforcer/SpatialLoadBalanceEnforcerTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalanceEnforcer/SpatialLoadBalanceEnforcerTest.cpp
@@ -19,14 +19,17 @@
 namespace
 {
 
-PhysicalWorkerName ValidWorkerOne = TEXT("ValidWorkerOne");
-PhysicalWorkerName ValidWorkerTwo = TEXT("ValidWorkerTwo");
+const PhysicalWorkerName ValidWorkerOne = TEXT("ValidWorkerOne");
+const PhysicalWorkerName ValidWorkerTwo = TEXT("ValidWorkerTwo");
 
-VirtualWorkerId VirtualWorkerOne = 1;
-VirtualWorkerId VirtualWorkerTwo = 2;
+constexpr VirtualWorkerId VirtualWorkerOne = 1;
+constexpr VirtualWorkerId VirtualWorkerTwo = 2;
 
-Worker_EntityId EntityIdOne = 1;
-Worker_EntityId EntityIdTwo = 2;
+constexpr Worker_EntityId EntityIdOne = 1;
+constexpr Worker_EntityId EntityIdTwo = 2;
+
+constexpr Worker_ComponentId TestComponentIdOne = 123;
+constexpr Worker_ComponentId TestComponentIdTwo = 456;
 
 void AddEntityToStaticComponentView(USpatialStaticComponentView& StaticComponentView,
 	const Worker_EntityId EntityId, VirtualWorkerId Id, Worker_Authority AuthorityIntentAuthority)
@@ -405,9 +408,6 @@ LOADBALANCEENFORCER_TEST(GIVEN_component_presence_change_op_WHEN_we_inform_load_
 
 	TUniquePtr<SpatialLoadBalanceEnforcer> LoadBalanceEnforcer = MakeUnique<SpatialLoadBalanceEnforcer>(ValidWorkerOne, StaticComponentView, VirtualWorkerTranslator.Get());
 
-	// Choose some explicit component IDs to add to our ComponentPresence component.
-	Worker_ComponentId TestComponentIdOne = 123;
-	Worker_ComponentId TestComponentIdTwo = 456;
 	TArray<Worker_ComponentId> PresentComponentIds{ TestComponentIdOne, TestComponentIdTwo };
 
 	// Create a ComponentPresence component update op with the required components.

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
@@ -839,6 +839,7 @@ SCHEMA_GENERATOR_TEST(GIVEN_source_and_destination_of_well_known_schema_files_WH
 	TArray<FString> GDKSchemaFilePaths =
 	{
 		"authority_intent.schema",
+		"component_presence.schema",
 		"core_types.schema",
 		"debug_metrics.schema",
 		"global_state_manager.schema",


### PR DESCRIPTION
#### Description
This PR enables the use of dynamic components in a zoned environment.

This GIF shows a new gym where the Character EntityACL is authoritative on a different worker to the rest of the simulated components. Pressing R adds a new ActorComponent to the character, which is visible in the component list (and also in the ComponentPresence list, and then in the write ACL mapping, resulting in the authority assignment). Pressing T removes the component, causing the data to unset in the Inspector (however the write ACL assignment intentionally remains).

![dynamic-components](https://user-images.githubusercontent.com/9222722/76338871-3db2f480-62f1-11ea-8b3b-ad404aea8f3d.gif)

##### Problem 

The dynamic components GDK implementation relies on the EntityACL being authoritative on the game server that performs the SpatialSender::GainAuthorityThenAddComponent call. Most of the time, this won’t be true in zoned deployments, because the EntityACL is load-balanced by the runtime, not the user-defined LB strategy. 

##### Solution

To resolve this, we need a way to communicate by the list of dynamically added (or removed) component IDs between the simulating worker and the enforcing worker. 

This PR introduces a new SpatialOS component on each Actor entity called ComponentPresence (currently only used when load-balancing is enabled). This contains a single property actor_component_list which is the list of component IDs that the game server should be authoritative over in order to be correctly simulating the entity. This should be useful in future for deducing entity completeness without critical sections but is used currently just found enabling dynamic components with zoning.

ComponentPresence component updates are used to communicate when components are dynamically added or removed from an entity. 

Currently, an enforcer worker, when it receives an AuthorityIntent component update (or gains EntityACL authority) will queue the relevant entity ID for an ACL assignment. This assignment involves checking the AuthorityIntent and VirtualWorkerTranslation and setting ALL components (except client and enforcer worker authoritative components) to the corresponding physical worker name. 

Now, the enforcer worker will also queue and entity ID for ACL assignment when a ComponentPresence AddComponentOp or ComponentUpdateOp is received. Assignment now involves ensuring that all component IDs in the ComponentPresence list of components is assigned in the write ACL. Note that this doesn’t remove things from the write ACL if they are removed from the ComponentPresence list. This is because 1) the current dynamic components single-server implementation doesn’t do this and 2) I can see this adding complications if we have both remove then add component ops in flight and there’s a difference in state between the simulating and enforcer workers. 

#### Tests
Extended enforcer with a few more unit tests
Tested manually with a new gym (https://github.com/spatialos/UnrealGDKTestGyms/pull/52) with key bindings for adding and removing a dynamic component.