### PR TITLE
[UNR-3078] Launch Configuration settings refactorisation + UX improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,10 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Add ability to disable outgoing RPC queue timeouts by setting `QueuedOutgoingRPCWaitTime` to 0.0f.
 - Added `bWorkerFlushAfterOutgoingNetworkOp` (defaulted false) which publishes changes to the GDK worker queue after RPCs and property replication to allow for lower latencies. Can be used in conjunction with `bRunSpatialWorkerConnectionOnGameThread` to get the lowest available latency at a trade-off with bandwidth.
 - You can now edit the project name field in the `Cloud Deployment` window.
+- Worker types are now defined in the runtime settings.
+- Local deployment will now use the map's load balancing strategy to get the launch configuration settings. The launch configuration file is saved per-map in the Intermediate/Improbable folder.
+- A launch configuration editor has been added under the Deploy toolbar button.
+- The cloud deployment window can now generate a launch configuration from the current map or use the launch configuration editor.
 
 ## Bug fixes:
 - Fixed a bug that caused queued RPCs to spam logs when an entity is deleted.

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
 #include "SpatialGDKSettings.h"
+
 #include "Improbable/SpatialEngineConstants.h"
 #include "Misc/MessageDialog.h"
 #include "Misc/CommandLine.h"
@@ -60,7 +61,7 @@ USpatialGDKSettings::USpatialGDKSettings(const FObjectInitializer& ObjectInitial
 	, ServicesRegion(EServicesRegion::Default)
 	, DefaultWorkerType(FWorkerType(SpatialConstants::DefaultServerWorkerType))
 	, bEnableOffloading(false)
-	, ServerWorkerTypes({ SpatialConstants::DefaultServerWorkerType })
+	, ServerWorkerTypes( { SpatialConstants::DefaultServerWorkerType } )
 	, WorkerLogLevel(ESettingsWorkerLogVerbosity::Warning)
 	, bEnableUnrealLoadBalancer(false)
 	, bRunSpatialWorkerConnectionOnGameThread(false)
@@ -135,6 +136,10 @@ void USpatialGDKSettings::PostEditChangeProperty(struct FPropertyChangedEvent& P
 		FMessageDialog::Open(EAppMsgType::Ok,
 			FText::FromString(FString::Printf(TEXT("You MUST regenerate schema using the full scan option after changing the number of max dynamic subobjects. "
 				"Failing to do will result in unintended behavior or crashes!"))));
+	}
+	else if (Name == GET_MEMBER_NAME_CHECKED(USpatialGDKSettings, ServerWorkerTypes))
+	{
+		OnWorkerTypesChangedDelegate.Broadcast();
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -13,6 +13,8 @@
 
 DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKSettings, Log, All);
 
+DECLARE_MULTICAST_DELEGATE(FOnWorkerTypesChanged)
+
 class ASpatialDebugger;
 
 /**
@@ -229,7 +231,7 @@ public:
 	TMap<FName, FActorGroupInfo> ActorGroups;
 
 	/** Available server worker types. */
-	UPROPERTY(Config)
+	UPROPERTY(EditAnywhere, Config, Category = "Workers")
 	TSet<FName> ServerWorkerTypes;
 
 	/** Controls the verbosity of worker logs which are sent to SpatialOS. These logs will appear in the Spatial Output and launch.log */
@@ -347,4 +349,6 @@ public:
 	bool bUseDevelopmentAuthenticationFlow;
 	FString DevelopmentAuthenticationToken;
 	FString DevelopmentDeploymentToConnect;
+
+	mutable FOnWorkerTypesChanged OnWorkerTypesChangedDelegate;
 };

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/EditorExtension/GridLBStrategyEditorExtension.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/EditorExtension/GridLBStrategyEditorExtension.cpp
@@ -2,6 +2,7 @@
 
 #include "GridLBStrategyEditorExtension.h"
 #include "SpatialGDKEditorSettings.h"
+#include "SpatialRuntimeLoadBalancingStrategies.h"
 
 class UGridBasedLBStrategy_Spy : public UGridBasedLBStrategy
 {
@@ -12,13 +13,14 @@ public:
 	using UGridBasedLBStrategy::Cols;
 };
 
