### PR TITLE
Handle duplicate add remove component ops a bit better

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -169,8 +169,9 @@ void USpatialReceiver::OnAddComponent(const Worker_AddComponentOp& Op)
 		// the data which is handled by the SpatialStaticComponentView.
 		return;
 	case SpatialConstants::UNREAL_METADATA_COMPONENT_ID:
-		// The unreal metadata component is used to indicate when an actor needs to be created from the entity.
-		// This means we need to be inside a critical section, otherwise we may not have all the requisite information at the point of creating the actor.
+		// The UnrealMetadata component is used to indicate when an Actor needs to be created from the entity.
+		// This means we need to be inside a critical section, otherwise we may not have all the requisite
+		// information at the point of creating the Actor.
 		check(bInCriticalSection);
 		PendingAddActors.AddUnique(Op.entity_id);
 		return;

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -166,7 +166,7 @@ void USpatialReceiver::OnAddComponent(const Worker_AddComponentOp& Op)
 	case SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID:
 	case SpatialConstants::SPATIAL_DEBUGGING_COMPONENT_ID:
 		// We either don't care about processing these components or we only need to store
-		// the data which is handled by the SpatialStaticComponentView.
+		// the data (which is handled by the SpatialStaticComponentView).
 		return;
 	case SpatialConstants::UNREAL_METADATA_COMPONENT_ID:
 		// The UnrealMetadata component is used to indicate when an Actor needs to be created from the entity.

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStaticComponentView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStaticComponentView.cpp
@@ -51,7 +51,7 @@ void USpatialStaticComponentView::OnAddComponent(const Worker_AddComponentOp& Op
 {
 	// With dynamic components enabled, it's possible to get duplicate AddComponent ops which need handling idempotently.
 	// For the sake of efficiency we just exit early here.
-	if (EntityComponentMap.Contains(Op.entity_id) && EntityComponentMap.Find(Op.entity_id)->Contains(Op.data.component_id))
+	if (HasComponent(Op.entity_id, Op.data.component_id))
 	{
 		return;
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStaticComponentView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStaticComponentView.cpp
@@ -49,6 +49,13 @@ bool USpatialStaticComponentView::HasComponent(Worker_EntityId EntityId, Worker_
 
 void USpatialStaticComponentView::OnAddComponent(const Worker_AddComponentOp& Op)
 {
+	// With dynamic components enabled, it's possible to get duplicate AddComponent ops which need handling idempotently.
+	// For the sake of efficiency we just exit early here.
+	if (EntityComponentMap.Contains(Op.entity_id) && EntityComponentMap.Find(Op.entity_id)->Contains(Op.data.component_id))
+	{
+		return;
+	}
+
 	TUniquePtr<SpatialGDK::Component> Data;
 	switch (Op.data.component_id)
 	{

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -37,6 +37,13 @@ struct PendingAddComponentWrapper
 	PendingAddComponentWrapper(Worker_EntityId InEntityId, Worker_ComponentId InComponentId, TUniquePtr<SpatialGDK::DynamicComponent>&& InData)
 		: EntityId(InEntityId), ComponentId(InComponentId), Data(MoveTemp(InData)) {}
 
+	// We define equality to cover just entity and component IDs since duplicated AddComponent ops
+	// will be moved into unique pointers and we cannot equalate the underlying Worker_ComponentData.
+	bool operator==(const PendingAddComponentWrapper& Other) const
+	{
+		return EntityId == Other.EntityId && ComponentId && Other.ComponentId;
+	}
+
 	Worker_EntityId EntityId;
 	Worker_ComponentId ComponentId;
 	TUniquePtr<SpatialGDK::DynamicComponent> Data;

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -38,7 +38,7 @@ struct PendingAddComponentWrapper
 		: EntityId(InEntityId), ComponentId(InComponentId), Data(MoveTemp(InData)) {}
 
 	// We define equality to cover just entity and component IDs since duplicated AddComponent ops
-	// will be moved into unique pointers and we cannot equalate the underlying Worker_ComponentData.
+	// will be moved into unique pointers and we cannot equate the underlying Worker_ComponentData.
 	bool operator==(const PendingAddComponentWrapper& Other) const
 	{
 		return EntityId == Other.EntityId && ComponentId && Other.ComponentId;

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SnapshotGenerator/SpatialGDKEditorSnapshotGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SnapshotGenerator/SpatialGDKEditorSnapshotGenerator.cpp
@@ -68,7 +68,6 @@ bool CreateSpawnerEntity(Worker_SnapshotOutputStream* OutputStream)
 	ComponentWriteAcl.Add(SpatialConstants::PERSISTENCE_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
 	ComponentWriteAcl.Add(SpatialConstants::ENTITY_ACL_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
 	ComponentWriteAcl.Add(SpatialConstants::PLAYER_SPAWNER_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
-	ComponentWriteAcl.Add(SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
 	ComponentWriteAcl.Add(SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
 
 	Components.Add(Position(DeploymentOrigin).CreatePositionData());
@@ -163,7 +162,6 @@ bool CreateGlobalStateManager(Worker_SnapshotOutputStream* OutputStream)
 	ComponentWriteAcl.Add(SpatialConstants::DEPLOYMENT_MAP_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
 	ComponentWriteAcl.Add(SpatialConstants::GSM_SHUTDOWN_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
 	ComponentWriteAcl.Add(SpatialConstants::STARTUP_ACTOR_MANAGER_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
-	ComponentWriteAcl.Add(SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
 	ComponentWriteAcl.Add(SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
 
 	Components.Add(Position(DeploymentOrigin).CreatePositionData());


### PR DESCRIPTION
Original ticket: https://improbableio.atlassian.net/browse/UNR-3147

#### Description
As part of enabling dynamic components in the worker SDK, we will get additional Add/RemoveComponent ops when the worker SDK receives delegate/undelegate ops from the runtime. We need to be more robust handling these. Specifically in how we handle double RemoveComponent ops for the UnrealMetadata component because this results in double-attempted Actor deletion.
