### PR TITLE
Bugfix/unr 3065 spatial output device crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,8 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Fixed an issue where deleted, initially dormant startup actors would still be present on other workers.
 - Force activation of RPC ring buffer when load balancing is enabled, to allow RPC handover when authority changes
 - Fixed a race where a client leaving the deployment could leave its actor behind on the server, to be cleaned up after a long timeout.
-- Fixed crash caused by state persisting across a transition from one deployment to another in SpatialGameInstance
+- Fixed crash caused by state persisting across a transition from one deployment to another in SpatialGameInstance.
+- Fixed crash when starting + stopping PIE multiple times.
 
 ### External contributors:
 @DW-Sebastien

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -939,6 +939,8 @@ void USpatialNetDriver::Shutdown()
 		}
 	}
 
+	SpatialOutputDevice = nullptr;
+
 	Super::Shutdown();
 
 	// This is done after Super::Shutdown so the NetDriver is given an opportunity to shutdown all open channels, and those


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Fix crash when starting + stopping PIE multiple times.  Details of crash explained on UNR-3065.

#### Release note
CHANGELOG.md updated.

#### Tests
Verified UnrealEd no longer crashes when starting/stopping/starting PIE again (not 100% repro, but it will eventually crash without this change).

STRONGLY SUGGESTED: How can this be verified by QA?

#### Documentation
release note

#### Primary reviewers
@m-samiec @kevinimprobable 