### PR TITLE
UNR-3420 - Dev Auth Token Generation performed Asynchronously

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDevAuthTokenGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDevAuthTokenGenerator.cpp
@@ -1,0 +1,102 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "SpatialGDKDevAuthTokenGenerator.h"
+
+#include "Async/Async.h"
+#include "Framework/Notifications/NotificationManager.h"
+
+#include "SpatialCommandUtils.h"
+#include "SpatialGDKEditorSettings.h"
+#include "SpatialGDKSettings.h"
+
+DEFINE_LOG_CATEGORY(LogSpatialGDKDevAuthTokenGenerator);
+
+FSpatialGDKDevAuthTokenGenerator::FSpatialGDKDevAuthTokenGenerator()
+	: bIsGenerating(false)
+{
+}
+
+void FSpatialGDKDevAuthTokenGenerator::GenerateDevAuthToken()
+{
+	if (!bIsGenerating)
+	{
+		bIsGenerating = true;
+		AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [this]
+			{
+				AsyncTask(ENamedThreads::GameThread, [this]()
+					{
+						this->ShowTaskStartedNotification(TEXT("Generating Developer Authentication Token"));
+					});
+				FString DevAuthToken;
+				USpatialGDKSettings* GDKRuntimeSettings = GetMutableDefault<USpatialGDKSettings>();
+				bool bSuccess = SpatialCommandUtils::GenerateDevAuthToken(GDKRuntimeSettings->IsRunningInChina(), DevAuthToken);
+
+				USpatialGDKEditorSettings* GDKEditorSettings = GetMutableDefault<USpatialGDKEditorSettings>();
+				GDKEditorSettings->DevelopmentAuthenticationToken = DevAuthToken;
+				GDKEditorSettings->SaveConfig();
+				GDKEditorSettings->SetRuntimeDevelopmentAuthenticationToken();
+
+				// Ensure we enable bUseDevelopmentAuthenticationFlow when using cloud deployment flow.
+				GDKRuntimeSettings->bUseDevelopmentAuthenticationFlow = true;
+				GDKRuntimeSettings->DevelopmentAuthenticationToken = DevAuthToken;
+
+				if (bSuccess)
+				{
+					AsyncTask(ENamedThreads::GameThread, [this]()
+						{
+							this->ShowTaskEndedNotification(TEXT("Developer Authentication Token Updated"), SNotificationItem::CS_Success);
+						});
+				}
+				else
+				{
+					UE_LOG(LogSpatialGDKDevAuthTokenGenerator, Error, TEXT("Failed to generate a development authentication token."));
+					AsyncTask(ENamedThreads::GameThread, [this]()
+						{
+							this->ShowTaskEndedNotification(TEXT("Developer Authentication Token Updated"), SNotificationItem::CS_Fail);
+						});
+
+				}
+
+				bIsGenerating = false;
+			});
+
+	}
+}
+
+void FSpatialGDKDevAuthTokenGenerator::ShowTaskStartedNotification(const FString& NotificationText)
+{
+	FNotificationInfo Info(FText::AsCultureInvariant(NotificationText));
+	//Info.ButtonDetails.Add(
+	//	FNotificationButtonInfo(
+	//		LOCTEXT("DevAuthTaskCancel", "Cancel"),
+	//		LOCTEXT("DevAuthTaskCancelToolTip", "Cancels execution of this task."),
+	//		FSimpleDelegate::CreateRaw(this, &FSpatialGDKDevAuthTokenGeneration::HandleCancelButtonClicked),
+	//		SNotificationItem::CS_Pending
+	//	)
+	//);
+	Info.ExpireDuration = 5.0f;
+	Info.bFireAndForget = false;
+
+	TaskNotificationPtr = FSlateNotificationManager::Get().AddNotification(Info);
+
+	if (TaskNotificationPtr.IsValid())
+	{
+		TaskNotificationPtr.Pin()->SetCompletionState(SNotificationItem::CS_Pending);
+	}
+}
+
+void FSpatialGDKDevAuthTokenGenerator::ShowTaskEndedNotification(const FString& NotificationText, SNotificationItem::ECompletionState CompletionState)
+{
+	TSharedPtr<SNotificationItem> Notification = TaskNotificationPtr.Pin();
+	if (Notification.IsValid())
+	{
+		Notification->SetFadeInDuration(0.1f);
+		Notification->SetFadeOutDuration(0.5f);
+		Notification->SetExpireDuration(5.0);
+		Notification->SetText(FText::AsCultureInvariant(NotificationText));
+		Notification->SetCompletionState(CompletionState);
+		Notification->ExpireAndFadeout();
+	}
+}
+
+#define LOCTEXT_NAMESPACE "SpatialGDKEditorPackageAssembly"

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDevAuthTokenGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDevAuthTokenGenerator.cpp
@@ -21,19 +21,19 @@ void FSpatialGDKDevAuthTokenGenerator::AsyncGenerateDevAuthToken()
 	bool bExpected = false;
 	if (bIsGenerating.CompareExchange(bExpected, true))
 	{
-		DevAuthToken.Empty();
-		AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [this]
+		bool bIsRunningInChina = GetMutableDefault<USpatialGDKSettings>()->IsRunningInChina();
+		AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [this, bIsRunningInChina]
 			{
 				AsyncTask(ENamedThreads::GameThread, [this]()
 					{
 						this->ShowTaskStartedNotification(TEXT("Generating Developer Authentication Token"));
 					});
 
-				USpatialGDKSettings* GDKRuntimeSettings = GetMutableDefault<USpatialGDKSettings>();
-				bool bSuccess = SpatialCommandUtils::GenerateDevAuthToken(GDKRuntimeSettings->IsRunningInChina(), DevAuthToken);
+				FString DevAuthToken;
+				bool bSuccess = SpatialCommandUtils::GenerateDevAuthToken(bIsRunningInChina, DevAuthToken);
 				if (bSuccess)
 				{
-					AsyncTask(ENamedThreads::GameThread, [this]()
+					AsyncTask(ENamedThreads::GameThread, [this, DevAuthToken]()
 						{
 							USpatialGDKEditorSettings* GDKEditorSettings = GetMutableDefault<USpatialGDKEditorSettings>();
 							GDKEditorSettings->DevelopmentAuthenticationToken = DevAuthToken;

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
@@ -16,6 +16,7 @@
 #include "Internationalization/Regex.h"
 #include "Misc/ScopedSlowTask.h"
 #include "Settings/ProjectPackagingSettings.h"
+#include "SpatialGDKDevAuthTokenGenerator.h"
 #include "SpatialGDKEditorPackageAssembly.h"
 #include "SpatialGDKEditorSettings.h"
 #include "SpatialGDKServicesConstants.h"
@@ -29,6 +30,7 @@ DEFINE_LOG_CATEGORY(LogSpatialGDKEditor);
 
 FSpatialGDKEditor::FSpatialGDKEditor()
 	: bSchemaGeneratorRunning(false)
+	, SpatialGDKDevAuthTokenGeneratorInstance(MakeShared<FSpatialGDKDevAuthTokenGenerator>())
 	, SpatialGDKPackageAssemblyInstance(MakeShared<FSpatialGDKPackageAssembly>())
 {
 }
@@ -302,6 +304,11 @@ void FSpatialGDKEditor::OnAssetLoaded(UObject* Asset)
 			World->UpdateWorldComponents(true, true);
 		}
 	}
+}
+
+TSharedRef<FSpatialGDKDevAuthTokenGenerator> FSpatialGDKEditor::GetDevAuthTokenGeneratorRef()
+{
+	return SpatialGDKDevAuthTokenGeneratorInstance;
 }
 
 TSharedRef<FSpatialGDKPackageAssembly> FSpatialGDKEditor::GetPackageAssemblyRef()

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKDevAuthTokenGenerator.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKDevAuthTokenGenerator.h
@@ -17,7 +17,6 @@ public:
 	void AsyncGenerateDevAuthToken();
 private:
 	TAtomic<bool> bIsGenerating;
-	FString DevAuthToken;
 
 	TWeakPtr<SNotificationItem> TaskNotificationPtr;
 	void ShowTaskStartedNotification(const FString& NotificationText);

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKDevAuthTokenGenerator.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKDevAuthTokenGenerator.h
@@ -1,0 +1,23 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Logging/LogMacros.h"
+#include "Widgets/Notifications/SNotificationList.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKDevAuthTokenGenerator, Log, All);
+
+class SPATIALGDKEDITOR_API FSpatialGDKDevAuthTokenGenerator : public TSharedFromThis<FSpatialGDKDevAuthTokenGenerator>
+{
+public:
+	FSpatialGDKDevAuthTokenGenerator();
+
+	void GenerateDevAuthToken();
+private:
+	bool bIsGenerating;
+
+	TWeakPtr<SNotificationItem> TaskNotificationPtr;
+	void ShowTaskStartedNotification(const FString& NotificationText);
+	void ShowTaskEndedNotification(const FString& NotificationText, SNotificationItem::ECompletionState CompletionState);
+};

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKDevAuthTokenGenerator.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKDevAuthTokenGenerator.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "Logging/LogMacros.h"
+#include "Templates/Atomic.h"
 #include "Widgets/Notifications/SNotificationList.h"
 
 DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKDevAuthTokenGenerator, Log, All);
@@ -13,9 +14,10 @@ class SPATIALGDKEDITOR_API FSpatialGDKDevAuthTokenGenerator : public TSharedFrom
 public:
 	FSpatialGDKDevAuthTokenGenerator();
 
-	void GenerateDevAuthToken();
+	void AsyncGenerateDevAuthToken();
 private:
-	bool bIsGenerating;
+	TAtomic<bool> bIsGenerating;
+	FString DevAuthToken;
 
 	TWeakPtr<SNotificationItem> TaskNotificationPtr;
 	void ShowTaskStartedNotification(const FString& NotificationText);

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKDevAuthTokenGenerator.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKDevAuthTokenGenerator.h
@@ -21,6 +21,6 @@ private:
 	TWeakPtr<SNotificationItem> TaskNotificationPtr;
 	void ShowTaskStartedNotification(const FString& NotificationText);
 	void ShowTaskEndedNotification(const FString& NotificationText, SNotificationItem::ECompletionState CompletionState);
-	void DoGenerateDevAuthToken();
+	void DoGenerateDevAuthTokenTasks();
 	void UpdateSettings(FString DevAuthToken);
 };

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKDevAuthTokenGenerator.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKDevAuthTokenGenerator.h
@@ -15,10 +15,12 @@ public:
 	FSpatialGDKDevAuthTokenGenerator();
 
 	void AsyncGenerateDevAuthToken();
+
 private:
 	TAtomic<bool> bIsGenerating;
-
 	TWeakPtr<SNotificationItem> TaskNotificationPtr;
 	void ShowTaskStartedNotification(const FString& NotificationText);
 	void ShowTaskEndedNotification(const FString& NotificationText, SNotificationItem::ECompletionState CompletionState);
+	void DoGenerateDevAuthToken();
+	void DoUpdateSettings(FString DevAuthToken);
 };

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKDevAuthTokenGenerator.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKDevAuthTokenGenerator.h
@@ -22,5 +22,5 @@ private:
 	void ShowTaskStartedNotification(const FString& NotificationText);
 	void ShowTaskEndedNotification(const FString& NotificationText, SNotificationItem::ECompletionState CompletionState);
 	void DoGenerateDevAuthToken();
