### PR TITLE
UNR-3304 Cloud Deployment Window: make project name field editable.

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -123,8 +123,8 @@ void SSpatialGDKSimulatedPlayerDeployment::Construct(const FArguments& InArgs)
 									SNew(SEditableTextBox)
 									.Text(FText::FromString(ProjectName))
 									.ToolTipText(FText::FromString(FString(TEXT("The name of the SpatialOS project."))))
-									.OnTextCommitted(this, &SSpatialGDKSimulatedPlayerDeployment::OnProjectNameCommited)
-									.OnTextChanged(this, &SSpatialGDKSimulatedPlayerDeployment::OnProjectNameCommited, ETextCommit::Default)
+									.OnTextCommitted(this, &SSpatialGDKSimulatedPlayerDeployment::OnProjectNameCommitted)
+									.OnTextChanged(this, &SSpatialGDKSimulatedPlayerDeployment::OnProjectNameCommitted, ETextCommit::Default)
 								]
 							]
 							// Assembly Name 
@@ -460,7 +460,7 @@ void SSpatialGDKSimulatedPlayerDeployment::OnDeploymentAssemblyCommited(const FT
 	SpatialGDKSettings->SetAssemblyName(InText.ToString());
 }
 
-void SSpatialGDKSimulatedPlayerDeployment::OnProjectNameCommited(const FText& InText, ETextCommit::Type InCommitType)
+void SSpatialGDKSimulatedPlayerDeployment::OnProjectNameCommitted(const FText& InText, ETextCommit::Type InCommitType)
 {
 	FSpatialGDKServicesModule::SetProjectName(InText.ToString());
 }

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -123,7 +123,8 @@ void SSpatialGDKSimulatedPlayerDeployment::Construct(const FArguments& InArgs)
 									SNew(SEditableTextBox)
 									.Text(FText::FromString(ProjectName))
 									.ToolTipText(FText::FromString(FString(TEXT("The name of the SpatialOS project."))))
-									.IsEnabled(false)
+									.OnTextCommitted(this, &SSpatialGDKSimulatedPlayerDeployment::OnProjectNameCommited)
+									.OnTextChanged(this, &SSpatialGDKSimulatedPlayerDeployment::OnProjectNameCommited, ETextCommit::Default)
 								]
 							]
 							// Assembly Name 
