### PR TITLE
[UNR-3010][MS] Modifying SpatialCommandUtils so that it better wraps up spatial cli commands.

### DIFF
--- a/SpatialGDK/Source/SpatialGDKServices/Private/Interop/Connection/EditorWorkerController.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/Interop/Connection/EditorWorkerController.cpp
@@ -67,14 +67,9 @@ struct EditorWorkerController
 
 	FProcHandle ReplaceWorker(const FString& OldWorker, const FString& NewWorker)
 	{
-		const FString CmdArgs = FString::Printf(
-			TEXT("local worker replace "
-				"--local_service_grpc_port %s "
-				"--existing_worker_id %s "
-				"--replacing_worker_id %s"), *ServicePort, *OldWorker, *NewWorker);
 		uint32 ProcessID = 0;
-		FProcHandle ProcHandle = SpatialCommandUtils::CreateSpatialProcess(CmdArgs, false, true, true, &ProcessID, 2 /*PriorityModifier*/,
-				nullptr, nullptr, nullptr, false);
+		FProcHandle ProcHandle = SpatialCommandUtils::LocalWorkerReplace(*ServicePort, *OldWorker, *NewWorker, false, false, true, true, &ProcessID, 2 /*PriorityModifier*/,
+				nullptr, nullptr, nullptr);
 
 		return ProcHandle;
 	}

--- a/SpatialGDK/Source/SpatialGDKServices/Private/Interop/Connection/EditorWorkerController.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/Interop/Connection/EditorWorkerController.cpp
@@ -68,10 +68,8 @@ struct EditorWorkerController
 	FProcHandle ReplaceWorker(const FString& OldWorker, const FString& NewWorker)
 	{
 		uint32 ProcessID = 0;
-		FProcHandle ProcHandle = SpatialCommandUtils::LocalWorkerReplace(*ServicePort, *OldWorker, *NewWorker, false, false, true, true, &ProcessID, 2 /*PriorityModifier*/,
-				nullptr, nullptr, nullptr);
-
-		return ProcHandle;
+		return SpatialCommandUtils::LocalWorkerReplace(*ServicePort, *OldWorker, *NewWorker, false, false, true, true, &ProcessID, 2 /*PriorityModifier*/,
+			nullptr, nullptr, nullptr);
 	}
 
 	void BlockUntilWorkerReady(int32 WorkerIdx)

--- a/SpatialGDK/Source/SpatialGDKServices/Private/Interop/Connection/EditorWorkerController.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/Interop/Connection/EditorWorkerController.cpp
@@ -68,8 +68,7 @@ struct EditorWorkerController
 	FProcHandle ReplaceWorker(const FString& OldWorker, const FString& NewWorker)
 	{
 		uint32 ProcessID = 0;
-		return SpatialCommandUtils::LocalWorkerReplace(*ServicePort, *OldWorker, *NewWorker, false, false, true, true, &ProcessID, 2 /*PriorityModifier*/,
-			nullptr, nullptr, nullptr);
+		return SpatialCommandUtils::LocalWorkerReplace(*ServicePort, *OldWorker, *NewWorker, false, &ProcessID);
 	}
 
 	void BlockUntilWorkerReady(int32 WorkerIdx)

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
@@ -49,13 +49,13 @@ bool SpatialCommandUtils::AttemptSpatialAuth(bool bIsRunningInChina)
 	bool bSuccess = OutExitCode == 0;
 	if (!bSuccess)
 	{
-		UE_LOG(LogSpatialCommandUtils, Warning, TEXT("Spatial auth login failed. Error Code: %d, Error Message: %s"), OutExitCode, *OutStdOut);
+		UE_LOG(LogSpatialCommandUtils, Warning, TEXT("Spatial auth login failed. Error Code: %d, StdOut Message: %s, StdErr Message: %s"), OutExitCode, *OutStdOut, *OutStdErr);
 	}
 
 	return bSuccess;
 }
 