-bool FGridLBStrategyEditorExtension::GetDefaultLaunchConfiguration(const UGridBasedLBStrategy* Strategy, FWorkerTypeLaunchSection& OutConfiguration, FIntPoint& OutWorldDimensions) const
+bool FGridLBStrategyEditorExtension::GetDefaultLaunchConfiguration(const UGridBasedLBStrategy* Strategy, UAbstractRuntimeLoadBalancingStrategy*& OutConfiguration, FIntPoint& OutWorldDimensions) const
 {
 	const UGridBasedLBStrategy_Spy* StrategySpy = static_cast<const UGridBasedLBStrategy_Spy*>(Strategy);
 
-	OutConfiguration.Rows = StrategySpy->Rows;
-	OutConfiguration.Columns = StrategySpy->Cols;
-	OutConfiguration.NumEditorInstances = StrategySpy->Rows * StrategySpy->Cols;
+	UGridRuntimeLoadBalancingStrategy* GridStrategy = NewObject<UGridRuntimeLoadBalancingStrategy>();
+	GridStrategy->Rows = StrategySpy->Rows;
+	GridStrategy->Columns = StrategySpy->Cols;
+	OutConfiguration = GridStrategy;
 
 	// Convert from cm to m.
 	OutWorldDimensions = FIntPoint(StrategySpy->WorldWidth / 100, StrategySpy->WorldHeight / 100);

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/EditorExtension/GridLBStrategyEditorExtension.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/EditorExtension/GridLBStrategyEditorExtension.h
@@ -8,5 +8,5 @@
 class FGridLBStrategyEditorExtension : public FLBStrategyEditorExtensionTemplate<UGridBasedLBStrategy, FGridLBStrategyEditorExtension>
 {
 public:
-	bool GetDefaultLaunchConfiguration(const UGridBasedLBStrategy* Strategy, FWorkerTypeLaunchSection& OutConfiguration, FIntPoint& OutWorldDimensions) const;
+	bool GetDefaultLaunchConfiguration(const UGridBasedLBStrategy* Strategy, UAbstractRuntimeLoadBalancingStrategy*& OutConfiguration, FIntPoint& OutWorldDimensions) const;
 };

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/EditorExtension/LBStrategyEditorExtension.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/EditorExtension/LBStrategyEditorExtension.cpp
@@ -29,7 +29,7 @@ bool InheritFromClosest(UClass* Derived, UClass* PotentialBase, uint32& InOutPre
 
 } // anonymous namespace
 
-bool FLBStrategyEditorExtensionManager::GetDefaultLaunchConfiguration(const UAbstractLBStrategy* Strategy, FWorkerTypeLaunchSection& OutConfiguration, FIntPoint& OutWorldDimensions) const
+bool FLBStrategyEditorExtensionManager::GetDefaultLaunchConfiguration(const UAbstractLBStrategy* Strategy, UAbstractRuntimeLoadBalancingStrategy*& OutConfiguration, FIntPoint& OutWorldDimensions) const
 {
 	if (!Strategy)
 	{

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
@@ -2,15 +2,19 @@
 
 #include "SpatialGDKDefaultLaunchConfigGenerator.h"
 
+#include "EditorExtension/LBStrategyEditorExtension.h"
+#include "EngineClasses/SpatialWorldSettings.h"
+#include "LoadBalancing/AbstractLBStrategy.h"
+#include "SpatialGDKEditorModule.h"
+#include "SpatialGDKSettings.h"
 #include "SpatialGDKEditorSettings.h"
-
-#include "Serialization/JsonWriter.h"
-#include "Misc/FileHelper.h"
-
-#include "Misc/MessageDialog.h"
+#include "SpatialRuntimeLoadBalancingStrategies.h"
 
 #include "ISettingsModule.h"
-#include "SpatialGDKSettings.h"
+#include "Misc/FileHelper.h"
+#include "Misc/MessageDialog.h"
+#include "Serialization/JsonWriter.h"
+#include "Settings/LevelEditorPlaySettings.h"
 
 DEFINE_LOG_CATEGORY(LogSpatialGDKDefaultLaunchConfigGenerator);
 
@@ -30,54 +34,54 @@ bool WriteFlagSection(TSharedRef<TJsonWriter<>> Writer, const FString& Key, cons
 	return true;
 }
 
-bool WriteWorkerSection(TSharedRef<TJsonWriter<>> Writer, const FWorkerTypeLaunchSection& Worker)
+bool WriteWorkerSection(TSharedRef<TJsonWriter<>> Writer, const FName& WorkerTypeName, const FWorkerTypeLaunchSection& WorkerConfig)
 {
 	Writer->WriteObjectStart();
-		Writer->WriteValue(TEXT("worker_type"), *Worker.WorkerTypeName.ToString());
+		Writer->WriteValue(TEXT("worker_type"), *WorkerTypeName.ToString());
 		Writer->WriteArrayStart(TEXT("flags"));
-			for (const auto& Flag : Worker.Flags)
+			for (const auto& Flag : WorkerConfig.Flags)
 			{
 				WriteFlagSection(Writer, Flag.Key, Flag.Value);
 			}
 		Writer->WriteArrayEnd();
 		Writer->WriteArrayStart(TEXT("permissions"));
 			Writer->WriteObjectStart();
-			if (Worker.WorkerPermissions.bAllPermissions)
-			{
-				Writer->WriteObjectStart(TEXT("all"));
-				Writer->WriteObjectEnd();
-			}
-			else
-			{
-				Writer->WriteObjectStart(TEXT("entity_creation"));
-					Writer->WriteValue(TEXT("allow"), Worker.WorkerPermissions.bAllowEntityCreation);
-				Writer->WriteObjectEnd();
-				Writer->WriteObjectStart(TEXT("entity_deletion"));
-					Writer->WriteValue(TEXT("allow"), Worker.WorkerPermissions.bAllowEntityDeletion);
-				Writer->WriteObjectEnd();
-				Writer->WriteObjectStart(TEXT("entity_query"));
-					Writer->WriteValue(TEXT("allow"), Worker.WorkerPermissions.bAllowEntityQuery);
-					Writer->WriteArrayStart("components");
-					for (const FString& Component : Worker.WorkerPermissions.Components)
-					{
-						Writer->WriteValue(Component);
-					}
-					Writer->WriteArrayEnd();
-				Writer->WriteObjectEnd();
-			}
+				if (WorkerConfig.WorkerPermissions.bAllPermissions)
+				{
+					Writer->WriteObjectStart(TEXT("all"));
+					Writer->WriteObjectEnd();
+				}
+				else
+				{
+					Writer->WriteObjectStart(TEXT("entity_creation"));
+						Writer->WriteValue(TEXT("allow"), WorkerConfig.WorkerPermissions.bAllowEntityCreation);
+					Writer->WriteObjectEnd();
+					Writer->WriteObjectStart(TEXT("entity_deletion"));
+						Writer->WriteValue(TEXT("allow"), WorkerConfig.WorkerPermissions.bAllowEntityDeletion);
+					Writer->WriteObjectEnd();
+					Writer->WriteObjectStart(TEXT("entity_query"));
+						Writer->WriteValue(TEXT("allow"), WorkerConfig.WorkerPermissions.bAllowEntityQuery);
+						Writer->WriteArrayStart("components");
+							for (const FString& Component : WorkerConfig.WorkerPermissions.Components)
+							{
+								Writer->WriteValue(Component);
+							}
+						Writer->WriteArrayEnd();
+					Writer->WriteObjectEnd();
+				}
 			Writer->WriteObjectEnd();
 		Writer->WriteArrayEnd();
-		if (Worker.MaxConnectionCapacityLimit > 0)
+		if (WorkerConfig.MaxConnectionCapacityLimit > 0)
 		{
 			Writer->WriteObjectStart(TEXT("connection_capacity_limit"));
-				Writer->WriteValue(TEXT("max_capacity"), Worker.MaxConnectionCapacityLimit);
+				Writer->WriteValue(TEXT("max_capacity"), WorkerConfig.MaxConnectionCapacityLimit);
 			Writer->WriteObjectEnd();
 		}
-		if (Worker.bLoginRateLimitEnabled)
+		if (WorkerConfig.bLoginRateLimitEnabled)
 		{
 			Writer->WriteObjectStart(TEXT("login_rate_limit"));
-				Writer->WriteValue(TEXT("duration"), Worker.LoginRateLimit.Duration);
-				Writer->WriteValue(TEXT("requests_per_duration"), Worker.LoginRateLimit.RequestsPerDuration);
+				Writer->WriteValue(TEXT("duration"), WorkerConfig.LoginRateLimit.Duration);
+				Writer->WriteValue(TEXT("requests_per_duration"), WorkerConfig.LoginRateLimit.RequestsPerDuration);
 			Writer->WriteObjectEnd();
 		}
 	Writer->WriteObjectEnd();
@@ -85,14 +89,11 @@ bool WriteWorkerSection(TSharedRef<TJsonWriter<>> Writer, const FWorkerTypeLaunc
 	return true;
 }
 
-bool WriteLoadbalancingSection(TSharedRef<TJsonWriter<>> Writer, const FName& WorkerType, const int32 Columns, const int32 Rows, const bool ManualWorkerConnectionOnly)
+bool WriteLoadbalancingSection(TSharedRef<TJsonWriter<>> Writer, const FName& WorkerType, UAbstractRuntimeLoadBalancingStrategy& Strategy, const bool ManualWorkerConnectionOnly)
 {
 	Writer->WriteObjectStart();
 		Writer->WriteValue(TEXT("layer"), *WorkerType.ToString());
-		Writer->WriteObjectStart("rectangle_grid");
-			Writer->WriteValue(TEXT("cols"), Columns);
-			Writer->WriteValue(TEXT("rows"), Rows);
-		Writer->WriteObjectEnd();
+		Strategy.WriteToConfiguration(Writer);
 		Writer->WriteObjectStart(TEXT("options"));
 			Writer->WriteValue(TEXT("manual_worker_connection_only"), ManualWorkerConnectionOnly);
 		Writer->WriteObjectEnd();
@@ -101,9 +102,85 @@ bool WriteLoadbalancingSection(TSharedRef<TJsonWriter<>> Writer, const FName& Wo
 	return true;
 }
 
+} // anonymous namespace
+
+void SetLevelEditorPlaySettingsWorkerTypes(const TMap<FName, FWorkerTypeLaunchSection>& InWorkers)
+{
+	ULevelEditorPlaySettings* PlayInSettings = GetMutableDefault<ULevelEditorPlaySettings>();
+
+	PlayInSettings->WorkerTypesToLaunch.Empty(InWorkers.Num());
+	for (const auto& Worker : InWorkers)
+	{
+		if (Worker.Value.bAutoNumEditorInstances)
+		{
+			PlayInSettings->WorkerTypesToLaunch.Add(Worker.Key, Worker.Value.WorkerLoadBalancing->GetNumberOfWorkersForPIE());
+		}
+		else
+		{
+			PlayInSettings->WorkerTypesToLaunch.Add(Worker.Key, Worker.Value.NumEditorInstances);
+		}
+	}
 }
 
-bool GenerateDefaultLaunchConfig(const FString& LaunchConfigPath, const FSpatialLaunchConfigDescription* InLaunchConfigDescription)
+bool GetLoadBalancingStrategyFromWorldSettings(const UWorld& World, UAbstractRuntimeLoadBalancingStrategy*& OutStrategy, FIntPoint& OutWorldDimension)
+{
+	const ASpatialWorldSettings* WorldSettings = Cast<ASpatialWorldSettings>(World.GetWorldSettings());
+
+	if (WorldSettings == nullptr)
+	{
+		UE_LOG(LogSpatialGDKDefaultLaunchConfigGenerator, Error, TEXT("Missing SpatialWorldSettings on map %s"), *World.GetMapName());
+		return false;
+	}
+
+	if (WorldSettings->LoadBalanceStrategy == nullptr)
+	{
+		UE_LOG(LogSpatialGDKDefaultLaunchConfigGenerator, Error, TEXT("Missing Load balancing strategy on map %s"), *World.GetMapName());
+		return false;
+	}
+
+	FSpatialGDKEditorModule& EditorModule = FModuleManager::GetModuleChecked<FSpatialGDKEditorModule>("SpatialGDKEditor");
+
+	if (!EditorModule.GetLBStrategyExtensionManager().GetDefaultLaunchConfiguration(WorldSettings->LoadBalanceStrategy->GetDefaultObject<UAbstractLBStrategy>(), OutStrategy, OutWorldDimension))
+	{
+		UE_LOG(LogSpatialGDKDefaultLaunchConfigGenerator, Error, TEXT("Could not get the SpatialOS Load balancing strategy from %s"), *WorldSettings->LoadBalanceStrategy->GetName());
+		return false;
+	}
+
+	return true;
+}
+
+bool FillWorkerConfigurationFromCurrentMap(TMap<FName, FWorkerTypeLaunchSection>& OutWorkers, FIntPoint& OutWorldDimensions)
+{
+	if (GEditor == nullptr || GEditor->GetWorldContexts().Num() == 0)
+	{
+		return false;
+	}
+
+	const USpatialGDKSettings* SpatialGDKSettings = GetDefault<USpatialGDKSettings>();
+	const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>();
+
+	UWorld* EditorWorld = GEditor->GetEditorWorldContext().World();
+	check(EditorWorld != nullptr);
+
+	USingleWorkerRuntimeStrategy* DefaultStrategy = USingleWorkerRuntimeStrategy::StaticClass()->GetDefaultObject<USingleWorkerRuntimeStrategy>();
+	UAbstractRuntimeLoadBalancingStrategy* LoadBalancingStrat = DefaultStrategy;
+
+	if (SpatialGDKSettings->bEnableUnrealLoadBalancer)
+	{
+		GetLoadBalancingStrategyFromWorldSettings(*EditorWorld, LoadBalancingStrat, OutWorldDimensions);
+	}
+
+	for (const TPair<FName, FWorkerTypeLaunchSection>& WorkerType : SpatialGDKEditorSettings->LaunchConfigDesc.ServerWorkersMap)
+	{
+		FWorkerTypeLaunchSection Conf = WorkerType.Value;
+		Conf.WorkerLoadBalancing = LoadBalancingStrat;
+		OutWorkers.Add(WorkerType.Key, Conf);
+	}
+
+	return true;
+}
+
+bool GenerateDefaultLaunchConfig(const FString& LaunchConfigPath, const FSpatialLaunchConfigDescription* InLaunchConfigDescription, const TMap<FName, FWorkerTypeLaunchSection>& InWorkers)
 {
 	if (InLaunchConfigDescription != nullptr)
 	{
@@ -120,42 +197,46 @@ bool GenerateDefaultLaunchConfig(const FString& LaunchConfigPath, const FSpatial
 					Writer->WriteValue(TEXT("x_meters"), LaunchConfigDescription.World.Dimensions.X);
 					Writer->WriteValue(TEXT("z_meters"), LaunchConfigDescription.World.Dimensions.Y);
 				Writer->WriteObjectEnd();
-			Writer->WriteValue(TEXT("chunk_edge_length_meters"), LaunchConfigDescription.World.ChunkEdgeLengthMeters);
-			Writer->WriteArrayStart(TEXT("legacy_flags"));
-			for (auto& Flag : LaunchConfigDescription.World.LegacyFlags)
-			{
-				WriteFlagSection(Writer, Flag.Key, Flag.Value);
-			}
-			Writer->WriteArrayEnd();
-			Writer->WriteArrayStart(TEXT("legacy_javaparams"));
-			for (auto& Parameter : LaunchConfigDescription.World.LegacyJavaParams)
-			{
-				WriteFlagSection(Writer, Parameter.Key, Parameter.Value);
-			}
-			Writer->WriteArrayEnd();
-			Writer->WriteObjectStart(TEXT("snapshots"));
-				Writer->WriteValue(TEXT("snapshot_write_period_seconds"), LaunchConfigDescription.World.SnapshotWritePeriodSeconds);
-			Writer->WriteObjectEnd();
-		Writer->WriteObjectEnd(); // World section end
-		Writer->WriteObjectStart(TEXT("load_balancing")); // Load balancing section begin
-			Writer->WriteArrayStart("layer_configurations");
-			for (const FWorkerTypeLaunchSection& Worker : LaunchConfigDescription.ServerWorkers)
-			{
-				WriteLoadbalancingSection(Writer, Worker.WorkerTypeName, Worker.Columns, Worker.Rows, Worker.bManualWorkerConnectionOnly);
-			}
-			Writer->WriteArrayEnd();
+				Writer->WriteValue(TEXT("chunk_edge_length_meters"), LaunchConfigDescription.World.ChunkEdgeLengthMeters);
+				Writer->WriteArrayStart(TEXT("legacy_flags"));
+				for (auto& Flag : LaunchConfigDescription.World.LegacyFlags)
+				{
+					WriteFlagSection(Writer, Flag.Key, Flag.Value);
+				}
+				Writer->WriteArrayEnd();
+				Writer->WriteArrayStart(TEXT("legacy_javaparams"));
+					for (auto& Parameter : LaunchConfigDescription.World.LegacyJavaParams)
+					{
+						WriteFlagSection(Writer, Parameter.Key, Parameter.Value);
+					}
+				Writer->WriteArrayEnd();
+				Writer->WriteObjectStart(TEXT("snapshots"));
+					Writer->WriteValue(TEXT("snapshot_write_period_seconds"), LaunchConfigDescription.World.SnapshotWritePeriodSeconds);
+				Writer->WriteObjectEnd();
+			Writer->WriteObjectEnd(); // World section end
+			Writer->WriteObjectStart(TEXT("load_balancing")); // Load balancing section begin
+				Writer->WriteArrayStart("layer_configurations");
+				for (const auto& Worker : InWorkers)
+				{
+					if (Worker.Value.WorkerLoadBalancing == nullptr)
+					{
+						UE_LOG(LogSpatialGDKDefaultLaunchConfigGenerator, Error, TEXT("Worker type '%s' is missing a load balancing setting."), *Worker.Key.ToString());
+						return false;
+					}
+					WriteLoadbalancingSection(Writer, Worker.Key, *Worker.Value.WorkerLoadBalancing, Worker.Value.bManualWorkerConnectionOnly);
+				}
+				Writer->WriteArrayEnd();
 			Writer->WriteObjectEnd(); // Load balancing section end
 			Writer->WriteArrayStart(TEXT("workers")); // Workers section begin
-			for (const FWorkerTypeLaunchSection& Worker : LaunchConfigDescription.ServerWorkers)
-			{
-				WriteWorkerSection(Writer, Worker);
-			}
-			// Write the client worker section
-			FWorkerTypeLaunchSection ClientWorker;
-			ClientWorker.WorkerTypeName = SpatialConstants::DefaultClientWorkerType;
-			ClientWorker.WorkerPermissions.bAllPermissions = true;
-			ClientWorker.bLoginRateLimitEnabled = false;
-			WriteWorkerSection(Writer, ClientWorker);
+				for (const auto& Worker : InWorkers)
+				{
+					WriteWorkerSection(Writer, Worker.Key, Worker.Value);
+				}
+				// Write the client worker section
+				FWorkerTypeLaunchSection ClientWorker;
+				ClientWorker.WorkerPermissions.bAllPermissions = true;
+				ClientWorker.bLoginRateLimitEnabled = false;
+				WriteWorkerSection(Writer, SpatialConstants::DefaultClientWorkerType, ClientWorker);
 			Writer->WriteArrayEnd(); // Worker section end
 		Writer->WriteObjectEnd(); // End of json
 
@@ -173,9 +254,22 @@ bool GenerateDefaultLaunchConfig(const FString& LaunchConfigPath, const FSpatial
 	return false;
 }
 
-bool ValidateGeneratedLaunchConfig(const FSpatialLaunchConfigDescription& LaunchConfigDesc)
+bool ValidateGeneratedLaunchConfig(const FSpatialLaunchConfigDescription& LaunchConfigDesc, const TMap<FName, FWorkerTypeLaunchSection>& InWorkers)
 {
 	const USpatialGDKSettings* SpatialGDKRuntimeSettings = GetDefault<USpatialGDKSettings>();
+
+	if (!ensure(InWorkers.Num() == SpatialGDKRuntimeSettings->ServerWorkerTypes.Num()))
+	{
+		return false;
+	}
+
+	for (const FName& WorkerType : SpatialGDKRuntimeSettings->ServerWorkerTypes)
+	{
+		if(!ensure(InWorkers.Contains(WorkerType)))
+		{
+			return false;
+		}
+	}
 
 	if (const FString* EnableChunkInterest = LaunchConfigDesc.World.LegacyFlags.Find(TEXT("enable_chunk_interest")))
 	{
@@ -192,22 +286,7 @@ bool ValidateGeneratedLaunchConfig(const FSpatialLaunchConfigDescription& Launch
 		}
 	}
 
-	if (LaunchConfigDesc.ServerWorkers.ContainsByPredicate([](const FWorkerTypeLaunchSection& Section)
-	{
-		return (Section.Rows * Section.Columns) < Section.NumEditorInstances;
-	}))
-	{
-		const EAppReturnType::Type Result = FMessageDialog::Open(EAppMsgType::YesNo, FText::FromString(TEXT("Attempting to launch too many servers for load balance configuration.\nThis is not supported.\n\nDo you want to configure your project settings now?")));
-
-		if (Result == EAppReturnType::Yes)
-		{
-			FModuleManager::LoadModuleChecked<ISettingsModule>("Settings").ShowViewer("Project", "SpatialGDKEditor", "Editor Settings");
-		}
-
-		return false;
-	}
-
-	if (!SpatialGDKRuntimeSettings->ServerWorkerTypes.Contains(SpatialGDKRuntimeSettings->DefaultWorkerType.WorkerTypeName))
+	if (!InWorkers.Contains(SpatialGDKRuntimeSettings->DefaultWorkerType.WorkerTypeName))
 	{
 		const EAppReturnType::Type Result = FMessageDialog::Open(EAppMsgType::YesNo, FText::FromString(TEXT("Default Worker Type is invalid, please choose a valid worker type as the default.\n\nDo you want to configure your project settings now?")));
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
@@ -110,11 +110,20 @@ void SetLevelEditorPlaySettingsWorkerTypes(const TMap<FName, FWorkerTypeLaunchSe
 	ULevelEditorPlaySettings* PlayInSettings = GetMutableDefault<ULevelEditorPlaySettings>();
 
 	PlayInSettings->WorkerTypesToLaunch.Empty(InWorkers.Num());
+
+	if (InWorkers.Num() == 0)
+	{
+		UE_LOG(LogSpatialGDKDefaultLaunchConfigGenerator, Warning, TEXT("No workers specified in SetLevelEditorPlaySettingsWorkerType."));
+	}
+
 	for (const auto& Worker : InWorkers)
 	{
 		if (Worker.Value.bAutoNumEditorInstances)
 		{
-			PlayInSettings->WorkerTypesToLaunch.Add(Worker.Key, Worker.Value.WorkerLoadBalancing->GetNumberOfWorkersForPIE());
+			if (Worker.Value.WorkerLoadBalancing != nullptr)
+			{
+				PlayInSettings->WorkerTypesToLaunch.Add(Worker.Key, Worker.Value.WorkerLoadBalancing->GetNumberOfWorkersForPIE());
+			}
 		}
 		else
 		{

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
@@ -10,6 +10,7 @@
 #include "SpatialGDKEditorSettings.h"
 #include "SpatialRuntimeLoadBalancingStrategies.h"
 
+#include "Editor.h"
 #include "ISettingsModule.h"
 #include "Misc/FileHelper.h"
 #include "Misc/MessageDialog.h"

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultWorkerJsonGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultWorkerJsonGenerator.cpp
@@ -2,7 +2,7 @@
 
 #include "SpatialGDKDefaultWorkerJsonGenerator.h"
 
-#include "SpatialGDKEditorSettings.h"
+#include "SpatialGDKSettings.h"
 #include "SpatialGDKServicesConstants.h"
 
 #include "Misc/FileHelper.h"
@@ -43,17 +43,16 @@ bool GenerateAllDefaultWorkerJsons(bool& bOutRedeployRequired)
 	const FString WorkerJsonDir = FPaths::Combine(SpatialGDKServicesConstants::SpatialOSDirectory, TEXT("workers/unreal"));
 	bool bAllJsonsGeneratedSuccessfully = true;
 
-	if (const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>())
+	if (const USpatialGDKSettings* SpatialGDKSettings = GetDefault<USpatialGDKSettings>())
 	{
-		const FSpatialLaunchConfigDescription& LaunchConfigDescription = SpatialGDKEditorSettings->LaunchConfigDesc;
-		for (const FWorkerTypeLaunchSection& Worker : LaunchConfigDescription.ServerWorkers)
+		for (const FName& Worker : SpatialGDKSettings->ServerWorkerTypes)
 		{
-			FString JsonPath = FPaths::Combine(WorkerJsonDir, FString::Printf(TEXT("spatialos.%s.worker.json"), *Worker.WorkerTypeName.ToString()));
+			FString JsonPath = FPaths::Combine(WorkerJsonDir, FString::Printf(TEXT("spatialos.%s.worker.json"), *Worker.ToString()));
 			if (!FPaths::FileExists(JsonPath))
 			{
 				UE_LOG(LogSpatialGDKDefaultWorkerJsonGenerator, Verbose, TEXT("Could not find worker json at %s"), *JsonPath);
 
-				if (!GenerateDefaultWorkerJson(JsonPath, Worker.WorkerTypeName.ToString(), bOutRedeployRequired))
+				if (!GenerateDefaultWorkerJson(JsonPath, Worker.ToString(), bOutRedeployRequired))
 				{
 					bAllJsonsGeneratedSuccessfully = false;
 				}

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
@@ -27,23 +27,23 @@ TSharedRef<IDetailCustomization> FSpatialGDKEditorLayoutDetails::MakeInstance()
 
 void FSpatialGDKEditorLayoutDetails::ForceRefreshLayout()
 {
-	if (MyLayout != nullptr)
+	if (CurrentLayout != nullptr)
 	{
 		TArray<TWeakObjectPtr<UObject>> Objects;
-		MyLayout->GetObjectsBeingCustomized(Objects);
+		CurrentLayout->GetObjectsBeingCustomized(Objects);
 		USpatialGDKEditorSettings* Settings = Objects.Num() > 0 ? Cast<USpatialGDKEditorSettings>(Objects[0].Get()) : nullptr;
 		if (Settings != nullptr)
 		{
 			// Force layout to happen in the right order, as delegates may not be ordered.
 			Settings->OnWorkerTypesChanged();
 		}
-		MyLayout->ForceRefreshDetails();
+		CurrentLayout->ForceRefreshDetails();
 	}
 }
 
 void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& DetailBuilder)
 {
-	MyLayout = &DetailBuilder;
+	CurrentLayout = &DetailBuilder;
 	const USpatialGDKSettings* GDKSettings = GetDefault<USpatialGDKSettings>();
 	GDKSettings->OnWorkerTypesChangedDelegate.AddSP(this, &FSpatialGDKEditorLayoutDetails::ForceRefreshLayout);
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -2,17 +2,19 @@
 
 #include "SpatialGDKEditorModule.h"
 
+#include "EditorExtension/GridLBStrategyEditorExtension.h"
 #include "SpatialGDKSettings.h"
 #include "SpatialGDKEditorSettings.h"
 #include "SpatialGDKEditorLayoutDetails.h"
+#include "SpatialLaunchConfigCustomization.h"
+#include "Utils/LaunchConfigEditor.h"
+#include "Utils/LaunchConfigEditorLayoutDetails.h"
+#include "WorkerTypeCustomization.h"
 
 #include "ISettingsModule.h"
 #include "ISettingsContainer.h"
 #include "ISettingsSection.h"
 #include "PropertyEditor/Public/PropertyEditorModule.h"
-#include "WorkerTypeCustomization.h"
-
-#include "EditorExtension/GridLBStrategyEditorExtension.h"
 
 #define LOCTEXT_NAMESPACE "FSpatialGDKEditorModule"
 
@@ -71,7 +73,9 @@ void FSpatialGDKEditorModule::RegisterSettings()
 
 	FPropertyEditorModule& PropertyModule = FModuleManager::LoadModuleChecked<FPropertyEditorModule>("PropertyEditor");
 	PropertyModule.RegisterCustomPropertyTypeLayout("WorkerType", FOnGetPropertyTypeCustomizationInstance::CreateStatic(&FWorkerTypeCustomization::MakeInstance));
+	PropertyModule.RegisterCustomPropertyTypeLayout("SpatialLaunchConfigDescription", FOnGetPropertyTypeCustomizationInstance::CreateStatic(&FSpatialLaunchConfigCustomization::MakeInstance));
 	PropertyModule.RegisterCustomClassLayout(USpatialGDKEditorSettings::StaticClass()->GetFName(), FOnGetDetailCustomizationInstance::CreateStatic(&FSpatialGDKEditorLayoutDetails::MakeInstance));
+	PropertyModule.RegisterCustomClassLayout(ULaunchConfigurationEditor::StaticClass()->GetFName(), FOnGetDetailCustomizationInstance::CreateStatic(&FLaunchConfigEditorLayoutDetails::MakeInstance));
 }
 
 void FSpatialGDKEditorModule::UnregisterSettings()

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -2,15 +2,15 @@
 
 #include "SpatialGDKEditorSettings.h"
 
+#include "SpatialConstants.h"
+#include "SpatialGDKSettings.h"
+
 #include "Internationalization/Regex.h"
 #include "ISettingsModule.h"
 #include "Misc/FileHelper.h"
 #include "Misc/MessageDialog.h"
 #include "Modules/ModuleManager.h"
-#include "Settings/LevelEditorPlaySettings.h"
 #include "Templates/SharedPointer.h"
-#include "SpatialConstants.h"
-#include "SpatialGDKSettings.h"
 
 #include "Serialization/JsonReader.h"
 #include "Serialization/JsonSerializer.h"
@@ -18,14 +18,24 @@
 DEFINE_LOG_CATEGORY(LogSpatialEditorSettings);
 #define LOCTEXT_NAMESPACE "USpatialGDKEditorSettings"
 
-void FSpatialLaunchConfigDescription::SetLevelEditorPlaySettingsWorkerTypes()
+void FSpatialLaunchConfigDescription::OnWorkerTypesChanged()
 {
-	ULevelEditorPlaySettings* PlayInSettings = GetMutableDefault<ULevelEditorPlaySettings>();
+	USpatialGDKSettings const* RuntimeSettings = GetDefault<USpatialGDKSettings>();
 
-	PlayInSettings->WorkerTypesToLaunch.Empty(ServerWorkers.Num());
-	for (const FWorkerTypeLaunchSection& WorkerLaunch : ServerWorkers)
+	for (const FName& WorkerType : RuntimeSettings->ServerWorkerTypes)
 	{
-		PlayInSettings->WorkerTypesToLaunch.Add(WorkerLaunch.WorkerTypeName, WorkerLaunch.NumEditorInstances);
+		if (!ServerWorkersMap.Contains(WorkerType))
+		{
+			ServerWorkersMap.Add(WorkerType, FWorkerTypeLaunchSection());
+		}
+	}
+
+	for (auto Iterator = ServerWorkersMap.CreateIterator(); Iterator; ++Iterator)
+	{
+		if (!RuntimeSettings->ServerWorkerTypes.Contains(Iterator->Key))
+		{
+			Iterator.RemoveCurrent();
+		}
 	}
 }
 
@@ -82,10 +92,6 @@ void USpatialGDKEditorSettings::PostEditChangeProperty(struct FPropertyChangedEv
 		PlayInSettings->PostEditChange();
 		PlayInSettings->SaveConfig();
 	}
-	else if (Name == GET_MEMBER_NAME_CHECKED(USpatialGDKEditorSettings, LaunchConfigDesc))
-	{
-		SetRuntimeWorkerTypes();
-	}
 	else if (Name == GET_MEMBER_NAME_CHECKED(USpatialGDKEditorSettings, bUseDevelopmentAuthenticationFlow))
 	{
 		SetRuntimeUseDevelopmentAuthenticationFlow();
@@ -100,6 +106,12 @@ void USpatialGDKEditorSettings::PostEditChangeProperty(struct FPropertyChangedEv
 	}
 }
 
+void USpatialGDKEditorSettings::OnWorkerTypesChanged()
+{
+	LaunchConfigDesc.OnWorkerTypesChanged();
+	PostEditChange();
+}
+
 void USpatialGDKEditorSettings::PostInitProperties()
 {
 	Super::PostInitProperties();
@@ -109,32 +121,28 @@ void USpatialGDKEditorSettings::PostInitProperties()
 	PlayInSettings->PostEditChange();
 	PlayInSettings->SaveConfig();
 
-	SetRuntimeWorkerTypes();
 	SetRuntimeUseDevelopmentAuthenticationFlow();
 	SetRuntimeDevelopmentAuthenticationToken();
 	SetRuntimeDevelopmentDeploymentToConnect();
-}
 
-void USpatialGDKEditorSettings::SetRuntimeWorkerTypes()
-{
-	TSet<FName> WorkerTypes;
-	
-	for (const FWorkerTypeLaunchSection& WorkerLaunch : LaunchConfigDesc.ServerWorkers)
+	const USpatialGDKSettings* GDKSettings = GetDefault<USpatialGDKSettings>();
+
+	if (LaunchConfigDesc.ServerWorkers_DEPRECATED.Num() > 0)
 	{
-		if (WorkerLaunch.WorkerTypeName != NAME_None)
+		for (FWorkerTypeLaunchSection& LaunchConfig : LaunchConfigDesc.ServerWorkers_DEPRECATED)
 		{
-			WorkerTypes.Add(WorkerLaunch.WorkerTypeName);
+			if (LaunchConfig.WorkerTypeName_DEPRECATED.IsValid() && GDKSettings->ServerWorkerTypes.Contains(LaunchConfig.WorkerTypeName_DEPRECATED))
+			{
+				LaunchConfigDesc.ServerWorkersMap.Add(LaunchConfig.WorkerTypeName_DEPRECATED, LaunchConfig);
+			}
 		}
+		LaunchConfigDesc.ServerWorkers_DEPRECATED.Empty();
+		SaveConfig();
 	}
 
-	USpatialGDKSettings* RuntimeSettings = GetMutableDefault<USpatialGDKSettings>();
-	if (RuntimeSettings != nullptr)
-	{
-		RuntimeSettings->ServerWorkerTypes.Empty(WorkerTypes.Num());
-		RuntimeSettings->ServerWorkerTypes.Append(WorkerTypes);
-		RuntimeSettings->PostEditChange();
-		RuntimeSettings->UpdateSinglePropertyInConfigFile(RuntimeSettings->GetClass()->FindPropertyByName(GET_MEMBER_NAME_CHECKED(USpatialGDKSettings, ServerWorkerTypes)), RuntimeSettings->GetDefaultConfigFilename());
-	}
+	LaunchConfigDesc.OnWorkerTypesChanged();
+
+	GDKSettings->OnWorkerTypesChangedDelegate.AddUObject(this, &USpatialGDKEditorSettings::OnWorkerTypesChanged);
 }
 
 void USpatialGDKEditorSettings::SetRuntimeUseDevelopmentAuthenticationFlow()

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialLaunchConfigCustomization.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialLaunchConfigCustomization.cpp
@@ -1,0 +1,99 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "SpatialLaunchConfigCustomization.h"
+
+#include "SpatialGDKSettings.h"
+#include "SpatialGDKEditorSettings.h"
+
+#include "IDetailChildrenBuilder.h"
+#include "IDetailGroup.h"
+#include "PropertyCustomizationHelpers.h"
+#include "PropertyHandle.h"
+#include "Widgets/SToolTip.h"
+#include "Widgets/Text/STextBlock.h"
+
+TSharedRef<IPropertyTypeCustomization> FSpatialLaunchConfigCustomization::MakeInstance()
+{
+	return MakeShared<FSpatialLaunchConfigCustomization>();
+}
+
+void FSpatialLaunchConfigCustomization::CustomizeHeader(TSharedRef<class IPropertyHandle> StructPropertyHandle, class FDetailWidgetRow& HeaderRow, IPropertyTypeCustomizationUtils& StructCustomizationUtils)
+{
+	
+}
+
+void FSpatialLaunchConfigCustomization::CustomizeChildren(TSharedRef<class IPropertyHandle> StructPropertyHandle, class IDetailChildrenBuilder& StructBuilder, IPropertyTypeCustomizationUtils& StructCustomizationUtils)
+{
+	TArray<UObject*> EditedObject;
+	StructPropertyHandle->GetOuterObjects(EditedObject);
+
+	if (EditedObject.Num() == 0)
+	{
+		return;
+	}
+
+	const bool bIsInSettings = Cast<USpatialGDKEditorSettings>(EditedObject[0]) != nullptr;
+
+	uint32 NumChildren;
+	StructPropertyHandle->GetNumChildren(NumChildren);
+	for (uint32 ChildIdx = 0; ChildIdx < NumChildren; ++ChildIdx)
+	{
+		TSharedPtr<IPropertyHandle> ChildProperty = StructPropertyHandle->GetChildHandle(ChildIdx);
+
+		// Layout regular properties as usual.
+		if (ChildProperty->GetProperty()->GetName() != "ServerWorkersMap")
+		{
+			StructBuilder.AddProperty(ChildProperty.ToSharedRef());
+			continue;
+		}
+
+		// Layout ServerWorkers map in a way that does not allow resizing and key edition.
+		uint32 numEntries;
+		ChildProperty->GetNumChildren(numEntries);
+
+		IDetailGroup& NewGroup = StructBuilder.AddGroup("ServerWorkersMap", ChildProperty->GetPropertyDisplayName());
+		NewGroup.HeaderRow()
+		.NameContent()
+		[
+			SNew(STextBlock).Text(FText::FromString(TEXT("Server Workers")))
+		]
+		.ValueContent()
+		[
+			SNew(STextBlock).Text(FText::FromString(FString::Printf(TEXT("%i Elements"), numEntries)))
+		];
+
+		const TMap<FName, FWorkerTypeLaunchSection>* CustomizedMap = reinterpret_cast<TMap<FName, FWorkerTypeLaunchSection>*>(ChildProperty->GetValueBaseAddress(reinterpret_cast<uint8*>(EditedObject[0])));
+
+		// Assume that the properties as listed in the same order as the map's iterator.
+		auto Iterator = CustomizedMap->CreateConstIterator();
+
+		for (uint32 entryIdx = 0; entryIdx < numEntries; ++entryIdx, ++Iterator)
+		{
+			TSharedPtr<IPropertyHandle> EntryProp = ChildProperty->GetChildHandle(entryIdx);
+
+			IDetailGroup& Entry = NewGroup.AddGroup(Iterator->Key, FText::FromName(Iterator->Key));
+			uint32 numEntryFields;
+			EntryProp->GetNumChildren(numEntryFields);
+
+			for (uint32 entryField = 0; entryField < numEntryFields; ++entryField)
+			{
+				TSharedPtr<IPropertyHandle> EntryFieldProp = EntryProp->GetChildHandle(entryField);
+
+				// Skip the load balancing property in the Editor settings.
+				if (bIsInSettings && EntryFieldProp->GetProperty()->GetFName() == GET_MEMBER_NAME_CHECKED(FWorkerTypeLaunchSection, WorkerLoadBalancing))
+				{
+					continue;
+				}
+
+				Entry.AddPropertyRow(EntryFieldProp.ToSharedRef()).CustomWidget(true).NameContent()
+				[
+					EntryFieldProp->CreatePropertyNameWidget()
+				]
+				.ValueContent()
+				[
+					EntryFieldProp->CreatePropertyValueWidget()
+				];
+			}
+		}		
+	}
+}

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialLaunchConfigCustomization.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialLaunchConfigCustomization.cpp
@@ -48,8 +48,8 @@ void FSpatialLaunchConfigCustomization::CustomizeChildren(TSharedRef<class IProp
 		}
 
 		// Layout ServerWorkers map in a way that does not allow resizing and key edition.
-		uint32 numEntries;
-		ChildProperty->GetNumChildren(numEntries);
+		uint32 NumEntries;
+		ChildProperty->GetNumChildren(NumEntries);
 
 		IDetailGroup& NewGroup = StructBuilder.AddGroup("ServerWorkersMap", ChildProperty->GetPropertyDisplayName());
 		NewGroup.HeaderRow()
@@ -59,7 +59,7 @@ void FSpatialLaunchConfigCustomization::CustomizeChildren(TSharedRef<class IProp
 		]
 		.ValueContent()
 		[
-			SNew(STextBlock).Text(FText::FromString(FString::Printf(TEXT("%i Elements"), numEntries)))
+			SNew(STextBlock).Text(FText::FromString(FString::Printf(TEXT("%i Elements"), NumEntries)))
 		];
 
 		const TMap<FName, FWorkerTypeLaunchSection>* CustomizedMap = reinterpret_cast<TMap<FName, FWorkerTypeLaunchSection>*>(ChildProperty->GetValueBaseAddress(reinterpret_cast<uint8*>(EditedObject[0])));
@@ -67,17 +67,17 @@ void FSpatialLaunchConfigCustomization::CustomizeChildren(TSharedRef<class IProp
 		// Assume that the properties as listed in the same order as the map's iterator.
 		auto Iterator = CustomizedMap->CreateConstIterator();
 
-		for (uint32 entryIdx = 0; entryIdx < numEntries; ++entryIdx, ++Iterator)
+		for (uint32 EntryIdx = 0; EntryIdx < NumEntries; ++EntryIdx, ++Iterator)
 		{
-			TSharedPtr<IPropertyHandle> EntryProp = ChildProperty->GetChildHandle(entryIdx);
+			TSharedPtr<IPropertyHandle> EntryProp = ChildProperty->GetChildHandle(EntryIdx);
 
 			IDetailGroup& Entry = NewGroup.AddGroup(Iterator->Key, FText::FromName(Iterator->Key));
-			uint32 numEntryFields;
-			EntryProp->GetNumChildren(numEntryFields);
+			uint32 NumEntryFields;
+			EntryProp->GetNumChildren(NumEntryFields);
 
-			for (uint32 entryField = 0; entryField < numEntryFields; ++entryField)
+			for (uint32 EntryField = 0; EntryField < NumEntryFields; ++EntryField)
 			{
-				TSharedPtr<IPropertyHandle> EntryFieldProp = EntryProp->GetChildHandle(entryField);
+				TSharedPtr<IPropertyHandle> EntryFieldProp = EntryProp->GetChildHandle(EntryField);
 
 				// Skip the load balancing property in the Editor settings.
 				if (bIsInSettings && EntryFieldProp->GetProperty()->GetFName() == GET_MEMBER_NAME_CHECKED(FWorkerTypeLaunchSection, WorkerLoadBalancing))

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialLaunchConfigCustomization.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialLaunchConfigCustomization.cpp
@@ -62,16 +62,16 @@ void FSpatialLaunchConfigCustomization::CustomizeChildren(TSharedRef<class IProp
 			SNew(STextBlock).Text(FText::FromString(FString::Printf(TEXT("%i Elements"), NumEntries)))
 		];
 
-		const TMap<FName, FWorkerTypeLaunchSection>* CustomizedMap = reinterpret_cast<TMap<FName, FWorkerTypeLaunchSection>*>(ChildProperty->GetValueBaseAddress(reinterpret_cast<uint8*>(EditedObject[0])));
-
-		// Assume that the properties as listed in the same order as the map's iterator.
-		auto Iterator = CustomizedMap->CreateConstIterator();
-
-		for (uint32 EntryIdx = 0; EntryIdx < NumEntries; ++EntryIdx, ++Iterator)
+		for (uint32 EntryIdx = 0; EntryIdx < NumEntries; ++EntryIdx)
 		{
 			TSharedPtr<IPropertyHandle> EntryProp = ChildProperty->GetChildHandle(EntryIdx);
+			check(EntryProp != nullptr);
+			TSharedPtr<IPropertyHandle> EntryKeyProp = EntryProp->GetKeyHandle();
+			check(EntryKeyProp != nullptr);
+			
+			FName* KeyPtr = reinterpret_cast<FName*>(EntryKeyProp->GetValueBaseAddress(reinterpret_cast<uint8*>(EditedObject[0])));
 
-			IDetailGroup& Entry = NewGroup.AddGroup(Iterator->Key, FText::FromName(Iterator->Key));
+			IDetailGroup& Entry = NewGroup.AddGroup(*KeyPtr, FText::FromName(*KeyPtr));
 			uint32 NumEntryFields;
 			EntryProp->GetNumChildren(NumEntryFields);
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialRuntimeLoadBalancingStrategies.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialRuntimeLoadBalancingStrategies.cpp
@@ -1,0 +1,62 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "SpatialRuntimeLoadBalancingStrategies.h"
+
+USingleWorkerRuntimeStrategy::USingleWorkerRuntimeStrategy() = default;
+
+bool USingleWorkerRuntimeStrategy::WriteToConfiguration(TSharedRef<TJsonWriter<>> Writer) const
+{
+	Writer->WriteObjectStart("rectangle_grid");
+	Writer->WriteValue(TEXT("cols"), 1);
+	Writer->WriteValue(TEXT("rows"), 1);
+	Writer->WriteObjectEnd();
+
+	return true;
+}
+
+int32 USingleWorkerRuntimeStrategy::GetNumberOfWorkersForPIE() const
+{
+	return 1;
+}
+
+UGridRuntimeLoadBalancingStrategy::UGridRuntimeLoadBalancingStrategy()
+	: Columns(1)
+	, Rows(1)
+{
+
+}
+
+bool UGridRuntimeLoadBalancingStrategy::WriteToConfiguration(TSharedRef<TJsonWriter<>> Writer) const
+{
+	Writer->WriteObjectStart("rectangle_grid");
+	Writer->WriteValue(TEXT("cols"), Columns);
+	Writer->WriteValue(TEXT("rows"), Rows);
+	Writer->WriteObjectEnd();
+
+	return true;
+}
+
+int32 UGridRuntimeLoadBalancingStrategy::GetNumberOfWorkersForPIE() const
+{
+	return Rows * Columns;
+}
+
+UEntityShardingRuntimeLoadBalancingStrategy::UEntityShardingRuntimeLoadBalancingStrategy()
+	: NumWorkers(1)
+{
+
+}
+
+bool UEntityShardingRuntimeLoadBalancingStrategy::WriteToConfiguration(TSharedRef<TJsonWriter<>> Writer) const
+{
+	Writer->WriteObjectStart("entity_id_sharding");
+	Writer->WriteValue(TEXT("numWorkers"), NumWorkers);
+	Writer->WriteObjectEnd();
+
+	return true;
+}
+
+int32 UEntityShardingRuntimeLoadBalancingStrategy::GetNumberOfWorkersForPIE() const
+{
+	return NumWorkers;
+}

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/Utils/LaunchConfigEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/Utils/LaunchConfigEditor.cpp
@@ -37,6 +37,11 @@ void ULaunchConfigurationEditor::OnWorkerTypesChanged()
 
 void ULaunchConfigurationEditor::SaveConfiguration()
 {
+	if (!ValidateGeneratedLaunchConfig(LaunchConfiguration, LaunchConfiguration.ServerWorkersMap))
+	{
+		return;
+	}
+
 	IDesktopPlatform* DesktopPlatform = FDesktopPlatformModule::Get();
 
 	FString DefaultOutPath = SpatialGDKServicesConstants::SpatialOSDirectory;
@@ -53,10 +58,8 @@ void ULaunchConfigurationEditor::SaveConfiguration()
 
 	if (bSaved && Filenames.Num() > 0)
 	{
-		if (ValidateGeneratedLaunchConfig(LaunchConfiguration, LaunchConfiguration.ServerWorkersMap))
+		if (GenerateLaunchConfig(Filenames[0], &LaunchConfiguration, LaunchConfiguration.ServerWorkersMap))
 		{
-			GenerateDefaultLaunchConfig(Filenames[0], &LaunchConfiguration, LaunchConfiguration.ServerWorkersMap);
-
 			OnConfigurationSaved.ExecuteIfBound(this, Filenames[0]);
 		}
 	}

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/Utils/LaunchConfigEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/Utils/LaunchConfigEditor.cpp
@@ -2,15 +2,14 @@
 
 #include "Utils/LaunchConfigEditor.h"
 
-#include "DesktopPlatformModule.h"
-#include "Editor.h"
-#include "Framework/Application/SlateApplication.h"
-#include "IDesktopPlatform.h"
-
 #include "SpatialGDKSettings.h"
 #include "SpatialGDKEditorSettings.h"
 #include "SpatialGDKDefaultLaunchConfigGenerator.h"
 #include "SpatialRuntimeLoadBalancingStrategies.h"
+
+#include "DesktopPlatformModule.h"
+#include "Framework/Application/SlateApplication.h"
+#include "IDesktopPlatform.h"
 
 void ULaunchConfigurationEditor::PostInitProperties()
 {

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/Utils/LaunchConfigEditorLayoutDetails.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/Utils/LaunchConfigEditorLayoutDetails.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "Utils/LaunchConfigEditorLayoutDetails.h"
+
+#include "SpatialGDKSettings.h"
+#include "Utils/LaunchConfigEditor.h"
+#include "DetailLayoutBuilder.h"
+
+TSharedRef<IDetailCustomization> FLaunchConfigEditorLayoutDetails::MakeInstance()
+{
+	return MakeShareable(new FLaunchConfigEditorLayoutDetails);
+}
+
+void FLaunchConfigEditorLayoutDetails::ForceRefreshLayout()
+{
+	if (MyLayout != nullptr)
+	{
+		TArray<TWeakObjectPtr<UObject>> Objects;
+		MyLayout->GetObjectsBeingCustomized(Objects);
+		ULaunchConfigurationEditor* Editor = Objects.Num() > 0 ? Cast<ULaunchConfigurationEditor>(Objects[0].Get()) : nullptr;
+		if (Editor != nullptr)
+		{
+			Editor->OnWorkerTypesChanged();
+		}
+		MyLayout->ForceRefreshDetails();
+	}
+}
+
+void FLaunchConfigEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& DetailBuilder)
+{
+	MyLayout = &DetailBuilder;
+	const USpatialGDKSettings* GDKSettings = GetDefault<USpatialGDKSettings>();
+	GDKSettings->OnWorkerTypesChangedDelegate.AddSP(this, &FLaunchConfigEditorLayoutDetails::ForceRefreshLayout);
+}

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/Utils/LaunchConfigEditorLayoutDetails.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/Utils/LaunchConfigEditorLayoutDetails.h
@@ -1,0 +1,18 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "Templates/SharedPointer.h"
+#include "IDetailCustomization.h"
+
+class FLaunchConfigEditorLayoutDetails : public IDetailCustomization
+{
+private:
+	void ForceRefreshLayout();
+
+	IDetailLayoutBuilder* MyLayout = nullptr;
+
+public:
+	static TSharedRef<IDetailCustomization> MakeInstance();
+	virtual void CustomizeDetails(IDetailLayoutBuilder& DetailBuilder) override;
+};

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/Utils/TransientUObjectEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/Utils/TransientUObjectEditor.cpp
@@ -47,16 +47,16 @@ namespace
 }
 
 // Rewrite of FPropertyEditorModule::CreateFloatingDetailsView to use the detail property view in a new window.
-void UTransientUObjectEditor::LaunchTransientUObjectEditor(const FString& EditorName, UClass* ObjectClass)
+UTransientUObjectEditor* UTransientUObjectEditor::LaunchTransientUObjectEditor(const FString& EditorName, UClass* ObjectClass)
 {
 	if (!ObjectClass)
 	{
-		return;
+		return nullptr;
 	}
 
 	if (!ObjectClass->IsChildOf<UTransientUObjectEditor>())
 	{
-		return;
+		return nullptr;
 	}
 
 	UTransientUObjectEditor* ObjectInstance = NewObject<UTransientUObjectEditor>(GetTransientPackage(), ObjectClass);
@@ -157,4 +157,6 @@ void UTransientUObjectEditor::LaunchTransientUObjectEditor(const FString& Editor
 		NewSlateWindow->Resize(NewSlateWindow->GetDesiredSize());
 		return EActiveTimerReturnType::Stop;
 	}));
+
+	return ObjectInstance;
 }

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/Utils/TransientUObjectEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/Utils/TransientUObjectEditor.cpp
@@ -47,7 +47,7 @@ namespace
 }
 
 // Rewrite of FPropertyEditorModule::CreateFloatingDetailsView to use the detail property view in a new window.
-UTransientUObjectEditor* UTransientUObjectEditor::LaunchTransientUObjectEditor(const FString& EditorName, UClass* ObjectClass)
+UTransientUObjectEditor* UTransientUObjectEditor::LaunchTransientUObjectEditor(const FString& EditorName, UClass* ObjectClass, TSharedPtr<SWindow> ParentWindow)
 {
 	if (!ObjectClass)
 	{
@@ -133,18 +133,16 @@ UTransientUObjectEditor* UTransientUObjectEditor::LaunchTransientUObjectEditor(c
 				VBoxBuilder
 			]
 		];
-
-	// If the main frame exists parent the window to it
-	TSharedPtr<SWindow> ParentWindow;
-	if (FModuleManager::Get().IsModuleLoaded("MainFrame"))
+	
+	if (!ParentWindow.IsValid() && FModuleManager::Get().IsModuleLoaded("MainFrame"))
 	{
+		// If the main frame exists parent the window to it
 		IMainFrameModule& MainFrame = FModuleManager::GetModuleChecked<IMainFrameModule>("MainFrame");
 		ParentWindow = MainFrame.GetParentWindow();
 	}
 
 	if (ParentWindow.IsValid())
 	{
-		// Parent the window to the main frame 
 		FSlateApplication::Get().AddWindowAsNativeChild(NewSlateWindow, ParentWindow.ToSharedRef());
 	}
 	else

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/EditorExtension/LBStrategyEditorExtension.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/EditorExtension/LBStrategyEditorExtension.h
@@ -8,6 +8,7 @@ DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKEditorLBExtension, Log, All);
 
 class UAbstractLBStrategy;
 class FLBStrategyEditorExtensionManager;
+class UAbstractRuntimeLoadBalancingStrategy;
 struct FWorkerTypeLaunchSection;
 
 class FLBStrategyEditorExtensionInterface
@@ -16,7 +17,7 @@ public:
 	virtual ~FLBStrategyEditorExtensionInterface() {}
 private:
 	friend FLBStrategyEditorExtensionManager;
-	virtual bool GetDefaultLaunchConfiguration_Virtual(const UAbstractLBStrategy* Strategy, FWorkerTypeLaunchSection& OutConfiguration, FIntPoint& OutWorldDimensions) const = 0;
+	virtual bool GetDefaultLaunchConfiguration_Virtual(const UAbstractLBStrategy* Strategy, UAbstractRuntimeLoadBalancingStrategy*& OutConfiguration, FIntPoint& OutWorldDimensions) const = 0;
 };
 
 template <typename StrategyImpl, typename Implementation>
@@ -26,7 +27,7 @@ public:
 	using ExtendedStrategy = StrategyImpl;
 
 private:
-	bool GetDefaultLaunchConfiguration_Virtual(const UAbstractLBStrategy* Strategy, FWorkerTypeLaunchSection& OutConfiguration, FIntPoint& OutWorldDimensions) const override
+	bool GetDefaultLaunchConfiguration_Virtual(const UAbstractLBStrategy* Strategy, UAbstractRuntimeLoadBalancingStrategy*& OutConfiguration, FIntPoint& OutWorldDimensions) const override
 	{
 		return static_cast<const Implementation*>(this)->GetDefaultLaunchConfiguration(static_cast<const StrategyImpl*>(Strategy), OutConfiguration, OutWorldDimensions);
 	}
@@ -35,7 +36,7 @@ private:
 class FLBStrategyEditorExtensionManager
 {
 public:
-	SPATIALGDKEDITOR_API bool GetDefaultLaunchConfiguration(const UAbstractLBStrategy* Strategy, FWorkerTypeLaunchSection& OutConfiguration, FIntPoint& OutWorldDimensions) const;
+	SPATIALGDKEDITOR_API bool GetDefaultLaunchConfiguration(const UAbstractLBStrategy* Strategy, UAbstractRuntimeLoadBalancingStrategy*& OutConfiguration, FIntPoint& OutWorldDimensions) const;
 
 	template <typename Extension>
 	void RegisterExtension()

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKDefaultLaunchConfigGenerator.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKDefaultLaunchConfigGenerator.h
@@ -4,10 +4,21 @@
 
 #include "Logging/LogMacros.h"
 
+#include "SpatialGDKSettings.h"
+#include "SpatialGDKEditorSettings.h"
+
 DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKDefaultLaunchConfigGenerator, Log, All);
 
+class UAbstractRuntimeLoadBalancingStrategy;
 struct FSpatialLaunchConfigDescription;
 
-bool SPATIALGDKEDITOR_API GenerateDefaultLaunchConfig(const FString& LaunchConfigPath, const FSpatialLaunchConfigDescription* InLaunchConfigDescription);
+/** Set WorkerTypesToLaunch in level editor play settings. */
+void SPATIALGDKEDITOR_API SetLevelEditorPlaySettingsWorkerTypes(const TMap<FName, FWorkerTypeLaunchSection>& InWorkers);
 
-bool SPATIALGDKEDITOR_API ValidateGeneratedLaunchConfig(const FSpatialLaunchConfigDescription& LaunchConfigDesc);
+bool SPATIALGDKEDITOR_API GetLoadBalancingStrategyFromWorldSettings(const UWorld& World, UAbstractRuntimeLoadBalancingStrategy*& OutStrategy, FIntPoint& OutWorldDimension);
+
+bool SPATIALGDKEDITOR_API FillWorkerConfigurationFromCurrentMap(TMap<FName, FWorkerTypeLaunchSection>& OutWorkers, FIntPoint& OutWorldDimensions);
+
+bool SPATIALGDKEDITOR_API GenerateDefaultLaunchConfig(const FString& LaunchConfigPath, const FSpatialLaunchConfigDescription* InLaunchConfigDescription, const TMap<FName, FWorkerTypeLaunchSection>& InWorkers);
+
+bool SPATIALGDKEDITOR_API ValidateGeneratedLaunchConfig(const FSpatialLaunchConfigDescription& LaunchConfigDesc, const TMap<FName, FWorkerTypeLaunchSection>& InWorkers);

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKDefaultLaunchConfigGenerator.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKDefaultLaunchConfigGenerator.h
@@ -19,6 +19,6 @@ bool SPATIALGDKEDITOR_API GetLoadBalancingStrategyFromWorldSettings(const UWorld
 
 bool SPATIALGDKEDITOR_API FillWorkerConfigurationFromCurrentMap(TMap<FName, FWorkerTypeLaunchSection>& OutWorkers, FIntPoint& OutWorldDimensions);
 
-bool SPATIALGDKEDITOR_API GenerateDefaultLaunchConfig(const FString& LaunchConfigPath, const FSpatialLaunchConfigDescription* InLaunchConfigDescription, const TMap<FName, FWorkerTypeLaunchSection>& InWorkers);
+bool SPATIALGDKEDITOR_API GenerateLaunchConfig(const FString& LaunchConfigPath, const FSpatialLaunchConfigDescription* InLaunchConfigDescription, const TMap<FName, FWorkerTypeLaunchSection>& InWorkers);
 
 bool SPATIALGDKEDITOR_API ValidateGeneratedLaunchConfig(const FSpatialLaunchConfigDescription& LaunchConfigDesc, const TMap<FName, FWorkerTypeLaunchSection>& InWorkers);

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
@@ -20,7 +20,7 @@ private:
 
 	void ForceRefreshLayout();
 
-	IDetailLayoutBuilder* MyLayout = nullptr;
+	IDetailLayoutBuilder* CurrentLayout = nullptr;
 
 public:
 	static TSharedRef<IDetailCustomization> MakeInstance();

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
@@ -18,6 +18,10 @@ private:
 	FReply PushCommandLineArgsToIOSDevice();
 	FReply PushCommandLineArgsToAndroidDevice();
 
+	void ForceRefreshLayout();
+
+	IDetailLayoutBuilder* MyLayout = nullptr;
+
 public:
 	static TSharedRef<IDetailCustomization> MakeInstance();
 	virtual void CustomizeDetails(IDetailLayoutBuilder& DetailBuilder) override;

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -5,14 +5,17 @@
 #include "CoreMinimal.h"
 #include "Engine/EngineTypes.h"
 #include "Misc/Paths.h"
-#include "SpatialConstants.h"
 #include "UObject/Package.h"
+
+#include "SpatialConstants.h"
 #include "SpatialGDKServicesConstants.h"
 #include "SpatialGDKServicesModule.h"
 
 #include "SpatialGDKEditorSettings.generated.h"
 
 DECLARE_LOG_CATEGORY_EXTERN(LogSpatialEditorSettings, Log, All);
+
+class UAbstractRuntimeLoadBalancingStrategy;
 
 USTRUCT()
 struct FWorldLaunchSection
@@ -111,21 +114,20 @@ struct FWorkerTypeLaunchSection
 	GENERATED_BODY()
 
 	FWorkerTypeLaunchSection()
-		: WorkerTypeName()
-		, WorkerPermissions()
+		: WorkerPermissions()
 		, MaxConnectionCapacityLimit(0)
 		, bLoginRateLimitEnabled(false)
 		, LoginRateLimit()
-		, Columns(1)
-		, Rows(1)
+		, bAutoNumEditorInstances(true)
 		, NumEditorInstances(1)
 		, bManualWorkerConnectionOnly(true)
+		, WorkerLoadBalancing(nullptr)
 	{
 	}
 
-	/** The name of the worker type, defined in the filename of its spatialos.<worker_type>.worker.json file. */
-	UPROPERTY(Category = "SpatialGDK", EditAnywhere, config)
-	FName WorkerTypeName;
+	/** Worker type name, deprecated in favor of defining them in the runtime settings.*/
+	UPROPERTY(config)
+	FName WorkerTypeName_DEPRECATED;
 
 	/** Defines the worker instance's permissions. */
 	UPROPERTY(Category = "SpatialGDK", EditAnywhere, config)
@@ -143,16 +145,12 @@ struct FWorkerTypeLaunchSection
 	UPROPERTY(Category = "SpatialGDK", EditAnywhere, config, meta = (EditCondition = "bLoginRateLimitEnabled"))
 	FLoginRateLimitSection LoginRateLimit;
 
-	/** Number of columns in the rectangle grid load balancing config. */
-	UPROPERTY(Category = "SpatialGDK", EditAnywhere, config, meta = (DisplayName = "Rectangle grid column count", ClampMin = "1", UIMin = "1"))
-	int32 Columns;
-
-	/** Number of rows in the rectangle grid load balancing config. */
-	UPROPERTY(Category = "SpatialGDK", EditAnywhere, config, meta = (DisplayName = "Rectangle grid row count", ClampMin = "1", UIMin = "1"))
-	int32 Rows;
+	/** Automatically or manually specifies the number of worker instances to launch in editor. */
+	UPROPERTY(Category = "SpatialGDK", EditAnywhere, config, meta = (DisplayName = "Automatically compute number of instances to launch in Editor"))
+	bool bAutoNumEditorInstances;
 
 	/** Number of instances to launch when playing in editor. */
-	UPROPERTY(Category = "SpatialGDK", EditAnywhere, config, meta = (DisplayName = "Instances to launch in editor", ClampMin = "0", UIMin = "0"))
+	UPROPERTY(Category = "SpatialGDK", EditAnywhere, config, meta = (DisplayName = "Instances to launch in editor", ClampMin = "0", UIMin = "0", EditCondition = "!bAutoNumEditorInstances"))
 	int32 NumEditorInstances;
 
 	/** Flags defined for a worker instance. */
@@ -162,6 +160,9 @@ struct FWorkerTypeLaunchSection
 	/** Determines if the worker instance is launched manually or by SpatialOS. */
 	UPROPERTY(Category = "SpatialGDK", EditAnywhere, config, meta = (DisplayName = "Manual worker connection only"))
 	bool bManualWorkerConnectionOnly;
+
+	UPROPERTY(Transient, Category = "SpatialGDK", EditAnywhere, Instanced)
+	UAbstractRuntimeLoadBalancingStrategy* WorkerLoadBalancing;
 };
 
 USTRUCT()
@@ -174,30 +175,13 @@ struct FSpatialLaunchConfigDescription
 		, World()
 	{
 		FWorkerTypeLaunchSection UnrealWorkerDefaultSetting;
-		UnrealWorkerDefaultSetting.WorkerTypeName = SpatialConstants::DefaultServerWorkerType;
-		UnrealWorkerDefaultSetting.Rows = 1;
-		UnrealWorkerDefaultSetting.Columns = 1;
 		UnrealWorkerDefaultSetting.bManualWorkerConnectionOnly = true;
 
-		ServerWorkers.Add(UnrealWorkerDefaultSetting);
+		ServerWorkersMap.Add(SpatialConstants::DefaultServerWorkerType, UnrealWorkerDefaultSetting);
 	}
-
-	FSpatialLaunchConfigDescription(const FName& WorkerTypeName)
-		: Template(TEXT("w2_r0500_e5"))
-		, World()
-	{
-		FWorkerTypeLaunchSection UnrealWorkerDefaultSetting;
-		UnrealWorkerDefaultSetting.WorkerTypeName = WorkerTypeName;
-		UnrealWorkerDefaultSetting.Rows = 1;
-		UnrealWorkerDefaultSetting.Columns = 1;
-		UnrealWorkerDefaultSetting.bManualWorkerConnectionOnly = true;
-
-		ServerWorkers.Add(UnrealWorkerDefaultSetting);
-	}
-
 
 	/** Set WorkerTypesToLaunch in level editor play settings. */
-	SPATIALGDKEDITOR_API void SetLevelEditorPlaySettingsWorkerTypes();
+	SPATIALGDKEDITOR_API void OnWorkerTypesChanged();
 
 	/** Deployment template. */
 	UPROPERTY(Category = "SpatialGDK", EditAnywhere, config)
@@ -208,8 +192,11 @@ struct FSpatialLaunchConfigDescription
 	FWorldLaunchSection World;
 
 	/** Worker-specific configuration parameters. */
-	UPROPERTY(Category = "SpatialGDK", EditAnywhere, config, meta = (TitleProperty = "WorkerTypeName"))
-	TArray<FWorkerTypeLaunchSection> ServerWorkers;
+	UPROPERTY(config)
+	TArray<FWorkerTypeLaunchSection> ServerWorkers_DEPRECATED;
+
+	UPROPERTY(Category = "SpatialGDK", EditAnywhere, EditFixedSize, config)
+	TMap<FName, FWorkerTypeLaunchSection> ServerWorkersMap;
 };
 
 /**
@@ -227,7 +214,7 @@ namespace ERegionCode
 	};
 }
 
-UCLASS(config = SpatialGDKEditorSettings, defaultconfig)
+UCLASS(config = SpatialGDKEditorSettings, defaultconfig, HideCategories = LoadBalancing)
 class SPATIALGDKEDITOR_API USpatialGDKEditorSettings : public UObject
 {
 	GENERATED_BODY()
@@ -238,10 +225,9 @@ public:
 	virtual void PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent) override;
 	virtual void PostInitProperties() override;
 
-private:
+	void OnWorkerTypesChanged();
 
-	/** Set WorkerTypes in runtime settings. */
-	void SetRuntimeWorkerTypes();
+private:
 
 	/** Set DAT in runtime settings. */
 	void SetRuntimeUseDevelopmentAuthenticationFlow();

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialLaunchConfigCustomization.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialLaunchConfigCustomization.h
@@ -12,5 +12,6 @@ public:
 	static TSharedRef<IPropertyTypeCustomization> MakeInstance();
 
 	/** IPropertyTypeCustomization interface */
+	virtual void CustomizeHeader(TSharedRef<class IPropertyHandle> StructPropertyHandle, class FDetailWidgetRow& HeaderRow, IPropertyTypeCustomizationUtils& StructCustomizationUtils) override;
 	virtual void CustomizeChildren(TSharedRef<class IPropertyHandle> StructPropertyHandle, class IDetailChildrenBuilder& StructBuilder, IPropertyTypeCustomizationUtils& StructCustomizationUtils) override;
 };

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialLaunchConfigCustomization.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialLaunchConfigCustomization.h
@@ -1,0 +1,16 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "IPropertyTypeCustomization.h"
+
+class FSpatialLaunchConfigCustomization : public IPropertyTypeCustomization
+{
+public:
+
+	static TSharedRef<IPropertyTypeCustomization> MakeInstance();
+
+	/** IPropertyTypeCustomization interface */
+	virtual void CustomizeChildren(TSharedRef<class IPropertyHandle> StructPropertyHandle, class IDetailChildrenBuilder& StructBuilder, IPropertyTypeCustomizationUtils& StructCustomizationUtils) override;
+};

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialRuntimeLoadBalancingStrategies.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialRuntimeLoadBalancingStrategies.h
@@ -1,0 +1,70 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "Serialization/JsonWriter.h"
+#include "UObject/Object.h"
+
+#include "SpatialRuntimeLoadBalancingStrategies.generated.h"
+
+UCLASS(Abstract)
+class SPATIALGDKEDITOR_API UAbstractRuntimeLoadBalancingStrategy : public UObject
+{
+	GENERATED_BODY()
+
+public:
+	virtual bool WriteToConfiguration(TSharedRef<TJsonWriter<>> Writer) const PURE_VIRTUAL(UAbstractRuntimeLoadBalancingStrategy::WriteToConfiguration,return false;);
+
+	virtual int32 GetNumberOfWorkersForPIE() const PURE_VIRTUAL(UAbstractRuntimeLoadBalancingStrategy::GetNumberOfWorkersForPIE, return 0;);
+};
+
+UCLASS()
+class SPATIALGDKEDITOR_API USingleWorkerRuntimeStrategy : public UAbstractRuntimeLoadBalancingStrategy
+{
+	GENERATED_BODY()
+
+public:
+	USingleWorkerRuntimeStrategy();
+
+	bool WriteToConfiguration(TSharedRef<TJsonWriter<>> Writer) const override;
+
+	int32 GetNumberOfWorkersForPIE() const override;
+};
+
+UCLASS(EditInlineNew)
+class SPATIALGDKEDITOR_API UGridRuntimeLoadBalancingStrategy : public UAbstractRuntimeLoadBalancingStrategy
+{
+	GENERATED_BODY()
+
+public:
+	UGridRuntimeLoadBalancingStrategy();
+
+	/** Number of columns in the rectangle grid load balancing config. */
+	UPROPERTY(Category = "LoadBalancing", EditAnywhere, meta = (DisplayName = "Rectangle grid column count", ClampMin = "1", UIMin = "1"))
+	int32 Columns;
+	
+	/** Number of rows in the rectangle grid load balancing config. */
+	UPROPERTY(Category = "LoadBalancing", EditAnywhere, meta = (DisplayName = "Rectangle grid row count", ClampMin = "1", UIMin = "1"))
+	int32 Rows;
+	
+	bool WriteToConfiguration(TSharedRef<TJsonWriter<>> Writer) const override;
+
+	int32 GetNumberOfWorkersForPIE() const override;
+};
+
+UCLASS(EditInlineNew)
+class SPATIALGDKEDITOR_API UEntityShardingRuntimeLoadBalancingStrategy : public UAbstractRuntimeLoadBalancingStrategy
+{
+	GENERATED_BODY()
+
+public:
+	UEntityShardingRuntimeLoadBalancingStrategy();
+
+	/** Number of columns in the rectangle grid load balancing config. */
+	UPROPERTY(Category = "LoadBalancing", EditAnywhere, meta = (DisplayName = "Number of workers", ClampMin = "1", UIMin = "1"))
+	int32 NumWorkers;
+
+	bool WriteToConfiguration(TSharedRef<TJsonWriter<>> Writer) const override;
+
+	int32 GetNumberOfWorkersForPIE() const override;
+};

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/Utils/LaunchConfigEditor.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/Utils/LaunchConfigEditor.h
@@ -7,10 +7,24 @@
 
 #include "LaunchConfigEditor.generated.h"
 
-UCLASS()
+class ULaunchConfigurationEditor;
+
+DECLARE_DELEGATE_TwoParams(FOnSpatialOSLaunchConfigurationSaved, ULaunchConfigurationEditor*, const FString&)
+
+class UAbstractRuntimeLoadBalancingStrategy;
+
+UCLASS(Transient, CollapseCategories)
 class SPATIALGDKEDITOR_API ULaunchConfigurationEditor : public UTransientUObjectEditor
 {
 	GENERATED_BODY()
+
+public:
+	FOnSpatialOSLaunchConfigurationSaved OnConfigurationSaved;
+
+	void OnWorkerTypesChanged();
+
+protected:
+	void PostInitProperties() override;
 
 	UPROPERTY(EditAnywhere, Category = "Launch Configuration")
 	FSpatialLaunchConfigDescription LaunchConfiguration;

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/Utils/LaunchConfigEditor.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/Utils/LaunchConfigEditor.h
@@ -23,11 +23,11 @@ public:
 
 	void OnWorkerTypesChanged();
 
-protected:
-	void PostInitProperties() override;
-
 	UPROPERTY(EditAnywhere, Category = "Launch Configuration")
 	FSpatialLaunchConfigDescription LaunchConfiguration;
+
+protected:
+	void PostInitProperties() override;
 
 	UFUNCTION(Exec)
 	void SaveConfiguration();

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/Utils/TransientUObjectEditor.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/Utils/TransientUObjectEditor.h
@@ -7,6 +7,10 @@
 
 #include "TransientUObjectEditor.generated.h"
 
+DECLARE_DELEGATE(FOnTransientUObjectEditorClosed)
+
+class SWindow;
+
 // Utility class to create Editor tools exposing a UObject Field and automatically adding Exec UFUNCTION as buttons.
 UCLASS(Blueprintable, Abstract)
 class SPATIALGDKEDITOR_API UTransientUObjectEditor : public UObject
@@ -15,11 +19,11 @@ class SPATIALGDKEDITOR_API UTransientUObjectEditor : public UObject
 public:
 
 	template <typename T>
-	static T* LaunchTransientUObjectEditor(const FString& EditorName)
+	static T* LaunchTransientUObjectEditor(const FString& EditorName, TSharedPtr<SWindow> ParentWindow)
 	{
-		return Cast<T>(LaunchTransientUObjectEditor(EditorName, T::StaticClass()));
+		return Cast<T>(LaunchTransientUObjectEditor(EditorName, T::StaticClass(), ParentWindow));
 	}
 
 private:
-	static UTransientUObjectEditor* LaunchTransientUObjectEditor(const FString& EditorName, UClass* ObjectClass);
+	static UTransientUObjectEditor* LaunchTransientUObjectEditor(const FString& EditorName, UClass* ObjectClass, TSharedPtr<SWindow> ParentWindow);
 };

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/Utils/TransientUObjectEditor.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/Utils/TransientUObjectEditor.h
@@ -15,11 +15,11 @@ class SPATIALGDKEDITOR_API UTransientUObjectEditor : public UObject
 public:
 
 	template <typename T>
-	static void LaunchTransientUObjectEditor(const FString& EditorName)
+	static T* LaunchTransientUObjectEditor(const FString& EditorName)
 	{
-		LaunchTransientUObjectEditor(EditorName, T::StaticClass());
+		return Cast<T>(LaunchTransientUObjectEditor(EditorName, T::StaticClass()));
 	}
 
 private:
-	static void LaunchTransientUObjectEditor(const FString& EditorName, UClass* ObjectClass);
+	static UTransientUObjectEditor* LaunchTransientUObjectEditor(const FString& EditorName, UClass* ObjectClass);
 };

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -621,6 +621,8 @@ void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment()
 	else
 	{
 		LaunchConfig = SpatialGDKEditorSettings->GetSpatialOSLaunchConfig();
+
+		SetLevelEditorPlaySettingsWorkerTypes(SpatialGDKEditorSettings->LaunchConfigDesc.ServerWorkersMap);
 	}
 
 	const FString LaunchFlags = SpatialGDKEditorSettings->GetSpatialOSCommandLineLaunchFlags();

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -599,7 +599,7 @@ void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment()
 			return;
 		}
 
-		GenerateDefaultLaunchConfig(LaunchConfig, &LaunchConfigDescription, WorkersMap);
+		GenerateLaunchConfig(LaunchConfig, &LaunchConfigDescription, WorkersMap);
 		SetLevelEditorPlaySettingsWorkerTypes(WorkersMap);
 
 		// Also create default launch config for cloud deployments.
@@ -610,7 +610,7 @@ void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment()
 			}
 
 			FString CloudLaunchConfig = FPaths::Combine(FPaths::ConvertRelativePathToFull(FPaths::ProjectIntermediateDir()), FString::Printf(TEXT("Improbable/%s_CloudLaunchConfig.json"), *EditorWorld->GetMapName()));
-			GenerateDefaultLaunchConfig(CloudLaunchConfig, &LaunchConfigDescription, WorkersMap);
+			GenerateLaunchConfig(CloudLaunchConfig, &LaunchConfigDescription, WorkersMap);
 		}
 
 		if (LoadBalancingStrat != DefaultStrategy)
@@ -816,7 +816,7 @@ void FSpatialGDKEditorToolbarModule::ShowSimulatedPlayerDeploymentDialog()
 
 void FSpatialGDKEditorToolbarModule::OpenLaunchConfigurationEditor()
 {
-	ULaunchConfigurationEditor::LaunchTransientUObjectEditor<ULaunchConfigurationEditor>(TEXT("Launch Configuration Editor"));
+	ULaunchConfigurationEditor::LaunchTransientUObjectEditor<ULaunchConfigurationEditor>(TEXT("Launch Configuration Editor"), nullptr);
 }
 
 void FSpatialGDKEditorToolbarModule::GenerateSchema(bool bFullScan)

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -33,6 +33,7 @@
 #include "SpatialGDKServicesModule.h"
 #include "SpatialGDKSettings.h"
 #include "SpatialGDKSimulatedPlayerDeployment.h"
+#include "SpatialRuntimeLoadBalancingStrategies.h"
 #include "Utils/LaunchConfigEditor.h"
 
 #include "Editor/EditorEngine.h"
@@ -44,8 +45,6 @@
 #include "LevelEditor.h"
 #include "Misc/FileHelper.h"
 #include "EngineClasses/SpatialWorldSettings.h"
-#include "EditorExtension/LBStrategyEditorExtension.h"
-#include "LoadBalancing/AbstractLBStrategy.h"
 #include "SpatialGDKEditorModule.h"
 
 DEFINE_LOG_CATEGORY(LogSpatialGDKEditorToolbar);
@@ -521,33 +520,6 @@ void FSpatialGDKEditorToolbarModule::StopSpatialServiceButtonClicked()
 	});
 }
 
-bool FSpatialGDKEditorToolbarModule::FillWorkerLaunchConfigFromWorldSettings(UWorld& World, FWorkerTypeLaunchSection& OutLaunchConfig, FIntPoint& OutWorldDimension)
-{
-	const ASpatialWorldSettings* WorldSettings = Cast<ASpatialWorldSettings>(World.GetWorldSettings());
-
-	if (!WorldSettings)
-	{
-		UE_LOG(LogSpatialGDKEditorToolbar, Error, TEXT("Missing SpatialWorldSettings on map %s"), *World.GetMapName());
-		return false;
-	}
-
-	if (!WorldSettings->LoadBalanceStrategy)
-	{
-		UE_LOG(LogSpatialGDKEditorToolbar, Error, TEXT("Missing Load balancing strategy on map %s"), *World.GetMapName());
-		return false;
-	}
-
-	FSpatialGDKEditorModule& EditorModule = FModuleManager::GetModuleChecked<FSpatialGDKEditorModule>("SpatialGDKEditor");
-
-	if (!EditorModule.GetLBStrategyExtensionManager().GetDefaultLaunchConfiguration(WorldSettings->LoadBalanceStrategy->GetDefaultObject<UAbstractLBStrategy>(), OutLaunchConfig, OutWorldDimension))
-	{
-		UE_LOG(LogSpatialGDKEditorToolbar, Error, TEXT("Could not get the number of worker to launch for load balancing strategy %s"), *WorldSettings->LoadBalanceStrategy->GetName());
-		return false;
-	}
-
-	return true;
-}
-
 void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment()
 {
 	// Don't try and start a local deployment if spatial networking is disabled.
@@ -603,46 +575,47 @@ void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment()
 		LaunchConfig = FPaths::Combine(FPaths::ConvertRelativePathToFull(FPaths::ProjectIntermediateDir()), FString::Printf(TEXT("Improbable/%s_LocalLaunchConfig.json"), *EditorWorld->GetMapName()));
 
 		FSpatialLaunchConfigDescription LaunchConfigDescription = SpatialGDKEditorSettings->LaunchConfigDesc;
-		if (SpatialGDKSettings->bEnableUnrealLoadBalancer)
+		USingleWorkerRuntimeStrategy* DefaultStrategy = USingleWorkerRuntimeStrategy::StaticClass()->GetDefaultObject<USingleWorkerRuntimeStrategy>();
+		UAbstractRuntimeLoadBalancingStrategy* LoadBalancingStrat = DefaultStrategy;
+
+		if (SpatialGDKSettings->bEnableUnrealLoadBalancer
+			&& GetLoadBalancingStrategyFromWorldSettings(*EditorWorld, LoadBalancingStrat, LaunchConfigDescription.World.Dimensions))
 		{
-			FIntPoint WorldDimensions;
-			FWorkerTypeLaunchSection WorkerLaunch;
-
-			if (FillWorkerLaunchConfigFromWorldSettings(*EditorWorld, WorkerLaunch, WorldDimensions))
-			{
-				LaunchConfigDescription.World.Dimensions = WorldDimensions;
-				LaunchConfigDescription.ServerWorkers.Empty(SpatialGDKSettings->ServerWorkerTypes.Num());
-
-				for (auto WorkerType : SpatialGDKSettings->ServerWorkerTypes)
-				{
-					LaunchConfigDescription.ServerWorkers.Add(WorkerLaunch);
-					LaunchConfigDescription.ServerWorkers.Last().WorkerTypeName = WorkerType;
-				}
-			}
+			LoadBalancingStrat->AddToRoot();
 		}
 
-		for (auto& WorkerLaunchSection : LaunchConfigDescription.ServerWorkers)
+		TMap<FName, FWorkerTypeLaunchSection> WorkersMap;
+
+		for (const TPair<FName, FWorkerTypeLaunchSection>& WorkerType : SpatialGDKEditorSettings->LaunchConfigDesc.ServerWorkersMap)
 		{
-			WorkerLaunchSection.bManualWorkerConnectionOnly = true;
+			FWorkerTypeLaunchSection Conf = WorkerType.Value;
+			Conf.WorkerLoadBalancing = LoadBalancingStrat;
+			Conf.bManualWorkerConnectionOnly = true;
+			WorkersMap.Add(WorkerType.Key, Conf);
 		}
 
-		if (!ValidateGeneratedLaunchConfig(LaunchConfigDescription))
+		if (!ValidateGeneratedLaunchConfig(LaunchConfigDescription, WorkersMap))
 		{
 			return;
 		}
 
-		GenerateDefaultLaunchConfig(LaunchConfig, &LaunchConfigDescription);
-		LaunchConfigDescription.SetLevelEditorPlaySettingsWorkerTypes();
+		GenerateDefaultLaunchConfig(LaunchConfig, &LaunchConfigDescription, WorkersMap);
+		SetLevelEditorPlaySettingsWorkerTypes(WorkersMap);
 
 		// Also create default launch config for cloud deployments.
 		{
-			for (auto& WorkerLaunchSection : LaunchConfigDescription.ServerWorkers)
+			for (auto& WorkerLaunchSection : WorkersMap)
 			{
-				WorkerLaunchSection.bManualWorkerConnectionOnly = false;
+				WorkerLaunchSection.Value.bManualWorkerConnectionOnly = false;
 			}
 
 			FString CloudLaunchConfig = FPaths::Combine(FPaths::ConvertRelativePathToFull(FPaths::ProjectIntermediateDir()), FString::Printf(TEXT("Improbable/%s_CloudLaunchConfig.json"), *EditorWorld->GetMapName()));
-			GenerateDefaultLaunchConfig(CloudLaunchConfig, &LaunchConfigDescription);
+			GenerateDefaultLaunchConfig(CloudLaunchConfig, &LaunchConfigDescription, WorkersMap);
+		}
+
+		if (LoadBalancingStrat != DefaultStrategy)
+		{
+			LoadBalancingStrat->RemoveFromRoot();
 		}
 	}
 	else

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -865,7 +865,7 @@ FReply SSpatialGDKSimulatedPlayerDeployment::OnGenerateConfigFromCurrentMap()
 
 	FillWorkerConfigurationFromCurrentMap(ServerWorkers, LaunchConfiguration.World.Dimensions);
 
-	GenerateDefaultLaunchConfig(LaunchConfig, &LaunchConfiguration, ServerWorkers);
+	GenerateLaunchConfig(LaunchConfig, &LaunchConfiguration, ServerWorkers);
 
 	OnPrimaryLaunchConfigPathPicked(LaunchConfig);
 
@@ -874,11 +874,17 @@ FReply SSpatialGDKSimulatedPlayerDeployment::OnGenerateConfigFromCurrentMap()
 
 FReply SSpatialGDKSimulatedPlayerDeployment::OnOpenLaunchConfigEditor()
 {
-	ULaunchConfigurationEditor* Editor = UTransientUObjectEditor::LaunchTransientUObjectEditor<ULaunchConfigurationEditor>("Launch Configuration Editor");
+	ULaunchConfigurationEditor* Editor = UTransientUObjectEditor::LaunchTransientUObjectEditor<ULaunchConfigurationEditor>("Launch Configuration Editor", ParentWindowPtr.Pin());
+
+	// Set the defaults launch setting to cloud-friendly ones.
+	for (auto& WorkerEntry : Editor->LaunchConfiguration.ServerWorkersMap)
+	{
+		WorkerEntry.Value.bManualWorkerConnectionOnly = false;
+	}
 
 	Editor->OnConfigurationSaved.BindLambda([WeakThis = TWeakPtr<SWidget>(this->AsShared())](ULaunchConfigurationEditor*, const FString& FilePath)
 	{
-		if (auto This = WeakThis.Pin())
+		if (TSharedPtr<SWidget> This = WeakThis.Pin())
 		{
 			static_cast<SSpatialGDKSimulatedPlayerDeployment*>(This.Get())->OnPrimaryLaunchConfigPathPicked(FilePath);
 		}

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -855,7 +855,7 @@ FReply SSpatialGDKSimulatedPlayerDeployment::OnGenerateConfigFromCurrentMap()
 	UWorld* EditorWorld = GEditor->GetEditorWorldContext().World();
 	check(EditorWorld != nullptr);
 
-	FString LaunchConfig = FPaths::Combine(FPaths::ConvertRelativePathToFull(FPaths::ProjectIntermediateDir()), FString::Printf(TEXT("Improbable/%s_LocalLaunchConfig.json"), *EditorWorld->GetMapName()));
+	const FString LaunchConfig = FPaths::Combine(FPaths::ConvertRelativePathToFull(FPaths::ProjectIntermediateDir()), FString::Printf(TEXT("Improbable/%s_LocalLaunchConfig.json"), *EditorWorld->GetMapName()));
 
 	const USpatialGDKSettings* SpatialGDKSettings = GetDefault<USpatialGDKSettings>();
 	const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>();

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -2,8 +2,17 @@
 
 #include "SpatialGDKSimulatedPlayerDeployment.h"
 
+#include "SpatialCommandUtils.h"
+#include "SpatialGDKDefaultLaunchConfigGenerator.h"
+#include "SpatialGDKEditorSettings.h"
+#include "SpatialGDKEditorToolbar.h"
+#include "SpatialGDKServicesConstants.h"
+#include "SpatialGDKServicesModule.h"
+#include "SpatialGDKSettings.h"
+
 #include "Async/Async.h"
 #include "DesktopPlatformModule.h"
+#include "Editor.h"
 #include "EditorDirectories.h"
 #include "EditorStyleSet.h"
 #include "Framework/Application/SlateApplication.h"
@@ -12,14 +21,9 @@
 #include "HAL/PlatformFilemanager.h"
 #include "Misc/MessageDialog.h"
 #include "Runtime/Launch/Resources/Version.h"
-#include "SpatialCommandUtils.h"
-#include "SpatialGDKSettings.h"
-#include "SpatialGDKEditorSettings.h"
-#include "SpatialGDKEditorToolbar.h"
-#include "SpatialGDKServicesConstants.h"
-#include "SpatialGDKServicesModule.h"
 #include "Templates/SharedPointer.h"
 #include "Textures/SlateIcon.h"
+#include "Utils/LaunchConfigEditor.h"
 #include "Widgets/Input/SButton.h"
 #include "Widgets/Input/SComboButton.h"
 #include "Widgets/Input/SFilePathPicker.h"
@@ -269,6 +273,46 @@ void SSpatialGDKSimulatedPlayerDeployment::Construct(const FArguments& InArgs)
 									.FilePath_UObject(SpatialGDKSettings, &USpatialGDKEditorSettings::GetPrimaryLaunchConfigPath)
 									.FileTypeFilter(TEXT("Launch configuration files (*.json)|*.json"))
 									.OnPathPicked(this, &SSpatialGDKSimulatedPlayerDeployment::OnPrimaryLaunchConfigPathPicked)
+								]
+							]
+							+ SVerticalBox::Slot()
+								.AutoHeight()
+								.Padding(2.0f)
+								[
+									SNew(SHorizontalBox)
+									+ SHorizontalBox::Slot()
+								.FillWidth(1.0f)
+								[
+									SNew(STextBlock)
+									.Text(FText::FromString(FString(TEXT(""))))
+								.ToolTipText(FText::FromString(FString(TEXT(""))))
+								]
+							+ SHorizontalBox::Slot()
+								.FillWidth(1.0f)
+								[
+									SNew(SButton)
+									.Text(FText::FromString(FString(TEXT("Generate from current map"))))
+									.OnClicked(this, &SSpatialGDKSimulatedPlayerDeployment::OnGenerateConfigFromCurrentMap)
+								]
+								]
+							+ SVerticalBox::Slot()
+								.AutoHeight()
+								.Padding(2.0f)
+								[
+									SNew(SHorizontalBox)
+									+ SHorizontalBox::Slot()
+								.FillWidth(1.0f)
+								[
+									SNew(STextBlock)
+									.Text(FText::FromString(FString(TEXT(""))))
+								.ToolTipText(FText::FromString(FString(TEXT(""))))
+								]
+							+ SHorizontalBox::Slot()
+								.FillWidth(1.0f)
+								[
+									SNew(SButton)
+									.Text(FText::FromString(FString(TEXT("Open Launch Configuration editor"))))
+									.OnClicked(this, &SSpatialGDKSimulatedPlayerDeployment::OnOpenLaunchConfigEditor)
 								]
 							]
 							// Primary Deployment Region Picker
@@ -803,4 +847,43 @@ FText SSpatialGDKSimulatedPlayerDeployment::GetSpatialOSRuntimeVersionToUseText(
 	const USpatialGDKEditorSettings* SpatialGDKSettings = GetDefault<USpatialGDKEditorSettings>();
 	const FString& RuntimeVersion = SpatialGDKSettings->bUseGDKPinnedRuntimeVersion ? SpatialGDKServicesConstants::SpatialOSRuntimePinnedVersion : SpatialGDKSettings->CloudRuntimeVersion;
 	return FText::FromString(RuntimeVersion);
+}
+
+
+FReply SSpatialGDKSimulatedPlayerDeployment::OnGenerateConfigFromCurrentMap()
+{
+	UWorld* EditorWorld = GEditor->GetEditorWorldContext().World();
+	check(EditorWorld != nullptr);
+
+	FString LaunchConfig = FPaths::Combine(FPaths::ConvertRelativePathToFull(FPaths::ProjectIntermediateDir()), FString::Printf(TEXT("Improbable/%s_LocalLaunchConfig.json"), *EditorWorld->GetMapName()));
+
+	const USpatialGDKSettings* SpatialGDKSettings = GetDefault<USpatialGDKSettings>();
+	const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>();
+
+	FSpatialLaunchConfigDescription LaunchConfiguration = SpatialGDKEditorSettings->LaunchConfigDesc;
+	TMap<FName, FWorkerTypeLaunchSection> ServerWorkers;
+
+	FillWorkerConfigurationFromCurrentMap(ServerWorkers, LaunchConfiguration.World.Dimensions);
+
+	GenerateDefaultLaunchConfig(LaunchConfig, &LaunchConfiguration, ServerWorkers);
+
+	OnPrimaryLaunchConfigPathPicked(LaunchConfig);
+
+	return FReply::Handled();
+}
+
+FReply SSpatialGDKSimulatedPlayerDeployment::OnOpenLaunchConfigEditor()
+{
+	ULaunchConfigurationEditor* Editor = UTransientUObjectEditor::LaunchTransientUObjectEditor<ULaunchConfigurationEditor>("Launch Configuration Editor");
+
+	Editor->OnConfigurationSaved.BindLambda([WeakThis = TWeakPtr<SWidget>(this->AsShared())](ULaunchConfigurationEditor*, const FString& FilePath)
+	{
+		if (auto This = WeakThis.Pin())
+		{
+			static_cast<SSpatialGDKSimulatedPlayerDeployment*>(This.Get())->OnPrimaryLaunchConfigPathPicked(FilePath);
+		}
+	}
+	);
+
+	return FReply::Handled();
 }

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -21,6 +21,7 @@ class SWindow;
 class USoundBase;
 
 struct FWorkerTypeLaunchSection;
+class UAbstractRuntimeLoadBalancingStrategy;
 
 DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKEditorToolbar, Log, All);
 
@@ -97,8 +98,6 @@ private:
 	void ShowSuccessNotification(const FString& NotificationText);
 
 	void ShowFailedNotification(const FString& NotificationText);
-
-	bool FillWorkerLaunchConfigFromWorldSettings(UWorld& World, FWorkerTypeLaunchSection& OutLaunchConfig, FIntPoint& OutWorldDimension);
 
 	void GenerateSchema(bool bFullScan);
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKSimulatedPlayerDeployment.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKSimulatedPlayerDeployment.h
@@ -115,4 +115,8 @@ private:
 
 	/** Delegate to determine the 'Launch Deployment' button enabled state */
 	bool IsDeploymentConfigurationValid() const;
+
+	FReply OnGenerateConfigFromCurrentMap();
+
+	FReply OnOpenLaunchConfigEditor();
 };

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/LoadBalancingEditorExtension/SpatialGDKEditorLBExtensionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/LoadBalancingEditorExtension/SpatialGDKEditorLBExtensionTest.cpp
@@ -31,11 +31,12 @@ struct TestFixture
 	bool GetDefaultLaunchConfiguration(const UAbstractLBStrategy* Strategy, UAbstractRuntimeLoadBalancingStrategy*& OutConfiguration, FIntPoint& OutWorldDimensions)
 	{
 		CleanupRuntimeStrategy();
-		bool bResult = ExtensionManager.GetDefaultLaunchConfiguration(Strategy, OutConfiguration, OutWorldDimensions);
+		const bool bResult = ExtensionManager.GetDefaultLaunchConfiguration(Strategy, OutConfiguration, OutWorldDimensions);
 
 		if (OutConfiguration)
 		{
 			OutConfiguration->AddToRoot();
+			RuntimeStrategy = OutConfiguration;
 		}
 
 		return bResult;
@@ -46,6 +47,7 @@ struct TestFixture
 		if (RuntimeStrategy)
 		{
 			RuntimeStrategy->RemoveFromRoot();
+			RuntimeStrategy = nullptr;
 		}
 	}
 

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/LoadBalancingEditorExtension/TestLoadBalancingStrategyEditorExtension.h
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/LoadBalancingEditorExtension/TestLoadBalancingStrategyEditorExtension.h
@@ -4,18 +4,21 @@
 
 #include "EditorExtension/LBStrategyEditorExtension.h"
 #include "TestLoadBalancingStrategy.h"
+#include "SpatialRuntimeLoadBalancingStrategies.h"
 
 class FTestLBStrategyEditorExtension : public FLBStrategyEditorExtensionTemplate<UDummyLoadBalancingStrategy, FTestLBStrategyEditorExtension>
 {
 public:
-	bool GetDefaultLaunchConfiguration(const UDummyLoadBalancingStrategy* Strategy, FWorkerTypeLaunchSection& OutConfiguration, FIntPoint& OutWorldDimensions) const
+	bool GetDefaultLaunchConfiguration(const UDummyLoadBalancingStrategy* Strategy, UAbstractRuntimeLoadBalancingStrategy*& OutConfiguration, FIntPoint& OutWorldDimensions) const
 	{
 		if (Strategy == nullptr)
 		{
 			return false;
 		}
 
-		OutConfiguration.NumEditorInstances = Strategy->NumberOfWorkers;
+		UEntityShardingRuntimeLoadBalancingStrategy* Conf = NewObject<UEntityShardingRuntimeLoadBalancingStrategy>();
+		Conf->NumWorkers = Strategy->NumberOfWorkers;
+		OutConfiguration = Conf;
 
 		OutWorldDimensions.X = OutWorldDimensions.Y = 0;
 
@@ -27,14 +30,16 @@ class FTestDerivedLBStrategyEditorExtension : public FLBStrategyEditorExtensionT
 {
 public:
 
-	bool GetDefaultLaunchConfiguration(const UDerivedDummyLoadBalancingStrategy* Strategy, FWorkerTypeLaunchSection& OutConfiguration, FIntPoint& OutWorldDimensions) const
+	bool GetDefaultLaunchConfiguration(const UDerivedDummyLoadBalancingStrategy* Strategy, UAbstractRuntimeLoadBalancingStrategy*& OutConfiguration, FIntPoint& OutWorldDimensions) const
 	{
 		if (Strategy == nullptr)
 		{
 			return false;
 		}
 
-		OutConfiguration.NumEditorInstances = Strategy->NumberOfWorkers;
+		UEntityShardingRuntimeLoadBalancingStrategy* Conf = NewObject<UEntityShardingRuntimeLoadBalancingStrategy>();
+		Conf->NumWorkers = Strategy->NumberOfWorkers;
+		OutConfiguration = Conf;
 
 		OutWorldDimensions.X = OutWorldDimensions.Y = 4242;
 

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/LoadBalancingEditorExtension/TestLoadBalancingStrategyEditorExtension.h
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/LoadBalancingEditorExtension/TestLoadBalancingStrategyEditorExtension.h
@@ -3,8 +3,8 @@
 #pragma once
 
 #include "EditorExtension/LBStrategyEditorExtension.h"
-#include "TestLoadBalancingStrategy.h"
 #include "SpatialRuntimeLoadBalancingStrategies.h"
+#include "TestLoadBalancingStrategy.h"
 
 class FTestLBStrategyEditorExtension : public FLBStrategyEditorExtensionTemplate<UDummyLoadBalancingStrategy, FTestLBStrategyEditorExtension>
 {

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKServices/LocalDeploymentManager/LocalDeploymentManagerUtilities.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKServices/LocalDeploymentManager/LocalDeploymentManagerUtilities.cpp
@@ -7,6 +7,7 @@
 #include "SpatialGDKDefaultWorkerJsonGenerator.h"
 #include "SpatialGDKEditorSettings.h"
 #include "SpatialGDKServicesConstants.h"
+#include "SpatialRuntimeLoadBalancingStrategies.h"
 
 #include "CoreMinimal.h"
 
@@ -74,13 +75,19 @@ bool FStartDeployment::Update()
 				return;
 			}
 
-			FSpatialLaunchConfigDescription LaunchConfigDescription(AutomationWorkerType);
-			LaunchConfigDescription.SetLevelEditorPlaySettingsWorkerTypes();
+			FSpatialLaunchConfigDescription LaunchConfigDescription;
 
-			if (!GenerateDefaultLaunchConfig(LaunchConfig, &LaunchConfigDescription))
+			TMap<FName, FWorkerTypeLaunchSection> WorkerConfigMap;
+
+			FWorkerTypeLaunchSection Conf;
+			Conf.WorkerLoadBalancing = USingleWorkerRuntimeStrategy::StaticClass()->GetDefaultObject<USingleWorkerRuntimeStrategy>();
+			WorkerConfigMap.Add(AutomationWorkerType, Conf);
+
+			if (!GenerateDefaultLaunchConfig(LaunchConfig, &LaunchConfigDescription, WorkerConfigMap))
 			{
 				return;
 			}
+			SetLevelEditorPlaySettingsWorkerTypes(WorkerConfigMap);
 
 			if (LocalDeploymentManager->IsLocalDeploymentRunning())
 			{

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKServices/LocalDeploymentManager/LocalDeploymentManagerUtilities.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKServices/LocalDeploymentManager/LocalDeploymentManagerUtilities.cpp
@@ -83,7 +83,7 @@ bool FStartDeployment::Update()
 			Conf.WorkerLoadBalancing = USingleWorkerRuntimeStrategy::StaticClass()->GetDefaultObject<USingleWorkerRuntimeStrategy>();
 			WorkerConfigMap.Add(AutomationWorkerType, Conf);
 
-			if (!GenerateDefaultLaunchConfig(LaunchConfig, &LaunchConfigDescription, WorkerConfigMap))
+			if (!GenerateLaunchConfig(LaunchConfig, &LaunchConfigDescription, WorkerConfigMap))
 			{
 				return;
 			}


### PR DESCRIPTION
#### Description

#### Editor Settings
![EditorSettings](https://user-images.githubusercontent.com/57392989/77669234-6b986a00-6f7c-11ea-9f10-5e4eaa91d480.png)

#### Runtime Settings
![RuntimeSettings](https://user-images.githubusercontent.com/57392989/77438606-f1ca7a00-6ddd-11ea-82a9-32d31452acbf.png)

#### Deploy Window
![Deploy](https://user-images.githubusercontent.com/57392989/77185115-bc194e80-6ac8-11ea-9486-d647dfa69513.png)

#### Launch Configuration editor
![LaunchConfigEditor](https://user-images.githubusercontent.com/57392989/77669251-6fc48780-6f7c-11ea-869b-b956e60ad048.png)

- Moved WorkerType definition from the Editor settings to the Runtime settings.
- Exposed WorkerType launch configurations through a read-only map (Keys are constant and map is of fixed size) for consistency
- Removed mention of the rectangular load balancing strategy in the settings.
- Added facilities to edit and set load balancing strategies for SpatialOS (USpatialOSAbstractLoadBalancingStrategy). These are editable in the launch configuration editor
- Pre-populate the launch configuration editor with the current map's settings.
- Added buttons to the sim player deployment panel to generate a launch configuration from the current map, or open the launch configuration editor.

#### Release note

#### Tests

#### Documentation
Should add documentation

#### Primary reviewers
