### PR TITLE
UNR-3300 Automatically pass in dev auth token when using mobile PIE flow to connect to spatial cloud deployment.(GDK part)

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -2,6 +2,7 @@
 
 #include "SpatialGDKEditorModule.h"
 
+#include "GeneralProjectSettings.h"
 #include "SpatialGDKSettings.h"
 #include "SpatialGDKEditorSettings.h"
 #include "SpatialGDKEditorLayoutDetails.h"
@@ -49,6 +50,16 @@ int FSpatialGDKEditorModule::GetSpatialOSNetFlowType() const
 {
 	const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>();
 	return SpatialGDKEditorSettings->SpatialOSNetFlowType;
+}
+
+bool FSpatialGDKEditorModule::ShouldConnectToCloudDeployment() const
+{
+	return GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking() && GetDefault<USpatialGDKEditorSettings>()->SpatialOSNetFlowType == ESpatialOSNetFlow::CloudDeployment;
+}
+
+FString FSpatialGDKEditorModule::GetDevAuthToken() const
+{
+	return GetDefault<USpatialGDKEditorSettings>()->DevelopmentAuthenticationToken;
 }
 
 void FSpatialGDKEditorModule::RegisterSettings()

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -40,6 +40,11 @@ void FSpatialGDKEditorModule::ShutdownModule()
 	}
 }
 
+FString FSpatialGDKEditorModule::GetSpatialOSCloudDeploymentName() const
+{
+	return GetDefault<USpatialGDKEditorSettings>()->DevelopmentDeploymentToConnect;
+}
+
 FString FSpatialGDKEditorModule::GetSpatialOSLocalDeploymentIP() const
 {
 	const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>();

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
@@ -23,6 +23,7 @@ public:
 	}
 
 protected:
+	virtual FString GetSpatialOSCloudDeploymentName() const override;
 	virtual FString GetSpatialOSLocalDeploymentIP() const override;
 	virtual int GetSpatialOSNetFlowType() const override;
 	virtual bool ShouldConnectToCloudDeployment() const override;

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
@@ -25,6 +25,8 @@ public:
 protected:
 	virtual FString GetSpatialOSLocalDeploymentIP() const override;
 	virtual int GetSpatialOSNetFlowType() const override;
+	virtual bool ShouldConnectToCloudDeployment() const override;
+	virtual FString GetDevAuthToken() const override;
 
 private:
 	void RegisterSettings();


### PR DESCRIPTION
#### Description
According to our documentation, we need to right now pass in the dev auth token manually for the mobile previewer flow.
In this PR, we changed this. If we connect to a cloud deployment, we automatically pass dev auth token in as a command line arg.

#### Tests
- Start a cloud deployment first.
- Select `connect to cloud deployment` in new Start drop down menu. This will prepare a dev auth token automatically.
![image](https://user-images.githubusercontent.com/5253969/80303955-e5bf4700-87e5-11ea-913c-5373aa33f782.png)

- Click `Mobile Preview(PIE)` to start a client, it will use the above dev auth token to connect to cloud deployment.

#### Documentation
TODO: Need to update document.
