### PR TITLE
[UNR-3411] Print a better error and don't attempt to connect if dev auth flow deployment not found

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
@@ -229,7 +229,7 @@ void USpatialConnectionManager::ProcessLoginTokensResponse(const Worker_Alpha_Lo
 
 		if (!bFoundDeployment)
 		{
-			OnConnectionFailure(WORKER_CONNECTION_STATUS_CODE_NETWORK_ERROR, FString::Printf(TEXT("Deployment '%s' not found!"), *DeploymentToConnect));
+			OnConnectionFailure(WORKER_CONNECTION_STATUS_CODE_NETWORK_ERROR, FString::Printf(TEXT("Deployment not found! Make sure that the deployment with name '%s' is running and has the 'dev_login' deployment tag."), *DeploymentToConnect));
 			return;
 		}
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
@@ -214,14 +214,23 @@ void USpatialConnectionManager::ProcessLoginTokensResponse(const Worker_Alpha_Lo
 	}
 	else
 	{
+		bool bFoundDeployment = false;
+
 		for (uint32 i = 0; i < LoginTokens->login_token_count; i++)
 		{
 			FString DeploymentName = UTF8_TO_TCHAR(LoginTokens->login_tokens[i].deployment_name);
 			if (DeploymentToConnect.Compare(DeploymentName) == 0)
 			{
 				DevAuthConfig.LoginToken = FString(LoginTokens->login_tokens[i].login_token);
+				bFoundDeployment = true;
 				break;
 			}
+		}
+
+		if (!bFoundDeployment)
+		{
+			OnConnectionFailure(WORKER_CONNECTION_STATUS_CODE_NETWORK_ERROR, FString::Printf(TEXT("Deployment '%s' not found!"), *DeploymentToConnect));
+			return;
 		}
 	}
 


### PR DESCRIPTION
#### Description
Easier to debug than `Log in via locator failed: gRPC error INVALID_ARGUMENT: could not decode LoginToken` (this is what would previously be printed after trying to connect to locator with an empty login token)

#### Primary reviewers
@jessicafalk @MatthewSandfordImprobable 
