### PR TITLE
UNR-3408 Remove UE4Commandline.txt when the session ended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - The Deploy button will launch the deployment directly if the necessary fields were filled previously in the `Deployment Configuration` window, selecting the `Deployment Configuration` menu item from the dropdown will allow changing of deployment settings.
 - Added `Build Client Worker` and `Build SimulatedPlayer` checkbox to the dropdown list of Deploy button to quickly enable/disable building and including the client worker or simulated player worker in the assembly.
 - Automatically add `dev_login` tag to cloud deployment when clicking launch deployment button.
+- Remove the UE4Commandline.txt from the device when the session ends (click Cancel button from Message window when launch game on Android or iOS)
 
 ## Bug fixes:
 - Fixed a bug that caused queued RPCs to spam logs when an entity is deleted.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - The Deploy button will launch the deployment directly if the necessary fields were filled previously in the `Deployment Configuration` window, selecting the `Deployment Configuration` menu item from the dropdown will allow changing of deployment settings.
 - Added `Build Client Worker` and `Build SimulatedPlayer` checkbox to the dropdown list of Deploy button to quickly enable/disable building and including the client worker or simulated player worker in the assembly.
 - Automatically add `dev_login` tag to cloud deployment when clicking launch deployment button.
-- Remove the UE4Commandline.txt from the device when the session ends (click Cancel button from Message window when launch game on Android or iOS)
+- Automatically removes the additional UE4Commandline.txt from the Android device when the Launch on Device session ends.
 
 ## Bug fixes:
 - Fixed a bug that caused queued RPCs to spam logs when an entity is deleted.

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDevAuthTokenGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDevAuthTokenGenerator.cpp
@@ -36,7 +36,8 @@ void FSpatialGDKDevAuthTokenGenerator::DoGenerateDevAuthTokenTasks()
 		});
 
 		FString DevAuthToken;
