### PR TITLE
UNR-3408 Automatically remove UE4Commandline.txt when the launcher session ended.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Enabled RPC ring buffers by default. We'll remove the legacy RPC mode in a future release.
 - Removed the `bPackRPCs` property and the `--OverrideRPCPacking` flag.
 - Added `OnClientOwnershipGained` and `OnClientOwnershipLost` events on Actors and Actor Components. These events trigger when an Actor is added to or removed from the ownership hierarchy of a client's PlayerController.
+- Automaticly remove UE4CommandLine.txt when session ended on Android device if UnrealEngine Version >= 4.24
 
 ## Bug fixes:
 - Queued RPCs no longer spam logs when an entity is deleted.

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDevAuthTokenGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDevAuthTokenGenerator.cpp
@@ -36,7 +36,8 @@ void FSpatialGDKDevAuthTokenGenerator::DoGenerateDevAuthTokenTasks()
 		});
 
 		FString DevAuthToken;
-		if (SpatialCommandUtils::GenerateDevAuthToken(bIsRunningInChina, DevAuthToken))
+		FString ErrorMessage;
+		if (SpatialCommandUtils::GenerateDevAuthToken(bIsRunningInChina, DevAuthToken, ErrorMessage))
 		{
 			AsyncTask(ENamedThreads::GameThread, [this, DevAuthToken]()
 			{
@@ -46,10 +47,10 @@ void FSpatialGDKDevAuthTokenGenerator::DoGenerateDevAuthTokenTasks()
 		}
 		else
 		{
-			UE_LOG(LogSpatialGDKDevAuthTokenGenerator, Error, TEXT("Failed to generate a development authentication token."));
-			AsyncTask(ENamedThreads::GameThread, [this]()
+			UE_LOG(LogSpatialGDKDevAuthTokenGenerator, Error, TEXT("Failed to generate a Development Authentication Token:%s"), *ErrorMessage);
+			AsyncTask(ENamedThreads::GameThread, [this,&ErrorMessage]()
 			{
-				this->ShowTaskEndedNotification(TEXT("Failed to generate Development Authentication Token"), SNotificationItem::CS_Fail);
+				this->ShowTaskEndedNotification(FString::Printf(TEXT("Failed to generate Development Authentication Token:%s"), *ErrorMessage), SNotificationItem::CS_Fail);
 			});
 		}
 	});

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
@@ -1,0 +1,304 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "SpatialGDKEditorCommandLineArgsManager.h"
+
+#include "Input/Reply.h"
+#include "IOSRuntimeSettings.h"
+#include "Logging/LogMacros.h"
+#include "Misc/FileHelper.h"
+#include "Misc/MessageDialog.h"
+#include "Serialization/JsonSerializer.h"
+#include "SpatialCommandUtils.h"
+#include "SpatialGDKEditorSettings.h"
+#include "SpatialGDKSettings.h"
+
+#ifdef ENABLE_LAUNCHER_DELEGATE
+//need this macro before "ILauncherServicesModule.h" to prevent compile error
+#define LAUNCHERSERVICES_API
+
+#include "Developer/LauncherServices/Public/ILauncherServicesModule.h"
+#include "Developer/LauncherServices/Public/ILauncherWorker.h"
+#include "Developer/LauncherServices/Public/ILauncher.h"
+#endif
+
+DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKEditorCommandLineArgsManager, Log, All);
+DEFINE_LOG_CATEGORY(LogSpatialGDKEditorCommandLineArgsManager);
+
+FSpatialGDKEditorCommandLineArgsManager::FSpatialGDKEditorCommandLineArgsManager()
+#ifdef ENABLE_LAUNCHER_DELEGATE
+	: bAndroidDevice(false)
+#endif
+{
+
+}
+
+void FSpatialGDKEditorCommandLineArgsManager::Startup()
+{
+#ifdef ENABLE_LAUNCHER_DELEGATE
+	ILauncherServicesModule& LauncherServicesModule = FModuleManager::LoadModuleChecked<ILauncherServicesModule>(TEXT("LauncherServices"));
+	LauncherServicesModule.OnCreateLauncherDelegate.AddRaw(this, &FSpatialGDKEditorCommandLineArgsManager::OnCreateLauncher);
+#endif
+}
+
+#ifdef ENABLE_LAUNCHER_DELEGATE
+void FSpatialGDKEditorCommandLineArgsManager::OnLauncherCanceled(double ExecutionTime)
+{
+	RemoveFromDevice();
+}
+
+void FSpatialGDKEditorCommandLineArgsManager::OnLauncherFinished(bool Outcome, double ExecutionTime, int32 ReturnCode)
+{
+	RemoveFromDevice();
+}
+
+void FSpatialGDKEditorCommandLineArgsManager::RemoveFromDevice()
+{
+	if (bAndroidDevice)
+	{
+		RemoveFromAndroidDevice();
+	}
+}
+
+void FSpatialGDKEditorCommandLineArgsManager::OnLaunch(ILauncherWorkerPtr LauncherWorkerPtr, ILauncherProfileRef LauncherProfileRef)
+{
+	LauncherWorkerPtr->OnCanceled().AddRaw(this, &FSpatialGDKEditorCommandLineArgsManager::OnLauncherCanceled);
+	LauncherWorkerPtr->OnCompleted().AddRaw(this, &FSpatialGDKEditorCommandLineArgsManager::OnLauncherFinished);
+
+	bAndroidDevice = false;
+	TArray<ILauncherTaskPtr> TaskList;
+	LauncherWorkerPtr->GetTasks(TaskList);
+	for (int32 idx = 0; idx < TaskList.Num(); ++idx)
+	{
+		if (TaskList[idx]->GetDesc().Contains(TEXT("android")))
+		{
+			bAndroidDevice = true;
+		}
+	}
+	if (bAndroidDevice)
+	{
+		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Log, TEXT("Android device launched"));
+	}
+}
+
+void FSpatialGDKEditorCommandLineArgsManager::OnCreateLauncher(ILauncherRef LauncherRef)
+{
+	LauncherRef->FLauncherWorkerStartedDelegate.AddRaw(this, &FSpatialGDKEditorCommandLineArgsManager::OnLaunch);
+}
+#endif
+
+namespace
+{
+	static FString GetAdbExePath()
+	{
+		FString AndroidHome = FPlatformMisc::GetEnvironmentVariable(TEXT("ANDROID_HOME"));
+		if (AndroidHome.IsEmpty())
+		{
+			UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("Environment variable ANDROID_HOME is not set. Please make sure to configure this."));
+			FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Environment variable ANDROID_HOME is not set. Please make sure to configure this.")));
+			return TEXT("");
+		}
+
+#if PLATFORM_WINDOWS
+		const FString AdbExe = FPaths::ConvertRelativePathToFull(FPaths::Combine(AndroidHome, TEXT("platform-tools/adb.exe")));
+#else
+		const FString AdbExe = FPaths::ConvertRelativePathToFull(FPaths::Combine(AndroidHome, TEXT("platform-tools/adb")));
+#endif
+
+		return AdbExe;
+	}
+}
+
+FReply FSpatialGDKEditorCommandLineArgsManager::PushToIOSDevice()
+{
+	const UIOSRuntimeSettings* IOSRuntimeSettings = GetDefault<UIOSRuntimeSettings>();
+	FString OutCommandLineArgsFile;
+
+	if (!TryConstructMobileCommandLineArgumentsFile(OutCommandLineArgsFile))
+	{
+		return FReply::Unhandled();
+	}
+
+	FString Executable = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/DotNET/IOS/deploymentserver.exe")));
+	FString DeploymentServerArguments = FString::Printf(TEXT("copyfile -bundle \"%s\" -file \"%s\" -file \"/Documents/ue4commandline.txt\""), *(IOSRuntimeSettings->BundleIdentifier.Replace(TEXT("[PROJECT_NAME]"), FApp::GetProjectName())), *OutCommandLineArgsFile);
+
+#if PLATFORM_MAC
+	DeploymentServerArguments = FString::Printf(TEXT("%s %s"), *Executable, *DeploymentServerArguments);
+	Executable = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/ThirdParty/Mono/Mac/bin/mono")));
+#endif
+
+	TryPushCommandLineArgsToDevice(Executable, DeploymentServerArguments, OutCommandLineArgsFile);
+	return FReply::Handled();
+}
+
+FReply FSpatialGDKEditorCommandLineArgsManager::PushToAndroidDevice()
+{
+	const FString AdbExe = GetAdbExePath();
+	if (AdbExe.IsEmpty())
+	{
+		return FReply::Unhandled();
+	}
+
+	FString OutCommandLineArgsFile;
+
+	if (!TryConstructMobileCommandLineArgumentsFile(OutCommandLineArgsFile))
+	{
+		return FReply::Unhandled();
+	}
+
+	const FString AndroidCommandLineFile = FString::Printf(TEXT("/mnt/sdcard/UE4Game/%s/UE4CommandLine.txt"), *FString(FApp::GetProjectName()));
+	const FString AdbArguments = FString::Printf(TEXT("push \"%s\" \"%s\""), *OutCommandLineArgsFile, *AndroidCommandLineFile);
+
+	TryPushCommandLineArgsToDevice(AdbExe, AdbArguments, OutCommandLineArgsFile);
+	return FReply::Handled();
+}
+
+FReply FSpatialGDKEditorCommandLineArgsManager::RemoveFromIOSDevice()
+{
+	const UIOSRuntimeSettings* IOSRuntimeSettings = GetDefault<UIOSRuntimeSettings>();
+
+	FString Executable = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/DotNET/IOS/deploymentserver.exe")));
+	FString DeploymentServerArguments = FString::Printf(TEXT("removefile -bundle \"%s\" -file \"/Documents/ue4commandline.txt\""), *(IOSRuntimeSettings->BundleIdentifier.Replace(TEXT("[PROJECT_NAME]"), FApp::GetProjectName())));
+
+#if PLATFORM_MAC
+	DeploymentServerArguments = FString::Printf(TEXT("%s %s"), *Executable, *DeploymentServerArguments);
+	Executable = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/ThirdParty/Mono/Mac/bin/mono")));
+#endif
+
+	FString ExeOutput;
+	FString StdErr;
+	int32 ExitCode;
+
+	FPlatformProcess::ExecProcess(*Executable, *DeploymentServerArguments, &ExitCode, &ExeOutput, &StdErr);
+	if (ExitCode != 0)
+	{
+		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("Failed to remove settings from the mobile client. %s %s"), *ExeOutput, *StdErr);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Failed to remove settings from the mobile client. See the Output log for more information.")));
+		return FReply::Unhandled();
+	}
+	UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Log, TEXT("Remove ue4commandline.txt from the iOS device. %s %s"), *ExeOutput, *StdErr);
+
+	return FReply::Handled();
+}
+
+FReply FSpatialGDKEditorCommandLineArgsManager::RemoveFromAndroidDevice()
+{
+	const FString AdbExe = GetAdbExePath();
+	if (AdbExe.IsEmpty())
+	{
+		return FReply::Unhandled();
+	}
+
+	FString ExeOutput;
+	FString StdErr;
+	int32 ExitCode;
+
+	FString ExeArguments = FString::Printf(TEXT("shell rm -f /mnt/sdcard/UE4Game/%s/UE4CommandLine.txt"), FApp::GetProjectName());
+
+	FPlatformProcess::ExecProcess(*AdbExe, *ExeArguments, &ExitCode, &ExeOutput, &StdErr);
+	if (ExitCode != 0)
+	{
+		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("Failed to remove settings from the mobile client. %s %s"), *ExeOutput, *StdErr);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Failed to remove settings from the mobile client. See the Output log for more information.")));
+		return FReply::Unhandled();
+	}
+	UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Log, TEXT("Remove ue4commandline.txt from the Android device. %s %s"), *ExeOutput, *StdErr);
+
+	return FReply::Handled();
+}
+
+bool FSpatialGDKEditorCommandLineArgsManager::TryConstructMobileCommandLineArgumentsFile(FString& CommandLineArgsFile)
+{
+	const USpatialGDKEditorSettings* SpatialGDKSettings = GetDefault<USpatialGDKEditorSettings>();
+	const FString ProjectName = FApp::GetProjectName();
+
+	// The project path is based on this: https://github.com/improbableio/UnrealEngine/blob/4.22-SpatialOSUnrealGDK-release/Engine/Source/Programs/AutomationTool/AutomationUtils/DeploymentContext.cs#L408
+	const FString MobileProjectPath = FString::Printf(TEXT("../../../%s/%s.uproject"), *ProjectName, *ProjectName);
+	FString TravelUrl;
+	FString SpatialOSOptions = FString::Printf(TEXT("-workerType %s"), *(SpatialGDKSettings->MobileWorkerType));
+	if (SpatialGDKSettings->bMobileConnectToLocalDeployment)
+	{
+		if (SpatialGDKSettings->MobileRuntimeIP.IsEmpty())
+		{
+			UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("The Runtime IP is currently not set. Please make sure to specify a Runtime IP."));
+			FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("The Runtime IP is currently not set. Please make sure to specify a Runtime IP."))));
+			return false;
+		}
+
+		TravelUrl = SpatialGDKSettings->MobileRuntimeIP;
+	}
+	else
+	{
+		TravelUrl = TEXT("connect.to.spatialos");
+
+		if (SpatialGDKSettings->DevelopmentAuthenticationToken.IsEmpty())
+		{
+			FReply GeneratedTokenReply = GenerateDevAuthToken();
+			if (!GeneratedTokenReply.IsEventHandled())
+			{
+				return false;
+			}
+		}
+
+		SpatialOSOptions += FString::Printf(TEXT(" +devauthToken %s"), *(SpatialGDKSettings->DevelopmentAuthenticationToken));
+		if (!SpatialGDKSettings->DevelopmentDeploymentToConnect.IsEmpty())
+		{
+			SpatialOSOptions += FString::Printf(TEXT(" +deployment %s"), *(SpatialGDKSettings->DevelopmentDeploymentToConnect));
+		}
+	}
+
+	const FString SpatialOSCommandLineArgs = FString::Printf(TEXT("%s %s %s %s"), *MobileProjectPath, *TravelUrl, *SpatialOSOptions, *(SpatialGDKSettings->MobileExtraCommandLineArgs));
+	CommandLineArgsFile = FPaths::ConvertRelativePathToFull(FPaths::Combine(*FPaths::ProjectLogDir(), TEXT("ue4commandline.txt")));
+
+	if (!FFileHelper::SaveStringToFile(SpatialOSCommandLineArgs, *CommandLineArgsFile, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM))
+	{
+		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("Failed to write command line args to file: %s"), *CommandLineArgsFile);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Failed to write command line args to file: %s"), *CommandLineArgsFile)));
+		return false;
+	}
+
+	return true;
+}
+
+FReply FSpatialGDKEditorCommandLineArgsManager::GenerateDevAuthToken()
+{
+	FString DevAuthToken;
+	FString ErrorMessage;
+	if (!SpatialCommandUtils::GenerateDevAuthToken(GetMutableDefault<USpatialGDKSettings>()->IsRunningInChina(), DevAuthToken, ErrorMessage))
+	{
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(ErrorMessage));
+		return FReply::Unhandled();
+	}
+	if (USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetMutableDefault<USpatialGDKEditorSettings>())
+	{
+		SpatialGDKEditorSettings->DevelopmentAuthenticationToken = DevAuthToken;
+		SpatialGDKEditorSettings->SaveConfig();
+		SpatialGDKEditorSettings->SetRuntimeDevelopmentAuthenticationToken();
+	}
+	return FReply::Handled();
+}
+
+bool FSpatialGDKEditorCommandLineArgsManager::TryPushCommandLineArgsToDevice(const FString& Executable, const FString& ExeArguments, const FString& CommandLineArgsFile)
+{
+	FString ExeOutput;
+	FString StdErr;
+	int32 ExitCode;
+
+	FPlatformProcess::ExecProcess(*Executable, *ExeArguments, &ExitCode, &ExeOutput, &StdErr);
+	if (ExitCode != 0)
+	{
+		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("Failed to update the mobile client. %s %s"), *ExeOutput, *StdErr);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Failed to update the mobile client. See the Output log for more information.")));
+		return false;
+	}
+
+	UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Log, TEXT("Successfully stored command line args on device: %s"), *ExeOutput);
+	IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
+	if (!PlatformFile.DeleteFile(*CommandLineArgsFile))
+	{
+		UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("Failed to delete file %s"), *CommandLineArgsFile);
+		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Failed to delete file %s"), *CommandLineArgsFile)));
+		return false;
+	}
+
+	return true;
+}

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
@@ -12,13 +12,12 @@
 #include "Misc/MessageDialog.h"
 #include "Serialization/JsonSerializer.h"
 #include "SpatialGDKSettings.h"
