### PR TITLE
UNR-2570 Make the Cloud Deployment window unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - The Deploy button will launch the deployment directly if the necessary fields were filled previously in the `Deployment Configuration` window, selecting the `Deployment Configuration` menu item from the dropdown will allow changing of deployment settings.
 - Added `Build Client Worker` and `Build SimulatedPlayer` checkbox to the dropdown list of Deploy button to quickly enable/disable building and including the client worker or simulated player worker in the assembly.
 - Automatically add `dev_login` tag to cloud deployment when clicking launch deployment button.
+- Remove the UE4Commandline.txt from the device when the session ends (click Cancel button from Message window when launch game on Android or iOS)
 
 ## Bug fixes:
 - Fixed a bug that caused queued RPCs to spam logs when an entity is deleted.

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
@@ -1,0 +1,338 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "SpatialGDKEditorCommandLineArgsManager.h"
+
+#include "Input/Reply.h"
+#include "IOSRuntimeSettings.h"
+#include "Logging/LogMacros.h"
+#include "Misc/FileHelper.h"
+#include "Misc/MessageDialog.h"
+#include "Serialization/JsonSerializer.h"
+#include "SpatialGDKSettings.h"
+#include "SpatialGDKEditorSettings.h"
+
+//need this macro before "ILauncherServicesModule.h" to prevent compile error
+#define LAUNCHERSERVICES_API
+
+#include "Developer\LauncherServices\Public\ILauncherServicesModule.h"
+#include "Developer\LauncherServices\Public\ILauncherWorker.h"
+#include "Developer\LauncherServices\Public\ILauncher.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKEditorCommandLineArgsManager, Log, All);
+DEFINE_LOG_CATEGORY(LogSpatialGDKEditorCommandLineArgsManager);
+
+FSpatialGDKEditorCommandLineArgsManager::FSpatialGDKEditorCommandLineArgsManager()
+	:bAndroidDevice(false)
+	, bIOSDevice(false)
+{
+
+}
+
+void FSpatialGDKEditorCommandLineArgsManager::Startup()
+{
+	ILauncherServicesModule& LauncherServicesModule = FModuleManager::LoadModuleChecked<ILauncherServicesModule>(TEXT("LauncherServices"));
+	LauncherServicesModule.OnCreateLauncherDelegate.AddRaw(this, &FSpatialGDKEditorCommandLineArgsManager::OnCreateLauncher);
+}
+
+void FSpatialGDKEditorCommandLineArgsManager::OnLauncherCanceled(double ExecutionTime)
+{
+	if (bAndroidDevice)
+	{
+		RemoveFromAndroidDevice();
+	}
+	if (bIOSDevice)
+	{
+		RemoveFromIOSDevice();
+	}
+}
+
+void FSpatialGDKEditorCommandLineArgsManager::OnLaunch(ILauncherWorkerPtr LauncherWorkerPtr, ILauncherProfileRef LauncherProfileRef)
+{
+	LauncherWorkerPtr->OnCanceled().AddRaw(this, &FSpatialGDKEditorCommandLineArgsManager::OnLauncherCanceled);
+
+	TArray<ILauncherTaskPtr> TaskList;
+	LauncherWorkerPtr->GetTasks(TaskList);
+	for (int32 idx = 0; idx < TaskList.Num(); ++idx)
+	{
+		if (TaskList[idx]->GetDesc().Contains(TEXT("android")))
+		{
+			bAndroidDevice = true;
+		}
+	}
+	if (bIOSDevice)
+	{
+		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Log, TEXT("Ios device launched"));
+	}
+	if (bAndroidDevice)
+	{
+		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Log, TEXT("Android device launched"));
+	}
+}
+
+void FSpatialGDKEditorCommandLineArgsManager::OnCreateLauncher(ILauncherRef LauncherRef)
+{
+	LauncherRef->FLauncherWorkerStartedDelegate.AddRaw(this, &FSpatialGDKEditorCommandLineArgsManager::OnLaunch);
+}
+
+namespace
+{
+	static FString GetAdbExePath()
+	{
+		FString AndroidHome = FPlatformMisc::GetEnvironmentVariable(TEXT("ANDROID_HOME"));
+		if (AndroidHome.IsEmpty())
+		{
+			UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("Environment variable ANDROID_HOME is not set. Please make sure to configure this."));
+			FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Environment variable ANDROID_HOME is not set. Please make sure to configure this.")));
+			return TEXT("");
+		}
+
+#if PLATFORM_WINDOWS
+		const FString AdbExe = FPaths::ConvertRelativePathToFull(FPaths::Combine(AndroidHome, TEXT("platform-tools/adb.exe")));
+#else
+		const FString AdbExe = FPaths::ConvertRelativePathToFull(FPaths::Combine(AndroidHome, TEXT("platform-tools/adb")));
+#endif
+
+		return AdbExe;
+	}
+}
+
+FReply FSpatialGDKEditorCommandLineArgsManager::PushToIOSDevice()
+{
+	const UIOSRuntimeSettings* IOSRuntimeSettings = GetDefault<UIOSRuntimeSettings>();
+	FString OutCommandLineArgsFile;
+
+	if (!TryConstructMobileCommandLineArgumentsFile(OutCommandLineArgsFile))
+	{
+		return FReply::Unhandled();
+	}
+
+	FString Executable = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/DotNET/IOS/deploymentserver.exe")));
+	FString DeploymentServerArguments = FString::Printf(TEXT("copyfile -bundle \"%s\" -file \"%s\" -file \"/Documents/ue4commandline.txt\""), *(IOSRuntimeSettings->BundleIdentifier.Replace(TEXT("[PROJECT_NAME]"), FApp::GetProjectName())), *OutCommandLineArgsFile);
+
+#if PLATFORM_MAC
+	DeploymentServerArguments = FString::Printf(TEXT("%s %s"), *Executable, *DeploymentServerArguments);
+	Executable = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/ThirdParty/Mono/Mac/bin/mono")));
+#endif
+
+	TryPushCommandLineArgsToDevice(Executable, DeploymentServerArguments, OutCommandLineArgsFile);
+	return FReply::Handled();
+}
+
+FReply FSpatialGDKEditorCommandLineArgsManager::PushToAndroidDevice()
+{
+	const FString AdbExe = GetAdbExePath();
+	if (AdbExe.IsEmpty())
+	{
+		return FReply::Unhandled();
+	}
+
+	FString OutCommandLineArgsFile;
+
+	if (!TryConstructMobileCommandLineArgumentsFile(OutCommandLineArgsFile))
+	{
+		return FReply::Unhandled();
+	}
+
+	const FString AndroidCommandLineFile = FString::Printf(TEXT("/mnt/sdcard/UE4Game/%s/UE4CommandLine.txt"), *FString(FApp::GetProjectName()));
+	const FString AdbArguments = FString::Printf(TEXT("push \"%s\" \"%s\""), *OutCommandLineArgsFile, *AndroidCommandLineFile);
+
+	TryPushCommandLineArgsToDevice(AdbExe, AdbArguments, OutCommandLineArgsFile);
+	return FReply::Handled();
+}
+
+FReply FSpatialGDKEditorCommandLineArgsManager::RemoveFromIOSDevice()
+{
+	const UIOSRuntimeSettings* IOSRuntimeSettings = GetDefault<UIOSRuntimeSettings>();
+
+	FString Executable = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/DotNET/IOS/deploymentserver.exe")));
+	FString DeploymentServerArguments = FString::Printf(TEXT("removefile -bundle \"%s\" -file \"/Documents/ue4commandline.txt\""), *(IOSRuntimeSettings->BundleIdentifier.Replace(TEXT("[PROJECT_NAME]"), FApp::GetProjectName())));
+
+#if PLATFORM_MAC
+	DeploymentServerArguments = FString::Printf(TEXT("%s %s"), *Executable, *DeploymentServerArguments);
+	Executable = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/ThirdParty/Mono/Mac/bin/mono")));
+#endif
+
+	FString ExeOutput;
+	FString StdErr;
+	int32 ExitCode;
+
+	FPlatformProcess::ExecProcess(*Executable, *DeploymentServerArguments, &ExitCode, &ExeOutput, &StdErr);
+	if (ExitCode != 0)
+	{
+		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("Failed to remove settings from the mobile client. %s %s"), *ExeOutput, *StdErr);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Failed to remove settings from the mobile client. See the Output log for more information.")));
+		return FReply::Unhandled();
+	}
+	UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Log, TEXT("Remove ue4commandline.txt from the iOS device. %s %s"), *ExeOutput, *StdErr);
+
+	return FReply::Handled();
+}
+
+FReply FSpatialGDKEditorCommandLineArgsManager::RemoveFromAndroidDevice()
+{
+	const FString AdbExe = GetAdbExePath();
+	if (AdbExe.IsEmpty())
+	{
+		return FReply::Unhandled();
+	}
+
+	FString ExeOutput;
+	FString StdErr;
+	int32 ExitCode;
+
+	FString ExeArguments = FString::Printf(TEXT("shell rm -f /mnt/sdcard/UE4Game/%s/UE4CommandLine.txt"), FApp::GetProjectName());
+
+	FPlatformProcess::ExecProcess(*AdbExe, *ExeArguments, &ExitCode, &ExeOutput, &StdErr);
+	if (ExitCode != 0)
+	{
+		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("Failed to remove settings from the mobile client. %s %s"), *ExeOutput, *StdErr);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Failed to remove settings from the mobile client. See the Output log for more information.")));
+		return FReply::Unhandled();
+	}
+	UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Log, TEXT("Remove ue4commandline.txt from the Android device. %s %s"), *ExeOutput, *StdErr);
+
+	return FReply::Handled();
+}
+
+FReply FSpatialGDKEditorCommandLineArgsManager::GenerateDevAuthToken()
+{
+	FString Arguments = TEXT("project auth dev-auth-token create --description=\"Unreal GDK Token\" --json_output");
+	if (GetDefault<USpatialGDKSettings>()->IsRunningInChina())
+	{
+		Arguments += TEXT(" --environment cn-production");
+	}
+
+	FString CreateDevAuthTokenResult;
+	int32 ExitCode;
+	FSpatialGDKServicesModule::ExecuteAndReadOutput(SpatialGDKServicesConstants::SpatialExe, Arguments, SpatialGDKServicesConstants::SpatialOSDirectory, CreateDevAuthTokenResult, ExitCode);
+
+	if (ExitCode != 0)
+	{
+		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("Unable to generate a development authentication token. Result: %s"), *CreateDevAuthTokenResult);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to generate a development authentication token. Result: %s"), *CreateDevAuthTokenResult)));
+		return FReply::Unhandled();
+	};
+
+	FString AuthResult;
+	FString DevAuthTokenResult;
+	bool bFoundNewline = CreateDevAuthTokenResult.TrimEnd().Split(TEXT("\n"), &AuthResult, &DevAuthTokenResult, ESearchCase::IgnoreCase, ESearchDir::FromEnd);
+	if (!bFoundNewline || DevAuthTokenResult.IsEmpty())
+	{
+		// This is necessary because depending on whether you are already authenticated against spatial, it will either return two json structs or one.
+		DevAuthTokenResult = CreateDevAuthTokenResult;
+	}
+
+	TSharedRef<TJsonReader<TCHAR>> JsonReader = TJsonReaderFactory<TCHAR>::Create(DevAuthTokenResult);
+	TSharedPtr<FJsonObject> JsonRootObject;
+	if (!(FJsonSerializer::Deserialize(JsonReader, JsonRootObject) && JsonRootObject.IsValid()))
+	{
+		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("Unable to parse the received development authentication token. Result: %s"), *DevAuthTokenResult);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to parse the received development authentication token. Result: %s"), *DevAuthTokenResult)));
+		return FReply::Unhandled();
+	}
+
+	// We need a pointer to a shared pointer due to how the JSON API works.
+	const TSharedPtr<FJsonObject>* JsonDataObject;
+	if (!(JsonRootObject->TryGetObjectField("json_data", JsonDataObject)))
+	{
+		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("Unable to parse the received json data. Result: %s"), *DevAuthTokenResult);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to parse the received json data. Result: %s"), *DevAuthTokenResult)));
+		return FReply::Unhandled();
+	}
+
+	FString TokenSecret;
+	if (!(*JsonDataObject)->TryGetStringField("token_secret", TokenSecret))
+	{
+		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("Unable to parse the token_secret field inside the received json data. Result: %s"), *DevAuthTokenResult);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to parse the token_secret field inside the received json data. Result: %s"), *DevAuthTokenResult)));
+		return FReply::Unhandled();
+	}
+
+	if (USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetMutableDefault<USpatialGDKEditorSettings>())
+	{
+		SpatialGDKEditorSettings->DevelopmentAuthenticationToken = TokenSecret;
+		SpatialGDKEditorSettings->SaveConfig();
+		SpatialGDKEditorSettings->SetRuntimeDevelopmentAuthenticationToken();
+	}
+
+	return FReply::Handled();
+}
+
+bool FSpatialGDKEditorCommandLineArgsManager::TryConstructMobileCommandLineArgumentsFile(FString& CommandLineArgsFile)
+{
+	const USpatialGDKEditorSettings* SpatialGDKSettings = GetDefault<USpatialGDKEditorSettings>();
+	const FString ProjectName = FApp::GetProjectName();
+
+	// The project path is based on this: https://github.com/improbableio/UnrealEngine/blob/4.22-SpatialOSUnrealGDK-release/Engine/Source/Programs/AutomationTool/AutomationUtils/DeploymentContext.cs#L408
+	const FString MobileProjectPath = FString::Printf(TEXT("../../../%s/%s.uproject"), *ProjectName, *ProjectName);
+	FString TravelUrl;
+	FString SpatialOSOptions = FString::Printf(TEXT("-workerType %s"), *(SpatialGDKSettings->MobileWorkerType));
+	if (SpatialGDKSettings->bMobileConnectToLocalDeployment)
+	{
+		if (SpatialGDKSettings->MobileRuntimeIP.IsEmpty())
+		{
+			UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("The Runtime IP is currently not set. Please make sure to specify a Runtime IP."));
+			FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("The Runtime IP is currently not set. Please make sure to specify a Runtime IP."))));
+			return false;
+		}
+
+		TravelUrl = SpatialGDKSettings->MobileRuntimeIP;
+	}
+	else
+	{
+		TravelUrl = TEXT("connect.to.spatialos");
+
+		if (SpatialGDKSettings->DevelopmentAuthenticationToken.IsEmpty())
+		{
+			FReply GeneratedTokenReply = GenerateDevAuthToken();
+			if (!GeneratedTokenReply.IsEventHandled())
+			{
+				return false;
+			}
+		}
+
+		SpatialOSOptions += FString::Printf(TEXT(" +devauthToken %s"), *(SpatialGDKSettings->DevelopmentAuthenticationToken));
+		if (!SpatialGDKSettings->DevelopmentDeploymentToConnect.IsEmpty())
+		{
+			SpatialOSOptions += FString::Printf(TEXT(" +deployment %s"), *(SpatialGDKSettings->DevelopmentDeploymentToConnect));
+		}
+	}
+
+	const FString SpatialOSCommandLineArgs = FString::Printf(TEXT("%s %s %s %s"), *MobileProjectPath, *TravelUrl, *SpatialOSOptions, *(SpatialGDKSettings->MobileExtraCommandLineArgs));
+	CommandLineArgsFile = FPaths::ConvertRelativePathToFull(FPaths::Combine(*FPaths::ProjectLogDir(), TEXT("ue4commandline.txt")));
+
+	if (!FFileHelper::SaveStringToFile(SpatialOSCommandLineArgs, *CommandLineArgsFile, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM))
+	{
+		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("Failed to write command line args to file: %s"), *CommandLineArgsFile);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Failed to write command line args to file: %s"), *CommandLineArgsFile)));
+		return false;
+	}
+
+	return true;
+}
+
+bool FSpatialGDKEditorCommandLineArgsManager::TryPushCommandLineArgsToDevice(const FString& Executable, const FString& ExeArguments, const FString& CommandLineArgsFile)
+{
+	FString ExeOutput;
+	FString StdErr;
+	int32 ExitCode;
+
+	FPlatformProcess::ExecProcess(*Executable, *ExeArguments, &ExitCode, &ExeOutput, &StdErr);
+	if (ExitCode != 0)
+	{
+		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("Failed to update the mobile client. %s %s"), *ExeOutput, *StdErr);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Failed to update the mobile client. See the Output log for more information.")));
+		return false;
+	}
+
+	UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Log, TEXT("Successfully stored command line args on device: %s"), *ExeOutput);
+	IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
+	if (!PlatformFile.DeleteFile(*CommandLineArgsFile))
+	{
+		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("Failed to delete file %s"), *CommandLineArgsFile);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Failed to delete file %s"), *CommandLineArgsFile)));
+		return false;
+	}
+
+	return true;
+}

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
@@ -50,6 +50,8 @@ void FSpatialGDKEditorCommandLineArgsManager::OnLaunch(ILauncherWorkerPtr Launch
 {
 	LauncherWorkerPtr->OnCanceled().AddRaw(this, &FSpatialGDKEditorCommandLineArgsManager::OnLauncherCanceled);
 
+	bIOSDevice = false;
+	bAndroidDevice = false;
 	TArray<ILauncherTaskPtr> TaskList;
 	LauncherWorkerPtr->GetTasks(TaskList);
 	for (int32 idx = 0; idx < TaskList.Num(); ++idx)
@@ -57,6 +59,10 @@ void FSpatialGDKEditorCommandLineArgsManager::OnLaunch(ILauncherWorkerPtr Launch
 		if (TaskList[idx]->GetDesc().Contains(TEXT("android")))
 		{
 			bAndroidDevice = true;
+		}
+		if (TaskList[idx]->GetDesc().Contains(TEXT("ios")))
+		{
+			bIOSDevice = true;
 		}
 	}
 	if (bIOSDevice)

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
@@ -6,19 +6,19 @@
 #include "DetailWidgetRow.h"
 #include "DetailCategoryBuilder.h"
 #include "HAL/PlatformFilemanager.h"
+#include "Input/Reply.h"
 #include "IOSRuntimeSettings.h"
 #include "Misc/App.h"
 #include "Misc/FileHelper.h"
 #include "Misc/MessageDialog.h"
-#include "Serialization/JsonSerializer.h"
 #include "SpatialGDKSettings.h"
 #include "SpatialGDKEditorSettings.h"
+#include "SpatialGDKEditorModule.h"
+#include "SpatialGDKEditorCommandLineArgsManager.h"
 #include "SpatialGDKServicesConstants.h"
 #include "SpatialGDKServicesModule.h"
 #include "Widgets/Text/STextBlock.h"
 #include "Widgets/Input/SButton.h"
-
-DEFINE_LOG_CATEGORY(LogSpatialGDKEditorLayoutDetails);
 
 TSharedRef<IDetailCustomization> FSpatialGDKEditorLayoutDetails::MakeInstance()
 {
@@ -156,262 +156,32 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 
 FReply FSpatialGDKEditorLayoutDetails::GenerateDevAuthToken()
 {
-	FString Arguments = TEXT("project auth dev-auth-token create --description=\"Unreal GDK Token\" --json_output");
-	if (GetDefault<USpatialGDKSettings>()->IsRunningInChina())
-	{
-		Arguments += TEXT(" --environment cn-production");
-	}
-
-	FString CreateDevAuthTokenResult;
-	int32 ExitCode;
-	FSpatialGDKServicesModule::ExecuteAndReadOutput(SpatialGDKServicesConstants::SpatialExe, Arguments, SpatialGDKServicesConstants::SpatialOSDirectory, CreateDevAuthTokenResult, ExitCode);
-
-	if (ExitCode != 0)
-	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Unable to generate a development authentication token. Result: %s"), *CreateDevAuthTokenResult);
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to generate a development authentication token. Result: %s"), *CreateDevAuthTokenResult)));
-		return FReply::Unhandled();
-	};
-
-	FString AuthResult;
-	FString DevAuthTokenResult;
-	bool bFoundNewline = CreateDevAuthTokenResult.TrimEnd().Split(TEXT("\n"), &AuthResult, &DevAuthTokenResult, ESearchCase::IgnoreCase, ESearchDir::FromEnd);
-	if (!bFoundNewline || DevAuthTokenResult.IsEmpty())
-	{
-		// This is necessary because depending on whether you are already authenticated against spatial, it will either return two json structs or one.
-		DevAuthTokenResult = CreateDevAuthTokenResult;
-	}
-
-	TSharedRef<TJsonReader<TCHAR>> JsonReader = TJsonReaderFactory<TCHAR>::Create(DevAuthTokenResult);
-	TSharedPtr<FJsonObject> JsonRootObject;
-	if (!(FJsonSerializer::Deserialize(JsonReader, JsonRootObject) && JsonRootObject.IsValid()))
-	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Unable to parse the received development authentication token. Result: %s"), *DevAuthTokenResult);
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to parse the received development authentication token. Result: %s"), *DevAuthTokenResult)));
-		return FReply::Unhandled();
-	}
-
-	// We need a pointer to a shared pointer due to how the JSON API works.
-	const TSharedPtr<FJsonObject>* JsonDataObject;
-	if (!(JsonRootObject->TryGetObjectField("json_data", JsonDataObject)))
-	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Unable to parse the received json data. Result: %s"), *DevAuthTokenResult);
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to parse the received json data. Result: %s"), *DevAuthTokenResult)));
-		return FReply::Unhandled();
-	}
-
-	FString TokenSecret;
-	if (!(*JsonDataObject)->TryGetStringField("token_secret", TokenSecret))
-	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Unable to parse the token_secret field inside the received json data. Result: %s"), *DevAuthTokenResult);
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to parse the token_secret field inside the received json data. Result: %s"), *DevAuthTokenResult)));
-		return FReply::Unhandled();
-	}
-
-	if (USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetMutableDefault<USpatialGDKEditorSettings>())
-	{
-		SpatialGDKEditorSettings->DevelopmentAuthenticationToken = TokenSecret;
-		SpatialGDKEditorSettings->SaveConfig();
-		SpatialGDKEditorSettings->SetRuntimeDevelopmentAuthenticationToken();
-	}
-
-	return FReply::Handled();
+	return GetCommandLineArgsManager().GenerateDevAuthToken();
 }
 
