### PR TITLE
Feature/UNR-3291

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Added `OnPlayerSpawnFailed` delegate to `SpatialGameInstance`. This is helpful if you have established a successful connection but the server worker crashed. `OnConnected` and `OnConnectionFailed` are now also blueprint-assignable.
 - `Launch Deployment` in the `Cloud Deployment` dialog will now generate schema, generate a snapshot, build the server worker, build the client, build the simulate player worker, and upload the assembly before launching the deployment all in one step, there are checkboxes to toggle generation of schema and snapshots as well as whether to build the client worker.
 - You can now edit the project name field in the `Cloud Deployment` window.
-- Change icon of 'start' toolbar button based on selected connection flow
+- Change the icon of the 'Start' toolbar button based on the selected connection flow.
 - Created a new dropdown menu in the Start toolbar button. This dropdown menu allows you to configure how to connect your PIE client or your Launch on Device client
   - You can choose between `Connect to local deployment`, `Connect to cloud deployment` and `Do not connect` to specify the flow the client should automatically take upon clicking the Play or the Launch button.
   - Added the `Local Deployment IP` field to specify which local deployment you want to connect to. By default, this will be `127.0.0.1`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Added `OnPlayerSpawnFailed` delegate to `SpatialGameInstance`. This is helpful if you have established a successful connection but the server worker crashed. `OnConnected` and `OnConnectionFailed` are now also blueprint-assignable.
 - `Launch Deployment` in the `Cloud Deployment` dialog will now generate schema, generate a snapshot, build the server worker, build the client, build the simulate player worker, and upload the assembly before launching the deployment all in one step, there are checkboxes to toggle generation of schema and snapshots as well as whether to build the client worker.
 - You can now edit the project name field in the `Cloud Deployment` window.
+- Change icon of 'start' toolbar button based on selected connection flow
 
 ## Bug fixes:
 - Fixed a bug that caused queued RPCs to spam logs when an entity is deleted.

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -200,11 +200,11 @@ void FSpatialGDKEditorToolbarModule::MapActions(TSharedPtr<class FUICommandList>
 		FCanExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::CanExecuteSnapshotGenerator));
 
 	InPluginCommands->MapAction(
-		FSpatialGDKEditorToolbarCommands::Get().StartNativeUnrealNetwork,
-		FExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartUnrealNativeNetworkingButtonClicked),
-		FCanExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartUnrealNativeNetworkingCanExecute),
+		FSpatialGDKEditorToolbarCommands::Get().StartNoAutomaticConnection,
+		FExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartNoAutomaticConnectionButtonClicked),
+		FCanExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartNoAutomaticConnectionCanExecute),
 		FIsActionChecked(),
-		FIsActionButtonVisible::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartUnrealNativeNetworkingIsVisible));
+		FIsActionButtonVisible::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartNoAutomaticConnectionIsVisible));
 
 	InPluginCommands->MapAction(
 		FSpatialGDKEditorToolbarCommands::Get().StartLocalSpatialDeployment,
@@ -315,7 +315,7 @@ void FSpatialGDKEditorToolbarModule::AddMenuExtension(FMenuBuilder& Builder)
 	{
 		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().CreateSpatialGDKSchema);
 		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().CreateSpatialGDKSnapshot);
-		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().StartNativeUnrealNetwork);
+		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().StartNoAutomaticConnection);
 		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().StartLocalSpatialDeployment);
 		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().StartCloudSpatialDeployment);
 		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().StopSpatialDeployment);
@@ -342,7 +342,7 @@ void FSpatialGDKEditorToolbarModule::AddToolbarExtension(FToolBarBuilder& Builde
 		true
 	);
 	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().CreateSpatialGDKSnapshot);
-	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().StartNativeUnrealNetwork);
+	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().StartNoAutomaticConnection);
 	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().StartLocalSpatialDeployment);
 	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().StartCloudSpatialDeployment);
 	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().StopSpatialDeployment);
@@ -817,7 +817,7 @@ void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment()
 	});
 }
 
-void FSpatialGDKEditorToolbarModule::StartUnrealNativeNetworkingButtonClicked()
+void FSpatialGDKEditorToolbarModule::StartNoAutomaticConnectionButtonClicked()
 {
 	//Do nothing
 }
@@ -881,12 +881,12 @@ void FSpatialGDKEditorToolbarModule::LaunchInspectorWebpageButtonClicked()
 	}
 }
 
