### PR TITLE
Early exit processing a server RPC if the Actor role has changed to SimulatedProxy

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1664,7 +1664,7 @@ void USpatialReceiver::HandleRPC(const Worker_ComponentUpdateOp& Op)
 		return;
 	}
 
-	const TWeakObjectPtr<UObject> ActorReceivingRpc = PackageMap->GetObjectFromEntityId(Op.entity_id);
+	const TWeakObjectPtr<UObject> ActorReceivingRPC = PackageMap->GetObjectFromEntityId(Op.entity_id);
 	if (!ActorReceivingRpc.IsValid())
 	{
 		UE_LOG(LogSpatialReceiver, Error, TEXT("Entity receiving ring buffer RPC does not exist in PackageMap! Entity: %lld, Component: %d"), Op.entity_id, Op.update.component_id);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1665,7 +1665,7 @@ void USpatialReceiver::HandleRPC(const Worker_ComponentUpdateOp& Op)
 	}
 
 	const TWeakObjectPtr<UObject> ActorReceivingRPC = PackageMap->GetObjectFromEntityId(Op.entity_id);
-	if (!ActorReceivingRpc.IsValid())
+	if (!ActorReceivingRPC.IsValid())
 	{
 		UE_LOG(LogSpatialReceiver, Error, TEXT("Entity receiving ring buffer RPC does not exist in PackageMap! Entity: %lld, Component: %d"), Op.entity_id, Op.update.component_id);
 		return;
@@ -1675,7 +1675,7 @@ void USpatialReceiver::HandleRPC(const Worker_ComponentUpdateOp& Op)
 	// This causes the engine to print errors when we try and processed received RPCs while not authoritative. Instead, we early
 	// exit here, and the RPC will be processed by the server that receives authority.
 	const bool bIsServerRpc = Op.update.component_id == SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID;
-	const bool bActorRoleIsSimulatedProxy = Cast<AActor>(ActorReceivingRpc.Get())->Role == ROLE_SimulatedProxy;
+	const bool bActorRoleIsSimulatedProxy = Cast<AActor>(ActorReceivingRPC.Get())->Role == ROLE_SimulatedProxy;
 	if (bIsServerRpc && bActorRoleIsSimulatedProxy)
 	{
 		UE_LOG(LogSpatialReceiver, Verbose, TEXT("Will not process server RPC, Actor role changed to SimulatedProxy. This happens on migration. Entity: %lld"), Op.entity_id);


### PR DESCRIPTION
#### Description
Early exit processing a server RPC if the Actor role has changed to SimulatedProxy (as would be the case if we were migrating the Actor to another work via updating the AuthorityIntent). This previously resulted in engine code spamming errors every time you cross a boundary for the RPCs that it attempts to process. Furthermore, I think it just fails to process the RPC but may still update the endpoint RPC count meaning those RPCs don't get validly processed by the next worker either. 

Now, exiting early should prevent the errors, and doesn't update the count, meaning these RPCs should be processed by the worker receiving authority.

Before:

![image](https://user-images.githubusercontent.com/9222722/77532969-df0f7e00-6e8d-11ea-9122-796583016e7e.png)

After:

![image](https://user-images.githubusercontent.com/9222722/77532984-e6368c00-6e8d-11ea-960b-58edb324a45c.png)
