### PR TITLE
UNR-3199 Remove obsolete code about exposing local deployment IP.

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -35,8 +35,6 @@ USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& O
 	, bDeleteDynamicEntities(true)
 	, bGenerateDefaultLaunchConfig(true)
 	, bUseGDKPinnedRuntimeVersion(true)
-	, bExposeRuntimeIP(false)
-	, ExposedRuntimeIP(TEXT(""))
 	, bStopSpatialOnExit(false)
 	, bAutoStartLocalDeployment(true)
 	, PrimaryDeploymentRegionCode(ERegionCode::US)

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -286,14 +286,6 @@ private:
 	FFilePath SpatialOSLaunchConfig;
 
 public:
-	/** Expose the runtime on a particular IP address when it is running on this machine. Changes are applied on next local deployment startup. */
-	UPROPERTY(EditAnywhere, config, Category = "Launch", meta = (DisplayName = "Expose local runtime"))
-	bool bExposeRuntimeIP;
-
-	/** If the runtime is set to be exposed, specify on which IP address it should be reachable. Changes are applied on next local deployment startup. */
-	UPROPERTY(EditAnywhere, config, Category = "Launch", meta = (EditCondition = "bExposeRuntimeIP", DisplayName = "Exposed local runtime IP address"))
-	FString ExposedRuntimeIP;
-
 	/** Select the check box to stop your game’s local deployment when you shut down Unreal Editor. */
 	UPROPERTY(EditAnywhere, config, Category = "Launch", meta = (DisplayName = "Stop local deployment on exit"))
 	bool bStopSpatialOnExit;

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -911,15 +911,8 @@ bool FSpatialGDKEditorToolbarModule::IsSchemaGenerated() const
 
 FString FSpatialGDKEditorToolbarModule::GetOptionalExposedRuntimeIP() const
 {
-	const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>();
-	if (SpatialGDKEditorSettings->bExposeRuntimeIP)
-	{
-		return SpatialGDKEditorSettings->ExposedRuntimeIP;
-	}
-	else
-	{
-		return TEXT("");
-	}
+	const UGeneralProjectSettings* GeneralProjectSettings = GetDefault<UGeneralProjectSettings>();
+	return GeneralProjectSettings->bEnableSpatialLocalLauncher ? GeneralProjectSettings->SpatialLocalDeploymentRuntimeIP : "";
 }
 
 #undef LOCTEXT_NAMESPACE


### PR DESCRIPTION
#### Description

- Remove `Expose local runtime` in GDK settings.
- Remove `Exposed local runtime IP address` in GDK settings.
- In place we will use new settings in GeneralProjectSettings to decide whether we should expose local deployment to outside.  

#### Tests
![4444](https://user-images.githubusercontent.com/5253969/78124668-941fd880-7442-11ea-8f24-bb81f325bc8c.png)

The above picture is the screenshot for SpatialOS mobile launch flow, when user check `Connect to  local deployment` and input the correct  local `Deployment IP`, the local deployment started by click `Start` button will listen on the specified IP address, or else it will only accept local connection.
