### PR TITLE
UNR-3481 Failed schema generation aborts quick deploy

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -48,6 +48,7 @@ public:
 		RETURN_QUICK_DECLARE_CYCLE_STAT(FSpatialGDKEditorToolbarModule, STATGROUP_Tickables);
 	}
 
+	void OnShowSingleFailureNotification(const FString& NotificationText);
 	void OnShowSuccessNotification(const FString& NotificationText);
 	void OnShowFailedNotification(const FString& NotificationText);
 	void OnShowTaskStartNotification(const FString& NotificationText);
@@ -136,6 +137,7 @@ private:
 	TSharedRef<SWidget> CreateLaunchDeploymentMenuContent();
 	TSharedRef<SWidget> CreateStartDropDownMenuContent();
 
+	void ShowSingleFailureNotification(const FString& NotificationText);
 	void ShowTaskStartNotification(const FString& NotificationText);
 
 	void ShowSuccessNotification(const FString& NotificationText);


### PR DESCRIPTION
If generate schema or snapshot fails display a toast and quit cloud deployment process.

Tested by making the scheme database readonly.