### PR TITLE
Added OnPlayerSpawnFailed delegate to SpatialGameInstance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Added `OnClientOwnershipGained` and `OnClientOwnershipLost` events on Actors and ActorComponents. These events trigger when an Actor is added to or removed from the ownership hierarchy of a client's PlayerController.
 - You can now generate valid schema for classes that start with a leading digit. The generated schema class will be prefixed with `ZZ` internally.
 - Handover properties will be automatically replicated when required for load balancing. `bEnableHandover` is off by default.
+- Added `OnPlayerSpawnFailed` delegate to `SpatialGameInstance`. This is helpful if you have established a successful connection but the server worker crashed. `OnConnected` and `OnConnectionFailed` are now also blueprint-assignable.
 
 ## Bug fixes:
 - Fixed a bug that caused queued RPCs to spam logs when an entity is deleted.

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
@@ -233,8 +233,8 @@ void USpatialGameInstance::HandleOnConnectionFailed(const FString& Reason)
 
 void USpatialGameInstance::HandleOnPlayerSpawnFailed(const FString& Reason)
 {
-	UE_LOG(LogSpatialGameInstance, Error, TEXT("Could not spawn the local player. Reason: %s"), *Reason);
-	OnPlayerSpawnFailed.Broadcast(Reason);
+	UE_LOG(LogSpatialGameInstance, Error, TEXT("Could not spawn the local player on SpatialOS. Reason: %s"), *Reason);
+	OnSpatialPlayerSpawnFailed.Broadcast(Reason);
 }
 
 void USpatialGameInstance::OnLevelInitializedNetworkActors(ULevel* LoadedLevel, UWorld* OwningWorld)

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
@@ -219,7 +219,7 @@ void USpatialGameInstance::HandleOnConnected()
 	WorkerConnection->OnEnqueueMessage.AddUObject(SpatialLatencyTracer, &USpatialLatencyTracer::OnEnqueueMessage);
 	WorkerConnection->OnDequeueMessage.AddUObject(SpatialLatencyTracer, &USpatialLatencyTracer::OnDequeueMessage);
 #endif
-	OnConnected.Broadcast();
+	OnSpatialConnected.Broadcast();
 }
 
 void USpatialGameInstance::HandleOnConnectionFailed(const FString& Reason)
@@ -228,7 +228,7 @@ void USpatialGameInstance::HandleOnConnectionFailed(const FString& Reason)
 #if TRACE_LIB_ACTIVE
 	SpatialLatencyTracer->ResetWorkerId();
 #endif
-	OnConnectionFailed.Broadcast(Reason);
+	OnSpatialConnectionFailed.Broadcast(Reason);
 }
 
 void USpatialGameInstance::HandleOnPlayerSpawnFailed(const FString& Reason)

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
@@ -231,6 +231,12 @@ void USpatialGameInstance::HandleOnConnectionFailed(const FString& Reason)
 	OnConnectionFailed.Broadcast(Reason);
 }
 
