### PR TITLE
UNR-3252: Remove shadowing variables

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -32,10 +32,10 @@ void USpatialPackageMapClient::Init(USpatialNetDriver* NetDriver, FTimerManager*
 	}
 }
 
-void GetSubobjects(UObject* Object, TArray<UObject*>& InSubobjects)
+void GetSubobjects(UObject* ParentObject, TArray<UObject*>& InSubobjects)
 {
 	InSubobjects.Empty();
-	ForEachObjectWithOuter(Object, [&InSubobjects](UObject* Object)
+	ForEachObjectWithOuter(ParentObject, [&InSubobjects](UObject* Object)
 	{
 		// Objects can only be allocated NetGUIDs if this is true.
 		if (Object->IsSupportedForNetworking() && !Object->IsPendingKill() && !Object->IsEditorOnly())

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -287,9 +287,9 @@ void USpatialSender::CreateServerWorkerEntity(int AttemptCounter)
 		FTimerHandle RetryTimer;
 		Sender->TimerManager->SetTimer(RetryTimer, [WeakSender, AttemptCounter]()
 		{
-			if (USpatialSender* Sender = WeakSender.Get())
+			if (USpatialSender* SpatialSender = WeakSender.Get())
 			{
-				Sender->CreateServerWorkerEntity(AttemptCounter + 1);
+				SpatialSender->CreateServerWorkerEntity(AttemptCounter + 1);
 			}
 		}, SpatialConstants::GetCommandRetryWaitTimeSeconds(AttemptCounter), false);
 	});

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/RPCServiceTest.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/RPCServiceTest.cpp
@@ -164,8 +164,8 @@ Worker_ComponentData GetComponentDataOnEntityCreationFromRPCService(SpatialGDK::
 	Worker_ComponentId ExpectedUpdateComponentId = SpatialGDK::RPCRingBufferUtils::GetRingBufferComponentId(RPCType);
 	TArray<Worker_ComponentData> ComponentDataArray = RPCService.GetRPCComponentsOnEntityCreation(EntityID);
 
-	const Worker_ComponentData* ComponentData = ComponentDataArray.FindByPredicate([ExpectedUpdateComponentId](const Worker_ComponentData& ComponentData) {
-		return ComponentData.component_id == ExpectedUpdateComponentId;
+	const Worker_ComponentData* ComponentData = ComponentDataArray.FindByPredicate([ExpectedUpdateComponentId](const Worker_ComponentData& CompData) {
+		return CompData.component_id == ExpectedUpdateComponentId;
 	});
 
 	if (ComponentData == nullptr)
@@ -481,8 +481,8 @@ RPC_SERVICE_TEST(GIVEN_receiving_an_rpc_WHEN_return_false_from_extract_callback_
 	TArray<SpatialGDK::SpatialRPCService::UpdateToSend> UpdateToSendArray = RPCService.GetRPCsAndAcksToSend();
 
 	bool bTestPassed = false;
-	SpatialGDK::SpatialRPCService::UpdateToSend* Update = UpdateToSendArray.FindByPredicate([](const SpatialGDK::SpatialRPCService::UpdateToSend& Update) {
-		return (Update.Update.component_id == SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID);
+	SpatialGDK::SpatialRPCService::UpdateToSend* Update = UpdateToSendArray.FindByPredicate([](const SpatialGDK::SpatialRPCService::UpdateToSend& UpdateToSend) {
+		return (UpdateToSend.Update.component_id == SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID);
 	});
 
 	if (Update != nullptr)


### PR DESCRIPTION
#### Description
Shadowing variables causes issues when building for Android using NDK 14. This fixes it. 

#### Tests
Tested it by building Android successfully using NDK 14.
