### PR TITLE
[UNR-3230] Fix external process connections 

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
@@ -447,7 +447,13 @@ void USpatialConnectionManager::SetupConnectionConfigFromURL(const FURL& URL, co
 	else
 	{
 		SetConnectionType(ESpatialConnectionType::Receptionist);
-		ReceptionistConfig.SetReceptionistHost(URL.Host);
+
+		// If we have a non-empty host then use this to connect. If not - use the default configured in FReceptionistConfig initialisation.
+		if (!URL.Host.IsEmpty())
+		{
+			ReceptionistConfig.SetReceptionistHost(URL.Host);
+		}
+
 		ReceptionistConfig.WorkerType = SpatialWorkerType;
 
 		const TCHAR* UseExternalIpForBridge = TEXT("useExternalIpForBridge");


### PR DESCRIPTION
#### Description
Discovered in UNR-3230 - External process connections were not working. 
Root cause is configuring the receptionist with an empty hostname if parsing commandline args did not find any hostname.
Correct behaviour is to use the default receptionist IP specified in user settings.
This PR fixes this.

#### Primary reviewers
@MatthewSandfordImprobable @m-samiec