### PR TITLE
Deleting ally's code

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -130,7 +130,6 @@ void USpatialSender::SendAddComponents(Worker_EntityId EntityId, TArray<FWorkerC
 	}
 
 	// Update ComponentPresence.
-	check(StaticComponentView->HasAuthority(EntityId, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID));
 	ComponentPresence* Presence = StaticComponentView->GetComponentData<ComponentPresence>(EntityId);
 	Presence->AddComponentDataIds(ComponentDatas);
 	FWorkerComponentUpdate Update = Presence->CreateComponentPresenceUpdate();


### PR DESCRIPTION
#### Description
Tilman hits the AuthorityIntent authority check(...) with this callstack:
```
    UE4Editor-SpatialGDK.dll!USpatialSender::SendAddComponents(__int64 EntityId, TArray<FTrackableWorkerType<worker::c::Worker_ComponentData>,TSizedDefaultAllocator<32> > ComponentDatas) Line 133   C++
    UE4Editor-SpatialGDK.dll!ASpatialDebugger::ActorAuthorityChanged(const worker::c::Worker_AuthorityChangeOp & AuthOp) Line 294   C++
    UE4Editor-SpatialGDK.dll!USpatialReceiver::HandleActorAuthority(const worker::c::Worker_AuthorityChangeOp & Op) Line 479    C++
    UE4Editor-SpatialGDK.dll!USpatialReceiver::LeaveCriticalSection() Line 110  C++
    UE4Editor-SpatialGDK.dll!SpatialDispatcher::ProcessOps(worker::c::Worker_OpList * OpList) Line 56   C++
    UE4Editor-SpatialGDK.dll!USpatialNetDriver::HandleStartupOpQueueing(const TArray<worker::c::Worker_OpList *,TSizedDefaultAllocator<32> > & InOpLists) Line 2393 C++
    UE4Editor-SpatialGDK.dll!USpatialNetDriver::TickDispatch(float DeltaTime) Line 1613 C++
    [Inline Frame] UE4Editor-Engine.dll!TMemberFunctionCaller<UNetDriver,void (__cdecl UNetDriver::*)(float)>::operator()(float &) Line 156   C++
    [Inline Frame] UE4Editor-Engine.dll!UE4Tuple_Private::TTupleImpl<TIntegerSequence<unsigned int> >::ApplyAfter(TMemberFunctionCaller<UNetDriver,void (__cdecl UNetDriver::*)(float)> &&) Line 285  C++
    [Inline Frame] UE4Editor-Engine.dll!TBaseUObjectMethodDelegateInstance<0,UNetDriver,TTypeWrapper<void> __cdecl(float)>::Execute(float) Line 649 C++
    UE4Editor-Engine.dll!TBaseUObjectMethodDelegateInstance<0,UNetDriver,void __cdecl(float)>::ExecuteIfSafe(float <Params_0>) Line 711 C++
    UE4Editor-Engine.dll!TBaseMulticastDelegate<void,float>::Broadcast(float <Params_0>) Line 1013  C++
    UE4Editor-Engine.dll!UWorld::Tick(ELevelTick TickType, float DeltaSeconds) Line 1421    C++
    UE4Editor-UnrealEd.dll!UEditorEngine::Tick(float DeltaSeconds, bool bIdleMode) Line 1685    C++
    UE4Editor-UnrealEd.dll!UUnrealEdEngine::Tick(float DeltaSeconds, bool bIdleMode) Line 410   C++
    UE4Editor.exe!FEngineLoop::Tick() Line 4485 C++
    [Inline Frame] UE4Editor.exe!EngineTick() Line 62   C++
    UE4Editor.exe!GuardedMain(const wchar_t * CmdLine, HINSTANCE__ * hInInstance, HINSTANCE__ * hPrevInstance, int nCmdShow) Line 173   C++
    UE4Editor.exe!WinMain(HINSTANCE__ * hInInstance, HINSTANCE__ * hPrevInstance, char * __formal, int nCmdShow) Line 252   C++
    [External Code] 
```

The error occurs when the worker authoritattive over the SpatialDebugger checks out an entity for the first time, and processes the AuthorityIntent update before the ComponentPresence op. Currently, when an AuthorityIntent authority gained op  is received for some Actor, we try and either send a component update for the SpatialDebugging component OR if the SpatialDebugging component isn't present, dynamically add it (with the relevant data). I initially thought this includes another race, since the SpatialDebugging authority gained op might not yet have been processed, however in the GDK, SendComponentUpdate are queued and processed in future, meaning the authority gained op (assuming it comes later in the critical section) WOULD be processed before the update. Either way, for ComponentPresence, SendAddComponents was edited to update ComponentPresence (as well as EntityACL if it existed), including the check Tilman's hitting. Easiest fix is to just delete the check, it makes things less safe in the broader, but should still not cause errors in this case since, as with the SpatialDebugging component, we know we'll synchronously get the HasAuthority op before the GDK actually processes the outgoing op.

tl;dr this is simplest easiest fix besides reorganising authority op list or buffering the SpatialDebugger SendAddComponent op, if someone tries to call method this without authority from elsewhere in the code, you'd still get a SpatialOS error