### PR TITLE
[UNR-3128] Fix startup actors receiving empty lists

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
@@ -109,7 +109,7 @@ void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject*
 	TArray<UProperty*> RepNotifies;
 
 	TArray<Schema_FieldId> InitialIds;
-	if (bIsInitialData)
+	if (UNLIKELY(bIsInitialData))
 	{
 		for (int32 HandleIndex = 0; HandleIndex < BaseHandleToCmdIndex.Num(); HandleIndex++)
 		{

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
@@ -108,7 +108,25 @@ void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject*
 
 	TArray<UProperty*> RepNotifies;
 
-	for (uint32 FieldId : UpdatedIds)
+	TArray<Schema_FieldId> InitialIds;
+	if (bIsInitialData)
+	{
+		for (int32 HandleIndex = 0; HandleIndex < BaseHandleToCmdIndex.Num(); HandleIndex++)
+		{
+			auto Parent = Parents[Cmds[BaseHandleToCmdIndex[HandleIndex].CmdIndex].ParentIndex];
+			for (int32 SchemaType = SCHEMA_Begin; SchemaType < SCHEMA_Count; SchemaType++)
+			{
+				if (ClassInfoManager->GetClassInfoByComponentId(ComponentId).SchemaComponents[SchemaType] != ComponentId) continue;
+				if (GetGroupFromCondition(Parent.Condition) == SchemaType)
+				{
+					InitialIds.Add(HandleIndex + 1);
+				}
+			}
+		}
+	}
+	const TArray<Schema_FieldId>& IdsToIterate = bIsInitialData ? InitialIds : UpdatedIds;
+
+	for (uint32 FieldId : IdsToIterate)
 	{
 		// FieldId is the same as rep handle
 		if (FieldId == 0 || (int)FieldId - 1 >= BaseHandleToCmdIndex.Num())

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
@@ -113,10 +113,15 @@ void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject*
 	{
 		for (int32 HandleIndex = 0; HandleIndex < BaseHandleToCmdIndex.Num(); HandleIndex++)
 		{
-			auto Parent = Parents[Cmds[BaseHandleToCmdIndex[HandleIndex].CmdIndex].ParentIndex];
+			const FRepParentCmd& Parent = Parents[Cmds[BaseHandleToCmdIndex[HandleIndex].CmdIndex].ParentIndex];
+			const FClassInfo& ClassInfo = ClassInfoManager->GetClassInfoByComponentId(ComponentId);
+
 			for (int32 SchemaType = SCHEMA_Begin; SchemaType < SCHEMA_Count; SchemaType++)
 			{
-				if (ClassInfoManager->GetClassInfoByComponentId(ComponentId).SchemaComponents[SchemaType] != ComponentId) continue;
+				if (ClassInfo.SchemaComponents[SchemaType] != ComponentId)
+				{
+					continue;
+				}
 				if (GetGroupFromCondition(Parent.Condition) == SchemaType)
 				{
 					InitialIds.Add(HandleIndex + 1);

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
@@ -108,11 +108,11 @@ void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject*
 
 	TArray<UProperty*> RepNotifies;
 
-	TArray<Schema_FieldId> InitialIds;
 	// If we are applying initial data, they must have come from a ComponentData (as it currently stands).
 	// ComponentData will be missing fields if they are completely empty (options, lists, and maps).
 	// However, we still want to apply this empty data, so we need to reconstruct the full
 	// list of field IDs for that component type (Data, OwnerOnly).
+	TArray<Schema_FieldId> InitialIds;
 	if (bIsInitialData)
 	{
 		const FClassInfo& ClassInfo = ClassInfoManager->GetClassInfoByComponentId(ComponentId);

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
@@ -109,23 +109,21 @@ void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject*
 	TArray<UProperty*> RepNotifies;
 
 	TArray<Schema_FieldId> InitialIds;
-	if (UNLIKELY(bIsInitialData))
+	// If we are applying initial data, they must have come from a ComponentData (as it currently stands).
+	// ComponentData will be missing fields if they are completely empty (options, lists, and maps).
+	// However, we still want to apply this empty data, so we need to reconstruct the full
+	// list of field IDs for that component type (Data, OwnerOnly).
+	if (bIsInitialData)
 	{
+		const FClassInfo& ClassInfo = ClassInfoManager->GetClassInfoByComponentId(ComponentId);
+
+		int32 SchemaType = ClassInfoManager->GetCategoryByComponentId(ComponentId);
 		for (int32 HandleIndex = 0; HandleIndex < BaseHandleToCmdIndex.Num(); HandleIndex++)
 		{
 			const FRepParentCmd& Parent = Parents[Cmds[BaseHandleToCmdIndex[HandleIndex].CmdIndex].ParentIndex];
-			const FClassInfo& ClassInfo = ClassInfoManager->GetClassInfoByComponentId(ComponentId);
-
-			for (int32 SchemaType = SCHEMA_Begin; SchemaType < SCHEMA_Count; SchemaType++)
+			if (GetGroupFromCondition(Parent.Condition) == SchemaType)
 			{
-				if (ClassInfo.SchemaComponents[SchemaType] != ComponentId)
-				{
-					continue;
-				}
-				if (GetGroupFromCondition(Parent.Condition) == SchemaType)
-				{
-					InitialIds.Add(HandleIndex + 1);
-				}
+				InitialIds.Add(HandleIndex + 1);
 			}
 		}
 	}


### PR DESCRIPTION
#### Description
Scenario where this would break:
1) A client checks out a `bNetLoadOnClient` startup actor which has a replicated TArray, with let's say [0,1,2]
2) The client walks away so the actor is no longer checked out
3) The startup actor is updated by the server, so the array is now empty []
4) The client comes back to the startup actor and checks it out again, the empty array would not be applied

#### Release note
TODO

#### Tests
Soon to come in EngineNetTest.

#### Documentation
N/A

#### Primary reviewers
@mattyoung-improbable @joshuahuburn 
