### PR TITLE
Re-enable linux build for the EngineNetTest repo

### DIFF
--- a/ci/generate-and-upload-build-steps.sh
+++ b/ci/generate-and-upload-build-steps.sh
@@ -52,9 +52,7 @@ generate_build_configuration_steps () {
             upload_build_configuration_step "${ENGINE_COMMIT_HASH}" "Win64" "Editor" "Development"
 
             # Linux Development NoEditor build configuration
-            if [[ "${ENGINE_NET_TEST:-false}" != "true" ]]; then
-                upload_build_configuration_step "${ENGINE_COMMIT_HASH}" "Linux" "" "Development"
-            fi
+            upload_build_configuration_step "${ENGINE_COMMIT_HASH}" "Linux" "" "Development"
         else
             echo "Building for all supported configurations. Generating the appropriate steps..."
 


### PR DESCRIPTION
#### Description
Linux was broken, let's just do linux builds as a premerge gate.

#### Release note
N/A

#### Tests
With CI.

#### Documentation
N/A

#### Primary reviewers
