### PR TITLE
UNR-3390 - On Mac do not support launch cloud deployment

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -903,6 +903,8 @@ bool FSpatialGDKEditorToolbarModule::StartCloudSpatialDeploymentIsVisible() cons
 bool FSpatialGDKEditorToolbarModule::StartCloudSpatialDeploymentCanExecute() const
 {
 #if PLATFORM_MAC
+	// Launching cloud deployments is not supported on Mac
+	// TODO: UNR-3396 - allow launching cloud deployments from mac
 	return false;
 #else
 	return CanBuildAndUpload();

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -1225,6 +1225,11 @@ FReply FSpatialGDKEditorToolbarModule::OnLaunchDeployment()
 
 	AddDeploymentTagIfMissing(SpatialConstants::DEV_LOGIN_TAG);
 
+#if PLATFORM_MAC
+	//go straight to launching the deployment
+	OnBuildSuccess();
+#else
+
 	CloudDeploymentConfiguration.InitFromSettings();
 
 	if (CloudDeploymentConfiguration.bGenerateSchema)
@@ -1240,6 +1245,7 @@ FReply FSpatialGDKEditorToolbarModule::OnLaunchDeployment()
 	TSharedRef<FSpatialGDKPackageAssembly> PackageAssembly = SpatialGDKEditorInstance->GetPackageAssemblyRef();
 	PackageAssembly->OnSuccess.BindRaw(this, &FSpatialGDKEditorToolbarModule::OnBuildSuccess);
 	PackageAssembly->BuildAndUploadAssembly(CloudDeploymentConfiguration);
+#endif
 
 	return FReply::Handled();
 }

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -902,7 +902,11 @@ bool FSpatialGDKEditorToolbarModule::StartCloudSpatialDeploymentIsVisible() cons
 
 bool FSpatialGDKEditorToolbarModule::StartCloudSpatialDeploymentCanExecute() const
 {
+#if PLATFORM_MAC
+	return false;
+#else
 	return CanBuildAndUpload();
+#endif
 }
 
 bool FSpatialGDKEditorToolbarModule::StopSpatialDeploymentIsVisible() const
@@ -1225,11 +1229,6 @@ FReply FSpatialGDKEditorToolbarModule::OnLaunchDeployment()
 
 	AddDeploymentTagIfMissing(SpatialConstants::DEV_LOGIN_TAG);
 
-#if PLATFORM_MAC
-	//go straight to launching the deployment
-	OnBuildSuccess();
-#else
-
 	CloudDeploymentConfiguration.InitFromSettings();
 
 	if (CloudDeploymentConfiguration.bGenerateSchema)
@@ -1245,7 +1244,6 @@ FReply FSpatialGDKEditorToolbarModule::OnLaunchDeployment()
 	TSharedRef<FSpatialGDKPackageAssembly> PackageAssembly = SpatialGDKEditorInstance->GetPackageAssemblyRef();
 	PackageAssembly->OnSuccess.BindRaw(this, &FSpatialGDKEditorToolbarModule::OnBuildSuccess);
 	PackageAssembly->BuildAndUploadAssembly(CloudDeploymentConfiguration);
-#endif
 
 	return FReply::Handled();
 }

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -93,32 +93,6 @@ void SSpatialGDKSimulatedPlayerDeployment::Construct(const FArguments& InArgs)
 						.Padding(1.0f)
 						[
 							SNew(SVerticalBox)
-#if PLATFORM_MAC
-							// Build explanation set
-							+ SVerticalBox::Slot()
-							.AutoHeight()
-							.Padding(2.0f)
-							.VAlign(VAlign_Center)
-							[
-								SNew(SWrapBox)
-								.UseAllottedWidth(true)
-							+ SWrapBox::Slot()
-							.VAlign(VAlign_Bottom)
-							[
-								SNew(STextBlock)
-								.AutoWrapText(true)
-							.Text(FText::FromString(FString(TEXT("NOTE: You can launch a deployment however the assembly must be prebuilt and uploaded from a compatibile system."))))
-							]
-							]
-						// Separator
-						+ SVerticalBox::Slot()
-							.AutoHeight()
-							.Padding(2.0f)
-							.VAlign(VAlign_Center)
-							[
-								SNew(SSeparator)
-							]
-#endif
 							// Project
 							+ SVerticalBox::Slot()
 							.AutoHeight()
@@ -543,7 +517,6 @@ void SSpatialGDKSimulatedPlayerDeployment::Construct(const FArguments& InArgs)
 							[
 								SNew(SSeparator)
 							]
-#if PLATFORM_WINDOWS
 							// Explanation text
 							+ SVerticalBox::Slot()
 							.AutoHeight()
@@ -672,7 +645,6 @@ void SSpatialGDKSimulatedPlayerDeployment::Construct(const FArguments& InArgs)
 							[
 								SNew(SSeparator)
 							]
-#endif
 							// Buttons
 							+ SVerticalBox::Slot()
 							.FillHeight(1.0f)

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -93,6 +93,32 @@ void SSpatialGDKSimulatedPlayerDeployment::Construct(const FArguments& InArgs)
 						.Padding(1.0f)
 						[
 							SNew(SVerticalBox)
+#if PLATFORM_MAC
+							// Build explanation set
+							+ SVerticalBox::Slot()
+							.AutoHeight()
+							.Padding(2.0f)
+							.VAlign(VAlign_Center)
+							[
+								SNew(SWrapBox)
+								.UseAllottedWidth(true)
+							+ SWrapBox::Slot()
+							.VAlign(VAlign_Bottom)
+							[
+								SNew(STextBlock)
+								.AutoWrapText(true)
+							.Text(FText::FromString(FString(TEXT("NOTE: You can launch a deployment however the assembly must be prebuilt and uploaded from a compatibile system."))))
+							]
+							]
+						// Separator
+						+ SVerticalBox::Slot()
+							.AutoHeight()
+							.Padding(2.0f)
+							.VAlign(VAlign_Center)
+							[
+								SNew(SSeparator)
+							]
+#endif
 							// Project
 							+ SVerticalBox::Slot()
 							.AutoHeight()
@@ -517,6 +543,7 @@ void SSpatialGDKSimulatedPlayerDeployment::Construct(const FArguments& InArgs)
 							[
 								SNew(SSeparator)
 							]
+#if PLATFORM_WINDOWS
 							// Explanation text
 							+ SVerticalBox::Slot()
 							.AutoHeight()
@@ -645,6 +672,7 @@ void SSpatialGDKSimulatedPlayerDeployment::Construct(const FArguments& InArgs)
 							[
 								SNew(SSeparator)
 							]
+#endif
 							// Buttons
 							+ SVerticalBox::Slot()
 							.FillHeight(1.0f)


### PR DESCRIPTION
With the new workflow changes we've added a button to launch a cloud deployment when the "Cloud Deployment" workflow is supported. Unfortunately on Mac launching a cloud deployment isn't supported. For now, grey the button, in the future we can support this, tracked in UNR-3496.