### PR TITLE
URN-2570 Make the Cloud Deployment Settings Window unique

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -1059,12 +1059,13 @@ void FSpatialGDKEditorToolbarModule::ShowCloudDeploymentDialog()
 			[
 				SAssignNew(SimulatedPlayerDeploymentConfigPtr, SSpatialGDKSimulatedPlayerDeployment)
 				.SpatialGDKEditor(SpatialGDKEditorInstance)
-			.ParentWindow(CloudDeploymentSettingsWindowPtr)
+				.ParentWindow(CloudDeploymentSettingsWindowPtr)
 			]
 		);
-		CloudDeploymentSettingsWindowPtr->SetOnWindowClosed(FOnWindowClosed::CreateLambda([=](const TSharedRef<SWindow>& WindowArg) {
+		CloudDeploymentSettingsWindowPtr->SetOnWindowClosed(FOnWindowClosed::CreateLambda([=](const TSharedRef<SWindow>& WindowArg)
+		{
 			CloudDeploymentSettingsWindowPtr = nullptr;
-			}));
+		}));
 		FSlateApplication::Get().AddWindow(CloudDeploymentSettingsWindowPtr.ToSharedRef());
 	}
 }

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -1040,24 +1040,33 @@ void FSpatialGDKEditorToolbarModule::OnPropertyChanged(UObject* ObjectBeingModif
 void FSpatialGDKEditorToolbarModule::ShowCloudDeploymentDialog()
 {
 	// Create and open the cloud configuration dialog
-	SimulatedPlayerDeploymentWindowPtr = SNew(SWindow)
-		.Title(LOCTEXT("SimulatedPlayerConfigurationTitle", "Cloud Deployment"))
-		.HasCloseButton(true)
-		.SupportsMaximize(false)
-		.SupportsMinimize(false)
-		.SizingRule(ESizingRule::Autosized);
+	if (CloudDeploymentSettingsWindowPtr.IsValid())
+	{
+		CloudDeploymentSettingsWindowPtr->BringToFront();
+	}
+	else
+	{
+		CloudDeploymentSettingsWindowPtr = SNew(SWindow)
+			.Title(LOCTEXT("SimulatedPlayerConfigurationTitle", "Cloud Deployment"))
+			.HasCloseButton(true)
+			.SupportsMaximize(false)
+			.SupportsMinimize(false)
+			.SizingRule(ESizingRule::Autosized);
 
-	SimulatedPlayerDeploymentWindowPtr->SetContent(
-		SNew(SBox)
-		.WidthOverride(700.0f)
-		[
-			SAssignNew(SimulatedPlayerDeploymentConfigPtr, SSpatialGDKSimulatedPlayerDeployment)
-			.SpatialGDKEditor(SpatialGDKEditorInstance)
-			.ParentWindow(SimulatedPlayerDeploymentWindowPtr)
-		]
-	);
-
-	FSlateApplication::Get().AddWindow(SimulatedPlayerDeploymentWindowPtr.ToSharedRef());
+		CloudDeploymentSettingsWindowPtr->SetContent(
+			SNew(SBox)
+			.WidthOverride(700.0f)
+			[
+				SAssignNew(SimulatedPlayerDeploymentConfigPtr, SSpatialGDKSimulatedPlayerDeployment)
+				.SpatialGDKEditor(SpatialGDKEditorInstance)
+			.ParentWindow(CloudDeploymentSettingsWindowPtr)
+			]
+		);
+		CloudDeploymentSettingsWindowPtr->SetOnWindowClosed(FOnWindowClosed::CreateLambda([=](const TSharedRef<SWindow>& WindowArg) {
+			CloudDeploymentSettingsWindowPtr = nullptr;
+			}));
+		FSlateApplication::Get().AddWindow(CloudDeploymentSettingsWindowPtr.ToSharedRef());
+	}
 }
 
 void FSpatialGDKEditorToolbarModule::OpenLaunchConfigurationEditor()

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -166,7 +166,7 @@ private:
 	TFuture<bool> SchemaGeneratorResult;
 	TSharedPtr<FSpatialGDKEditor> SpatialGDKEditorInstance;
 
-	TSharedPtr<SWindow> SimulatedPlayerDeploymentWindowPtr;
+	TSharedPtr<SWindow> CloudDeploymentSettingsWindowPtr;
 	TSharedPtr<SSpatialGDKSimulatedPlayerDeployment> SimulatedPlayerDeploymentConfigPtr;
 	
 	FLocalDeploymentManager* LocalDeploymentManager;


### PR DESCRIPTION
#### Description
bring the settings window to front if already have a cloud deployment settings window and click the button again.
fix the bug of UNR-2570.

#### Release note
REQUIRED: check the windows' pointer if valid.
bring it to the front if valid. and open a new window if not.
bind event on the window destroyed so that clear CloudDeploymentSettingsWindowPtr.
rename SimulatedPlayerDeploymentWindowPtr to CloudDeploymentSettingsWindowPtr.

