### PR TITLE
Allow smaller master builds in CI

### DIFF
--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -57,8 +57,7 @@ steps:
   # Trigger an Example Project build for any merges into master, preview or release branches of UnrealGDK
   - trigger: "unrealgdkexampleproject-nightly"
     label: "post-merge-example-project-build"
-    branches: "master preview release"
-    if: build.env("ENGINE_NET_TEST") != "true"
+    if: build.env("ENGINE_NET_TEST") != "true" && (build.branch == "master" || build.branch == "preview" || build.branch == "release")
     async: true
     build:
       env:

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -58,6 +58,7 @@ steps:
   - trigger: "unrealgdkexampleproject-nightly"
     label: "post-merge-example-project-build"
     branches: "master preview release"
+    if: build.env("ENGINE_NET_TEST") != "true"
     async: true
     build:
       env:
@@ -78,6 +79,6 @@ steps:
     <<: *script_runner
   
   - label: "slack-notify"
-    if: (build.env("SLACK_NOTIFY") == "true" || build.branch == "master") && build.env("SLACK_NOTIFY") != "false"
+    if: (build.env("SLACK_NOTIFY") == "true" || build.branch == "master") && build.env("SLACK_NOTIFY") != "false" && build.env("ENGINE_NET_TEST") != "true"
     commands: "powershell ./ci/build-and-send-slack-notification.ps1"
     <<: *windows

--- a/ci/generate-and-upload-build-steps.sh
+++ b/ci/generate-and-upload-build-steps.sh
@@ -52,7 +52,9 @@ generate_build_configuration_steps () {
             upload_build_configuration_step "${ENGINE_COMMIT_HASH}" "Win64" "Editor" "Development"
 
             # Linux Development NoEditor build configuration
-            upload_build_configuration_step "${ENGINE_COMMIT_HASH}" "Linux" "" "Development"
+            if [[ "${ENGINE_NET_TEST:-false}" != "true" ]]; then
+                upload_build_configuration_step "${ENGINE_COMMIT_HASH}" "Linux" "" "Development"
+            fi
         else
             echo "Building for all supported configurations. Generating the appropriate steps..."
 


### PR DESCRIPTION
#### Description
EngineNetTest would like to call our CI, but our builds are too big, this makes them smaller for the EngineNetTest.

#### Primary reviewers

