### PR TITLE
[UNR-2809] Add editor extension to get the number of workers to launch from a load balancing strategy

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/EditorExtension/GridLBStrategyEditorExtension.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/EditorExtension/GridLBStrategyEditorExtension.cpp
@@ -1,0 +1,25 @@
+#include "GridLBStrategyEditorExtension.h"
+#include "SpatialGDKEditorSettings.h"
+
+class UGridBasedLBStrategy_Spy : public UGridBasedLBStrategy
+{
+public:
+	using UGridBasedLBStrategy::WorldWidth;
+	using UGridBasedLBStrategy::WorldHeight;
+	using UGridBasedLBStrategy::Rows;
+	using UGridBasedLBStrategy::Cols;
+};
+
+bool FGridLBStrategyEditorExtension::GetDefaultLaunchConfiguration(const UGridBasedLBStrategy* Strategy, FWorkerTypeLaunchSection& OutConfiguration, FIntPoint& OutWorldDimensions) const
+{
+	const UGridBasedLBStrategy_Spy* StrategySpy = static_cast<const UGridBasedLBStrategy_Spy*>(Strategy);
+
+	OutConfiguration.Rows = StrategySpy->Rows;
+	OutConfiguration.Columns = StrategySpy->Cols;
+	OutConfiguration.NumEditorInstances = StrategySpy->Rows * StrategySpy->Cols;
+
+	// m ? cm ?
+	OutWorldDimensions = FIntPoint(StrategySpy->WorldWidth, StrategySpy->WorldHeight);
+
+	return true;
+}

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/EditorExtension/GridLBStrategyEditorExtension.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/EditorExtension/GridLBStrategyEditorExtension.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
 #include "GridLBStrategyEditorExtension.h"
 #include "SpatialGDKEditorSettings.h"
 
@@ -18,8 +20,8 @@ bool FGridLBStrategyEditorExtension::GetDefaultLaunchConfiguration(const UGridBa
 	OutConfiguration.Columns = StrategySpy->Cols;
 	OutConfiguration.NumEditorInstances = StrategySpy->Rows * StrategySpy->Cols;
 
-	// m ? cm ?
-	OutWorldDimensions = FIntPoint(StrategySpy->WorldWidth, StrategySpy->WorldHeight);
+	// Convert from cm to m.
+	OutWorldDimensions = FIntPoint(StrategySpy->WorldWidth / 100, StrategySpy->WorldHeight / 100);
 
 	return true;
 }

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/EditorExtension/GridLBStrategyEditorExtension.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/EditorExtension/GridLBStrategyEditorExtension.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "EditorExtension/LBStrategyEditorExtension.h"
+#include "LoadBalancing/GridBasedLBStrategy.h"
+
+class FGridLBStrategyEditorExtension : public FLBStrategyEditorExtensionTemplate<UGridBasedLBStrategy, FGridLBStrategyEditorExtension>
+{
+public:
+	bool GetDefaultLaunchConfiguration(const UGridBasedLBStrategy* Strategy, FWorkerTypeLaunchSection& OutConfiguration, FIntPoint& OutWorldDimensions) const;
+};

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/EditorExtension/GridLBStrategyEditorExtension.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/EditorExtension/GridLBStrategyEditorExtension.h
@@ -1,3 +1,5 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
 #pragma once
 
 #include "EditorExtension/LBStrategyEditorExtension.h"

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/EditorExtension/LBStrategyEditorExtension.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/EditorExtension/LBStrategyEditorExtension.cpp
@@ -1,8 +1,6 @@
 #include "EditorExtension/LBStrategyEditorExtension.h"
 #include "LoadBalancing/AbstractLBStrategy.h"
 
-//DEFINE_LOG_CATEGORY(LogSpatialGDKEditorExtensions);
-
 namespace
 {
 	bool InheritFromClosest(UClass* Derived, UClass* PotentialBase, uint32& InOutPreviousDistance)
@@ -26,8 +24,6 @@ namespace
 	}
 }
 
