### PR TITLE
Don't prematurely set channel authority on entity checkout

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -844,8 +844,6 @@ void USpatialReceiver::ReceiveActor(Worker_EntityId EntityId)
 #endif
 	}
 
-	Channel->RefreshAuthority();
-
 	TArray<ObjectPtrRefPair> ObjectsToResolvePendingOpsFor;
 
 	// Apply initial replicated properties.


### PR DESCRIPTION
#### Description
Removing an addition that was recently made in this PR https://github.com/spatialos/UnrealGDK/pull/1762 

We don't want to set the channel authority this early (and leave it at the false defaults), because it means when we're applying component data in `ApplyComponentDataOnActorCreation` we won't swap the role and remote role inside `ComponentReader::ApplySchemaObject`. This required the role to be explicitly set before BeginPlay was called.

We can rely on the authority being set correctly after the entity is checked out when we process the authority op inside `HandleActorAuthority`

#### Release note
Bugfix to a recent change - no release note

#### Tests
Ran test gyms, and resumed from snapshots.

#### Primary reviewers
@mironec @improbable-valentyn 
