### PR TITLE
Add ability to remove command line file from mobile devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - The GDK now uses SpatialOS 14.6.1.
 - Add ability to disable outgoing RPC queue timeouts by setting `QueuedOutgoingRPCWaitTime` to 0.0f.
 - Added `bWorkerFlushAfterOutgoingNetworkOp` (defaulted false) which publishes changes to the GDK worker queue after RPCs and property replication to allow for lower latencies. Can be used in conjunction with `bRunSpatialWorkerConnectionOnGameThread` to get the lowest available latency at a trade-off with bandwidth.
+- Added buttons to the Mobile section in SpatialGDK Editor settings to remove the command line file from mobile devices.
 
 ## Bug fixes:
 - Fixed a bug that caused queued RPCs to spam logs when an entity is deleted.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - The GDK now uses SpatialOS 14.6.1.
 - Add ability to disable outgoing RPC queue timeouts by setting `QueuedOutgoingRPCWaitTime` to 0.0f.
 - Added `bWorkerFlushAfterOutgoingNetworkOp` (defaulted false) which publishes changes to the GDK worker queue after RPCs and property replication to allow for lower latencies. Can be used in conjunction with `bRunSpatialWorkerConnectionOnGameThread` to get the lowest available latency at a trade-off with bandwidth.
-- Added buttons to the Mobile section in SpatialGDK Editor settings to remove the command line file from mobile devices.
+- Added buttons to the Mobile section in the SpatialGDK Editor settings to allow you to remove the `UE4CommandLine.txt` from mobile devices.
 
 ## Bug fixes:
 - Fixed a bug that caused queued RPCs to spam logs when an entity is deleted.

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
@@ -291,6 +291,7 @@ bool FSpatialGDKEditorLayoutDetails::TryRemoveCommandLineArgsFromDevice(const FS
 		return false;
 	}
 
+	UE_LOG(LogSpatialGDKEditorLayoutDetails, Log, TEXT("Successfully removed command line args from device!"));
 	return true;
 }
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
@@ -279,25 +279,27 @@ bool FSpatialGDKEditorLayoutDetails::TryPushCommandLineArgsToDevice(const FStrin
 
 namespace
 {
-	static FString GetAdbExePath()
+
+FString GetAdbExePath()
+{
+	FString AndroidHome = FPlatformMisc::GetEnvironmentVariable(TEXT("ANDROID_HOME"));
+	if (AndroidHome.IsEmpty())
 	{
-		FString AndroidHome = FPlatformMisc::GetEnvironmentVariable(TEXT("ANDROID_HOME"));
-		if (AndroidHome.IsEmpty())
-		{
-			UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Environment variable ANDROID_HOME is not set. Please make sure to configure this."));
-			FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Environment variable ANDROID_HOME is not set. Please make sure to configure this.")));
-			return TEXT("");
-		}
+		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Environment variable ANDROID_HOME is not set. Please make sure to configure this."));
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Environment variable ANDROID_HOME is not set. Please make sure to configure this.")));
+		return TEXT("");
+	}
 
 #if PLATFORM_WINDOWS
-		const FString AdbExe = FPaths::ConvertRelativePathToFull(FPaths::Combine(AndroidHome, TEXT("platform-tools/adb.exe")));
+	const FString AdbExe = FPaths::ConvertRelativePathToFull(FPaths::Combine(AndroidHome, TEXT("platform-tools/adb.exe")));
 #else
-		const FString AdbExe = FPaths::ConvertRelativePathToFull(FPaths::Combine(AndroidHome, TEXT("platform-tools/adb")));
+	const FString AdbExe = FPaths::ConvertRelativePathToFull(FPaths::Combine(AndroidHome, TEXT("platform-tools/adb")));
 #endif
 
-		return AdbExe;
-	}
+	return AdbExe;
 }
+
+} // anonymous namespace
 
 FReply FSpatialGDKEditorLayoutDetails::PushCommandLineArgsToAndroidDevice()
 {

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
@@ -319,13 +319,15 @@ FString GetAdbExePath()
 
 void GetDeploymentServerExecutableAndArgs(FString& OutExe, FString& OutArgs, const FString& DeploymentServerArguments)
 {
-	OutExe = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/DotNET/IOS/deploymentserver.exe")));
-	OutArgs = DeploymentServerArguments;
+	const FString& DeploymentServerExe = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/DotNET/IOS/deploymentserver.exe")));
 
 #if PLATFORM_MAC
 	// On Mac we need to run mono as the executable and pass the deployment server as the first argument to that.
-	DeploymentServerArguments = FString::Printf(TEXT("%s %s"), *OutExe, *DeploymentServerArguments);
 	OutExe = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/ThirdParty/Mono/Mac/bin/mono")));
+	OutArgs = FString::Printf(TEXT("%s %s"), *DeploymentServerExe, *DeploymentServerArguments);
+#else
+	OutExe = DeploymentServerExe;
+	OutArgs = DeploymentServerArguments;
 #endif
 }
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
@@ -17,6 +17,8 @@ private:
 	FReply GenerateDevAuthToken();
 	FReply PushCommandLineArgsToIOSDevice();
 	FReply PushCommandLineArgsToAndroidDevice();
+	FReply RemoveCommandLineArgsFromIOSDevice();
+	FReply RemoveCommandLineArgsFromAndroidDevice();
 
 public:
 	static TSharedRef<IDetailCustomization> MakeInstance();

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
@@ -13,6 +13,7 @@ class FSpatialGDKEditorLayoutDetails : public IDetailCustomization
 private:
 	bool TryConstructMobileCommandLineArgumentsFile(FString& CommandLineArgsFile);
 	bool TryPushCommandLineArgsToDevice(const FString& Executable, const FString& ExeArguments, const FString& CommandLineArgsFile);
+	bool TryRemoveCommandLineArgsFromDevice(const FString& Executable, const FString& ExeArguments);
 
 	FReply GenerateDevAuthToken();
 	FReply PushCommandLineArgsToIOSDevice();


### PR DESCRIPTION
#### Description
Added buttons to the Mobile section in SpatialGDK Editor settings to remove the command line file from mobile devices.

Original author: @jayprobable 
Original PR for reference: https://github.com/spatialos/UnrealGDK/pull/2016

#### Primary reviewers
@joshuahuburn @samiwh 
