### PR TITLE
Ensuring empty runtime versions are not used when deploying.

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -51,7 +51,7 @@ USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& O
 
 const FString& USpatialGDKEditorSettings::GetSpatialOSRuntimeVersionForLocal() const
 {
-	if (bUseGDKPinnedRuntimeVersion)
+	if (bUseGDKPinnedRuntimeVersion || LocalRuntimeVersion.IsEmpty())
 	{
 		return SpatialGDKServicesConstants::SpatialOSRuntimePinnedVersion;
 	}
@@ -60,7 +60,7 @@ const FString& USpatialGDKEditorSettings::GetSpatialOSRuntimeVersionForLocal() c
 
 const FString& USpatialGDKEditorSettings::GetSpatialOSRuntimeVersionForCloud() const
 {
-	if (bUseGDKPinnedRuntimeVersion)
+	if (bUseGDKPinnedRuntimeVersion || CloudRuntimeVersion.IsEmpty())
 	{
 		return SpatialGDKServicesConstants::SpatialOSRuntimePinnedVersion;
 	}

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -720,5 +720,6 @@ bool SSpatialGDKSimulatedPlayerDeployment::IsUsingCustomRuntimeVersion() const
 FText SSpatialGDKSimulatedPlayerDeployment::GetSpatialOSRuntimeVersionToUseText() const
 {
 	const USpatialGDKEditorSettings* SpatialGDKSettings = GetDefault<USpatialGDKEditorSettings>();
-	return FText::FromString(SpatialGDKSettings->GetSpatialOSRuntimeVersionForCloud());
+	FString RuntimeVersion = SpatialGDKSettings->bUseGDKPinnedRuntimeVersion ? SpatialGDKServicesConstants::SpatialOSRuntimePinnedVersion : SpatialGDKSettings->CloudRuntimeVersion;
+	return FText::FromString(RuntimeVersion);
 }


### PR DESCRIPTION
#### Description
Ensuring we always have a runtime version string when launching a deployment. Previously using an empty runtime version would result in a vague error.

Also changed up how the string is retrieved for the deployment options. The value can be empty which reflects the settings in editor settings. If "Use GDK Pinned version" is enable the string will display the pinned version. 
