### PR TITLE
Fixed crash caused by uninitialised shadow data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Fixed a race where a client leaving the deployment could leave its actor behind on the server, to be cleaned up after a long timeout.
 - Fixed crash caused by state persisting across a transition from one deployment to another in SpatialGameInstance.
 - Fixed crash when starting + stopping PIE multiple times.
+- Fixed crash when shadow data was uninitialized when resolving unresolved objects.
 
 ### External contributors:
 @DW-Sebastien

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -2219,6 +2219,10 @@ void USpatialReceiver::ResolveIncomingOperations(UObject* Object, const FUnrealO
 
 		FRepLayout& RepLayout = DependentChannel->GetObjectRepLayout(ReplicatingObject);
 		FRepStateStaticBuffer& ShadowData = DependentChannel->GetObjectStaticBuffer(ReplicatingObject);
+		if (ShadowData.Num() == 0)
+		{
+			DependentChannel->ResetShadowData(RepLayout, ShadowData, ReplicatingObject);
+		}
 
 		ResolveObjectReferences(RepLayout, ReplicatingObject, *RepState, RepState->ReferenceMap, ShadowData.GetData(), (uint8*)ReplicatingObject, ReplicatingObject->GetClass()->GetPropertiesSize(), RepNotifies, bSomeObjectsWereMapped);
 


### PR DESCRIPTION
#### Description
Shadow data could be uninitialised when resolving objects, add call to initialise if required.

#### Tests
Validated by internal teams

#### Primary reviewers
@mironec @yumnuska 