+#include "SpatialGDKEditorCommandLineArgsManager.h"
 #include "SpatialGDKEditorSettings.h"
 #include "SpatialGDKServicesConstants.h"
 #include "SpatialGDKServicesModule.h"
 #include "Widgets/Text/STextBlock.h"
 #include "Widgets/Input/SButton.h"
-
-DEFINE_LOG_CATEGORY(LogSpatialGDKEditorLayoutDetails);
 
 TSharedRef<IDetailCustomization> FSpatialGDKEditorLayoutDetails::MakeInstance()
 {
@@ -85,7 +84,9 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 		[
 			SNew(SButton)
 			.VAlign(VAlign_Center)
-			.OnClicked(this, &FSpatialGDKEditorLayoutDetails::GenerateDevAuthToken)
+			.OnClicked(FOnClicked::CreateLambda([] {
+				return FSpatialGDKEditorCommandLineArgsManager::GenerateDevAuthToken();
+			}))
 			.Content()
 			[
 				SNew(STextBlock).Text(FText::FromString("Generate Dev Auth Token"))
@@ -104,7 +105,9 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 			[
 				SNew(SButton)
 				.VAlign(VAlign_Center)
-				.OnClicked(this, &FSpatialGDKEditorLayoutDetails::PushCommandLineArgsToAndroidDevice)
+				.OnClicked(FOnClicked::CreateLambda([] {
+					return FSpatialGDKEditorCommandLineArgsManager::PushToAndroidDevice();
+				}))
 				.Content()
 				[
 					SNew(STextBlock).Text(FText::FromString("Push SpatialOS settings to Android device"))
@@ -115,7 +118,9 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 			[
 				SNew(SButton)
 				.VAlign(VAlign_Center)
-				.OnClicked(this, &FSpatialGDKEditorLayoutDetails::RemoveCommandLineArgsFromAndroidDevice)
+				.OnClicked(FOnClicked::CreateLambda([] {
+					return FSpatialGDKEditorCommandLineArgsManager::RemoveFromAndroidDevice();
+				}))
 				.Content()
 				[
 					SNew(STextBlock).Text(FText::FromString("Remove SpatialOS settings from Android device"))
@@ -134,7 +139,9 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 			[
 				SNew(SButton)
 				.VAlign(VAlign_Center)
-				.OnClicked(this, &FSpatialGDKEditorLayoutDetails::PushCommandLineArgsToIOSDevice)
+				.OnClicked(FOnClicked::CreateLambda([] {
+					return FSpatialGDKEditorCommandLineArgsManager::PushToIOSDevice();
+				}))
 				.Content()
 				[
 					SNew(STextBlock).Text(FText::FromString("Push SpatialOS settings to iOS device"))
@@ -145,7 +152,9 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 			[
 				SNew(SButton)
 				.VAlign(VAlign_Center)
-				.OnClicked(this, &FSpatialGDKEditorLayoutDetails::RemoveCommandLineArgsFromIOSDevice)
+				.OnClicked(FOnClicked::CreateLambda([] {
+					return FSpatialGDKEditorCommandLineArgsManager::RemoveFromIOSDevice();
+				}))
 				.Content()
 				[
 					SNew(STextBlock).Text(FText::FromString("Remove SpatialOS settings from iOS device"))
@@ -153,265 +162,3 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 			]
 		];
 }
-
-FReply FSpatialGDKEditorLayoutDetails::GenerateDevAuthToken()
-{
-	FString Arguments = TEXT("project auth dev-auth-token create --description=\"Unreal GDK Token\" --json_output");
-	if (GetDefault<USpatialGDKSettings>()->IsRunningInChina())
-	{
-		Arguments += TEXT(" --environment cn-production");
-	}
-
-	FString CreateDevAuthTokenResult;
-	int32 ExitCode;
-	FSpatialGDKServicesModule::ExecuteAndReadOutput(SpatialGDKServicesConstants::SpatialExe, Arguments, SpatialGDKServicesConstants::SpatialOSDirectory, CreateDevAuthTokenResult, ExitCode);
-
-	if (ExitCode != 0)
-	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Unable to generate a development authentication token. Result: %s"), *CreateDevAuthTokenResult);
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to generate a development authentication token. Result: %s"), *CreateDevAuthTokenResult)));
-		return FReply::Unhandled();
-	};
-
-	FString AuthResult;
-	FString DevAuthTokenResult;
-	bool bFoundNewline = CreateDevAuthTokenResult.TrimEnd().Split(TEXT("\n"), &AuthResult, &DevAuthTokenResult, ESearchCase::IgnoreCase, ESearchDir::FromEnd);
-	if (!bFoundNewline || DevAuthTokenResult.IsEmpty())
-	{
-		// This is necessary because depending on whether you are already authenticated against spatial, it will either return two json structs or one.
-		DevAuthTokenResult = CreateDevAuthTokenResult;
-	}
-
-	TSharedRef<TJsonReader<TCHAR>> JsonReader = TJsonReaderFactory<TCHAR>::Create(DevAuthTokenResult);
-	TSharedPtr<FJsonObject> JsonRootObject;
-	if (!(FJsonSerializer::Deserialize(JsonReader, JsonRootObject) && JsonRootObject.IsValid()))
-	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Unable to parse the received development authentication token. Result: %s"), *DevAuthTokenResult);
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to parse the received development authentication token. Result: %s"), *DevAuthTokenResult)));
-		return FReply::Unhandled();
-	}
-
-	// We need a pointer to a shared pointer due to how the JSON API works.
-	const TSharedPtr<FJsonObject>* JsonDataObject;
-	if (!(JsonRootObject->TryGetObjectField("json_data", JsonDataObject)))
-	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Unable to parse the received json data. Result: %s"), *DevAuthTokenResult);
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to parse the received json data. Result: %s"), *DevAuthTokenResult)));
-		return FReply::Unhandled();
-	}
-
-	FString TokenSecret;
-	if (!(*JsonDataObject)->TryGetStringField("token_secret", TokenSecret))
-	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Unable to parse the token_secret field inside the received json data. Result: %s"), *DevAuthTokenResult);
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to parse the token_secret field inside the received json data. Result: %s"), *DevAuthTokenResult)));
-		return FReply::Unhandled();
-	}
-
-	if (USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetMutableDefault<USpatialGDKEditorSettings>())
-	{
-		SpatialGDKEditorSettings->DevelopmentAuthenticationToken = TokenSecret;
-		SpatialGDKEditorSettings->SaveConfig();
-		SpatialGDKEditorSettings->SetRuntimeDevelopmentAuthenticationToken();
-	}
-
-	return FReply::Handled();
-}
-
-bool FSpatialGDKEditorLayoutDetails::TryConstructMobileCommandLineArgumentsFile(FString& CommandLineArgsFile)
-{
-	const USpatialGDKEditorSettings* SpatialGDKSettings = GetDefault<USpatialGDKEditorSettings>();
-	const FString ProjectName = FApp::GetProjectName();
-
-	// The project path is based on this: https://github.com/improbableio/UnrealEngine/blob/4.22-SpatialOSUnrealGDK-release/Engine/Source/Programs/AutomationTool/AutomationUtils/DeploymentContext.cs#L408
-	const FString MobileProjectPath = FString::Printf(TEXT("../../../%s/%s.uproject"), *ProjectName, *ProjectName);
-	FString TravelUrl;
-	FString SpatialOSOptions = FString::Printf(TEXT("-workerType %s"), *(SpatialGDKSettings->MobileWorkerType));
-	if (SpatialGDKSettings->bMobileConnectToLocalDeployment)
-	{
-		if (SpatialGDKSettings->MobileRuntimeIP.IsEmpty())
-		{
-			UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("The Runtime IP is currently not set. Please make sure to specify a Runtime IP."));
-			FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("The Runtime IP is currently not set. Please make sure to specify a Runtime IP."))));
-			return false;
-		}
-
-		TravelUrl = SpatialGDKSettings->MobileRuntimeIP;
-	}
-	else
-	{
-		TravelUrl = TEXT("connect.to.spatialos");
-
-		if (SpatialGDKSettings->DevelopmentAuthenticationToken.IsEmpty())
-		{
-			FReply GeneratedTokenReply = GenerateDevAuthToken();
-			if (!GeneratedTokenReply.IsEventHandled())
-			{
-				return false;
-			}
-		}
-
-		SpatialOSOptions += FString::Printf(TEXT(" +devauthToken %s"), *(SpatialGDKSettings->DevelopmentAuthenticationToken));
-		if (!SpatialGDKSettings->DevelopmentDeploymentToConnect.IsEmpty())
-		{
-			SpatialOSOptions += FString::Printf(TEXT(" +deployment %s"), *(SpatialGDKSettings->DevelopmentDeploymentToConnect));
-		}
-	}
-
-	const FString SpatialOSCommandLineArgs = FString::Printf(TEXT("%s %s %s %s"), *MobileProjectPath, *TravelUrl, *SpatialOSOptions, *(SpatialGDKSettings->MobileExtraCommandLineArgs));
-	CommandLineArgsFile = FPaths::ConvertRelativePathToFull(FPaths::Combine(*FPaths::ProjectLogDir(), TEXT("ue4commandline.txt")));
-
-	if (!FFileHelper::SaveStringToFile(SpatialOSCommandLineArgs, *CommandLineArgsFile, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM))
-	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Failed to write command line args to file: %s"), *CommandLineArgsFile);
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Failed to write command line args to file: %s"), *CommandLineArgsFile)));
-		return false;
-	}
-
-	return true;
-}
-
-bool FSpatialGDKEditorLayoutDetails::TryPushCommandLineArgsToDevice(const FString& Executable, const FString& ExeArguments, const FString& CommandLineArgsFile)
-{
-	FString ExeOutput;
-	FString StdErr;
-	int32 ExitCode;
-
-	FPlatformProcess::ExecProcess(*Executable, *ExeArguments, &ExitCode, &ExeOutput, &StdErr);
-	if (ExitCode != 0)
-	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Failed to update the mobile client. %s %s"), *ExeOutput, *StdErr);
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Failed to update the mobile client. See the Output log for more information.")));
-		return false;
-	}
-
-	UE_LOG(LogSpatialGDKEditorLayoutDetails, Log, TEXT("Successfully stored command line args on device: %s"), *ExeOutput);
-	IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
-	if (!PlatformFile.DeleteFile(*CommandLineArgsFile))
-	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Failed to delete file %s"), *CommandLineArgsFile);
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Failed to delete file %s"), *CommandLineArgsFile)));
-		return false;
-	}
-
-	return true;
-}
-
-namespace
-{
-	static FString GetAdbExePath()
-	{
-		FString AndroidHome = FPlatformMisc::GetEnvironmentVariable(TEXT("ANDROID_HOME"));
-		if (AndroidHome.IsEmpty())
-		{
-			UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Environment variable ANDROID_HOME is not set. Please make sure to configure this."));
-			FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Environment variable ANDROID_HOME is not set. Please make sure to configure this.")));
-			return TEXT("");
-		}
-
-#if PLATFORM_WINDOWS
-		const FString AdbExe = FPaths::ConvertRelativePathToFull(FPaths::Combine(AndroidHome, TEXT("platform-tools/adb.exe")));
-#else
-		const FString AdbExe = FPaths::ConvertRelativePathToFull(FPaths::Combine(AndroidHome, TEXT("platform-tools/adb")));
-#endif
-
-		return AdbExe;
-	}
-}
-
-FReply FSpatialGDKEditorLayoutDetails::PushCommandLineArgsToAndroidDevice()
-{
-	const FString AdbExe = GetAdbExePath();
-	if (AdbExe.IsEmpty())
-	{
-		return FReply::Unhandled();
-	}
-
-	FString OutCommandLineArgsFile;
-
-	if (!TryConstructMobileCommandLineArgumentsFile(OutCommandLineArgsFile))
-	{
-		return FReply::Unhandled();
-	}
-
-	const FString AndroidCommandLineFile = FString::Printf(TEXT("/mnt/sdcard/UE4Game/%s/UE4CommandLine.txt"), *FString(FApp::GetProjectName()));
-	const FString AdbArguments = FString::Printf(TEXT("push \"%s\" \"%s\""), *OutCommandLineArgsFile, *AndroidCommandLineFile);
-
-	TryPushCommandLineArgsToDevice(AdbExe, AdbArguments, OutCommandLineArgsFile);
-	return FReply::Handled();
-}
-
-FReply FSpatialGDKEditorLayoutDetails::PushCommandLineArgsToIOSDevice()
-{
-	const UIOSRuntimeSettings* IOSRuntimeSettings = GetDefault<UIOSRuntimeSettings>();
-	FString OutCommandLineArgsFile;
-
-	if (!TryConstructMobileCommandLineArgumentsFile(OutCommandLineArgsFile))
-	{
-		return FReply::Unhandled();
-	}
-
-	FString Executable = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/DotNET/IOS/deploymentserver.exe")));
-	FString DeploymentServerArguments = FString::Printf(TEXT("copyfile -bundle \"%s\" -file \"%s\" -file \"/Documents/ue4commandline.txt\""), *(IOSRuntimeSettings->BundleIdentifier.Replace(TEXT("[PROJECT_NAME]"), FApp::GetProjectName())), *OutCommandLineArgsFile);
-
-#if PLATFORM_MAC
-	DeploymentServerArguments = FString::Printf(TEXT("%s %s"), *Executable, *DeploymentServerArguments);
-	Executable = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/ThirdParty/Mono/Mac/bin/mono")));
-#endif
-
-	TryPushCommandLineArgsToDevice(Executable, DeploymentServerArguments, OutCommandLineArgsFile);
-	return FReply::Handled();
-}
-
-FReply FSpatialGDKEditorLayoutDetails::RemoveCommandLineArgsFromIOSDevice()
-{
-	const UIOSRuntimeSettings* IOSRuntimeSettings = GetDefault<UIOSRuntimeSettings>();
-
-	FString Executable = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/DotNET/IOS/deploymentserver.exe")));
-	FString DeploymentServerArguments = FString::Printf(TEXT("removefile -bundle \"%s\" -file \"/Documents/ue4commandline.txt\""), *(IOSRuntimeSettings->BundleIdentifier.Replace(TEXT("[PROJECT_NAME]"), FApp::GetProjectName())));
-
-#if PLATFORM_MAC
-	DeploymentServerArguments = FString::Printf(TEXT("%s %s"), *Executable, *DeploymentServerArguments);
-	Executable = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::EngineDir(), TEXT("Binaries/ThirdParty/Mono/Mac/bin/mono")));
-#endif
-
-	FString ExeOutput;
-	FString StdErr;
-	int32 ExitCode;
-
-	FPlatformProcess::ExecProcess(*Executable, *DeploymentServerArguments, &ExitCode, &ExeOutput, &StdErr);
-	if (ExitCode != 0)
-	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Failed to remove settings from the mobile client. %s %s"), *ExeOutput, *StdErr);
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Failed to remove settings from the mobile client. See the Output log for more information.")));
-		return FReply::Unhandled();
-	}
-
-	return FReply::Handled();
-}
-
-FReply FSpatialGDKEditorLayoutDetails::RemoveCommandLineArgsFromAndroidDevice()
-{
-	const FString AdbExe = GetAdbExePath();
-	if (AdbExe.IsEmpty())
-	{
-		return FReply::Unhandled();
-	}
-
-	FString ExeOutput;
-	FString StdErr;
-	int32 ExitCode;
-
-	FString ExeArguments = FString::Printf(TEXT("shell rm -f /mnt/sdcard/UE4Game/%s/UE4CommandLine.txt"), FApp::GetProjectName());
-
-	FPlatformProcess::ExecProcess(*AdbExe, *ExeArguments, &ExitCode, &ExeOutput, &StdErr);
-	if (ExitCode != 0)
-	{
-		UE_LOG(LogSpatialGDKEditorLayoutDetails, Error, TEXT("Failed to remove settings from the mobile client. %s %s"), *ExeOutput, *StdErr);
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("Failed to remove settings from the mobile client. See the Output log for more information.")));
-		return FReply::Unhandled();
-	}
-
-	return FReply::Handled();
-}
-

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -9,6 +9,7 @@
 #include "PropertyEditor/Public/PropertyEditorModule.h"
 
 #include "EditorExtension/GridLBStrategyEditorExtension.h"
