### PR TITLE
[UNR-3201] Fix multiple dynamic subobjects being created in the same tick

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -639,16 +639,17 @@ void USpatialReceiver::ReceiveActor(Worker_EntityId EntityId)
 		// Apply initial replicated properties.
 		// This was moved to after FinishingSpawning because components existing only in blueprints aren't added until spawning is complete
 		// Potentially we could split out the initial actor state and the initial component state
-		for (PendingAddComponentWrapper& PendingAddComponent : PendingAddComponents)
+		for (auto PendingAddComponentIt = PendingAddComponents.CreateIterator(); PendingAddComponentIt; PendingAddComponentIt++)
 		{
-			if (ClassInfoManager->IsSublevelComponent(PendingAddComponent.ComponentId))
+			if (ClassInfoManager->IsSublevelComponent(PendingAddComponentIt->ComponentId))
 			{
 				continue;
 			}
 
-			if (PendingAddComponent.EntityId == EntityId)
+			if (PendingAddComponentIt->EntityId == EntityId)
 			{
-				ApplyComponentDataOnActorCreation(EntityId, *PendingAddComponent.Data->ComponentData, Channel, ActorClassInfo);
+				ApplyComponentDataOnActorCreation(EntityId, *PendingAddComponentIt->Data->ComponentData, Channel, ActorClassInfo);
+				PendingAddComponentIt.RemoveCurrent();
 			}
 		}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -93,7 +93,7 @@ void USpatialReceiver::LeaveCriticalSection()
 
 	for (PendingAddComponentWrapper& PendingAddComponent : PendingAddComponents)
 	{
-		if (StaticComponentView->GetComponentData<UnrealMetadata>(PendingAddComponent.EntityId) == nullptr)
+		if (!StaticComponentView->HasComponent(PendingAddComponent.EntityId, UnrealMetadata::ComponentId))
 		{
 			continue;
 		}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -89,6 +89,10 @@ void USpatialReceiver::LeaveCriticalSection()
 
 	for (PendingAddComponentWrapper& PendingAddComponent : PendingAddComponents)
 	{
+		if (StaticComponentView->GetComponentData<UnrealMetadata>(PendingAddComponent.EntityId) == nullptr)
+		{
+			continue;
+		}
 		if (ClassInfoManager->IsSublevelComponent(PendingAddComponent.ComponentId))
 		{
 			continue;

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -89,6 +89,10 @@ void USpatialReceiver::LeaveCriticalSection()
 
 	for (PendingAddComponentWrapper& PendingAddComponent : PendingAddComponents)
 	{
+		if (ClassInfoManager->IsSublevelComponent(PendingAddComponent.ComponentId))
+		{
+			continue;
+		}
 		HandleIndividualAddComponent_Internal(PendingAddComponent.EntityId, PendingAddComponent.ComponentId, MoveTemp(PendingAddComponent.Data));
 	}
 
@@ -995,7 +999,7 @@ void USpatialReceiver::HandleIndividualAddComponent_Internal(Worker_EntityId Ent
 	bool bIsDynamicSubobject = !ActorClassInfo.SubobjectInfo.Contains(Offset);
 	if (!bIsDynamicSubobject)
 	{
-		UE_LOG(LogSpatialReceiver, Verbose, TEXT("Tried to apply component data on add component for a static subobject that's been deleted, will skip. Entity: %lld, Component: %d, Actor: %s"), EntityId, ComponentId, *Actor->GetPathName());
+		UE_LOG(LogSpatialReceiver, Log, TEXT("Tried to apply component data on add component for a static subobject that's been deleted, will skip. Entity: %lld, Component: %d, Actor: %s"), EntityId, ComponentId, *Actor->GetPathName());
 		return;
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -175,6 +175,7 @@ private:
 	void ApplyComponentData(UObject* TargetObject, USpatialActorChannel* Channel, const Worker_ComponentData& Data);
 	// This is called for AddComponentOps not in a critical section, which means they are not a part of the initial entity creation.
 	void HandleIndividualAddComponent(const Worker_AddComponentOp& Op);
+	void HandleIndividualAddComponent_Internal(Worker_EntityId EntityId, Worker_ComponentId ComponentId, TUniquePtr<SpatialGDK::DynamicComponent>&& Data);
 	void AttachDynamicSubobject(AActor* Actor, Worker_EntityId EntityId, const FClassInfo& Info);
 
 	void ApplyComponentUpdate(const Worker_ComponentUpdate& ComponentUpdate, UObject* TargetObject, USpatialActorChannel* Channel, bool bIsHandover);


### PR DESCRIPTION
#### Description
Creating multiple dynamic subobjects in the same tick would break, due to them arriving in the same critical section.

#### Release note
TODO

#### Tests
TODO

#### Documentation
TODO

#### Primary reviewers
TODO
