### PR TITLE
Feature/unr 3311 open console page

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -250,6 +250,9 @@ const FString LOCATOR_HOST    = TEXT("locator.improbable.io");
 const FString LOCATOR_HOST_CN = TEXT("locator.spatialoschina.com");
 const uint16 LOCATOR_PORT     = 443;
 
+const FString CONSOLE_HOST    = TEXT("console.improbable.io");
+const FString CONSOLE_HOST_CN = TEXT("console.spatialoschina.com");
+
 const FString AssemblyPattern   = TEXT("^[a-zA-Z0-9_.-]{5,64}$");
 const FString ProjectPattern    = TEXT("^[a-z0-9_]{3,32}$");
 const FString DeploymentPattern = TEXT("^[a-z0-9_]{2,32}$");

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -1120,4 +1120,3 @@ bool SSpatialGDKSimulatedPlayerDeployment::CanOpenCloudDeploymentPage() const
 
 	return true;
 }
-

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -1095,7 +1095,7 @@ FReply SSpatialGDKSimulatedPlayerDeployment::OnOpenCloudDeploymentPageClicked()
 	FString WebError;
 	FString ProjectName = FSpatialGDKServicesModule::GetProjectName();
 	bool bChina = GetDefault<USpatialGDKSettings>()->IsRunningInChina();