+#include "SpatialGDKEditorCommandLineArgsManager.h"
 #include "SpatialGDKSettings.h"
 #include "SpatialGDKEditorSettings.h"
 #include "SpatialGDKEditorLayoutDetails.h"
@@ -21,6 +22,7 @@
 
 FSpatialGDKEditorModule::FSpatialGDKEditorModule()
 	: ExtensionManager(MakeUnique<FLBStrategyEditorExtensionManager>())
+	, CommandLineArgsManager(MakeUnique<FSpatialGDKEditorCommandLineArgsManager>())
 {
 
 }
@@ -30,6 +32,7 @@ void FSpatialGDKEditorModule::StartupModule()
 	RegisterSettings();
 
 	ExtensionManager->RegisterExtension<FGridLBStrategyEditorExtension>();
+	CommandLineArgsManager->Startup();
 }
 
 void FSpatialGDKEditorModule::ShutdownModule()

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCommandLineArgsManager.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorCommandLineArgsManager.h
@@ -1,0 +1,45 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "Templates/SharedPointer.h"
+
+class FReply;
+
+typedef TSharedRef<class ILauncher> ILauncherRef;
+typedef TSharedPtr<class ILauncherWorker> ILauncherWorkerPtr;
+typedef TSharedRef<class ILauncherProfile> ILauncherProfileRef;
+
+#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION >= 24
+#define ENABLE_LAUNCHER_DELEGATE
+#endif
+
+class FSpatialGDKEditorCommandLineArgsManager
+{
+public:
+	FSpatialGDKEditorCommandLineArgsManager();
+
+	void Startup();
+
+	static FReply GenerateDevAuthToken();
+	static FReply PushToIOSDevice();
+	static FReply PushToAndroidDevice();
+	static FReply RemoveFromIOSDevice();
+	static FReply RemoveFromAndroidDevice();
+
+private:
+#ifdef ENABLE_LAUNCHER_DELEGATE
+	void OnCreateLauncher(ILauncherRef LauncherRef);
+	void OnLaunch(ILauncherWorkerPtr LauncherWorkerPtr, ILauncherProfileRef LauncherProfileRef);
+	void OnLauncherCanceled(double ExecutionTime);
+	void OnLauncherFinished(bool Outcome, double ExecutionTime, int32 ReturnCode);
+	void RemoveFromDevice();
+#endif
+	static bool TryConstructMobileCommandLineArgumentsFile(FString& CommandLineArgsFile);
+	static bool TryPushCommandLineArgsToDevice(const FString& Executable, const FString& ExeArguments, const FString& CommandLineArgsFile);
+
+private:
+#ifdef ENABLE_LAUNCHER_DELEGATE
+	bool bAndroidDevice;
+#endif
+};

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
@@ -4,28 +4,16 @@
 
 #include "CoreMinimal.h"
 #include "IDetailCustomization.h"
