### PR TITLE
UNR-3290 Create dropdown for choosing connection flow in the Start toolbar button

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -39,6 +39,18 @@ void FSpatialGDKEditorModule::ShutdownModule()
 	}
 }
 
+FString FSpatialGDKEditorModule::GetSpatialOSLocalDeploymentIP() const
+{
+	const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>();
+	return SpatialGDKEditorSettings->ExposedRuntimeIP;
+}
+
+int FSpatialGDKEditorModule::GetSpatialOSNetFlowType() const
+{
+	const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>();
+	return SpatialGDKEditorSettings->SpatialOSNetFlowType;
+}
+
 void FSpatialGDKEditorModule::RegisterSettings()
 {
 	if (ISettingsModule* SettingsModule = FModuleManager::GetModulePtr<ISettingsModule>("Settings"))

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -35,7 +35,6 @@ USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& O
 	, bDeleteDynamicEntities(true)
 	, bGenerateDefaultLaunchConfig(true)
 	, bUseGDKPinnedRuntimeVersion(true)
-	, bExposeRuntimeIP(false)
 	, ExposedRuntimeIP(TEXT(""))
 	, bStopSpatialOnExit(false)
 	, bAutoStartLocalDeployment(true)

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
@@ -1,11 +1,12 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
+#include "Improbable/SpatialGDKSettingsBridge.h"
 #include "Modules/ModuleInterface.h"
 #include "Modules/ModuleManager.h"
 
 class FLBStrategyEditorExtensionManager;
 
-class FSpatialGDKEditorModule : public IModuleInterface
+class FSpatialGDKEditorModule : public ISpatialGDKEditorModule
 {
 public:
 
@@ -20,6 +21,10 @@ public:
 	{
 		return true;
 	}
+
+protected:
+	virtual FString GetSpatialOSLocalDeploymentIP() const override;
+	virtual int GetSpatialOSNetFlowType() const override;
 
 private:
 	void RegisterSettings();

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -227,6 +227,17 @@ namespace ERegionCode
 	};
 }
 
+UENUM()
+namespace ESpatialOSNetFlow
+{
+	enum Type
+	{
+		UnrealNativeNetworking,
+		SpatialOSLocalNetworking,
+		SpatialOSCloudNetworking
+	};
+}
+
 UCLASS(config = SpatialGDKEditorSettings, defaultconfig)
 class SPATIALGDKEDITOR_API USpatialGDKEditorSettings : public UObject
 {
@@ -286,10 +297,6 @@ private:
 	FFilePath SpatialOSLaunchConfig;
 
 public:
-	/** Expose the runtime on a particular IP address when it is running on this machine. Changes are applied on next local deployment startup. */
-	UPROPERTY(EditAnywhere, config, Category = "Launch", meta = (DisplayName = "Expose local runtime"))
-	bool bExposeRuntimeIP;
-
 	/** If the runtime is set to be exposed, specify on which IP address it should be reachable. Changes are applied on next local deployment startup. */
 	UPROPERTY(EditAnywhere, config, Category = "Launch", meta = (EditCondition = "bExposeRuntimeIP", DisplayName = "Exposed local runtime IP address"))
 	FString ExposedRuntimeIP;
@@ -604,4 +611,7 @@ public:
 	bool IsDeploymentConfigurationValid() const;
 
 	void SetRuntimeDevelopmentAuthenticationToken();
+
+	UPROPERTY(EditAnywhere, config, Category = "SpatialGDK")
+	TEnumAsByte<ESpatialOSNetFlow::Type> SpatialOSNetFlowType = ESpatialOSNetFlow::UnrealNativeNetworking;
 };

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -947,7 +947,7 @@ void FSpatialGDKEditorToolbarModule::SpatialOSCloudNetworkingClicked() const
 	FString DevAuthToken;
 	if (!SpatialCommandUtils::GenerateDevAuthToken(SpatialGDKSettings->IsRunningInChina(), DevAuthToken))
 	{
-		UE_LOG(LogSpatialGDKEditorToolbar, Error, TEXT("Genenrate Dev Auth Token failed."));
+		UE_LOG(LogSpatialGDKEditorToolbar, Error, TEXT("Failed to generate a development authentication token."));
 	}
 	SpatialGDKEditorSettings->DevelopmentAuthenticationToken = DevAuthToken;
 	SpatialGDKEditorSettings->SaveConfig();

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -250,7 +250,7 @@ void FSpatialGDKEditorToolbarModule::MapActions(TSharedPtr<class FUICommandList>
 
 	InPluginCommands->MapAction(FSpatialGDKEditorToolbarCommands::Get().UnrealNativeNetworking,
 		FExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::UnrealNativeNetworkingClicked),
-		FCanExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::OnIsSpatialNetworkingEnabled),
+		FCanExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::IsSpatialOSNetFlowCanChange),
 		FIsActionChecked::CreateRaw(this, &FSpatialGDKEditorToolbarModule::IsUnrealNativeNetworkingChecked)
 	);
 
