### PR TITLE
Slow GDK tests will only run nightly

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Public/Tests/TestDefinitions.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Tests/TestDefinitions.h
@@ -10,3 +10,10 @@
 
 #define GDK_COMPLEX_TEST(ModuleName, ComponentName, TestName) \
 	IMPLEMENT_COMPLEX_AUTOMATION_TEST(TestName, "SpatialGDK."#ModuleName"."#ComponentName"."#TestName, EAutomationTestFlags::ApplicationContextMask | EAutomationTestFlags::EngineFilter)
+
+#define GDK_SLOW_TEST(ModuleName, ComponentName, TestName) \
+	IMPLEMENT_SIMPLE_AUTOMATION_TEST(TestName, "SpatialGDKSlow."#ModuleName"."#ComponentName"."#TestName, EAutomationTestFlags::ApplicationContextMask | EAutomationTestFlags::EngineFilter) \
+	bool TestName::RunTest(const FString& Parameters)
+
+#define GDK_SLOW_COMPLEX_TEST(ModuleName, ComponentName, TestName) \
+	IMPLEMENT_COMPLEX_AUTOMATION_TEST(TestName, "SpatialGDKSlow."#ModuleName"."#ComponentName"."#TestName, EAutomationTestFlags::ApplicationContextMask | EAutomationTestFlags::EngineFilter)

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Utils/Misc/SpatialActivationFlagsTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Utils/Misc/SpatialActivationFlagsTest.cpp
@@ -19,7 +19,7 @@ void InitializeSpatialFlagEarlyValues()
 	bEarliestFlag = GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking();
 }
 
-GDK_TEST(Core, UGeneralProjectSettings, SpatialActivationReport)
+GDK_SLOW_TEST(Core, UGeneralProjectSettings, SpatialActivationReport)
 {
 	const UGeneralProjectSettings* ProjectSettings = GetDefault<UGeneralProjectSettings>();
 

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Utils/Misc/SpatialActivationFlagsTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Utils/Misc/SpatialActivationFlagsTest.cpp
@@ -69,7 +69,7 @@ struct SpatialActivationFlagTestFixture
 	{
 		ProjectPath = FPaths::GetProjectFilePath();
 		CommandLineArgs = ProjectPath;
-		CommandLineArgs.Append(TEXT(" -ExecCmds=\"Automation RunTests SpatialGDK.Core.UGeneralProjectSettings.SpatialActivationReport; Quit\""));
+		CommandLineArgs.Append(TEXT(" -ExecCmds=\"Automation RunTests SpatialGDKSlow.Core.UGeneralProjectSettings.SpatialActivationReport; Quit\""));
 		CommandLineArgs.Append(TEXT(" -TestExit=\"Automation Test Queue Empty\""));
 		CommandLineArgs.Append(TEXT(" -nopause"));
 		CommandLineArgs.Append(TEXT(" -nosplash"));

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Utils/Misc/SpatialActivationFlagsTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Utils/Misc/SpatialActivationFlagsTest.cpp
@@ -131,7 +131,7 @@ bool FRunSubProcessCommand::Update()
 }
 
 
-GDK_TEST(Core, UGeneralProjectSettings, SpatialActivationSetting_False)
+GDK_SLOW_TEST(Core, UGeneralProjectSettings, SpatialActivationSetting_False)
 {
 	auto TestFixture = MakeShared<SpatialActivationFlagTestFixture>(*this);
 	TestFixture->ChangeSetting(false);
@@ -141,7 +141,7 @@ GDK_TEST(Core, UGeneralProjectSettings, SpatialActivationSetting_False)
 	return true;
 }
 
-GDK_TEST(Core, UGeneralProjectSettings, SpatialActivationSetting_True)
+GDK_SLOW_TEST(Core, UGeneralProjectSettings, SpatialActivationSetting_True)
 {
 	auto TestFixture = MakeShared<SpatialActivationFlagTestFixture>(*this);
 	TestFixture->ChangeSetting(true);
@@ -151,7 +151,7 @@ GDK_TEST(Core, UGeneralProjectSettings, SpatialActivationSetting_True)
 	return true;
 }
 
-GDK_TEST(Core, UGeneralProjectSettings, SpatialActivationOverride_True)
+GDK_SLOW_TEST(Core, UGeneralProjectSettings, SpatialActivationOverride_True)
 {
 	auto TestFixture = MakeShared<SpatialActivationFlagTestFixture>(*this);
 	TestFixture->ChangeSetting(false);
@@ -165,7 +165,7 @@ GDK_TEST(Core, UGeneralProjectSettings, SpatialActivationOverride_True)
 	return true;
 }
 
-GDK_TEST(Core, UGeneralProjectSettings, SpatialActivationOverride_False)
+GDK_SLOW_TEST(Core, UGeneralProjectSettings, SpatialActivationOverride_False)
 {
 	auto TestFixture = MakeShared<SpatialActivationFlagTestFixture>(*this);
 	TestFixture->ChangeSetting(false);

--- a/ci/setup-build-test-gdk.ps1
+++ b/ci/setup-build-test-gdk.ps1
@@ -57,20 +57,23 @@ if (Test-Path env:BUILD_ALL_CONFIGURATIONS) {
     $test_repo_map = "EmptyGym"
     $test_project_name = "GDKTestGyms"
 
-    $tests += [TestSuite]::new("$test_repo_url", "$test_repo_branch", "$test_repo_relative_uproject_path", "$test_repo_map", "$test_project_name", "TestResults", "SpatialGDK", "bEnableUnrealLoadBalancer=false$user_gdk_settings", $True)
+    $tests += [TestSuite]::new("$test_repo_url", "$test_repo_branch", "$test_repo_relative_uproject_path", "$test_repo_map", "$test_project_name", "TestResults", "SpatialGDK.", "bEnableUnrealLoadBalancer=false$user_gdk_settings", $True)
 }
 else{
     if ((Test-Path env:TEST_CONFIG) -And ($env:TEST_CONFIG -eq "Native")) {
         $tests += [TestSuite]::new("$test_repo_url", "$test_repo_branch", "$test_repo_relative_uproject_path", "$test_repo_map", "$test_project_name", "VanillaTestResults", "/Game/SpatialNetworkingMap", "$user_gdk_settings", $False)
     }
     else {
-        $tests += [TestSuite]::new("$test_repo_url", "$test_repo_branch", "$test_repo_relative_uproject_path", "$test_repo_map", "$test_project_name", "TestResults", "SpatialGDK+/Game/SpatialNetworkingMap", "$user_gdk_settings", $True)
+        $tests += [TestSuite]::new("$test_repo_url", "$test_repo_branch", "$test_repo_relative_uproject_path", "$test_repo_map", "$test_project_name", "TestResults", "SpatialGDK.+/Game/SpatialNetworkingMap", "$user_gdk_settings", $True)
         # enable load-balancing once the tests pass reliably and the testing repo is updated
         # $tests += [TestSuite]::new("$test_repo_url", "$test_repo_branch", "$test_repo_relative_uproject_path", "$test_repo_map", "$test_project_name", "LoadbalancerTestResults", "/Game/Spatial_ZoningMap_1S_2C", "bEnableUnrealLoadBalancer=true;LoadBalancingWorkerType=(WorkerTypeName=`"UnrealWorker`")$user_gdk_settings", $True)
     }
 
     if ($env:SLOW_NETWORKING_TESTS -like "true") {
         $tests[0].tests_path += "+/Game/NetworkingMap"
+        if($env:TEST_CONFIG -ne "Native") {
+            $tests[0].tests_path += "+SpatialGDKSlow."
+        }
         $tests[0].test_results_dir = "Slow" + $tests[0].test_results_dir
     }
 }


### PR DESCRIPTION
#### Description
Adds the ability to specify slower/more flaky GDK tests with the macros `GDK_SLOW_TEST` and `GDK_SLOW_COMPLEX_TEST`. These tests will run in the nightly, rather than the premerge.

#### Release note
N/A

#### Tests
Ran premerge and slow networking tests in CI.

#### Documentation
N/A

#### Primary reviewers
@aleximprobable 
