### PR TITLE
UNR-3485 Friendly dev auth error message

### DIFF
--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
@@ -152,7 +152,14 @@ bool SpatialCommandUtils::GenerateDevAuthToken(bool bIsRunningInChina, FString& 
 
 	if (ExitCode != 0)
 	{
-		OutErrorMessage = FString::Printf(TEXT("Unable to generate a development authentication token. Result: %s"), *CreateDevAuthTokenResult);
+		FString ErrorMessage = CreateDevAuthTokenResult;
+		TSharedRef<TJsonReader<TCHAR>> JsonReader = TJsonReaderFactory<TCHAR>::Create(CreateDevAuthTokenResult);
+		TSharedPtr<FJsonObject> JsonRootObject;
+		if (FJsonSerializer::Deserialize(JsonReader, JsonRootObject) && JsonRootObject.IsValid())
+		{
+			JsonRootObject->TryGetStringField("error", ErrorMessage);
+		}
+		OutErrorMessage = FString::Printf(TEXT("Unable to generate a development authentication token. Result: %s"), *ErrorMessage);
 		return false;
 	};
 


### PR DESCRIPTION
Parse the "error" text field out of the returned json when spatial CLI reports a failure generating a dev auth token. This message is more user friendly than the entire json text.

Tested this by changing my project name to something invalid and generating dev auth tokens from both the settings button and by select Use Cloud Deployment from the workflow dropdown menu.

![devautherror 2020-05-26 103918](https://user-images.githubusercontent.com/49975160/82858963-f62f2280-9f47-11ea-98e8-70a456269033.jpg)
![devautherror 2020-05-26 103919](https://user-images.githubusercontent.com/49975160/82858965-f7604f80-9f47-11ea-8414-133e0b5780fc.jpg)
