### PR TITLE
Bugfix/unr 3405 unrealed workflow problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Fix problem where load balanced cloud deploys could fail to start while under heavy load.
 - Fix to avoid using packages still being processed in the async loading thread.
 - Fixed a bug when running GDK setup scripts fail to unzip dependencies sometimes.
+- Fixed a bug where enabling autogenerate config to run a Load Balanced PIE deployment, then later disabling it, results in deployments still having multiple servers.
 
 ### External contributors:
 @DW-Sebastien

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -648,6 +648,9 @@ void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment()
 	else
 	{
 		LaunchConfig = SpatialGDKEditorSettings->GetSpatialOSLaunchConfig();
+
+		FSpatialLaunchConfigDescription LaunchConfigDescription;
+		LaunchConfigDescription.SetLevelEditorPlaySettingsWorkerTypes();
 	}
 
 	const FString LaunchFlags = SpatialGDKEditorSettings->GetSpatialOSCommandLineLaunchFlags();


### PR DESCRIPTION
#### Description
Fixed a bug where enabling autogenerate config to run a Load Balanced PIE deployment, then later disabling it, results in deployments still having multiple servers.


#### Release note
Added a bugfix note to changelog.md.

#### Tests
Verified the problem described no longer occurs with this change.

STRONGLY SUGGESTED: How can this be verified by QA?
Follow the repro steps on UNR-3405 and observe the problem no longer happens.

#### Documentation
Release note.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