-		if (SpatialCommandUtils::GenerateDevAuthToken(bIsRunningInChina, DevAuthToken))
+		FString ErrorMessage;
+		if (SpatialCommandUtils::GenerateDevAuthToken(bIsRunningInChina, DevAuthToken, ErrorMessage))
 		{
 			AsyncTask(ENamedThreads::GameThread, [this, DevAuthToken]()
 			{
@@ -46,7 +47,7 @@ void FSpatialGDKDevAuthTokenGenerator::DoGenerateDevAuthTokenTasks()
 		}
 		else
 		{
-			UE_LOG(LogSpatialGDKDevAuthTokenGenerator, Error, TEXT("Failed to generate a development authentication token."));
+			UE_LOG(LogSpatialGDKDevAuthTokenGenerator, Error, TEXT("Failed to generate a development authentication token: %s"), *ErrorMessage);
 			AsyncTask(ENamedThreads::GameThread, [this]()
 			{
 				this->ShowTaskEndedNotification(TEXT("Failed to generate Development Authentication Token"), SNotificationItem::CS_Fail);

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
@@ -16,9 +16,9 @@
 //need this macro before "ILauncherServicesModule.h" to prevent compile error
 #define LAUNCHERSERVICES_API
 
-#include "Developer\LauncherServices\Public\ILauncherServicesModule.h"
-#include "Developer\LauncherServices\Public\ILauncherWorker.h"
-#include "Developer\LauncherServices\Public\ILauncher.h"
+#include "Developer/LauncherServices/Public/ILauncherServicesModule.h"
+#include "Developer/LauncherServices/Public/ILauncherWorker.h"
+#include "Developer/LauncherServices/Public/ILauncher.h"
 #endif
 
 DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKEditorCommandLineArgsManager, Log, All);

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
@@ -11,29 +11,36 @@
 #include "SpatialGDKSettings.h"
 #include "SpatialGDKEditorSettings.h"
 
+#ifdef ENABLE_LAUNCHER_DELEGATE
 //need this macro before "ILauncherServicesModule.h" to prevent compile error
 #define LAUNCHERSERVICES_API
 
 #include "Developer\LauncherServices\Public\ILauncherServicesModule.h"
 #include "Developer\LauncherServices\Public\ILauncherWorker.h"
 #include "Developer\LauncherServices\Public\ILauncher.h"
+#endif
 
 DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKEditorCommandLineArgsManager, Log, All);
 DEFINE_LOG_CATEGORY(LogSpatialGDKEditorCommandLineArgsManager);
 
 FSpatialGDKEditorCommandLineArgsManager::FSpatialGDKEditorCommandLineArgsManager()
+#ifdef ENABLE_LAUNCHER_DELEGATE
 	:bAndroidDevice(false)
 	, bIOSDevice(false)
+#endif
 {
 
 }
 
 void FSpatialGDKEditorCommandLineArgsManager::Startup()
 {
+#ifdef ENABLE_LAUNCHER_DELEGATE
 	ILauncherServicesModule& LauncherServicesModule = FModuleManager::LoadModuleChecked<ILauncherServicesModule>(TEXT("LauncherServices"));
 	LauncherServicesModule.OnCreateLauncherDelegate.AddRaw(this, &FSpatialGDKEditorCommandLineArgsManager::OnCreateLauncher);
+#endif
 }
 
+#ifdef ENABLE_LAUNCHER_DELEGATE
 void FSpatialGDKEditorCommandLineArgsManager::OnLauncherCanceled(double ExecutionTime)
 {
 	RemoveFromDevice();
@@ -90,6 +97,7 @@ void FSpatialGDKEditorCommandLineArgsManager::OnCreateLauncher(ILauncherRef Laun
 {
 	LauncherRef->FLauncherWorkerStartedDelegate.AddRaw(this, &FSpatialGDKEditorCommandLineArgsManager::OnLaunch);
 }
+#endif
 
 namespace
 {

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
@@ -26,7 +26,7 @@ DEFINE_LOG_CATEGORY(LogSpatialGDKEditorCommandLineArgsManager);
 
 FSpatialGDKEditorCommandLineArgsManager::FSpatialGDKEditorCommandLineArgsManager()
 #ifdef ENABLE_LAUNCHER_DELEGATE
-	:bAndroidDevice(false)
+	: bAndroidDevice(false)
 	, bIOSDevice(false)
 #endif
 {
@@ -58,10 +58,6 @@ void FSpatialGDKEditorCommandLineArgsManager::RemoveFromDevice()
 	{
 		RemoveFromAndroidDevice();
 	}
-	if (bIOSDevice)
-	{
-		RemoveFromIOSDevice();
-	}
 }
 
 void FSpatialGDKEditorCommandLineArgsManager::OnLaunch(ILauncherWorkerPtr LauncherWorkerPtr, ILauncherProfileRef LauncherProfileRef)
@@ -79,14 +75,6 @@ void FSpatialGDKEditorCommandLineArgsManager::OnLaunch(ILauncherWorkerPtr Launch
 		{
 			bAndroidDevice = true;
 		}
-		if (TaskList[idx]->GetDesc().Contains(TEXT("ios")))
-		{
-			bIOSDevice = true;
-		}
-	}
-	if (bIOSDevice)
-	{
-		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Log, TEXT("Ios device launched"));
 	}
 	if (bAndroidDevice)
 	{

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
@@ -36,6 +36,16 @@ void FSpatialGDKEditorCommandLineArgsManager::Startup()
 
 void FSpatialGDKEditorCommandLineArgsManager::OnLauncherCanceled(double ExecutionTime)
 {
+	RemoveFromDevice();
+}
+
+void FSpatialGDKEditorCommandLineArgsManager::OnLauncherFinished(bool Outcome, double ExecutionTime, int32 ReturnCode)
+{
+	RemoveFromDevice();
+}
+
+void FSpatialGDKEditorCommandLineArgsManager::RemoveFromDevice()
+{
 	if (bAndroidDevice)
 	{
 		RemoveFromAndroidDevice();
@@ -49,6 +59,7 @@ void FSpatialGDKEditorCommandLineArgsManager::OnLauncherCanceled(double Executio
 void FSpatialGDKEditorCommandLineArgsManager::OnLaunch(ILauncherWorkerPtr LauncherWorkerPtr, ILauncherProfileRef LauncherProfileRef)
 {
 	LauncherWorkerPtr->OnCanceled().AddRaw(this, &FSpatialGDKEditorCommandLineArgsManager::OnLauncherCanceled);
+	LauncherWorkerPtr->OnCompleted().AddRaw(this, &FSpatialGDKEditorCommandLineArgsManager::OnLauncherFinished);
 
 	bIOSDevice = false;
 	bAndroidDevice = false;

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
@@ -9,8 +9,8 @@
 #include "Misc/MessageDialog.h"
 #include "Serialization/JsonSerializer.h"
 #include "SpatialCommandUtils.h"
-#include "SpatialGDKSettings.h"
 #include "SpatialGDKEditorSettings.h"
+#include "SpatialGDKSettings.h"
 
 #ifdef ENABLE_LAUNCHER_DELEGATE
 //need this macro before "ILauncherServicesModule.h" to prevent compile error

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
@@ -27,7 +27,6 @@ DEFINE_LOG_CATEGORY(LogSpatialGDKEditorCommandLineArgsManager);
 FSpatialGDKEditorCommandLineArgsManager::FSpatialGDKEditorCommandLineArgsManager()
 #ifdef ENABLE_LAUNCHER_DELEGATE
 	: bAndroidDevice(false)
-	, bIOSDevice(false)
 #endif
 {
 
@@ -65,7 +64,6 @@ void FSpatialGDKEditorCommandLineArgsManager::OnLaunch(ILauncherWorkerPtr Launch
 	LauncherWorkerPtr->OnCanceled().AddRaw(this, &FSpatialGDKEditorCommandLineArgsManager::OnLauncherCanceled);
 	LauncherWorkerPtr->OnCompleted().AddRaw(this, &FSpatialGDKEditorCommandLineArgsManager::OnLauncherFinished);
 
-	bIOSDevice = false;
 	bAndroidDevice = false;
 	TArray<ILauncherTaskPtr> TaskList;
 	LauncherWorkerPtr->GetTasks(TaskList);

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
@@ -1,0 +1,338 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "SpatialGDKEditorCommandLineArgsManager.h"
+
+#include "Input/Reply.h"
+#include "IOSRuntimeSettings.h"
+#include "Logging/LogMacros.h"
+#include "Misc/FileHelper.h"
+#include "Misc/MessageDialog.h"
+#include "Serialization/JsonSerializer.h"
+#include "SpatialGDKSettings.h"
+#include "SpatialGDKEditorSettings.h"
+
+//need this macro before "ILauncherServicesModule.h" to prevent compile error
+#define LAUNCHERSERVICES_API
+
+#include "Developer\LauncherServices\Public\ILauncherServicesModule.h"
+#include "Developer\LauncherServices\Public\ILauncherWorker.h"
+#include "Developer\LauncherServices\Public\ILauncher.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKEditorCommandLineArgsManager, Log, All);
+DEFINE_LOG_CATEGORY(LogSpatialGDKEditorCommandLineArgsManager);
+
+FSpatialGDKEditorCommandLineArgsManager::FSpatialGDKEditorCommandLineArgsManager()
+	:bAndroidDevice(false)
+	, bIOSDevice(false)
+{
+
+}
+
+void FSpatialGDKEditorCommandLineArgsManager::Startup()
+{
+	ILauncherServicesModule& LauncherServicesModule = FModuleManager::LoadModuleChecked<ILauncherServicesModule>(TEXT("LauncherServices"));
+	LauncherServicesModule.OnCreateLauncherDelegate.AddRaw(this, &FSpatialGDKEditorCommandLineArgsManager::OnCreateLauncher);
+}
+
+void FSpatialGDKEditorCommandLineArgsManager::OnLauncherCanceled(double ExecutionTime)
+{
+	if (bAndroidDevice)
+	{
+		RemoveFromAndroidDevice();
+	}
+	if (bIOSDevice)
+	{
+		RemoveFromIOSDevice();
+	}
+}
+
+void FSpatialGDKEditorCommandLineArgsManager::OnLaunch(ILauncherWorkerPtr LauncherWorkerPtr, ILauncherProfileRef LauncherProfileRef)
+{
+	LauncherWorkerPtr->OnCanceled().AddRaw(this, &FSpatialGDKEditorCommandLineArgsManager::OnLauncherCanceled);
+
+	TArray<ILauncherTaskPtr> TaskList;
+	LauncherWorkerPtr->GetTasks(TaskList);
+	for (int32 idx = 0; idx < TaskList.Num(); ++idx)
+	{
+		if (TaskList[idx]->GetDesc().Contains(TEXT("android")))
+		{
+			bAndroidDevice = true;
+		}
+	}
+	if (bIOSDevice)
+	{
+		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Log, TEXT("Ios device launched"));
+	}
+	if (bAndroidDevice)
+	{
+		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Log, TEXT("Android device launched"));
+	}
+}
+
+void FSpatialGDKEditorCommandLineArgsManager::OnCreateLauncher(ILauncherRef LauncherRef)
+{
+	LauncherRef->FLauncherWorkerStartedDelegate.AddRaw(this, &FSpatialGDKEditorCommandLineArgsManager::OnLaunch);
+}
+
+namespace
+{
+	static FString GetAdbExePath()
+	{
+		FString AndroidHome = FPlatformMisc::GetEnvironmentVariable(TEXT("ANDROID_HOME"));
+		if (AndroidHome.IsEmpty())
+		{
+			UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("Environment variable ANDROID_HOME is not set. Please make sure to configure this."));
+			FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Environment variable ANDROID_HOME is not set. Please make sure to configure this.")));
+			return TEXT("");
+		}
+
+#if PLATFORM_WINDOWS
+		const FString AdbExe = FPaths::ConvertRelativePathToFull(FPaths::Combine(AndroidHome, TEXT("platform-tools/adb.exe")));
+#else
+		const FString AdbExe = FPaths::ConvertRelativePathToFull(FPaths::Combine(AndroidHome, TEXT("platform-tools/adb")));
+#endif
+
+		return AdbExe;
+	}
+}
+
+FReply FSpatialGDKEditorCommandLineArgsManager::PushToIOSDevice()
+{
+	const UIOSRuntimeSettings* IOSRuntimeSettings = GetDefault<UIOSRuntimeSettings>();
+	FString OutCommandLineArgsFile;
+
+	if (!TryConstructMobileCommandLineArgumentsFile(OutCommandLineArgsFile))
+	{
+		return FReply::Unhandled();
+	}
+
+	FString Executable = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/DotNET/IOS/deploymentserver.exe")));
+	FString DeploymentServerArguments = FString::Printf(TEXT("copyfile -bundle \"%s\" -file \"%s\" -file \"/Documents/ue4commandline.txt\""), *(IOSRuntimeSettings->BundleIdentifier.Replace(TEXT("[PROJECT_NAME]"), FApp::GetProjectName())), *OutCommandLineArgsFile);
+
+#if PLATFORM_MAC
+	DeploymentServerArguments = FString::Printf(TEXT("%s %s"), *Executable, *DeploymentServerArguments);
+	Executable = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/ThirdParty/Mono/Mac/bin/mono")));
+#endif
+
+	TryPushCommandLineArgsToDevice(Executable, DeploymentServerArguments, OutCommandLineArgsFile);
+	return FReply::Handled();
+}
+
+FReply FSpatialGDKEditorCommandLineArgsManager::PushToAndroidDevice()
+{
+	const FString AdbExe = GetAdbExePath();
+	if (AdbExe.IsEmpty())
+	{
+		return FReply::Unhandled();
+	}
+
+	FString OutCommandLineArgsFile;
+
+	if (!TryConstructMobileCommandLineArgumentsFile(OutCommandLineArgsFile))
+	{
+		return FReply::Unhandled();
+	}
+
+	const FString AndroidCommandLineFile = FString::Printf(TEXT("/mnt/sdcard/UE4Game/%s/UE4CommandLine.txt"), *FString(FApp::GetProjectName()));
+	const FString AdbArguments = FString::Printf(TEXT("push \"%s\" \"%s\""), *OutCommandLineArgsFile, *AndroidCommandLineFile);
+
+	TryPushCommandLineArgsToDevice(AdbExe, AdbArguments, OutCommandLineArgsFile);
+	return FReply::Handled();
+}
+
+FReply FSpatialGDKEditorCommandLineArgsManager::RemoveFromIOSDevice()
+{
+	const UIOSRuntimeSettings* IOSRuntimeSettings = GetDefault<UIOSRuntimeSettings>();
+
+	FString Executable = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/DotNET/IOS/deploymentserver.exe")));
+	FString DeploymentServerArguments = FString::Printf(TEXT("removefile -bundle \"%s\" -file \"/Documents/ue4commandline.txt\""), *(IOSRuntimeSettings->BundleIdentifier.Replace(TEXT("[PROJECT_NAME]"), FApp::GetProjectName())));
+
+#if PLATFORM_MAC
+	DeploymentServerArguments = FString::Printf(TEXT("%s %s"), *Executable, *DeploymentServerArguments);
+	Executable = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/ThirdParty/Mono/Mac/bin/mono")));
+#endif
+
+	FString ExeOutput;
+	FString StdErr;
+	int32 ExitCode;
+
+	FPlatformProcess::ExecProcess(*Executable, *DeploymentServerArguments, &ExitCode, &ExeOutput, &StdErr);
+	if (ExitCode != 0)
+	{
+		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("Failed to remove settings from the mobile client. %s %s"), *ExeOutput, *StdErr);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Failed to remove settings from the mobile client. See the Output log for more information.")));
+		return FReply::Unhandled();
+	}
+	UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Log, TEXT("Remove ue4commandline.txt from the iOS device. %s %s"), *ExeOutput, *StdErr);
+
+	return FReply::Handled();
+}
+
+FReply FSpatialGDKEditorCommandLineArgsManager::RemoveFromAndroidDevice()
+{
+	const FString AdbExe = GetAdbExePath();
+	if (AdbExe.IsEmpty())
+	{
+		return FReply::Unhandled();
+	}
+
+	FString ExeOutput;
+	FString StdErr;
+	int32 ExitCode;
+
+	FString ExeArguments = FString::Printf(TEXT("shell rm -f /mnt/sdcard/UE4Game/%s/UE4CommandLine.txt"), FApp::GetProjectName());
+
+	FPlatformProcess::ExecProcess(*AdbExe, *ExeArguments, &ExitCode, &ExeOutput, &StdErr);
+	if (ExitCode != 0)
+	{
+		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("Failed to remove settings from the mobile client. %s %s"), *ExeOutput, *StdErr);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Failed to remove settings from the mobile client. See the Output log for more information.")));
+		return FReply::Unhandled();
+	}
+	UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Log, TEXT("Remove ue4commandline.txt from the Android device. %s %s"), *ExeOutput, *StdErr);
+
+	return FReply::Handled();
+}
+
+FReply FSpatialGDKEditorCommandLineArgsManager::GenerateDevAuthToken()
+{
+	FString Arguments = TEXT("project auth dev-auth-token create --description=\"Unreal GDK Token\" --json_output");
+	if (GetDefault<USpatialGDKSettings>()->IsRunningInChina())
+	{
+		Arguments += TEXT(" --environment cn-production");
+	}
+
+	FString CreateDevAuthTokenResult;
+	int32 ExitCode;
+	FSpatialGDKServicesModule::ExecuteAndReadOutput(SpatialGDKServicesConstants::SpatialExe, Arguments, SpatialGDKServicesConstants::SpatialOSDirectory, CreateDevAuthTokenResult, ExitCode);
+
+	if (ExitCode != 0)
+	{
+		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("Unable to generate a development authentication token. Result: %s"), *CreateDevAuthTokenResult);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to generate a development authentication token. Result: %s"), *CreateDevAuthTokenResult)));
+		return FReply::Unhandled();
+	};
+
+	FString AuthResult;
+	FString DevAuthTokenResult;
+	bool bFoundNewline = CreateDevAuthTokenResult.TrimEnd().Split(TEXT("\n"), &AuthResult, &DevAuthTokenResult, ESearchCase::IgnoreCase, ESearchDir::FromEnd);
+	if (!bFoundNewline || DevAuthTokenResult.IsEmpty())
+	{
+		// This is necessary because depending on whether you are already authenticated against spatial, it will either return two json structs or one.
+		DevAuthTokenResult = CreateDevAuthTokenResult;
+	}
+
+	TSharedRef<TJsonReader<TCHAR>> JsonReader = TJsonReaderFactory<TCHAR>::Create(DevAuthTokenResult);
+	TSharedPtr<FJsonObject> JsonRootObject;
+	if (!(FJsonSerializer::Deserialize(JsonReader, JsonRootObject) && JsonRootObject.IsValid()))
+	{
+		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("Unable to parse the received development authentication token. Result: %s"), *DevAuthTokenResult);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to parse the received development authentication token. Result: %s"), *DevAuthTokenResult)));
+		return FReply::Unhandled();
+	}
+
+	// We need a pointer to a shared pointer due to how the JSON API works.
+	const TSharedPtr<FJsonObject>* JsonDataObject;
+	if (!(JsonRootObject->TryGetObjectField("json_data", JsonDataObject)))
+	{
+		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("Unable to parse the received json data. Result: %s"), *DevAuthTokenResult);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to parse the received json data. Result: %s"), *DevAuthTokenResult)));
+		return FReply::Unhandled();
+	}
+
+	FString TokenSecret;
+	if (!(*JsonDataObject)->TryGetStringField("token_secret", TokenSecret))
+	{
+		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("Unable to parse the token_secret field inside the received json data. Result: %s"), *DevAuthTokenResult);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to parse the token_secret field inside the received json data. Result: %s"), *DevAuthTokenResult)));
+		return FReply::Unhandled();
+	}
+
+	if (USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetMutableDefault<USpatialGDKEditorSettings>())
+	{
+		SpatialGDKEditorSettings->DevelopmentAuthenticationToken = TokenSecret;
+		SpatialGDKEditorSettings->SaveConfig();
+		SpatialGDKEditorSettings->SetRuntimeDevelopmentAuthenticationToken();
+	}
+
+	return FReply::Handled();
+}
+
+bool FSpatialGDKEditorCommandLineArgsManager::TryConstructMobileCommandLineArgumentsFile(FString& CommandLineArgsFile)
+{
+	const USpatialGDKEditorSettings* SpatialGDKSettings = GetDefault<USpatialGDKEditorSettings>();
+	const FString ProjectName = FApp::GetProjectName();
+
+	// The project path is based on this: https://github.com/improbableio/UnrealEngine/blob/4.22-SpatialOSUnrealGDK-release/Engine/Source/Programs/AutomationTool/AutomationUtils/DeploymentContext.cs#L408
+	const FString MobileProjectPath = FString::Printf(TEXT("../../../%s/%s.uproject"), *ProjectName, *ProjectName);
+	FString TravelUrl;
+	FString SpatialOSOptions = FString::Printf(TEXT("-workerType %s"), *(SpatialGDKSettings->MobileWorkerType));
+	if (SpatialGDKSettings->bMobileConnectToLocalDeployment)
+	{
+		if (SpatialGDKSettings->MobileRuntimeIP.IsEmpty())
+		{
+			UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("The Runtime IP is currently not set. Please make sure to specify a Runtime IP."));
+			FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("The Runtime IP is currently not set. Please make sure to specify a Runtime IP."))));
+			return false;
+		}
+
+		TravelUrl = SpatialGDKSettings->MobileRuntimeIP;
+	}
+	else
+	{
+		TravelUrl = TEXT("connect.to.spatialos");
+
+		if (SpatialGDKSettings->DevelopmentAuthenticationToken.IsEmpty())
+		{
+			FReply GeneratedTokenReply = GenerateDevAuthToken();
+			if (!GeneratedTokenReply.IsEventHandled())
+			{
+				return false;
+			}
+		}
+
+		SpatialOSOptions += FString::Printf(TEXT(" +devauthToken %s"), *(SpatialGDKSettings->DevelopmentAuthenticationToken));
+		if (!SpatialGDKSettings->DevelopmentDeploymentToConnect.IsEmpty())
+		{
+			SpatialOSOptions += FString::Printf(TEXT(" +deployment %s"), *(SpatialGDKSettings->DevelopmentDeploymentToConnect));
+		}
+	}
+
+	const FString SpatialOSCommandLineArgs = FString::Printf(TEXT("%s %s %s %s"), *MobileProjectPath, *TravelUrl, *SpatialOSOptions, *(SpatialGDKSettings->MobileExtraCommandLineArgs));
+	CommandLineArgsFile = FPaths::ConvertRelativePathToFull(FPaths::Combine(*FPaths::ProjectLogDir(), TEXT("ue4commandline.txt")));
+
+	if (!FFileHelper::SaveStringToFile(SpatialOSCommandLineArgs, *CommandLineArgsFile, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM))
+	{
+		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("Failed to write command line args to file: %s"), *CommandLineArgsFile);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Failed to write command line args to file: %s"), *CommandLineArgsFile)));
+		return false;
+	}
+
+	return true;
+}
+
+bool FSpatialGDKEditorCommandLineArgsManager::TryPushCommandLineArgsToDevice(const FString& Executable, const FString& ExeArguments, const FString& CommandLineArgsFile)
+{
+	FString ExeOutput;
+	FString StdErr;
+	int32 ExitCode;
+
+	FPlatformProcess::ExecProcess(*Executable, *ExeArguments, &ExitCode, &ExeOutput, &StdErr);
+	if (ExitCode != 0)
+	{
+		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("Failed to update the mobile client. %s %s"), *ExeOutput, *StdErr);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Failed to update the mobile client. See the Output log for more information.")));
+		return false;
+	}
+
+	UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Log, TEXT("Successfully stored command line args on device: %s"), *ExeOutput);
+	IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
+	if (!PlatformFile.DeleteFile(*CommandLineArgsFile))
+	{
+		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("Failed to delete file %s"), *CommandLineArgsFile);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Failed to delete file %s"), *CommandLineArgsFile)));
+		return false;
+	}
+
+	return true;
+}

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
@@ -50,6 +50,8 @@ void FSpatialGDKEditorCommandLineArgsManager::OnLaunch(ILauncherWorkerPtr Launch
 {
 	LauncherWorkerPtr->OnCanceled().AddRaw(this, &FSpatialGDKEditorCommandLineArgsManager::OnLauncherCanceled);
 
+	bIOSDevice = false;
+	bAndroidDevice = false;
 	TArray<ILauncherTaskPtr> TaskList;
 	LauncherWorkerPtr->GetTasks(TaskList);
 	for (int32 idx = 0; idx < TaskList.Num(); ++idx)
@@ -57,6 +59,10 @@ void FSpatialGDKEditorCommandLineArgsManager::OnLaunch(ILauncherWorkerPtr Launch
 		if (TaskList[idx]->GetDesc().Contains(TEXT("android")))
 		{
 			bAndroidDevice = true;
+		}
+		if (TaskList[idx]->GetDesc().Contains(TEXT("ios")))
+		{
+			bIOSDevice = true;
 		}
 	}
 	if (bIOSDevice)

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
@@ -6,19 +6,19 @@
 #include "DetailWidgetRow.h"
 #include "DetailCategoryBuilder.h"
 #include "HAL/PlatformFilemanager.h"
+#include "Input/Reply.h"
 #include "IOSRuntimeSettings.h"
 #include "Misc/App.h"
 #include "Misc/FileHelper.h"
 #include "Misc/MessageDialog.h"
-#include "Serialization/JsonSerializer.h"
 #include "SpatialGDKSettings.h"
 #include "SpatialGDKEditorSettings.h"
+#include "SpatialGDKEditorModule.h"
+#include "SpatialGDKEditorCommandLineArgsManager.h"
 #include "SpatialGDKServicesConstants.h"
 #include "SpatialGDKServicesModule.h"
 #include "Widgets/Text/STextBlock.h"
 #include "Widgets/Input/SButton.h"
-
-DEFINE_LOG_CATEGORY(LogSpatialGDKEditorLayoutDetails);
 
 TSharedRef<IDetailCustomization> FSpatialGDKEditorLayoutDetails::MakeInstance()
 {
@@ -156,262 +156,32 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 
 FReply FSpatialGDKEditorLayoutDetails::GenerateDevAuthToken()
 {
-	FString Arguments = TEXT("project auth dev-auth-token create --description=\"Unreal GDK Token\" --json_output");
-	if (GetDefault<USpatialGDKSettings>()->IsRunningInChina())
-	{
-		Arguments += TEXT(" --environment cn-production");
-	}
-
-	FString CreateDevAuthTokenResult;
-	int32 ExitCode;
-	FSpatialGDKServicesModule::ExecuteAndReadOutput(SpatialGDKServicesConstants::SpatialExe, Arguments, SpatialGDKServicesConstants::SpatialOSDirectory, CreateDevAuthTokenResult, ExitCode);
-
-	if (ExitCode != 0)
-	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Unable to generate a development authentication token. Result: %s"), *CreateDevAuthTokenResult);
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to generate a development authentication token. Result: %s"), *CreateDevAuthTokenResult)));
-		return FReply::Unhandled();
-	};
-
-	FString AuthResult;
-	FString DevAuthTokenResult;
-	bool bFoundNewline = CreateDevAuthTokenResult.TrimEnd().Split(TEXT("\n"), &AuthResult, &DevAuthTokenResult, ESearchCase::IgnoreCase, ESearchDir::FromEnd);
-	if (!bFoundNewline || DevAuthTokenResult.IsEmpty())
-	{
-		// This is necessary because depending on whether you are already authenticated against spatial, it will either return two json structs or one.
-		DevAuthTokenResult = CreateDevAuthTokenResult;
-	}
-
-	TSharedRef<TJsonReader<TCHAR>> JsonReader = TJsonReaderFactory<TCHAR>::Create(DevAuthTokenResult);
-	TSharedPtr<FJsonObject> JsonRootObject;
-	if (!(FJsonSerializer::Deserialize(JsonReader, JsonRootObject) && JsonRootObject.IsValid()))
-	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Unable to parse the received development authentication token. Result: %s"), *DevAuthTokenResult);
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to parse the received development authentication token. Result: %s"), *DevAuthTokenResult)));
-		return FReply::Unhandled();
-	}
-
-	// We need a pointer to a shared pointer due to how the JSON API works.
-	const TSharedPtr<FJsonObject>* JsonDataObject;
-	if (!(JsonRootObject->TryGetObjectField("json_data", JsonDataObject)))
-	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Unable to parse the received json data. Result: %s"), *DevAuthTokenResult);
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to parse the received json data. Result: %s"), *DevAuthTokenResult)));
-		return FReply::Unhandled();
-	}
-
-	FString TokenSecret;
-	if (!(*JsonDataObject)->TryGetStringField("token_secret", TokenSecret))
-	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Unable to parse the token_secret field inside the received json data. Result: %s"), *DevAuthTokenResult);
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to parse the token_secret field inside the received json data. Result: %s"), *DevAuthTokenResult)));
-		return FReply::Unhandled();
-	}
-
-	if (USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetMutableDefault<USpatialGDKEditorSettings>())
-	{
-		SpatialGDKEditorSettings->DevelopmentAuthenticationToken = TokenSecret;
-		SpatialGDKEditorSettings->SaveConfig();
-		SpatialGDKEditorSettings->SetRuntimeDevelopmentAuthenticationToken();
-	}
-
-	return FReply::Handled();
+	return GetCommandLineArgsManager().GenerateDevAuthToken();
 }
 
