### PR TITLE
[UNR-2809] Use map's load balancing strategy when starting local deployment

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/EditorExtension/LBStrategyEditorExtension.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/EditorExtension/LBStrategyEditorExtension.cpp
@@ -28,7 +28,7 @@ bool InheritFromClosest(UClass* Derived, UClass* PotentialBase, uint32& InOutPre
 
 } // anonymous namespace
 
-bool FLBStrategyEditorExtensionManager::GetDefaultLaunchConfiguration(const UAbstractLBStrategy* Strategy, FWorkerTypeLaunchSection& OutConfiguration, FIntPoint& OutWorldDimensions)
+bool FLBStrategyEditorExtensionManager::GetDefaultLaunchConfiguration(const UAbstractLBStrategy* Strategy, FWorkerTypeLaunchSection& OutConfiguration, FIntPoint& OutWorldDimensions) const
 {
 	if (!Strategy)
 	{

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
@@ -7,6 +7,11 @@
 #include "Serialization/JsonWriter.h"
 #include "Misc/FileHelper.h"
 
+#include "Misc/MessageDialog.h"
+
+#include "ISettingsModule.h"
+#include "SpatialGDKSettings.h"
+
 DEFINE_LOG_CATEGORY(LogSpatialGDKDefaultLaunchConfigGenerator);
 
 #define LOCTEXT_NAMESPACE "SpatialGDKDefaultLaunchConfigGenerator"
@@ -166,6 +171,89 @@ bool GenerateDefaultLaunchConfig(const FString& LaunchConfigPath, const FSpatial
 	}
 
 	return false;
+}
+
+bool ValidateGeneratedLaunchConfig(const FSpatialLaunchConfigDescription& LaunchConfigDesc)
+{
+	//const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>();
+	const USpatialGDKSettings* SpatialGDKRuntimeSettings = GetDefault<USpatialGDKSettings>();
+
+	if (const FString* EnableChunkInterest = LaunchConfigDesc.World.LegacyFlags.Find(TEXT("enable_chunk_interest")))
+	{
+		if (*EnableChunkInterest == TEXT("true"))
+		{
+			const EAppReturnType::Type Result = FMessageDialog::Open(EAppMsgType::YesNo, FText::FromString(TEXT("The legacy flag \"enable_chunk_interest\" is set to true in the generated launch configuration. Chunk interest is not supported and this flag needs to be set to false.\n\nDo you want to configure your launch config settings now?")));
+
+			if (Result == EAppReturnType::Yes)
+			{
+				FModuleManager::LoadModuleChecked<ISettingsModule>("Settings").ShowViewer("Project", "SpatialGDKEditor", "Editor Settings");
+			}
+
+			return false;
+		}
+	}
+
+	if (!SpatialGDKRuntimeSettings->bEnableHandover && LaunchConfigDesc.ServerWorkers.ContainsByPredicate([](const FWorkerTypeLaunchSection& Section)
+	{
+		return (Section.Rows * Section.Columns) > 1;
+	}))
+	{
+		const EAppReturnType::Type Result = FMessageDialog::Open(EAppMsgType::YesNo, FText::FromString(TEXT("Property handover is disabled and a zoned deployment is specified.\nThis is not supported.\n\nDo you want to configure your project settings now?")));
+
+		if (Result == EAppReturnType::Yes)
+		{
+			FModuleManager::LoadModuleChecked<ISettingsModule>("Settings").ShowViewer("Project", "SpatialGDKEditor", "Runtime Settings");
+		}
+
+		return false;
+	}
+
+	if (LaunchConfigDesc.ServerWorkers.ContainsByPredicate([](const FWorkerTypeLaunchSection& Section)
+	{
+		return (Section.Rows * Section.Columns) < Section.NumEditorInstances;
+	}))
+	{
+		const EAppReturnType::Type Result = FMessageDialog::Open(EAppMsgType::YesNo, FText::FromString(TEXT("Attempting to launch too many servers for load balance configuration.\nThis is not supported.\n\nDo you want to configure your project settings now?")));
+
+		if (Result == EAppReturnType::Yes)
+		{
+			FModuleManager::LoadModuleChecked<ISettingsModule>("Settings").ShowViewer("Project", "SpatialGDKEditor", "Editor Settings");
+		}
+
+		return false;
+	}
+
+	if (!SpatialGDKRuntimeSettings->ServerWorkerTypes.Contains(SpatialGDKRuntimeSettings->DefaultWorkerType.WorkerTypeName))
+	{
+		const EAppReturnType::Type Result = FMessageDialog::Open(EAppMsgType::YesNo, FText::FromString(TEXT("Default Worker Type is invalid, please choose a valid worker type as the default.\n\nDo you want to configure your project settings now?")));
+
+		if (Result == EAppReturnType::Yes)
+		{
+			FModuleManager::LoadModuleChecked<ISettingsModule>("Settings").ShowViewer("Project", "SpatialGDKEditor", "Runtime Settings");
+		}
+
+		return false;
+	}
+
+	if (SpatialGDKRuntimeSettings->bEnableOffloading)
+	{
+		for (const TPair<FName, FActorGroupInfo>& ActorGroup : SpatialGDKRuntimeSettings->ActorGroups)
+		{
+			if (!SpatialGDKRuntimeSettings->ServerWorkerTypes.Contains(ActorGroup.Value.OwningWorkerType.WorkerTypeName))
+			{
+				const EAppReturnType::Type Result = FMessageDialog::Open(EAppMsgType::YesNo, FText::FromString(FString::Printf(TEXT("Actor Group '%s' has an invalid Owning Worker Type, please choose a valid worker type.\n\nDo you want to configure your project settings now?"), *ActorGroup.Key.ToString())));
+
+				if (Result == EAppReturnType::Yes)
+				{
+					FModuleManager::LoadModuleChecked<ISettingsModule>("Settings").ShowViewer("Project", "SpatialGDKEditor", "Runtime Settings");
+				}
+
+				return false;
+			}
+		}
+	}
+
+	return true;
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
@@ -175,7 +175,6 @@ bool GenerateDefaultLaunchConfig(const FString& LaunchConfigPath, const FSpatial
 
 bool ValidateGeneratedLaunchConfig(const FSpatialLaunchConfigDescription& LaunchConfigDesc)
 {
-	//const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>();
 	const USpatialGDKSettings* SpatialGDKRuntimeSettings = GetDefault<USpatialGDKSettings>();
 
 	if (const FString* EnableChunkInterest = LaunchConfigDesc.World.LegacyFlags.Find(TEXT("enable_chunk_interest")))

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -18,6 +18,17 @@
 DEFINE_LOG_CATEGORY(LogSpatialEditorSettings);
 #define LOCTEXT_NAMESPACE "USpatialGDKEditorSettings"
 
+void FSpatialLaunchConfigDescription::SetLevelEditorPlaySettingsWorkerTypes()
+{
+	ULevelEditorPlaySettings* PlayInSettings = GetMutableDefault<ULevelEditorPlaySettings>();
+
+	PlayInSettings->WorkerTypesToLaunch.Empty(ServerWorkers.Num());
+	for (const FWorkerTypeLaunchSection& WorkerLaunch : ServerWorkers)
+	{
+		PlayInSettings->WorkerTypesToLaunch.Add(WorkerLaunch.WorkerTypeName, WorkerLaunch.NumEditorInstances);
+	}
+}
+
 USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 	, bShowSpatialServiceButton(false)
@@ -142,17 +153,6 @@ void USpatialGDKEditorSettings::SetRuntimeDevelopmentDeploymentToConnect()
 {
 	USpatialGDKSettings* RuntimeSettings = GetMutableDefault<USpatialGDKSettings>();
 	RuntimeSettings->DevelopmentDeploymentToConnect = DevelopmentDeploymentToConnect;
-}
-
-void FSpatialLaunchConfigDescription::SetLevelEditorPlaySettingsWorkerTypes()
-{
-	ULevelEditorPlaySettings* PlayInSettings = GetMutableDefault<ULevelEditorPlaySettings>();
-
-	PlayInSettings->WorkerTypesToLaunch.Empty(ServerWorkers.Num());
-	for (const FWorkerTypeLaunchSection& WorkerLaunch : ServerWorkers)
-	{
-		PlayInSettings->WorkerTypesToLaunch.Add(WorkerLaunch.WorkerTypeName, WorkerLaunch.NumEditorInstances);
-	}
 }
 
 bool USpatialGDKEditorSettings::IsAssemblyNameValid(const FString& Name)

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -74,7 +74,6 @@ void USpatialGDKEditorSettings::PostEditChangeProperty(struct FPropertyChangedEv
 	else if (Name == GET_MEMBER_NAME_CHECKED(USpatialGDKEditorSettings, LaunchConfigDesc))
 	{
 		SetRuntimeWorkerTypes();
-		SetLevelEditorPlaySettingsWorkerTypes();
 	}
 	else if (Name == GET_MEMBER_NAME_CHECKED(USpatialGDKEditorSettings, bUseDevelopmentAuthenticationFlow))
 	{
@@ -103,13 +102,12 @@ void USpatialGDKEditorSettings::PostInitProperties()
 	SetRuntimeUseDevelopmentAuthenticationFlow();
 	SetRuntimeDevelopmentAuthenticationToken();
 	SetRuntimeDevelopmentDeploymentToConnect();
-	SetLevelEditorPlaySettingsWorkerTypes();
 }
 
 void USpatialGDKEditorSettings::SetRuntimeWorkerTypes()
 {
 	TSet<FName> WorkerTypes;
-
+	
 	for (const FWorkerTypeLaunchSection& WorkerLaunch : LaunchConfigDesc.ServerWorkers)
 	{
 		if (WorkerLaunch.WorkerTypeName != NAME_None)
@@ -146,12 +144,12 @@ void USpatialGDKEditorSettings::SetRuntimeDevelopmentDeploymentToConnect()
 	RuntimeSettings->DevelopmentDeploymentToConnect = DevelopmentDeploymentToConnect;
 }
 
-void USpatialGDKEditorSettings::SetLevelEditorPlaySettingsWorkerTypes()
+void FSpatialLaunchConfigDescription::SetLevelEditorPlaySettingsWorkerTypes()
 {
 	ULevelEditorPlaySettings* PlayInSettings = GetMutableDefault<ULevelEditorPlaySettings>();
 
-	PlayInSettings->WorkerTypesToLaunch.Empty(LaunchConfigDesc.ServerWorkers.Num());
-	for (const FWorkerTypeLaunchSection& WorkerLaunch : LaunchConfigDesc.ServerWorkers)
+	PlayInSettings->WorkerTypesToLaunch.Empty(ServerWorkers.Num());
+	for (const FWorkerTypeLaunchSection& WorkerLaunch : ServerWorkers)
 	{
 		PlayInSettings->WorkerTypesToLaunch.Add(WorkerLaunch.WorkerTypeName, WorkerLaunch.NumEditorInstances);
 	}

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/EditorExtension/LBStrategyEditorExtension.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/EditorExtension/LBStrategyEditorExtension.h
@@ -31,7 +31,7 @@ private:
 class FLBStrategyEditorExtensionManager
 {
 public:
-	SPATIALGDKEDITOR_API bool GetDefaultLaunchConfiguration(const UAbstractLBStrategy* Strategy, FWorkerTypeLaunchSection& OutConfiguration, FIntPoint& OutWorldDimensions);
+	SPATIALGDKEDITOR_API bool GetDefaultLaunchConfiguration(const UAbstractLBStrategy* Strategy, FWorkerTypeLaunchSection& OutConfiguration, FIntPoint& OutWorldDimensions) const;
 
 	template <typename Extension>
 	void RegisterExtension()

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKDefaultLaunchConfigGenerator.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKDefaultLaunchConfigGenerator.h
@@ -9,3 +9,5 @@ DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKDefaultLaunchConfigGenerator, Log, All)
 struct FSpatialLaunchConfigDescription;
 
 bool SPATIALGDKEDITOR_API GenerateDefaultLaunchConfig(const FString& LaunchConfigPath, const FSpatialLaunchConfigDescription* InLaunchConfigDescription);
+
+bool SPATIALGDKEDITOR_API ValidateGeneratedLaunchConfig(const FSpatialLaunchConfigDescription& LaunchConfigDesc);

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -195,6 +195,10 @@ struct FSpatialLaunchConfigDescription
 		ServerWorkers.Add(UnrealWorkerDefaultSetting);
 	}
 
+
+	/** Set WorkerTypesToLaunch in level editor play settings. */
+	SPATIALGDKEDITOR_API void SetLevelEditorPlaySettingsWorkerTypes();
+
 	/** Deployment template. */
 	UPROPERTY(Category = "SpatialGDK", EditAnywhere, config)
 	FString Template;
@@ -242,9 +246,6 @@ private:
 	/** Set DAT in runtime settings. */
 	void SetRuntimeUseDevelopmentAuthenticationFlow();
 	void SetRuntimeDevelopmentDeploymentToConnect();
-
-	/** Set WorkerTypesToLaunch in level editor play settings. */
-	void SetLevelEditorPlaySettingsWorkerTypes();
 
 public:
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -43,9 +43,9 @@
 #include "GeneralProjectSettings.h"
 #include "LevelEditor.h"
 #include "Misc/FileHelper.h"
-#include "SpatialWorldSettings.h"
+#include "EngineClasses/SpatialWorldSettings.h"
 #include "EditorExtension/LBStrategyEditorExtension.h"
-#include "AbstractLBStrategy.h"
+#include "LoadBalancing/AbstractLBStrategy.h"
 #include "SpatialGDKEditorModule.h"
 
 DEFINE_LOG_CATEGORY(LogSpatialGDKEditorToolbar);

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -536,9 +536,11 @@ bool FSpatialGDKEditorToolbarModule::FillWorkerLaunchConfigFromWorldSettings(UWo
 		return false;
 	}
 
-	if (!FLBStrategyEditorExtensionManager::GetDefaultLaunchConfiguration(WorldSettings->LoadBalanceStrategy->GetDefaultObject<UAbstractLBStrategy>(), OutLaunchConfig, OutWorldDimension))
+	FSpatialGDKEditorModule& EditorModule = FModuleManager::GetModuleChecked<FSpatialGDKEditorModule>("SpatialGDKEditor");
+
+	if (!EditorModule.GetLBStrategyExtensionManager().GetDefaultLaunchConfiguration(WorldSettings->LoadBalanceStrategy->GetDefaultObject<UAbstractLBStrategy>(), OutLaunchConfig, OutWorldDimension))
 	{
-		UE_LOG(LogSpatialGDKEditorToolbar, Error, TEXT("Could not get the number of worker to launch for load balancing strategy %s"), WorldSettings->LoadBalanceStrategy->GetName());
+		UE_LOG(LogSpatialGDKEditorToolbar, Error, TEXT("Could not get the number of worker to launch for load balancing strategy %s"), *WorldSettings->LoadBalanceStrategy->GetName());
 		return false;
 	}
 
@@ -593,6 +595,9 @@ void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment()
 		{
 			LocalDeploymentManager->SetRedeployRequired();
 		}
+
+		UWorld* EditorWorld = GEditor->GetEditorWorldContext().World();
+		check(EditorWorld);
 
 		LaunchConfig = FPaths::Combine(FPaths::ConvertRelativePathToFull(SpatialGDKServicesConstants::SpatialOSDirectory), FString::Printf(TEXT("%s_LocalLaunchConfig.json"), *EditorWorld->GetMapName()));
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -43,6 +43,10 @@
 #include "GeneralProjectSettings.h"
 #include "LevelEditor.h"
 #include "Misc/FileHelper.h"
+#include "SpatialWorldSettings.h"
+#include "EditorExtension/LBStrategyEditorExtension.h"
+#include "AbstractLBStrategy.h"
+#include "SpatialGDKEditorModule.h"
 
 DEFINE_LOG_CATEGORY(LogSpatialGDKEditorToolbar);
 
@@ -471,102 +475,6 @@ void FSpatialGDKEditorToolbarModule::ShowFailedNotification(const FString& Notif
 	}
 }
 
-bool FSpatialGDKEditorToolbarModule::ValidateGeneratedLaunchConfig() const
-{
-	const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>();
-	const USpatialGDKSettings* SpatialGDKRuntimeSettings = GetDefault<USpatialGDKSettings>();
-	const FSpatialLaunchConfigDescription& LaunchConfigDescription = SpatialGDKEditorSettings->LaunchConfigDesc;
-
-	if (const FString* EnableChunkInterest = LaunchConfigDescription.World.LegacyFlags.Find(TEXT("enable_chunk_interest")))
-	{
-		if (*EnableChunkInterest == TEXT("true"))
-		{
-			const EAppReturnType::Type Result = FMessageDialog::Open(EAppMsgType::YesNo, FText::FromString(TEXT("The legacy flag \"enable_chunk_interest\" is set to true in the generated launch configuration. Chunk interest is not supported and this flag needs to be set to false.\n\nDo you want to configure your launch config settings now?")));
-
-			if (Result == EAppReturnType::Yes)
-			{
-				FModuleManager::LoadModuleChecked<ISettingsModule>("Settings").ShowViewer("Project", "SpatialGDKEditor", "Editor Settings");
-			}
-
-			return false;
-		}
-	}
-
-	if (!SpatialGDKRuntimeSettings->bEnableHandover && SpatialGDKEditorSettings->LaunchConfigDesc.ServerWorkers.ContainsByPredicate([](const FWorkerTypeLaunchSection& Section)
-		{
-			return (Section.Rows * Section.Columns) > 1;
-		}))
-	{
-		const EAppReturnType::Type Result = FMessageDialog::Open(EAppMsgType::YesNo, FText::FromString(TEXT("Property handover is disabled and a zoned deployment is specified.\nThis is not supported.\n\nDo you want to configure your project settings now?")));
-
-		if (Result == EAppReturnType::Yes)
-		{
-			FModuleManager::LoadModuleChecked<ISettingsModule>("Settings").ShowViewer("Project", "SpatialGDKEditor", "Runtime Settings");
-		}
-
-		return false;
-	}
-
-	if (SpatialGDKEditorSettings->LaunchConfigDesc.ServerWorkers.ContainsByPredicate([](const FWorkerTypeLaunchSection& Section)
-		{
-			return (Section.Rows * Section.Columns) < Section.NumEditorInstances;
-		}))
-	{
-		const EAppReturnType::Type Result = FMessageDialog::Open(EAppMsgType::YesNo, FText::FromString(TEXT("Attempting to launch too many servers for load balance configuration.\nThis is not supported.\n\nDo you want to configure your project settings now?")));
-
-		if (Result == EAppReturnType::Yes)
-		{
-			FModuleManager::LoadModuleChecked<ISettingsModule>("Settings").ShowViewer("Project", "SpatialGDKEditor", "Editor Settings");
-		}
-
-		return false;
-	}
-
-	if (!SpatialGDKRuntimeSettings->ServerWorkerTypes.Contains(SpatialGDKRuntimeSettings->DefaultWorkerType.WorkerTypeName))
-	{
-		const EAppReturnType::Type Result = FMessageDialog::Open(EAppMsgType::YesNo, FText::FromString(TEXT("Default Worker Type is invalid, please choose a valid worker type as the default.\n\nDo you want to configure your project settings now?")));
-
-		if (Result == EAppReturnType::Yes)
-		{
-			FModuleManager::LoadModuleChecked<ISettingsModule>("Settings").ShowViewer("Project", "SpatialGDKEditor", "Runtime Settings");
-		}
-
-		return false;
-	}
-
-	if (SpatialGDKRuntimeSettings->bEnableOffloading)
-	{
-		if (SpatialGDKRuntimeSettings->bEnableUnrealLoadBalancer)
-		{
-			const EAppReturnType::Type Result = FMessageDialog::Open(EAppMsgType::YesNo, FText::FromString(TEXT("Offloading and the UnrealLoadBalancer are both turned on, this is not supported at the moment.\n\nDo you want to configure your project settings now?")));
-
-			if (Result == EAppReturnType::Yes)
-			{
-				FModuleManager::LoadModuleChecked<ISettingsModule>("Settings").ShowViewer("Project", "SpatialGDKEditor", "Runtime Settings");
-			}
-
-			return false;
-		}
-
-		for (const TPair<FName, FActorGroupInfo>& ActorGroup : SpatialGDKRuntimeSettings->ActorGroups)
-		{
-			if (!SpatialGDKRuntimeSettings->ServerWorkerTypes.Contains(ActorGroup.Value.OwningWorkerType.WorkerTypeName))
-			{
-				const EAppReturnType::Type Result = FMessageDialog::Open(EAppMsgType::YesNo, FText::FromString(FString::Printf(TEXT("Actor Group '%s' has an invalid Owning Worker Type, please choose a valid worker type.\n\nDo you want to configure your project settings now?"), *ActorGroup.Key.ToString())));
-
-				if (Result == EAppReturnType::Yes)
-				{
-					FModuleManager::LoadModuleChecked<ISettingsModule>("Settings").ShowViewer("Project", "SpatialGDKEditor", "Runtime Settings");
-				}
-
-				return false;
-			}
-		}
-	}
-
-	return true;
-}
-
 void FSpatialGDKEditorToolbarModule::StartSpatialServiceButtonClicked()
 {
 	AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [this]
@@ -645,15 +553,12 @@ void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment()
 	}
 
 	// Get the latest launch config.
-	const USpatialGDKEditorSettings* SpatialGDKSettings = GetDefault<USpatialGDKEditorSettings>();
+	const USpatialGDKSettings* SpatialGDKSettings = GetDefault<USpatialGDKSettings>();
+	const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>();
 
 	FString LaunchConfig;
-	if (SpatialGDKSettings->bGenerateDefaultLaunchConfig)
+	if (SpatialGDKEditorSettings->bGenerateDefaultLaunchConfig)
 	{
-		if (!ValidateGeneratedLaunchConfig())
-		{
-			return;
-		}
 
 		bool bRedeployRequired = false;
 		if (!GenerateAllDefaultWorkerJsons(bRedeployRequired))
@@ -665,21 +570,67 @@ void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment()
 			LocalDeploymentManager->SetRedeployRequired();
 		}
 
-		LaunchConfig = FPaths::Combine(FPaths::ConvertRelativePathToFull(FPaths::ProjectIntermediateDir()), TEXT("Improbable/DefaultLaunchConfig.json"));
-		if (const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>())
+		UWorld* EditorWorld = GEditor->GetEditorWorldContext(false).World();
+		check(EditorWorld);
+
+		LaunchConfig = FPaths::Combine(FPaths::ConvertRelativePathToFull(SpatialGDKServicesConstants::SpatialOSDirectory), FString::Printf(TEXT("%s_LocalLaunchConfig.json"), *EditorWorld->GetMapName()));
+
+		FSpatialLaunchConfigDescription LaunchConfigDescription = SpatialGDKEditorSettings->LaunchConfigDesc;
+		if (SpatialGDKSettings->bEnableUnrealLoadBalancer)
 		{
-			const FSpatialLaunchConfigDescription& LaunchConfigDescription = SpatialGDKEditorSettings->LaunchConfigDesc;
-			GenerateDefaultLaunchConfig(LaunchConfig, &LaunchConfigDescription);
+			const ASpatialWorldSettings* WorldSettings = Cast<ASpatialWorldSettings>(EditorWorld->GetWorldSettings());
+			if (WorldSettings && WorldSettings->LoadBalanceStrategy)
+			{
+				FIntPoint WorldDimensions;
+				FWorkerTypeLaunchSection WorkerLaunch;
+				WorkerLaunch.bManualWorkerConnectionOnly = true;
+				if (FLBStrategyEditorExtensionManager::GetDefaultLaunchConfiguration(WorldSettings->LoadBalanceStrategy->GetDefaultObject<UAbstractLBStrategy>(), WorkerLaunch, WorldDimensions))
+				{
+					LaunchConfigDescription.World.Dimensions = WorldDimensions;
+					LaunchConfigDescription.ServerWorkers.Empty(SpatialGDKSettings->ServerWorkerTypes.Num());
+
+					for (auto WorkerType : SpatialGDKSettings->ServerWorkerTypes)
+					{
+						LaunchConfigDescription.ServerWorkers.Add(WorkerLaunch);
+						LaunchConfigDescription.ServerWorkers.Last().WorkerTypeName = WorkerType;
+					}
+				}
+			}
+			else
+			{
+				UE_LOG(LogSpatialGDKEditorToolbar, Error, TEXT("Missing load balancing strategy on map ???"));
+			}
 		}
+
+		if (!ValidateGeneratedLaunchConfig(LaunchConfigDescription))
+		{
+			return;
+		}
+
+		GenerateDefaultLaunchConfig(LaunchConfig, &LaunchConfigDescription);
+		LaunchConfigDescription.SetLevelEditorPlaySettingsWorkerTypes();
+
+		// Also create launch config for cloud deployments.
+		{
+			for (auto& WorkerLaunchSection : LaunchConfigDescription.ServerWorkers)
+			{
+				WorkerLaunchSection.bManualWorkerConnectionOnly = false;
+			}
+
+			FString CloudLaunchConfig = FPaths::Combine(FPaths::ConvertRelativePathToFull(SpatialGDKServicesConstants::SpatialOSDirectory), FString::Printf(TEXT("%s_CloudLaunchConfig.json"), *EditorWorld->GetMapName()));
+			GenerateDefaultLaunchConfig(CloudLaunchConfig, &LaunchConfigDescription);
+		}
+		
+
 	}
 	else
 	{
-		LaunchConfig = SpatialGDKSettings->GetSpatialOSLaunchConfig();
+		LaunchConfig = SpatialGDKEditorSettings->GetSpatialOSLaunchConfig();
 	}
 
-	const FString LaunchFlags = SpatialGDKSettings->GetSpatialOSCommandLineLaunchFlags();
-	const FString SnapshotName = SpatialGDKSettings->GetSpatialOSSnapshotToLoad();
-	const FString RuntimeVersion = SpatialGDKSettings->GetSpatialOSRuntimeVersionForLocal();
+	const FString LaunchFlags = SpatialGDKEditorSettings->GetSpatialOSCommandLineLaunchFlags();
+	const FString SnapshotName = SpatialGDKEditorSettings->GetSpatialOSSnapshotToLoad();
+	const FString RuntimeVersion = SpatialGDKEditorSettings->GetSpatialOSRuntimeVersionForLocal();
 
 	AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [this, LaunchConfig, LaunchFlags, SnapshotName, RuntimeVersion]
 	{

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -599,7 +599,7 @@ void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment()
 		UWorld* EditorWorld = GEditor->GetEditorWorldContext().World();
 		check(EditorWorld);
 
-		LaunchConfig = FPaths::Combine(FPaths::ConvertRelativePathToFull(SpatialGDKServicesConstants::SpatialOSDirectory), FString::Printf(TEXT("%s_LocalLaunchConfig.json"), *EditorWorld->GetMapName()));
+		LaunchConfig = FPaths::Combine(FPaths::ConvertRelativePathToFull(FPaths::ProjectIntermediateDir()), FString::Printf(TEXT("Improbable/%s_LocalLaunchConfig.json"), *EditorWorld->GetMapName()));
 
 		FSpatialLaunchConfigDescription LaunchConfigDescription = SpatialGDKEditorSettings->LaunchConfigDesc;
 		if (SpatialGDKSettings->bEnableUnrealLoadBalancer)
@@ -640,7 +640,7 @@ void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment()
 				WorkerLaunchSection.bManualWorkerConnectionOnly = false;
 			}
 
-			FString CloudLaunchConfig = FPaths::Combine(FPaths::ConvertRelativePathToFull(SpatialGDKServicesConstants::SpatialOSDirectory), FString::Printf(TEXT("%s_CloudLaunchConfig.json"), *EditorWorld->GetMapName()));
+			FString CloudLaunchConfig = FPaths::Combine(FPaths::ConvertRelativePathToFull(FPaths::ProjectIntermediateDir()), FString::Printf(TEXT("Improbable/%s_CloudLaunchConfig.json"), *EditorWorld->GetMapName()));
 			GenerateDefaultLaunchConfig(CloudLaunchConfig, &LaunchConfigDescription);
 		}
 	}

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -97,7 +97,7 @@ void FSpatialGDKEditorToolbarModule::StartupModule()
 		});
 	}
 