-	void DoUpdateSettings(FString DevAuthToken);
+	void UpdateSettings(FString DevAuthToken);
 };

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditor.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditor.h
@@ -10,6 +10,7 @@ DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKEditor, Log, All);
 
 DECLARE_DELEGATE_OneParam(FSpatialGDKEditorErrorHandler, FString);
 
+class FSpatialGDKDevAuthTokenGenerator;
 class FSpatialGDKPackageAssembly;
 
 class SPATIALGDKEDITOR_API FSpatialGDKEditor
@@ -25,6 +26,7 @@ public:
 	bool IsSchemaGeneratorRunning() { return bSchemaGeneratorRunning; }
 	bool FullScanRequired();
 
+	TSharedRef<FSpatialGDKDevAuthTokenGenerator> GetDevAuthTokenGeneratorRef();
 	TSharedRef<FSpatialGDKPackageAssembly> GetPackageAssemblyRef();
 
 private:
@@ -39,5 +41,6 @@ private:
 	void OnAssetLoaded(UObject* Asset);
 	void RemoveEditorAssetLoadedCallback();
 
+	TSharedRef<FSpatialGDKDevAuthTokenGenerator> SpatialGDKDevAuthTokenGeneratorInstance;
 	TSharedRef<FSpatialGDKPackageAssembly>SpatialGDKPackageAssemblyInstance;
 };

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -241,7 +241,6 @@ public:
 private:
 
 	/** Set DAT in runtime settings. */
