### PR TITLE
Revert "Call BroadcastNetworkFailure when the PlayerController gets deleted by the server."

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1022,15 +1022,6 @@ void USpatialReceiver::RemoveActor(Worker_EntityId EntityId)
 	{
 		// Force APlayerController::DestroyNetworkActorHandled to return false
 		PC->Player = nullptr;
-		
-		if (!NetDriver->IsServer())
-		{
-			// The client's PlayerController can be deleted while the client is still conneted to the deployment when the server 
-			// is no longer receiving heartbeats from the client. When this happens, we call BroadcastNetworkFailure to allow the client
-			// to handle heartbeating failure. Once the heartbeat component is removed with UNR-3006, this call can be removed.
-			GEngine->BroadcastNetworkFailure(NetDriver->GetWorld(), NetDriver, ENetworkFailure::ConnectionLost, 
-							 FString::Printf(TEXT("PlayerController %s deleted. Server believes we have been timed out."), *PC->GetName()));
-		}
 	}
 
 	// Workaround for camera loss on handover: prevent UnPossess() (non-authoritative destruction of pawn, while being authoritative over the controller)


### PR DESCRIPTION
Reverts spatialos/UnrealGDK#1957

This breaks server travel