### PR TITLE
Display the Notification about cloud deployment.

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -1283,6 +1283,7 @@ void FSpatialGDKEditorToolbarModule::OnBuildSuccess()
 
 	auto LaunchCloudDeployment = [this]()
 	{
+		OnShowTaskStartNotification(FString::Printf(TEXT("Launching cloud deployment: %s"), *GetDefault<USpatialGDKEditorSettings>()->GetPrimaryDeploymentName()));
 		SpatialGDKEditorInstance->LaunchCloudDeployment(
 			FSimpleDelegate::CreateLambda([this]()
 			{


### PR DESCRIPTION
Notification toasts about Launching a cloud deployment were missing.
This was because no start notification was issued, it is necessary to create a start notification to generate a valid notification pointer.

Added a start notification when launching a cloud deployment, now the success or failure notification will also display and the notification stays alive for the duration of the launch deployment task.