### PR TITLE
Disable stdout register unless we're actually outputting

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
@@ -66,10 +66,13 @@ void USpatialLatencyTracer::RegisterProject(UObject* WorldContextObject, const F
 
 	StackdriverExporter::Register({ TCHAR_TO_UTF8(*ProjectId) });
 
-	std::cout.rdbuf(&Stream);
-	std::cerr.rdbuf(&Stream);
+	if (LogSpatialLatencyTracing.GetVerbosity() >= ELogVerbosity::Verbose)
+	{
+		std::cout.rdbuf(&Stream);
+		std::cerr.rdbuf(&Stream);
 
-	StdoutExporter::Register();
+		StdoutExporter::Register();
+	}
 #endif // TRACE_LIB_ACTIVE
 }
 


### PR DESCRIPTION
#### Description
Altered latency tracer to only register stdout if we intend to pipe it to unreal output.

This was done because sim clients also capture *all* stdout, not just what unreal outputs, so they were always capturing the tracer output, which was often many MB. Can still be turned on by altering the `LogSpatialLatencyTracing` category, but must be done before the call to `SpatialLatencyTracer::RegisterProject`

#### Release note
Internal tool, not externally documented.

#### Primary reviewers
@ImprobableVlad @improbable-danny 
