### PR TITLE
Bugfix/unr 3072 commandline configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - The GDK now uses SpatialOS 14.6.1.
 - Add ability to disable outgoing RPC queue timeouts by setting `QueuedOutgoingRPCWaitTime` to 0.0f.
 - Added `bWorkerFlushAfterOutgoingNetworkOp` (defaulted false) which publishes changes to the GDK worker queue after RPCs and property replication to allow for lower latencies. Can be used in conjunction with `bRunSpatialWorkerConnectionOnGameThread` to get the lowest available latency at a trade-off with bandwidth.
+- When using the `-receptionistHost` command line parameter with a non-local host, it's no longer necessary to set `-useExternalIpForBridge true` as this will be inferred automatically.
 
 ## Bug fixes:
 - Fixed a bug that caused queued RPCs to spam logs when an entity is deleted.
@@ -117,6 +118,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Fix problem where load balanced cloud deploys could fail to start while under heavy load.
 - Fix to avoid using packages still being processed in the async loading thread.
 - Fixed a bug when running GDK setup scripts fail to unzip dependencies sometimes.
+- When using a URL with options in the command line, receptionist parameters will be parsed correctly, making use of the URL if necessary.
 
 ### External contributors:
 @DW-Sebastien

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
@@ -460,19 +460,8 @@ void USpatialConnectionManager::SetupConnectionConfigFromURL(const FURL& URL, co
 	{
 		SetConnectionType(ESpatialConnectionType::Receptionist);
 
-		// If we have a non-empty host then use this to connect. If not - use the default configured in FReceptionistConfig initialisation.
-		if (!URL.Host.IsEmpty())
-		{
-			ReceptionistConfig.SetReceptionistHost(URL);
-		}
-
+		ReceptionistConfig.SetReceptionistHost(URL);
 		ReceptionistConfig.WorkerType = SpatialWorkerType;
-
-		// Need to keep this around, although it's handled in SetReceptionistHost as well, since we can have host-less URLs
-		if (URL.HasOption(*SpatialConstants::URL_USE_EXTERNAL_IP_FOR_BRIDGE_OPTION))
-		{
-			ReceptionistConfig.UseExternalIp = true;
-		}
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
@@ -459,11 +459,9 @@ void USpatialConnectionManager::SetupConnectionConfigFromURL(const FURL& URL, co
 
 		ReceptionistConfig.WorkerType = SpatialWorkerType;
 
-		const TCHAR* UseExternalIpForBridge = TEXT("useExternalIpForBridge");
-		if (URL.HasOption(UseExternalIpForBridge))
+		if (URL.HasOption(*SpatialConstants::URL_USE_EXTERNAL_IP_FOR_BRIDGE_OPTION))
 		{
-			FString UseExternalIpOption = URL.GetOption(UseExternalIpForBridge, TEXT(""));
-			ReceptionistConfig.UseExternalIp = !UseExternalIpOption.Equals(TEXT("false"), ESearchCase::IgnoreCase);
+			ReceptionistConfig.UseExternalIp = true;
 		}
 	}
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
@@ -454,11 +454,12 @@ void USpatialConnectionManager::SetupConnectionConfigFromURL(const FURL& URL, co
 		// If we have a non-empty host then use this to connect. If not - use the default configured in FReceptionistConfig initialisation.
 		if (!URL.Host.IsEmpty())
 		{
-			ReceptionistConfig.SetReceptionistHost(URL.Host);
+			ReceptionistConfig.SetReceptionistHost(URL);
 		}
 
 		ReceptionistConfig.WorkerType = SpatialWorkerType;
 
+		// Need to keep this around, although it's handled in SetReceptionistHost as well, since we can have host-less URLs
 		if (URL.HasOption(*SpatialConstants::URL_USE_EXTERNAL_IP_FOR_BRIDGE_OPTION))
 		{
 			ReceptionistConfig.UseExternalIp = true;

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
@@ -460,7 +460,7 @@ void USpatialConnectionManager::SetupConnectionConfigFromURL(const FURL& URL, co
 	{
 		SetConnectionType(ESpatialConnectionType::Receptionist);
 
-		ReceptionistConfig.SetReceptionistHost(URL);
+		ReceptionistConfig.SetupFromURL(URL);
 		ReceptionistConfig.WorkerType = SpatialWorkerType;
 	}
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
@@ -206,10 +206,10 @@ public:
 		if (!Host.IsEmpty())
 		{
 			ReceptionistHost = Host;
-		}
-		if (ReceptionistHost.Compare(SpatialConstants::LOCAL_HOST) != 0)
-		{
-			UseExternalIp = true;
+			if (ReceptionistHost.Compare(SpatialConstants::LOCAL_HOST) != 0)
+			{
+				UseExternalIp = true;
+			}
 		}
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
@@ -8,6 +8,7 @@
 #include "Misc/Parse.h"
 #include "SpatialConstants.h"
 #include "SpatialGDKSettings.h"
+#include <WorkerSDK/improbable/c_worker.h>
 
 struct FConnectionConfig
 {
@@ -187,17 +188,9 @@ public:
 			FString URLAddress;
 			FParse::Token(CommandLine, URLAddress, false);
 			const FURL URL(nullptr, *URLAddress, TRAVEL_Absolute);
-			if (URL.Valid)
+			if (URL.Valid && !URL.Host.IsEmpty())
 			{
-				if (!URL.Host.IsEmpty())
-				{
-					SetReceptionistHost(URL.Host);
-
-					if (URL.HasOption(*SpatialConstants::URL_USE_EXTERNAL_IP_FOR_BRIDGE_OPTION))
-					{
-						UseExternalIp = true;
-					}
-				}
+				SetReceptionistHost(URL);
 			}
 		}
 		else
@@ -212,6 +205,15 @@ public:
 	{
 		ReceptionistHost = host;
 		if (ReceptionistHost.Compare(SpatialConstants::LOCAL_HOST) != 0)
+		{
+			UseExternalIp = true;
+		}
+	}
+
+	void SetReceptionistHost(const FURL& URL)
+	{
+		SetReceptionistHost(URL.Host);
+		if (URL.HasOption(*SpatialConstants::URL_USE_EXTERNAL_IP_FOR_BRIDGE_OPTION))
 		{
 			UseExternalIp = true;
 		}

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
@@ -175,6 +175,9 @@ public:
 	{
 		const TCHAR* CommandLine = FCommandLine::Get();
 
+		// Get command line options first since the URL handling will modify the CommandLine string
+		FParse::Value(CommandLine, TEXT("receptionistPort"), ReceptionistPort);
+
 		// Parse the command line for receptionistHost, if it exists then use this as the host IP.
 		FString Host;
 		if (!FParse::Value(CommandLine, TEXT("receptionistHost"), Host))
@@ -202,7 +205,6 @@ public:
 			SetReceptionistHost(Host);
 		}
 
-		FParse::Value(CommandLine, TEXT("receptionistPort"), ReceptionistPort);
 		return true;
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
@@ -190,7 +190,7 @@ public:
 			const FURL URL(nullptr, *URLAddress, TRAVEL_Absolute);
 			if (URL.Valid)
 			{
-				SetReceptionistHost(URL);
+				SetupFromURL(URL);
 			}
 		}
 		else
@@ -201,19 +201,7 @@ public:
 		return true;
 	}
 
-	void SetReceptionistHost(const FString& Host)
-	{
-		if (!Host.IsEmpty())
-		{
-			ReceptionistHost = Host;
-			if (ReceptionistHost.Compare(SpatialConstants::LOCAL_HOST) != 0)
-			{
-				UseExternalIp = true;
-			}
-		}
-	}
-
-	void SetReceptionistHost(const FURL& URL)
+	void SetupFromURL(const FURL& URL)
 	{
 		if (!URL.Host.IsEmpty())
 		{
@@ -230,5 +218,17 @@ public:
 	uint16 ReceptionistPort;
 
 private:
+	void SetReceptionistHost(const FString& Host)
+	{
+		if (!Host.IsEmpty())
+		{
+			ReceptionistHost = Host;
+			if (ReceptionistHost.Compare(SpatialConstants::LOCAL_HOST) != 0)
+			{
+				UseExternalIp = true;
+			}
+		}
+	}
+
 	FString ReceptionistHost;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
@@ -188,7 +188,7 @@ public:
 			FString URLAddress;
 			FParse::Token(CommandLine, URLAddress, false);
 			const FURL URL(nullptr, *URLAddress, TRAVEL_Absolute);
-			if (URL.Valid && !URL.Host.IsEmpty())
+			if (URL.Valid)
 			{
 				SetReceptionistHost(URL);
 			}
@@ -201,9 +201,12 @@ public:
 		return true;
 	}
 
-	void SetReceptionistHost(const FString& host)
+	void SetReceptionistHost(const FString& Host)
 	{
-		ReceptionistHost = host;
+		if (!Host.IsEmpty())
+		{
+			ReceptionistHost = Host;
+		}
 		if (ReceptionistHost.Compare(SpatialConstants::LOCAL_HOST) != 0)
 		{
 			UseExternalIp = true;

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
@@ -186,8 +186,8 @@ public:
 			// If a receptionistHost is not specified then parse for an IP address as the first argument and use this instead.
 			// This is how native Unreal handles connecting to other IPs, a map name can also be specified, in this case we use the default IP.
 			FString URLAddress;
-			FParse::Token(CommandLine, URLAddress, false);
-			const FURL URL(nullptr, *URLAddress, TRAVEL_Absolute);
+			FParse::Token(CommandLine, URLAddress, false /* UseEscape */);
+			const FURL URL(nullptr /* Base */, *URLAddress, TRAVEL_Absolute);
 			if (URL.Valid)
 			{
 				SetupFromURL(URL);

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
@@ -9,8 +9,6 @@
 #include "SpatialConstants.h"
 #include "SpatialGDKSettings.h"
 
-#include <WorkerSDK/improbable/c_worker.h>
-
 struct FConnectionConfig
 {
 	FConnectionConfig()
@@ -26,10 +24,10 @@ struct FConnectionConfig
 		const TCHAR* CommandLine = FCommandLine::Get();
 
 		FParse::Value(CommandLine, TEXT("workerId"), WorkerId);
-		FParse::Bool(CommandLine, TEXT("useExternalIpForBridge"), UseExternalIp);
+		FParse::Bool(CommandLine, *SpatialConstants::URL_USE_EXTERNAL_IP_FOR_BRIDGE_OPTION, UseExternalIp);
 		FParse::Bool(CommandLine, TEXT("enableProtocolLogging"), EnableProtocolLoggingAtStartup);
 		FParse::Value(CommandLine, TEXT("protocolLoggingPrefix"), ProtocolLoggingPrefix);
-        
+
 		FString LinkProtocolString;
 		FParse::Value(CommandLine, TEXT("linkProtocol"), LinkProtocolString);
 		if (LinkProtocolString == TEXT("Tcp"))
@@ -73,7 +71,7 @@ struct FConnectionConfig
 	bool EnableProtocolLoggingAtStartup;
 	FString ProtocolLoggingPrefix;
 	Worker_NetworkConnectionType LinkProtocol;
-	Worker_ConnectionParameters ConnectionParams;
+	Worker_ConnectionParameters ConnectionParams = {};
 	uint8 TcpMultiplexLevel;
 	uint8 TcpNoDelay;
 	uint8 UdpUpstreamIntervalMS;
@@ -142,14 +140,13 @@ public:
 
 	bool TryLoadCommandLineArgs()
 	{
-		bool bSuccess = true;
 		const TCHAR* CommandLine = FCommandLine::Get();
 		FParse::Value(CommandLine, TEXT("locatorHost"), LocatorHost);
 		FParse::Value(CommandLine, TEXT("deployment"), Deployment);
 		FParse::Value(CommandLine, TEXT("playerId"), PlayerId);
 		FParse::Value(CommandLine, TEXT("displayName"), DisplayName);
 		FParse::Value(CommandLine, TEXT("metaData"), MetaData);
-		bSuccess = FParse::Value(CommandLine, TEXT("devAuthToken"), DevelopmentAuthToken);
+		const bool bSuccess = FParse::Value(CommandLine, TEXT("devAuthToken"), DevelopmentAuthToken);
 		return bSuccess;
 	}
 
@@ -176,27 +173,37 @@ public:
 
 	bool TryLoadCommandLineArgs()
 	{
-		bool bSuccess = true;
 		const TCHAR* CommandLine = FCommandLine::Get();
 
 		// Parse the command line for receptionistHost, if it exists then use this as the host IP.
-		if (!FParse::Value(CommandLine, TEXT("receptionistHost"), ReceptionistHost))
+		FString Host;
+		if (!FParse::Value(CommandLine, TEXT("receptionistHost"), Host))
 		{
 			// If a receptionistHost is not specified then parse for an IP address as the first argument and use this instead.
 			// This is how native Unreal handles connecting to other IPs, a map name can also be specified, in this case we use the default IP.
 			FString URLAddress;
-			FParse::Token(CommandLine, URLAddress, 0);
-			FRegexPattern Ipv4RegexPattern(TEXT("^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$"));
-			FRegexMatcher IpV4RegexMatcher(Ipv4RegexPattern, *URLAddress);
-			bSuccess = IpV4RegexMatcher.FindNext();
-			if (bSuccess)
+			FParse::Token(CommandLine, URLAddress, false);
+			const FURL URL(nullptr, *URLAddress, TRAVEL_Absolute);
+			if (URL.Valid)
 			{
-				SetReceptionistHost(URLAddress);
+				if (!URL.Host.IsEmpty())
+				{
+					SetReceptionistHost(URL.Host);
+
+					if (URL.HasOption(*SpatialConstants::URL_USE_EXTERNAL_IP_FOR_BRIDGE_OPTION))
+					{
+						UseExternalIp = true;
+					}
+				}
 			}
+		}
+		else
+		{
+			SetReceptionistHost(Host);
 		}
 
 		FParse::Value(CommandLine, TEXT("receptionistPort"), ReceptionistPort);
-		return bSuccess;
+		return true;
 	}
 
 	void SetReceptionistHost(const FString& host)

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
@@ -212,7 +212,10 @@ public:
 
 	void SetReceptionistHost(const FURL& URL)
 	{
-		SetReceptionistHost(URL.Host);
+		if (!URL.Host.IsEmpty())
+		{
+			SetReceptionistHost(URL.Host);
+		}
 		if (URL.HasOption(*SpatialConstants::URL_USE_EXTERNAL_IP_FOR_BRIDGE_OPTION))
 		{
 			UseExternalIp = true;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -276,6 +276,7 @@ const FString URL_TARGET_DEPLOYMENT_OPTION = TEXT("deployment=");
 const FString URL_PLAYER_ID_OPTION = TEXT("playerid=");
 const FString URL_DISPLAY_NAME_OPTION = TEXT("displayname=");
 const FString URL_METADATA_OPTION = TEXT("metadata=");
+const FString URL_USE_EXTERNAL_IP_FOR_BRIDGE_OPTION = TEXT("useExternalIpForBridge");
 
 const FString DEVELOPMENT_AUTH_PLAYER_ID = TEXT("Player Id");
 

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/Connection/SpatialConnectionManagerTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/Connection/SpatialConnectionManagerTest.cpp
@@ -27,11 +27,12 @@ private:
 
 CONNECTIONMANAGER_TEST(SetupFromURL_Locator_CustomLocator)
 {
+	// GIVEN
+	FTemporaryCommandLine TemporaryCommandLine("-locatorHost 99.88.77.66");
+	const FURL URL(nullptr, TEXT("10.20.30.40?locator?customLocator?playeridentity=foo?login=bar"), TRAVEL_Absolute);
 	USpatialConnectionManager* Manager = NewObject<USpatialConnectionManager>();
 
 	// WHEN
-	const FURL URL(nullptr, TEXT("10.20.30.40?locator?customLocator?playeridentity=foo?login=bar"), TRAVEL_Absolute);
-	FTemporaryCommandLine TemporaryCommandLine("-locatorHost 99.88.77.66");
 	Manager->SetupConnectionConfigFromURL(URL, "SomeWorkerType");
 
 	// THEN
@@ -45,11 +46,12 @@ CONNECTIONMANAGER_TEST(SetupFromURL_Locator_CustomLocator)
 
 CONNECTIONMANAGER_TEST(SetupFromURL_Locator_LocatorHost)
 {
+	// GIVEN
+	FTemporaryCommandLine TemporaryCommandLine("-locatorHost 99.88.77.66");
+	const FURL URL(nullptr, TEXT("10.20.30.40?locator?playeridentity=foo?login=bar"), TRAVEL_Absolute);
 	USpatialConnectionManager* Manager = NewObject<USpatialConnectionManager>();
 
 	// WHEN
-	const FURL URL(nullptr, TEXT("10.20.30.40?locator?playeridentity=foo?login=bar"), TRAVEL_Absolute);
-	FTemporaryCommandLine TemporaryCommandLine("-locatorHost 99.88.77.66");
 	Manager->SetupConnectionConfigFromURL(URL, "SomeWorkerType");
 
 	// THEN
@@ -63,13 +65,14 @@ CONNECTIONMANAGER_TEST(SetupFromURL_Locator_LocatorHost)
 
 CONNECTIONMANAGER_TEST(SetupFromURL_DevAuth)
 {
-	USpatialConnectionManager* Manager = NewObject<USpatialConnectionManager>();
-
-	// WHEN
+	// GIVEN
+	FTemporaryCommandLine TemporaryCommandLine("-locatorHost 99.88.77.66");
 	const FURL URL(nullptr,
 		TEXT("10.20.30.40?devauth?customLocator?devauthtoken=foo?deployment=bar?playerid=666?displayname=n00bkilla?metadata=important"),
 		TRAVEL_Absolute);
-	FTemporaryCommandLine TemporaryCommandLine("-locatorHost 99.88.77.66");
+	USpatialConnectionManager* Manager = NewObject<USpatialConnectionManager>();
+
+	// WHEN
 	Manager->SetupConnectionConfigFromURL(URL, "SomeWorkerType");
 
 	// THEN
@@ -86,11 +89,12 @@ CONNECTIONMANAGER_TEST(SetupFromURL_DevAuth)
 
 CONNECTIONMANAGER_TEST(SetupFromURL_DevAuth_LocatorHost)
 {
+	// GIVEN
+	FTemporaryCommandLine TemporaryCommandLine("-locatorHost 99.88.77.66");
+	const FURL URL(nullptr, TEXT("10.20.30.40?devauth"),TRAVEL_Absolute);
 	USpatialConnectionManager* Manager = NewObject<USpatialConnectionManager>();
 
 	// WHEN
-	const FURL URL(nullptr, TEXT("10.20.30.40?devauth"),TRAVEL_Absolute);
-	FTemporaryCommandLine TemporaryCommandLine("-locatorHost 99.88.77.66");
 	Manager->SetupConnectionConfigFromURL(URL, "SomeWorkerType");
 
 	// THEN
@@ -101,11 +105,12 @@ CONNECTIONMANAGER_TEST(SetupFromURL_DevAuth_LocatorHost)
 
 CONNECTIONMANAGER_TEST(SetupFromURL_Receptionist_Localhost)
 {
+	// GIVEN
+	FTemporaryCommandLine TemporaryCommandLine("");
+	const FURL URL(nullptr, TEXT("127.0.0.1"), TRAVEL_Absolute);
 	USpatialConnectionManager* Manager = NewObject<USpatialConnectionManager>();
 
 	// WHEN
-	const FURL URL(nullptr, TEXT("127.0.0.1"), TRAVEL_Absolute);
-	FTemporaryCommandLine TemporaryCommandLine("");
 	Manager->SetupConnectionConfigFromURL(URL, "SomeWorkerType");
 
 	// THEN
@@ -118,11 +123,12 @@ CONNECTIONMANAGER_TEST(SetupFromURL_Receptionist_Localhost)
 
 CONNECTIONMANAGER_TEST(SetupFromURL_Receptionist_ExternalHost)
 {
+	// GIVEN
+	FTemporaryCommandLine TemporaryCommandLine("");
+	const FURL URL(nullptr, TEXT("10.20.30.40"), TRAVEL_Absolute);
 	USpatialConnectionManager* Manager = NewObject<USpatialConnectionManager>();
 
 	// WHEN
-	const FURL URL(nullptr, TEXT("10.20.30.40"), TRAVEL_Absolute);
-	FTemporaryCommandLine TemporaryCommandLine("");
 	Manager->SetupConnectionConfigFromURL(URL, "SomeWorkerType");
 
 	// THEN
@@ -135,11 +141,12 @@ CONNECTIONMANAGER_TEST(SetupFromURL_Receptionist_ExternalHost)
 
 CONNECTIONMANAGER_TEST(SetupFromURL_Receptionist_ExternalBridge)
 {
+	// GIVEN
+	FTemporaryCommandLine TemporaryCommandLine("");
+	const FURL URL(nullptr, TEXT("127.0.0.1?useExternalIpForBridge"), TRAVEL_Absolute);
 	USpatialConnectionManager* Manager = NewObject<USpatialConnectionManager>();
 
 	// WHEN
-	const FURL URL(nullptr, TEXT("127.0.0.1?useExternalIpForBridge"), TRAVEL_Absolute);
-	FTemporaryCommandLine TemporaryCommandLine("");
 	Manager->SetupConnectionConfigFromURL(URL, "SomeWorkerType");
 
 	// THEN
@@ -152,10 +159,11 @@ CONNECTIONMANAGER_TEST(SetupFromURL_Receptionist_ExternalBridge)
 
 CONNECTIONMANAGER_TEST(SetupFromCommandLine_Locator)
 {
+	// GIVEN
+	FTemporaryCommandLine TemporaryCommandLine("-locatorHost 10.20.30.40 -playerIdentityToken foo -loginToken bar");
 	USpatialConnectionManager* Manager = NewObject<USpatialConnectionManager>();
 
 	// WHEN
-	FTemporaryCommandLine TemporaryCommandLine("-locatorHost 10.20.30.40 -playerIdentityToken foo -loginToken bar");
 	const bool bSuccess = Manager->TrySetupConnectionConfigFromCommandLine("SomeWorkerType");
 
 	// THEN
@@ -170,10 +178,11 @@ CONNECTIONMANAGER_TEST(SetupFromCommandLine_Locator)
 
 CONNECTIONMANAGER_TEST(SetupFromCommandLine_DevAuth)
 {
+	// GIVEN
+	FTemporaryCommandLine TemporaryCommandLine("-locatorHost 10.20.30.40 -devAuthToken foo -deployment bar -playerId 666 -displayName n00bkilla -metadata important");
 	USpatialConnectionManager* Manager = NewObject<USpatialConnectionManager>();
 
 	// WHEN
-	FTemporaryCommandLine TemporaryCommandLine("-locatorHost 10.20.30.40 -devAuthToken foo -deployment bar -playerId 666 -displayName n00bkilla -metadata important");
 	const bool bSuccess = Manager->TrySetupConnectionConfigFromCommandLine("SomeWorkerType");
 
 	// THEN
@@ -191,10 +200,11 @@ CONNECTIONMANAGER_TEST(SetupFromCommandLine_DevAuth)
 
 CONNECTIONMANAGER_TEST(SetupFromCommandLine_Receptionist_ReceptionistHost)
 {
+	// GIVEN
+	FTemporaryCommandLine TemporaryCommandLine("-receptionistHost 10.20.30.40 -receptionistPort 666");
 	USpatialConnectionManager* Manager = NewObject<USpatialConnectionManager>();
 
 	// WHEN
-	FTemporaryCommandLine TemporaryCommandLine("-receptionistHost 10.20.30.40 -receptionistPort 666");
 	const bool bSuccess = Manager->TrySetupConnectionConfigFromCommandLine("SomeWorkerType");
 
 	// THEN
@@ -207,12 +217,51 @@ CONNECTIONMANAGER_TEST(SetupFromCommandLine_Receptionist_ReceptionistHost)
 	return true;
 }
 
-CONNECTIONMANAGER_TEST(SetupFromCommandLine_Receptionist_URL)
+CONNECTIONMANAGER_TEST(SetupFromCommandLine_Receptionist_ReceptionistHostLocal)
 {
+	// GIVEN
+	FTemporaryCommandLine TemporaryCommandLine("-receptionistPort 666");
 	USpatialConnectionManager* Manager = NewObject<USpatialConnectionManager>();
 
 	// WHEN
+	const bool bSuccess = Manager->TrySetupConnectionConfigFromCommandLine("SomeWorkerType");
+
+	// THEN
+	TestEqual("Success", bSuccess, true);
+	TestEqual("UseExternalIp", Manager->ReceptionistConfig.UseExternalIp, false);
+	TestEqual("ReceptionistHost", Manager->ReceptionistConfig.GetReceptionistHost(), "127.0.0.1");
+	TestEqual("ReceptionistPort", Manager->ReceptionistConfig.ReceptionistPort, 666);
+	TestEqual("WorkerType", Manager->ReceptionistConfig.WorkerType, "SomeWorkerType");
+
+	return true;
+}
+
+CONNECTIONMANAGER_TEST(SetupFromCommandLine_Receptionist_ReceptionistHostLocalExternalBridge)
+{
+	// GIVEN
+	FTemporaryCommandLine TemporaryCommandLine("-receptionistPort 666 -useExternalIpForBridge true");
+	USpatialConnectionManager* Manager = NewObject<USpatialConnectionManager>();
+
+	// WHEN
+	const bool bSuccess = Manager->TrySetupConnectionConfigFromCommandLine("SomeWorkerType");
+
+	// THEN
+	TestEqual("Success", bSuccess, true);
+	TestEqual("UseExternalIp", Manager->ReceptionistConfig.UseExternalIp, true);
+	TestEqual("ReceptionistHost", Manager->ReceptionistConfig.GetReceptionistHost(), "127.0.0.1");
+	TestEqual("ReceptionistPort", Manager->ReceptionistConfig.ReceptionistPort, 666);
+	TestEqual("WorkerType", Manager->ReceptionistConfig.WorkerType, "SomeWorkerType");
+
+	return true;
+}
+
+CONNECTIONMANAGER_TEST(SetupFromCommandLine_Receptionist_URL)
+{
+	// GIVEN
 	FTemporaryCommandLine TemporaryCommandLine("10.20.30.40?someUnknownFlag?otherFlag -receptionistPort 666");
+	USpatialConnectionManager* Manager = NewObject<USpatialConnectionManager>();
+
+	// WHEN
 	const bool bSuccess = Manager->TrySetupConnectionConfigFromCommandLine("SomeWorkerType");
 
 	// THEN
@@ -227,10 +276,11 @@ CONNECTIONMANAGER_TEST(SetupFromCommandLine_Receptionist_URL)
 
 CONNECTIONMANAGER_TEST(SetupFromCommandLine_Receptionist_URLAndExternalBridge)
 {
+	// GIVEN
+	FTemporaryCommandLine TemporaryCommandLine("127.0.0.1?useExternalIpForBridge -receptionistPort 666");
 	USpatialConnectionManager* Manager = NewObject<USpatialConnectionManager>();
 
 	// WHEN
-	FTemporaryCommandLine TemporaryCommandLine("127.0.0.1?useExternalIpForBridge -receptionistPort 666");
 	Manager->TrySetupConnectionConfigFromCommandLine("SomeWorkerType");
 
 	// THEN

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/Connection/SpatialConnectionManagerTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/Connection/SpatialConnectionManagerTest.cpp
@@ -10,19 +10,19 @@
 class FTemporaryCommandLine
 {
 public:
-    FTemporaryCommandLine(const FString& NewCommandLine)
+	explicit FTemporaryCommandLine(const FString& NewCommandLine)
     {
     	if (OldCommandLine.IsEmpty())
     	{
     		OldCommandLine = FCommandLine::GetOriginal();
     		FCommandLine::Set(*NewCommandLine);
-    		DidSetCommandLine = true;
+    		bDidSetCommandLine = true;
     	}
     }
 
 	~FTemporaryCommandLine()
     {
-	    if (DidSetCommandLine)
+	    if (bDidSetCommandLine)
 	    {
 		    FCommandLine::Set(*OldCommandLine);
 	    	OldCommandLine.Empty();
@@ -31,7 +31,7 @@ public:
 
 private:
     static FString OldCommandLine;
-	bool DidSetCommandLine = false;
+	bool bDidSetCommandLine = false;
 };
 
 FString FTemporaryCommandLine::OldCommandLine;

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/Connection/SpatialConnectionManagerTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/Connection/SpatialConnectionManagerTest.cpp
@@ -1,0 +1,243 @@
+﻿// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "Tests/TestDefinitions.h"
+#include "Interop/Connection/SpatialConnectionManager.h"
+#include "CoreMinimal.h"
+
+#define CONNECTIONMANAGER_TEST(TestName) \
+	GDK_TEST(Core, SpatialConnectionManager, TestName)
+
+class FTemporaryCommandLine
+{
+public:
+    FTemporaryCommandLine(const FString& NewCommandLine)
+    {
+    	OldCommandLine = FCommandLine::GetOriginal();
+    	FCommandLine::Set(*NewCommandLine);
+    }
+
+	~FTemporaryCommandLine()
+    {
+    	FCommandLine::Set(*OldCommandLine);
+    }
+
+private:
+    FString OldCommandLine;
+};
+
+CONNECTIONMANAGER_TEST(SetupFromURL_Locator_CustomLocator)
+{
+	USpatialConnectionManager* Manager = NewObject<USpatialConnectionManager>();
+
+	// WHEN
+	const FURL URL(nullptr, TEXT("10.20.30.40?locator?customLocator?playeridentity=foo?login=bar"), TRAVEL_Absolute);
+	FTemporaryCommandLine TemporaryCommandLine("-locatorHost 99.88.77.66");
+	Manager->SetupConnectionConfigFromURL(URL, "SomeWorkerType");
+
+	// THEN
+	TestEqual("LocatorHost", Manager->LocatorConfig.LocatorHost, "10.20.30.40");
+	TestEqual("PlayerIdentityToken", Manager->LocatorConfig.PlayerIdentityToken, "foo");
+	TestEqual("LoginToken", Manager->LocatorConfig.LoginToken, "bar");
+	TestEqual("WorkerType", Manager->LocatorConfig.WorkerType, "SomeWorkerType");
+
+	return true;
+}
+
+CONNECTIONMANAGER_TEST(SetupFromURL_Locator_LocatorHost)
+{
+	USpatialConnectionManager* Manager = NewObject<USpatialConnectionManager>();
+
+	// WHEN
+	const FURL URL(nullptr, TEXT("10.20.30.40?locator?playeridentity=foo?login=bar"), TRAVEL_Absolute);
+	FTemporaryCommandLine TemporaryCommandLine("-locatorHost 99.88.77.66");
+	Manager->SetupConnectionConfigFromURL(URL, "SomeWorkerType");
+
+	// THEN
+	TestEqual("LocatorHost", Manager->LocatorConfig.LocatorHost, "99.88.77.66");
+	TestEqual("PlayerIdentityToken", Manager->LocatorConfig.PlayerIdentityToken, "foo");
+	TestEqual("LoginToken", Manager->LocatorConfig.LoginToken, "bar");
+	TestEqual("WorkerType", Manager->LocatorConfig.WorkerType, "SomeWorkerType");
+
+	return true;
+}
+
+CONNECTIONMANAGER_TEST(SetupFromURL_DevAuth)
+{
+	USpatialConnectionManager* Manager = NewObject<USpatialConnectionManager>();
+
+	// WHEN
+	const FURL URL(nullptr,
+		TEXT("10.20.30.40?devauth?customLocator?devauthtoken=foo?deployment=bar?playerid=666?displayname=n00bkilla?metadata=important"),
+		TRAVEL_Absolute);
+	FTemporaryCommandLine TemporaryCommandLine("-locatorHost 99.88.77.66");
+	Manager->SetupConnectionConfigFromURL(URL, "SomeWorkerType");
+
+	// THEN
+	TestEqual("LocatorHost", Manager->DevAuthConfig.LocatorHost, "10.20.30.40");
+	TestEqual("DevAuthToken", Manager->DevAuthConfig.DevelopmentAuthToken, "foo");
+	TestEqual("Deployment", Manager->DevAuthConfig.Deployment, "bar");
+	TestEqual("PlayerId", Manager->DevAuthConfig.PlayerId, "666");
+	TestEqual("DisplayName", Manager->DevAuthConfig.DisplayName, "n00bkilla");
+	TestEqual("Metadata", Manager->DevAuthConfig.MetaData, "important");
+	TestEqual("WorkerType", Manager->DevAuthConfig.WorkerType, "SomeWorkerType");
+
+	return true;
+}
+
+CONNECTIONMANAGER_TEST(SetupFromURL_DevAuth_LocatorHost)
+{
+	USpatialConnectionManager* Manager = NewObject<USpatialConnectionManager>();
+
+	// WHEN
+	const FURL URL(nullptr, TEXT("10.20.30.40?devauth"),TRAVEL_Absolute);
+	FTemporaryCommandLine TemporaryCommandLine("-locatorHost 99.88.77.66");
+	Manager->SetupConnectionConfigFromURL(URL, "SomeWorkerType");
+
+	// THEN
+	TestEqual("LocatorHost", Manager->DevAuthConfig.LocatorHost, "99.88.77.66");
+
+	return true;
+}
+
+CONNECTIONMANAGER_TEST(SetupFromURL_Receptionist_Localhost)
+{
+	USpatialConnectionManager* Manager = NewObject<USpatialConnectionManager>();
+
+	// WHEN
+	const FURL URL(nullptr, TEXT("127.0.0.1"), TRAVEL_Absolute);
+	FTemporaryCommandLine TemporaryCommandLine("");
+	Manager->SetupConnectionConfigFromURL(URL, "SomeWorkerType");
+
+	// THEN
+	TestEqual("UseExternalIp", Manager->ReceptionistConfig.UseExternalIp, false);
+	TestEqual("ReceptionistHost", Manager->ReceptionistConfig.GetReceptionistHost(), "127.0.0.1");
+	TestEqual("WorkerType", Manager->ReceptionistConfig.WorkerType, "SomeWorkerType");
+
+	return true;
+}
+
+CONNECTIONMANAGER_TEST(SetupFromURL_Receptionist_ExternalHost)
+{
+	USpatialConnectionManager* Manager = NewObject<USpatialConnectionManager>();
+
+	// WHEN
+	const FURL URL(nullptr, TEXT("10.20.30.40"), TRAVEL_Absolute);
+	FTemporaryCommandLine TemporaryCommandLine("");
+	Manager->SetupConnectionConfigFromURL(URL, "SomeWorkerType");
+
+	// THEN
+	TestEqual("UseExternalIp", Manager->ReceptionistConfig.UseExternalIp, true);
+	TestEqual("ReceptionistHost", Manager->ReceptionistConfig.GetReceptionistHost(), "10.20.30.40");
+	TestEqual("WorkerType", Manager->ReceptionistConfig.WorkerType, "SomeWorkerType");
+
+	return true;
+}
+
+CONNECTIONMANAGER_TEST(SetupFromURL_Receptionist_ExternalBridge)
+{
+	USpatialConnectionManager* Manager = NewObject<USpatialConnectionManager>();
+
+	// WHEN
+	const FURL URL(nullptr, TEXT("127.0.0.1?useExternalIpForBridge"), TRAVEL_Absolute);
+	FTemporaryCommandLine TemporaryCommandLine("");
+	Manager->SetupConnectionConfigFromURL(URL, "SomeWorkerType");
+
+	// THEN
+	TestEqual("UseExternalIp", Manager->ReceptionistConfig.UseExternalIp, true);
+	TestEqual("ReceptionistHost", Manager->ReceptionistConfig.GetReceptionistHost(), "127.0.0.1");
+	TestEqual("WorkerType", Manager->ReceptionistConfig.WorkerType, "SomeWorkerType");
+
+	return true;
+}
+
+CONNECTIONMANAGER_TEST(SetupFromCommandLine_Locator)
+{
+	USpatialConnectionManager* Manager = NewObject<USpatialConnectionManager>();
+
+	// WHEN
+	FTemporaryCommandLine TemporaryCommandLine("-locatorHost 10.20.30.40 -playerIdentityToken foo -loginToken bar");
+	const bool bSuccess = Manager->TrySetupConnectionConfigFromCommandLine("SomeWorkerType");
+
+	// THEN
+	TestEqual("Success", bSuccess, true);
+	TestEqual("LocatorHost", Manager->LocatorConfig.LocatorHost, "10.20.30.40");
+	TestEqual("PlayerIdentityToken", Manager->LocatorConfig.PlayerIdentityToken, "foo");
+	TestEqual("LoginToken", Manager->LocatorConfig.LoginToken, "bar");
+	TestEqual("WorkerType", Manager->LocatorConfig.WorkerType, "SomeWorkerType");
+
+	return true;
+}
+
+CONNECTIONMANAGER_TEST(SetupFromCommandLine_DevAuth)
+{
+	USpatialConnectionManager* Manager = NewObject<USpatialConnectionManager>();
+
+	// WHEN
+	FTemporaryCommandLine TemporaryCommandLine("-locatorHost 10.20.30.40 -devAuthToken foo -deployment bar -playerId 666 -displayName n00bkilla -metadata important");
+	const bool bSuccess = Manager->TrySetupConnectionConfigFromCommandLine("SomeWorkerType");
+
+	// THEN
+	TestEqual("Success", bSuccess, true);
+	TestEqual("LocatorHost", Manager->DevAuthConfig.LocatorHost, "10.20.30.40");
+	TestEqual("DevAuthToken", Manager->DevAuthConfig.DevelopmentAuthToken, "foo");
+	TestEqual("Deployment", Manager->DevAuthConfig.Deployment, "bar");
+	TestEqual("PlayerId", Manager->DevAuthConfig.PlayerId, "666");
+	TestEqual("DisplayName", Manager->DevAuthConfig.DisplayName, "n00bkilla");
+	TestEqual("Metadata", Manager->DevAuthConfig.MetaData, "important");
+	TestEqual("WorkerType", Manager->DevAuthConfig.WorkerType, "SomeWorkerType");
+
+	return true;
+}
+
+CONNECTIONMANAGER_TEST(SetupFromCommandLine_Receptionist_ReceptionistHost)
+{
+	USpatialConnectionManager* Manager = NewObject<USpatialConnectionManager>();
+
+	// WHEN
+	FTemporaryCommandLine TemporaryCommandLine("-receptionistHost 10.20.30.40 -receptionistPort 666");
+	const bool bSuccess = Manager->TrySetupConnectionConfigFromCommandLine("SomeWorkerType");
+
+	// THEN
+	TestEqual("Success", bSuccess, true);
+	TestEqual("UseExternalIp", Manager->ReceptionistConfig.UseExternalIp, true);
+	TestEqual("ReceptionistHost", Manager->ReceptionistConfig.GetReceptionistHost(), "10.20.30.40");
+	TestEqual("ReceptionistPort", Manager->ReceptionistConfig.ReceptionistPort, 666);
+	TestEqual("WorkerType", Manager->ReceptionistConfig.WorkerType, "SomeWorkerType");
+
+	return true;
+}
+
+CONNECTIONMANAGER_TEST(SetupFromCommandLine_Receptionist_URL)
+{
+	USpatialConnectionManager* Manager = NewObject<USpatialConnectionManager>();
+
+	// WHEN
+	FTemporaryCommandLine TemporaryCommandLine("10.20.30.40?someUnknownFlag?otherFlag -receptionistPort 666");
+	const bool bSuccess = Manager->TrySetupConnectionConfigFromCommandLine("SomeWorkerType");
+
+	// THEN
+	TestEqual("Success", bSuccess, true);
+	TestEqual("UseExternalIp", Manager->ReceptionistConfig.UseExternalIp, true);
+	TestEqual("ReceptionistHost", Manager->ReceptionistConfig.GetReceptionistHost(), "10.20.30.40");
+	TestEqual("ReceptionistPort", Manager->ReceptionistConfig.ReceptionistPort, 666);
+	TestEqual("WorkerType", Manager->ReceptionistConfig.WorkerType, "SomeWorkerType");
+
+	return true;
+}
+
+CONNECTIONMANAGER_TEST(SetupFromCommandLine_Receptionist_URLAndExternalBridge)
+{
+	USpatialConnectionManager* Manager = NewObject<USpatialConnectionManager>();
+
+	// WHEN
+	FTemporaryCommandLine TemporaryCommandLine("127.0.0.1?useExternalIpForBridge -receptionistPort 666");
+	Manager->TrySetupConnectionConfigFromCommandLine("SomeWorkerType");
+
+	// THEN
+	TestEqual("UseExternalIp", Manager->ReceptionistConfig.UseExternalIp, true);
+	TestEqual("ReceptionistHost", Manager->ReceptionistConfig.GetReceptionistHost(), "127.0.0.1");
+	TestEqual("ReceptionistPort", Manager->ReceptionistConfig.ReceptionistPort, 666);
+	TestEqual("WorkerType", Manager->ReceptionistConfig.WorkerType, "SomeWorkerType");
+
+	return true;
+}

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/Connection/SpatialWorkerConnectionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/Connection/SpatialWorkerConnectionTest.cpp
@@ -37,7 +37,7 @@ void StartSetupConnectionConfigFromURL(USpatialConnectionManager* ConnectionMana
 	bOutUseReceptionist = (URL.Host != SpatialConstants::LOCATOR_HOST) && !URL.HasOption(TEXT("locator"));
 	if (bOutUseReceptionist)
 	{
-		ConnectionManager->ReceptionistConfig.SetReceptionistHost(URL.Host);
+		ConnectionManager->ReceptionistConfig.SetupFromURL(URL);
 	}
 	else
 	{
@@ -57,11 +57,6 @@ void FinishSetupConnectionConfig(USpatialConnectionManager* ConnectionManager, c
 
 		FReceptionistConfig& ReceptionistConfig = ConnectionManager->ReceptionistConfig;
 		ReceptionistConfig.WorkerType = WorkerType;
-
-		if (URL.HasOption(*SpatialConstants::URL_USE_EXTERNAL_IP_FOR_BRIDGE_OPTION))
-		{
-			ReceptionistConfig.UseExternalIp = true;
-		}
 	}
 	else
 	{

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/Connection/SpatialWorkerConnectionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/Connection/SpatialWorkerConnectionTest.cpp
@@ -58,11 +58,9 @@ void FinishSetupConnectionConfig(USpatialConnectionManager* ConnectionManager, c
 		FReceptionistConfig& ReceptionistConfig = ConnectionManager->ReceptionistConfig;
 		ReceptionistConfig.WorkerType = WorkerType;
 
-		const TCHAR* UseExternalIpForBridge = TEXT("useExternalIpForBridge");
-		if (URL.HasOption(UseExternalIpForBridge))
+		if (URL.HasOption(*SpatialConstants::URL_USE_EXTERNAL_IP_FOR_BRIDGE_OPTION))
 		{
-			FString UseExternalIpOption = URL.GetOption(UseExternalIpForBridge, TEXT(""));
-			ReceptionistConfig.UseExternalIp = !UseExternalIpOption.Equals(TEXT("false"), ESearchCase::IgnoreCase);
+			ReceptionistConfig.UseExternalIp = true;
 		}
 	}
 	else
@@ -75,7 +73,7 @@ void FinishSetupConnectionConfig(USpatialConnectionManager* ConnectionManager, c
 	}
 }
 } // anonymous namespace
- 
+
 DEFINE_LATENT_AUTOMATION_COMMAND_ONE_PARAMETER(FWaitForSeconds, double, Seconds);
 bool FWaitForSeconds::Update()
 {


### PR DESCRIPTION
#### Description
- Receptionist options are now properly parsed even if a URL with options is present.
- When using `receptionistHost` with a non-local host, it's no longer necessary to explicitly set `useExternalIpForBridge true` as well.
- Added unit tests for URL and command line parsing

#### Documentation
Release note