+void USpatialGameInstance::HandleOnPlayerSpawnFailed(const FString& Reason)
+{
+	UE_LOG(LogSpatialGameInstance, Error, TEXT("Could not spawn the local player. Reason: %s"), *Reason);
+	OnPlayerSpawnFailed.Broadcast(Reason);
+}
+
 void USpatialGameInstance::OnLevelInitializedNetworkActors(ULevel* LoadedLevel, UWorld* OwningWorld)
 {
 	const FString WorkerType = GetSpatialWorkerType().ToString();

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -404,6 +404,7 @@ void USpatialNetDriver::CreateAndInitializeCoreClasses()
 	GlobalStateManager->Init(this);
 	SnapshotManager->Init(Connection, GlobalStateManager, Receiver);
 	PlayerSpawner->Init(this, &TimerManager);
+	PlayerSpawner->OnPlayerSpawnFailed.BindUObject(GameInstance, &USpatialGameInstance::HandleOnPlayerSpawnFailed);
 	SpatialMetrics->Init(Connection, NetServerMaxTickRate, IsServer());
 	SpatialMetrics->ControllerRefProvider.BindUObject(this, &USpatialNetDriver::GetCurrentPlayerControllerRef);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialGameInstance.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialGameInstance.h
@@ -58,10 +58,10 @@ public:
 
 	// Invoked when this worker has successfully connected to SpatialOS
 	UPROPERTY(BlueprintAssignable)
-	FOnConnectedEvent OnConnected;
+	FOnConnectedEvent OnSpatialConnected;
 	// Invoked when this worker fails to initiate a connection to SpatialOS
 	UPROPERTY(BlueprintAssignable)
-	FOnConnectionFailedEvent OnConnectionFailed;
+	FOnConnectionFailedEvent OnSpatialConnectionFailed;
 	// Invoked when the player could not be spawned
 	UPROPERTY(BlueprintAssignable)
 	FOnPlayerSpawnFailedEvent OnPlayerSpawnFailed;

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialGameInstance.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialGameInstance.h
@@ -64,7 +64,7 @@ public:
 	FOnConnectionFailedEvent OnSpatialConnectionFailed;
 	// Invoked when the player could not be spawned
 	UPROPERTY(BlueprintAssignable)
-	FOnPlayerSpawnFailedEvent OnPlayerSpawnFailed;
+	FOnPlayerSpawnFailedEvent OnSpatialPlayerSpawnFailed;
 
 	void SetFirstConnectionToSpatialOSAttempted() { bFirstConnectionToSpatialOSAttempted = true; };
 	bool GetFirstConnectionToSpatialOSAttempted() const { return bFirstConnectionToSpatialOSAttempted; };

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialGameInstance.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialGameInstance.h
@@ -15,8 +15,9 @@ class USpatialStaticComponentView;
 
 DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGameInstance, Log, All);
 
-DECLARE_EVENT(USpatialGameInstance, FOnConnectedEvent);
-DECLARE_EVENT_OneParam(USpatialGameInstance, FOnConnectionFailedEvent, const FString&);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnConnectedEvent);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnConnectionFailedEvent, const FString&, Reason);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnPlayerSpawnFailedEvent, const FString&, Reason);
 
 UCLASS(config = Engine)
 class SPATIALGDK_API USpatialGameInstance : public UGameInstance
@@ -53,11 +54,17 @@ public:
 
 	void HandleOnConnected();
 	void HandleOnConnectionFailed(const FString& Reason);
+	void HandleOnPlayerSpawnFailed(const FString& Reason);
 
 	// Invoked when this worker has successfully connected to SpatialOS
+	UPROPERTY(BlueprintAssignable)
 	FOnConnectedEvent OnConnected;
 	// Invoked when this worker fails to initiate a connection to SpatialOS
+	UPROPERTY(BlueprintAssignable)
 	FOnConnectionFailedEvent OnConnectionFailed;
+	// Invoked when the player could not be spawned
+	UPROPERTY(BlueprintAssignable)
+	FOnPlayerSpawnFailedEvent OnPlayerSpawnFailed;
 
 	void SetFirstConnectionToSpatialOSAttempted() { bFirstConnectionToSpatialOSAttempted = true; };
 	bool GetFirstConnectionToSpatialOSAttempted() const { return bFirstConnectionToSpatialOSAttempted; };

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialPlayerSpawner.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialPlayerSpawner.h
@@ -19,6 +19,8 @@ DECLARE_LOG_CATEGORY_EXTERN(LogSpatialPlayerSpawner, Log, All);
 class FTimerManager;
 class USpatialNetDriver;
 
+DECLARE_DELEGATE_OneParam(FOnPlayerSpawnFailed, const FString&);
+
 UCLASS()
 class SPATIALGDK_API USpatialPlayerSpawner : public UObject
 {
@@ -31,6 +33,8 @@ public:
 	// Client
 	void SendPlayerSpawnRequest();
 	void ReceivePlayerSpawnResponseOnClient(const Worker_CommandResponseOp& Op);
+
+	FOnPlayerSpawnFailed OnPlayerSpawnFailed;
 
 	// Authoritative server worker
 	void ReceivePlayerSpawnRequestOnServer(const Worker_CommandRequestOp& Op);


### PR DESCRIPTION
Added OnPlayerSpawnFailed delegate to SpatialGameInstance;
Made OnConnected and OnConnectionFailed BlueprintAssignable

#### Tests
Started a local deployment and deleted the SpatialSpawner to force the spawn request to fail.

#### Documentation
release note
