### PR TITLE
Remove and Add component ops processed in the wrong order.

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -127,7 +127,7 @@ void USpatialReceiver::OnAddEntity(const Worker_AddEntityOp& Op)
 void USpatialReceiver::RemoveRedundantRemoveComponentOps(const Worker_AddComponentOp& Op)
 {
 	int32 RemovedOps = 0;
-	for (int32 i = 0; i < QueuedRemoveComponentOps.Num();)
+	for (int32 i = QueuedRemoveComponentOps.Num() - 1; i >= 0; --i)
 	{
 		const Worker_RemoveComponentOp& RemoveComponentOp = QueuedRemoveComponentOps[i];
 		if (RemoveComponentOp.entity_id == Op.entity_id &&
@@ -136,15 +136,11 @@ void USpatialReceiver::RemoveRedundantRemoveComponentOps(const Worker_AddCompone
 			QueuedRemoveComponentOps.RemoveAt(i);
 			RemovedOps++;
 		}
-		else
-		{
-			++i;
-		}
 	}
 
 	if (RemovedOps >= 2)
 	{
-		UE_LOG(LogSpatialReceiver, Warning, TEXT("Removing more than one RemoveComponentOp. Entity %d, Component %d "), Op.entity_id, Op.data.component_id);
+		UE_LOG(LogSpatialReceiver, Warning, TEXT("Removing more than one RemoveComponentOp. Entity %d, Component %d"), Op.entity_id, Op.data.component_id);
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -157,6 +157,7 @@ void USpatialReceiver::OnAddComponent(const Worker_AddComponentOp& Op)
 	}
 
 	// Remove all RemoveComponentOps that have already been received and have the same entityId and componentId as the AddComponentOp.
+	// TODO: This can probably be removed when spatial view is added.
 	RemoveRedundantRemoveComponentOps(Op);
 
 	switch (Op.data.component_id)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -126,17 +126,10 @@ void USpatialReceiver::OnAddEntity(const Worker_AddEntityOp& Op)
 
 void USpatialReceiver::RemoveRedundantRemoveComponentOps(const Worker_AddComponentOp& Op)
 {
-	int32 RemovedOps = 0;
-	for (int32 i = QueuedRemoveComponentOps.Num() - 1; i >= 0; --i)
-	{
-		const Worker_RemoveComponentOp& RemoveComponentOp = QueuedRemoveComponentOps[i];
-		if (RemoveComponentOp.entity_id == Op.entity_id &&
-			RemoveComponentOp.component_id == Op.data.component_id)
-		{
-			QueuedRemoveComponentOps.RemoveAt(i);
-			RemovedOps++;
-		}
-	}
+	int32 RemovedOps = QueuedRemoveComponentOps.RemoveAll([&Op](const Worker_RemoveComponentOp& RemoveComponentOp) {
+		return RemoveComponentOp.entity_id == Op.entity_id &&
+			RemoveComponentOp.component_id == Op.data.component_id;
+	});
 
 	if (RemovedOps >= 2)
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -136,6 +136,21 @@ void USpatialReceiver::OnAddComponent(const Worker_AddComponentOp& Op)
 		return;
 	}
 
+	// Remove all RemoveComponentOps have already been received that have the same entityId and componentId.
+	for (int32 i = 0; i < QueuedRemoveComponentOps.Num();)
+	{
+		const Worker_RemoveComponentOp& RemoveComponentOp = QueuedRemoveComponentOps[i];
+		if (RemoveComponentOp.entity_id == Op.entity_id &&
+			RemoveComponentOp.component_id == Op.data.component_id)
+		{
+			QueuedRemoveComponentOps.RemoveAt(i);
+		}
+		else
+		{
+			++i;
+		}
+	}
+
 	switch (Op.data.component_id)
 	{
 	case SpatialConstants::METADATA_COMPONENT_ID:

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -185,6 +185,8 @@ private:
 	};
 
 	void HandleQueuedOpForAsyncLoad(QueuedOpForAsyncLoad& Op);
+
+	void RemoveRedundantRemoveComponentOps(const Worker_AddComponentOp& Op);
 	// END TODO
 
 public:

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -186,8 +186,9 @@ private:
 
 	void HandleQueuedOpForAsyncLoad(QueuedOpForAsyncLoad& Op);
 
-	void RemoveRedundantRemoveComponentOps(const Worker_AddComponentOp& Op);
 	// END TODO
+
+	void RemoveRedundantRemoveComponentOps(const Worker_AddComponentOp& Op);
 
 public:
 	TMap<TPair<Worker_EntityId_Key, Worker_ComponentId>, TSharedRef<FPendingSubobjectAttachment>> PendingEntitySubobjectDelegations;

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -187,8 +187,6 @@ private:
 	void HandleQueuedOpForAsyncLoad(QueuedOpForAsyncLoad& Op);
 	// END TODO
 
-	void RemoveRedundantRemoveComponentOps(const Worker_AddComponentOp& Op);
-
 public:
 	TMap<TPair<Worker_EntityId_Key, Worker_ComponentId>, TSharedRef<FPendingSubobjectAttachment>> PendingEntitySubobjectDelegations;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -185,7 +185,6 @@ private:
 	};
 
 	void HandleQueuedOpForAsyncLoad(QueuedOpForAsyncLoad& Op);
-
 	// END TODO
 
 	void RemoveRedundantRemoveComponentOps(const Worker_AddComponentOp& Op);


### PR DESCRIPTION
#### Description
Removing RemoveComponentOps that have already been queued that have the same entityId and componentId as an incoming AddComponentOp. 

This fixes an issue where a component was not being added correctly. This is due to the fact that we immediately add a component to the view upon receiving an add component op but queue a remove component op. In the case you receive RemoveComponent -> AddComponent the ops will be processed in the reverse order. 

#### Tests
Tested in test gyms using multiple ownership gym.

#### Primary reviewers
@improbable-valentyn  @m-samiec 