-	FString Url = bChina ? FString::Printf(TEXT("https://console.spatialoschina.com/projects/%s"), *ProjectName) : FString::Printf(TEXT("https://console.improbable.io/projects/%s"), *ProjectName);
+	FString Url = bChina ? FString::Printf(TEXT("https://%s/projects/%s"), *SpatialConstants::CONSOLE_HOST_CN, *ProjectName) : FString::Printf(TEXT("https://%s/projects/%s"), *SpatialConstants::CONSOLE_HOST, *ProjectName);
 	FPlatformProcess::LaunchURL(*Url, TEXT(""), &WebError);
 	if (!WebError.IsEmpty())
 	{

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -600,9 +600,9 @@ void SSpatialGDKSimulatedPlayerDeployment::Construct(const FArguments& InArgs)
 								SNew(SHorizontalBox)
 								+ SHorizontalBox::Slot()
 								.FillWidth(1.0f)
-								.HAlign(HAlign_Right)
+								.HAlign(HAlign_Left)
 								[
-									// Launch Simulated Players Deployment Button
+									// Open Deployment Page 
 									SNew(SUniformGridPanel)
 									.SlotPadding(FMargin(2.0f, 20.0f, 0.0f, 0.0f))
 									+ SUniformGridPanel::Slot(0, 0)
@@ -613,6 +613,14 @@ void SSpatialGDKSimulatedPlayerDeployment::Construct(const FArguments& InArgs)
 										.OnClicked(this, &SSpatialGDKSimulatedPlayerDeployment::OnOpenCloudDeploymentPageClicked)
 										.IsEnabled(this, &SSpatialGDKSimulatedPlayerDeployment::CanOpenCloudDeploymentPage)
 									]
+								]
+								+ SHorizontalBox::Slot()
+								.FillWidth(1.0f)
+								.HAlign(HAlign_Right)
+								[
+									// Launch Simulated Players Deployment Button
+									SNew(SUniformGridPanel)
+									.SlotPadding(FMargin(2.0f, 20.0f, 0.0f, 0.0f))
 									+ SUniformGridPanel::Slot(1, 0)
 									[
 										SNew(SButton)

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -609,6 +609,14 @@ void SSpatialGDKSimulatedPlayerDeployment::Construct(const FArguments& InArgs)
 									[
 										SNew(SButton)
 										.HAlign(HAlign_Center)
+										.Text(FText::FromString(FString(TEXT("Open Deployment Page"))))
+										.OnClicked(this, &SSpatialGDKSimulatedPlayerDeployment::OnOpenCloudDeploymentPageClicked)
+										.IsEnabled(this, &SSpatialGDKSimulatedPlayerDeployment::CanOpenCloudDeploymentPage)
+									]
+									+ SUniformGridPanel::Slot(1, 0)
+									[
+										SNew(SButton)
+										.HAlign(HAlign_Center)
 										.Text(FText::FromString(FString(TEXT("Launch Deployment"))))
 										.OnClicked(this, &SSpatialGDKSimulatedPlayerDeployment::OnLaunchClicked)
 										.IsEnabled(this, &SSpatialGDKSimulatedPlayerDeployment::CanLaunchDeployment)
@@ -1081,3 +1089,35 @@ bool SSpatialGDKSimulatedPlayerDeployment::CanLaunchDeployment() const
 {
 	return IsDeploymentConfigurationValid() && CanBuildAndUpload();
 }
+
+FReply SSpatialGDKSimulatedPlayerDeployment::OnOpenCloudDeploymentPageClicked()
+{
+	FString WebError;
+	FString ProjectName = FSpatialGDKServicesModule::GetProjectName();
+	bool bChina = GetDefault<USpatialGDKSettings>()->IsRunningInChina();
+	FString Url = bChina ? FString::Printf(TEXT("https://console.spatialoschina.com/projects/%s"), *ProjectName) : FString::Printf(TEXT("https://console.improbable.io/projects/%s"), *ProjectName);
+	FPlatformProcess::LaunchURL(*Url, TEXT(""), &WebError);
+	if (!WebError.IsEmpty())
+	{
+		FNotificationInfo Info(FText::FromString(WebError));
+		Info.ExpireDuration = 3.0f;
+		Info.bUseSuccessFailIcons = true;
+		TSharedPtr<SNotificationItem> NotificationItem = FSlateNotificationManager::Get().AddNotification(Info);
+		NotificationItem->SetCompletionState(SNotificationItem::CS_Fail);
+		NotificationItem->ExpireAndFadeout();
+	}
+
+	return FReply::Handled();
+}
+
+bool SSpatialGDKSimulatedPlayerDeployment::CanOpenCloudDeploymentPage() const
+{
+	FString ProjectName = FSpatialGDKServicesModule::GetProjectName();
+	if (ProjectName.IsEmpty())
+	{
+		return false;
+	}
+
+	return true;
+}
+

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -1121,5 +1121,5 @@ FReply SSpatialGDKSimulatedPlayerDeployment::OnOpenCloudDeploymentPageClicked()
 
 bool SSpatialGDKSimulatedPlayerDeployment::CanOpenCloudDeploymentPage() const
 {
-	return FSpatialGDKServicesModule::GetProjectName().IsEmpty() ? false : true;
+	return !FSpatialGDKServicesModule::GetProjectName().IsEmpty();
 }

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -1105,6 +1105,7 @@ FReply SSpatialGDKSimulatedPlayerDeployment::OnOpenCloudDeploymentPageClicked()
 		TSharedPtr<SNotificationItem> NotificationItem = FSlateNotificationManager::Get().AddNotification(Info);
 		NotificationItem->SetCompletionState(SNotificationItem::CS_Fail);
 		NotificationItem->ExpireAndFadeout();
+		return FReply::Unhandled();
 	}
 
 	return FReply::Handled();
@@ -1112,11 +1113,5 @@ FReply SSpatialGDKSimulatedPlayerDeployment::OnOpenCloudDeploymentPageClicked()
 
 bool SSpatialGDKSimulatedPlayerDeployment::CanOpenCloudDeploymentPage() const
 {
-	FString ProjectName = FSpatialGDKServicesModule::GetProjectName();
-	if (ProjectName.IsEmpty())
-	{
-		return false;
-	}
-
-	return true;
+	return FSpatialGDKServicesModule::GetProjectName().IsEmpty() ? false : true;
 }

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKSimulatedPlayerDeployment.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKSimulatedPlayerDeployment.h
@@ -133,4 +133,7 @@ private:
 	void OnBuildSuccess();
 
 	bool CanLaunchDeployment() const;
+
+	FReply OnOpenCloudDeploymentPageClicked();
+	bool CanOpenCloudDeploymentPage() const;
 };


### PR DESCRIPTION
#### Description
Add a button that can open a new page to our deployment page in spatialos console
![image](https://user-images.githubusercontent.com/61775315/80091090-1c515380-8593-11ea-841f-5051d57b5110.png)


#### Release note
TODO: Update CHANGELOG.md

#### Tests
Fill the necessary fields in the could deployment menu, click the button see if it works

Change To CN Platform
Change the region setting in SpatialOS Runtime Settings => Region Settings, change it to CN
Change the project name to the corresponding name in your China platform
Reboot your UE editor
Goto deploy menu, Click the button see if it can jump to China deployment page

STRONGLY SUGGESTED: Try this button on different platform (CN and non-CN)

#### Documentation
TODO: Update documentation

#### Primary reviewers
@jayprobable @raymonwang @jessicafalk @improbable-valentyn 
