### PR TITLE
Save arguments passed to Setup.bat when creating git hooks

### DIFF
--- a/Setup.bat
+++ b/Setup.bat
@@ -23,7 +23,7 @@ call :MarkStartOfBlock "Setup the git hooks"
     echo check_run() {>>.git\hooks\post-merge
     echo echo "$changed_files" ^| grep --quiet "$1" ^&^& exec $2>>.git\hooks\post-merge
     echo }>>.git\hooks\post-merge
-    echo check_run RequireSetup "cmd.exe /c Setup.bat">>.git\hooks\post-merge
+    echo check_run RequireSetup "cmd.exe /c Setup.bat %*">>.git\hooks\post-merge
 
     :SkipGitHooks
 call :MarkEndOfBlock "Setup the git hooks"


### PR DESCRIPTION
#### Description
If you run `Setup.bat --mobile` or `--china`, it should automatically pass those flags when run from a git hook.

#### Primary reviewers
@jessicafalk @joshuahuburn 