@@ -262,7 +262,7 @@ void FSpatialGDKEditorToolbarModule::MapActions(TSharedPtr<class FUICommandList>
 
 	InPluginCommands->MapAction(FSpatialGDKEditorToolbarCommands::Get().SpatialOSCloudNetworking,
 		FExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::SpatialOSCloudNetworkingClicked),
-		FCanExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::OnIsSpatialNetworkingEnabled),
+		FCanExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::IsSpatialOSNetFlowCanChange),
 		FIsActionChecked::CreateRaw(this, &FSpatialGDKEditorToolbarModule::IsSpatialOSCloudNetworkingChecked)
 	);
 
@@ -327,6 +327,7 @@ void FSpatialGDKEditorToolbarModule::AddToolbarExtension(FToolBarBuilder& Builde
 	);
 	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().CreateSpatialGDKSnapshot);
 	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().StartSpatialDeployment);
+	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().StopSpatialDeployment);
 	Builder.AddComboButton(
 		FUIAction(),
 		FOnGetContent::CreateRaw(this, &FSpatialGDKEditorToolbarModule::CreateStartDropDownMenuContent),
@@ -335,7 +336,6 @@ void FSpatialGDKEditorToolbarModule::AddToolbarExtension(FToolBarBuilder& Builde
 		FSlateIcon(FEditorStyle::GetStyleSetName(), "GDK.start"),
 		true
 	);
-	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().StopSpatialDeployment);
 	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().LaunchInspectorWebPageAction);
 #if PLATFORM_WINDOWS
 	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().OpenSimulatedPlayerConfigurationWindowAction);
@@ -850,7 +850,7 @@ bool FSpatialGDKEditorToolbarModule::StartSpatialDeploymentIsVisible() const
 
 bool FSpatialGDKEditorToolbarModule::StartSpatialDeploymentCanExecute() const
 {
-	return !LocalDeploymentManager->IsDeploymentStarting() && GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking();
+	return !LocalDeploymentManager->IsDeploymentStarting() && GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking() && GetDefault<USpatialGDKEditorSettings>()->SpatialOSNetFlowType == ESpatialOSNetFlow::SpatialOSLocalNetworking;
 }
 
 bool FSpatialGDKEditorToolbarModule::StopSpatialDeploymentIsVisible() const
