### PR TITLE
Split up actor entity ID functions

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
@@ -175,12 +175,12 @@ void USpatialStatics::PrintTextSpatial(UObject* WorldContextObject, const FText 
 
 int64 USpatialStatics::GetActorEntityId(const AActor* Actor)
 {
-	if (Actor != nullptr)
+	check(Actor);
+	check(Actor->GetNetDriver());
+
+	if (const USpatialNetDriver* SpatialNetDriver = Cast<USpatialNetDriver>(Actor->GetNetDriver()))
 	{
-		if (const USpatialNetDriver* SpatialNetDriver = Cast<USpatialNetDriver>(Actor->GetNetDriver()))
-		{
-			return (int64)SpatialNetDriver->PackageMap->GetEntityIdFromObject(Actor);
-		}
+		return static_cast<int64>(SpatialNetDriver->PackageMap->GetEntityIdFromObject(Actor));
 	}
 	return 0;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
@@ -173,16 +173,29 @@ void USpatialStatics::PrintTextSpatial(UObject* WorldContextObject, const FText 
 	PrintStringSpatial(WorldContextObject, InText.ToString(), bPrintToScreen, TextColor, Duration);
 }
 
-FString USpatialStatics::GetActorEntityIDString(const AActor* Actor)
+int64 USpatialStatics::GetActorEntityId(const AActor* Actor)
 {
 	if (Actor != nullptr)
 	{
 		if (const USpatialNetDriver* SpatialNetDriver = Cast<USpatialNetDriver>(Actor->GetNetDriver()))
 		{
-			const Worker_EntityId EntityId = SpatialNetDriver->PackageMap->GetEntityIdFromObject(Actor);
-			return FString::Printf(TEXT("%lld"), EntityId);
+			return (int64)SpatialNetDriver->PackageMap->GetEntityIdFromObject(Actor);
 		}
 	}
+	return 0;
+}
 
-	return FString();
+FString USpatialStatics::EntityIdToString(int64 EntityId)
+{
+	if (EntityId <= SpatialConstants::INVALID_ENTITY_ID)
+	{
+		return FString("Invalid");
+	}
+
+	return FString::Printf(TEXT("%lld"), EntityId);
+}
+
+FString USpatialStatics::GetActorEntityIdAsString(const AActor* Actor)
+{
+	return EntityIdToString(GetActorEntityId(Actor));
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
@@ -176,8 +176,6 @@ void USpatialStatics::PrintTextSpatial(UObject* WorldContextObject, const FText 
 int64 USpatialStatics::GetActorEntityId(const AActor* Actor)
 {
 	check(Actor);
-	check(Actor->GetNetDriver());
-
 	if (const USpatialNetDriver* SpatialNetDriver = Cast<USpatialNetDriver>(Actor->GetNetDriver()))
 	{
 		return static_cast<int64>(SpatialNetDriver->PackageMap->GetEntityIdFromObject(Actor));

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialStatics.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialStatics.h
@@ -109,10 +109,23 @@ public:
 	static FColor GetInspectorColorForWorkerName(const FString& WorkerName);
 
 	/**
-	 * Returns the entity ID of a given actor, or an empty string if we are not using spatial networking or actor is nullptr.
+	 * Returns the entity ID of a given actor, or 0 if we are not using spatial networking or Actor is nullptr.
 	 */
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "SpatialOS")
-	static FString GetActorEntityIDString(const AActor* Actor);
+	static int64 GetActorEntityId(const AActor* Actor);
+
+	/**
+	 * Returns the entity ID as a string if the ID is valid, or "Invalid" if not
+	 */
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "SpatialOS")
+	static FString EntityIdToString(int64 EntityId);
+
+	/**
+	 * Returns the entity ID of a given actor as a string, or "Invalid" if we are not using spatial networking or Actor is nullptr.
+	 */
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "SpatialOS")
+	static FString GetActorEntityIdAsString(const AActor* Actor);
+
 
 private:
 


### PR DESCRIPTION
#### Description
Added the option to either get an int64 entity ID from an actor, or a convenience method to get an FString directly.

#### Release note
REQUIRED: Add a release note to the `##Unreleased` section of CHANGELOG.md. You can find guidance for writing useful release notes [here](../SpatialGDK/Extras/internal-documentation/how-to-write-good-release-notes.md). Documentation changes are exempt from this requirement.

#### Tests
How did you test these changes prior to submitting this pull request?
What automated tests are included in this PR?

STRONGLY SUGGESTED: How can this be verified by QA?

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