-TArray<TPair<UClass*, FLBStrategyEditorExtensionInterface*>> FLBStrategyEditorExtensionManager::ExtensionMap;
-
 bool FLBStrategyEditorExtensionManager::GetDefaultLaunchConfiguration(const UAbstractLBStrategy* Strategy, FWorkerTypeLaunchSection& OutConfiguration, FIntPoint& OutWorldDimensions)
 {
 	if (!Strategy)
@@ -44,7 +40,7 @@ bool FLBStrategyEditorExtensionManager::GetDefaultLaunchConfiguration(const UAbs
 	{
 		if (InheritFromClosest(StrategyClass, Extension.Key, InheritanceDistance))
 		{
-			StrategyInterface = Extension.Value;
+			StrategyInterface = Extension.Value.Get();
 		}
 	}
 
@@ -53,7 +49,15 @@ bool FLBStrategyEditorExtensionManager::GetDefaultLaunchConfiguration(const UAbs
 		return StrategyInterface->GetDefaultLaunchConfiguration_Virtual(Strategy, OutConfiguration, OutWorldDimensions);
 	}
 
-	//UE_LOG(LogSpatialGDKEditorExtensions, Error, TEXT(""))
-
 	return false;
+}
+
+void FLBStrategyEditorExtensionManager::RegisterExtension(UClass* StrategyClass, FLBStrategyEditorExtensionInterface* StrategyExtension)
+{
+	ExtensionMap.Push(decltype(ExtensionMap)::ElementType(StrategyClass, StrategyExtension));
+}
+
+void FLBStrategyEditorExtensionManager::Cleanup()
+{
+	ExtensionMap.Empty();
 }

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/EditorExtension/LBStrategyEditorExtension.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/EditorExtension/LBStrategyEditorExtension.cpp
@@ -1,0 +1,59 @@
+#include "EditorExtension/LBStrategyEditorExtension.h"
+#include "LoadBalancing/AbstractLBStrategy.h"
+
+//DEFINE_LOG_CATEGORY(LogSpatialGDKEditorExtensions);
+
+namespace
+{
+	bool InheritFromClosest(UClass* Derived, UClass* PotentialBase, uint32& InOutPreviousDistance)
+	{
+		uint32 InheritanceDistance = 0;
+		for (const UStruct* TempStruct = Derived; TempStruct; TempStruct = TempStruct->GetSuperStruct())
+		{
+			if (TempStruct == PotentialBase)
+			{
+				break;
+			}
+			++InheritanceDistance;
+			if (InheritanceDistance > InOutPreviousDistance)
+			{
+				return false;
+			}
+		}
+
+		InOutPreviousDistance = InheritanceDistance;
+		return true;
+	}
+}
+
+TArray<TPair<UClass*, FLBStrategyEditorExtensionInterface*>> FLBStrategyEditorExtensionManager::ExtensionMap;
+
+bool FLBStrategyEditorExtensionManager::GetDefaultLaunchConfiguration(const UAbstractLBStrategy* Strategy, FWorkerTypeLaunchSection& OutConfiguration, FIntPoint& OutWorldDimensions)
+{
+	if (!Strategy)
+	{
+		return false;
+	}
+
+	UClass* StrategyClass = Strategy->GetClass();
+
+	FLBStrategyEditorExtensionInterface* StrategyInterface = nullptr;
+	uint32 InheritanceDistance = UINT32_MAX;
+
+	for (auto& Extension : ExtensionMap)
+	{
+		if (InheritFromClosest(StrategyClass, Extension.Key, InheritanceDistance))
+		{
+			StrategyInterface = Extension.Value;
+		}
+	}
+
+	if (StrategyInterface)
+	{
+		return StrategyInterface->GetDefaultLaunchConfiguration_Virtual(Strategy, OutConfiguration, OutWorldDimensions);
+	}
+
+	//UE_LOG(LogSpatialGDKEditorExtensions, Error, TEXT(""))
+
+	return false;
+}

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/EditorExtension/LBStrategyEditorExtension.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/EditorExtension/LBStrategyEditorExtension.cpp
@@ -24,7 +24,7 @@ namespace
 		InOutPreviousDistance = InheritanceDistance;
 		return true;
 	}