-bool FSpatialGDKEditorLayoutDetails::TryConstructMobileCommandLineArgumentsFile(FString& CommandLineArgsFile)
+FSpatialGDKEditorCommandLineArgsManager& FSpatialGDKEditorLayoutDetails::GetCommandLineArgsManager()
 {
-	const USpatialGDKEditorSettings* SpatialGDKSettings = GetDefault<USpatialGDKEditorSettings>();
-	const FString ProjectName = FApp::GetProjectName();
-
-	// The project path is based on this: https://github.com/improbableio/UnrealEngine/blob/4.22-SpatialOSUnrealGDK-release/Engine/Source/Programs/AutomationTool/AutomationUtils/DeploymentContext.cs#L408
-	const FString MobileProjectPath = FString::Printf(TEXT("../../../%s/%s.uproject"), *ProjectName, *ProjectName);
-	FString TravelUrl;
-	FString SpatialOSOptions = FString::Printf(TEXT("-workerType %s"), *(SpatialGDKSettings->MobileWorkerType));
-	if (SpatialGDKSettings->bMobileConnectToLocalDeployment)
-	{
-		if (SpatialGDKSettings->MobileRuntimeIP.IsEmpty())
-		{
-			UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("The Runtime IP is currently not set. Please make sure to specify a Runtime IP."));
-			FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("The Runtime IP is currently not set. Please make sure to specify a Runtime IP."))));
-			return false;
-		}
-
-		TravelUrl = SpatialGDKSettings->MobileRuntimeIP;
-	}
-	else
-	{
-		TravelUrl = TEXT("connect.to.spatialos");
-
-		if (SpatialGDKSettings->DevelopmentAuthenticationToken.IsEmpty())
-		{
-			FReply GeneratedTokenReply = GenerateDevAuthToken();
-			if (!GeneratedTokenReply.IsEventHandled())
-			{
-				return false;
-			}
-		}
-
-		SpatialOSOptions += FString::Printf(TEXT(" +devauthToken %s"), *(SpatialGDKSettings->DevelopmentAuthenticationToken));
-		if (!SpatialGDKSettings->DevelopmentDeploymentToConnect.IsEmpty())
-		{
-			SpatialOSOptions += FString::Printf(TEXT(" +deployment %s"), *(SpatialGDKSettings->DevelopmentDeploymentToConnect));
-		}
-	}
-
-	const FString SpatialOSCommandLineArgs = FString::Printf(TEXT("%s %s %s %s"), *MobileProjectPath, *TravelUrl, *SpatialOSOptions, *(SpatialGDKSettings->MobileExtraCommandLineArgs));
-	CommandLineArgsFile = FPaths::ConvertRelativePathToFull(FPaths::Combine(*FPaths::ProjectLogDir(), TEXT("ue4commandline.txt")));
-
-	if (!FFileHelper::SaveStringToFile(SpatialOSCommandLineArgs, *CommandLineArgsFile, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM))
-	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Failed to write command line args to file: %s"), *CommandLineArgsFile);
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Failed to write command line args to file: %s"), *CommandLineArgsFile)));
-		return false;
-	}
-
-	return true;
-}
-
-bool FSpatialGDKEditorLayoutDetails::TryPushCommandLineArgsToDevice(const FString& Executable, const FString& ExeArguments, const FString& CommandLineArgsFile)
-{
-	FString ExeOutput;
-	FString StdErr;
-	int32 ExitCode;
-
-	FPlatformProcess::ExecProcess(*Executable, *ExeArguments, &ExitCode, &ExeOutput, &StdErr);
-	if (ExitCode != 0)
-	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Failed to update the mobile client. %s %s"), *ExeOutput, *StdErr);
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Failed to update the mobile client. See the Output log for more information.")));
-		return false;
-	}
-
-	UE_LOG(LogSpatialGDKEditorLayoutDetails, Log, TEXT("Successfully stored command line args on device: %s"), *ExeOutput);
-	IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
-	if (!PlatformFile.DeleteFile(*CommandLineArgsFile))
-	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Failed to delete file %s"), *CommandLineArgsFile);
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Failed to delete file %s"), *CommandLineArgsFile)));
-		return false;
-	}
-
-	return true;
-}
-
-namespace
-{
-	static FString GetAdbExePath()
-	{
-		FString AndroidHome = FPlatformMisc::GetEnvironmentVariable(TEXT("ANDROID_HOME"));
-		if (AndroidHome.IsEmpty())
-		{
-			UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Environment variable ANDROID_HOME is not set. Please make sure to configure this."));
-			FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Environment variable ANDROID_HOME is not set. Please make sure to configure this.")));
-			return TEXT("");
-		}
-
-#if PLATFORM_WINDOWS
-		const FString AdbExe = FPaths::ConvertRelativePathToFull(FPaths::Combine(AndroidHome, TEXT("platform-tools/adb.exe")));
-#else
-		const FString AdbExe = FPaths::ConvertRelativePathToFull(FPaths::Combine(AndroidHome, TEXT("platform-tools/adb")));
-#endif
-
-		return AdbExe;
-	}
-}
-
-FReply FSpatialGDKEditorLayoutDetails::PushCommandLineArgsToAndroidDevice()
-{
-	const FString AdbExe = GetAdbExePath();
-	if (AdbExe.IsEmpty())
-	{
-		return FReply::Unhandled();
-	}
-
-	FString OutCommandLineArgsFile;
-
-	if (!TryConstructMobileCommandLineArgumentsFile(OutCommandLineArgsFile))
-	{
-		return FReply::Unhandled();
-	}
-
-	const FString AndroidCommandLineFile = FString::Printf(TEXT("/mnt/sdcard/UE4Game/%s/UE4CommandLine.txt"), *FString(FApp::GetProjectName()));
-	const FString AdbArguments = FString::Printf(TEXT("push \"%s\" \"%s\""), *OutCommandLineArgsFile, *AndroidCommandLineFile);
-
-	TryPushCommandLineArgsToDevice(AdbExe, AdbArguments, OutCommandLineArgsFile);
-	return FReply::Handled();
+	FSpatialGDKEditorModule& EditorModule = FModuleManager::GetModuleChecked<FSpatialGDKEditorModule>("SpatialGDKEditor");
+	return EditorModule.GetCommandLineArgsManager();
 }
 
 FReply FSpatialGDKEditorLayoutDetails::PushCommandLineArgsToIOSDevice()
 {
-	const UIOSRuntimeSettings* IOSRuntimeSettings = GetDefault<UIOSRuntimeSettings>();
-	FString OutCommandLineArgsFile;
+	return GetCommandLineArgsManager().PushToIOSDevice();
+}
 