-	void SetRuntimeUseDevelopmentAuthenticationFlow();
 	void SetRuntimeDevelopmentDeploymentToConnect();
 
 public:
@@ -605,6 +604,7 @@ public:
 	bool IsDeploymentConfigurationValid() const;
 
 	void SetRuntimeDevelopmentAuthenticationToken();
+	void SetRuntimeUseDevelopmentAuthenticationFlow();
 
 	static bool IsProjectNameValid(const FString& Name);
 };

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -33,6 +33,7 @@
 #include "SpatialConstants.h"
 #include "SpatialGDKDefaultLaunchConfigGenerator.h"
 #include "SpatialGDKDefaultWorkerJsonGenerator.h"
+#include "SpatialGDKDevAuthTokenGenerator.h"
 #include "SpatialGDKEditor.h"
 #include "SpatialGDKEditorModule.h"
 #include "SpatialGDKEditorSchemaGenerator.h"
@@ -978,24 +979,9 @@ void FSpatialGDKEditorToolbarModule::CloudDeploymentClicked()
 	USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetMutableDefault<USpatialGDKEditorSettings>();
 	SpatialGDKEditorSettings->SpatialOSNetFlowType = ESpatialOSNetFlow::CloudDeployment;
 	SpatialGDKEditorSettings->bUseDevelopmentAuthenticationFlow = true;
