### PR TITLE
Temp singletons zoning fix

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
@@ -75,6 +75,11 @@ bool UGridBasedLBStrategy::ShouldHaveAuthority(const AActor& Actor) const
 		UE_LOG(LogGridBasedLBStrategy, Warning, TEXT("GridBasedLBStrategy not ready to relinquish authority for Actor %s."), *AActor::GetDebugName(&Actor));
 		return false;
 	}
+	// Temp zoning singleton fix, singletons should never migrate, so ShouldHaveAuthority can always return true.
+	if (Actor.GetClass()->HasAllSpatialClassFlags(SPATIALCLASS_Singleton))
+	{
+		return true;
+	}
 
 	const FVector2D Actor2DLocation = FVector2D(SpatialGDK::GetActorSpatialPosition(&Actor));
 	return IsInside(WorkerCells[LocalVirtualWorkerId - 1], Actor2DLocation);
@@ -88,11 +93,9 @@ VirtualWorkerId UGridBasedLBStrategy::WhoShouldHaveAuthority(const AActor& Actor
 		return SpatialConstants::INVALID_VIRTUAL_WORKER_ID;
 	}
 
-	// Temp fix - if we have singleton auth, let's not migrate it.
-	if (Actor.GetClass()->HasAnySpatialClassFlags(SPATIALCLASS_Singleton))
-	{
-		return true;
-	}
+	// Temp zoning singleton fix, singletons should never migrate, so ShouldHaveAuthority should always return true,
+	// and so WhoShouldHaveAuthority should never be called.
+	check(!Actor.GetClass()->HasAllSpatialClassFlags(SPATIALCLASS_Singleton));
 
 	const FVector2D Actor2DLocation = FVector2D(SpatialGDK::GetActorSpatialPosition(&Actor));
 

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
@@ -88,6 +88,12 @@ VirtualWorkerId UGridBasedLBStrategy::WhoShouldHaveAuthority(const AActor& Actor
 		return SpatialConstants::INVALID_VIRTUAL_WORKER_ID;
 	}
 
+	// Temp fix - if we have singleton auth, let's not migrate it.
+	if (Actor.GetClass()->HasAnySpatialClassFlags(SPATIALCLASS_Singleton))
+	{
+		return true;
+	}
+
 	const FVector2D Actor2DLocation = FVector2D(SpatialGDK::GetActorSpatialPosition(&Actor));
 
 	for (int i = 0; i < WorkerCells.Num(); i++)

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -88,7 +88,9 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 
 		const UAbstractLBStrategy* LBStrategy = NetDriver->LoadBalanceStrategy;
 		check(LBStrategy != nullptr);
-		IntendedVirtualWorkerId = LBStrategy->WhoShouldHaveAuthority(*Actor);
+		IntendedVirtualWorkerId = Actor->GetClass()->HasAllSpatialClassFlags(SPATIALCLASS_Singleton) ?
+			LBStrategy->LocalVirtualWorkerId :
+			LBStrategy->WhoShouldHaveAuthority(*Actor);
 		if (IntendedVirtualWorkerId == SpatialConstants::INVALID_VIRTUAL_WORKER_ID)
 		{
 			UE_LOG(LogEntityFactory, Error, TEXT("Load balancing strategy provided invalid virtual worker ID to spawn actor with. Actor: %s. Strategy: %s"), *Actor->GetName(), *LBStrategy->GetName());

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLBStrategy.h
@@ -53,7 +53,8 @@ public:
 	*/
 	virtual FVector GetWorkerEntityPosition() const { return FVector::ZeroVector; }
 
+	VirtualWorkerId LocalVirtualWorkerId;
+
 protected:
 
-	VirtualWorkerId LocalVirtualWorkerId;
 };


### PR DESCRIPTION
#### Description
Temporary fix for broken singletons in zoning

This is a temporary fix for singletons not functioning correctly in zoning, to be adopted in the short-term while the proper fixed is merged into GDK master. All singletons will be authoritative and have their entity spawned from the worker authoritative over the GSM. Also, singletons will never migrate server.