### PR TITLE
Disable legacy include

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/WorkerViewTest.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/WorkerViewTest.cpp
@@ -3,7 +3,7 @@
 #include "Tests/TestDefinitions.h"
 
 #include "SpatialView/WorkerView.h"
-#include "OpList/ViewDeltaLegacyOpList.h"
+#include "SpatialView/OpList/ViewDeltaLegacyOpList.h"
 
 #define WORKERVIEW_TEST(TestName) \
 	GDK_TEST(Core, WorkerView, TestName)

--- a/SpatialGDK/Source/SpatialGDK/SpatialGDK.Build.cs
+++ b/SpatialGDK/Source/SpatialGDK/SpatialGDK.Build.cs
@@ -13,6 +13,7 @@ public class SpatialGDK : ModuleRules
 {
     public SpatialGDK(ReadOnlyTargetRules Target) : base(Target)
     {
+		bLegacyPublicIncludePaths = false;
         PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
 #pragma warning disable 0618
         bFasterWithoutUnity = true;             // Deprecated in 4.24, replace with bUseUnity = false; once we drop support for 4.23

--- a/SpatialGDK/Source/SpatialGDKEditor/SpatialGDKEditor.Build.cs
+++ b/SpatialGDK/Source/SpatialGDKEditor/SpatialGDKEditor.Build.cs
@@ -6,6 +6,7 @@ public class SpatialGDKEditor : ModuleRules
 {
 	public SpatialGDKEditor(ReadOnlyTargetRules Target) : base(Target)
 	{
+		bLegacyPublicIncludePaths = false;
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 #pragma warning disable 0618
 		bFasterWithoutUnity = true;             // Deprecated in 4.24, replace with bUseUnity = false; once we drop support for 4.23

--- a/SpatialGDK/Source/SpatialGDKEditorCommandlet/SpatialGDKEditorCommandlet.Build.cs
+++ b/SpatialGDK/Source/SpatialGDKEditorCommandlet/SpatialGDKEditorCommandlet.Build.cs
@@ -6,6 +6,7 @@ public class SpatialGDKEditorCommandlet : ModuleRules
 {
 	public SpatialGDKEditorCommandlet(ReadOnlyTargetRules Target) : base(Target)
 	{
+		bLegacyPublicIncludePaths = false;
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 #pragma warning disable 0618
 		bFasterWithoutUnity = true;             // Deprecated in 4.24, replace with bUseUnity = false; once we drop support for 4.23

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/SpatialGDKEditorToolbar.Build.cs
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/SpatialGDKEditorToolbar.Build.cs
@@ -6,6 +6,7 @@ public class SpatialGDKEditorToolbar : ModuleRules
 {
     public SpatialGDKEditorToolbar(ReadOnlyTargetRules Target) : base(Target)
     {
+		bLegacyPublicIncludePaths = false;
         PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
 #pragma warning disable 0618
         bFasterWithoutUnity = true;             // Deprecated in 4.24, replace with bUseUnity = false; once we drop support for 4.23

--- a/SpatialGDK/Source/SpatialGDKServices/SpatialGDKServices.Build.cs
+++ b/SpatialGDK/Source/SpatialGDKServices/SpatialGDKServices.Build.cs
@@ -6,6 +6,7 @@ public class SpatialGDKServices : ModuleRules
 {
 	public SpatialGDKServices(ReadOnlyTargetRules Target) : base(Target)
 	{
+		bLegacyPublicIncludePaths = false;
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 #pragma warning disable 0618
 		bFasterWithoutUnity = true;             // Deprecated in 4.24, replace with bUseUnity = false; once we drop support for 4.23

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKTests.Build.cs
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKTests.Build.cs
@@ -6,6 +6,7 @@ public class SpatialGDKTests : ModuleRules
 {
 	public SpatialGDKTests(ReadOnlyTargetRules Target) : base(Target)
 	{
+		bLegacyPublicIncludePaths = false;
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 #pragma warning disable 0618
 		bFasterWithoutUnity = true;             // Deprecated in 4.24, replace with bUseUnity = false; once we drop support for 4.23


### PR DESCRIPTION
#### Description
In order to have the same build settings between project and engines plugins, we set the bLegacyPublicIncludePaths to false.

#### Release note

#### Tests
This PR's CI should be broken right now. 

#### Documentation

#### Primary reviewers