-bool FSpatialGDKEditorLayoutDetails::TryConstructMobileCommandLineArgumentsFile(FString& CommandLineArgsFile)
+FSpatialGDKEditorCommandLineArgsManager& FSpatialGDKEditorLayoutDetails::GetCommandLineArgsManager()
 {
-	const USpatialGDKEditorSettings* SpatialGDKSettings = GetDefault<USpatialGDKEditorSettings>();
-	const FString ProjectName = FApp::GetProjectName();
-
-	// The project path is based on this: https://github.com/improbableio/UnrealEngine/blob/4.22-SpatialOSUnrealGDK-release/Engine/Source/Programs/AutomationTool/AutomationUtils/DeploymentContext.cs#L408
-	const FString MobileProjectPath = FString::Printf(TEXT("../../../%s/%s.uproject"), *ProjectName, *ProjectName);
-	FString TravelUrl;
-	FString SpatialOSOptions = FString::Printf(TEXT("-workerType %s"), *(SpatialGDKSettings->MobileWorkerType));
-	if (SpatialGDKSettings->bMobileConnectToLocalDeployment)
-	{
-		if (SpatialGDKSettings->MobileRuntimeIP.IsEmpty())
-		{
-			UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("The Runtime IP is currently not set. Please make sure to specify a Runtime IP."));
-			FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("The Runtime IP is currently not set. Please make sure to specify a Runtime IP."))));
-			return false;
-		}
-
-		TravelUrl = SpatialGDKSettings->MobileRuntimeIP;
-	}
-	else
-	{
-		TravelUrl = TEXT("connect.to.spatialos");
-
-		if (SpatialGDKSettings->DevelopmentAuthenticationToken.IsEmpty())
-		{
-			FReply GeneratedTokenReply = GenerateDevAuthToken();
-			if (!GeneratedTokenReply.IsEventHandled())
-			{
-				return false;
-			}
-		}
-
-		SpatialOSOptions += FString::Printf(TEXT(" +devauthToken %s"), *(SpatialGDKSettings->DevelopmentAuthenticationToken));
-		if (!SpatialGDKSettings->DevelopmentDeploymentToConnect.IsEmpty())
-		{
-			SpatialOSOptions += FString::Printf(TEXT(" +deployment %s"), *(SpatialGDKSettings->DevelopmentDeploymentToConnect));
-		}
-	}
-
-	const FString SpatialOSCommandLineArgs = FString::Printf(TEXT("%s %s %s %s"), *MobileProjectPath, *TravelUrl, *SpatialOSOptions, *(SpatialGDKSettings->MobileExtraCommandLineArgs));
-	CommandLineArgsFile = FPaths::ConvertRelativePathToFull(FPaths::Combine(*FPaths::ProjectLogDir(), TEXT("ue4commandline.txt")));
-
-	if (!FFileHelper::SaveStringToFile(SpatialOSCommandLineArgs, *CommandLineArgsFile, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM))
-	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Failed to write command line args to file: %s"), *CommandLineArgsFile);
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Failed to write command line args to file: %s"), *CommandLineArgsFile)));
-		return false;
-	}
-
-	return true;
-}
-
-bool FSpatialGDKEditorLayoutDetails::TryPushCommandLineArgsToDevice(const FString& Executable, const FString& ExeArguments, const FString& CommandLineArgsFile)
-{
-	FString ExeOutput;
-	FString StdErr;
-	int32 ExitCode;
-
-	FPlatformProcess::ExecProcess(*Executable, *ExeArguments, &ExitCode, &ExeOutput, &StdErr);
-	if (ExitCode != 0)
-	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Failed to update the mobile client. %s %s"), *ExeOutput, *StdErr);
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Failed to update the mobile client. See the Output log for more information.")));
-		return false;
-	}
-
-	UE_LOG(LogSpatialGDKEditorLayoutDetails, Log, TEXT("Successfully stored command line args on device: %s"), *ExeOutput);
-	IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
-	if (!PlatformFile.DeleteFile(*CommandLineArgsFile))
-	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Failed to delete file %s"), *CommandLineArgsFile);
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Failed to delete file %s"), *CommandLineArgsFile)));
-		return false;
-	}
-
-	return true;
-}
-
-namespace
-{
-	static FString GetAdbExePath()
-	{
-		FString AndroidHome = FPlatformMisc::GetEnvironmentVariable(TEXT("ANDROID_HOME"));
-		if (AndroidHome.IsEmpty())
-		{
-			UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Environment variable ANDROID_HOME is not set. Please make sure to configure this."));
-			FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Environment variable ANDROID_HOME is not set. Please make sure to configure this.")));
-			return TEXT("");
-		}
-
-#if PLATFORM_WINDOWS
-		const FString AdbExe = FPaths::ConvertRelativePathToFull(FPaths::Combine(AndroidHome, TEXT("platform-tools/adb.exe")));
-#else
-		const FString AdbExe = FPaths::ConvertRelativePathToFull(FPaths::Combine(AndroidHome, TEXT("platform-tools/adb")));
-#endif
-
-		return AdbExe;
-	}
-}
-
-FReply FSpatialGDKEditorLayoutDetails::PushCommandLineArgsToAndroidDevice()
-{
-	const FString AdbExe = GetAdbExePath();
-	if (AdbExe.IsEmpty())
-	{
-		return FReply::Unhandled();
-	}
-
-	FString OutCommandLineArgsFile;
-
-	if (!TryConstructMobileCommandLineArgumentsFile(OutCommandLineArgsFile))
-	{
-		return FReply::Unhandled();
-	}
-
-	const FString AndroidCommandLineFile = FString::Printf(TEXT("/mnt/sdcard/UE4Game/%s/UE4CommandLine.txt"), *FString(FApp::GetProjectName()));
-	const FString AdbArguments = FString::Printf(TEXT("push \"%s\" \"%s\""), *OutCommandLineArgsFile, *AndroidCommandLineFile);
-
-	TryPushCommandLineArgsToDevice(AdbExe, AdbArguments, OutCommandLineArgsFile);
-	return FReply::Handled();
+	FSpatialGDKEditorModule& EditorModule = FModuleManager::GetModuleChecked<FSpatialGDKEditorModule>("SpatialGDKEditor");
+	return EditorModule.GetCommandLineArgsManager();
 }
 
 FReply FSpatialGDKEditorLayoutDetails::PushCommandLineArgsToIOSDevice()
 {
-	const UIOSRuntimeSettings* IOSRuntimeSettings = GetDefault<UIOSRuntimeSettings>();
-	FString OutCommandLineArgsFile;
+	return GetCommandLineArgsManager().PushToIOSDevice();
+}
 
