### PR TITLE
[UNR-3503] Check that AutomationTool is up to date when running Schema generation from the editor

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
@@ -60,7 +60,7 @@ bool CheckAutomationToolsUpToDate()
 #if PLATFORM_WINDOWS
 	FString FullCommandLine = FString::Printf(TEXT("/c \"\"%s\" -list\""), *UatPath);
 #else
-	FString FullCommandLine = FString::Printf(TEXT("\"%s\" %s"), *UatPath, *CommandLine);
+	FString FullCommandLine = FString::Printf(TEXT("\"%s\" -list"), *UatPath);
 #endif
 
 	FString ListCommandResult;


### PR DESCRIPTION
#### Description
There is no dependency between the engine project and the automation tool. So when checking out the new engine version that is supposed to add the automation tool command we use to run schema generation, the user still has the old version. Then, when launching the schema generation from the editor, the command is not found and the generation fails.

With this modification, we check that the AutomationTool has the command we want to run, and asks the user to rebuild them if the command is not found.
It seems to be the cheapest and quickest fix since adding the dependency bewteen the projects would require modifying the Unreal Build Tool, regenerating projects (which users will likely not do), and recompile the engine (since the build tool has been updated).