### PR TITLE
Avoid crash trying to update non-auth pawn

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -561,7 +561,7 @@ void USpatialReceiver::HandleActorAuthority(const Worker_AuthorityChangeOp& Op)
 						// The following check will return false on non-authoritative servers if the Pawn hasn't been received yet.
 						if (APawn* PawnFromPlayerState = PlayerState->GetPawn())
 						{
-							if (PawnFromPlayerState->IsPlayerControlled())
+							if (PawnFromPlayerState->IsPlayerControlled() && PawnFromPlayerState->HasAuthority())
 							{
 								PawnFromPlayerState->RemoteRole = ROLE_AutonomousProxy;
 							}


### PR DESCRIPTION
#### Description
This fixes a really infrequent bug where the player controller and state migrate server before the character does. 

When gaining authority over the player state's position we do this:

```
 if (const APlayerState* PlayerState = Cast<APlayerState>(Actor))
{
	// The following check will return false on non-authoritative servers if the Pawn hasn't been received yet.
	if (APawn* PawnFromPlayerState = PlayerState->GetPawn())
	{
		if (PawnFromPlayerState->IsPlayerControlled() && PawnFromPlayerState->HasAuthority())
		{
			PawnFromPlayerState->RemoteRole = ROLE_AutonomousProxy;
		}
	}
}
```

This leaves the character Actor on the server that _will_ gain auth in a state where the role is simulated proxy and remote role is autonomous proxy.

This hits a check when trying to replicate the player controller which only checks that the character has remote role autonomous proxy before trying to send data to it.

However, since role is simulated proxy, we hit a failure later on:

![image](https://user-images.githubusercontent.com/9222722/78357275-0f9b9a00-75a9-11ea-8807-0d63bcb2f36f.png)

![image](https://user-images.githubusercontent.com/9222722/78357288-15917b00-75a9-11ea-8a8a-f93d8adce9ba.png)

We can fix this by not setting character role to autonomous proxy when receiving player state position auth if we don't also have character auth. The reason the current conditional exists is to cater for the situation where the character is already received but not the player, which remains unaffected.