### PR TITLE
Add tracePrefix command line argument

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
@@ -55,6 +55,7 @@ USpatialLatencyTracer::USpatialLatencyTracer()
 {
 #if TRACE_LIB_ACTIVE
 	ResetWorkerId();
+	FParse::Value(FCommandLine::Get(), TEXT("tracePrefix"), MessagePrefix);
 #endif
 }
 


### PR DESCRIPTION
This change sets the trace prefix (which I will probably be renaming to "trace identifier" in the future) to the `tracePrefix` command line arg (if it has been passed in). I'm merging this into your branch because I'm testing it with your branch as well.