### PR TITLE
Schema names for unreal names with leading digits are prepended with ZZ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,8 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Added `bEnableNetCullDistanceInterest` (defaulted true) to enable client interest to be exposed through component tagging. This functionality has closer parity to native unreal client interest.
 - Added `bEnableNetCullDistanceFrequency` (defaulted false) to enable client interest queries to use frequency. This functionality is configured using `InterestRangeFrequencyPairs` and `FullFrequencyNetCullDistanceRatio`.
 - Added support for Android.
-- Introduced feature flag `bEnableResultTypes` (defaulted true). This configures Interest queries to only include the set of components required to run. Should give bandwidth savings depending on your game. 
-- Dynamic interest overrides are disabled if the `bEnableResultTypes` flag is set to true. 
+- Introduced feature flag `bEnableResultTypes` (defaulted true). This configures Interest queries to only include the set of components required to run. Should give bandwidth savings depending on your game.
+- Dynamic interest overrides are disabled if the `bEnableResultTypes` flag is set to true.
 - Moved Dev Auth settings from runtime settings to editor settings.
 - Added the option to use the development authentication flow using the command line.
 - Added a button to generate the Development Authentication Token inside the Unreal Editor. To use it, navigate to **Edit** > **Project Setting** > **SpatialOS GDK for Unreal** > **Editor Settings** > **Cloud Connection**.
@@ -67,6 +67,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Added the ability to connect to a local deployment when launching on a device by checking "Connect to a local deployment" and specifying the local IP of your computer in the Launch dropdown.
 - The Spatial GDK now default enables RPC Ring Buffers, and the legacy RPC mode will be removed in a subsequent release.
 - The `bPackRPCs` property has been removed, and the flag `--OverrideRPCPacking` has been removed.
+- You can now generate valid schema for classes that start with a leading digit. The generated schema class will be prefixed with `ZZ` internally.
 
 ## Bug fixes:
 - Fixed a bug that caused queued RPCs to spam logs when an entity is deleted.

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -106,14 +106,6 @@ bool CheckSchemaNameValidity(const FString& Name, const FString& Identifier, con
 	return true;
 }
 
