### PR TITLE
Explicitly set Actors as non-authoritative before calling BeginPlay a…

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -898,12 +898,10 @@ void USpatialReceiver::ReceiveActor(Worker_EntityId EntityId)
 	// Taken from PostNetInit
 	if (NetDriver->GetWorld()->HasBegunPlay() && !EntityActor->HasActorBegunPlay())
 	{
-		// Whenever we receive an actor over the wire, the expectation is that it is not in an authoritative
-		// state. This is because it should already have had authoritative BeginPlay() called. The Actor role
-		// can be authority here if a PendingAddComponent processed above set the role. Calling BeginPlay()
-		// with authority a 2nd time globally is always incorrect, so we set role to SimulatedProxy and let
-		// the processing of authority ops (later in the LeaveCriticalSection flow) take care of setting
-		// authority correctly.
+		// The Actor role can be authority here if a PendingAddComponent processed above set the role.
+		// Calling BeginPlay() with authority a 2nd time globally is always incorrect, so we set role
+		// to SimulatedProxy and let the processing of authority ops (later in the LeaveCriticalSection
+		// flow) take care of setting roles correctly.
 		if (EntityActor->HasAuthority())
 		{
 			EntityActor->Role = ROLE_SimulatedProxy;

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1367,7 +1367,7 @@ struct USpatialReceiver::RepStateUpdateHelper
 			{
 				ObjectRepState->UpdateRefToRepStateMap(Receiver.ObjectRefToRepStateMap);
 
-				if (ObjectRepState->ReferencedObj.Num( ) == 0)
+				if (ObjectRepState->ReferencedObj.Num() == 0)
 				{
 					Channel.ObjectReferenceMap.Remove(ObjectPtr);
 				}


### PR DESCRIPTION
[[UNR-3048] Load-balanced PlayerController can crash in SpatialReceiver
](https://improbableio.atlassian.net/browse/UNR-3048)

#### Description
Previously we had a `check(role != authority)` before calling BeginPlay on an Actor corresponding to an entity received over the network. This is because we guarantee that an Actor calls BeginPlay with authority once globally.

This check gets hit because PendingAddComponents can have properties which override the role and change it to authority. The easiest way of resolving this is temporarily setting any authoritative roles to simulated proxy before BeginPlay is called. When authority ops are handled, the role and remote role will be properly set.

An alternative was adding extra logic to `ComponentReader::ApplySchemaObject` to only accept role and remoterole changes if BeginPlay has been called for this Actor. However, this involves changing much lower level logic, and I think the intent and implementation is better placed in higher-level code (in this case immediately preceding the TriggerBeginPlay call).

#### Release note
REQUIRED: Add a release note to the `##Unreleased` section of CHANGELOG.md. You can find guidance for writing useful release notes [here](../SpatialGDK/Extras/internal-documentation/how-to-write-good-release-notes.md). Documentation changes are exempt from this requirement.

#### Tests
This previously reliably caused crashes when using zoning with example project / test gyms with small boundaries / any zoning project with teleporting.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.


[UNR-3048]: https://improbableio.atlassian.net/browse/UNR-3048