### PR TITLE
UNR-3425 Add regex checking on text committed for deployment and assembly name.

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -250,8 +250,11 @@ const FString CONSOLE_HOST    = TEXT("console.improbable.io");
 const FString CONSOLE_HOST_CN = TEXT("console.spatialoschina.com");
 
 const FString AssemblyPattern   = TEXT("^[a-zA-Z0-9_.-]{5,64}$");
+const FString AssemblyPatternHint = TEXT("Assembly name may only contain alphanumeric characters, '_', '.', or '-', and must be between 5 and 64 characters long.");
 const FString ProjectPattern    = TEXT("^[a-z0-9_]{3,32}$");
+const FString ProjectPatternHint = TEXT("Project name may only contain lowercase alphanumeric characters or '_', and must be between 3 and 32 characters long.");
 const FString DeploymentPattern = TEXT("^[a-z0-9_]{2,32}$");
+const FString DeploymentPatternHint = TEXT("Deployment name may only contain lowercase alphanumeric characters or '_', and must be between 2 and 32 characters long.");
 
 inline float GetCommandRetryWaitTimeSeconds(uint32 NumAttempts)
 {

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -362,8 +362,6 @@ private:
 	UPROPERTY(EditAnywhere, config, Category = "Simulated Players", meta = (EditCondition = "bSimulatedPlayersIsEnabled", DisplayName = "Number of simulated players"))
 		uint32 NumberOfSimulatedPlayers;
 
-	static bool IsAssemblyNameValid(const FString& Name);
-	static bool IsDeploymentNameValid(const FString& Name);
 	static bool IsRegionCodeValid(const ERegionCode::Type RegionCode);
 	static bool IsManualWorkerConnectionSet(const FString& LaunchConfigPath, TArray<FString>& OutWorkersManuallyLaunched);
 
@@ -562,4 +560,6 @@ public:
 	void SetRuntimeDevelopmentAuthenticationToken();
 
 	static bool IsProjectNameValid(const FString& Name);
+	static bool IsAssemblyNameValid(const FString& Name);
+	static bool IsDeploymentNameValid(const FString& Name);
 };

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKSimulatedPlayerDeployment.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKSimulatedPlayerDeployment.h
@@ -43,8 +43,10 @@ private:
 	/** Pointer to the SpatialGDK editor */
 	TWeakPtr<FSpatialGDKEditor> SpatialGDKEditorPtr;
 
-	// Project name edit box
-	TSharedPtr<SEditableTextBox> ProjectNameEdit;
+	// Error reporting
+	TSharedPtr<IErrorReportingWidget> ProjectNameInputErrorReporting;
+	TSharedPtr<IErrorReportingWidget> AssemblyNameInputErrorReporting;
+	TSharedPtr<IErrorReportingWidget> DeploymentNameInputErrorReporting;
 
 	TFuture<bool> AttemptSpatialAuthResult;
 
@@ -125,7 +127,4 @@ private:
 
 	FReply OnOpenCloudDeploymentPageClicked();
 	bool CanOpenCloudDeploymentPage() const;
-
-	TSharedPtr<IErrorReportingWidget> AssemblyInputErrorReporting;
-	TSharedPtr<IErrorReportingWidget> DeploymentNameInputErrorReporting;
 };

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKSimulatedPlayerDeployment.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKSimulatedPlayerDeployment.h
@@ -125,4 +125,7 @@ private:
 
 	FReply OnOpenCloudDeploymentPageClicked();
 	bool CanOpenCloudDeploymentPage() const;
+
+	TSharedPtr<IErrorReportingWidget> AssemblyInputErrorReporting;
+	TSharedPtr<IErrorReportingWidget> DeploymentNameInputErrorReporting;
 };


### PR DESCRIPTION
#### Description
- Set the two interface `IsAssemblyNameValid` and `IsDeploymentNameValid` in SpatialGDKEditorSettings.h to public section.
- Before we save assembly name and deployment name inputted by users into INI file, do some regex checking.