### PR TITLE
UNR-3295 Add Remove UE4CommandLine.txt from Device

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
@@ -76,28 +76,60 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 	MobileCategory.AddCustomRow(FText::FromString("Push SpatialOS settings to Android device"))
 		.ValueContent()
 		.VAlign(VAlign_Center)
-		.MinDesiredWidth(250)
+		.MinDesiredWidth(550)
 		[
-			SNew(SButton)
-			.VAlign(VAlign_Center)
-			.OnClicked(this, &FSpatialGDKEditorLayoutDetails::PushCommandLineArgsToAndroidDevice)
-			.Content()
+			SNew(SHorizontalBox)
+			+ SHorizontalBox::Slot()
+			.FillWidth(1.0f)
 			[
-				SNew(STextBlock).Text(FText::FromString("Push SpatialOS settings to Android device"))
+				SNew(SButton)
+				.VAlign(VAlign_Center)
+				.OnClicked(this, &FSpatialGDKEditorLayoutDetails::PushCommandLineArgsToAndroidDevice)
+				.Content()
+				[
+					SNew(STextBlock).Text(FText::FromString("Push SpatialOS settings to Android device"))
+				]
+			]
+			+ SHorizontalBox::Slot()
+			.FillWidth(1.0f)
+			[
+				SNew(SButton)
+				.VAlign(VAlign_Center)
+				.OnClicked(this, &FSpatialGDKEditorLayoutDetails::RemoveCommandLineArgsFromAndroidDevice)
+				.Content()
+				[
+					SNew(STextBlock).Text(FText::FromString("Remove SpatialOS settings from Android device"))
+				]
 			]
 		];
 
 	MobileCategory.AddCustomRow(FText::FromString("Push SpatialOS settings to iOS device"))
 		.ValueContent()
 		.VAlign(VAlign_Center)
-		.MinDesiredWidth(250)
+		.MinDesiredWidth(550)
 		[
-			SNew(SButton)
-			.VAlign(VAlign_Center)
-			.OnClicked(this, &FSpatialGDKEditorLayoutDetails::PushCommandLineArgsToIOSDevice)
-			.Content()
+			SNew(SHorizontalBox)
+			+ SHorizontalBox::Slot()
+			.FillWidth(1.0f)
 			[
-				SNew(STextBlock).Text(FText::FromString("Push SpatialOS settings to iOS device"))
+				SNew(SButton)
+				.VAlign(VAlign_Center)
+				.OnClicked(this, &FSpatialGDKEditorLayoutDetails::PushCommandLineArgsToIOSDevice)
+				.Content()
+				[
+					SNew(STextBlock).Text(FText::FromString("Push SpatialOS settings to iOS device"))
+				]
+			]
+			+ SHorizontalBox::Slot()
+			.FillWidth(1.0f)
+			[
+				SNew(SButton)
+				.VAlign(VAlign_Center)
+				.OnClicked(this, &FSpatialGDKEditorLayoutDetails::RemoveCommandLineArgsFromIOSDevice)
+				.Content()
+				[
+					SNew(STextBlock).Text(FText::FromString("Remove SpatialOS settings from iOS device"))
+				]
 			]
 		];
 }
@@ -245,13 +277,33 @@ bool FSpatialGDKEditorLayoutDetails::TryPushCommandLineArgsToDevice(const FStrin
 	return true;
 }
 
+namespace
+{
+	static FString GetAdbExePath()
+	{
+		FString AndroidHome = FPlatformMisc::GetEnvironmentVariable(TEXT("ANDROID_HOME"));
+		if (AndroidHome.IsEmpty())
+		{
+			UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Environment variable ANDROID_HOME is not set. Please make sure to configure this."));
+			FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Environment variable ANDROID_HOME is not set. Please make sure to configure this.")));
+			return TEXT("");
+		}
+
+#if PLATFORM_WINDOWS
+		const FString AdbExe = FPaths::ConvertRelativePathToFull(FPaths::Combine(AndroidHome, TEXT("platform-tools/adb.exe")));
+#else
+		const FString AdbExe = FPaths::ConvertRelativePathToFull(FPaths::Combine(AndroidHome, TEXT("platform-tools/adb")));
+#endif
+
+		return AdbExe;
+	}
+}
+
 FReply FSpatialGDKEditorLayoutDetails::PushCommandLineArgsToAndroidDevice()
 {
-	FString AndroidHome = FPlatformMisc::GetEnvironmentVariable(TEXT("ANDROID_HOME"));
-	if (AndroidHome.IsEmpty())
+	const FString AdbExe = GetAdbExePath();
+	if (AdbExe.IsEmpty())
 	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Environment variable ANDROID_HOME is not set. Please make sure to configure this."));
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Environment variable ANDROID_HOME is not set. Please make sure to configure this.")));
 		return FReply::Unhandled();
 	}
 