-	
-	AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [this]
-		{
-			FString DevAuthToken;
-			USpatialGDKSettings* GDKRuntimeSettings = GetMutableDefault<USpatialGDKSettings>();
-			if (!SpatialCommandUtils::GenerateDevAuthToken(GDKRuntimeSettings->IsRunningInChina(), DevAuthToken))
-			{
-				UE_LOG(LogSpatialGDKEditorToolbar, Error, TEXT("Failed to generate a development authentication token."));
-			}
-			USpatialGDKEditorSettings* GDKEditorSettings = GetMutableDefault<USpatialGDKEditorSettings>();
-			GDKEditorSettings->DevelopmentAuthenticationToken = DevAuthToken;
-			GDKEditorSettings->SaveConfig();
-			GDKEditorSettings->SetRuntimeDevelopmentAuthenticationToken();
 
-			// Ensure we enable bUseDevelopmentAuthenticationFlow when using cloud deployment flow.
-			GDKRuntimeSettings->bUseDevelopmentAuthenticationFlow = true;
-			GDKRuntimeSettings->DevelopmentAuthenticationToken = DevAuthToken;
-		});
+	TSharedRef<FSpatialGDKDevAuthTokenGenerator> DevAuth = SpatialGDKEditorInstance->GetDevAuthTokenGeneratorRef();
+	DevAuth->GenerateDevAuthToken();
 	RefreshAutoStartLocalDeployment();
 }
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -978,21 +978,25 @@ void FSpatialGDKEditorToolbarModule::CloudDeploymentClicked()
 	USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetMutableDefault<USpatialGDKEditorSettings>();
 	SpatialGDKEditorSettings->SpatialOSNetFlowType = ESpatialOSNetFlow::CloudDeployment;
 	SpatialGDKEditorSettings->bUseDevelopmentAuthenticationFlow = true;
