### PR TITLE
UNR-3294 Hook up cloud connection flow in new UI(GDK part)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
   - Added the `Cloud deployment name` field to specify which cloud deployment you want to connect to. If no cloud deployment is specified and you select `Connect to cloud deployment`, it will try to connect to the first running deployment that has the `dev_login` deployment tag.
   - Added the `Editor Settings` field to allow you to quickly get to the **SpatialOS Editor Settings**
 - Added `Open Deployment Page` button to the `Cloud Deployment` window.
+- If users choose `Connect to cloud deployment` in start dropdown menu and input correct `Cloud deployment name`, the Launch flow can start client on mobile device and connect to the specified cloud deployment.
+- If users choose `Connect to local deployment` in start dropdown menu and input correct `Local Deployment IP`, the Launch flow can start client on mobile device and connect to your local deployment.
 
 ## Bug fixes:
 - Fixed a bug that caused queued RPCs to spam logs when an entity is deleted.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,8 +86,6 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
   - Added the `Cloud deployment name` field to specify which cloud deployment you want to connect to. If no cloud deployment is specified and you select `Connect to cloud deployment`, it will try to connect to the first running deployment that has the `dev_login` deployment tag.
   - Added the `Editor Settings` field to allow you to quickly get to the **SpatialOS Editor Settings**
 - Added `Open Deployment Page` button to the `Cloud Deployment` window.
-- If users choose `Connect to cloud deployment` in start dropdown menu and input correct `Cloud deployment name`, the Launch flow can start client on mobile device and connect to the specified cloud deployment.
-- If users choose `Connect to local deployment` in start dropdown menu and input correct `Local Deployment IP`, the Launch flow can start client on mobile device and connect to your local deployment.
 - The Deploy button will launch the deployment directly if the necessary fields were filled previously in the `Deployment Configuration` window, selecting the `Deployment Configuration` menu item from the dropdown will allow changing of deployment settings.
 - Added `Build Client Worker` and `Build SimulatedPlayer` checkbox to the dropdown list of Deploy button to quickly enable/disable building and including the client worker or simulated player worker in the assembly.
 - Automatically add `dev_login` tag to cloud deployment when clicking launch deployment button.

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -51,12 +51,6 @@ FString FSpatialGDKEditorModule::GetSpatialOSLocalDeploymentIP() const
 	return SpatialGDKEditorSettings->ExposedRuntimeIP;
 }
 
-int FSpatialGDKEditorModule::GetSpatialOSNetFlowType() const
-{
-	const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>();
-	return SpatialGDKEditorSettings->SpatialOSNetFlowType;
-}
-
 bool FSpatialGDKEditorModule::ShouldConnectToLocalDeployment() const
 {
 	return GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking() && GetDefault<USpatialGDKEditorSettings>()->SpatialOSNetFlowType == ESpatialOSNetFlow::LocalDeployment;

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -57,6 +57,11 @@ int FSpatialGDKEditorModule::GetSpatialOSNetFlowType() const
 	return SpatialGDKEditorSettings->SpatialOSNetFlowType;
 }
 
+bool FSpatialGDKEditorModule::ShouldConnectToLocalDeployment() const
+{
+	return GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking() && GetDefault<USpatialGDKEditorSettings>()->SpatialOSNetFlowType == ESpatialOSNetFlow::LocalDeployment;
+}
+
 bool FSpatialGDKEditorModule::ShouldConnectToCloudDeployment() const
 {
 	return GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking() && GetDefault<USpatialGDKEditorSettings>()->SpatialOSNetFlowType == ESpatialOSNetFlow::CloudDeployment;

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
@@ -26,6 +26,7 @@ protected:
 	virtual FString GetSpatialOSCloudDeploymentName() const override;
 	virtual FString GetSpatialOSLocalDeploymentIP() const override;
 	virtual int GetSpatialOSNetFlowType() const override;
+	virtual bool ShouldConnectToLocalDeployment() const override;
 	virtual bool ShouldConnectToCloudDeployment() const override;
 	virtual FString GetDevAuthToken() const override;
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
@@ -25,7 +25,6 @@ public:
 protected:
 	virtual FString GetSpatialOSCloudDeploymentName() const override;
 	virtual FString GetSpatialOSLocalDeploymentIP() const override;
-	virtual int GetSpatialOSNetFlowType() const override;
 	virtual bool ShouldConnectToLocalDeployment() const override;
 	virtual bool ShouldConnectToCloudDeployment() const override;
 	virtual FString GetDevAuthToken() const override;

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -409,6 +409,10 @@ void OnLocalDeploymentIPChanged(const FText& InText, ETextCommit::Type InCommitT
 
 void OnCloudDeploymentNameChanged(const FText& InText, ETextCommit::Type InCommitType)
 {
+	USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetMutableDefault<USpatialGDKEditorSettings>();
+	SpatialGDKEditorSettings->DevelopmentDeploymentToConnect = InText.ToString();
+	SpatialGDKEditorSettings->SaveConfig();
+
 	USpatialGDKSettings* SpatialGDKSettings = GetMutableDefault<USpatialGDKSettings>();
 	SpatialGDKSettings->DevelopmentDeploymentToConnect = InText.ToString();
 	SpatialGDKSettings->SaveConfig();
@@ -418,7 +422,7 @@ TSharedRef<SWidget> FSpatialGDKEditorToolbarModule::CreateStartDropDownMenuConte
 {
 	FMenuBuilder MenuBuilder(false /*bInShouldCloseWindowAfterMenuSelection*/, PluginCommands);
 	UGeneralProjectSettings* GeneralProjectSettings = GetMutableDefault<UGeneralProjectSettings>();
-	USpatialGDKSettings* SpatialGDKSettings = GetMutableDefault<USpatialGDKSettings>();
+	USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetMutableDefault<USpatialGDKEditorSettings>();
 	MenuBuilder.BeginSection(NAME_None, LOCTEXT("SpatialOSSettings", "SpatialOS Settings"));
 	{
 		MenuBuilder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().EnableSpatialNetworking);
@@ -450,7 +454,7 @@ TSharedRef<SWidget> FSpatialGDKEditorToolbarModule::CreateStartDropDownMenuConte
 		MenuBuilder.AddWidget(SNew(SEditableText)
 			.OnTextChanged_Static(OnCloudDeploymentNameChanged, ETextCommit::Default)
 			.OnTextCommitted_Static(OnCloudDeploymentNameChanged)
-			.Text(FText::FromString(SpatialGDKSettings->DevelopmentDeploymentToConnect))
+			.Text(FText::FromString(SpatialGDKEditorSettings->DevelopmentDeploymentToConnect))
 			.SelectAllTextWhenFocused(true)
 			.ColorAndOpacity(FLinearColor::White * 0.8f)
 			.IsEnabled_Raw(this, &FSpatialGDKEditorToolbarModule::IsCloudDeploymentNameEditable)


### PR DESCRIPTION
================================================
Implement ShouldConnectToLocalDeployment function.

#### Description
Launched client on android device can connect to the specified cloud deployment when user choose `connect to cloud deployment` and input target deployment name using new UI.

#### Tests

- Choose `connect to cloud deployment` like the following picture.

![image](https://user-images.githubusercontent.com/5253969/80476960-b9d6c980-897d-11ea-9228-379b0aa36def.png)

- Click `Launch` button to start a client in android device.
![image](https://user-images.githubusercontent.com/5253969/80477116-f9051a80-897d-11ea-8e15-03652462fadc.png)

- The client should be able to connect to the cloud deployment.

- The flow also works for local deployment flow.

#### Documentation
TODO.
