### PR TITLE
Added SpatialPackageService

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
@@ -51,7 +51,7 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 
 	IDetailPropertyRow* CustomRow = DetailBuilder.EditDefaultProperty(UsePinnedVersionProperty);
 
-	FString PinnedVersionDisplay = FString::Printf(TEXT("GDK Pinned Version : %s"), *SpatialGDKServicesConstants::SpatialOSRuntimePinnedVersion);
+	FString PinnedVersionDisplay = FString::Printf(TEXT("GDK Pinned Version : %s"), *SpatialGDKServicesConstants::SpatialOSDistributedRuntimePinnedVersion);
 
 	CustomRow->CustomWidget()
 		.NameContent()

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -65,7 +65,7 @@ const FString& USpatialGDKEditorSettings::GetSpatialOSRuntimeVersionForLocal() c
 {
 	if (bUseGDKPinnedRuntimeVersion || LocalRuntimeVersion.IsEmpty())
 	{
-		return SpatialGDKServicesConstants::SpatialOSRuntimePinnedVersion;
+		return SpatialGDKServicesConstants::SpatialOSDistributedRuntimePinnedVersion;
 	}
 	return LocalRuntimeVersion;
 }
@@ -74,7 +74,7 @@ const FString& USpatialGDKEditorSettings::GetSpatialOSRuntimeVersionForCloud() c
 {
 	if (bUseGDKPinnedRuntimeVersion || CloudRuntimeVersion.IsEmpty())
 	{
-		return SpatialGDKServicesConstants::SpatialOSRuntimePinnedVersion;
+		return SpatialGDKServicesConstants::SpatialOSDistributedRuntimePinnedVersion;
 	}
 	return CloudRuntimeVersion;
 }

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -906,7 +906,7 @@ bool SSpatialGDKSimulatedPlayerDeployment::IsUsingCustomRuntimeVersion() const
 FText SSpatialGDKSimulatedPlayerDeployment::GetSpatialOSRuntimeVersionToUseText() const
 {
 	const USpatialGDKEditorSettings* SpatialGDKSettings = GetDefault<USpatialGDKEditorSettings>();
-	const FString& RuntimeVersion = SpatialGDKSettings->bUseGDKPinnedRuntimeVersion ? SpatialGDKServicesConstants::SpatialOSRuntimePinnedVersion : SpatialGDKSettings->CloudRuntimeVersion;
+	const FString& RuntimeVersion = SpatialGDKSettings->bUseGDKPinnedRuntimeVersion ? SpatialGDKServicesConstants::SpatialOSDistributedRuntimePinnedVersion : SpatialGDKSettings->CloudRuntimeVersion;
 	return FText::FromString(RuntimeVersion);
 }
 

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialPackageService.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialPackageService.cpp
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "SpatialPackageService.h"
+
+#include "Async/Async.h"
+#include "HAL/FileManager.h"
+#include "SpatialGDKServicesConstants.h"
+#include "SpatialGDKServicesModule.h"
+
+DEFINE_LOG_CATEGORY(LogSpatialPackageService);
+
+namespace
+{
+	bool DownloadPackage(const FSpatialPackageDescriptor& Package)
+	{
+		UE_LOG(LogSpatialPackageService, Log, TEXT("Downloading package: '%s'"), *Package.ToString());
+
+		const FString Args = FString::Printf(TEXT("package retrieve %s %s %s %s --unzip"),
+			*Package.Type, *Package.Name, *Package.Version, *Package.GetExecutableDir());
+
+		FString Result;
+		int32 ExitCode;
+		FSpatialGDKServicesModule::ExecuteAndReadOutput(*SpatialGDKServicesConstants::SpatialExe, Args,
+            *SpatialGDKServicesConstants::GDKProgramPath, Result, ExitCode);
+
+		if (ExitCode != 0)
+		{
+			UE_LOG(LogSpatialPackageService, Error, TEXT("Could not download package '%s' from package service"), *Package.ToString());
+			return false;
+		}
+
+		UE_LOG(LogSpatialPackageService, Log, TEXT("Downloaded package: %s"), *Result);
+		return true;
+	}
+}
+
+FString FSpatialPackageDescriptor::ToString() const
+{
+	return FString::Printf(TEXT("%s %s %s"), *Type, *Name, *Version);
+}
+
+FString FSpatialPackageDescriptor::GetExecutable() const
+{
+	return FString::Printf(TEXT("%s/%s"), *GetExecutableDir(), *GetExecutableName());
+}
+
+FString FSpatialPackageDescriptor::GetExecutableDir() const
+{
+	return FString::Printf(TEXT("%s/%s/%s"), *SpatialGDKServicesConstants::GDKProgramPath, *Type, *Version);
+}
+
+FString FSpatialPackageDescriptor::GetExecutableName() const
+{
+#ifdef PLATFORM_WINDOWS
+	return FString::Printf(TEXT("%s.exe"), *Type);
+#endif
+}
+
+FSpatialPackageDescriptor FSpatialPackageService::MakeRuntimeDescriptor(const FString& Version)
+{
+#ifdef PLATFORM_WINDOWS
+	return FSpatialPackageDescriptor{"runtime", "x86_64-win32", Version};
+#endif
+}
+
+void FSpatialPackageService::GetPackage(const FSpatialPackageDescriptor& Package, TFunction<void(bool)> Callback)
+{
+	if (!IFileManager::Get().FileExists(*Package.GetExecutable()))
+	{
+		AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [Package, Callback]
+		{
+			const bool Result = DownloadPackage(Package);
+			Callback(Result);
+		});
+	}
+	else
+	{
+		Callback(true);
+	}
+}

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialPackageService.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialPackageService.cpp
@@ -39,7 +39,7 @@ FString FSpatialPackageDescriptor::ToString() const
 	return FString::Printf(TEXT("%s %s %s"), *Type, *Name, *Version);
 }
 