-bool FSpatialGDKEditorToolbarModule::StartUnrealNativeNetworkingIsVisible() const
+bool FSpatialGDKEditorToolbarModule::StartNoAutomaticConnectionIsVisible() const
 {
 	return GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking() && GetDefault<USpatialGDKEditorSettings>()->SpatialOSNetFlowType == ESpatialOSNetFlow::NoAutomaticConnection;
 }
 
-bool FSpatialGDKEditorToolbarModule::StartUnrealNativeNetworkingCanExecute() const
+bool FSpatialGDKEditorToolbarModule::StartNoAutomaticConnectionCanExecute() const
 {
 	return GetDefault<USpatialGDKEditorSettings>()->SpatialOSNetFlowType == ESpatialOSNetFlow::NoAutomaticConnection;
 }

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -865,7 +865,8 @@ void FSpatialGDKEditorToolbarModule::LaunchInspectorWebpageButtonClicked()
 
 bool FSpatialGDKEditorToolbarModule::StartNoAutomaticConnectionIsVisible() const
 {
-	return GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking() && GetDefault<USpatialGDKEditorSettings>()->SpatialOSNetFlowType == ESpatialOSNetFlow::NoAutomaticConnection;
+	auto settings = GetDefault<UGeneralProjectSettings>();
+	return (false == settings->UsesSpatialNetworking()) || GetDefault<USpatialGDKEditorSettings>()->SpatialOSNetFlowType == ESpatialOSNetFlow::NoAutomaticConnection;
 }
 
 bool FSpatialGDKEditorToolbarModule::StartNoAutomaticConnectionCanExecute() const

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -200,11 +200,11 @@ void FSpatialGDKEditorToolbarModule::MapActions(TSharedPtr<class FUICommandList>
 		FCanExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::CanExecuteSnapshotGenerator));
 
 	InPluginCommands->MapAction(
-		FSpatialGDKEditorToolbarCommands::Get().StartNativeUnrealDeployment,
-		FExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartNativeUnrealDeploymentButtonClicked),
-		FCanExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartNativeUnrealDeploymentCanExecute),
+		FSpatialGDKEditorToolbarCommands::Get().StartNativeUnrealNetwork,
+		FExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartUnrealNativeNetworkingButtonClicked),
+		FCanExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartUnrealNativeNetworkingCanExecute),
 		FIsActionChecked(),
-		FIsActionButtonVisible::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartNativeUnrealDeploymentIsVisible));
+		FIsActionButtonVisible::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartUnrealNativeNetworkingIsVisible));
 
 	InPluginCommands->MapAction(
 		FSpatialGDKEditorToolbarCommands::Get().StartLocalSpatialDeployment,
@@ -315,7 +315,7 @@ void FSpatialGDKEditorToolbarModule::AddMenuExtension(FMenuBuilder& Builder)
 	{
 		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().CreateSpatialGDKSchema);
 		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().CreateSpatialGDKSnapshot);
-		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().StartNativeUnrealDeployment);
+		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().StartNativeUnrealNetwork);
 		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().StartLocalSpatialDeployment);
 		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().StartCloudSpatialDeployment);
 		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().StopSpatialDeployment);
@@ -342,7 +342,7 @@ void FSpatialGDKEditorToolbarModule::AddToolbarExtension(FToolBarBuilder& Builde
 		true
 	);
 	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().CreateSpatialGDKSnapshot);
-	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().StartNativeUnrealDeployment);
+	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().StartNativeUnrealNetwork);
 	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().StartLocalSpatialDeployment);
 	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().StartCloudSpatialDeployment);
 	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().StopSpatialDeployment);
@@ -818,7 +818,7 @@ void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment()
 	});
 }
 
-void FSpatialGDKEditorToolbarModule::StartNativeUnrealDeploymentButtonClicked()
+void FSpatialGDKEditorToolbarModule::StartUnrealNativeNetworkingButtonClicked()
 {
 
 }
@@ -864,12 +864,12 @@ void FSpatialGDKEditorToolbarModule::LaunchInspectorWebpageButtonClicked()
 	}
 }
 
-bool FSpatialGDKEditorToolbarModule::StartNativeUnrealDeploymentIsVisible() const
+bool FSpatialGDKEditorToolbarModule::StartUnrealNativeNetworkingIsVisible() const
 {
 	return GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking() && GetDefault<USpatialGDKEditorSettings>()->SpatialOSNetFlowType == ESpatialOSNetFlow::UnrealNativeNetworking;
 }
 