-	FEditorDelegates::PostPIEStarted.AddLambda([this](bool bIsSimulatingInEditor)
+	FEditorDelegates::PreBeginPIE.AddLambda([this](bool bIsSimulatingInEditor)
 	{
 		if (GIsAutomationTesting && GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking())
 		{

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -520,7 +520,7 @@ void FSpatialGDKEditorToolbarModule::StopSpatialServiceButtonClicked()
 	});
 }
 
-bool FSpatialGDKEditorToolbarModule::FillWorkerLaunchConfigFromWorldSettings(UWorld& World, FWorkerTypeLaunchSection& OutLaunchConfig, FIntPoint OutWorldDimension)
+bool FSpatialGDKEditorToolbarModule::FillWorkerLaunchConfigFromWorldSettings(UWorld& World, FWorkerTypeLaunchSection& OutLaunchConfig, FIntPoint& OutWorldDimension)
 {
 	const ASpatialWorldSettings* WorldSettings = Cast<ASpatialWorldSettings>(World.GetWorldSettings());
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -98,7 +98,7 @@ private:
 
 	void ShowFailedNotification(const FString& NotificationText);
 
-	bool FillWorkerLaunchConfigFromWorldSettings(UWorld& World, FWorkerTypeLaunchSection& OutLaunchConfig, FIntPoint OutWorldDimension);
+	bool FillWorkerLaunchConfigFromWorldSettings(UWorld& World, FWorkerTypeLaunchSection& OutLaunchConfig, FIntPoint& OutWorldDimension);
 
 	void GenerateSchema(bool bFullScan);
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -98,6 +98,8 @@ private:
 
 	void ShowFailedNotification(const FString& NotificationText);
 
+	bool FillWorkerLaunchConfigFromWorldSettings(UWorld& World, FWorkerTypeLaunchSection& OutLaunchConfig, FIntPoint OutWorldDimension);
+
 	void GenerateSchema(bool bFullScan);
 
 	bool IsSnapshotGenerated() const;

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -98,8 +98,6 @@ private:
 
 	void ShowFailedNotification(const FString& NotificationText);
 
-	bool ValidateGeneratedLaunchConfig() const;
-
 	void GenerateSchema(bool bFullScan);
 
 	bool IsSnapshotGenerated() const;

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKServices/LocalDeploymentManager/LocalDeploymentManagerUtilities.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKServices/LocalDeploymentManager/LocalDeploymentManagerUtilities.cpp
@@ -75,6 +75,7 @@ bool FStartDeployment::Update()
 			}
 
 			FSpatialLaunchConfigDescription LaunchConfigDescription(AutomationWorkerType);
+			LaunchConfigDescription.SetLevelEditorPlaySettingsWorkerTypes();
 
 			if (!GenerateDefaultLaunchConfig(LaunchConfig, &LaunchConfigDescription))
 			{


### PR DESCRIPTION
#### Description
When starting a local deployment, the current opened map's load balancing strategy will be checked to create the right amount of workers, instead of having to change the editor's settings as it is now.
Along this change, the launch configuration will be saved with the map's name, as well as a version for the cloud, which will make it more convenient to have the right configuration out of the box.

Another PR will follow up to have a cleaner user experience around launch co,figurations.

TODO : How to check the the current running deployment has to be restarted ?

#### Release note
TODO

#### Tests

#### Documentation

#### Primary reviewers