-FString FSpatialPackageDescriptor::GetExecutable() const
+FString FSpatialPackageDescriptor::GetExecutablePath() const
 {
 	return FString::Printf(TEXT("%s/%s"), *GetExecutableDir(), *GetExecutableName());
 }
@@ -65,7 +65,7 @@ FSpatialPackageDescriptor FSpatialPackageService::MakeRuntimeDescriptor(const FS
 
 void FSpatialPackageService::GetPackage(const FSpatialPackageDescriptor& Package, TFunction<void(bool)> Callback)
 {
-	if (!IFileManager::Get().FileExists(*Package.GetExecutable()))
+	if (!IFileManager::Get().FileExists(*Package.GetExecutablePath()))
 	{
 		AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [Package, Callback]
 		{

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialPackageService.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialPackageService.cpp
@@ -21,7 +21,7 @@ namespace
 		FString Result;
 		int32 ExitCode;
 		FSpatialGDKServicesModule::ExecuteAndReadOutput(*SpatialGDKServicesConstants::SpatialExe, Args,
-            *SpatialGDKServicesConstants::GDKProgramPath, Result, ExitCode);
+			*SpatialGDKServicesConstants::GDKProgramPath, Result, ExitCode);
 
 		if (ExitCode != 0)
 		{

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesConstants.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesConstants.h
@@ -29,6 +29,7 @@ namespace SpatialGDKServicesConstants
 	const FString SpotExe = CreateExePath(GDKProgramPath, TEXT("spot"));
 	const FString SchemaCompilerExe = CreateExePath(GDKProgramPath, TEXT("schema_compiler"));
 	const FString SpatialOSDirectory = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectDir(), TEXT("/../spatial/")));
-	const FString SpatialOSRuntimePinnedVersion("14.5.1");
+	const FString SpatialOSDistributedRuntimePinnedVersion("14.5.1");
+	const FString SpatialOSSingleNodeRuntimePinnedVersion("0.3.1");
 	const FString SpatialOSConfigFileName = TEXT("spatialos.json");
 }

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialPackageService.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialPackageService.h
@@ -18,7 +18,7 @@ struct FSpatialPackageDescriptor
 	FString ToString() const;
 
 	// ExecutableDir + ExecutableName
-	FString GetExecutable() const;
+	FString GetExecutablePath() const;
 	// Directory that contains the package executable
 	FString GetExecutableDir() const;
 	// Name of the executable

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialPackageService.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialPackageService.h
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "SpatialGDKServicesConstants.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogSpatialPackageService, Log, All);
+
+// Represents a package that can be downloaded via the package service.
+// This currently assumes that the package will extract into at least an executable with the same name as Type.
+struct FSpatialPackageDescriptor
+{
+	const FString Type;
+	const FString Name;
+	const FString Version;
+
+	FString ToString() const;
+
+	// ExecutableDir + ExecutableName
+	FString GetExecutable() const;
+	// Directory that contains the package executable
+	FString GetExecutableDir() const;
+	// Name of the executable
+	FString GetExecutableName() const;
+};
+
+class FSpatialPackageService
+{
+public:
+	// Creates a package descriptor that can be used to download a runtime with the specified version
+	SPATIALGDKSERVICES_API static FSpatialPackageDescriptor MakeRuntimeDescriptor(const FString& Version = SpatialGDKServicesConstants::SpatialOSSingleNodeRuntimePinnedVersion);
+
+	// Ensures that the specified package is downloaded and extracted from the package service.
+	// Does nothing if the package was already downloaded and extracted.
+	// Callback will be executed with a true parameter if the package (now) exists at its extracted location, otherwise with false.
+	SPATIALGDKSERVICES_API static void GetPackage(const FSpatialPackageDescriptor& Package,
+	                                              TFunction<void(bool)> Callback);
+};

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialPackageService.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialPackageService.h
@@ -34,6 +34,5 @@ public:
 	// Ensures that the specified package is downloaded and extracted from the package service.
 	// Does nothing if the package was already downloaded and extracted.
 	// Callback will be executed with a true parameter if the package (now) exists at its extracted location, otherwise with false.
-	SPATIALGDKSERVICES_API static void GetPackage(const FSpatialPackageDescriptor& Package,
-	                                              TFunction<void(bool)> Callback);
+	SPATIALGDKSERVICES_API static void GetPackage(const FSpatialPackageDescriptor& Package, TFunction<void(bool)> Callback);
 };


### PR DESCRIPTION
Turned out to be much less code than anticipated. `spatial` already caches packages in `AppData/Local/.improbable/cache/worker_package` and there is even an option to get and unzip at the same time.

After the package has been downloaded and extracted, you can use `FSpatialPackageService::MakeRuntimeDescriptor().GetExecutable()` to get the path to the executable.