### PR TITLE
Force-enable handover properties when required for load balancing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,8 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Added `bEnableNetCullDistanceInterest` (defaulted true) to enable client interest to be exposed through component tagging. This functionality has closer parity to native unreal client interest.
 - Added `bEnableNetCullDistanceFrequency` (defaulted false) to enable client interest queries to use frequency. This functionality is configured using `InterestRangeFrequencyPairs` and `FullFrequencyNetCullDistanceRatio`.
 - Added support for Android.
-- Introduced feature flag `bEnableResultTypes` (defaulted true). This configures Interest queries to only include the set of components required to run. Should give bandwidth savings depending on your game. 
-- Dynamic interest overrides are disabled if the `bEnableResultTypes` flag is set to true. 
+- Introduced feature flag `bEnableResultTypes` (defaulted true). This configures Interest queries to only include the set of components required to run. Should give bandwidth savings depending on your game.
+- Dynamic interest overrides are disabled if the `bEnableResultTypes` flag is set to true.
 - Moved Dev Auth settings from runtime settings to editor settings.
 - Added the option to use the development authentication flow using the command line.
 - Added a button to generate the Development Authentication Token inside the Unreal Editor. To use it, navigate to **Edit** > **Project Setting** > **SpatialOS GDK for Unreal** > **Editor Settings** > **Cloud Connection**.
@@ -67,6 +67,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Added the ability to connect to a local deployment when launching on a device by checking "Connect to a local deployment" and specifying the local IP of your computer in the Launch dropdown.
 - The Spatial GDK now default enables RPC Ring Buffers, and the legacy RPC mode will be removed in a subsequent release.
 - The `bPackRPCs` property has been removed, and the flag `--OverrideRPCPacking` has been removed.