-}
+} // anonymous namespace
 
 bool FLBStrategyEditorExtensionManager::GetDefaultLaunchConfiguration(const UAbstractLBStrategy* Strategy, FWorkerTypeLaunchSection& OutConfiguration, FIntPoint& OutWorldDimensions)
 {
@@ -38,7 +38,7 @@ bool FLBStrategyEditorExtensionManager::GetDefaultLaunchConfiguration(const UAbs
 	FLBStrategyEditorExtensionInterface* StrategyInterface = nullptr;
 	uint32 InheritanceDistance = UINT32_MAX;
 
-	for (auto& Extension : ExtensionMap)
+	for (auto& Extension : Extensions)
 	{
 		if (InheritFromClosest(StrategyClass, Extension.Key, InheritanceDistance))
 		{
@@ -54,12 +54,12 @@ bool FLBStrategyEditorExtensionManager::GetDefaultLaunchConfiguration(const UAbs
 	return false;
 }
 
-void FLBStrategyEditorExtensionManager::RegisterExtension(UClass* StrategyClass, FLBStrategyEditorExtensionInterface* StrategyExtension)
+void FLBStrategyEditorExtensionManager::RegisterExtension(UClass* StrategyClass, TUniquePtr<FLBStrategyEditorExtensionInterface>&& StrategyExtension)
 {
-	ExtensionMap.Push(decltype(ExtensionMap)::ElementType(StrategyClass, StrategyExtension));
+	Extensions.Push(ExtensionArray::ElementType(StrategyClass, MoveTemp(StrategyExtension)));
 }
 
 void FLBStrategyEditorExtensionManager::Cleanup()
 {
-	ExtensionMap.Empty();
+	Extensions.Empty();
 }

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/EditorExtension/LBStrategyEditorExtension.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/EditorExtension/LBStrategyEditorExtension.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
 #include "EditorExtension/LBStrategyEditorExtension.h"
 #include "LoadBalancing/AbstractLBStrategy.h"
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/EditorExtension/LBStrategyEditorExtension.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/EditorExtension/LBStrategyEditorExtension.cpp
@@ -5,25 +5,27 @@
 
 namespace
 {
-	bool InheritFromClosest(UClass* Derived, UClass* PotentialBase, uint32& InOutPreviousDistance)
-	{
-		uint32 InheritanceDistance = 0;
-		for (const UStruct* TempStruct = Derived; TempStruct; TempStruct = TempStruct->GetSuperStruct())
-		{
-			if (TempStruct == PotentialBase)
-			{
-				break;
-			}
-			++InheritanceDistance;
-			if (InheritanceDistance > InOutPreviousDistance)
-			{
-				return false;
-			}
-		}
 
-		InOutPreviousDistance = InheritanceDistance;
-		return true;
+bool InheritFromClosest(UClass* Derived, UClass* PotentialBase, uint32& InOutPreviousDistance)
+{
+	uint32 InheritanceDistance = 0;
+	for (const UStruct* TempStruct = Derived; TempStruct; TempStruct = TempStruct->GetSuperStruct())
+	{
+		if (TempStruct == PotentialBase)
+		{
+			break;
+		}
+		++InheritanceDistance;
+		if (InheritanceDistance > InOutPreviousDistance)
+		{
+			return false;
+		}
 	}
+
+	InOutPreviousDistance = InheritanceDistance;
+	return true;
+}
+
 } // anonymous namespace
 
 bool FLBStrategyEditorExtensionManager::GetDefaultLaunchConfiguration(const UAbstractLBStrategy* Strategy, FWorkerTypeLaunchSection& OutConfiguration, FIntPoint& OutWorldDimensions)
@@ -54,7 +56,7 @@ bool FLBStrategyEditorExtensionManager::GetDefaultLaunchConfiguration(const UAbs
 	return false;
 }
 
-void FLBStrategyEditorExtensionManager::RegisterExtension(UClass* StrategyClass, TUniquePtr<FLBStrategyEditorExtensionInterface>&& StrategyExtension)
+void FLBStrategyEditorExtensionManager::RegisterExtension(UClass* StrategyClass, TUniquePtr<FLBStrategyEditorExtensionInterface> StrategyExtension)
 {
 	Extensions.Push(ExtensionArray::ElementType(StrategyClass, MoveTemp(StrategyExtension)));
 }

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -16,15 +16,23 @@
 
 #define LOCTEXT_NAMESPACE "FSpatialGDKEditorModule"
 
+FSpatialGDKEditorModule::FSpatialGDKEditorModule()
+	: ExtensionManager(new FLBStrategyEditorExtensionManager)
+{
+
+}
+
 void FSpatialGDKEditorModule::StartupModule()
 {
 	RegisterSettings();
 
-	FLBStrategyEditorExtensionManager::RegisterExtension<FGridLBStrategyEditorExtension>();
+	ExtensionManager->RegisterExtension<FGridLBStrategyEditorExtension>();
 }
 
 void FSpatialGDKEditorModule::ShutdownModule()
 {
+	ExtensionManager->Cleanup();
+
 	if (UObjectInitialized())
 	{
 		UnregisterSettings();

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -12,11 +12,15 @@
 #include "PropertyEditor/Public/PropertyEditorModule.h"
 #include "WorkerTypeCustomization.h"
 
+#include "EditorExtension/GridLBStrategyEditorExtension.h"
+
 #define LOCTEXT_NAMESPACE "FSpatialGDKEditorModule"
 
 void FSpatialGDKEditorModule::StartupModule()
 {
 	RegisterSettings();
+
+	FLBStrategyEditorExtensionManager::RegisterExtension<FGridLBStrategyEditorExtension>();
 }
 
 void FSpatialGDKEditorModule::ShutdownModule()

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -17,7 +17,7 @@
 #define LOCTEXT_NAMESPACE "FSpatialGDKEditorModule"
 
 FSpatialGDKEditorModule::FSpatialGDKEditorModule()
-	: ExtensionManager(new FLBStrategyEditorExtensionManager)
+	: ExtensionManager(MakeUnique<FLBStrategyEditorExtensionManager>())
 {
 
 }

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/EditorExtension/LBStrategyEditorExtension.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/EditorExtension/LBStrategyEditorExtension.h
@@ -1,3 +1,5 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
 #pragma once
 
 #include "CoreMinimal.h"

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/EditorExtension/LBStrategyEditorExtension.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/EditorExtension/LBStrategyEditorExtension.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+class UAbstractLBStrategy;
+struct FWorkerTypeLaunchSection;
+
+class FLBStrategyEditorExtensionInterface
+{
+private:
+	friend class FLBStrategyEditorExtensionManager;
+	virtual bool GetDefaultLaunchConfiguration_Virtual(const UAbstractLBStrategy* Strategy, FWorkerTypeLaunchSection& OutConfiguration, FIntPoint& OutWorldDimensions) const = 0;
+};
+
+template <typename StrategyImpl, typename Implementation>
+class FLBStrategyEditorExtensionTemplate : public FLBStrategyEditorExtensionInterface
+{
+public:
+	typedef StrategyImpl ExtendedStrategy;
+private:
+
+	bool GetDefaultLaunchConfiguration_Virtual(const UAbstractLBStrategy* Strategy, FWorkerTypeLaunchSection& OutConfiguration, FIntPoint& OutWorldDimensions) const override
+	{
+		return static_cast<const Implementation*>(this)->GetDefaultLaunchConfiguration(static_cast<const StrategyImpl*>(Strategy), OutConfiguration, OutWorldDimensions);
+	}
+};
+
+class FLBStrategyEditorExtensionManager
+{
+public:
+	SPATIALGDKEDITOR_API static bool GetDefaultLaunchConfiguration(const UAbstractLBStrategy* Strategy, FWorkerTypeLaunchSection& OutConfiguration, FIntPoint& OutWorldDimensions);
+
+	template <typename Extension>
+	static void RegisterExtension()
+	{
+		RegisterExtension(Extension::ExtendedStrategy::StaticClass(), new Extension);
+	}
+
+private:
+
+	static void RegisterExtension(UClass* StrategyClass, FLBStrategyEditorExtensionInterface* StrategyExtension)
+	{
+		ExtensionMap.Push(decltype(ExtensionMap)::ElementType(StrategyClass, StrategyExtension));
+	}
+
+	static TArray<TPair<UClass*, FLBStrategyEditorExtensionInterface*>> ExtensionMap;
+};

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/EditorExtension/LBStrategyEditorExtension.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/EditorExtension/LBStrategyEditorExtension.h
@@ -28,20 +28,19 @@ private:
 class FLBStrategyEditorExtensionManager
 {
 public:
-	SPATIALGDKEDITOR_API static bool GetDefaultLaunchConfiguration(const UAbstractLBStrategy* Strategy, FWorkerTypeLaunchSection& OutConfiguration, FIntPoint& OutWorldDimensions);
+	SPATIALGDKEDITOR_API bool GetDefaultLaunchConfiguration(const UAbstractLBStrategy* Strategy, FWorkerTypeLaunchSection& OutConfiguration, FIntPoint& OutWorldDimensions);
 
 	template <typename Extension>
-	static void RegisterExtension()
+	void RegisterExtension()
 	{
 		RegisterExtension(Extension::ExtendedStrategy::StaticClass(), new Extension);
 	}
 
+	void Cleanup();
+
 private:
 
-	static void RegisterExtension(UClass* StrategyClass, FLBStrategyEditorExtensionInterface* StrategyExtension)
-	{
-		ExtensionMap.Push(decltype(ExtensionMap)::ElementType(StrategyClass, StrategyExtension));
-	}
+	void RegisterExtension(UClass* StrategyClass, FLBStrategyEditorExtensionInterface* StrategyExtension);
 
-	static TArray<TPair<UClass*, FLBStrategyEditorExtensionInterface*>> ExtensionMap;
+	TArray<TPair<UClass*, TUniquePtr<FLBStrategyEditorExtensionInterface>>> ExtensionMap;
 };

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/EditorExtension/LBStrategyEditorExtension.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/EditorExtension/LBStrategyEditorExtension.h
@@ -35,14 +35,16 @@ public:
 	template <typename Extension>
 	void RegisterExtension()
 	{
-		RegisterExtension(Extension::ExtendedStrategy::StaticClass(), new Extension);
+		RegisterExtension(Extension::ExtendedStrategy::StaticClass(), MakeUnique<Extension>());
 	}
 
 	void Cleanup();
 
 private:
 
-	void RegisterExtension(UClass* StrategyClass, FLBStrategyEditorExtensionInterface* StrategyExtension);
+	void RegisterExtension(UClass* StrategyClass, TUniquePtr<FLBStrategyEditorExtensionInterface>&& StrategyExtension);
 
-	TArray<TPair<UClass*, TUniquePtr<FLBStrategyEditorExtensionInterface>>> ExtensionMap;
+	using ExtensionArray = TArray<TPair<UClass*, TUniquePtr<FLBStrategyEditorExtensionInterface>>>;
+
+	ExtensionArray Extensions;
 };

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/EditorExtension/LBStrategyEditorExtension.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/EditorExtension/LBStrategyEditorExtension.h
@@ -5,12 +5,13 @@
 #include "CoreMinimal.h"
 
 class UAbstractLBStrategy;
+class FLBStrategyEditorExtensionManager;
 struct FWorkerTypeLaunchSection;
 
 class FLBStrategyEditorExtensionInterface
 {
 private:
-	friend class FLBStrategyEditorExtensionManager;
+	friend FLBStrategyEditorExtensionManager;
 	virtual bool GetDefaultLaunchConfiguration_Virtual(const UAbstractLBStrategy* Strategy, FWorkerTypeLaunchSection& OutConfiguration, FIntPoint& OutWorldDimensions) const = 0;
 };
 
@@ -18,7 +19,7 @@ template <typename StrategyImpl, typename Implementation>
 class FLBStrategyEditorExtensionTemplate : public FLBStrategyEditorExtensionInterface
 {
 public:
-	typedef StrategyImpl ExtendedStrategy;
+	using ExtendedStrategy = StrategyImpl;
 private:
 
 	bool GetDefaultLaunchConfiguration_Virtual(const UAbstractLBStrategy* Strategy, FWorkerTypeLaunchSection& OutConfiguration, FIntPoint& OutWorldDimensions) const override

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/EditorExtension/LBStrategyEditorExtension.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/EditorExtension/LBStrategyEditorExtension.h
@@ -20,8 +20,8 @@ class FLBStrategyEditorExtensionTemplate : public FLBStrategyEditorExtensionInte
 {
 public:
 	using ExtendedStrategy = StrategyImpl;
-private:
 
+private:
 	bool GetDefaultLaunchConfiguration_Virtual(const UAbstractLBStrategy* Strategy, FWorkerTypeLaunchSection& OutConfiguration, FIntPoint& OutWorldDimensions) const override
 	{
 		return static_cast<const Implementation*>(this)->GetDefaultLaunchConfiguration(static_cast<const StrategyImpl*>(Strategy), OutConfiguration, OutWorldDimensions);
@@ -42,8 +42,7 @@ public:
 	void Cleanup();
 
 private:
-
-	void RegisterExtension(UClass* StrategyClass, TUniquePtr<FLBStrategyEditorExtensionInterface>&& StrategyExtension);
+	void RegisterExtension(UClass* StrategyClass, TUniquePtr<FLBStrategyEditorExtensionInterface> StrategyExtension);
 
 	using ExtensionArray = TArray<TPair<UClass*, TUniquePtr<FLBStrategyEditorExtensionInterface>>>;
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
@@ -3,9 +3,16 @@
 #include "Modules/ModuleInterface.h"
 #include "Modules/ModuleManager.h"
 
+class FLBStrategyEditorExtensionManager;
+
 class FSpatialGDKEditorModule : public IModuleInterface
 {
 public:
+
+	FSpatialGDKEditorModule();
+
+	SPATIALGDKEDITOR_API const FLBStrategyEditorExtensionManager& GetLBStrategyExtensionManager() { return *ExtensionManager; }
+
 	virtual void StartupModule() override;
 	virtual void ShutdownModule() override;
 
@@ -20,4 +27,6 @@ private:
 	bool HandleEditorSettingsSaved();
 	bool HandleRuntimeSettingsSaved();
 	bool HandleCloudLauncherSettingsSaved();
+
+	TUniquePtr<FLBStrategyEditorExtensionManager> ExtensionManager;
 };


### PR DESCRIPTION
#### Description
We want to be able to launch a local deployment with the right amount of workers to satisfy the load balancing strategy's requirements. While we could add virtual methods to the load balancing strategy to do that, we would need to add another structure to bridge the gap between editor-only structs.
This could happen eventually, but this part of the GDK is still in flux at the moment. So the "virtual" part of getting the right amount of workers for the editor is done in an editor only extension. This is just register a class instance against a strategy's UClass.
It does not prevent us from adding these facilities to the strategy itself eventually, but it keeps both notions separated for the time being.

#### Release note

#### Tests

#### Documentation

#### Primary reviewers