-bool FSpatialGDKEditorToolbarModule::StartNativeUnrealDeploymentCanExecute() const
+bool FSpatialGDKEditorToolbarModule::StartUnrealNativeNetworkingCanExecute() const
 {
 	return GetDefault<USpatialGDKEditorSettings>()->SpatialOSNetFlowType == ESpatialOSNetFlow::UnrealNativeNetworking;
 }

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -865,8 +865,7 @@ void FSpatialGDKEditorToolbarModule::LaunchInspectorWebpageButtonClicked()
 
 bool FSpatialGDKEditorToolbarModule::StartNoAutomaticConnectionIsVisible() const
 {
-	auto settings = GetDefault<UGeneralProjectSettings>();
-	return (false == settings->UsesSpatialNetworking()) || GetDefault<USpatialGDKEditorSettings>()->SpatialOSNetFlowType == ESpatialOSNetFlow::NoAutomaticConnection;
+	return (!GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking()) || GetDefault<USpatialGDKEditorSettings>()->SpatialOSNetFlowType == ESpatialOSNetFlow::NoAutomaticConnection;
 }
 
 bool FSpatialGDKEditorToolbarModule::StartNoAutomaticConnectionCanExecute() const

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -820,7 +820,7 @@ void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment()
 
 void FSpatialGDKEditorToolbarModule::StartUnrealNativeNetworkingButtonClicked()
 {
-
+	//Do nothing
 }
 
 void FSpatialGDKEditorToolbarModule::StartLocalSpatialDeploymentButtonClicked()
@@ -830,7 +830,25 @@ void FSpatialGDKEditorToolbarModule::StartLocalSpatialDeploymentButtonClicked()
 
 void FSpatialGDKEditorToolbarModule::StartCloudSpatialDeploymentButtonClicked()
 {
+	// Create and open the cloud configuration dialog
+	SimulatedPlayerDeploymentWindowPtr = SNew(SWindow)
+		.Title(LOCTEXT("SimulatedPlayerConfigurationTitle", "Cloud Deployment"))
+		.HasCloseButton(true)
+		.SupportsMaximize(false)
+		.SupportsMinimize(false)
+		.SizingRule(ESizingRule::Autosized);
 
+	SimulatedPlayerDeploymentWindowPtr->SetContent(
+		SNew(SBox)
+		.WidthOverride(700.0f)
+		[
+			SAssignNew(SimulatedPlayerDeploymentConfigPtr, SSpatialGDKSimulatedPlayerDeployment)
+			.SpatialGDKEditor(SpatialGDKEditorInstance)
+		.ParentWindow(SimulatedPlayerDeploymentWindowPtr)
+		]
+	);
+
+	FSlateApplication::Get().AddWindow(SimulatedPlayerDeploymentWindowPtr.ToSharedRef());
 }
 
 void FSpatialGDKEditorToolbarModule::StopSpatialDeploymentButtonClicked()
@@ -898,7 +916,7 @@ bool FSpatialGDKEditorToolbarModule::StartCloudSpatialDeploymentIsVisible() cons
 
 bool FSpatialGDKEditorToolbarModule::StartCloudSpatialDeploymentCanExecute() const
 {
-	return false;
+	return true;
 }
 
 bool FSpatialGDKEditorToolbarModule::StopSpatialDeploymentIsVisible() const

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -200,11 +200,25 @@ void FSpatialGDKEditorToolbarModule::MapActions(TSharedPtr<class FUICommandList>
 		FCanExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::CanExecuteSnapshotGenerator));
 
 	InPluginCommands->MapAction(
-		FSpatialGDKEditorToolbarCommands::Get().StartSpatialDeployment,
-		FExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartSpatialDeploymentButtonClicked),
-		FCanExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartSpatialDeploymentCanExecute),
+		FSpatialGDKEditorToolbarCommands::Get().StartNativeUnrealDeployment,
+		FExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartNativeUnrealDeploymentButtonClicked),
+		FCanExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartNativeUnrealDeploymentCanExecute),
 		FIsActionChecked(),
