### PR TITLE
Bugfix/unr 3144 rpc failed to send

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/EngineVersionCheck.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/EngineVersionCheck.h
@@ -7,7 +7,7 @@
 // GDK Version to be updated with SPATIAL_ENGINE_VERSION
 // when breaking changes are made to the engine that requires
 // changes to the GDK to remain compatible
-#define SPATIAL_GDK_VERSION 18
+#define SPATIAL_GDK_VERSION 19
 
 // Check if GDK is compatible with the current version of Unreal Engine
 // SPATIAL_ENGINE_VERSION is incremented in engine when breaking changes


### PR DESCRIPTION
#### Description
Call new method on PlayerController that sends the ServerUpdateMultipleLevelsVisibilityRPC once we receive authority over the client endpoint (or legacy) component.
