### PR TITLE
[UNR-3320] Avoid using packages being async loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Fixed crash when shadow data was uninitialized when resolving unresolved objects.
 - Fixed sending component RPCs on a recently created actor.
 - Fix problem where load balanced cloud deploys could fail to start while under heavy load.
+- Fix to avoid using packages still being processed in the async loading thread.
 
 ### External contributors:
 @DW-Sebastien

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -2428,7 +2428,32 @@ void USpatialReceiver::PeriodicallyProcessIncomingRPCs()
 
 bool USpatialReceiver::NeedToLoadClass(const FString& ClassPath)
 {
-	return FindObject<UClass>(nullptr, *ClassPath, false) == nullptr;
+	UObject* ClassObject = FindObject<UClass>(nullptr, *ClassPath, false);
+	if (!ClassObject)
+	{
+		return true;
+	}
+
+	FString PackagePath = GetPackagePath(ClassPath);
+	FName PackagePathName = *PackagePath;
+
+	// UNR-3320 The following test checks if the package is currently being processed in the async loading thread.
+	// Without it, we could be using an object loaded in memory, but not completely ready to be used.
+	// Looking through PackageMapClient's code, which handles asset async loading in Native unreal, checking
+	// UPackage::IsFullyLoaded, or UObject::HasAnyInternalFlag(EInternalObjectFlag::AsyncLoading) should tell us if it is the case.
+	// In practice, these tests are not enough to prevent using objects too early (symptom is RF_NeedPostLoad being set, and crash when using them later).
+	// GetAsyncLoadPercentage will actually look through the async loading thread's UAsyncPackage maps to see if there are any entries.
+	// TODO : UNR-XXXX This looks like an expensive check, but it does the job. We should investigate further 
+	// what is the issue with the other flags and why they do not give us reliable information.
+
+	float Percentage = GetAsyncLoadPercentage(PackagePathName);
+	if (Percentage != -1.0f)
+	{
+		UE_LOG(LogSpatialReceiver, Warning, TEXT("Class %s package is registered in async loading thread."), *ClassPath)
+		return true;
+	}
+	
+	return false;
 }
 
 FString USpatialReceiver::GetPackagePath(const FString& ClassPath)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -2429,7 +2429,7 @@ void USpatialReceiver::PeriodicallyProcessIncomingRPCs()
 bool USpatialReceiver::NeedToLoadClass(const FString& ClassPath)
 {
 	UObject* ClassObject = FindObject<UClass>(nullptr, *ClassPath, false);
-	if (!ClassObject)
+	if (ClassObject == nullptr)
 	{
 		return true;
 	}
@@ -2443,7 +2443,7 @@ bool USpatialReceiver::NeedToLoadClass(const FString& ClassPath)
 	// UPackage::IsFullyLoaded, or UObject::HasAnyInternalFlag(EInternalObjectFlag::AsyncLoading) should tell us if it is the case.
 	// In practice, these tests are not enough to prevent using objects too early (symptom is RF_NeedPostLoad being set, and crash when using them later).
 	// GetAsyncLoadPercentage will actually look through the async loading thread's UAsyncPackage maps to see if there are any entries.
-	// TODO : UNR-XXXX This looks like an expensive check, but it does the job. We should investigate further 
+	// TODO : UNR-3374 This looks like an expensive check, but it does the job. We should investigate further 
 	// what is the issue with the other flags and why they do not give us reliable information.
 
 	float Percentage = GetAsyncLoadPercentage(PackagePathName);


### PR DESCRIPTION
#### Description
When asynchronously loading classes, it could happen that we used it too early, when it was still being loaded in the background.
This PR adds a check, through GetAsyncLoadingPercentage, to avoid this situation.

#### Release note

#### Tests
The bug is a data race on async loading, and the precise set of circumstances when it happens is still unclear. So the test will likely be empirical.
Reproducing it involves starting a fresh client, and having it load replicated actors's classes on the fly (the map should contains soft references to actors to spawn after a while).
Tested in-game, before and after, checked that there were no crashes, and that the situation we are testing for (package being registered in the async loading thread) actually happens.

#### Documentation

#### Primary reviewers