-		FIsActionButtonVisible::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartSpatialDeploymentIsVisible));
+		FIsActionButtonVisible::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartNativeUnrealDeploymentIsVisible));
+
+	InPluginCommands->MapAction(
+		FSpatialGDKEditorToolbarCommands::Get().StartLocalSpatialDeployment,
+		FExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartLocalSpatialDeploymentButtonClicked),
+		FCanExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartLocalSpatialDeploymentCanExecute),
+		FIsActionChecked(),
+		FIsActionButtonVisible::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartLocalSpatialDeploymentIsVisible));
+
+	InPluginCommands->MapAction(
+		FSpatialGDKEditorToolbarCommands::Get().StartCloudSpatialDeployment,
+		FExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartCloudSpatialDeploymentButtonClicked),
+		FCanExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartCloudSpatialDeploymentCanExecute),
+		FIsActionChecked(),
+		FIsActionButtonVisible::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartCloudSpatialDeploymentIsVisible));
 
 	InPluginCommands->MapAction(
 		FSpatialGDKEditorToolbarCommands::Get().StopSpatialDeployment,
@@ -301,7 +315,9 @@ void FSpatialGDKEditorToolbarModule::AddMenuExtension(FMenuBuilder& Builder)
 	{
 		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().CreateSpatialGDKSchema);
 		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().CreateSpatialGDKSnapshot);
-		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().StartSpatialDeployment);
+		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().StartNativeUnrealDeployment);
+		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().StartLocalSpatialDeployment);
+		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().StartCloudSpatialDeployment);
 		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().StopSpatialDeployment);
 		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().LaunchInspectorWebPageAction);
 #if PLATFORM_WINDOWS
@@ -326,7 +342,9 @@ void FSpatialGDKEditorToolbarModule::AddToolbarExtension(FToolBarBuilder& Builde
 		true
 	);
 	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().CreateSpatialGDKSnapshot);
-	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().StartSpatialDeployment);
+	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().StartNativeUnrealDeployment);
+	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().StartLocalSpatialDeployment);
+	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().StartCloudSpatialDeployment);
 	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().StopSpatialDeployment);
 	Builder.AddComboButton(
 		FUIAction(),
@@ -800,9 +818,19 @@ void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment()
 	});
 }
 
-void FSpatialGDKEditorToolbarModule::StartSpatialDeploymentButtonClicked()
+void FSpatialGDKEditorToolbarModule::StartNativeUnrealDeploymentButtonClicked()
+{
+
+}
+
+void FSpatialGDKEditorToolbarModule::StartLocalSpatialDeploymentButtonClicked()
 {
 	VerifyAndStartDeployment();
+}
+
+void FSpatialGDKEditorToolbarModule::StartCloudSpatialDeploymentButtonClicked()
+{
+
 }
 
 void FSpatialGDKEditorToolbarModule::StopSpatialDeploymentButtonClicked()
@@ -836,7 +864,22 @@ void FSpatialGDKEditorToolbarModule::LaunchInspectorWebpageButtonClicked()
 	}
 }
 
-bool FSpatialGDKEditorToolbarModule::StartSpatialDeploymentIsVisible() const
+bool FSpatialGDKEditorToolbarModule::StartNativeUnrealDeploymentIsVisible() const
+{
+	return GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking() && GetDefault<USpatialGDKEditorSettings>()->SpatialOSNetFlowType == ESpatialOSNetFlow::UnrealNativeNetworking;
+}
+
+bool FSpatialGDKEditorToolbarModule::StartNativeUnrealDeploymentCanExecute() const
+{
+	return GetDefault<USpatialGDKEditorSettings>()->SpatialOSNetFlowType == ESpatialOSNetFlow::UnrealNativeNetworking;
+}
+	 
+bool FSpatialGDKEditorToolbarModule::StartLocalSpatialDeploymentIsVisible() const
+{
+	return !LocalDeploymentManager->IsLocalDeploymentRunning() && GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking() && GetDefault<USpatialGDKEditorSettings>()->SpatialOSNetFlowType == ESpatialOSNetFlow::SpatialOSLocalNetworking;
+}
+
+bool FSpatialGDKEditorToolbarModule::StartLocalSpatialDeploymentCanExecute() const
 {
 	if (LocalDeploymentManager->IsSpatialServiceRunning())
 	{
@@ -847,10 +890,15 @@ bool FSpatialGDKEditorToolbarModule::StartSpatialDeploymentIsVisible() const
 		return true;
 	}
 }
