### PR TITLE
UNR-3244: Fixing dev auth token generation

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
@@ -123,7 +123,8 @@ FReply FSpatialGDKEditorLayoutDetails::GenerateDevAuthToken()
 
 	FString AuthResult;
 	FString DevAuthTokenResult;
-	if (!CreateDevAuthTokenResult.TrimEnd().Split(TEXT("\n"), &AuthResult, &DevAuthTokenResult, ESearchCase::IgnoreCase, ESearchDir::FromEnd) || DevAuthTokenResult.IsEmpty())
+	bool bFoundNewline = CreateDevAuthTokenResult.TrimEnd().Split(TEXT("\n"), &AuthResult, &DevAuthTokenResult, ESearchCase::IgnoreCase, ESearchDir::FromEnd);
+	if (!bFoundNewline || DevAuthTokenResult.IsEmpty())
 	{
 		// This is necessary because depending on whether you are already authenticated against spatial, it will either return two json structs or one.
 		DevAuthTokenResult = CreateDevAuthTokenResult;

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
@@ -123,7 +123,7 @@ FReply FSpatialGDKEditorLayoutDetails::GenerateDevAuthToken()
 
 	FString AuthResult;
 	FString DevAuthTokenResult;
-	if (!CreateDevAuthTokenResult.Split(TEXT("\n"), &AuthResult, &DevAuthTokenResult) || DevAuthTokenResult.IsEmpty())
+	if (!CreateDevAuthTokenResult.TrimEnd().Split(TEXT("\n"), &AuthResult, &DevAuthTokenResult, ESearchCase::IgnoreCase, ESearchDir::FromEnd) || DevAuthTokenResult.IsEmpty())
 	{
 		// This is necessary because depending on whether you are already authenticated against spatial, it will either return two json structs or one.
 		DevAuthTokenResult = CreateDevAuthTokenResult;


### PR DESCRIPTION
This fixes the issue where we generate a dev auth token sometimes fails due to having more than 2 lines. The last line always contains the json response with the token, so we change the split to search from the end to definitely get the last line.