### PR TITLE
UNR-3421 Swap the toolbar button actions for deployment

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -205,7 +205,7 @@ void FSpatialGDKEditorToolbarModule::MapActions(TSharedPtr<class FUICommandList>
 
 	InPluginCommands->MapAction(
 		FSpatialGDKEditorToolbarCommands::Get().StartCloudSpatialDeployment,
-		FExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartCloudSpatialDeploymentButtonClicked),
+		FExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::LaunchOrShowDeployment),
 		FCanExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartCloudSpatialDeploymentCanExecute),
 		FIsActionChecked(),
 		FIsActionButtonVisible::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartCloudSpatialDeploymentIsVisible));
@@ -224,7 +224,7 @@ void FSpatialGDKEditorToolbarModule::MapActions(TSharedPtr<class FUICommandList>
 
 	InPluginCommands->MapAction(
 		FSpatialGDKEditorToolbarCommands::Get().QuickDeployAction,
-		FExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::LaunchOrShowDeployment),
+		FExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartCloudSpatialDeploymentButtonClicked),
 		FCanExecuteAction());
 
 	InPluginCommands->MapAction(
@@ -395,7 +395,6 @@ TSharedRef<SWidget> FSpatialGDKEditorToolbarModule::CreateLaunchDeploymentMenuCo
 	FMenuBuilder MenuBuilder(true /*bInShouldCloseWindowAfterMenuSelection*/, PluginCommands);
 	MenuBuilder.BeginSection(NAME_None, LOCTEXT("GDKDeploymentOptionsHeader", "Deployment Tools"));
 	{
-		MenuBuilder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().OpenSimulatedPlayerConfigurationWindowAction);
 		MenuBuilder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().EnableBuildClientWorker);
 		MenuBuilder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().EnableBuildSimulatedPlayer);
 		MenuBuilder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().OpenLaunchConfigurationEditorAction);

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -223,11 +223,6 @@ void FSpatialGDKEditorToolbarModule::MapActions(TSharedPtr<class FUICommandList>
 		FCanExecuteAction());
 
 	InPluginCommands->MapAction(
-		FSpatialGDKEditorToolbarCommands::Get().QuickDeployAction,
-		FExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartCloudSpatialDeploymentButtonClicked),
-		FCanExecuteAction());
-
-	InPluginCommands->MapAction(
 		FSpatialGDKEditorToolbarCommands::Get().EnableBuildClientWorker,
 		FExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::OnCheckedBuildClientWorker),
 		FCanExecuteAction(),
@@ -240,8 +235,8 @@ void FSpatialGDKEditorToolbarModule::MapActions(TSharedPtr<class FUICommandList>
 		FIsActionChecked::CreateRaw(this, &FSpatialGDKEditorToolbarModule::IsSimulatedPlayersEnabled));
 
 	InPluginCommands->MapAction(
-		FSpatialGDKEditorToolbarCommands::Get().OpenSimulatedPlayerConfigurationWindowAction,
-		FExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::ShowSimulatedPlayerDeploymentDialog),
+		FSpatialGDKEditorToolbarCommands::Get().OpenCloudDeploymentWindowAction,
+		FExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::ShowCloudDeploymentDialog),
 		FCanExecuteAction());
 
 	InPluginCommands->MapAction(
@@ -328,7 +323,7 @@ void FSpatialGDKEditorToolbarModule::AddMenuExtension(FMenuBuilder& Builder)
 		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().StopSpatialDeployment);
 		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().LaunchInspectorWebPageAction);
 #if PLATFORM_WINDOWS
-		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().QuickDeployAction);
+		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().OpenCloudDeploymentWindowAction);
 #endif
 		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().StartSpatialService);
 		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().StopSpatialService);
@@ -363,7 +358,7 @@ void FSpatialGDKEditorToolbarModule::AddToolbarExtension(FToolBarBuilder& Builde
 	);
 	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().LaunchInspectorWebPageAction);
 #if PLATFORM_WINDOWS
-	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().QuickDeployAction);
+	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().OpenCloudDeploymentWindowAction);
 	Builder.AddComboButton(
 		FUIAction(),
 		FOnGetContent::CreateRaw(this, &FSpatialGDKEditorToolbarModule::CreateLaunchDeploymentMenuContent),
@@ -818,11 +813,6 @@ void FSpatialGDKEditorToolbarModule::StartLocalSpatialDeploymentButtonClicked()
 	VerifyAndStartDeployment();
 }
 
-void FSpatialGDKEditorToolbarModule::StartCloudSpatialDeploymentButtonClicked()
-{
-	ShowSimulatedPlayerDeploymentDialog();
-}
-
 void FSpatialGDKEditorToolbarModule::StopSpatialDeploymentButtonClicked()
 {
 	AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [this]
@@ -1054,7 +1044,7 @@ void FSpatialGDKEditorToolbarModule::OnPropertyChanged(UObject* ObjectBeingModif
 	}
 }
 
