### PR TITLE
Feature/GV-329 New NFR parameter and new span name format

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
@@ -55,7 +55,7 @@ USpatialLatencyTracer::USpatialLatencyTracer()
 {
 #if TRACE_LIB_ACTIVE
 	ResetWorkerId();
-	FParse::Value(FCommandLine::Get(), TEXT("tracePrefix"), MessagePrefix);
+	FParse::Value(FCommandLine::Get(), TEXT("traceMetadata"), TraceMetadata);
 #endif
 }
 
@@ -73,12 +73,12 @@ void USpatialLatencyTracer::RegisterProject(UObject* WorldContextObject, const F
 #endif // TRACE_LIB_ACTIVE
 }
 
-bool USpatialLatencyTracer::SetMessagePrefix(UObject* WorldContextObject, const FString& NewMessagePrefix)
+bool USpatialLatencyTracer::SetTraceMetadata(UObject* WorldContextObject, const FString& NewTraceMetadata)
 {
 #if TRACE_LIB_ACTIVE
 	if (USpatialLatencyTracer* Tracer = GetTracer(WorldContextObject))
 	{
-		Tracer->MessagePrefix = NewMessagePrefix;
+		Tracer->TraceMetadata = NewTraceMetadata;
 		return true;
 	}
 #endif // TRACE_LIB_ACTIVE
@@ -570,7 +570,13 @@ void USpatialLatencyTracer::WriteKeyFrameToTrace(const TraceSpan* Trace, const F
 
 FString USpatialLatencyTracer::FormatMessage(const FString& Message) const
 {
-	return FString::Printf(TEXT("%s(%s) : %s"), *MessagePrefix, *WorkerId.Left(18), *Message);
+	if (TraceMetadata.IsEmpty()) {
+		return FString::Printf(TEXT("%s (%s)"), *Message, *WorkerId.Left(18));
+	}
+	else
+	{
+		return FString::Printf(TEXT("%s (%s : %s)"), *Message, *TraceMetadata, *WorkerId.Left(18));
+	}
 }
 
 #endif // TRACE_LIB_ACTIVE

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
@@ -568,9 +568,9 @@ void USpatialLatencyTracer::WriteKeyFrameToTrace(const TraceSpan* Trace, const F
 	}
 }
 
-FString USpatialLatencyTracer::FormatMessage(const FString& Message, bool firstSpan) const
+FString USpatialLatencyTracer::FormatMessage(const FString& Message, bool bIncludeMetadata) const
 {
-	if (firstSpan)
+	if (bIncludeMetadata)
 	{
 		return FString::Printf(TEXT("%s (%s : %s)"), *Message, *TraceMetadata, *WorkerId.Left(18));
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
@@ -373,7 +373,7 @@ bool USpatialLatencyTracer::BeginLatencyTrace_Internal(const FString& TraceDesc,
 	SCOPE_CYCLE_COUNTER(STAT_BeginLatencyTraceRPC_Internal);
 	FScopeLock Lock(&Mutex);
 
-	FString SpanMsg = FormatMessage(TraceDesc);
+	FString SpanMsg = FormatMessage(TraceDesc, true);
 	TraceSpan NewTrace = improbable::trace::Span::StartSpan(TCHAR_TO_UTF8(*SpanMsg), nullptr);
 
 	// Construct payload data from trace
@@ -568,14 +568,15 @@ void USpatialLatencyTracer::WriteKeyFrameToTrace(const TraceSpan* Trace, const F
 	}
 }
 
-FString USpatialLatencyTracer::FormatMessage(const FString& Message) const
+FString USpatialLatencyTracer::FormatMessage(const FString& Message, bool firstSpan = false) const
 {
-	if (TraceMetadata.IsEmpty()) {
-		return FString::Printf(TEXT("%s (%s)"), *Message, *WorkerId.Left(18));
+	if (firstSpan)
+	{
+		return FString::Printf(TEXT("%s (%s : %s)"), *Message, *TraceMetadata, *WorkerId.Left(18));
 	}
 	else
 	{
-		return FString::Printf(TEXT("%s (%s : %s)"), *Message, *TraceMetadata, *WorkerId.Left(18));
+		return FString::Printf(TEXT("%s (%s)"), *Message, *WorkerId.Left(18));
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
@@ -568,7 +568,7 @@ void USpatialLatencyTracer::WriteKeyFrameToTrace(const TraceSpan* Trace, const F
 	}
 }
 
-FString USpatialLatencyTracer::FormatMessage(const FString& Message, bool firstSpan = false) const
+FString USpatialLatencyTracer::FormatMessage(const FString& Message, bool firstSpan) const
 {
 	if (firstSpan)
 	{

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracer.h
@@ -84,13 +84,13 @@ public:
 
 	// Front-end exposed, allows users to register, start, continue, and end traces
 
-	// Call with your google project id. This must be called before latency trace calls are made
+	// Call with your google project id. This must be called before latency trace calls are made.
 	UFUNCTION(BlueprintCallable, Category = "SpatialOS", meta = (WorldContext = "WorldContextObject"))
 	static void RegisterProject(UObject* WorldContextObject, const FString& ProjectId);
 
-	// Set a prefix to be used for all span names. Resulting uploaded span names are of the format "PREFIX(WORKER_ID) : USER_SPECIFIED_NAME".
+	// Set metadata string to be included in all span names. Resulting uploaded span names are of the format "USER_SPECIFIED_NAME (METADATA : WORKER_ID)".
 	UFUNCTION(BlueprintCallable, Category = "SpatialOS", meta = (WorldContext = "WorldContextObject"))
-	static bool SetMessagePrefix(UObject* WorldContextObject, const FString& NewMessagePrefix);
+	static bool SetTraceMetadata(UObject* WorldContextObject, const FString& NewTraceMetadata);
 
 	// Start a latency trace. This will start the latency timer and return you a LatencyPayload object. This payload can then be "continued" via a ContinueLatencyTrace call.
 	UFUNCTION(BlueprintCallable, Category = "SpatialOS", meta = (WorldContext = "WorldContextObject"))
@@ -164,7 +164,7 @@ private:
 	FString FormatMessage(const FString& Message) const;
 
 	FString WorkerId;
-	FString MessagePrefix;
+	FString TraceMetadata;
 
 	TraceKey NextTraceKey = 1;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracer.h
@@ -161,7 +161,7 @@ private:
 	void ResolveKeyInLatencyPayload(FSpatialLatencyPayload& Payload);
 
 	void WriteKeyFrameToTrace(const TraceSpan* Trace, const FString& TraceDesc);
-	FString FormatMessage(const FString& Message) const;
+	FString FormatMessage(const FString& Message, bool firstSpan = false) const;
 
 	FString WorkerId;
 	FString TraceMetadata;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracer.h
@@ -161,7 +161,7 @@ private:
 	void ResolveKeyInLatencyPayload(FSpatialLatencyPayload& Payload);
 
 	void WriteKeyFrameToTrace(const TraceSpan* Trace, const FString& TraceDesc);
-	FString FormatMessage(const FString& Message, bool firstSpan = false) const;
+	FString FormatMessage(const FString& Message, bool bIncludeMetadata = false) const;
 
 	FString WorkerId;
 	FString TraceMetadata;


### PR DESCRIPTION
This PR is is one of four related ones (from major to minor):
* [NFR Framework](https://github.com/improbable/nfr-benchmark-pipeline/pull/116)
* [UnrealGDK](https://github.com/spatialos/UnrealGDK/pull/1975)
* [TestGymBuildkite](https://github.com/improbable/TestGymBuildKite/pull/57)
* [UnrealGDKTestGyms](https://github.com/spatialos/UnrealGDKTestGyms/pull/68)

These PRs implement/accommodate two changes to NFR latency testing:

**New required "trace descriptions" parameter**
Users now have to supply "trace descriptions". The framework will now only include traces whose root span names include one of the user-cupplied trace descriptions. This gives users more control over what exact interactions they want to log.

**Span name format change**
The format of span names has been updated so that root span names now always start with the trace description. This allows users to compare traces with the same description _across_ deployments on Stackdriver's "Trace List" page (as the only supported span name filter only matches prefixes).

**Testing**
A test build that covers all four affected branches has been kicked off here:
https://buildkite.com/improbable/unrealgdk-nfr/builds/1269

#### Release note
No release note has been added

#### Documentation
Existing code has been updated, no new functionality has been added. Documentation has remained the same.

#### Primary reviewers
@improbable-danny @m-samiec 