@@ -917,6 +917,11 @@ bool FSpatialGDKEditorToolbarModule::IsSpatialOSCloudNetworkingChecked() const
 {
 	const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>();
 	return SpatialGDKEditorSettings->SpatialOSNetFlowType == ESpatialOSNetFlow::SpatialOSCloudNetworking;
+}
+
+bool FSpatialGDKEditorToolbarModule::IsSpatialOSNetFlowCanChange() const
+{
+	return OnIsSpatialNetworkingEnabled() && !(LocalDeploymentManager->IsLocalDeploymentRunning());
 }
 
 void FSpatialGDKEditorToolbarModule::UnrealNativeNetworkingClicked() const

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarCommands.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarCommands.cpp
@@ -20,7 +20,7 @@ void FSpatialGDKEditorToolbarCommands::RegisterCommands()
 	UI_COMMAND(EnableSpatialNetworking, "Spatial Networking", "If checked, the SpatialOS networking is used. Otherwise, native Unreal networking is used.", EUserInterfaceActionType::ToggleButton, FInputChord());
 	UI_COMMAND(GDKEditorSettings, "Editor Settings", "Open the SpatialOS GDK Editor Settings", EUserInterfaceActionType::Button, FInputChord());
 	UI_COMMAND(UnrealNativeNetworking, "Do not connect", "Don't connect automatically using SpatialOS", EUserInterfaceActionType::RadioButton, FInputChord());
