### PR TITLE
Call BroadcastNetworkFailure when the PlayerController gets deleted by the server.

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1021,7 +1021,7 @@ void USpatialReceiver::RemoveActor(Worker_EntityId EntityId)
 		if (!NetDriver->IsServer())
 		{
 			GEngine->BroadcastNetworkFailure(NetDriver->GetWorld(), NetDriver, ENetworkFailure::ConnectionLost, 
-							 TEXT("PlayerController %s deleted. Server believes we have been timed out."), *PC->GetName());
+							 FString::Printf(TEXT("PlayerController %s deleted. Server believes we have been timed out."), *PC->GetName()));
 		}
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1012,6 +1012,12 @@ void USpatialReceiver::RemoveActor(Worker_EntityId EntityId)
 	{
 		// Force APlayerController::DestroyNetworkActorHandled to return false
 		PC->Player = nullptr;
+		
+		if (!NetDriver->IsServer())
+		{
+			GEngine->BroadcastNetworkFailure(NetDriver->GetWorld(), NetDriver, ENetworkFailure::ConnectionLost, 
+							 TEXT("PlayerController %s deleted. Server believes we have been timed out."), *PC->GetName());
+		}
 	}
 
 	// Workaround for camera loss on handover: prevent UnPossess() (non-authoritative destruction of pawn, while being authoritative over the controller)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1020,6 +1020,9 @@ void USpatialReceiver::RemoveActor(Worker_EntityId EntityId)
 		
 		if (!NetDriver->IsServer())
 		{
+			// The client's PlayerController can be deleted while the client is still conneted to the deployment when the server 
+			// is no longer receiving heartbeats from the client. When this happens, we call BroadcastNetworkFailure to allow the client
+			// to handle heartbeating failure. Once the heartbeat component is removed with UNR-3006, this call can be removed.
 			GEngine->BroadcastNetworkFailure(NetDriver->GetWorld(), NetDriver, ENetworkFailure::ConnectionLost, 
 							 FString::Printf(TEXT("PlayerController %s deleted. Server believes we have been timed out."), *PC->GetName()));
 		}


### PR DESCRIPTION
#### Description
If the server stops receiving heartbeats from the client, it close the client's connection and delete the PlayerController and all associated Actors. However the client could still be connected to SpatialOS when this happens. In this case, we should notify the client of a network failure and allow the developer to hand the fail condition.

#### Tests
Test locally and on Android

#### Primary reviewers
@improbable-valentyn @m-samiec 