@@ -264,12 +316,6 @@ FReply FSpatialGDKEditorLayoutDetails::PushCommandLineArgsToAndroidDevice()
 
 	const FString AndroidCommandLineFile = FString::Printf(TEXT("/mnt/sdcard/UE4Game/%s/UE4CommandLine.txt"), *FString(FApp::GetProjectName()));
 	const FString AdbArguments = FString::Printf(TEXT("push \"%s\" \"%s\""), *OutCommandLineArgsFile, *AndroidCommandLineFile);
-
-#if PLATFORM_WINDOWS
-	const FString AdbExe = FPaths::ConvertRelativePathToFull(FPaths::Combine(AndroidHome, TEXT("platform-tools/adb.exe")));
-#else
-	const FString AdbExe = FPaths::ConvertRelativePathToFull(FPaths::Combine(AndroidHome, TEXT("platform-tools/adb")));
-#endif
 
 	TryPushCommandLineArgsToDevice(AdbExe, AdbArguments, OutCommandLineArgsFile);
 	return FReply::Handled();
@@ -296,3 +342,34 @@ FReply FSpatialGDKEditorLayoutDetails::PushCommandLineArgsToIOSDevice()
 	TryPushCommandLineArgsToDevice(Executable, DeploymentServerArguments, OutCommandLineArgsFile);
 	return FReply::Handled();
 }
+
+FReply FSpatialGDKEditorLayoutDetails::RemoveCommandLineArgsFromIOSDevice()
+{
+	return FReply::Handled();
+}
+
+FReply FSpatialGDKEditorLayoutDetails::RemoveCommandLineArgsFromAndroidDevice()
+{
+	const FString AdbExe = GetAdbExePath();
+	if (AdbExe.IsEmpty())
+	{
+		return FReply::Unhandled();
+	}
+
+	FString ExeOutput;
+	FString StdErr;
+	int32 ExitCode;
+
+	FString ExeArguments = FString::Printf(TEXT("shell rm -f /mnt/sdcard/UE4Game/%s/UE4CommandLine.txt"), FApp::GetProjectName());
+
+	FPlatformProcess::ExecProcess(*AdbExe, *ExeArguments, &ExitCode, &ExeOutput, &StdErr);
+	if (ExitCode != 0)
+	{
+		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Failed to remove settings from the mobile client. %s %s"), *ExeOutput, *StdErr);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Failed to remove settings from the mobile client. See the Output log for more information.")));
+		return FReply::Unhandled();
+	}
+
+	return FReply::Handled();
+}
+

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
@@ -80,11 +80,11 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 		[
 			SNew(SButton)
 			.VAlign(VAlign_Center)
-		.OnClicked(this, &FSpatialGDKEditorLayoutDetails::PushCommandLineArgsToAndroidDevice)
-		.Content()
-		[
-			SNew(STextBlock).Text(FText::FromString("Push SpatialOS settings to Android device"))
-		]
+			.OnClicked(this, &FSpatialGDKEditorLayoutDetails::PushCommandLineArgsToAndroidDevice)
+			.Content()
+			[
+				SNew(STextBlock).Text(FText::FromString("Push SpatialOS settings to Android device"))
+			]
 		];
 
 	MobileCategory.AddCustomRow(FText::FromString("Push SpatialOS settings to iOS device"))
@@ -94,11 +94,11 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 		[
 			SNew(SButton)
 			.VAlign(VAlign_Center)
-		.OnClicked(this, &FSpatialGDKEditorLayoutDetails::PushCommandLineArgsToIOSDevice)
-		.Content()
-		[
-			SNew(STextBlock).Text(FText::FromString("Push SpatialOS settings to iOS device"))
-		]
+			.OnClicked(this, &FSpatialGDKEditorLayoutDetails::PushCommandLineArgsToIOSDevice)
+			.Content()
+			[
+				SNew(STextBlock).Text(FText::FromString("Push SpatialOS settings to iOS device"))
+			]
 		];
 }
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
@@ -17,6 +17,9 @@ private:
 	FReply GenerateDevAuthToken();
 	FReply PushCommandLineArgsToIOSDevice();
 	FReply PushCommandLineArgsToAndroidDevice();
+	FReply RemoveCommandLineArgsFromIOSDevice();
+	FReply RemoveCommandLineArgsFromAndroidDevice();
+
 
 public:
 	static TSharedRef<IDetailCustomization> MakeInstance();


### PR DESCRIPTION
#### Description
Add ability to remove the UE4CommandLine.txt from a device.

![image](https://user-images.githubusercontent.com/49975160/79933887-cd68c880-8483-11ea-9cf8-6084e6dad193.png)

#### Release note
TODO: Update CHANGELOG.md

#### Tests
I deleted the file from Android device and used ADB shell ls to confirm it was gone.
IOS I deleted the file from the bundle.. but I haven't validated it's removed from the bundle, only that the command did not complain.

STRONGLY SUGGESTED: Create a cloud deployment and dev-auth token, then push the command line with dev auth token to the device (Android and iOS) then connect successfully to the cloud deployment, then remove the command line (Android and iOS) using the remove buttons and confirm it is no longer possible to connect to the cloud deployment.

#### Documentation
TODO: Update documentation

#### Primary reviewers
@improbable-valentyn @jessicafalk @raymonwang