### PR TITLE
Move CleanupLevelInitializedNetworkActors to SpatialNetDriver

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -66,8 +66,8 @@ void USpatialSender::Init(USpatialNetDriver* InNetDriver, FTimerManager* InTimer
 	Receiver = InNetDriver->Receiver;
 	PackageMap = InNetDriver->PackageMap;
 	ClassInfoManager = InNetDriver->ClassInfoManager;
-	check(InNetDriver->ActorGroupManager != nullptr);
-	ActorGroupManager = InNetDriver->ActorGroupManager;
+	check(InNetDriver->ActorGroupManager.IsValid());
+	ActorGroupManager = InNetDriver->ActorGroupManager.Get();
 	TimerManager = InTimerManager;
 	RPCService = InRPCService;
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
@@ -9,7 +9,6 @@
 #include "Interop/SpatialWorkerFlags.h"
 #include "Kismet/KismetSystemLibrary.h"
 #include "SpatialConstants.h"
-#include "EngineClasses/SpatialGameInstance.h"
 #include "SpatialGDKSettings.h"
 #include "Utils/InspectionColors.h"
 #include "Utils/SpatialActorGroupManager.h"
@@ -25,10 +24,10 @@ SpatialActorGroupManager* USpatialStatics::GetActorGroupManager(const UObject* W
 {
 	if (const UWorld* World = WorldContext->GetWorld())
 	{
-		if (const USpatialGameInstance* SpatialGameInstance = Cast<USpatialGameInstance>(World->GetGameInstance()))
+		if (const USpatialNetDriver* SpatialNetDriver = Cast<USpatialNetDriver>(World->GetNetDriver()))
 		{
-			check(SpatialGameInstance->ActorGroupManager.IsValid());
-			return SpatialGameInstance->ActorGroupManager.Get();
+			check(SpatialNetDriver->ActorGroupManager.IsValid());
+			return SpatialNetDriver->ActorGroupManager.Get();
 		}
 	}
 	return nullptr;

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialGameInstance.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialGameInstance.h
@@ -4,7 +4,6 @@
 
 #include "CoreMinimal.h"
 #include "Engine/GameInstance.h"
-#include "Utils/SpatialActorGroupManager.h"
 
 #include "SpatialGameInstance.generated.h"
 
@@ -68,10 +67,6 @@ public:
 
 	void SetFirstConnectionToSpatialOSAttempted() { bFirstConnectionToSpatialOSAttempted = true; };
 	bool GetFirstConnectionToSpatialOSAttempted() const { return bFirstConnectionToSpatialOSAttempted; };
-
-	TUniquePtr<SpatialActorGroupManager> ActorGroupManager;
-
-	void CleanupLevelInitializedNetworkActors() const;
 
 protected:
 	// Checks whether the current net driver is a USpatialNetDriver.

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -157,7 +157,8 @@ public:
 	UPROPERTY()
 	USpatialWorkerFlags* SpatialWorkerFlags;
 
-	SpatialActorGroupManager* ActorGroupManager;
+	TUniquePtr<SpatialActorGroupManager> ActorGroupManager;
+
 	TUniquePtr<SpatialGDK::InterestFactory> InterestFactory;
 	TUniquePtr<SpatialLoadBalanceEnforcer> LoadBalanceEnforcer;
 	TUniquePtr<SpatialVirtualWorkerTranslator> VirtualWorkerTranslator;
@@ -287,4 +288,6 @@ private:
 	// Checks the GSM is acceptingPlayers and that the SessionId on the GSM matches the SessionId on the net-driver.
 	// The SessionId on the net-driver is set by looking at the sessionId option in the URL sent to the client for ServerTravel.
 	bool ClientCanSendPlayerSpawnRequests();
+
+	void CleanupLevelInitializedNetworkActors() const;
 };


### PR DESCRIPTION
#### Description

This is purely moving code around. 

As part of the initial change to LevelInitializedNetworkActors  (https://github.com/spatialos/UnrealGDK/pull/1762) the ActorGroupManager was moved from the SpatialNetDriver to the SpatialGameInstance. Now that https://github.com/spatialos/UnrealGDK/pull/2073 is moving the cleanup to after the connection to SpatialOS is complete, this can move back into the NetDriver.

The entire point of this PR is to make the Offloading as a LBStrategy PR smaller and easier to review.

#### Release note
REQUIRED: Add a release note to the `##Unreleased` section of CHANGELOG.md. You can find guidance for writing useful release notes [here](../SpatialGDK/Extras/internal-documentation/how-to-write-good-release-notes.md). Documentation changes are exempt from this requirement.

#### Tests

Ran the Offloading Test Gym. There should be no functional change.

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