+- Handover properties will be automatically replicated when required for load balancing. `bEnableHandover` is off by default.
 
 ## Bug fixes:
 - Fixed a bug that caused queued RPCs to spam logs when an entity is deleted.

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
@@ -282,10 +282,16 @@ void USpatialClassInfoManager::FinishConstructingSubobjectClassInfo(const FStrin
 
 bool USpatialClassInfoManager::ShouldTrackHandoverProperties() const
 {
+	if (!NetDriver->IsServer())
+	{
+		return false;
+	}
+
 	const USpatialGDKSettings* Settings = GetDefault<USpatialGDKSettings>();
 	if (Settings->bEnableUnrealLoadBalancer)
 	{
-		if (const UAbstractLBStrategy* Strategy = NetDriver->LoadBalanceStrategy)
+		const UAbstractLBStrategy* Strategy = NetDriver->LoadBalanceStrategy;
+		if (ensure(Strategy != nullptr))
 		{
 			return Strategy->RequiresHandoverData() || Settings->bEnableHandover;
 		}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
@@ -185,22 +185,22 @@ void USpatialClassInfoManager::CreateClassInfoForClass(UClass* Class)
 void USpatialClassInfoManager::FinishConstructingActorClassInfo(const FString& ClassPath, TSharedRef<FClassInfo>& Info)
 {
 	ForAllSchemaComponentTypes([&](ESchemaComponentType Type)
+	{
+		Worker_ComponentId ComponentId = SchemaDatabase->ActorClassPathToSchema[ClassPath].SchemaComponents[Type];
+
+		if (!ShouldTrackHandoverProperties() && Type == SCHEMA_Handover)
 		{
-			Worker_ComponentId ComponentId = SchemaDatabase->ActorClassPathToSchema[ClassPath].SchemaComponents[Type];
+			return;
+		}
 
-			if (!ShouldTrackHandoverProperties() && Type == SCHEMA_Handover)
-			{
-				return;
-			}
-
-			if (ComponentId != SpatialConstants::INVALID_COMPONENT_ID)
-			{
-				Info->SchemaComponents[Type] = ComponentId;
-				ComponentToClassInfoMap.Add(ComponentId, Info);
-				ComponentToOffsetMap.Add(ComponentId, 0);
-				ComponentToCategoryMap.Add(ComponentId, (ESchemaComponentType)Type);
-			}
-		});
+		if (ComponentId != SpatialConstants::INVALID_COMPONENT_ID)
+		{
+			Info->SchemaComponents[Type] = ComponentId;
+			ComponentToClassInfoMap.Add(ComponentId, Info);
+			ComponentToOffsetMap.Add(ComponentId, 0);
+			ComponentToCategoryMap.Add(ComponentId, (ESchemaComponentType)Type);
+		}
+	});
 
 	for (auto& SubobjectClassDataPair : SchemaDatabase->ActorClassPathToSchema[ClassPath].SubobjectData)
 	{
@@ -221,21 +221,21 @@ void USpatialClassInfoManager::FinishConstructingActorClassInfo(const FString& C
 		ActorSubobjectInfo->SubobjectName = SubobjectSchemaData.Name;
 
 		ForAllSchemaComponentTypes([&](ESchemaComponentType Type)
+		{
+			if (!ShouldTrackHandoverProperties() && Type == SCHEMA_Handover)
 			{
-				if (!ShouldTrackHandoverProperties() && Type == SCHEMA_Handover)
-				{
-					return;
-				}
+				return;
+			}
 
-				Worker_ComponentId ComponentId = SubobjectSchemaData.SchemaComponents[Type];
-				if (ComponentId != 0)
-				{
-					ActorSubobjectInfo->SchemaComponents[Type] = ComponentId;
-					ComponentToClassInfoMap.Add(ComponentId, ActorSubobjectInfo);
-					ComponentToOffsetMap.Add(ComponentId, Offset);
-					ComponentToCategoryMap.Add(ComponentId, ESchemaComponentType(Type));
-				}
-			});
+			Worker_ComponentId ComponentId = SubobjectSchemaData.SchemaComponents[Type];
+			if (ComponentId != 0)
+			{
+				ActorSubobjectInfo->SchemaComponents[Type] = ComponentId;
+				ComponentToClassInfoMap.Add(ComponentId, ActorSubobjectInfo);
+				ComponentToOffsetMap.Add(ComponentId, Offset);
+				ComponentToCategoryMap.Add(ComponentId, ESchemaComponentType(Type));
+			}
+		});
 
 		Info->SubobjectInfo.Add(Offset, ActorSubobjectInfo);
 	}
@@ -264,17 +264,17 @@ void USpatialClassInfoManager::FinishConstructingSubobjectClassInfo(const FStrin
 		check(Offset != SpatialConstants::INVALID_COMPONENT_ID);
 
 		ForAllSchemaComponentTypes([&](ESchemaComponentType Type)
-			{
-				Worker_ComponentId ComponentId = DynamicSubobjectData.SchemaComponents[Type];
+		{
+			Worker_ComponentId ComponentId = DynamicSubobjectData.SchemaComponents[Type];
 
-				if (ComponentId != SpatialConstants::INVALID_COMPONENT_ID)
-				{
-					SpecificDynamicSubobjectInfo->SchemaComponents[Type] = ComponentId;
-					ComponentToClassInfoMap.Add(ComponentId, SpecificDynamicSubobjectInfo);
-					ComponentToOffsetMap.Add(ComponentId, Offset);
-					ComponentToCategoryMap.Add(ComponentId, ESchemaComponentType(Type));
-				}
-			});
+			if (ComponentId != SpatialConstants::INVALID_COMPONENT_ID)
+			{
+				SpecificDynamicSubobjectInfo->SchemaComponents[Type] = ComponentId;
+				ComponentToClassInfoMap.Add(ComponentId, SpecificDynamicSubobjectInfo);
+				ComponentToOffsetMap.Add(ComponentId, Offset);
+				ComponentToCategoryMap.Add(ComponentId, ESchemaComponentType(Type));
+			}
+		});
 
 		Info->DynamicSubobjectInfo.Add(SpecificDynamicSubobjectInfo);
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1194,7 +1194,7 @@ void USpatialReceiver::ApplyComponentDataOnActorCreation(Worker_EntityId EntityI
 	bool bFoundOffset = ClassInfoManager->GetOffsetByComponentId(Data.component_id, Offset);
 	if (!bFoundOffset)
 	{
-		UE_LOG(LogSpatialReceiver, Warning, TEXT("EntityId %lld, ComponentId %d - Could not find offset for component id when applying component data to Actor %s!"), EntityId, Data.component_id, *Actor->GetPathName());
+		UE_LOG(LogSpatialReceiver, Warning, TEXT("Worker: %s EntityId: %lld, ComponentId: %d - Could not find offset for component id when applying component data to Actor %s!"), *NetDriver->Connection->GetWorkerId(), EntityId, Data.component_id, *Actor->GetPathName());
 		return;
 	}
 
@@ -1557,13 +1557,11 @@ void USpatialReceiver::OnComponentUpdate(const Worker_ComponentUpdateOp& Op)
 		}
 	}
 
