### PR TITLE
UNR-2811 Custom Locator URL

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
@@ -397,20 +397,34 @@ bool USpatialConnectionManager::TrySetupConnectionConfigFromCommandLine(const FS
 
 void USpatialConnectionManager::SetupConnectionConfigFromURL(const FURL& URL, const FString& SpatialWorkerType)
 {
-	if (URL.Host == SpatialConstants::LOCATOR_HOST && URL.HasOption(TEXT("locator")))
+	if (URL.HasOption(TEXT("locator")))
 	{
 		SetConnectionType(ESpatialConnectionType::Locator);
-		// TODO: UNR-2811 We might add a feature whereby we get the locator host from the URL option.
-		FParse::Value(FCommandLine::Get(), TEXT("locatorHost"), LocatorConfig.LocatorHost);
+		if (URL.Host == SpatialConstants::LOCATOR_HOST)
+		{
+			FParse::Value(FCommandLine::Get(), TEXT("locatorHost"), LocatorConfig.LocatorHost);
+		}
+		else
+		{
+			LocatorConfig.LocatorHost = URL.Host;
+		}
+
 		LocatorConfig.PlayerIdentityToken = URL.GetOption(*SpatialConstants::URL_PLAYER_IDENTITY_OPTION, TEXT(""));
 		LocatorConfig.LoginToken = URL.GetOption(*SpatialConstants::URL_LOGIN_OPTION, TEXT(""));
 		LocatorConfig.WorkerType = SpatialWorkerType;
 	}
-	else if (URL.Host == SpatialConstants::LOCATOR_HOST && URL.HasOption(TEXT("devauth")))
+	else if (URL.HasOption(TEXT("devauth")))
 	{
 		SetConnectionType(ESpatialConnectionType::DevAuthFlow);
-		// TODO: UNR-2811 Also set the locator host of DevAuthConfig from URL.
-		FParse::Value(FCommandLine::Get(), TEXT("locatorHost"), DevAuthConfig.LocatorHost);
+		if (URL.Host == SpatialConstants::LOCATOR_HOST)
+		{
+			FParse::Value(FCommandLine::Get(), TEXT("locatorHost"), DevAuthConfig.LocatorHost);
+		}
+		else
+		{
+			DevAuthConfig.LocatorHost = URL.Host;
+		}
+
 		DevAuthConfig.DevelopmentAuthToken = URL.GetOption(*SpatialConstants::URL_DEV_AUTH_TOKEN_OPTION, TEXT(""));
 		DevAuthConfig.Deployment = URL.GetOption(*SpatialConstants::URL_TARGET_DEPLOYMENT_OPTION, TEXT(""));
 		DevAuthConfig.PlayerId = URL.GetOption(*SpatialConstants::URL_PLAYER_ID_OPTION, *SpatialConstants::DEVELOPMENT_AUTH_PLAYER_ID);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
@@ -397,40 +397,34 @@ bool USpatialConnectionManager::TrySetupConnectionConfigFromCommandLine(const FS
 
 void USpatialConnectionManager::SetupConnectionConfigFromURL(const FURL& URL, const FString& SpatialWorkerType)
 {
-	if (URL.HasOption(TEXT("locator")))
+	if (URL.Host == SpatialConstants::LOCATOR_HOST && URL.HasOption(TEXT("locator")))
 	{
 		SetConnectionType(ESpatialConnectionType::Locator);
-		if (URL.Host == SpatialConstants::LOCATOR_HOST)
-		{
-			FParse::Value(FCommandLine::Get(), TEXT("locatorHost"), LocatorConfig.LocatorHost);
-		}
-		else
-		{
-			LocatorConfig.LocatorHost = URL.Host;
-		}
-
+		// TODO: UNR-2811 We might add a feature whereby we get the locator host from the URL option.
+		FParse::Value(FCommandLine::Get(), TEXT("locatorHost"), LocatorConfig.LocatorHost);
 		LocatorConfig.PlayerIdentityToken = URL.GetOption(*SpatialConstants::URL_PLAYER_IDENTITY_OPTION, TEXT(""));
 		LocatorConfig.LoginToken = URL.GetOption(*SpatialConstants::URL_LOGIN_OPTION, TEXT(""));
 		LocatorConfig.WorkerType = SpatialWorkerType;
 	}
-	else if (URL.HasOption(TEXT("devauth")))
+	else if (URL.Host == SpatialConstants::LOCATOR_HOST && URL.HasOption(TEXT("devauth")))
 	{
 		SetConnectionType(ESpatialConnectionType::DevAuthFlow);
-		if (URL.Host == SpatialConstants::LOCATOR_HOST)
-		{
-			FParse::Value(FCommandLine::Get(), TEXT("locatorHost"), DevAuthConfig.LocatorHost);
-		}
-		else
-		{
-			DevAuthConfig.LocatorHost = URL.Host;
-		}
-
+		// TODO: UNR-2811 Also set the locator host of DevAuthConfig from URL.
+		FParse::Value(FCommandLine::Get(), TEXT("locatorHost"), DevAuthConfig.LocatorHost);
 		DevAuthConfig.DevelopmentAuthToken = URL.GetOption(*SpatialConstants::URL_DEV_AUTH_TOKEN_OPTION, TEXT(""));
 		DevAuthConfig.Deployment = URL.GetOption(*SpatialConstants::URL_TARGET_DEPLOYMENT_OPTION, TEXT(""));
 		DevAuthConfig.PlayerId = URL.GetOption(*SpatialConstants::URL_PLAYER_ID_OPTION, *SpatialConstants::DEVELOPMENT_AUTH_PLAYER_ID);
 		DevAuthConfig.DisplayName = URL.GetOption(*SpatialConstants::URL_DISPLAY_NAME_OPTION, TEXT(""));
 		DevAuthConfig.MetaData = URL.GetOption(*SpatialConstants::URL_METADATA_OPTION, TEXT(""));
 		DevAuthConfig.WorkerType = SpatialWorkerType;
+	}
+	else if (URL.HasOption(TEXT("customLocator")))
+	{
+		SetConnectionType(ESpatialConnectionType::Locator);
+		LocatorConfig.LocatorHost = URL.Host;
+		LocatorConfig.PlayerIdentityToken = URL.GetOption(*SpatialConstants::URL_PLAYER_IDENTITY_OPTION, TEXT(""));
+		LocatorConfig.LoginToken = URL.GetOption(*SpatialConstants::URL_LOGIN_OPTION, TEXT(""));
+		LocatorConfig.WorkerType = SpatialWorkerType;
 	}
 	else
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
@@ -397,34 +397,45 @@ bool USpatialConnectionManager::TrySetupConnectionConfigFromCommandLine(const FS
 
 void USpatialConnectionManager::SetupConnectionConfigFromURL(const FURL& URL, const FString& SpatialWorkerType)
 {
-	if (URL.Host == SpatialConstants::LOCATOR_HOST && URL.HasOption(TEXT("locator")))
+	if (URL.HasOption(TEXT("locator")) || URL.HasOption(TEXT("devauth")))
 	{
-		SetConnectionType(ESpatialConnectionType::Locator);
-		// TODO: UNR-2811 We might add a feature whereby we get the locator host from the URL option.
-		FParse::Value(FCommandLine::Get(), TEXT("locatorHost"), LocatorConfig.LocatorHost);
-		LocatorConfig.PlayerIdentityToken = URL.GetOption(*SpatialConstants::URL_PLAYER_IDENTITY_OPTION, TEXT(""));
-		LocatorConfig.LoginToken = URL.GetOption(*SpatialConstants::URL_LOGIN_OPTION, TEXT(""));
-		LocatorConfig.WorkerType = SpatialWorkerType;
-	}
-	else if (URL.Host == SpatialConstants::LOCATOR_HOST && URL.HasOption(TEXT("devauth")))
-	{
-		SetConnectionType(ESpatialConnectionType::DevAuthFlow);
-		// TODO: UNR-2811 Also set the locator host of DevAuthConfig from URL.
-		FParse::Value(FCommandLine::Get(), TEXT("locatorHost"), DevAuthConfig.LocatorHost);
-		DevAuthConfig.DevelopmentAuthToken = URL.GetOption(*SpatialConstants::URL_DEV_AUTH_TOKEN_OPTION, TEXT(""));
-		DevAuthConfig.Deployment = URL.GetOption(*SpatialConstants::URL_TARGET_DEPLOYMENT_OPTION, TEXT(""));
-		DevAuthConfig.PlayerId = URL.GetOption(*SpatialConstants::URL_PLAYER_ID_OPTION, *SpatialConstants::DEVELOPMENT_AUTH_PLAYER_ID);
-		DevAuthConfig.DisplayName = URL.GetOption(*SpatialConstants::URL_DISPLAY_NAME_OPTION, TEXT(""));
-		DevAuthConfig.MetaData = URL.GetOption(*SpatialConstants::URL_METADATA_OPTION, TEXT(""));
-		DevAuthConfig.WorkerType = SpatialWorkerType;
-	}
-	else if (URL.HasOption(TEXT("customLocator")))
-	{
-		SetConnectionType(ESpatialConnectionType::Locator);
-		LocatorConfig.LocatorHost = URL.Host;
-		LocatorConfig.PlayerIdentityToken = URL.GetOption(*SpatialConstants::URL_PLAYER_IDENTITY_OPTION, TEXT(""));
-		LocatorConfig.LoginToken = URL.GetOption(*SpatialConstants::URL_LOGIN_OPTION, TEXT(""));
-		LocatorConfig.WorkerType = SpatialWorkerType;
+		FString LocatorHostOverride;
+		if (URL.HasOption(TEXT("customLocator")))
+		{
+			LocatorHostOverride = URL.Host;
+		}
+		else
+		{
+			FParse::Value(FCommandLine::Get(), TEXT("locatorHost"), LocatorHostOverride);
+		}
+
+		if (URL.HasOption(TEXT("devauth")))
+		{
+			// Use devauth login flow.
+			SetConnectionType(ESpatialConnectionType::DevAuthFlow);
+			if (LocatorHostOverride != "")
+			{
+				DevAuthConfig.LocatorHost = LocatorHostOverride;
+			}
+			DevAuthConfig.DevelopmentAuthToken = URL.GetOption(*SpatialConstants::URL_DEV_AUTH_TOKEN_OPTION, TEXT(""));
+			DevAuthConfig.Deployment = URL.GetOption(*SpatialConstants::URL_TARGET_DEPLOYMENT_OPTION, TEXT(""));
+			DevAuthConfig.PlayerId = URL.GetOption(*SpatialConstants::URL_PLAYER_ID_OPTION, *SpatialConstants::DEVELOPMENT_AUTH_PLAYER_ID);
+			DevAuthConfig.DisplayName = URL.GetOption(*SpatialConstants::URL_DISPLAY_NAME_OPTION, TEXT(""));
+			DevAuthConfig.MetaData = URL.GetOption(*SpatialConstants::URL_METADATA_OPTION, TEXT(""));
+			DevAuthConfig.WorkerType = SpatialWorkerType;
+		}
+		else
+		{
+			// Use locator login flow.
+			SetConnectionType(ESpatialConnectionType::Locator);
+			if (LocatorHostOverride != "")
+			{
+				LocatorConfig.LocatorHost = LocatorHostOverride;
+			}
+			LocatorConfig.PlayerIdentityToken = URL.GetOption(*SpatialConstants::URL_PLAYER_IDENTITY_OPTION, TEXT(""));
+			LocatorConfig.LoginToken = URL.GetOption(*SpatialConstants::URL_LOGIN_OPTION, TEXT(""));
+			LocatorConfig.WorkerType = SpatialWorkerType;
+		}
 	}
 	else
 	{


### PR DESCRIPTION
#### Description
Support using a custom locator host in the URL.
Previously, URLs that use the locator flow must start with `locator.improbable.io`, with the option to overwrite the locator host as a cmd line arg. This change allows for custom locator hosts by having any URL with the `?customLocator` option go through the Locator login flow and using the URL's host as the locator host. This makes it possible to have a dynamic locator host that might not yet be known at startup and cannot be passed as a command line arg.

Have considered the alternative of adding a `?locatorHost=` URL option but think that's less preferable for the following reasons:
* The URL then needs to be escaped by the user
* Seems counterintuitive that the URL starts with a different host, e.g. `locator.improbable.io/?locator&locatorHost=https%3A%2F%2Fmy.custom.locator.host%2Flocator`
* This change has a low chance of breaking existing URLs, only if a URL was meant to be used for the Receptionist but has a `?customLocator` option it will now be used for the Locator flow.

#### Tests
Should there be any? Playtests have been using this change