### PR TITLE
[UNR-2770] Actually enable locking immediate after spawning

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -88,15 +88,18 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 
 		const UAbstractLBStrategy* LBStrategy = NetDriver->LoadBalanceStrategy;
 		check(LBStrategy != nullptr);
-		IntendedVirtualWorkerId = LBStrategy->WhoShouldHaveAuthority(*Actor);
-		if (IntendedVirtualWorkerId == SpatialConstants::INVALID_VIRTUAL_WORKER_ID)
-		{
-			UE_LOG(LogEntityFactory, Error, TEXT("Load balancing strategy provided invalid virtual worker ID to spawn actor with. Actor: %s. Strategy: %s"), *Actor->GetName(), *LBStrategy->GetName());
-		}
-		else
+		const UAbstractLockingPolicy* LockingPolicy = NetDriver->LockingPolicy;
+		check(LockingPolicy != nullptr);
+
+		IntendedVirtualWorkerId = LockingPolicy->IsLocked(Actor) ? LBStrategy->GetLocalVirtualWorkerId() : LBStrategy->WhoShouldHaveAuthority(*Actor);
+		if (IntendedVirtualWorkerId != SpatialConstants::INVALID_VIRTUAL_WORKER_ID)
 		{
 			const PhysicalWorkerName* IntendedAuthoritativePhysicalWorkerName = NetDriver->VirtualWorkerTranslator->GetPhysicalWorkerForVirtualWorker(IntendedVirtualWorkerId);
 			WorkerAttributeOrSpecificWorker = { FString::Format(TEXT("workerId:{0}"), { *IntendedAuthoritativePhysicalWorkerName }) };
+		}
+		else
+		{
+			UE_LOG(LogEntityFactory, Error, TEXT("Load balancing strategy provided invalid virtual worker ID to spawn actor with. Actor: %s. Strategy: %s"), *Actor->GetName(), *LBStrategy->GetName());
 		}
 	}
 
@@ -262,13 +265,13 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 		{
 			check(NetDriver->VirtualWorkerTranslator != nullptr);
 
-			VirtualWorkerId IntentVirtualWorkerId = NetDriver->VirtualWorkerTranslator->GetLocalVirtualWorkerId();
-
-			const PhysicalWorkerName* PhysicalWorkerName = NetDriver->VirtualWorkerTranslator->GetPhysicalWorkerForVirtualWorker(IntentVirtualWorkerId);
+			const PhysicalWorkerName* PhysicalWorkerName = NetDriver->VirtualWorkerTranslator->GetPhysicalWorkerForVirtualWorker(IntendedVirtualWorkerId);
 			FColor InvalidServerTintColor = NetDriver->SpatialDebugger->InvalidServerTintColor;
 			FColor IntentColor = PhysicalWorkerName == nullptr ? InvalidServerTintColor : SpatialGDK::GetColorForWorkerName(*PhysicalWorkerName);
 
-			SpatialDebugging DebuggingInfo(SpatialConstants::INVALID_VIRTUAL_WORKER_ID, InvalidServerTintColor, IntentVirtualWorkerId, IntentColor, false);
+			const bool bIsLocked = NetDriver->LockingPolicy->IsLocked(Actor);
+
+			SpatialDebugging DebuggingInfo(SpatialConstants::INVALID_VIRTUAL_WORKER_ID, InvalidServerTintColor, IntendedVirtualWorkerId, IntentColor, bIsLocked);
 			ComponentDatas.Add(DebuggingInfo.CreateSpatialDebuggingData());
 		}
 

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLBStrategy.h
@@ -36,6 +36,7 @@ public:
 
 	bool IsReady() const { return LocalVirtualWorkerId != SpatialConstants::INVALID_VIRTUAL_WORKER_ID; }
 
+	VirtualWorkerId GetLocalVirtualWorkerId() const { return LocalVirtualWorkerId; };
 	void SetLocalVirtualWorkerId(VirtualWorkerId LocalVirtualWorkerId);
 
 	virtual TSet<VirtualWorkerId> GetVirtualWorkerIds() const PURE_VIRTUAL(UAbstractLBStrategy::GetVirtualWorkerIds, return {};)
@@ -57,6 +58,5 @@ public:
 	virtual FVector GetWorkerEntityPosition() const { return FVector::ZeroVector; }
 
 protected:
-
 	VirtualWorkerId LocalVirtualWorkerId;
 };


### PR DESCRIPTION
[Ticket](https://improbableio.atlassian.net/browse/UNR-2770)

#### Description
This actually fixes an issue that a [previous PR](https://github.com/spatialos/UnrealGDK/pull/1946) claimed to. Actors spawned an immediately locked did not respect locks in the sense that the CreateEntity would have the AuthorityIntent component being sent with the strategized virtual worker (as well as the SpatialDebugging component).

Now, we check for a lock while constructing the CreateEntity request, and if set, use the local virtual worker id instead of the strategized one (and this is also applied to the SpatialDebugging component).
