### PR TITLE
[UNR-2987] Actor hierarchy migration

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -781,12 +781,6 @@ int64 USpatialActorChannel::ReplicateActor()
 			{
 				if (NewAuthVirtualWorkerId != SpatialConstants::INVALID_VIRTUAL_WORKER_ID)
 				{
-					if (auto* Character = Cast<ACharacter>(Actor))
-					{
-						FVector Location = Actor->GetActorLocation();
-						UE_LOG(LogSpatialActorChannel, Display, TEXT("[UGH] Migrating actor %s at (%f,%f,%f)"), *Actor->GetName(), Location.X, Location.Y, Location.Z);
-					}
-
 					Sender->SendAuthorityIntentUpdate(*Actor, NewAuthVirtualWorkerId);
 
 					// If we're setting a different authority intent, preemptively changed to ROLE_SimulatedProxy 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -309,7 +309,7 @@ private:
 	void InitializeHandoverShadowData(TArray<uint8>& ShadowData, UObject* Object);
 	FHandoverChangeState GetHandoverChangeList(TArray<uint8>& ShadowData, UObject* Object);
 
-	void GetLatestAuthorityChangeFromHierarchy(AActor* RootActor, uint64& OutTimestamp);
+	void GetLatestAuthorityChangeFromHierarchy(const AActor* RootActor, uint64& OutTimestamp);
 	
 public:
 	// If this actor channel is responsible for creating a new entity, this will be set to true once the entity creation request is issued.

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -369,6 +369,6 @@ private:
 	// Band-aid until we get Actor Sets.
 	// Record when an actor got authority from a zoning transition.
 	// If an actor whose position depends on other in the same ownership hierarchy arrives before the others, it could report a position different
-	// from the position it is migrating to. So we prevent the actor from migrating immediately after to leave some time for the other actors it depends on to arrive.
+	// from the position it is migrating to. So we prevent the actor from migrating immediately after, we leave some time for the other actors it depends on to arrive.
 	uint64 AuthorityTimestamp;
 };


### PR DESCRIPTION
#### Description
Actors belonging to the same ownership hierarchy depends on each other to work. This change makes sure that they all send a transition request together.
They could arrive at different time on their destination though, and could try to transition to an incorrect position. A transition backoff period has been added to mitigate this issue.
Edge cases remains related to snapshot or worker crash, and would need actor sets to be properly handled.

#### Release note
TODO

#### Tests
TODO : Teleporting Gym.

#### Documentation

#### Primary reviewers
