### PR TITLE
Prevent new actor channels for dying actors

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1427,7 +1427,11 @@ void USpatialNetDriver::ProcessRPC(AActor* Actor, UObject* SubObject, UFunction*
 	if (IsServer())
 	{
 		// Creating channel to ensure that object will be resolvable
-		GetOrCreateSpatialActorChannel(CallingObject);
+		if (GetOrCreateSpatialActorChannel(CallingObject) == nullptr)
+		{
+			// No point processing any further since there is no channel, possibly because the actor is being destroyed.
+			return;
+		}
 	}
 
 	// If this object's class isn't present in the schema database, we will log an error and tell the

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -2191,6 +2191,13 @@ USpatialActorChannel* USpatialNetDriver::GetOrCreateSpatialActorChannel(UObject*
 			UE_LOG(LogSpatialOSNetDriver, Warning, TEXT("GetOrCreateSpatialActorChannel: No channel for target object but channel already present for actor. Target object: %s, actor: %s"), *TargetObject->GetPathName(), *TargetActor->GetPathName());
 			return ActorChannel;
 		}
+
+		if (TargetActor->IsPendingKillPending())
+		{
+			UE_LOG(LogSpatialOSNetDriver, Log, TEXT("A SpatialActorChannel will not be created for %s because the Actor is being destroyed."), *GetNameSafe(TargetActor));
+			return nullptr;
+		}
+
 		Channel = CreateSpatialActorChannel(TargetActor);
 	}
 #if !UE_BUILD_SHIPPING

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -418,6 +418,10 @@ USpatialActorChannel* USpatialReceiver::GetOrRecreateChannelForDomantActor(AActo
 {
 	// Receive would normally create channel in ReceiveActor - this function is used to recreate the channel after waking up a dormant actor
 	USpatialActorChannel* Channel = NetDriver->GetOrCreateSpatialActorChannel(Actor);
+	if (Channel == nullptr)
+	{
+		return nullptr;
+	}
 	check(!Channel->bCreatingNewEntity);
 	check(Channel->GetEntityId() == EntityID);
 


### PR DESCRIPTION
Fixes an `ensure` when using an actor marked `PendingKillPending` is used to send an RPC, which would (without this change) cause a new channel to be created in this callchain:

```
Server!FDebug::OptionallyLogFormattedEnsureMessageReturningFalseImpl(bool, char const*, char const*, int, char16_t const*, ...)(493) 
Server!FNetworkObjectList::FindOrAdd(AActor*, UNetDriver*, bool*)::$_39::operator()() const(64) 
Server!FNetworkObjectList::FindOrAdd(AActor*, UNetDriver*, bool*)(64) 
Server!FNetworkObjectList::MarkActive(AActor*, UNetConnection*, UNetDriver*)(216) 
Server!UActorChannel::SetChannelActor(AActor*, ESetChannelActorFlags)(2171) 
Server!USpatialActorChannel::SetChannelActor(AActor*, ESetChannelActorFlags)(1058) 
Server!USpatialNetDriver::CreateSpatialActorChannel(AActor*)(2335) 
Server!USpatialNetDriver::GetOrCreateSpatialActorChannel(UObject*)(2213) 
Server!USpatialNetDriver::ProcessRPC(AActor*, UObject*, UFunction*, void*)(1453) 
```