-#include "Input/Reply.h"
-
-DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKEditorLayoutDetails, Log, All);
 
 class FSpatialGDKEditorLayoutDetails : public IDetailCustomization
 {
-private:
-	bool TryConstructMobileCommandLineArgumentsFile(FString& CommandLineArgsFile);
-	bool TryPushCommandLineArgsToDevice(const FString& Executable, const FString& ExeArguments, const FString& CommandLineArgsFile);
-
-	FReply GenerateDevAuthToken();
-	FReply PushCommandLineArgsToIOSDevice();
-	FReply PushCommandLineArgsToAndroidDevice();
-	FReply RemoveCommandLineArgsFromIOSDevice();
-	FReply RemoveCommandLineArgsFromAndroidDevice();
-
-
-	void ForceRefreshLayout();
-
-	IDetailLayoutBuilder* CurrentLayout = nullptr;
-
 public:
 	static TSharedRef<IDetailCustomization> MakeInstance();
 	virtual void CustomizeDetails(IDetailLayoutBuilder& DetailBuilder) override;
+
+private:
+	void ForceRefreshLayout();
+
+private:
+	IDetailLayoutBuilder* CurrentLayout = nullptr;
 };

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
@@ -1,9 +1,12 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
+#pragma once
+
 #include "Improbable/SpatialGDKSettingsBridge.h"
 #include "Modules/ModuleManager.h"
 
 class FLBStrategyEditorExtensionManager;
