### PR TITLE
[UNR-3078] Launch config files fixups

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -120,7 +120,7 @@ struct FWorkerTypeLaunchSection
 		, LoginRateLimit()
 		, bAutoNumEditorInstances(true)
 		, NumEditorInstances(1)
-		, bManualWorkerConnectionOnly(true)
+		, bManualWorkerConnectionOnly(false)
 		, WorkerLoadBalancing(nullptr)
 	{
 	}
@@ -376,9 +376,7 @@ public:
 
 	FORCEINLINE FString GetSpatialOSLaunchConfig() const
 	{
-		return SpatialOSLaunchConfig.FilePath.IsEmpty()
-			? FPaths::Combine(SpatialGDKServicesConstants::SpatialOSDirectory, TEXT("default_launch.json"))
-			: SpatialOSLaunchConfig.FilePath;
+		return SpatialOSLaunchConfig.FilePath;
 	}
 
 	FORCEINLINE FString GetSpatialOSSnapshotToSave() const

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -590,6 +590,7 @@ void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment()
 		{
 			FWorkerTypeLaunchSection Conf = WorkerType.Value;
 			Conf.WorkerLoadBalancing = LoadBalancingStrat;
+			// Force manual connection to true as this is the config for PIE.
 			Conf.bManualWorkerConnectionOnly = true;
 			WorkersMap.Add(WorkerType.Key, Conf);
 		}
@@ -604,9 +605,10 @@ void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment()
 
 		// Also create default launch config for cloud deployments.
 		{
-			for (auto& WorkerLaunchSection : WorkersMap)
+			// Revert to the setting's flag value for manual connection.
+			for (auto& WorkerLaunchSectionSettings : SpatialGDKEditorSettings->LaunchConfigDesc.ServerWorkersMap)
 			{
-				WorkerLaunchSection.Value.bManualWorkerConnectionOnly = false;
+				WorkersMap[WorkerLaunchSectionSettings.Key].bManualWorkerConnectionOnly = WorkerLaunchSectionSettings.Value.bManualWorkerConnectionOnly;
 			}
 
 			FString CloudLaunchConfig = FPaths::Combine(FPaths::ConvertRelativePathToFull(FPaths::ProjectIntermediateDir()), FString::Printf(TEXT("Improbable/%s_CloudLaunchConfig.json"), *EditorWorld->GetMapName()));

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -855,7 +855,7 @@ FReply SSpatialGDKSimulatedPlayerDeployment::OnGenerateConfigFromCurrentMap()
 	UWorld* EditorWorld = GEditor->GetEditorWorldContext().World();
 	check(EditorWorld != nullptr);
 
-	const FString LaunchConfig = FPaths::Combine(FPaths::ConvertRelativePathToFull(FPaths::ProjectIntermediateDir()), FString::Printf(TEXT("Improbable/%s_LocalLaunchConfig.json"), *EditorWorld->GetMapName()));
+	const FString LaunchConfig = FPaths::Combine(FPaths::ConvertRelativePathToFull(FPaths::ProjectIntermediateDir()), FString::Printf(TEXT("Improbable/%s_CloudLaunchConfig.json"), *EditorWorld->GetMapName()));
 
 	const USpatialGDKSettings* SpatialGDKSettings = GetDefault<USpatialGDKSettings>();
 	const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>();
@@ -875,12 +875,6 @@ FReply SSpatialGDKSimulatedPlayerDeployment::OnGenerateConfigFromCurrentMap()
 FReply SSpatialGDKSimulatedPlayerDeployment::OnOpenLaunchConfigEditor()
 {
 	ULaunchConfigurationEditor* Editor = UTransientUObjectEditor::LaunchTransientUObjectEditor<ULaunchConfigurationEditor>("Launch Configuration Editor", ParentWindowPtr.Pin());
-
-	// Set the defaults launch setting to cloud-friendly ones.
-	for (auto& WorkerEntry : Editor->LaunchConfiguration.ServerWorkersMap)
-	{
-		WorkerEntry.Value.bManualWorkerConnectionOnly = false;
-	}
 
 	Editor->OnConfigurationSaved.BindLambda([WeakThis = TWeakPtr<SWidget>(this->AsShared())](ULaunchConfigurationEditor*, const FString& FilePath)
 	{


### PR DESCRIPTION
#### Description
Stop proposing default_launch_config.json as the default launch config for cloud deployment. Instead, the field stays blank, and the added buttons, "Generate from current map" and "Open launch config editor" propose a simple way to get good defaults.
There was some mixups when getting the bManualWorkerConnection's flag value. As we are forcing the value of this flag to false when launching PIE, I changed the default value in the settings to false, and I respect these settings when generating the configuration file for the cloud. That way we have good defaults for the cloud, and the user can persist its own preference instead of us forcing it.