-	USpatialGDKSettings* SpatialGDKSettings = GetMutableDefault<USpatialGDKSettings>();
+	
 
-	FString DevAuthToken;
-	if (!SpatialCommandUtils::GenerateDevAuthToken(SpatialGDKSettings->IsRunningInChina(), DevAuthToken))
-	{
-		UE_LOG(LogSpatialGDKEditorToolbar, Error, TEXT("Failed to generate a development authentication token."));
-	}
-	SpatialGDKEditorSettings->DevelopmentAuthenticationToken = DevAuthToken;
-	SpatialGDKEditorSettings->SaveConfig();
-	SpatialGDKEditorSettings->SetRuntimeDevelopmentAuthenticationToken();
+	AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [this]
+		{
+			FString DevAuthToken;
+			USpatialGDKSettings* GDKRuntimeSettings = GetMutableDefault<USpatialGDKSettings>();
+			if (!SpatialCommandUtils::GenerateDevAuthToken(GDKRuntimeSettings->IsRunningInChina(), DevAuthToken))
+			{
+				UE_LOG(LogSpatialGDKEditorToolbar, Error, TEXT("Failed to generate a development authentication token."));
+			}
+			USpatialGDKEditorSettings* GDKEditorSettings = GetMutableDefault<USpatialGDKEditorSettings>();
+			GDKEditorSettings->DevelopmentAuthenticationToken = DevAuthToken;
+			GDKEditorSettings->SaveConfig();
+			GDKEditorSettings->SetRuntimeDevelopmentAuthenticationToken();
 
-	// Ensure we enable bUseDevelopmentAuthenticationFlow when using cloud deployment flow.
-	SpatialGDKSettings->bUseDevelopmentAuthenticationFlow = true;
-	SpatialGDKSettings->DevelopmentAuthenticationToken = DevAuthToken;
-
+			// Ensure we enable bUseDevelopmentAuthenticationFlow when using cloud deployment flow.
+			GDKRuntimeSettings->bUseDevelopmentAuthenticationFlow = true;
+			GDKRuntimeSettings->DevelopmentAuthenticationToken = DevAuthToken;
+		});
 	RefreshAutoStartLocalDeployment();
 }
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -981,7 +981,7 @@ void FSpatialGDKEditorToolbarModule::CloudDeploymentClicked()
 	SpatialGDKEditorSettings->bUseDevelopmentAuthenticationFlow = true;
 
 	TSharedRef<FSpatialGDKDevAuthTokenGenerator> DevAuth = SpatialGDKEditorInstance->GetDevAuthTokenGeneratorRef();
-	DevAuth->GenerateDevAuthToken();
+	DevAuth->AsyncGenerateDevAuthToken();
 	RefreshAutoStartLocalDeployment();
 }
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -979,7 +979,6 @@ void FSpatialGDKEditorToolbarModule::CloudDeploymentClicked()
 	SpatialGDKEditorSettings->SpatialOSNetFlowType = ESpatialOSNetFlow::CloudDeployment;
 	SpatialGDKEditorSettings->bUseDevelopmentAuthenticationFlow = true;
 	
-
 	AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [this]
 		{
 			FString DevAuthToken;


### PR DESCRIPTION
This code encapsulates the Dev Auth Generation into a type that will ensure that it is not performed in overlapping fashion and provides editor notifications while being run in an asynchronous fashion.

Per feedback from @improbable-valentyn ...

This occurs when switching to a cloud deployment via the deployment type radio buttons.

This code does not address generating a dev auth token when pushing the button in the settings window, as perhaps that should be "modal"/blocking...