-	if (!TryConstructMobileCommandLineArgumentsFile(OutCommandLineArgsFile))
-	{
-		return FReply::Unhandled();
-	}
-
-	FString Executable = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/DotNET/IOS/deploymentserver.exe")));
-	FString DeploymentServerArguments = FString::Printf(TEXT("copyfile -bundle \"%s\" -file \"%s\" -file \"/Documents/ue4commandline.txt\""), *(IOSRuntimeSettings->BundleIdentifier.Replace(TEXT("[PROJECT_NAME]"), FApp::GetProjectName())), *OutCommandLineArgsFile);
-
-#if PLATFORM_MAC
-	DeploymentServerArguments = FString::Printf(TEXT("%s %s"), *Executable, *DeploymentServerArguments);
-	Executable = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/ThirdParty/Mono/Mac/bin/mono")));
-#endif
-
-	TryPushCommandLineArgsToDevice(Executable, DeploymentServerArguments, OutCommandLineArgsFile);
-	return FReply::Handled();
+FReply FSpatialGDKEditorLayoutDetails::PushCommandLineArgsToAndroidDevice()
+{
+	return GetCommandLineArgsManager().PushToAndroidDevice();
 }
 
 FReply FSpatialGDKEditorLayoutDetails::RemoveCommandLineArgsFromIOSDevice()
 {
-	const UIOSRuntimeSettings* IOSRuntimeSettings = GetDefault<UIOSRuntimeSettings>();
-
-	FString Executable = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/DotNET/IOS/deploymentserver.exe")));
-	FString DeploymentServerArguments = FString::Printf(TEXT("removefile -bundle \"%s\" -file \"/Documents/ue4commandline.txt\""), *(IOSRuntimeSettings->BundleIdentifier.Replace(TEXT("[PROJECT_NAME]"), FApp::GetProjectName())));
-
-#if PLATFORM_MAC
-	DeploymentServerArguments = FString::Printf(TEXT("%s %s"), *Executable, *DeploymentServerArguments);
-	Executable = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/ThirdParty/Mono/Mac/bin/mono")));
-#endif
-
-	FString ExeOutput;
-	FString StdErr;
-	int32 ExitCode;
-
-	FPlatformProcess::ExecProcess(*Executable, *DeploymentServerArguments, &ExitCode, &ExeOutput, &StdErr);
-	if (ExitCode != 0)
-	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Failed to remove settings from the mobile client. %s %s"), *ExeOutput, *StdErr);
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Failed to remove settings from the mobile client. See the Output log for more information.")));
-		return FReply::Unhandled();
-	}
-
-	return FReply::Handled();
+	return GetCommandLineArgsManager().RemoveFromIOSDevice();
 }
 
 FReply FSpatialGDKEditorLayoutDetails::RemoveCommandLineArgsFromAndroidDevice()
 {
-	const FString AdbExe = GetAdbExePath();
-	if (AdbExe.IsEmpty())
-	{
-		return FReply::Unhandled();
-	}
-
-	FString ExeOutput;
-	FString StdErr;
-	int32 ExitCode;
-
-	FString ExeArguments = FString::Printf(TEXT("shell rm -f /mnt/sdcard/UE4Game/%s/UE4CommandLine.txt"), FApp::GetProjectName());
-
-	FPlatformProcess::ExecProcess(*AdbExe, *ExeArguments, &ExitCode, &ExeOutput, &StdErr);
-	if (ExitCode != 0)
-	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Failed to remove settings from the mobile client. %s %s"), *ExeOutput, *StdErr);
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Failed to remove settings from the mobile client. See the Output log for more information.")));
-		return FReply::Unhandled();
-	}
-
-	return FReply::Handled();
+	return GetCommandLineArgsManager().RemoveFromAndroidDevice();
 }
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
@@ -95,7 +95,7 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 		[
 			SNew(SButton)
 			.VAlign(VAlign_Center)
-			.OnClicked(FOnClicked::CreateLambda([this] {
+			.OnClicked(FOnClicked::CreateLambda([] {
 				return GetCommandLineArgsManager().GenerateDevAuthToken();
 			}))
 			.Content()
@@ -116,7 +116,7 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 			[
 				SNew(SButton)
 				.VAlign(VAlign_Center)
-				.OnClicked(FOnClicked::CreateLambda([this] {
+				.OnClicked(FOnClicked::CreateLambda([] {
 					return GetCommandLineArgsManager().PushToAndroidDevice();
 				}))
 				.Content()
@@ -129,7 +129,7 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 			[
 				SNew(SButton)
 				.VAlign(VAlign_Center)
-				.OnClicked(FOnClicked::CreateLambda([this] {
+				.OnClicked(FOnClicked::CreateLambda([] {
 					return GetCommandLineArgsManager().RemoveFromAndroidDevice();
 				}))
 				.Content()
@@ -150,7 +150,7 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 			[
 				SNew(SButton)
 				.VAlign(VAlign_Center)
-				.OnClicked(FOnClicked::CreateLambda([this] {
+				.OnClicked(FOnClicked::CreateLambda([] {
 					return GetCommandLineArgsManager().PushToIOSDevice();
 				}))
 				.Content()
@@ -163,7 +163,7 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 			[
 				SNew(SButton)
 				.VAlign(VAlign_Center)
-				.OnClicked(FOnClicked::CreateLambda([this] {
+				.OnClicked(FOnClicked::CreateLambda([] {
 					return GetCommandLineArgsManager().RemoveFromIOSDevice();
 				}))
 				.Content()

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
@@ -11,6 +11,7 @@
 #include "Misc/App.h"
 #include "Misc/FileHelper.h"
 #include "Misc/MessageDialog.h"
+#include "SpatialCommandUtils.h"
 #include "SpatialGDKSettings.h"
 #include "SpatialGDKEditorSettings.h"
 #include "SpatialGDKEditorModule.h"
@@ -38,6 +39,15 @@ void FSpatialGDKEditorLayoutDetails::ForceRefreshLayout()
 			Settings->OnWorkerTypesChanged();
 		}
 		CurrentLayout->ForceRefreshDetails();
+	}
+}
+
+namespace
+{
+	FSpatialGDKEditorCommandLineArgsManager& GetCommandLineArgsManager()
+	{
+		FSpatialGDKEditorModule& EditorModule = FModuleManager::GetModuleChecked<FSpatialGDKEditorModule>("SpatialGDKEditor");
+		return EditorModule.GetCommandLineArgsManager();
 	}
 }
 
@@ -85,7 +95,9 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 		[
 			SNew(SButton)
 			.VAlign(VAlign_Center)
-			.OnClicked(this, &FSpatialGDKEditorLayoutDetails::GenerateDevAuthToken)
+			.OnClicked(FOnClicked::CreateLambda([this] {
+				return GetCommandLineArgsManager().GenerateDevAuthToken();
+			}))
 			.Content()
 			[
 				SNew(STextBlock).Text(FText::FromString("Generate Dev Auth Token"))
@@ -104,7 +116,9 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 			[
 				SNew(SButton)
 				.VAlign(VAlign_Center)
-				.OnClicked(this, &FSpatialGDKEditorLayoutDetails::PushCommandLineArgsToAndroidDevice)
+				.OnClicked(FOnClicked::CreateLambda([this] {
+					return GetCommandLineArgsManager().PushToAndroidDevice();
+				}))
 				.Content()
 				[
 					SNew(STextBlock).Text(FText::FromString("Push SpatialOS settings to Android device"))
@@ -115,7 +129,9 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 			[
 				SNew(SButton)
 				.VAlign(VAlign_Center)
-				.OnClicked(this, &FSpatialGDKEditorLayoutDetails::RemoveCommandLineArgsFromAndroidDevice)
+				.OnClicked(FOnClicked::CreateLambda([this] {
+					return GetCommandLineArgsManager().RemoveFromAndroidDevice();
+				}))
 				.Content()
 				[
 					SNew(STextBlock).Text(FText::FromString("Remove SpatialOS settings from Android device"))
@@ -134,7 +150,9 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 			[
 				SNew(SButton)
 				.VAlign(VAlign_Center)
-				.OnClicked(this, &FSpatialGDKEditorLayoutDetails::PushCommandLineArgsToIOSDevice)
+				.OnClicked(FOnClicked::CreateLambda([this] {
+					return GetCommandLineArgsManager().PushToIOSDevice();
+				}))
 				.Content()
 				[
 					SNew(STextBlock).Text(FText::FromString("Push SpatialOS settings to iOS device"))
@@ -145,7 +163,9 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 			[
 				SNew(SButton)
 				.VAlign(VAlign_Center)
-				.OnClicked(this, &FSpatialGDKEditorLayoutDetails::RemoveCommandLineArgsFromIOSDevice)
+				.OnClicked(FOnClicked::CreateLambda([this] {
+					return GetCommandLineArgsManager().RemoveFromIOSDevice();
+				}))
 				.Content()
 				[
 					SNew(STextBlock).Text(FText::FromString("Remove SpatialOS settings from iOS device"))
@@ -153,35 +173,3 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 			]
 		];
 }
-
-FReply FSpatialGDKEditorLayoutDetails::GenerateDevAuthToken()
-{
-	return GetCommandLineArgsManager().GenerateDevAuthToken();
-}
-
-FSpatialGDKEditorCommandLineArgsManager& FSpatialGDKEditorLayoutDetails::GetCommandLineArgsManager()
-{
-	FSpatialGDKEditorModule& EditorModule = FModuleManager::GetModuleChecked<FSpatialGDKEditorModule>("SpatialGDKEditor");
-	return EditorModule.GetCommandLineArgsManager();
-}
-
-FReply FSpatialGDKEditorLayoutDetails::PushCommandLineArgsToIOSDevice()
-{
-	return GetCommandLineArgsManager().PushToIOSDevice();
-}
-
-FReply FSpatialGDKEditorLayoutDetails::PushCommandLineArgsToAndroidDevice()
-{
-	return GetCommandLineArgsManager().PushToAndroidDevice();
-}
-
-FReply FSpatialGDKEditorLayoutDetails::RemoveCommandLineArgsFromIOSDevice()
-{
-	return GetCommandLineArgsManager().RemoveFromIOSDevice();
-}
-
-FReply FSpatialGDKEditorLayoutDetails::RemoveCommandLineArgsFromAndroidDevice()
-{
-	return GetCommandLineArgsManager().RemoveFromAndroidDevice();
-}
-

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
@@ -42,15 +42,6 @@ void FSpatialGDKEditorLayoutDetails::ForceRefreshLayout()
 	}
 }
 
-namespace
-{
-	FSpatialGDKEditorCommandLineArgsManager& GetCommandLineArgsManager()
-	{
-		FSpatialGDKEditorModule& EditorModule = FModuleManager::GetModuleChecked<FSpatialGDKEditorModule>("SpatialGDKEditor");
-		return EditorModule.GetCommandLineArgsManager();
-	}
-}
-
 void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& DetailBuilder)
 {
 	CurrentLayout = &DetailBuilder;
@@ -95,8 +86,8 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 		[
 			SNew(SButton)
 			.VAlign(VAlign_Center)
-			.OnClicked(FOnClicked::CreateLambda([] {
-				return GetCommandLineArgsManager().GenerateDevAuthToken();
+			.OnClicked(FOnClicked::CreateLambda([=] {
+				return FSpatialGDKEditorCommandLineArgsManager::GenerateDevAuthToken();
 			}))
 			.Content()
 			[
@@ -116,8 +107,8 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 			[
 				SNew(SButton)
 				.VAlign(VAlign_Center)
-				.OnClicked(FOnClicked::CreateLambda([] {
-					return GetCommandLineArgsManager().PushToAndroidDevice();
+				.OnClicked(FOnClicked::CreateLambda([=] {
+					return FSpatialGDKEditorCommandLineArgsManager::PushToAndroidDevice();
 				}))
 				.Content()
 				[
@@ -129,8 +120,8 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 			[
 				SNew(SButton)
 				.VAlign(VAlign_Center)
-				.OnClicked(FOnClicked::CreateLambda([] {
-					return GetCommandLineArgsManager().RemoveFromAndroidDevice();
+				.OnClicked(FOnClicked::CreateLambda([=] {
+					return FSpatialGDKEditorCommandLineArgsManager::RemoveFromAndroidDevice();
 				}))
 				.Content()
 				[
@@ -150,8 +141,8 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 			[
 				SNew(SButton)
 				.VAlign(VAlign_Center)
-				.OnClicked(FOnClicked::CreateLambda([] {
-					return GetCommandLineArgsManager().PushToIOSDevice();
+				.OnClicked(FOnClicked::CreateLambda([=] {
+					return FSpatialGDKEditorCommandLineArgsManager::PushToIOSDevice();
 				}))
 				.Content()
 				[
@@ -163,8 +154,8 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 			[
 				SNew(SButton)
 				.VAlign(VAlign_Center)
-				.OnClicked(FOnClicked::CreateLambda([] {
-					return GetCommandLineArgsManager().RemoveFromIOSDevice();
+				.OnClicked(FOnClicked::CreateLambda([=] {
+					return FSpatialGDKEditorCommandLineArgsManager::RemoveFromIOSDevice();
 				}))
 				.Content()
 				[

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -12,6 +12,7 @@
 #include "SpatialGDKSettings.h"
 #include "SpatialGDKEditorSettings.h"
 #include "SpatialGDKEditorLayoutDetails.h"
+#include "SpatialGDKEditorCommandLineArgsManager.h"
 #include "SpatialLaunchConfigCustomization.h"
 #include "Utils/LaunchConfigEditor.h"
 #include "Utils/LaunchConfigEditorLayoutDetails.h"
@@ -21,6 +22,7 @@
 
 FSpatialGDKEditorModule::FSpatialGDKEditorModule()
 	: ExtensionManager(MakeUnique<FLBStrategyEditorExtensionManager>())
+	, CommandLineArgsManager(MakeUnique<FSpatialGDKEditorCommandLineArgsManager>())
 {
 
 }
@@ -30,6 +32,7 @@ void FSpatialGDKEditorModule::StartupModule()
 	RegisterSettings();
 
 	ExtensionManager->RegisterExtension<FGridLBStrategyEditorExtension>();
+	CommandLineArgsManager->Startup();
 }
 
 void FSpatialGDKEditorModule::ShutdownModule()

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCommandLineArgsManager.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCommandLineArgsManager.h
@@ -1,0 +1,32 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+#include "Templates/SharedPointer.h"
+
+class FReply;
+
+typedef TSharedRef<class ILauncher> ILauncherRef;
+typedef TSharedPtr<class ILauncherWorker> ILauncherWorkerPtr;
+typedef TSharedRef<class ILauncherProfile> ILauncherProfileRef;
+
+class FSpatialGDKEditorCommandLineArgsManager
+{
+public:
+	FSpatialGDKEditorCommandLineArgsManager();
+
+	void Startup();
+
+	FReply GenerateDevAuthToken();
+	FReply PushToIOSDevice();
+	FReply PushToAndroidDevice();
+	FReply RemoveFromIOSDevice();
+	FReply RemoveFromAndroidDevice();
+private:
+	void OnCreateLauncher(ILauncherRef LauncherRef);
+	void OnLaunch(ILauncherWorkerPtr LauncherWorkerPtr, ILauncherProfileRef LauncherProfileRef);
+	void OnLauncherCanceled(double ExecutionTime);
+
+	bool TryConstructMobileCommandLineArgumentsFile(FString& CommandLineArgsFile);
+	bool TryPushCommandLineArgsToDevice(const FString& Executable, const FString& ExeArguments, const FString& CommandLineArgsFile);
+private:
+	bool bAndroidDevice;
+	bool bIOSDevice;
+};

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCommandLineArgsManager.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCommandLineArgsManager.h
@@ -7,6 +7,10 @@ typedef TSharedRef<class ILauncher> ILauncherRef;
 typedef TSharedPtr<class ILauncherWorker> ILauncherWorkerPtr;
 typedef TSharedRef<class ILauncherProfile> ILauncherProfileRef;
 
+//#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION >= 24
+//#define ENABLE_LAUNCHER_DELEGATE
+//#endif
+
 class FSpatialGDKEditorCommandLineArgsManager
 {
 public:
@@ -20,15 +24,18 @@ public:
 	FReply RemoveFromIOSDevice();
 	FReply RemoveFromAndroidDevice();
 private:
+#ifdef ENABLE_LAUNCHER_DELEGATE
 	void OnCreateLauncher(ILauncherRef LauncherRef);
 	void OnLaunch(ILauncherWorkerPtr LauncherWorkerPtr, ILauncherProfileRef LauncherProfileRef);
 	void OnLauncherCanceled(double ExecutionTime);
 	void OnLauncherFinished(bool Outcome, double ExecutionTime, int32 ReturnCode);
 	void RemoveFromDevice();
-
+#endif
 	bool TryConstructMobileCommandLineArgumentsFile(FString& CommandLineArgsFile);
 	bool TryPushCommandLineArgsToDevice(const FString& Executable, const FString& ExeArguments, const FString& CommandLineArgsFile);
 private:
+#ifdef ENABLE_LAUNCHER_DELEGATE
 	bool bAndroidDevice;
 	bool bIOSDevice;
+#endif
 };

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCommandLineArgsManager.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCommandLineArgsManager.h
@@ -1,4 +1,7 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
 #include "Templates/SharedPointer.h"
 
 class FReply;
@@ -18,11 +21,11 @@ public:
 
 	void Startup();
 
-	FReply GenerateDevAuthToken();
-	FReply PushToIOSDevice();
-	FReply PushToAndroidDevice();
-	FReply RemoveFromIOSDevice();
-	FReply RemoveFromAndroidDevice();
+	static FReply GenerateDevAuthToken();
+	static FReply PushToIOSDevice();
+	static FReply PushToAndroidDevice();
+	static FReply RemoveFromIOSDevice();
+	static FReply RemoveFromAndroidDevice();
 private:
 #ifdef ENABLE_LAUNCHER_DELEGATE
 	void OnCreateLauncher(ILauncherRef LauncherRef);
@@ -31,11 +34,10 @@ private:
 	void OnLauncherFinished(bool Outcome, double ExecutionTime, int32 ReturnCode);
 	void RemoveFromDevice();
 #endif
-	bool TryConstructMobileCommandLineArgumentsFile(FString& CommandLineArgsFile);
-	bool TryPushCommandLineArgsToDevice(const FString& Executable, const FString& ExeArguments, const FString& CommandLineArgsFile);
+	static bool TryConstructMobileCommandLineArgumentsFile(FString& CommandLineArgsFile);
+	static bool TryPushCommandLineArgsToDevice(const FString& Executable, const FString& ExeArguments, const FString& CommandLineArgsFile);
 private:
 #ifdef ENABLE_LAUNCHER_DELEGATE
 	bool bAndroidDevice;
-	bool bIOSDevice;
 #endif
 };

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCommandLineArgsManager.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCommandLineArgsManager.h
@@ -7,9 +7,9 @@ typedef TSharedRef<class ILauncher> ILauncherRef;
 typedef TSharedPtr<class ILauncherWorker> ILauncherWorkerPtr;
 typedef TSharedRef<class ILauncherProfile> ILauncherProfileRef;
 
-//#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION >= 24
-//#define ENABLE_LAUNCHER_DELEGATE
-//#endif
+#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION >= 24
+#define ENABLE_LAUNCHER_DELEGATE
+#endif
 
 class FSpatialGDKEditorCommandLineArgsManager
 {

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCommandLineArgsManager.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCommandLineArgsManager.h
@@ -23,6 +23,8 @@ private:
 	void OnCreateLauncher(ILauncherRef LauncherRef);
 	void OnLaunch(ILauncherWorkerPtr LauncherWorkerPtr, ILauncherProfileRef LauncherProfileRef);
 	void OnLauncherCanceled(double ExecutionTime);
+	void OnLauncherFinished(bool Outcome, double ExecutionTime, int32 ReturnCode);
+	void RemoveFromDevice();
 
 	bool TryConstructMobileCommandLineArgumentsFile(FString& CommandLineArgsFile);
 	bool TryPushCommandLineArgsToDevice(const FString& Executable, const FString& ExeArguments, const FString& CommandLineArgsFile);

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCommandLineArgsManager.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCommandLineArgsManager.h
@@ -26,6 +26,7 @@ public:
 	static FReply PushToAndroidDevice();
 	static FReply RemoveFromIOSDevice();
 	static FReply RemoveFromAndroidDevice();
+
 private:
 #ifdef ENABLE_LAUNCHER_DELEGATE
 	void OnCreateLauncher(ILauncherRef LauncherRef);
@@ -36,6 +37,7 @@ private:
 #endif
 	static bool TryConstructMobileCommandLineArgumentsFile(FString& CommandLineArgsFile);
 	static bool TryPushCommandLineArgsToDevice(const FString& Executable, const FString& ExeArguments, const FString& CommandLineArgsFile);
+
 private:
 #ifdef ENABLE_LAUNCHER_DELEGATE
 	bool bAndroidDevice;

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
@@ -10,8 +10,10 @@ class FSpatialGDKEditorLayoutDetails : public IDetailCustomization
 public:
 	static TSharedRef<IDetailCustomization> MakeInstance();
 	virtual void CustomizeDetails(IDetailLayoutBuilder& DetailBuilder) override;
+
 private:
 	void ForceRefreshLayout();
+
 private:
 	IDetailLayoutBuilder* CurrentLayout = nullptr;
 };

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
@@ -4,15 +4,14 @@
 
 #include "CoreMinimal.h"
 #include "IDetailCustomization.h"
-#include "Input/Reply.h"
 
-DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKEditorLayoutDetails, Log, All);
+class FReply;
+class FSpatialGDKEditorCommandLineArgsManager;
 
 class FSpatialGDKEditorLayoutDetails : public IDetailCustomization
 {
 private:
-	bool TryConstructMobileCommandLineArgumentsFile(FString& CommandLineArgsFile);
-	bool TryPushCommandLineArgsToDevice(const FString& Executable, const FString& ExeArguments, const FString& CommandLineArgsFile);
+	FSpatialGDKEditorCommandLineArgsManager& GetCommandLineArgsManager();
 
 	FReply GenerateDevAuthToken();
 	FReply PushCommandLineArgsToIOSDevice();

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
@@ -5,26 +5,13 @@
 #include "CoreMinimal.h"
 #include "IDetailCustomization.h"
 
-class FReply;
-class FSpatialGDKEditorCommandLineArgsManager;
-
 class FSpatialGDKEditorLayoutDetails : public IDetailCustomization
 {
-private:
-	FSpatialGDKEditorCommandLineArgsManager& GetCommandLineArgsManager();
-
-	FReply GenerateDevAuthToken();
-	FReply PushCommandLineArgsToIOSDevice();
-	FReply PushCommandLineArgsToAndroidDevice();
-	FReply RemoveCommandLineArgsFromIOSDevice();
-	FReply RemoveCommandLineArgsFromAndroidDevice();
-
-
-	void ForceRefreshLayout();
-
-	IDetailLayoutBuilder* CurrentLayout = nullptr;
-
 public:
 	static TSharedRef<IDetailCustomization> MakeInstance();
 	virtual void CustomizeDetails(IDetailLayoutBuilder& DetailBuilder) override;
+private:
+	void ForceRefreshLayout();
+private:
+	IDetailLayoutBuilder* CurrentLayout = nullptr;
 };

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
@@ -4,6 +4,7 @@
 #include "Modules/ModuleManager.h"
 
 class FLBStrategyEditorExtensionManager;
+class FSpatialGDKEditorCommandLineArgsManager;
 
 class FSpatialGDKEditorModule : public ISpatialGDKEditorModule
 {
@@ -12,6 +13,7 @@ public:
 	FSpatialGDKEditorModule();
 
 	SPATIALGDKEDITOR_API FLBStrategyEditorExtensionManager& GetLBStrategyExtensionManager() { return *ExtensionManager; }
+	SPATIALGDKEDITOR_API FSpatialGDKEditorCommandLineArgsManager& GetCommandLineArgsManager() { return *CommandLineArgsManager; }
 
 	virtual void StartupModule() override;
 	virtual void ShutdownModule() override;
@@ -39,4 +41,6 @@ private:
 	bool HandleCloudLauncherSettingsSaved();
 
 	TUniquePtr<FLBStrategyEditorExtensionManager> ExtensionManager;
+
+	TUniquePtr<FSpatialGDKEditorCommandLineArgsManager> CommandLineArgsManager;
 };

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -998,9 +998,10 @@ void FSpatialGDKEditorToolbarModule::CloudDeploymentClicked()
 	SpatialGDKEditorSettings->bUseDevelopmentAuthenticationFlow = true;
 	USpatialGDKSettings* SpatialGDKSettings = GetMutableDefault<USpatialGDKSettings>();
 
-	FString DevAuthToken;
-	if (!SpatialCommandUtils::GenerateDevAuthToken(SpatialGDKSettings->IsRunningInChina(), DevAuthToken))
+	FString DevAuthToken,ErrorMessage;
+	if (!SpatialCommandUtils::GenerateDevAuthToken(SpatialGDKSettings->IsRunningInChina(), DevAuthToken, ErrorMessage))
 	{
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(ErrorMessage));
 		UE_LOG(LogSpatialGDKEditorToolbar, Error, TEXT("Failed to generate a development authentication token."));
 	}
 	SpatialGDKEditorSettings->DevelopmentAuthenticationToken = DevAuthToken;

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -998,7 +998,8 @@ void FSpatialGDKEditorToolbarModule::CloudDeploymentClicked()
 	SpatialGDKEditorSettings->bUseDevelopmentAuthenticationFlow = true;
 	USpatialGDKSettings* SpatialGDKSettings = GetMutableDefault<USpatialGDKSettings>();
 
-	FString DevAuthToken,ErrorMessage;
+	FString DevAuthToken;
+	FString ErrorMessage;
 	if (!SpatialCommandUtils::GenerateDevAuthToken(SpatialGDKSettings->IsRunningInChina(), DevAuthToken, ErrorMessage))
 	{
 		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(ErrorMessage));

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
@@ -144,7 +144,7 @@ FProcHandle SpatialCommandUtils::LocalWorkerReplace(const FString& ServicePort, 
 		nullptr, nullptr, nullptr);
 }
 
-bool SpatialCommandUtils::GenerateDevAuthToken(bool IsRunningInChina, FString& OutTokenSecret)
+bool SpatialCommandUtils::GenerateDevAuthToken(bool IsRunningInChina, FString& OutTokenSecret, FString& ErrorMessage)
 {
 	FString Arguments = TEXT("project auth dev-auth-token create --description=\"Unreal GDK Token\" --json_output");
 	if (IsRunningInChina)
@@ -158,7 +158,7 @@ bool SpatialCommandUtils::GenerateDevAuthToken(bool IsRunningInChina, FString& O
 
 	if (ExitCode != 0)
 	{
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to generate a development authentication token. Result: %s"), *CreateDevAuthTokenResult)));
+		ErrorMessage = FString::Printf(TEXT("Unable to generate a development authentication token. Result: %s"), *CreateDevAuthTokenResult);
 		return false;
 	};
 
@@ -175,7 +175,7 @@ bool SpatialCommandUtils::GenerateDevAuthToken(bool IsRunningInChina, FString& O
 	TSharedPtr<FJsonObject> JsonRootObject;
 	if (!(FJsonSerializer::Deserialize(JsonReader, JsonRootObject) && JsonRootObject.IsValid()))
 	{
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to parse the received development authentication token. Result: %s"), *DevAuthTokenResult)));
+		ErrorMessage = FString::Printf(TEXT("Unable to parse the received development authentication token. Result: %s"), *DevAuthTokenResult);
 		return false;
 	}
 
@@ -183,14 +183,14 @@ bool SpatialCommandUtils::GenerateDevAuthToken(bool IsRunningInChina, FString& O
 	const TSharedPtr<FJsonObject>* JsonDataObject;
 	if (!(JsonRootObject->TryGetObjectField("json_data", JsonDataObject)))
 	{
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to parse the received json data. Result: %s"), *DevAuthTokenResult)));
+		ErrorMessage = FString::Printf(TEXT("Unable to parse the received json data. Result: %s"), *DevAuthTokenResult);
 		return false;
 	}
 
 	FString TokenSecret;
 	if (!(*JsonDataObject)->TryGetStringField("token_secret", TokenSecret))
 	{
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to parse the token_secret field inside the received json data. Result: %s"), *DevAuthTokenResult)));
+		ErrorMessage = FString::Printf(TEXT("Unable to parse the token_secret field inside the received json data. Result: %s"), *DevAuthTokenResult);
 		return false;
 	}
 

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
@@ -16,5 +16,5 @@ public:
 	SPATIALGDKSERVICES_API static bool StopSpatialService(bool bIsRunningInChina, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode);
 	SPATIALGDKSERVICES_API static bool BuildWorkerConfig(bool bIsRunningInChina, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode);
 	SPATIALGDKSERVICES_API static FProcHandle LocalWorkerReplace(const FString& ServicePort, const FString& OldWorker, const FString& NewWorker, bool bIsRunningInChina, uint32* OutProcessID);
-	SPATIALGDKSERVICES_API static bool GenerateDevAuthToken(bool IsRunningInChina, FString& OutTokenSecret);
+	SPATIALGDKSERVICES_API static bool GenerateDevAuthToken(bool IsRunningInChina, FString& OutTokenSecret, FString& ErrorMessage);
 };


### PR DESCRIPTION
#### Description
remove the UE4Commandline.txt from the device when the session ends (when click **Cancel** button from Running GDKShooter on xx message window) 
or exit game on the device remove the file too.

#### Release note
REQUIRED: add new class FSpatialGDKEditorCommandLineArgsManager to push or remove the ue4commandlineargs.txt. Modify class FSpatialGDKEditorLayoutDetails to use the interface from 
FSpatialGDKEditorCommandLineArgsManager to push or remove it.
Do not modify the Unreal Engine source code
Register delegate to hook the event when the Cancel button was clicked.
Clean up some unused code from FSpatialGDKEditorLayoutDetails 
Add log when the file was removed.

#### Tests
I test it on Android device but I haven't the iOS device to test this issue.
If success show 'LogSpatialGDKEditorCommandLineArgsManager: Remove ue4commandline.txt from the Android device.  ' on Output Log window.

![image](https://user-images.githubusercontent.com/30972673/81466783-c32a2680-9206-11ea-98a9-e2503ddbe3bd.png)
