### PR TITLE
Fix zoning rubberbanding

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/SpawnData.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/SpawnData.h
@@ -53,6 +53,21 @@ struct SpawnData : Component
 		return Data;
 	}
 
+	Worker_ComponentUpdate CreateSpawnDataUpdate()
+	{
+		Worker_ComponentUpdate Update = {};
+		Update.component_id = ComponentId;
+		Update.schema_type = Schema_CreateComponentUpdate();
+		Schema_Object* ComponentObject = Schema_GetComponentUpdateFields(Update.schema_type);
+
+		AddVectorToSchema(ComponentObject, 1, Location);
+		AddRotatorToSchema(ComponentObject, 2, Rotation);
+		AddVectorToSchema(ComponentObject, 3, Scale);
+		AddVectorToSchema(ComponentObject, 4, Velocity);
+
+		return Update;
+	}
+
 	FVector Location;
 	FRotator Rotation;
 	FVector Scale;

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/SpawnData.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/SpawnData.h
@@ -60,10 +60,8 @@ struct SpawnData : Component
 		Update.schema_type = Schema_CreateComponentUpdate();
 		Schema_Object* ComponentObject = Schema_GetComponentUpdateFields(Update.schema_type);
 
+		// Currently, we only want to update SpawnData location when an Actor migrates worker.
 		AddVectorToSchema(ComponentObject, 1, Location);
-		AddRotatorToSchema(ComponentObject, 2, Rotation);
-		AddVectorToSchema(ComponentObject, 3, Scale);
-		AddVectorToSchema(ComponentObject, 4, Velocity);
 
 		return Update;
 	}


### PR DESCRIPTION
Original problem:

![player-rubber-banding](https://user-images.githubusercontent.com/9222722/78705759-e01cc280-7905-11ea-89d7-a64aeb0b7565.gif)

#### Description
Rubberbanding happens because a worker receiving authority sets initial position based on the SpawnData component and sets the AuthorityIntent back to the original worker before the proper location is processed.

#### Tests
This was a super reliable repro in zoning projects with small interest radiuses before. Can't repro now.
