### PR TITLE
Call OnAuthorityLost callback when sending auth intent

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -723,6 +723,8 @@ int64 USpatialActorChannel::ReplicateActor()
 				// If we're setting a different authority intent, preemptively changed to ROLE_SimulatedProxy 
 				Actor->Role = ROLE_SimulatedProxy;
 				Actor->RemoteRole = ROLE_Authority;
+
+				Actor->OnAuthorityLost();
 			}
 			else
 			{

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -591,10 +591,16 @@ void USpatialReceiver::HandleActorAuthority(const Worker_AuthorityChangeOp& Op)
 					ActorChannel->bCreatedEntity = false;
 				}
 
-				Actor->Role = ROLE_SimulatedProxy;
-				Actor->RemoteRole = ROLE_Authority;
+				// With load-balancing enabled, we set ROLE_SimulatedProxy and trigger OnAuthorityLost when we
+				// set AuthorityIntent to another worker.This conditional exists to dodge call OnAuthorityLost
+				// twice.
+				if (Actor->Role != ROLE_SimulatedProxy)
+				{
+					Actor->Role = ROLE_SimulatedProxy;
+					Actor->RemoteRole = ROLE_Authority;
 
-				Actor->OnAuthorityLost();
+					Actor->OnAuthorityLost();
+				}
 			}
 		}
 


### PR DESCRIPTION
#### Description
Currently, we preemptively set local role to SimulatedProxy when sending an AuthorityIntent update since we know we're going to lose authority imminently. However, we don't trigger the OnAuthorityLost callback. Instead, this would be triggered when SpatialOS eventually sends us the op, however, having a state where we've changed from Role_Authority to SimulatedProxy but not yet triggered OnAuthorityLost seems bad.

There's an additional change to the code where we receive the AuthorityLost op to make sure we don't call OnAuthorityLost twice.
