### PR TITLE
[UNR-3532] Better platform selection for cook and generate schema

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -449,15 +449,6 @@ FString USpatialGDKEditorSettings::GetCookAndGenerateSchemaTargetPlatform() cons
 		return CookAndGeneratePlatform;
 	}
 
-	const FString PreferredPlatformForCookAndGenerateSchema(TEXT("Linux"));
-
-	ITargetPlatformManagerModule* TPM = GetTargetPlatformManager();
-
-	if (TPM->FindTargetPlatform(PreferredPlatformForCookAndGenerateSchema) != nullptr)
-	{
-		return PreferredPlatformForCookAndGenerateSchema;
-	}
-
 	// Return current Editor's Build variant as default.
 	return FPlatformProcess::GetBinariesSubdirectory();
 }

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -2,6 +2,7 @@
 
 #include "SpatialGDKEditorSettings.h"
 
+#include "Interfaces/ITargetPlatformManagerModule.h"
 #include "Internationalization/Regex.h"
 #include "ISettingsModule.h"
 #include "Misc/FileHelper.h"
@@ -48,7 +49,7 @@ USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& O
 	, ExposedRuntimeIP(TEXT(""))
 	, bStopSpatialOnExit(false)
 	, bAutoStartLocalDeployment(true)
-	, CookAndGeneratePlatform("Win64")
+	, CookAndGeneratePlatform("")
 	, CookAndGenerateAdditionalArguments("-cookall -unversioned")
 	, PrimaryDeploymentRegionCode(ERegionCode::US)
 	, SimulatedPlayerLaunchConfigPath(FSpatialGDKServicesModule::GetSpatialGDKPluginDirectory(TEXT("SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/SpatialConfig/cloud_launch_sim_player_deployment.json")))
@@ -439,4 +440,24 @@ void USpatialGDKEditorSettings::SetSpatialOSNetFlowType(ESpatialOSNetFlow::Type 
 {
 	SpatialOSNetFlowType = NetFlowType;
 	SaveConfig();
+}
+
+FString USpatialGDKEditorSettings::GetCookAndGenerateSchemaTargetPlatform() const
+{
+	if (!CookAndGeneratePlatform.IsEmpty())
+	{
+		return CookAndGeneratePlatform;
+	}
+
+	const FString PreferredPlatformForCookAndGenerateSchema(TEXT("Linux"));
+
+	ITargetPlatformManagerModule* TPM = GetTargetPlatformManager();
+
+	if (TPM->FindTargetPlatform(PreferredPlatformForCookAndGenerateSchema) != nullptr)
+	{
+		return PreferredPlatformForCookAndGenerateSchema;
+	}
+
+	// Return current Editor's Build variant as default.
+	return FPlatformProcess::GetBinariesSubdirectory();
 }

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -297,7 +297,7 @@ private:
 	UPROPERTY(EditAnywhere, config, Category = "Snapshots", meta = (DisplayName = "Snapshot to load"))
 	FString SpatialOSSnapshotToLoad;
 
-	UPROPERTY(EditAnywhere, config, Category = "Schema Generation", meta = (Tooltip = "Platform to target when using Cook And Generate Schema (if empty, defaults to Linux if available, Editor's platform if not)"))
+	UPROPERTY(EditAnywhere, config, Category = "Schema Generation", meta = (Tooltip = "Platform to target when using Cook And Generate Schema (if empty, defaults to Editor's platform)"))
 	FString CookAndGeneratePlatform;
 
 	UPROPERTY(EditAnywhere, config, Category = "Schema Generation", meta = (Tooltip = "Additional arguments passed to Cook And Generate Schema"))

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -297,7 +297,7 @@ private:
 	UPROPERTY(EditAnywhere, config, Category = "Snapshots", meta = (DisplayName = "Snapshot to load"))
 	FString SpatialOSSnapshotToLoad;
 
-	UPROPERTY(EditAnywhere, config, Category = "Schema Generation", meta = (Tooltip = "Platform to target when using Cook And Generate Schema"))
+	UPROPERTY(EditAnywhere, config, Category = "Schema Generation", meta = (Tooltip = "Platform to target when using Cook And Generate Schema (if empty, defaults to Linux if available, Editor's platform if not)"))
 	FString CookAndGeneratePlatform;
 
 	UPROPERTY(EditAnywhere, config, Category = "Schema Generation", meta = (Tooltip = "Additional arguments passed to Cook And Generate Schema"))

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -448,10 +448,7 @@ public:
 			: SpatialOSSnapshotToLoad;
 	}
 
-	FORCEINLINE FString GetCookAndGenerateSchemaTargetPlatform() const
-	{
-		return CookAndGeneratePlatform;
-	}
+	FString GetCookAndGenerateSchemaTargetPlatform() const;
 
 	FORCEINLINE FString GetCookAndGenerateSchemaAdditionalArgs() const
 	{


### PR DESCRIPTION
#### Description
Win64 was the default platform for CookAndGenerateSchema, but that did not work for other Editor platforms.
This setting was added to be able to specify Linux as a build platforms for schema generation, while providing a sensible defaults for the ones who did not build with Linux support.
The change makes automatic platform selection when no setting is set, trying to use Linux if it is available, and falling back to the Editor's platform otherwise.

#### Release note

#### Tests

#### Documentation

#### Primary reviewers
