### PR TITLE
[UNR-3230][MS] Fixing assert on server travel by clearing client GSM singleton map.

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -539,6 +539,9 @@ void USpatialNetDriver::OnGSMQuerySuccess()
 			WorldContext.PendingNetGame->bSuccessfullyConnected = true;
 			WorldContext.PendingNetGame->bSentJoinRequest = false;
 			WorldContext.PendingNetGame->URL = RedirectURL;
+
+			// Ensure the singleton map is reset as it will contain bad data from the old map
+			GlobalStateManager->RemoveAllSingletons();
 		}
 		else
 		{

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
@@ -387,6 +387,11 @@ void UGlobalStateManager::RemoveSingletonInstance(const AActor* SingletonActor)
 	SingletonClassPathToActorChannels.Remove(SingletonActor->GetClass()->GetPathName());
 }
 
+void UGlobalStateManager::RemoveAllSingletons()
+{
+	SingletonClassPathToActorChannels.Reset();
+}
+
 void UGlobalStateManager::RegisterSingletonChannel(AActor* SingletonActor, USpatialActorChannel* SingletonChannel)
 {
 	TPair<AActor*, USpatialActorChannel*>& ActorChannelPair = SingletonClassPathToActorChannels.FindOrAdd(SingletonActor->GetClass()->GetPathName());

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/GlobalStateManager.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/GlobalStateManager.h
@@ -72,6 +72,7 @@ public:
 	USpatialActorChannel* AddSingleton(AActor* SingletonActor);
 	void RegisterSingletonChannel(AActor* SingletonActor, USpatialActorChannel* SingletonChannel);
 	void RemoveSingletonInstance(const AActor* SingletonActor);
+	void RemoveAllSingletons();
 
 	Worker_EntityId GlobalStateManagerEntityId;
 


### PR DESCRIPTION
After a server travel on the client the GSM singleton map contain garbage data. This was causing checks to fire. We now clear the GSM singleton map when we are about to load a map.

Will cherry pick this into the RC.