-	if (!TryConstructMobileCommandLineArgumentsFile(OutCommandLineArgsFile))
-	{
-		return FReply::Unhandled();
-	}
-
-	FString Executable = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/DotNET/IOS/deploymentserver.exe")));
-	FString DeploymentServerArguments = FString::Printf(TEXT("copyfile -bundle \"%s\" -file \"%s\" -file \"/Documents/ue4commandline.txt\""), *(IOSRuntimeSettings->BundleIdentifier.Replace(TEXT("[PROJECT_NAME]"), FApp::GetProjectName())), *OutCommandLineArgsFile);
-
-#if PLATFORM_MAC
-	DeploymentServerArguments = FString::Printf(TEXT("%s %s"), *Executable, *DeploymentServerArguments);
-	Executable = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/ThirdParty/Mono/Mac/bin/mono")));
-#endif
-
-	TryPushCommandLineArgsToDevice(Executable, DeploymentServerArguments, OutCommandLineArgsFile);
-	return FReply::Handled();
+FReply FSpatialGDKEditorLayoutDetails::PushCommandLineArgsToAndroidDevice()
+{
+	return GetCommandLineArgsManager().PushToAndroidDevice();
 }
 
 FReply FSpatialGDKEditorLayoutDetails::RemoveCommandLineArgsFromIOSDevice()
 {
-	const UIOSRuntimeSettings* IOSRuntimeSettings = GetDefault<UIOSRuntimeSettings>();
-
-	FString Executable = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/DotNET/IOS/deploymentserver.exe")));
-	FString DeploymentServerArguments = FString::Printf(TEXT("removefile -bundle \"%s\" -file \"/Documents/ue4commandline.txt\""), *(IOSRuntimeSettings->BundleIdentifier.Replace(TEXT("[PROJECT_NAME]"), FApp::GetProjectName())));
-
-#if PLATFORM_MAC
-	DeploymentServerArguments = FString::Printf(TEXT("%s %s"), *Executable, *DeploymentServerArguments);
-	Executable = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/ThirdParty/Mono/Mac/bin/mono")));
-#endif
-
-	FString ExeOutput;
-	FString StdErr;
-	int32 ExitCode;
-
-	FPlatformProcess::ExecProcess(*Executable, *DeploymentServerArguments, &ExitCode, &ExeOutput, &StdErr);
-	if (ExitCode != 0)
-	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Failed to remove settings from the mobile client. %s %s"), *ExeOutput, *StdErr);
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Failed to remove settings from the mobile client. See the Output log for more information.")));
-		return FReply::Unhandled();
-	}
-
-	return FReply::Handled();
+	return GetCommandLineArgsManager().RemoveFromIOSDevice();
 }
 
 FReply FSpatialGDKEditorLayoutDetails::RemoveCommandLineArgsFromAndroidDevice()
 {
-	const FString AdbExe = GetAdbExePath();
-	if (AdbExe.IsEmpty())
-	{
-		return FReply::Unhandled();
-	}
-
-	FString ExeOutput;
-	FString StdErr;
-	int32 ExitCode;
-
-	FString ExeArguments = FString::Printf(TEXT("shell rm -f /mnt/sdcard/UE4Game/%s/UE4CommandLine.txt"), FApp::GetProjectName());
-
-	FPlatformProcess::ExecProcess(*AdbExe, *ExeArguments, &ExitCode, &ExeOutput, &StdErr);
-	if (ExitCode != 0)
-	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Failed to remove settings from the mobile client. %s %s"), *ExeOutput, *StdErr);
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Failed to remove settings from the mobile client. See the Output log for more information.")));
-		return FReply::Unhandled();
-	}
-
-	return FReply::Handled();
+	return GetCommandLineArgsManager().RemoveFromAndroidDevice();
 }
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -12,6 +12,7 @@
 #include "SpatialGDKSettings.h"
 #include "SpatialGDKEditorSettings.h"
 #include "SpatialGDKEditorLayoutDetails.h"
