### PR TITLE
Revert #1961 + Override exposed runtime IP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Use the SpatialOS runtime version 14.5.0 by default.
 - Config setting bPreventAutoConnectWithLocator has been renamed to bPreventClientCloudDeploymentAutoConnect. It has been moved to GDK Setting. If using this feature please update enable the setting in GDK Settings.
 - USpatialMetrics::WorkerMetricsRecieved was made static.
+- Added the ability to connect to a local deployment when launching on a device by checking "Connect to a local deployment" and specifying the local IP of your computer in the Launch dropdown.
 
 ## Bug fixes:
 - Fixed a bug that caused queued RPCs to spam logs when an entity is deleted.

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -35,6 +35,8 @@ USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& O
 	, bDeleteDynamicEntities(true)
 	, bGenerateDefaultLaunchConfig(true)
 	, bUseGDKPinnedRuntimeVersion(true)
+	, bExposeRuntimeIP(false)
+	, ExposedRuntimeIP(TEXT(""))
 	, bStopSpatialOnExit(false)
 	, bAutoStartLocalDeployment(true)
 	, PrimaryDeploymentRegionCode(ERegionCode::US)

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -286,6 +286,14 @@ private:
 	FFilePath SpatialOSLaunchConfig;
 
 public:
+	/** Expose the runtime on a particular IP address when it is running on this machine. Changes are applied on next local deployment startup. */
+	UPROPERTY(EditAnywhere, config, Category = "Launch", meta = (DisplayName = "Expose local runtime"))
+	bool bExposeRuntimeIP;
+
+	/** If the runtime is set to be exposed, specify on which IP address it should be reachable. Changes are applied on next local deployment startup. */
+	UPROPERTY(EditAnywhere, config, Category = "Launch", meta = (EditCondition = "bExposeRuntimeIP", DisplayName = "Exposed local runtime IP address"))
+	FString ExposedRuntimeIP;
+
 	/** Select the check box to stop your game’s local deployment when you shut down Unreal Editor. */
 	UPROPERTY(EditAnywhere, config, Category = "Launch", meta = (DisplayName = "Stop local deployment on exit"))
 	bool bStopSpatialOnExit;

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -911,8 +911,15 @@ bool FSpatialGDKEditorToolbarModule::IsSchemaGenerated() const
 
 FString FSpatialGDKEditorToolbarModule::GetOptionalExposedRuntimeIP() const
 {
-	const UGeneralProjectSettings* GeneralProjectSettings = GetDefault<UGeneralProjectSettings>();
-	return GeneralProjectSettings->bEnableSpatialLocalLauncher ? GeneralProjectSettings->SpatialLocalDeploymentRuntimeIP : "";
+	const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>();
+	if (SpatialGDKEditorSettings->bExposeRuntimeIP)
+	{
+		return SpatialGDKEditorSettings->ExposedRuntimeIP;
+	}
+	else
+	{
+		return TEXT("");
+	}
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -911,7 +911,19 @@ bool FSpatialGDKEditorToolbarModule::IsSchemaGenerated() const
 
 FString FSpatialGDKEditorToolbarModule::GetOptionalExposedRuntimeIP() const
 {
+	const UGeneralProjectSettings* GeneralProjectSettings = GetDefault<UGeneralProjectSettings>();
 	const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>();
+	if (GeneralProjectSettings->bEnableSpatialLocalLauncher)
+	{
+		if (SpatialGDKEditorSettings->bExposeRuntimeIP && GeneralProjectSettings->SpatialLocalDeploymentRuntimeIP != SpatialGDKEditorSettings->ExposedRuntimeIP)
+		{
+			UE_LOG(LogSpatialGDKEditorToolbar, Warning, TEXT("Local runtime IP specified from both general settings and Spatial settings! "
+				"Using IP specified in general settings: %s (Spatial settings has \"%s\")"),
+				*GeneralProjectSettings->SpatialLocalDeploymentRuntimeIP, *SpatialGDKEditorSettings->ExposedRuntimeIP);
+		}
+		return GeneralProjectSettings->SpatialLocalDeploymentRuntimeIP;
+	}
+
 	if (SpatialGDKEditorSettings->bExposeRuntimeIP)
 	{
 		return SpatialGDKEditorSettings->ExposedRuntimeIP;


### PR DESCRIPTION
#### Description
Reverted https://github.com/spatialos/UnrealGDK/pull/1961 to allow more time to coordinate with customers before removing the "Expose runtime IP" setting.
Made the value in the general settings (that you can set in the Launch dropdown) override the value in SpatialGDKEditorSettings.

#### Tests
Tested manually by changing the settings and restarting the local deployment.

#### Primary reviewers
@jessicafalk @raymonwang 