### PR TITLE
RPCs can now be called on UINTERFACE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Add ability to disable outgoing RPC queue timeouts by setting `QueuedOutgoingRPCWaitTime` to 0.0f.
 - Added `bWorkerFlushAfterOutgoingNetworkOp` (defaulted false) which publishes changes to the GDK worker queue after RPCs and property replication to allow for lower latencies. Can be used in conjunction with `bRunSpatialWorkerConnectionOnGameThread` to get the lowest available latency at a trade-off with bandwidth.
 - You can now edit the project name field in the `Cloud Deployment` window.
+- RPCs declared in a UINTERFACE can now be executed. Previously, this would lead to a runtime assertion.
 
 ## Bug fixes:
 - Fixed a bug that caused queued RPCs to spam logs when an entity is deleted.

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
@@ -214,14 +214,23 @@ void USpatialConnectionManager::ProcessLoginTokensResponse(const Worker_Alpha_Lo
 	}
 	else
 	{
+		bool bFoundDeployment = false;
+
 		for (uint32 i = 0; i < LoginTokens->login_token_count; i++)
 		{
 			FString DeploymentName = UTF8_TO_TCHAR(LoginTokens->login_tokens[i].deployment_name);
 			if (DeploymentToConnect.Compare(DeploymentName) == 0)
 			{
 				DevAuthConfig.LoginToken = FString(LoginTokens->login_tokens[i].login_token);
+				bFoundDeployment = true;
 				break;
 			}
+		}
+
+		if (!bFoundDeployment)
+		{
+			OnConnectionFailure(WORKER_CONNECTION_STATUS_CODE_NETWORK_ERROR, FString::Printf(TEXT("Deployment not found! Make sure that the deployment with name '%s' is running and has the 'dev_login' deployment tag."), *DeploymentToConnect));
+			return;
 		}
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/RepLayoutUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/RepLayoutUtils.h
@@ -87,7 +87,7 @@ inline void RepLayout_SendPropertiesForRPC(FRepLayout& RepLayout, FNetBitWriter&
 		if (!Cast<UBoolProperty>(Parent.Property))
 		{
 			// check for a complete match, including arrays
-			// (we're comparing against zero data here, since 
+			// (we're comparing against zero data here, since
 			// that's the default.)
 			bSend = !Parent.Property->Identical_InContainer(Data, NULL, Parent.ArrayIndex);
 
@@ -162,7 +162,9 @@ inline TArray<UFunction*> GetClassRPCFunctions(const UClass* Class)
 	// Get all remote functions from the class. This includes parents super functions and child override functions.
 	TArray<UFunction*> AllClassFunctions;
 
-	for (TFieldIterator<UFunction> RemoteFunction(Class); RemoteFunction; ++RemoteFunction)
+	TFieldIterator<UFunction> RemoteFunction(Class, EFieldIteratorFlags::IncludeSuper, EFieldIteratorFlags::IncludeDeprecated,
+		EFieldIteratorFlags::IncludeInterfaces);
+	for (; RemoteFunction; ++RemoteFunction)
 	{
 		if (RemoteFunction->FunctionFlags & FUNC_NetClient ||
 			RemoteFunction->FunctionFlags & FUNC_NetServer ||


### PR DESCRIPTION
#### Description
`RepLayoutUtils::GetClassRPCFunctions` ignored interfaces when iterating over the class field.

#### Tests
Added an automated test: https://github.com/improbable/UnrealGDKEngineNetTest/pull/30

