### PR TITLE
UNR-3512 Parse new runtime logs

### DIFF
--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -486,7 +486,7 @@ bool FLocalDeploymentManager::TryStopLocalDeployment()
 	{
 		if (DeploymentStatus == TEXT("STOPPED"))
 		{
-			UE_LOG(LogSpatialDeploymentManager, Log, TEXT("Successfully stopped local deplyoment"));
+			UE_LOG(LogSpatialDeploymentManager, Log, TEXT("Successfully stopped local deployment"));
 			LocalRunningDeploymentID.Empty();
 			bLocalDeploymentRunning = false;
 			bSuccess = true;

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SSpatialOutputLog.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SSpatialOutputLog.cpp
@@ -22,7 +22,8 @@ namespace
 	const FString LaunchLogFilename(TEXT("launch.log"));
 	const FString RuntimeLogFilename(TEXT("runtime.log"));
 	const float PollTimeInterval(0.05f);
-	const float DirChangeRetryInterval(1.5f);
+	const float DirChangeRetryInterval(1.0f);
+	const uint32 LogOpenRetries(10);
 }
 
 void FArchiveLogFileReader::UpdateFileSize()
@@ -46,7 +47,7 @@ void FSpatialLogFileReader::ResetLogDirectory(const FString& LogDirectory)
 	CloseLogReader();
 	AsyncTask(ENamedThreads::GameThread, [this, LogDirectory]
 	{
-		InternalResetDirectory(LogDirectory, 5 /* TriesRemaining */);
+		InternalResetDirectory(LogDirectory, LogOpenRetries);
 	});
 }
 

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SSpatialOutputLog.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SSpatialOutputLog.h
@@ -33,6 +33,7 @@ public:
 private:
 	TUniquePtr<FArchiveLogFileReader> CreateLogFileReader(const TCHAR* InFilename, uint32 Flags, uint32 BufferSize) const;
 	void CloseLogReader();
+	void InternalResetDirectory(const FString& LogDirectory, uint32 TriesRemaining);
 
 	void PollLogFile(const FString& LogFilePath);
 	void StartPollTimer(const FString& LogFilePath);
@@ -64,10 +65,14 @@ private:
 	void OnLogDirectoryChanged(const TArray<FFileChangeData>& FileChanges);
 
 	void OnClearLog() override;
+	void AppendOutput(const FString& LogMessage, ELogVerbosity::Type Verbosity, const FString& Category);
 
 	void ParseLaunchLogContent(const FString& Content);
-	void FormatAndPrintRawLaunchLogLine(const FString& LogLine);
 	void FormatAndPrintRawLaunchLogErrorLine(const FString& LogLine);
+	void FormatAndPrintRawLaunchLogLine(const FString& LogLine);
+
+	void ParseSingleNodeRuntimeLogContent(const FString& Content);
+	void FormatAndPrintSingleNodeRuntimeLogLine(const FString& LogLine);
 
 	FDelegateHandle LogDirectoryChangedDelegateHandle;
 	IDirectoryWatcher::FDirectoryChanged LogDirectoryChangedDelegate;

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SSpatialOutputLog.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SSpatialOutputLog.h
@@ -59,16 +59,15 @@ public:
 private:
 	void ResetReadersWithLatestLogDir();
 
-	void ParseLaunchLogContent(const FString& Content);
-
-	void FormatAndPrintRawLogLine(const FString& LogLine);
-	void FormatAndPrintRawErrorLine(const FString& LogLine);
-
 	void StartUpLogDirectoryWatcher(const FString& LogDirectory);
 	void ShutdownLogDirectoryWatcher(const FString& LogDirectory) const;
 	void OnLogDirectoryChanged(const TArray<FFileChangeData>& FileChanges);
 
 	void OnClearLog() override;
+
+	void ParseLaunchLogContent(const FString& Content);
+	void FormatAndPrintRawLaunchLogLine(const FString& LogLine);
+	void FormatAndPrintRawLaunchLogErrorLine(const FString& LogLine);
 
 	FDelegateHandle LogDirectoryChangedDelegateHandle;
 	IDirectoryWatcher::FDirectoryChanged LogDirectoryChangedDelegate;


### PR DESCRIPTION
#### Description
This adds support to `SSpatialOutput` for reading more than one spatial log file at the same time. We now also read `runtime.log` and append all messages to the output. This will only match the format of the new runtime, so we still get the same output with the old runtime.

I moved code around a lot so this probably looks bigger than it is.
