### PR TITLE
Unbind launch delegate when we're not in local deployment mode.

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -955,7 +955,7 @@ void FSpatialGDKEditorToolbarModule::NoAutomaticConnectionClicked() const
 	SpatialGDKEditorSettings->SaveConfig();
 }
 
-void FSpatialGDKEditorToolbarModule::LocalDeploymentClicked() const
+void FSpatialGDKEditorToolbarModule::LocalDeploymentClicked()
 {
 	USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetMutableDefault<USpatialGDKEditorSettings>();
 	SpatialGDKEditorSettings->SpatialOSNetFlowType = ESpatialOSNetFlow::LocalDeployment;
@@ -964,7 +964,7 @@ void FSpatialGDKEditorToolbarModule::LocalDeploymentClicked() const
 	{
 		UEditorEngine::TryStartSpatialDeployment.BindLambda([this]
 		{
-			const_cast<FSpatialGDKEditorToolbarModule*>(this)->VerifyAndStartDeployment();
+			VerifyAndStartDeployment();
 		});
 	}
 	SpatialGDKEditorSettings->SaveConfig();

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -99,7 +99,7 @@ private:
 	bool IsCloudDeploymentSelected() const;
 	bool IsSpatialOSNetFlowConfigurable() const;
 	void NoAutomaticConnectionClicked() const;
-	void LocalDeploymentClicked() const;
+	void LocalDeploymentClicked();
 	void CloudDeploymentClicked() const;
 	bool IsLocalDeploymentIPEditable() const;
 	bool IsCloudDeploymentNameEditable() const;


### PR DESCRIPTION
#### Description
If we are not in local deployment mode disable starting a local deployment.

#### Release note
TBD

#### Tests
I started the PIE session when in local deployment and not in local deployment
Testing PIE sessions in local deployment, cloud deployment and no auto startup modes.

#### Documentation
TBD

#### Primary reviewers
@raymonwang @improbable-valentyn @jessicafalk 