-	UI_COMMAND(SpatialOSLocalNetworking, "SpatialOS Local Networking", "Connect to spatial local deployment", EUserInterfaceActionType::RadioButton, FInputChord());
+	UI_COMMAND(SpatialOSLocalNetworking, "Connect to local deployment", "Automatically connect to a local deployment", EUserInterfaceActionType::RadioButton, FInputChord());
 	UI_COMMAND(SpatialOSCloudNetworking, "SpatialOS Cloud Networking", "Connect to spatial cloud deployment", EUserInterfaceActionType::RadioButton, FInputChord());
 }
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarCommands.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarCommands.cpp
@@ -17,6 +17,11 @@ void FSpatialGDKEditorToolbarCommands::RegisterCommands()
 	UI_COMMAND(OpenLaunchConfigurationEditorAction, "Create Launch Configuration", "Opens an editor to create SpatialOS Launch configurations", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(StartSpatialService, "Start Service", "Starts the Spatial service daemon.", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(StopSpatialService, "Stop Service", "Stops the Spatial service daemon.", EUserInterfaceActionType::Button, FInputGesture());
+	UI_COMMAND(EnableSpatialNetworking, "Spatial Networking", "If checked, the SpatialOS networking is used. Otherwise, native Unreal networking is used.", EUserInterfaceActionType::ToggleButton, FInputChord());
+	UI_COMMAND(GDKEditorSettings, "Editor Settings", "Open the SpatialOS GDK Editor Settings", EUserInterfaceActionType::Button, FInputChord());
+	UI_COMMAND(UnrealNativeNetworking, "Unreal Native Networking", "Use standard Unreal native networking flow", EUserInterfaceActionType::RadioButton, FInputChord());
+	UI_COMMAND(SpatialOSLocalNetworking, "SpatialOS Local Networking", "Connect to spatial local deployment", EUserInterfaceActionType::RadioButton, FInputChord());
+	UI_COMMAND(SpatialOSCloudNetworking, "SpatialOS Cloud Networking", "Connect to spatial cloud deployment", EUserInterfaceActionType::RadioButton, FInputChord());
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarCommands.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarCommands.cpp
@@ -19,7 +19,7 @@ void FSpatialGDKEditorToolbarCommands::RegisterCommands()
 	UI_COMMAND(StopSpatialService, "Stop Service", "Stops the Spatial service daemon.", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(EnableSpatialNetworking, "Spatial Networking", "If checked, the SpatialOS networking is used. Otherwise, native Unreal networking is used.", EUserInterfaceActionType::ToggleButton, FInputChord());
 	UI_COMMAND(GDKEditorSettings, "Editor Settings", "Open the SpatialOS GDK Editor Settings", EUserInterfaceActionType::Button, FInputChord());
-	UI_COMMAND(UnrealNativeNetworking, "Unreal Native Networking", "Use standard Unreal native networking flow", EUserInterfaceActionType::RadioButton, FInputChord());
+	UI_COMMAND(UnrealNativeNetworking, "Do not connect", "Don't connect automatically using SpatialOS", EUserInterfaceActionType::RadioButton, FInputChord());
 	UI_COMMAND(SpatialOSLocalNetworking, "SpatialOS Local Networking", "Connect to spatial local deployment", EUserInterfaceActionType::RadioButton, FInputChord());
 	UI_COMMAND(SpatialOSCloudNetworking, "SpatialOS Cloud Networking", "Connect to spatial cloud deployment", EUserInterfaceActionType::RadioButton, FInputChord());
 }

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -75,6 +75,19 @@ private:
 	bool StopSpatialServiceIsVisible() const;
 	bool StopSpatialServiceCanExecute() const;
 
+	void OnToggleSpatialNetworking();
+	bool OnIsSpatialNetworkingEnabled() const;
+
+	void GDKEditorSettingsClicked() const;
+	bool IsUnrealNativeNetworkingChecked() const;
+	bool IsSpatialOSLocalNetworkingChecked() const;
+	bool IsSpatialOSCloudNetworkingChecked() const;
+	void UnrealNativeNetworkingClicked() const;
+	void SpatialOSLocalNetworkingClicked() const;
+	void SpatialOSCloudNetworkingClicked() const;
+	bool IsLocalDeploymentIPEditable() const;
+	bool IsCloudDeploymentNameEditable() const;
+
 	void LaunchInspectorWebpageButtonClicked();
 	void CreateSnapshotButtonClicked();
 	void SchemaGenerateButtonClicked();
@@ -91,6 +104,7 @@ private:
 
 	TSharedRef<SWidget> CreateGenerateSchemaMenuContent();
 	TSharedRef<SWidget> CreateLaunchDeploymentMenuContent();
+	TSharedRef<SWidget> CreateStartDropDownMenuContent();
 
 	void ShowTaskStartNotification(const FString& NotificationText);
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -82,6 +82,7 @@ private:
 	bool IsUnrealNativeNetworkingChecked() const;
 	bool IsSpatialOSLocalNetworkingChecked() const;
 	bool IsSpatialOSCloudNetworkingChecked() const;
+	bool IsSpatialOSNetFlowCanChange() const;
 	void UnrealNativeNetworkingClicked() const;
 	void SpatialOSLocalNetworkingClicked() const;
 	void SpatialOSCloudNetworkingClicked() const;

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbarCommands.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbarCommands.h
@@ -33,4 +33,9 @@ public:
 
 	TSharedPtr<FUICommandInfo> StartSpatialService;
 	TSharedPtr<FUICommandInfo> StopSpatialService;
+	TSharedPtr<FUICommandInfo> EnableSpatialNetworking;
+	TSharedPtr<FUICommandInfo> GDKEditorSettings;
+	TSharedPtr<FUICommandInfo> UnrealNativeNetworking;
+	TSharedPtr<FUICommandInfo> SpatialOSLocalNetworking;
+	TSharedPtr<FUICommandInfo> SpatialOSCloudNetworking;
 };

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
@@ -1,5 +1,8 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
+#include "Logging/LogMacros.h"
+#include "Misc/MessageDialog.h"
+#include "Serialization/JsonSerializer.h"
 #include "SpatialCommandUtils.h"
 #include "SpatialGDKServicesConstants.h"
 #include "SpatialGDKServicesModule.h"
@@ -139,4 +142,58 @@ FProcHandle SpatialCommandUtils::LocalWorkerReplace(const FString& ServicePort, 
 
 	return FPlatformProcess::CreateProc(*SpatialGDKServicesConstants::SpatialExe, *Command, false, true, true, OutProcessID, 2 /*PriorityModifier*/,
 		nullptr, nullptr, nullptr);
+}
+
+bool SpatialCommandUtils::GenerateDevAuthToken(bool IsRunningInChina, FString& OutTokenSecret)
+{
+	FString Arguments = TEXT("project auth dev-auth-token create --description=\"Unreal GDK Token\" --json_output");
+	if (IsRunningInChina)
+	{
+		Arguments += TEXT(" --environment cn-production");
+	}
+
+	FString CreateDevAuthTokenResult;
+	int32 ExitCode;
+	FSpatialGDKServicesModule::ExecuteAndReadOutput(SpatialGDKServicesConstants::SpatialExe, Arguments, SpatialGDKServicesConstants::SpatialOSDirectory, CreateDevAuthTokenResult, ExitCode);
+
+	if (ExitCode != 0)
+	{
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to generate a development authentication token. Result: %s"), *CreateDevAuthTokenResult)));
+		return false;
+	};
+
+	FString AuthResult;
+	FString DevAuthTokenResult;
+	bool bFoundNewline = CreateDevAuthTokenResult.TrimEnd().Split(TEXT("\n"), &AuthResult, &DevAuthTokenResult, ESearchCase::IgnoreCase, ESearchDir::FromEnd);
+	if (!bFoundNewline || DevAuthTokenResult.IsEmpty())
+	{
+		// This is necessary because depending on whether you are already authenticated against spatial, it will either return two json structs or one.
+		DevAuthTokenResult = CreateDevAuthTokenResult;
+	}
+
+	TSharedRef<TJsonReader<TCHAR>> JsonReader = TJsonReaderFactory<TCHAR>::Create(DevAuthTokenResult);
+	TSharedPtr<FJsonObject> JsonRootObject;
+	if (!(FJsonSerializer::Deserialize(JsonReader, JsonRootObject) && JsonRootObject.IsValid()))
+	{
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to parse the received development authentication token. Result: %s"), *DevAuthTokenResult)));
+		return false;
+	}
+
+	// We need a pointer to a shared pointer due to how the JSON API works.
+	const TSharedPtr<FJsonObject>* JsonDataObject;
+	if (!(JsonRootObject->TryGetObjectField("json_data", JsonDataObject)))
+	{
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to parse the received json data. Result: %s"), *DevAuthTokenResult)));
+		return false;
+	}
+
+	FString TokenSecret;
+	if (!(*JsonDataObject)->TryGetStringField("token_secret", TokenSecret))
+	{
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to parse the token_secret field inside the received json data. Result: %s"), *DevAuthTokenResult)));
+		return false;
+	}
+
+	OutTokenSecret = TokenSecret;
+	return true;
 }

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
@@ -16,5 +16,5 @@ public:
 	SPATIALGDKSERVICES_API static bool StopSpatialService(bool bIsRunningInChina, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode);
 	SPATIALGDKSERVICES_API static bool BuildWorkerConfig(bool bIsRunningInChina, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode);
 	SPATIALGDKSERVICES_API static FProcHandle LocalWorkerReplace(const FString& ServicePort, const FString& OldWorker, const FString& NewWorker, bool bIsRunningInChina, uint32* OutProcessID);
-
+	SPATIALGDKSERVICES_API static bool GenerateDevAuthToken(bool IsRunningInChina, FString& OutTokenSecret);
 };


### PR DESCRIPTION
#### Description
* Add Spatial Networking checkbox in 'start' toolbar button dropdown menu.
* Add a dropdown for selecting which connection flow: Native, Local, Cloud.
    The Connection field should show which one is currently selected.
    If a local deployment is running, disable changing the flow.
* Add a Local Deployment IP field which is editable. 
* Add a Cloud Deployment Name field which is editable.
* If Local is selected: 
    Disable “Cloud Deployment Name”.
    Take the Local Deployment IP as the runtime IP when starting the deployment.
* If Cloud is selected: 
    Disable “Local Deployment IP”
    Prepare a dev auth token. 
* If Native is selected: disable both fields
* Add a field / link to the Editor settings

New UI looks like the following picture:
![image](https://user-images.githubusercontent.com/5253969/79981031-95d73c00-84d6-11ea-9a5f-246961d22f87.png)

Todo: update the changelog file.