-	const FClassInfo& Info = ClassInfoManager->GetClassInfoByComponentId(Op.update.component_id);
-
 	uint32 Offset;
 	bool bFoundOffset = ClassInfoManager->GetOffsetByComponentId(Op.update.component_id, Offset);
 	if (!bFoundOffset)
 	{
-		UE_LOG(LogSpatialReceiver, Warning, TEXT("Entity: %d Component: %d - Couldn't find Offset for component id"), Op.entity_id, Op.update.component_id);
+		UE_LOG(LogSpatialReceiver, Warning, TEXT("Worker: %s EntityId %d ComponentId %d - Could not find offset for component id when receiving a component update."), *NetDriver->Connection->GetWorkerId(), Op.entity_id, Op.update.component_id);
 		return;
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -44,7 +44,7 @@ USpatialGDKSettings::USpatialGDKSettings(const FObjectInitializer& ObjectInitial
 	, EntityCreationRateLimit(0)
 	, bUseIsActorRelevantForConnection(false)
 	, OpsUpdateRate(1000.0f)
-	, bEnableHandover(true)
+	, bEnableHandover(false)
 	, MaxNetCullDistanceSquared(0.0f) // Default disabled
 	, QueuedIncomingRPCWaitTime(1.0f)
 	, QueuedOutgoingRPCWaitTime(1.0f)

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -107,14 +107,6 @@ void USpatialGDKSettings::PostInitProperties()
 	CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideActorRelevantForConnection"), TEXT("Actor relevant for connection"), bUseIsActorRelevantForConnection);
 	CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideBatchSpatialPositionUpdates"), TEXT("Batch spatial position updates"), bBatchSpatialPositionUpdates);
 
-	if (bEnableUnrealLoadBalancer)
-	{
-		if (bEnableHandover == false)
-		{
-			UE_LOG(LogSpatialGDKSettings, Warning, TEXT("Unreal load balancing is enabled, but handover is disabled."));
-		}
-	}
-
 #if WITH_EDITOR
 	ULevelEditorPlaySettings* PlayInSettings = GetMutableDefault<ULevelEditorPlaySettings>();
 	PlayInSettings->bEnableOffloading = bEnableOffloading;

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialClassInfoManager.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialClassInfoManager.h
@@ -143,6 +143,8 @@ private:
 	void FinishConstructingActorClassInfo(const FString& ClassPath, TSharedRef<FClassInfo>& Info);
 	void FinishConstructingSubobjectClassInfo(const FString& ClassPath, TSharedRef<FClassInfo>& Info);
 
+	bool ShouldTrackHandoverProperties() const;
+
 private:
 	UPROPERTY()
 	USpatialNetDriver* NetDriver;

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLBStrategy.h
@@ -48,6 +48,9 @@ public:
 	*/
 	virtual SpatialGDK::QueryConstraint GetWorkerInterestQueryConstraint() const PURE_VIRTUAL(UAbstractLBStrategy::GetWorkerInterestQueryConstraint, return {};)
 
+	/** True if this load balancing strategy requires handover data to be transmitted. */
+	virtual bool RequiresHandoverData() const { return false; }
+
 	/**
 	* Get a logical worker entity position for this strategy. For example, the centre of a grid square in a grid-based strategy. Optional- otherwise returns the origin.
 	*/

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLBStrategy.h
@@ -49,7 +49,7 @@ public:
 	virtual SpatialGDK::QueryConstraint GetWorkerInterestQueryConstraint() const PURE_VIRTUAL(UAbstractLBStrategy::GetWorkerInterestQueryConstraint, return {};)
 
 	/** True if this load balancing strategy requires handover data to be transmitted. */
-	virtual bool RequiresHandoverData() const { return false; }
+	virtual bool RequiresHandoverData() const PURE_VIRTUAL(UAbstractLBStrategy::RequiresHandover, return false;)
 
 	/**
 	* Get a logical worker entity position for this strategy. For example, the centre of a grid square in a grid-based strategy. Optional- otherwise returns the origin.

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/GridBasedLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/GridBasedLBStrategy.h
@@ -45,6 +45,8 @@ public:
 
 	virtual SpatialGDK::QueryConstraint GetWorkerInterestQueryConstraint() const override;
 
+	virtual bool RequiresHandoverData() const override { return Rows * Cols > 1; }
+
 	virtual FVector GetWorkerEntityPosition() const override;
 /* End UAbstractLBStrategy Interface */
 

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -138,7 +138,7 @@ public:
 	UPROPERTY(EditAnywhere, config, Category = "Replication", meta = (DisplayName = "SpatialOS Network Update Rate"))
 	float OpsUpdateRate;
 
-	/** Replicate handover properties between servers, required for zoned worker deployments.*/
+	/** Replicate handover properties between servers, required for zoned worker deployments. If Unreal Load Balancing is enabled, this will be set based on the load balancing strategy.*/
 	UPROPERTY(EditAnywhere, config, Category = "Replication")
 	bool bEnableHandover;
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
@@ -192,21 +192,6 @@ bool ValidateGeneratedLaunchConfig(const FSpatialLaunchConfigDescription& Launch
 		}
 	}
 
-	if (!SpatialGDKRuntimeSettings->bEnableHandover && LaunchConfigDesc.ServerWorkers.ContainsByPredicate([](const FWorkerTypeLaunchSection& Section)
-	{
-		return (Section.Rows * Section.Columns) > 1;
-	}))
-	{
-		const EAppReturnType::Type Result = FMessageDialog::Open(EAppMsgType::YesNo, FText::FromString(TEXT("Property handover is disabled and a zoned deployment is specified.\nThis is not supported.\n\nDo you want to configure your project settings now?")));
-
-		if (Result == EAppReturnType::Yes)
-		{
-			FModuleManager::LoadModuleChecked<ISettingsModule>("Settings").ShowViewer("Project", "SpatialGDKEditor", "Runtime Settings");
-		}
-
-		return false;
-	}
-
 	if (LaunchConfigDesc.ServerWorkers.ContainsByPredicate([](const FWorkerTypeLaunchSection& Section)
 	{
 		return (Section.Rows * Section.Columns) < Section.NumEditorInstances;

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/GridBasedLBStrategyTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/GridBasedLBStrategyTest.cpp
@@ -249,6 +249,27 @@ GRIDBASEDLBSTRATEGY_TEST(GIVEN_four_cells_WHEN_get_worker_entity_position_for_vi
 	return true;
 }
 
+GRIDBASEDLBSTRATEGY_TEST(GIVEN_one_cell_WHEN_requires_handover_data_called_THEN_returns_false)
+{
+	Strat = UTestGridBasedLBStrategy::Create(1, 1, 10000.f, 10000.f, 1000.0f);
+	TestFalse("Strategy doesn't require handover data",Strat->RequiresHandoverData());
+	return true;
+}
+
+GRIDBASEDLBSTRATEGY_TEST(GIVEN_more_than_one_row_WHEN_requires_handover_data_called_THEN_returns_true)
+{
+	Strat = UTestGridBasedLBStrategy::Create(2, 1, 10000.f, 10000.f, 1000.0f);
+	TestTrue("Strategy doesn't require handover data",Strat->RequiresHandoverData());
+	return true;
+}
+
+GRIDBASEDLBSTRATEGY_TEST(GIVEN_more_than_one_column_WHEN_requires_handover_data_called_THEN_returns_true)
+{
+	Strat = UTestGridBasedLBStrategy::Create(1, 2, 10000.f, 10000.f, 1000.0f);
+	TestTrue("Strategy doesn't require handover data",Strat->RequiresHandoverData());
+	return true;
+}
+
 }  // anonymous namespace
 
 GRIDBASEDLBSTRATEGY_TEST(GIVEN_a_single_cell_and_valid_local_id_WHEN_should_relinquish_called_THEN_returns_false)
@@ -334,3 +355,4 @@ GRIDBASEDLBSTRATEGY_TEST(GIVEN_two_cells_WHEN_actor_in_one_cell_THEN_strategy_re
 
 	return true;
 }
+


### PR DESCRIPTION
#### Description
- Add API to UAbstractLBStrategy to indicate whether a strategy requires handover data replication.
- Implement said interface for grid based loadbalancing.
- Force handover property replication when required by the strategy if load balancing is enabled.
- Switch bEnableHandover off by default.

#### Tests
Tested in handover gym with and without load balancing, with and without the handover setting enabled.

#### Primary reviewers
@m-samiec 