### PR TITLE
Add NetOwningClient worker to enforcer worker query

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -238,7 +238,7 @@ void InterestFactory::AddServerSelfInterest(Interest& OutInterest, const Worker_
 	// Add a query for the load balancing worker (whoever is delegated the ACL) to read the authority intent
 	Query LoadBalanceQuery;
 	LoadBalanceQuery.Constraint.EntityIdConstraint = EntityId;
-	LoadBalanceQuery.ResultComponentIds = SchemaResultType{ SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID };
+	LoadBalanceQuery.ResultComponentIds = SchemaResultType{ SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID, SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID, SpatialConstants::NET_OWNING_CLIENT_WORKER_COMPONENT_ID };
 	AddComponentQueryPairToInterestComponent(OutInterest, SpatialConstants::ENTITY_ACL_COMPONENT_ID, LoadBalanceQuery);
 }
 


### PR DESCRIPTION
In SpatialLoadBalanceEnforcer, the worker authoritative over the ACL component (the acl-auth worker) will not process an ACL assignment request if the NetOwningClientWorker component is not present. This ACL assignment process is needed so that the worker authoritative over the rest of the entity (the sim-auth worker) becomes authoritative over the Unreal metadata component (and some other components).
However, the acl-auth worker doesn't necessarily check out the NetOwningClientWorker. It checks it out either when:

1. acl-auth worker == sim-auth worker, because the sim-auth worker already has authority over the NetOwningClientWorker
2. It's run on Kraken, since Kraken has a full initial checkout if you become authoritative over part of the entity.

So if it's run on Squid with multiple workers, it breaks whenever acl-auth != sim-auth. Due to how the worker that performs the role of acl-auth is determined (via runtime load balancing strategy), this becomes increasingly more likely as you increase the number of workers.