-void FSpatialGDKEditorToolbarModule::ShowSimulatedPlayerDeploymentDialog()
+void FSpatialGDKEditorToolbarModule::ShowCloudDeploymentDialog()
 {
 	// Create and open the cloud configuration dialog
 	SimulatedPlayerDeploymentWindowPtr = SNew(SWindow)
@@ -1090,7 +1080,7 @@ void FSpatialGDKEditorToolbarModule::LaunchOrShowDeployment()
 		return;
 	}
 
-	ShowSimulatedPlayerDeploymentDialog();
+	ShowCloudDeploymentDialog();
 }
 
 void FSpatialGDKEditorToolbarModule::GenerateSchema(bool bFullScan)

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarCommands.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarCommands.cpp
@@ -15,9 +15,8 @@ void FSpatialGDKEditorToolbarCommands::RegisterCommands()
 	UI_COMMAND(StartCloudSpatialDeployment, "Cloud", "Connect to cloud SpatialOS service", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(StopSpatialDeployment, "Stop", "Stops SpatialOS.", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(LaunchInspectorWebPageAction, "Inspector", "Launches default web browser to SpatialOS Inspector.", EUserInterfaceActionType::Button, FInputGesture());
-	UI_COMMAND(OpenSimulatedPlayerConfigurationWindowAction, "Deployment Configuration", "Opens a configuration menu for cloud deployments.", EUserInterfaceActionType::Button, FInputGesture());
+	UI_COMMAND(OpenCloudDeploymentWindowAction, "Deploy", "Opens a configuration menu for cloud deployments.", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(OpenLaunchConfigurationEditorAction, "Create Launch Configuration", "Opens an editor to create SpatialOS Launch configurations", EUserInterfaceActionType::Button, FInputGesture());
-	UI_COMMAND(QuickDeployAction, "Deploy", "Launch Deployment.", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(EnableBuildClientWorker, "Build Client Worker", "If checked, ClientWorker will be built and uploaded when launching the cloud deployment.", EUserInterfaceActionType::ToggleButton, FInputChord());
 	UI_COMMAND(EnableBuildSimulatedPlayer, "Build Simulated Player", "If checked, SimulatedPlayer client will be built and uploaded when launching the cloud deployment.", EUserInterfaceActionType::ToggleButton, FInputChord());
 	UI_COMMAND(StartSpatialService, "Start Service", "Starts the Spatial service daemon.", EUserInterfaceActionType::Button, FInputGesture());

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarStyle.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarStyle.cpp
@@ -91,10 +91,10 @@ TSharedRef<FSlateStyleSet> FSpatialGDKEditorToolbarStyle::Create()
 	Style->Set("SpatialGDKEditorToolbar.LaunchInspectorWebPageAction.Small",
 		new IMAGE_BRUSH(TEXT("Inspector@0.5x"), Icon20x20));
 
-	Style->Set("SpatialGDKEditorToolbar.QuickDeployAction",
+	Style->Set("SpatialGDKEditorToolbar.OpenCloudDeploymentWindowAction",
 		new IMAGE_BRUSH(TEXT("Cloud"), Icon40x40));
 
-	Style->Set("SpatialGDKEditorToolbar.QuickDeployAction.Small",
+	Style->Set("SpatialGDKEditorToolbar.OpenCloudDeploymentWindowAction.Small",
 		new IMAGE_BRUSH(TEXT("Cloud@0.5x"), Icon20x20));
 
 	Style->Set("SpatialGDKEditorToolbar.StartSpatialService",

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -75,7 +75,6 @@ private:
 
 	void StartNoAutomaticConnectionButtonClicked();
 	void StartLocalSpatialDeploymentButtonClicked();
-	void StartCloudSpatialDeploymentButtonClicked();
 	void StopSpatialDeploymentButtonClicked();
 
 	void StartSpatialServiceButtonClicked();
@@ -120,7 +119,7 @@ private:
 	void DeleteSchemaDatabaseButtonClicked();
 	void OnPropertyChanged(UObject* ObjectBeingModified, FPropertyChangedEvent& PropertyChangedEvent);
 
-	void ShowSimulatedPlayerDeploymentDialog();
+	void ShowCloudDeploymentDialog();
 	void OpenLaunchConfigurationEditor();
 	void LaunchOrShowDeployment();
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbarCommands.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbarCommands.h
@@ -30,9 +30,8 @@ public:
 	TSharedPtr<FUICommandInfo> StopSpatialDeployment;
 	TSharedPtr<FUICommandInfo> LaunchInspectorWebPageAction;
 	
-	TSharedPtr<FUICommandInfo> OpenSimulatedPlayerConfigurationWindowAction;
+	TSharedPtr<FUICommandInfo> OpenCloudDeploymentWindowAction;
 	TSharedPtr<FUICommandInfo> OpenLaunchConfigurationEditorAction;
-	TSharedPtr<FUICommandInfo> QuickDeployAction;
 	TSharedPtr<FUICommandInfo> EnableBuildClientWorker;
 	TSharedPtr<FUICommandInfo> EnableBuildSimulatedPlayer;
 


### PR DESCRIPTION
Swap the Cloud "Deploy" button action with the Spatial Launch so that quick deploy is on spatial launch and Cloud "Deploy" is the original button.