-bool SpatialCommandUtils::StartSpatialService(FString Version, FString RuntimeIP, bool bIsRunningInChina, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode)
+bool SpatialCommandUtils::StartSpatialService(const FString& Version, const FString& RuntimeIP, bool bIsRunningInChina, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode)
 {
 	FString Command = TEXT("service start");
 
@@ -126,7 +126,7 @@ bool SpatialCommandUtils::BuildWorkerConfig(bool bIsRunningInChina, const FStrin
 	return bSuccess;
 }
 
-FProcHandle SpatialCommandUtils::LocalWorkerReplace(FString ServicePort, FString OldWorker, FString NewWorker, bool bIsRunningInChina, bool bLaunchDetached, bool bLaunchHidden, bool bLaunchReallyHidden, uint32* OutProcessID, int32 PriorityModifier, const TCHAR* OptionalWorkingDirectory, void* PipeWriteChild, void * PipeReadChild)
+FProcHandle SpatialCommandUtils::LocalWorkerReplace(const FString& ServicePort, const FString& OldWorker, const FString& NewWorker, bool bIsRunningInChina, bool bLaunchDetached, bool bLaunchHidden, bool bLaunchReallyHidden, uint32* OutProcessID, int32 PriorityModifier, const TCHAR* OptionalWorkingDirectory, void* PipeWriteChild, void* PipeReadChild)
 {
 	FString Command = TEXT("worker build build-config");
 

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
@@ -130,20 +130,24 @@ FProcHandle SpatialCommandUtils::LocalWorkerReplace(const FString& ServicePort, 
 {
 	FString Command = TEXT("worker build build-config");
 
-	if (!ServicePort.IsEmpty())
+	if (ServicePort.IsEmpty())
 	{
-		Command.Append(FString::Printf(TEXT(" --local_service_grpc_port %s"), *ServicePort));
+		UE_LOG(LogSpatialCommandUtils, Error, TEXT("Calling LocalWorkerReplace with no ServicePort"));
 	}
 
-	if (!OldWorker.IsEmpty())
+	if (OldWorker.IsEmpty())
 	{
-		Command.Append(FString::Printf(TEXT(" --existing_worker_id %s"), *OldWorker));
+		UE_LOG(LogSpatialCommandUtils, Error, TEXT("Calling LocalWorkerReplace with no OldWorker"));
 	}
 
-	if (!NewWorker.IsEmpty())
+	if (NewWorker.IsEmpty())
 	{
-		Command.Append(FString::Printf(TEXT(" --replacing_worker_id %s"), *NewWorker));
+		UE_LOG(LogSpatialCommandUtils, Error, TEXT("Calling LocalWorkerReplace with no NewWorker"));
 	}
+
+	Command.Append(FString::Printf(TEXT(" --local_service_grpc_port %s"), *ServicePort));
+	Command.Append(FString::Printf(TEXT(" --existing_worker_id %s"), *OldWorker));
+	Command.Append(FString::Printf(TEXT(" --replacing_worker_id %s"), *NewWorker));
 
 	return FPlatformProcess::CreateProc(*SpatialGDKServicesConstants::SpatialExe, *Command, bLaunchDetached, bLaunchHidden, bLaunchReallyHidden, OutProcessID, PriorityModifier, OptionalWorkingDirectory, PipeWriteChild, PipeReadChild);
 }

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
@@ -126,28 +126,17 @@ bool SpatialCommandUtils::BuildWorkerConfig(bool bIsRunningInChina, const FStrin
 	return bSuccess;
 }
 
-FProcHandle SpatialCommandUtils::LocalWorkerReplace(const FString& ServicePort, const FString& OldWorker, const FString& NewWorker, bool bIsRunningInChina, bool bLaunchDetached, bool bLaunchHidden, bool bLaunchReallyHidden, uint32* OutProcessID, int32 PriorityModifier, const TCHAR* OptionalWorkingDirectory, void* PipeWriteChild, void* PipeReadChild)
+FProcHandle SpatialCommandUtils::LocalWorkerReplace(const FString& ServicePort, const FString& OldWorker, const FString& NewWorker, bool bIsRunningInChina, uint32* OutProcessID)
 {
+	check(!ServicePort.IsEmpty());
+	check(!OldWorker.IsEmpty());
+	check(!NewWorker.IsEmpty());
+
 	FString Command = TEXT("worker build build-config");
-
-	if (ServicePort.IsEmpty())
-	{
-		UE_LOG(LogSpatialCommandUtils, Error, TEXT("Calling LocalWorkerReplace with no ServicePort"));
-	}
-
-	if (OldWorker.IsEmpty())
-	{
-		UE_LOG(LogSpatialCommandUtils, Error, TEXT("Calling LocalWorkerReplace with no OldWorker"));
-	}
-
-	if (NewWorker.IsEmpty())
-	{
-		UE_LOG(LogSpatialCommandUtils, Error, TEXT("Calling LocalWorkerReplace with no NewWorker"));
-	}
-
 	Command.Append(FString::Printf(TEXT(" --local_service_grpc_port %s"), *ServicePort));
 	Command.Append(FString::Printf(TEXT(" --existing_worker_id %s"), *OldWorker));
 	Command.Append(FString::Printf(TEXT(" --replacing_worker_id %s"), *NewWorker));
 
-	return FPlatformProcess::CreateProc(*SpatialGDKServicesConstants::SpatialExe, *Command, bLaunchDetached, bLaunchHidden, bLaunchReallyHidden, OutProcessID, PriorityModifier, OptionalWorkingDirectory, PipeWriteChild, PipeReadChild);
+	return FPlatformProcess::CreateProc(*SpatialGDKServicesConstants::SpatialExe, *Command, false, true, true, OutProcessID, 2 /*PriorityModifier*/,
+		nullptr, nullptr, nullptr);
 }

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
@@ -11,46 +11,139 @@ namespace
 	FString ChinaEnvironmentArgument = TEXT(" --environment=cn-production");
 } // anonymous namespace
 
-void SpatialCommandUtils::ExecuteSpatialCommandAndReadOutput(FString Arguments, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode, bool bIsRunningInChina)
+bool SpatialCommandUtils::SpatialVersion(bool bIsRunningInChina, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode)
 {
+	FString Command = TEXT("version");
+
 	if (bIsRunningInChina)
 	{
-		Arguments += ChinaEnvironmentArgument;
+		Command += ChinaEnvironmentArgument;
 	}
 
-	FSpatialGDKServicesModule::ExecuteAndReadOutput(*SpatialGDKServicesConstants::SpatialExe, Arguments, DirectoryToRun, OutResult, OutExitCode);
-}
+	FSpatialGDKServicesModule::ExecuteAndReadOutput(*SpatialGDKServicesConstants::SpatialExe, Command, DirectoryToRun, OutResult, OutExitCode);
 
-void SpatialCommandUtils::ExecuteSpatialCommand(FString Arguments, int32* OutExitCode, FString* OutStdOut, FString* OutStdEr, bool bIsRunningInChina)
-{
-	if (bIsRunningInChina)
+	bool bSuccess = OutExitCode == 0;
+	if (!bSuccess)
 	{
-		Arguments += ChinaEnvironmentArgument;
+		UE_LOG(LogSpatialCommandUtils, Warning, TEXT("Spatial version failed. Error Code: %d, Error Message: %s"), OutExitCode, *OutResult);
 	}
-	FPlatformProcess::ExecProcess(*SpatialGDKServicesConstants::SpatialExe, *Arguments, OutExitCode, OutStdOut, OutStdEr);
-}
 
-FProcHandle SpatialCommandUtils::CreateSpatialProcess(FString Arguments, bool bLaunchDetached, bool bLaunchHidden, bool bLaunchReallyHidden, uint32* OutProcessID, int32 PriorityModifier, const TCHAR* OptionalWorkingDirectory, void* PipeWriteChild, void * PipeReadChild, bool bIsRunningInChina)
-{
-	if (bIsRunningInChina)
-	{
-		Arguments += ChinaEnvironmentArgument;
-	}
-	return FPlatformProcess::CreateProc(*SpatialGDKServicesConstants::SpatialExe, *Arguments, bLaunchDetached, bLaunchHidden, bLaunchReallyHidden, OutProcessID, PriorityModifier, OptionalWorkingDirectory, PipeWriteChild, PipeReadChild);
+	return bSuccess;
 }
 
 bool SpatialCommandUtils::AttemptSpatialAuth(bool bIsRunningInChina)
 {
-	FString SpatialInfoResult;
-	FString StdErr;
-	int32 ExitCode;
-	ExecuteSpatialCommand(TEXT("auth login"), &ExitCode, &SpatialInfoResult, &StdErr, bIsRunningInChina);
+	FString Command = TEXT("auth login");
 
-	bool bSuccess = ExitCode == 0;
+	if (bIsRunningInChina)
+	{
+		Command += ChinaEnvironmentArgument;
+	}
+
+	int32 OutExitCode;
+	FString OutStdOut;
+	FString OutStdErr;
+
+	FPlatformProcess::ExecProcess(*SpatialGDKServicesConstants::SpatialExe, *Command, &OutExitCode, &OutStdOut, &OutStdErr);
+
+	bool bSuccess = OutExitCode == 0;
 	if (!bSuccess)
 	{
-		UE_LOG(LogSpatialCommandUtils, Warning, TEXT("Spatial auth login failed. Error Code: %d, Error Message: %s"), ExitCode, *SpatialInfoResult);
+		UE_LOG(LogSpatialCommandUtils, Warning, TEXT("Spatial auth login failed. Error Code: %d, Error Message: %s"), OutExitCode, *OutStdOut);
 	}
 
 	return bSuccess;
+}
+
+bool SpatialCommandUtils::StartSpatialService(FString Version, FString RuntimeIP, bool bIsRunningInChina, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode)
+{
+	FString Command = TEXT("service start");
+
+	if (bIsRunningInChina)
+	{
+		Command += ChinaEnvironmentArgument;
+	}
+
+	if (!Version.IsEmpty())
+	{
+		Command.Append(FString::Printf(TEXT(" --version=%s"), *Version));
+	}
+
+	if (!RuntimeIP.IsEmpty())
+	{
+		Command.Append(FString::Printf(TEXT(" --runtime_ip=%s"), *RuntimeIP));
+		UE_LOG(LogSpatialCommandUtils, Verbose, TEXT("Trying to start spatial service with exposed runtime ip: %s"), *RuntimeIP);
+	}
+
+	FSpatialGDKServicesModule::ExecuteAndReadOutput(*SpatialGDKServicesConstants::SpatialExe, Command, DirectoryToRun, OutResult, OutExitCode);
+
+	bool bSuccess = OutExitCode == 0;
+	if (!bSuccess)
+	{
+		UE_LOG(LogSpatialCommandUtils, Warning, TEXT("Spatial start service failed. Error Code: %d, Error Message: %s"), OutExitCode, *OutResult);
+	}
+
+	return bSuccess;
+}
+
+bool SpatialCommandUtils::StopSpatialService(bool bIsRunningInChina, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode)
+{
+	FString Command = TEXT("service stop");
+
+	if (bIsRunningInChina)
+	{
+		Command += ChinaEnvironmentArgument;
+	}
+
+	FSpatialGDKServicesModule::ExecuteAndReadOutput(*SpatialGDKServicesConstants::SpatialExe, Command, DirectoryToRun, OutResult, OutExitCode);
+
+	bool bSuccess = OutExitCode == 0;
+	if (!bSuccess)
+	{
+		UE_LOG(LogSpatialCommandUtils, Warning, TEXT("Spatial stop service failed. Error Code: %d, Error Message: %s"), OutExitCode, *OutResult);
+	}
+
+	return bSuccess;
+}
+
+bool SpatialCommandUtils::BuildWorkerConfig(bool bIsRunningInChina, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode)
+{
+	FString Command = TEXT("worker build build-config");
+
+	if (bIsRunningInChina)
+	{
+		Command += ChinaEnvironmentArgument;
+	}
+
+	FSpatialGDKServicesModule::ExecuteAndReadOutput(*SpatialGDKServicesConstants::SpatialExe, Command, DirectoryToRun, OutResult, OutExitCode);
+
+	bool bSuccess = OutExitCode == 0;
+	if (!bSuccess)
+	{
+		UE_LOG(LogSpatialCommandUtils, Warning, TEXT("Spatial build worker config failed. Error Code: %d, Error Message: %s"), OutExitCode, *OutResult);
+	}
+
+	return bSuccess;
+}
+
+FProcHandle SpatialCommandUtils::LocalWorkerReplace(FString ServicePort, FString OldWorker, FString NewWorker, bool bIsRunningInChina, bool bLaunchDetached, bool bLaunchHidden, bool bLaunchReallyHidden, uint32* OutProcessID, int32 PriorityModifier, const TCHAR* OptionalWorkingDirectory, void* PipeWriteChild, void * PipeReadChild)
+{
+	FString Command = TEXT("worker build build-config");
+
+	if (!ServicePort.IsEmpty())
+	{
+		Command.Append(FString::Printf(TEXT(" --local_service_grpc_port %s"), *ServicePort));
+	}
+
+	if (!OldWorker.IsEmpty())
+	{
+		Command.Append(FString::Printf(TEXT(" --existing_worker_id %s"), *OldWorker));
+	}
+
+	if (!NewWorker.IsEmpty())
+	{
+		Command.Append(FString::Printf(TEXT(" --replacing_worker_id %s"), *NewWorker));
+	}
+
+	return FPlatformProcess::CreateProc(*SpatialGDKServicesConstants::SpatialExe, *Command, bLaunchDetached, bLaunchHidden, bLaunchReallyHidden, OutProcessID, PriorityModifier, OptionalWorkingDirectory, PipeWriteChild, PipeReadChild);
 }

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialGDKServicesModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialGDKServicesModule.cpp
@@ -77,9 +77,9 @@ bool FSpatialGDKServicesModule::SpatialPreRunChecks(bool bIsInChina)
 {
 	FString SpatialExistenceCheckResult;
 	int32 ExitCode;
-	SpatialCommandUtils::ExecuteSpatialCommandAndReadOutput(TEXT("version"), SpatialGDKServicesConstants::SpatialOSDirectory, SpatialExistenceCheckResult, ExitCode, bIsInChina);
+	bool bSuccess = SpatialCommandUtils::SpatialVersion(bIsInChina, SpatialGDKServicesConstants::SpatialOSDirectory, SpatialExistenceCheckResult, ExitCode);
 
-	if (ExitCode != 0)
+	if (!bSuccess)
 	{
 		UE_LOG(LogSpatialDeploymentManager, Warning, TEXT("%s does not exist on this machine! Please make sure Spatial is installed before trying to start a local deployment. %s"), *SpatialGDKServicesConstants::SpatialExe, *SpatialExistenceCheckResult);
 		return false;

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
@@ -12,9 +12,9 @@ public:
 
 	SPATIALGDKSERVICES_API static bool SpatialVersion(bool bIsRunningInChina, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode);
 	SPATIALGDKSERVICES_API static bool AttemptSpatialAuth(bool bIsRunningInChina);
-	SPATIALGDKSERVICES_API static bool StartSpatialService(FString Version, FString RuntimeIP, bool bIsRunningInChina, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode);
+	SPATIALGDKSERVICES_API static bool StartSpatialService(const FString& Version, const FString& RuntimeIP, bool bIsRunningInChina, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode);
 	SPATIALGDKSERVICES_API static bool StopSpatialService(bool bIsRunningInChina, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode);
 	SPATIALGDKSERVICES_API static bool BuildWorkerConfig(bool bIsRunningInChina, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode);
-	SPATIALGDKSERVICES_API static FProcHandle LocalWorkerReplace(FString ServicePort, FString OldWorker, FString NewWorker, bool bIsRunningInChina, bool bLaunchDetached, bool bLaunchHidden, bool bLaunchReallyHidden, uint32* OutProcessID, int32 PriorityModifier, const TCHAR* OptionalWorkingDirectory, void* PipeWriteChild, void * PipeReadChild);
+	SPATIALGDKSERVICES_API static FProcHandle LocalWorkerReplace(const FString& ServicePort, const FString& OldWorker, const FString& NewWorker, bool bIsRunningInChina, bool bLaunchDetached, bool bLaunchHidden, bool bLaunchReallyHidden, uint32* OutProcessID, int32 PriorityModifier, const TCHAR* OptionalWorkingDirectory, void* PipeWriteChild, void* PipeReadChild);
 
 };

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
@@ -10,11 +10,11 @@ class SpatialCommandUtils
 {
 public:
 
-	SPATIALGDKSERVICES_API static void ExecuteSpatialCommandAndReadOutput(FString Arguments, const FString& DirectoryToRun, FString& OutResult, int32& ExitCode, bool bIsRunningInChina);
-
-	SPATIALGDKSERVICES_API static void ExecuteSpatialCommand(FString Arguments, int32* OutReturnCode, FString* OutStdOut, FString* OutStdEr, bool bIsRunningInChina);
-
-	SPATIALGDKSERVICES_API static FProcHandle CreateSpatialProcess(FString Arguments, bool bLaunchDetached, bool bLaunchHidden, bool bLaunchReallyHidden, uint32* OutProcessID, int32 PriorityModifier, const TCHAR* OptionalWorkingDirectory, void* PipeWriteChild, void * PipeReadChild, bool bIsRunningInChina);
-
+	SPATIALGDKSERVICES_API static bool SpatialVersion(bool bIsRunningInChina, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode);
 	SPATIALGDKSERVICES_API static bool AttemptSpatialAuth(bool bIsRunningInChina);
+	SPATIALGDKSERVICES_API static bool StartSpatialService(FString Version, FString RuntimeIP, bool bIsRunningInChina, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode);
+	SPATIALGDKSERVICES_API static bool StopSpatialService(bool bIsRunningInChina, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode);
+	SPATIALGDKSERVICES_API static bool BuildWorkerConfig(bool bIsRunningInChina, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode);
+	SPATIALGDKSERVICES_API static FProcHandle LocalWorkerReplace(FString ServicePort, FString OldWorker, FString NewWorker, bool bIsRunningInChina, bool bLaunchDetached, bool bLaunchHidden, bool bLaunchReallyHidden, uint32* OutProcessID, int32 PriorityModifier, const TCHAR* OptionalWorkingDirectory, void* PipeWriteChild, void * PipeReadChild);
+
 };

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
@@ -15,6 +15,6 @@ public:
 	SPATIALGDKSERVICES_API static bool StartSpatialService(const FString& Version, const FString& RuntimeIP, bool bIsRunningInChina, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode);
 	SPATIALGDKSERVICES_API static bool StopSpatialService(bool bIsRunningInChina, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode);
 	SPATIALGDKSERVICES_API static bool BuildWorkerConfig(bool bIsRunningInChina, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode);
-	SPATIALGDKSERVICES_API static FProcHandle LocalWorkerReplace(const FString& ServicePort, const FString& OldWorker, const FString& NewWorker, bool bIsRunningInChina, bool bLaunchDetached, bool bLaunchHidden, bool bLaunchReallyHidden, uint32* OutProcessID, int32 PriorityModifier, const TCHAR* OptionalWorkingDirectory, void* PipeWriteChild, void* PipeReadChild);
+	SPATIALGDKSERVICES_API static FProcHandle LocalWorkerReplace(const FString& ServicePort, const FString& OldWorker, const FString& NewWorker, bool bIsRunningInChina, uint32* OutProcessID);
 
 };


### PR DESCRIPTION

#### Description
Cleaning up SpatialCommandUtils so that calls to it only contain parameters. Essentially all string manipulation is handled inside SpatialCommandUtils.

#### Tests
Tested local deployment which tests StartSpatialService and StopSpatialService. 
Opening editor tests SpatialVersion.
Modified files in PROJECT/spatial/worker whilst editor was open to test BuildWorkerConfig.

Would like to know how to test LocalWorkerReplace. 