-
-bool FSpatialGDKEditorToolbarModule::StartSpatialDeploymentCanExecute() const
+	 
+bool FSpatialGDKEditorToolbarModule::StartCloudSpatialDeploymentIsVisible() const
 {
-	return !LocalDeploymentManager->IsDeploymentStarting() && GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking() && GetDefault<USpatialGDKEditorSettings>()->SpatialOSNetFlowType == ESpatialOSNetFlow::SpatialOSLocalNetworking;
+	return GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking() && GetDefault<USpatialGDKEditorSettings>()->SpatialOSNetFlowType == ESpatialOSNetFlow::SpatialOSCloudNetworking;
+}
+
+bool FSpatialGDKEditorToolbarModule::StartCloudSpatialDeploymentCanExecute() const
+{
+	return false;
 }
 
 bool FSpatialGDKEditorToolbarModule::StopSpatialDeploymentIsVisible() const

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -870,7 +870,7 @@ bool FSpatialGDKEditorToolbarModule::StartNoAutomaticConnectionIsVisible() const
 
 bool FSpatialGDKEditorToolbarModule::StartNoAutomaticConnectionCanExecute() const
 {
-	return GetDefault<USpatialGDKEditorSettings>()->SpatialOSNetFlowType == ESpatialOSNetFlow::NoAutomaticConnection;
+	return false;
 }
 	 
 bool FSpatialGDKEditorToolbarModule::StartLocalSpatialDeploymentIsVisible() const

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -829,25 +829,7 @@ void FSpatialGDKEditorToolbarModule::StartLocalSpatialDeploymentButtonClicked()
 
 void FSpatialGDKEditorToolbarModule::StartCloudSpatialDeploymentButtonClicked()
 {
-	// Create and open the cloud configuration dialog
-	SimulatedPlayerDeploymentWindowPtr = SNew(SWindow)
-		.Title(LOCTEXT("SimulatedPlayerConfigurationTitle", "Cloud Deployment"))
-		.HasCloseButton(true)
-		.SupportsMaximize(false)
-		.SupportsMinimize(false)
-		.SizingRule(ESizingRule::Autosized);
-
-	SimulatedPlayerDeploymentWindowPtr->SetContent(
-		SNew(SBox)
-		.WidthOverride(700.0f)
-		[
-			SAssignNew(SimulatedPlayerDeploymentConfigPtr, SSpatialGDKSimulatedPlayerDeployment)
-			.SpatialGDKEditor(SpatialGDKEditorInstance)
-		.ParentWindow(SimulatedPlayerDeploymentWindowPtr)
-		]
-	);
-
-	FSlateApplication::Get().AddWindow(SimulatedPlayerDeploymentWindowPtr.ToSharedRef());
+	ShowSimulatedPlayerDeploymentDialog();
 }
 
 void FSpatialGDKEditorToolbarModule::StopSpatialDeploymentButtonClicked()

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarCommands.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarCommands.cpp
@@ -10,7 +10,9 @@ void FSpatialGDKEditorToolbarCommands::RegisterCommands()
 	UI_COMMAND(CreateSpatialGDKSchemaFull, "Schema (Full Scan)", "Creates SpatialOS Unreal GDK schema for all assets.", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(DeleteSchemaDatabase, "Delete schema database", "Deletes the scheme database file", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(CreateSpatialGDKSnapshot, "Snapshot", "Creates SpatialOS Unreal GDK snapshot.", EUserInterfaceActionType::Button, FInputGesture());
-	UI_COMMAND(StartSpatialDeployment, "Start", "Starts a local instance of SpatialOS.", EUserInterfaceActionType::Button, FInputGesture());
+	UI_COMMAND(StartNativeUnrealDeployment, "Start", "Start Unreal native network.", EUserInterfaceActionType::Button, FInputGesture());
+	UI_COMMAND(StartLocalSpatialDeployment, "Start", "Connect to local deployment service", EUserInterfaceActionType::Button, FInputGesture());
+	UI_COMMAND(StartCloudSpatialDeployment, "Start", "Connect to cloud SpatialOS service", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(StopSpatialDeployment, "Stop", "Stops SpatialOS.", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(LaunchInspectorWebPageAction, "Inspector", "Launches default web browser to SpatialOS Inspector.", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(OpenSimulatedPlayerConfigurationWindowAction, "Deploy", "Opens a configuration menu for cloud deployments.", EUserInterfaceActionType::Button, FInputGesture());

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarCommands.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarCommands.cpp
@@ -10,7 +10,7 @@ void FSpatialGDKEditorToolbarCommands::RegisterCommands()
 	UI_COMMAND(CreateSpatialGDKSchemaFull, "Schema (Full Scan)", "Creates SpatialOS Unreal GDK schema for all assets.", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(DeleteSchemaDatabase, "Delete schema database", "Deletes the scheme database file", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(CreateSpatialGDKSnapshot, "Snapshot", "Creates SpatialOS Unreal GDK snapshot.", EUserInterfaceActionType::Button, FInputGesture());
-	UI_COMMAND(StartNativeUnrealNetwork, "Start", "Start Unreal native network.", EUserInterfaceActionType::Button, FInputGesture());
+	UI_COMMAND(StartNoAutomaticConnection, "Start", "Not Automatic Connect to service", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(StartLocalSpatialDeployment, "Start", "Connect to local deployment service", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(StartCloudSpatialDeployment, "Start", "Connect to cloud SpatialOS service", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(StopSpatialDeployment, "Stop", "Stops SpatialOS.", EUserInterfaceActionType::Button, FInputGesture());

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarCommands.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarCommands.cpp
@@ -11,8 +11,8 @@ void FSpatialGDKEditorToolbarCommands::RegisterCommands()
 	UI_COMMAND(DeleteSchemaDatabase, "Delete schema database", "Deletes the scheme database file", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(CreateSpatialGDKSnapshot, "Snapshot", "Creates SpatialOS Unreal GDK snapshot.", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(StartNoAutomaticConnection, "Start", "Not Automatic Connect to service", EUserInterfaceActionType::Button, FInputGesture());
-	UI_COMMAND(StartLocalSpatialDeployment, "Start", "Connect to local deployment service", EUserInterfaceActionType::Button, FInputGesture());
-	UI_COMMAND(StartCloudSpatialDeployment, "Start", "Connect to cloud SpatialOS service", EUserInterfaceActionType::Button, FInputGesture());
+	UI_COMMAND(StartLocalSpatialDeployment, "Local", "Connect to local deployment service", EUserInterfaceActionType::Button, FInputGesture());
+	UI_COMMAND(StartCloudSpatialDeployment, "Cloud", "Connect to cloud SpatialOS service", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(StopSpatialDeployment, "Stop", "Stops SpatialOS.", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(LaunchInspectorWebPageAction, "Inspector", "Launches default web browser to SpatialOS Inspector.", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(OpenSimulatedPlayerConfigurationWindowAction, "Deploy", "Opens a configuration menu for cloud deployments.", EUserInterfaceActionType::Button, FInputGesture());

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarCommands.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarCommands.cpp
@@ -10,7 +10,7 @@ void FSpatialGDKEditorToolbarCommands::RegisterCommands()
 	UI_COMMAND(CreateSpatialGDKSchemaFull, "Schema (Full Scan)", "Creates SpatialOS Unreal GDK schema for all assets.", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(DeleteSchemaDatabase, "Delete schema database", "Deletes the scheme database file", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(CreateSpatialGDKSnapshot, "Snapshot", "Creates SpatialOS Unreal GDK snapshot.", EUserInterfaceActionType::Button, FInputGesture());
-	UI_COMMAND(StartNativeUnrealDeployment, "Start", "Start Unreal native network.", EUserInterfaceActionType::Button, FInputGesture());
+	UI_COMMAND(StartNativeUnrealNetwork, "Start", "Start Unreal native network.", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(StartLocalSpatialDeployment, "Start", "Connect to local deployment service", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(StartCloudSpatialDeployment, "Start", "Connect to cloud SpatialOS service", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(StopSpatialDeployment, "Stop", "Stops SpatialOS.", EUserInterfaceActionType::Button, FInputGesture());

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarStyle.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarStyle.cpp
@@ -61,11 +61,23 @@ TSharedRef<FSlateStyleSet> FSpatialGDKEditorToolbarStyle::Create()
 	Style->Set("SpatialGDKEditorToolbar.CreateSpatialGDKSchema.Small",
 		new IMAGE_BRUSH(TEXT("Schema@0.5x"), Icon20x20));
 
-	Style->Set("SpatialGDKEditorToolbar.StartSpatialDeployment",
+	Style->Set("SpatialGDKEditorToolbar.StartNativeUnrealDeployment",
 		new IMAGE_BRUSH(TEXT("Launch"), Icon40x40));
 
-	Style->Set("SpatialGDKEditorToolbar.StartSpatialDeployment.Small",
+	Style->Set("SpatialGDKEditorToolbar.StartNativeUnrealDeployment.Small",
 		new IMAGE_BRUSH(TEXT("Launch@0.5x"), Icon20x20));
+
+	Style->Set("SpatialGDKEditorToolbar.StartLocalSpatialDeployment",
+		new IMAGE_BRUSH(TEXT("Launch"), Icon40x40));
+
+	Style->Set("SpatialGDKEditorToolbar.StartLocalSpatialDeployment.Small",
+		new IMAGE_BRUSH(TEXT("Launch@0.5x"), Icon20x20));
+
+	Style->Set("SpatialGDKEditorToolbar.StartCloudSpatialDeployment",
+		new IMAGE_BRUSH(TEXT("Cloud"), Icon40x40));
+
+	Style->Set("SpatialGDKEditorToolbar.StartCloudSpatialDeployment.Small",
+		new IMAGE_BRUSH(TEXT("Cloud@0.5x"), Icon20x20));
 	
 	Style->Set("SpatialGDKEditorToolbar.StopSpatialDeployment",
 		new IMAGE_BRUSH(TEXT("Stop"), Icon40x40));

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarStyle.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarStyle.cpp
@@ -61,10 +61,10 @@ TSharedRef<FSlateStyleSet> FSpatialGDKEditorToolbarStyle::Create()
 	Style->Set("SpatialGDKEditorToolbar.CreateSpatialGDKSchema.Small",
 		new IMAGE_BRUSH(TEXT("Schema@0.5x"), Icon20x20));
 
-	Style->Set("SpatialGDKEditorToolbar.StartNativeUnrealDeployment",
+	Style->Set("SpatialGDKEditorToolbar.StartNoAutomaticConnection",
 		new IMAGE_BRUSH(TEXT("Launch"), Icon40x40));
 
-	Style->Set("SpatialGDKEditorToolbar.StartNativeUnrealDeployment.Small",
+	Style->Set("SpatialGDKEditorToolbar.StartNoAutomaticConnection.Small",
 		new IMAGE_BRUSH(TEXT("Launch@0.5x"), Icon20x20));
 
 	Style->Set("SpatialGDKEditorToolbar.StartLocalSpatialDeployment",

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -57,7 +57,7 @@ private:
 
 	void VerifyAndStartDeployment();
 
-	void StartNativeUnrealDeploymentButtonClicked();
+	void StartUnrealNativeNetworkingButtonClicked();
 	void StartLocalSpatialDeploymentButtonClicked();
 	void StartCloudSpatialDeploymentButtonClicked();
 	void StopSpatialDeploymentButtonClicked();
@@ -65,8 +65,8 @@ private:
 	void StartSpatialServiceButtonClicked();
 	void StopSpatialServiceButtonClicked();
 
-	bool StartNativeUnrealDeploymentIsVisible() const;
-	bool StartNativeUnrealDeploymentCanExecute() const;
+	bool StartUnrealNativeNetworkingIsVisible() const;
+	bool StartUnrealNativeNetworkingCanExecute() const;
 
 	bool StartLocalSpatialDeploymentIsVisible() const;
 	bool StartLocalSpatialDeploymentCanExecute() const;

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -57,7 +57,7 @@ private:
 
 	void VerifyAndStartDeployment();
 
-	void StartUnrealNativeNetworkingButtonClicked();
+	void StartNoAutomaticConnectionButtonClicked();
 	void StartLocalSpatialDeploymentButtonClicked();
 	void StartCloudSpatialDeploymentButtonClicked();
 	void StopSpatialDeploymentButtonClicked();
@@ -65,8 +65,8 @@ private:
 	void StartSpatialServiceButtonClicked();
 	void StopSpatialServiceButtonClicked();
 
-	bool StartUnrealNativeNetworkingIsVisible() const;
-	bool StartUnrealNativeNetworkingCanExecute() const;
+	bool StartNoAutomaticConnectionIsVisible() const;
+	bool StartNoAutomaticConnectionCanExecute() const;
 
 	bool StartLocalSpatialDeploymentIsVisible() const;
 	bool StartLocalSpatialDeploymentCanExecute() const;

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -57,14 +57,22 @@ private:
 
 	void VerifyAndStartDeployment();
 
-	void StartSpatialDeploymentButtonClicked();
+	void StartNativeUnrealDeploymentButtonClicked();
+	void StartLocalSpatialDeploymentButtonClicked();
+	void StartCloudSpatialDeploymentButtonClicked();
 	void StopSpatialDeploymentButtonClicked();
 
 	void StartSpatialServiceButtonClicked();
 	void StopSpatialServiceButtonClicked();
 
-	bool StartSpatialDeploymentIsVisible() const;
-	bool StartSpatialDeploymentCanExecute() const;
+	bool StartNativeUnrealDeploymentIsVisible() const;
+	bool StartNativeUnrealDeploymentCanExecute() const;
+
+	bool StartLocalSpatialDeploymentIsVisible() const;
+	bool StartLocalSpatialDeploymentCanExecute() const;
+
+	bool StartCloudSpatialDeploymentIsVisible() const;
+	bool StartCloudSpatialDeploymentCanExecute() const;
 
 	bool StopSpatialDeploymentIsVisible() const;
 	bool StopSpatialDeploymentCanExecute() const;

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbarCommands.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbarCommands.h
@@ -24,7 +24,9 @@ public:
 	TSharedPtr<FUICommandInfo> CreateSpatialGDKSchemaFull;
 	TSharedPtr<FUICommandInfo> DeleteSchemaDatabase;
 	TSharedPtr<FUICommandInfo> CreateSpatialGDKSnapshot;
-	TSharedPtr<FUICommandInfo> StartSpatialDeployment;
+	TSharedPtr<FUICommandInfo> StartNativeUnrealDeployment;
+	TSharedPtr<FUICommandInfo> StartLocalSpatialDeployment;
+	TSharedPtr<FUICommandInfo> StartCloudSpatialDeployment;
 	TSharedPtr<FUICommandInfo> StopSpatialDeployment;
 	TSharedPtr<FUICommandInfo> LaunchInspectorWebPageAction;
 	

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbarCommands.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbarCommands.h
@@ -24,7 +24,7 @@ public:
 	TSharedPtr<FUICommandInfo> CreateSpatialGDKSchemaFull;
 	TSharedPtr<FUICommandInfo> DeleteSchemaDatabase;
 	TSharedPtr<FUICommandInfo> CreateSpatialGDKSnapshot;
-	TSharedPtr<FUICommandInfo> StartNativeUnrealNetwork;
+	TSharedPtr<FUICommandInfo> StartNoAutomaticConnection;
 	TSharedPtr<FUICommandInfo> StartLocalSpatialDeployment;
 	TSharedPtr<FUICommandInfo> StartCloudSpatialDeployment;
 	TSharedPtr<FUICommandInfo> StopSpatialDeployment;

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbarCommands.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbarCommands.h
@@ -24,7 +24,7 @@ public:
 	TSharedPtr<FUICommandInfo> CreateSpatialGDKSchemaFull;
 	TSharedPtr<FUICommandInfo> DeleteSchemaDatabase;
 	TSharedPtr<FUICommandInfo> CreateSpatialGDKSnapshot;
-	TSharedPtr<FUICommandInfo> StartNativeUnrealDeployment;
+	TSharedPtr<FUICommandInfo> StartNativeUnrealNetwork;
 	TSharedPtr<FUICommandInfo> StartLocalSpatialDeployment;
 	TSharedPtr<FUICommandInfo> StartCloudSpatialDeployment;
 	TSharedPtr<FUICommandInfo> StopSpatialDeployment;

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbarStyle.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbarStyle.h
@@ -14,7 +14,8 @@ public:
 	static void Shutdown();
 	static void ReloadTextures();
 	static const ISlateStyle& Get();
-	static FName GetStyleSetName();	
+	static FName GetStyleSetName();
+
 private:
 	static TSharedRef<FSlateStyleSet> Create();
 	static TSharedPtr<FSlateStyleSet> StyleInstance;

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbarStyle.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbarStyle.h
@@ -14,8 +14,7 @@ public:
 	static void Shutdown();
 	static void ReloadTextures();
 	static const ISlateStyle& Get();
-	static FName GetStyleSetName();
-
+	static FName GetStyleSetName();	
 private:
 	static TSharedRef<FSlateStyleSet> Create();
 	static TSharedPtr<FSlateStyleSet> StyleInstance;


### PR DESCRIPTION
#### Description
Change icon of 'start' toolbar button based on selected connection flow

#### Release note
when choosing the options in 'native/local/cloud'  of  'Start' toolbar button, change the start button's icon

#### Tests
Only editor code change. So that test it in the editor. Click 'start' toolbar button when choosing a different option such as 'Do not connect/local depolyment/cloud deployment'

#### Documentation
None

![image](https://user-images.githubusercontent.com/30972673/80588343-bfe6ac00-8a4a-11ea-9960-57c0c5c48bf1.png)
![image](https://user-images.githubusercontent.com/30972673/80588434-ec9ac380-8a4a-11ea-8245-79bdd0499b5b.png)
![image](https://user-images.githubusercontent.com/30972673/80588472-050ade00-8a4b-11ea-8032-3eb43ef813dd.png)
![image](https://user-images.githubusercontent.com/30972673/80588548-2075e900-8a4b-11ea-967d-a9d46dfd55b2.png)