-void CheckWarnAboutRename(const FString& Name, const FString& Identifier, const FString& Path, const FString& Category)
-{
-	if (FChar::IsDigit(Identifier[0]))
-	{
-		UE_LOG(LogSpatialGDKSchemaGenerator, Warning, TEXT("%s %s (%s) starts with a digit so its schema name was changed to %s instead."), *Category, *Identifier, *Path, *Name);
-	}
-}
-
 void CheckIdentifierNameValidity(TSharedPtr<FUnrealType> TypeInfo, bool& bOutSuccess)
 {
 	// Check Replicated data.
@@ -204,15 +196,11 @@ bool ValidateIdentifierNames(TArray<TSharedPtr<FUnrealType>>& TypeInfos)
 		check(Class);
 		const FString& ClassName = Class->GetName();
 		const FString& ClassPath = Class->GetPathName();
-		FString SchemaName = UnrealNameToSchemaName(ClassName);
+		FString SchemaName = UnrealNameToSchemaName(ClassName, true);
 
 		if (!CheckSchemaNameValidity(SchemaName, ClassPath, TEXT("Class")))
 		{
 			bSuccess = false;
-		}
-		else
-		{
-			CheckWarnAboutRename(SchemaName, ClassName, ClassPath, TEXT("Class"));
 		}
 
 		FString DesiredSchemaName = SchemaName;

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/Utils/DataTypeUtilities.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/Utils/DataTypeUtilities.cpp
@@ -31,10 +31,10 @@ FString UnrealNameToSchemaName(const FString& UnrealName, bool bWarnAboutRename 
 	FString Sanitized = AlphanumericSanitization(UnrealName);
 	if (Sanitized.IsValidIndex(0) && FChar::IsDigit(Sanitized[0]))
 	{
-		FString Result = "ZZ" + Sanitized;
+		FString Result = TEXT("ZZ") + Sanitized;
 		if (bWarnAboutRename)
 		{
-			UE_LOG(LogSpatialGDKSchemaGenerator, Warning, TEXT("%s starts with a digit (potentially after removing non-alphanumeric characters), so its schema name was changed to %s instead."), *UnrealName, *Result);
+			UE_LOG(LogSpatialGDKSchemaGenerator, Warning, TEXT("%s starts with a digit (potentially after removing non-alphanumeric characters), so its schema name was changed to %s instead. To remove this warning, rename your asset."), *UnrealName, *Result);
 		}
 		return Result;
 	}

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/Utils/DataTypeUtilities.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/Utils/DataTypeUtilities.cpp
@@ -4,6 +4,7 @@
 
 #include "Algo/Transform.h"
 #include "Internationalization/Regex.h"
+#include "SpatialGDKEditorSchemaGenerator.h"
 
 // Regex pattern matcher to match alphanumeric characters.
 const FRegexPattern AlphanumericPattern(TEXT("[A-Za-z0-9]"));
@@ -25,13 +26,19 @@ FString GetEnumDataType(const UEnumProperty* EnumProperty)
 	return DataType;
 }
 
-FString UnrealNameToSchemaName(const FString& UnrealName)
+FString UnrealNameToSchemaName(const FString& UnrealName, bool bWarnAboutRename /* = false */)
 {
-	if (UnrealName.IsValidIndex(0) && FChar::IsDigit(UnrealName[0]))
+	FString Sanitized = AlphanumericSanitization(UnrealName);
+	if (Sanitized.IsValidIndex(0) && FChar::IsDigit(Sanitized[0]))
 	{
-		return "ZZ" + AlphanumericSanitization(UnrealName);
+		FString Result = "ZZ" + Sanitized;
+		if (bWarnAboutRename)
+		{
+			UE_LOG(LogSpatialGDKSchemaGenerator, Warning, TEXT("%s starts with a digit (potentially after removing non-alphanumeric characters), so its schema name was changed to %s instead."), *UnrealName, *Result);
+		}
+		return Result;
 	}
-	return AlphanumericSanitization(UnrealName);
+	return Sanitized;
 }
 
 FString AlphanumericSanitization(const FString& InString)

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/Utils/DataTypeUtilities.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/Utils/DataTypeUtilities.cpp
@@ -27,6 +27,10 @@ FString GetEnumDataType(const UEnumProperty* EnumProperty)
 
 FString UnrealNameToSchemaName(const FString& UnrealName)
 {
+	if (UnrealName.IsValidIndex(0) && FChar::IsDigit(UnrealName[0]))
+	{
+		return "ZZ" + AlphanumericSanitization(UnrealName);
+	}
 	return AlphanumericSanitization(UnrealName);
 }
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/Utils/DataTypeUtilities.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/Utils/DataTypeUtilities.h
@@ -12,7 +12,7 @@ extern TMap<FString, FString> ClassPathToSchemaName;
 FString GetEnumDataType(const UEnumProperty* EnumProperty);
 
 // Given a class or function name, generates the name used for naming schema components and types. Removes all non-alphanumeric characters.
-FString UnrealNameToSchemaName(const FString& UnrealName);
+FString UnrealNameToSchemaName(const FString& UnrealName, bool bWarnAboutRename = false);
 
 // Given an object name, generates the name used for naming schema components. Removes all non-alphanumeric characters and capitalizes the first letter.
 FString UnrealNameToSchemaComponentName(const FString& UnrealName);

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSchemaGenerator.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSchemaGenerator.h
@@ -32,7 +32,7 @@ namespace SpatialGDKEditor
 		
 		SPATIALGDKEDITOR_API bool LoadGeneratorStateFromSchemaDatabase(const FString& FileName);
 
-		SPATIALGDKEDITOR_API bool IsAssetReadOnly(FString FileName);
+		SPATIALGDKEDITOR_API bool IsAssetReadOnly(const FString& FileName);
 		
 		SPATIALGDKEDITOR_API bool GeneratedSchemaDatabaseExists();
 		


### PR DESCRIPTION
#### Description
https://improbableio.atlassian.net/browse/UNR-1349

Unreal names that begin with a leading digit are now prefixed with `ZZ` when being converted to a schema name to make them valid.

Also fixed various by-value `FString` parameters that should be `const&`.

#### Tests
Created a new blueprint actor with a leading digit in its name and generated schema. Schema generation is now successful.

#### Documentation
release note