+#include "SpatialGDKEditorCommandLineArgsManager.h"
 #include "SpatialLaunchConfigCustomization.h"
 #include "Utils/LaunchConfigEditor.h"
 #include "Utils/LaunchConfigEditorLayoutDetails.h"
@@ -21,6 +22,7 @@
 
 FSpatialGDKEditorModule::FSpatialGDKEditorModule()
 	: ExtensionManager(MakeUnique<FLBStrategyEditorExtensionManager>())
+	, CommandLineArgsManager(MakeUnique<FSpatialGDKEditorCommandLineArgsManager>())
 {
 
 }
@@ -30,6 +32,7 @@ void FSpatialGDKEditorModule::StartupModule()
 	RegisterSettings();
 
 	ExtensionManager->RegisterExtension<FGridLBStrategyEditorExtension>();
+	CommandLineArgsManager->Startup();
 }
 
 void FSpatialGDKEditorModule::ShutdownModule()

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCommandLineArgsManager.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCommandLineArgsManager.h
@@ -1,0 +1,32 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+#include "Templates/SharedPointer.h"
+
+class FReply;
+
+typedef TSharedRef<class ILauncher> ILauncherRef;
+typedef TSharedPtr<class ILauncherWorker> ILauncherWorkerPtr;
+typedef TSharedRef<class ILauncherProfile> ILauncherProfileRef;
+
+class FSpatialGDKEditorCommandLineArgsManager
+{
+public:
+	FSpatialGDKEditorCommandLineArgsManager();
+
+	void Startup();
+
+	FReply GenerateDevAuthToken();
+	FReply PushToIOSDevice();
+	FReply PushToAndroidDevice();
+	FReply RemoveFromIOSDevice();
+	FReply RemoveFromAndroidDevice();
+private:
+	void OnCreateLauncher(ILauncherRef LauncherRef);
+	void OnLaunch(ILauncherWorkerPtr LauncherWorkerPtr, ILauncherProfileRef LauncherProfileRef);
+	void OnLauncherCanceled(double ExecutionTime);
+
+	bool TryConstructMobileCommandLineArgumentsFile(FString& CommandLineArgsFile);
+	bool TryPushCommandLineArgsToDevice(const FString& Executable, const FString& ExeArguments, const FString& CommandLineArgsFile);
+private:
+	bool bAndroidDevice;
+	bool bIOSDevice;
+};

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
@@ -4,15 +4,14 @@
 
 #include "CoreMinimal.h"
 #include "IDetailCustomization.h"
