### PR TITLE
[UNR-3313][MS] Giving users the option to cancel SimPlayer deployments if built Simplayers can not be found.

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -577,8 +577,7 @@ FReply SSpatialGDKSimulatedPlayerDeployment::OnLaunchClicked()
 		{
 			FString MissingSimPlayerBuildText = FString::Printf(TEXT("Warning: Detected that %s is missing. To launch a successful SimPlayer deployment ensure that SimPlayers is built and uploaded.\n\nWould you still like to continue with the deployment?"), *BuiltSimPlayersName);
 			EAppReturnType::Type UserAnswer = FMessageDialog::Open(EAppMsgType::YesNo, FText::FromString(MissingSimPlayerBuildText));
-
-			if (UserAnswer == EAppReturnType::No)
+			if (UserAnswer == EAppReturnType::No || UserAnswer == EAppReturnType::Cancel)
 			{
 				return FReply::Handled();
 			}

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -575,8 +575,13 @@ FReply SSpatialGDKSimulatedPlayerDeployment::OnLaunchClicked()
 
 		if (!PlatformFile.FileExists(*BuiltSimPlayerPath))
 		{
-			FString MissingSimPlayerBuildText = FString::Printf(TEXT("Warning: Detected that %s is missing. To launch a successful SimPlayer deployment ensure that SimPlayers is built and uploaded."), *BuiltSimPlayersName);
-			FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(MissingSimPlayerBuildText));
+			FString MissingSimPlayerBuildText = FString::Printf(TEXT("Warning: Detected that %s is missing. To launch a successful SimPlayer deployment ensure that SimPlayers is built and uploaded.\n\nWould you still like to continue with the deployment?"), *BuiltSimPlayersName);
+			EAppReturnType::Type UserAnswer = FMessageDialog::Open(EAppMsgType::YesNo, FText::FromString(MissingSimPlayerBuildText));
+
+			if (UserAnswer == EAppReturnType::No)
+			{
+				return FReply::Handled();
+			}
 		}
 	}
 


### PR DESCRIPTION
#### Description

This error appears if you do not have SimPlayers built on your machine. This does not necessarily mean that deploying a SimPlayers deployment would fail. You might be using an uploaded assembly the does have SimPlayers and you just locally deleted you zipped SimPlayers folder.

Old:
![image](https://user-images.githubusercontent.com/56311103/79441698-74a2b700-7fcf-11ea-9ee2-ac1a79dc4448.png)

New:
![image](https://user-images.githubusercontent.com/56311103/79441653-6bb1e580-7fcf-11ea-809c-c59aa3e4ebd9.png)