@@ -457,6 +458,11 @@ void SSpatialGDKSimulatedPlayerDeployment::OnDeploymentAssemblyCommited(const FT
 {
 	USpatialGDKEditorSettings* SpatialGDKSettings = GetMutableDefault<USpatialGDKEditorSettings>();
 	SpatialGDKSettings->SetAssemblyName(InText.ToString());
+}
+
+void SSpatialGDKSimulatedPlayerDeployment::OnProjectNameCommited(const FText& InText, ETextCommit::Type InCommitType)
+{
+	FSpatialGDKServicesModule::SetProjectName(InText.ToString());
 }
 
 void SSpatialGDKSimulatedPlayerDeployment::OnPrimaryDeploymentNameCommited(const FText& InText, ETextCommit::Type InCommitType)

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKSimulatedPlayerDeployment.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKSimulatedPlayerDeployment.h
@@ -46,7 +46,7 @@ private:
 	TFuture<bool> AttemptSpatialAuthResult;
 
 	/** Delegate to commit project name */
-	void OnProjectNameCommited(const FText& InText, ETextCommit::Type InCommitType);
+	void OnProjectNameCommitted(const FText& InText, ETextCommit::Type InCommitType);
 
 	/** Delegate to commit assembly name */
 	void OnDeploymentAssemblyCommited(const FText& InText, ETextCommit::Type InCommitType);

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKSimulatedPlayerDeployment.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKSimulatedPlayerDeployment.h
@@ -45,6 +45,9 @@ private:
 
 	TFuture<bool> AttemptSpatialAuthResult;
 
+	/** Delegate to commit project name */
+	void OnProjectNameCommited(const FText& InText, ETextCommit::Type InCommitType);
+
 	/** Delegate to commit assembly name */
 	void OnDeploymentAssemblyCommited(const FText& InText, ETextCommit::Type InCommitType);
 

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialGDKServicesModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialGDKServicesModule.cpp
@@ -143,6 +143,11 @@ void FSpatialGDKServicesModule::SetProjectName(const FString& InProjectName)
 {
 	FString SpatialFileResult;
 
+	if (!JsonParsedSpatialFile)
+	{
+		UE_LOG(LogSpatialGDKServices, Error, TEXT("Failed to set project name (%s). Check there are %s file in your spatial folder."), *InProjectName, *SpatialGDKServicesConstants::SpatialOSConfigFileName);
+		return;
+	}
 	JsonParsedSpatialFile->SetStringField("name", InProjectName);
 
 	TSharedRef<TJsonWriter<>> JsonWriter = TJsonWriterFactory<>::Create(&SpatialFileResult);

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialGDKServicesModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialGDKServicesModule.cpp
@@ -18,7 +18,6 @@
 #include "Widgets/Docking/SDockTab.h"
 
 #define LOCTEXT_NAMESPACE "FSpatialGDKServicesModule"
-#define SpatialOSConfigFile "spatialos.json"
 
 DEFINE_LOG_CATEGORY(LogSpatialGDKServices);
 
@@ -142,31 +141,28 @@ void FSpatialGDKServicesModule::ExecuteAndReadOutput(const FString& Executable, 
 
 void FSpatialGDKServicesModule::SetProjectName(const FString& InProjectName)
 {
-	FString SpatialFileName = TEXT(SpatialOSConfigFile);
 	FString SpatialFileResult;
 
 	JsonParsedSpatialFile->SetStringField("name", InProjectName);
-	
+
 	TSharedRef<TJsonWriter<>> JsonWriter = TJsonWriterFactory<>::Create(&SpatialFileResult);
 	if (!FJsonSerializer::Serialize(JsonParsedSpatialFile.ToSharedRef(), JsonWriter))
 	{
 		UE_LOG(LogSpatialGDKServices, Error, TEXT("Write project name failed! Can not Serialize content to json file!"));
 		return;
 	}
-	if (!FFileHelper::SaveStringToFile(SpatialFileResult, *FPaths::Combine(SpatialGDKServicesConstants::SpatialOSDirectory, SpatialFileName)))
+	if (!FFileHelper::SaveStringToFile(SpatialFileResult, *FPaths::Combine(SpatialGDKServicesConstants::SpatialOSDirectory, SpatialGDKServicesConstants::SpatialOSConfigFileName)))
 	{
-		UE_LOG(LogSpatialGDKServices, Error, TEXT("Failed to write file content to %s"), *SpatialFileName);
+		UE_LOG(LogSpatialGDKServices, Error, TEXT("Failed to write file content to %s"), *SpatialGDKServicesConstants::SpatialOSConfigFileName);
 	}
 }
 
 FString FSpatialGDKServicesModule::ParseProjectName()
 {
 	FString ProjectNameParsed;
-
-	FString SpatialFileName = TEXT(SpatialOSConfigFile);
 	FString SpatialFileResult;
 
-	if (FFileHelper::LoadFileToString(SpatialFileResult, *FPaths::Combine(SpatialGDKServicesConstants::SpatialOSDirectory, SpatialFileName)))
+	if (FFileHelper::LoadFileToString(SpatialFileResult, *FPaths::Combine(SpatialGDKServicesConstants::SpatialOSDirectory, SpatialGDKServicesConstants::SpatialOSConfigFileName)))
 	{
 		if (ParseJson(SpatialFileResult, JsonParsedSpatialFile))
 		{

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesConstants.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesConstants.h
@@ -30,4 +30,5 @@ namespace SpatialGDKServicesConstants
 	const FString SchemaCompilerExe = CreateExePath(GDKProgramPath, TEXT("schema_compiler"));
 	const FString SpatialOSDirectory = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectDir(), TEXT("/../spatial/")));
 	const FString SpatialOSRuntimePinnedVersion("14.5.1");
+	const FString SpatialOSConfigFileName = TEXT("spatialos.json");
 }

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesModule.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesModule.h
@@ -29,6 +29,7 @@ public:
 	{
 		return ProjectName;
 	}
+	static void SetProjectName(const FString& InProjectName);
 
 	static bool ParseJson(const FString& RawJsonString, TSharedPtr<FJsonObject>& JsonParsed);
 	static void ExecuteAndReadOutput(const FString& Executable, const FString& Arguments, const FString& DirectoryToRun, FString& OutResult, int32& ExitCode);

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesModule.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesModule.h
@@ -29,6 +29,7 @@ public:
 	{
 		return ProjectName;
 	}
+	
 	static void SetProjectName(const FString& InProjectName);
 
 	static bool ParseJson(const FString& RawJsonString, TSharedPtr<FJsonObject>& JsonParsed);


### PR DESCRIPTION
#### Description
Make project name field editable in cloud deployment window.

#### Release note
REQUIRED: Add a release note to the `##Unreleased` section of CHANGELOG.md. You can find guidance for writing useful release notes [here](../SpatialGDK/Extras/internal-documentation/how-to-write-good-release-notes.md). Documentation changes are exempt from this requirement.

#### Tests
![5555](https://user-images.githubusercontent.com/5253969/79544041-f9b9c900-80c0-11ea-8c6c-7426ef66a3c3.png)
After change the content in the text editor, you can check the value of key `name` in `Samples\UnrealGDKExampleProject\spatial\spatialos.json` and see the new project name.

#### Documentation
Users can modify their project name in unreal editor much easier and it is not necessary modify it through command line any more.