-#include "Input/Reply.h"
 
-DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKEditorLayoutDetails, Log, All);
+class FReply;
+class FSpatialGDKEditorCommandLineArgsManager;
 
 class FSpatialGDKEditorLayoutDetails : public IDetailCustomization
 {
 private:
-	bool TryConstructMobileCommandLineArgumentsFile(FString& CommandLineArgsFile);
-	bool TryPushCommandLineArgsToDevice(const FString& Executable, const FString& ExeArguments, const FString& CommandLineArgsFile);
+	FSpatialGDKEditorCommandLineArgsManager& GetCommandLineArgsManager();
 
 	FReply GenerateDevAuthToken();
 	FReply PushCommandLineArgsToIOSDevice();

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
@@ -4,6 +4,7 @@
 #include "Modules/ModuleManager.h"
 
 class FLBStrategyEditorExtensionManager;
+class FSpatialGDKEditorCommandLineArgsManager;
 
 class FSpatialGDKEditorModule : public ISpatialGDKEditorModule
 {
@@ -12,6 +13,7 @@ public:
 	FSpatialGDKEditorModule();
 
 	SPATIALGDKEDITOR_API FLBStrategyEditorExtensionManager& GetLBStrategyExtensionManager() { return *ExtensionManager; }
+	SPATIALGDKEDITOR_API FSpatialGDKEditorCommandLineArgsManager& GetCommandLineArgsManager() { return *CommandLineArgsManager; }
 
 	virtual void StartupModule() override;
 	virtual void ShutdownModule() override;
@@ -39,4 +41,6 @@ private:
 	bool HandleCloudLauncherSettingsSaved();
 
 	TUniquePtr<FLBStrategyEditorExtensionManager> ExtensionManager;
+
+	TUniquePtr<FSpatialGDKEditorCommandLineArgsManager> CommandLineArgsManager;
 };

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -1058,24 +1058,33 @@ void FSpatialGDKEditorToolbarModule::OnPropertyChanged(UObject* ObjectBeingModif
 void FSpatialGDKEditorToolbarModule::ShowSimulatedPlayerDeploymentDialog()
 {
 	// Create and open the cloud configuration dialog
-	SimulatedPlayerDeploymentWindowPtr = SNew(SWindow)
-		.Title(LOCTEXT("SimulatedPlayerConfigurationTitle", "Cloud Deployment"))
-		.HasCloseButton(true)
-		.SupportsMaximize(false)
-		.SupportsMinimize(false)
-		.SizingRule(ESizingRule::Autosized);
+	if (CloudDeploymentSettingsWindowPtr.IsValid())
+	{
+		CloudDeploymentSettingsWindowPtr->BringToFront();
+	}
+	else
+	{
+		CloudDeploymentSettingsWindowPtr = SNew(SWindow)
+			.Title(LOCTEXT("SimulatedPlayerConfigurationTitle", "Cloud Deployment"))
+			.HasCloseButton(true)
+			.SupportsMaximize(false)
+			.SupportsMinimize(false)
+			.SizingRule(ESizingRule::Autosized);
 
-	SimulatedPlayerDeploymentWindowPtr->SetContent(
-		SNew(SBox)
-		.WidthOverride(700.0f)
-		[
-			SAssignNew(SimulatedPlayerDeploymentConfigPtr, SSpatialGDKSimulatedPlayerDeployment)
-			.SpatialGDKEditor(SpatialGDKEditorInstance)
-			.ParentWindow(SimulatedPlayerDeploymentWindowPtr)
-		]
-	);
-
-	FSlateApplication::Get().AddWindow(SimulatedPlayerDeploymentWindowPtr.ToSharedRef());
+		CloudDeploymentSettingsWindowPtr->SetContent(
+			SNew(SBox)
+			.WidthOverride(700.0f)
+			[
+				SAssignNew(SimulatedPlayerDeploymentConfigPtr, SSpatialGDKSimulatedPlayerDeployment)
+				.SpatialGDKEditor(SpatialGDKEditorInstance)
+			.ParentWindow(CloudDeploymentSettingsWindowPtr)
+			]
+		);
+		CloudDeploymentSettingsWindowPtr->SetOnWindowClosed(FOnWindowClosed::CreateLambda([=](const TSharedRef<SWindow>& WindowArg) {
+			CloudDeploymentSettingsWindowPtr = nullptr;
+			}));
+		FSlateApplication::Get().AddWindow(CloudDeploymentSettingsWindowPtr.ToSharedRef());
+	}
 }
 
 void FSpatialGDKEditorToolbarModule::OpenLaunchConfigurationEditor()

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -167,7 +167,7 @@ private:
 	TFuture<bool> SchemaGeneratorResult;
 	TSharedPtr<FSpatialGDKEditor> SpatialGDKEditorInstance;
 
-	TSharedPtr<SWindow> SimulatedPlayerDeploymentWindowPtr;
+	TSharedPtr<SWindow> CloudDeploymentSettingsWindowPtr;
 	TSharedPtr<SSpatialGDKSimulatedPlayerDeployment> SimulatedPlayerDeploymentConfigPtr;
 	
 	FLocalDeploymentManager* LocalDeploymentManager;


### PR DESCRIPTION
#### Description
bring the settings window to front if already have a cloud deployment settings window and click the button again.
fix the bug of UNR-2570.

#### Release note
REQUIRED: check the windows' pointer if valid.
bring it to the front if valid. and open a new window if not.
bind event on the window destroyed.
rename SimulatedPlayerDeploymentWindowPtr to CloudDeploymentSettingsWindowPtr