+class FSpatialGDKEditorCommandLineArgsManager;
 
 class FSpatialGDKEditorModule : public ISpatialGDKEditorModule
 {
@@ -39,5 +42,7 @@ private:
 	bool HandleRuntimeSettingsSaved();
 	bool HandleCloudLauncherSettingsSaved();
 
+private:
 	TUniquePtr<FLBStrategyEditorExtensionManager> ExtensionManager;
+	TUniquePtr<FSpatialGDKEditorCommandLineArgsManager> CommandLineArgsManager;
 };

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
@@ -139,7 +139,7 @@ FProcHandle SpatialCommandUtils::LocalWorkerReplace(const FString& ServicePort, 
 		nullptr, nullptr, nullptr);
 }
 
-bool SpatialCommandUtils::GenerateDevAuthToken(bool IsRunningInChina, FString& OutTokenSecret)
+bool SpatialCommandUtils::GenerateDevAuthToken(bool IsRunningInChina, FString& OutTokenSecret, FString& ErrorMessage)
 {
 	FString Arguments = TEXT("project auth dev-auth-token create --description=\"Unreal GDK Token\" --json_output");
 	if (IsRunningInChina)
@@ -153,7 +153,7 @@ bool SpatialCommandUtils::GenerateDevAuthToken(bool IsRunningInChina, FString& O
 
 	if (ExitCode != 0)
 	{
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to generate a development authentication token. Result: %s"), *CreateDevAuthTokenResult)));
+		ErrorMessage = FString::Printf(TEXT("Unable to generate a development authentication token. Result: %s"), *CreateDevAuthTokenResult);
 		return false;
 	};
 
@@ -170,7 +170,7 @@ bool SpatialCommandUtils::GenerateDevAuthToken(bool IsRunningInChina, FString& O
 	TSharedPtr<FJsonObject> JsonRootObject;
 	if (!(FJsonSerializer::Deserialize(JsonReader, JsonRootObject) && JsonRootObject.IsValid()))
 	{
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to parse the received development authentication token. Result: %s"), *DevAuthTokenResult)));
+		ErrorMessage = FString::Printf(TEXT("Unable to parse the received development authentication token. Result: %s"), *DevAuthTokenResult);
 		return false;
 	}
 
@@ -178,14 +178,14 @@ bool SpatialCommandUtils::GenerateDevAuthToken(bool IsRunningInChina, FString& O
 	const TSharedPtr<FJsonObject>* JsonDataObject;
 	if (!(JsonRootObject->TryGetObjectField("json_data", JsonDataObject)))
 	{
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to parse the received json data. Result: %s"), *DevAuthTokenResult)));
+		ErrorMessage = FString::Printf(TEXT("Unable to parse the received json data. Result: %s"), *DevAuthTokenResult);
 		return false;
 	}
 
 	FString TokenSecret;
 	if (!(*JsonDataObject)->TryGetStringField("token_secret", TokenSecret))
 	{
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("Unable to parse the token_secret field inside the received json data. Result: %s"), *DevAuthTokenResult)));
+		ErrorMessage = FString::Printf(TEXT("Unable to parse the token_secret field inside the received json data. Result: %s"), *DevAuthTokenResult);
 		return false;
 	}
 

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
@@ -16,5 +16,5 @@ public:
 	SPATIALGDKSERVICES_API static bool StopSpatialService(bool bIsRunningInChina, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode);
 	SPATIALGDKSERVICES_API static bool BuildWorkerConfig(bool bIsRunningInChina, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode);
 	SPATIALGDKSERVICES_API static FProcHandle LocalWorkerReplace(const FString& ServicePort, const FString& OldWorker, const FString& NewWorker, bool bIsRunningInChina, uint32* OutProcessID);
-	SPATIALGDKSERVICES_API static bool GenerateDevAuthToken(bool IsRunningInChina, FString& OutTokenSecret);
+	SPATIALGDKSERVICES_API static bool GenerateDevAuthToken(bool IsRunningInChina, FString& OutTokenSecret, FString& ErrorMessage);
 };


### PR DESCRIPTION
#### Description
Automatically remove UE4Commandline.txt when the launcher session ended in Android device if UnrealEngine version >= 4.24

#### Release note
Automatically remove UE4CommandLine.txt when the launch session ended in Android device if UnrealEngine version >= 4.24.
Because only after 4.24 have events to delegated so that doesn't change UnrealEngine sourcecode anymore.

#### Tests
Automatically remove the file after click 'Cancel' Button or exit App on Android device.
