### PR TITLE
UNR-3217 - Use new runtime locally

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
@@ -79,20 +79,19 @@ struct ConfigureConnection
 		Params.network.modular_kcp.upstream_heartbeat = &HeartbeatParams;
 #endif
 
-		if (!bConnectAsClient && GetDefault<USpatialGDKSettings>()->bUseSecureServerConnection)
+		// Use insecure connections default.
+		Params.network.modular_kcp.security_type = WORKER_NETWORK_SECURITY_TYPE_INSECURE;
+		Params.network.modular_tcp.security_type = WORKER_NETWORK_SECURITY_TYPE_INSECURE;
+
+		// Override the security type to be secure only if the user has requested it and we are not using an editor build.
+		if ((!bConnectAsClient && GetDefault<USpatialGDKSettings>()->bUseSecureServerConnection) || (bConnectAsClient && GetDefault<USpatialGDKSettings>()->bUseSecureClientConnection))
 		{
+#if WITH_EDITOR
+			UE_LOG(LogSpatialWorkerConnection, Warning, TEXT("Secure connection requested but this is not supported in Editor builds. Connection will be insecure."));
+#else
 			Params.network.modular_kcp.security_type = WORKER_NETWORK_SECURITY_TYPE_TLS;
 			Params.network.modular_tcp.security_type = WORKER_NETWORK_SECURITY_TYPE_TLS;
-		}
-		else if (bConnectAsClient && GetDefault<USpatialGDKSettings>()->bUseSecureClientConnection)
-		{
-			Params.network.modular_kcp.security_type = WORKER_NETWORK_SECURITY_TYPE_TLS;
-			Params.network.modular_tcp.security_type = WORKER_NETWORK_SECURITY_TYPE_TLS;
-		}
-		else
-		{
-			Params.network.modular_kcp.security_type = WORKER_NETWORK_SECURITY_TYPE_INSECURE;
-			Params.network.modular_tcp.security_type = WORKER_NETWORK_SECURITY_TYPE_INSECURE;
+#endif
 		}
 
 		Params.enable_dynamic_components = true;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -329,11 +329,11 @@ public:
 	UPROPERTY(EditAnywhere, Config, Category = "Interest", meta = (EditCondition = "bEnableNetCullDistanceFrequency"))
 	TArray<FDistanceFrequencyPair> InterestRangeFrequencyPairs;
 
-	/** Use TLS encryption for UnrealClient workers connection. May impact performance. */
+	/** Use TLS encryption for UnrealClient workers connection. May impact performance. Only works in non-editor builds. */
 	UPROPERTY(EditAnywhere, Config, Category = "Connection")
 	bool bUseSecureClientConnection;
 
-	/** Use TLS encryption for UnrealWorker (server) workers connection. May impact performance. */
+	/** Use TLS encryption for UnrealWorker (server) workers connection. May impact performance. Only works in non-editor builds. */
 	UPROPERTY(EditAnywhere, Config, Category = "Connection")
 	bool bUseSecureServerConnection;
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/CloudDeploymentConfiguration.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/CloudDeploymentConfiguration.cpp
@@ -9,7 +9,7 @@ void FCloudDeploymentConfiguration::InitFromSettings()
 	const USpatialGDKEditorSettings* Settings = GetDefault<USpatialGDKEditorSettings>();
 
 	AssemblyName = Settings->GetAssemblyName();
-	RuntimeVersion = Settings->GetSpatialOSRuntimeVersionForCloud();
+	RuntimeVersion = Settings->GetSelectedRuntimeVariantVersion().GetVersionForCloud();
 	PrimaryDeploymentName = Settings->GetPrimaryDeploymentName();
 	PrimaryLaunchConfigPath = Settings->GetPrimaryLaunchConfigPath();
 	SnapshotPath = Settings->GetSnapshotPath();

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
@@ -49,36 +49,6 @@ void FSpatialGDKEditorLayoutDetails::CustomizeDetails(IDetailLayoutBuilder& Deta
 	const USpatialGDKSettings* GDKSettings = GetDefault<USpatialGDKSettings>();
 	GDKSettings->OnWorkerTypesChangedDelegate.AddSP(this, &FSpatialGDKEditorLayoutDetails::ForceRefreshLayout);
 
-	TSharedPtr<IPropertyHandle> UsePinnedVersionProperty = DetailBuilder.GetProperty(GET_MEMBER_NAME_CHECKED(USpatialGDKEditorSettings, bUseGDKPinnedRuntimeVersion));
-
-	IDetailPropertyRow* CustomRow = DetailBuilder.EditDefaultProperty(UsePinnedVersionProperty);
-
-	FString PinnedVersionDisplay = FString::Printf(TEXT("GDK Pinned Version : %s"), *SpatialGDKServicesConstants::SpatialOSRuntimePinnedVersion);
-
-	CustomRow->CustomWidget()
-		.NameContent()
-		[
-			UsePinnedVersionProperty->CreatePropertyNameWidget()
-		]
-		.ValueContent()
-		[
-			SNew(SHorizontalBox)
-			+SHorizontalBox::Slot()
-			.HAlign(HAlign_Left)
-			.AutoWidth()
-			[
-				UsePinnedVersionProperty->CreatePropertyValueWidget()
-			]
-			+SHorizontalBox::Slot()
-			.Padding(5)
-			.HAlign(HAlign_Center)
-			.AutoWidth()
-			[
-				SNew(STextBlock)
-				.Text(FText::FromString(PinnedVersionDisplay))
-			]
-		];
-
 	IDetailCategoryBuilder& CloudConnectionCategory = DetailBuilder.EditCategory("Cloud Connection");
 	CloudConnectionCategory.AddCustomRow(FText::FromString("Generate Development Authentication Token"))
 		.ValueContent()

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -13,6 +13,7 @@
 #include "SpatialGDKEditorSettings.h"
 #include "SpatialGDKEditorLayoutDetails.h"
 #include "SpatialLaunchConfigCustomization.h"
+#include "SpatialRuntimeVersionCustomization.h"
 #include "Utils/LaunchConfigEditor.h"
 #include "Utils/LaunchConfigEditorLayoutDetails.h"
 #include "WorkerTypeCustomization.h"
@@ -105,6 +106,7 @@ void FSpatialGDKEditorModule::RegisterSettings()
 	FPropertyEditorModule& PropertyModule = FModuleManager::LoadModuleChecked<FPropertyEditorModule>("PropertyEditor");
 	PropertyModule.RegisterCustomPropertyTypeLayout("WorkerType", FOnGetPropertyTypeCustomizationInstance::CreateStatic(&FWorkerTypeCustomization::MakeInstance));
 	PropertyModule.RegisterCustomPropertyTypeLayout("SpatialLaunchConfigDescription", FOnGetPropertyTypeCustomizationInstance::CreateStatic(&FSpatialLaunchConfigCustomization::MakeInstance));
+	PropertyModule.RegisterCustomPropertyTypeLayout("RuntimeVariantVersion", FOnGetPropertyTypeCustomizationInstance::CreateStatic(&FSpatialRuntimeVersionCustomization::MakeInstance));
 	PropertyModule.RegisterCustomClassLayout(USpatialGDKEditorSettings::StaticClass()->GetFName(), FOnGetDetailCustomizationInstance::CreateStatic(&FSpatialGDKEditorLayoutDetails::MakeInstance));
 	PropertyModule.RegisterCustomClassLayout(ULaunchConfigurationEditor::StaticClass()->GetFName(), FOnGetDetailCustomizationInstance::CreateStatic(&FLaunchConfigEditorLayoutDetails::MakeInstance));
 }

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -88,10 +88,10 @@ FRuntimeVariantVersion& USpatialGDKEditorSettings::GetRuntimeVariantVersion(ESpa
 {
 	if (Variant == ESpatialOSRuntimeVariant::CompatabilityMode)
 	{
-		return StandardRuntimeVersion;
+		return CompatabilityModeRuntimeVersion;
 	}
 	check(Variant == ESpatialOSRuntimeVariant::Standard);
-	return CompatabilityModeRuntimeVersion;
+	return StandardRuntimeVersion;
 }
 
 void USpatialGDKEditorSettings::PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent)

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -86,6 +86,10 @@ USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& O
 
 FRuntimeVariantVersion& USpatialGDKEditorSettings::GetRuntimeVariantVersion(ESpatialOSRuntimeVariant::Type Variant)
 {
+#if PLATFORM_MAC
+	return CompatabilityModeRuntimeVersion;
+#endif
+
 	if (Variant == ESpatialOSRuntimeVariant::CompatabilityMode)
 	{
 		return CompatabilityModeRuntimeVersion;

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -39,12 +39,34 @@ void FSpatialLaunchConfigDescription::OnWorkerTypesChanged()
 	}
 }
 
+FRuntimeVariantVersion::FRuntimeVariantVersion() = default;
+
+const FString& FRuntimeVariantVersion::GetVersionForLocal() const
+{
+	if (bUseGDKPinnedRuntimeVersion || LocalRuntimeVersion.IsEmpty())
+	{
+		return PinnedVersion;
+	}
+	return LocalRuntimeVersion;
+}
+
+const FString& FRuntimeVariantVersion::GetVersionForCloud() const
+{
+	if (bUseGDKPinnedRuntimeVersion || CloudRuntimeVersion.IsEmpty())
+	{
+		return PinnedVersion;
+	}
+	return CloudRuntimeVersion;
+}
+
 USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 	, bShowSpatialServiceButton(false)
 	, bDeleteDynamicEntities(true)
 	, bGenerateDefaultLaunchConfig(true)
-	, bUseGDKPinnedRuntimeVersion(true)
+	, RuntimeVariant(ESpatialOSRuntimeVariant::Standard)
+	, StandardRuntimeVersion(SpatialGDKServicesConstants::SpatialOSRuntimePinnedStandardVersion)
+	, CompatabilityModeRuntimeVersion(SpatialGDKServicesConstants::SpatialOSRuntimePinnedCompatbilityModeVersion)
 	, ExposedRuntimeIP(TEXT(""))
 	, bStopSpatialOnExit(false)
 	, bAutoStartLocalDeployment(true)
@@ -62,22 +84,14 @@ USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& O
 	SpatialOSSnapshotToLoad = GetSpatialOSSnapshotToLoad();
 }
 
-const FString& USpatialGDKEditorSettings::GetSpatialOSRuntimeVersionForLocal() const
+FRuntimeVariantVersion& USpatialGDKEditorSettings::GetRuntimeVariantVersion(ESpatialOSRuntimeVariant::Type Variant)
 {
-	if (bUseGDKPinnedRuntimeVersion || LocalRuntimeVersion.IsEmpty())
+	if (Variant == ESpatialOSRuntimeVariant::CompatabilityMode)
 	{
-		return SpatialGDKServicesConstants::SpatialOSRuntimePinnedVersion;
+		return StandardRuntimeVersion;
 	}
-	return LocalRuntimeVersion;
-}
-
-const FString& USpatialGDKEditorSettings::GetSpatialOSRuntimeVersionForCloud() const
-{
-	if (bUseGDKPinnedRuntimeVersion || CloudRuntimeVersion.IsEmpty())
-	{
-		return SpatialGDKServicesConstants::SpatialOSRuntimePinnedVersion;
-	}
-	return CloudRuntimeVersion;
+	check(Variant == ESpatialOSRuntimeVariant::Standard);
+	return CompatabilityModeRuntimeVersion;
 }
 
 void USpatialGDKEditorSettings::PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent)
@@ -261,15 +275,15 @@ void USpatialGDKEditorSettings::SetGenerateSnapshot(bool bGenerate)
 	SaveConfig();
 }
 
-void USpatialGDKEditorSettings::SetUseGDKPinnedRuntimeVersion(bool Use)
+void USpatialGDKEditorSettings::SetUseGDKPinnedRuntimeVersion(ESpatialOSRuntimeVariant::Type Variant, bool Use)
 {
-	bUseGDKPinnedRuntimeVersion = Use;
+	GetRuntimeVariantVersion(Variant).bUseGDKPinnedRuntimeVersion = Use;
 	SaveConfig();
 }
 
-void USpatialGDKEditorSettings::SetCustomCloudSpatialOSRuntimeVersion(const FString& Version)
+void USpatialGDKEditorSettings::SetCustomCloudSpatialOSRuntimeVersion(ESpatialOSRuntimeVariant::Type Variant, const FString& Version)
 {
-	CloudRuntimeVersion = Version;
+	GetRuntimeVariantVersion(Variant).CloudRuntimeVersion = Version;
 	SaveConfig();
 }
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -66,7 +66,7 @@ USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& O
 	, bGenerateDefaultLaunchConfig(true)
 	, RuntimeVariant(ESpatialOSRuntimeVariant::Standard)
 	, StandardRuntimeVersion(SpatialGDKServicesConstants::SpatialOSRuntimePinnedStandardVersion)
-	, CompatabilityModeRuntimeVersion(SpatialGDKServicesConstants::SpatialOSRuntimePinnedCompatbilityModeVersion)
+	, CompatibilityModeRuntimeVersion(SpatialGDKServicesConstants::SpatialOSRuntimePinnedCompatbilityModeVersion)
 	, ExposedRuntimeIP(TEXT(""))
 	, bStopSpatialOnExit(false)
 	, bAutoStartLocalDeployment(true)
@@ -87,12 +87,12 @@ USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& O
 FRuntimeVariantVersion& USpatialGDKEditorSettings::GetRuntimeVariantVersion(ESpatialOSRuntimeVariant::Type Variant)
 {
 #if PLATFORM_MAC
-	return CompatabilityModeRuntimeVersion;
+	return CompatibilityModeRuntimeVersion;
 #endif
 
-	if (Variant == ESpatialOSRuntimeVariant::CompatabilityMode)
+	if (Variant == ESpatialOSRuntimeVariant::CompatibilityMode)
 	{
-		return CompatabilityModeRuntimeVersion;
+		return CompatibilityModeRuntimeVersion;
 	}
 	check(Variant == ESpatialOSRuntimeVariant::Standard);
 	return StandardRuntimeVersion;

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialRuntimeVersionCustomization.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialRuntimeVersionCustomization.cpp
@@ -1,0 +1,86 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "SpatialRuntimeVersionCustomization.h"
+
+#include "SpatialGDKEditorSettings.h"
+
+#include "DetailWidgetRow.h"
+#include "IDetailChildrenBuilder.h"
+#include "IDetailPropertyRow.h"
+#include "PropertyHandle.h"
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/Text/STextBlock.h"
+
+TSharedRef<IPropertyTypeCustomization> FSpatialRuntimeVersionCustomization::MakeInstance()
+{
+	return MakeShareable(new FSpatialRuntimeVersionCustomization);
+}
+
+void FSpatialRuntimeVersionCustomization::CustomizeHeader(TSharedRef<IPropertyHandle> StructPropertyHandle, FDetailWidgetRow& HeaderRow, IPropertyTypeCustomizationUtils& StructCustomizationUtils)
+{
+	HeaderRow
+		.NameContent()
+		[
+			StructPropertyHandle->CreatePropertyNameWidget()
+		];
+}
+
+void FSpatialRuntimeVersionCustomization::CustomizeChildren(TSharedRef<IPropertyHandle> StructPropertyHandle, IDetailChildrenBuilder& StructBuilder, IPropertyTypeCustomizationUtils& StructCustomizationUtils)
+{
+	const FName& PinnedGDKPropertyName = GET_MEMBER_NAME_CHECKED(FRuntimeVariantVersion, bUseGDKPinnedRuntimeVersion);
+	const FName& PinnedGDKPropertyVersionName = GET_MEMBER_NAME_CHECKED(FRuntimeVariantVersion, PinnedVersion);
+
+	uint32 NumChildren;
+	StructPropertyHandle->GetNumChildren(NumChildren);
+
+	// Get the correct pinned version name
+	FString PinnedVersionString;
+	for (uint32 ChildIdx = 0; ChildIdx < NumChildren; ++ChildIdx)
+	{
+		TSharedPtr<IPropertyHandle> ChildProperty = StructPropertyHandle->GetChildHandle(ChildIdx);
+		if (ChildProperty->GetProperty()->GetFName() == PinnedGDKPropertyVersionName)
+		{
+			ChildProperty->GetValueAsFormattedString(PinnedVersionString);
+		}
+	}
+
+	for (uint32 ChildIdx = 0; ChildIdx < NumChildren; ++ChildIdx)
+	{
+		TSharedPtr<IPropertyHandle> ChildProperty = StructPropertyHandle->GetChildHandle(ChildIdx);
+
+		// Layout other properties as usual.
+		if (ChildProperty->GetProperty()->GetFName() != PinnedGDKPropertyName)
+		{
+			StructBuilder.AddProperty(ChildProperty.ToSharedRef());
+			continue;
+		}
+
+		IDetailPropertyRow& CustomRow = StructBuilder.AddProperty(ChildProperty.ToSharedRef());
+
+		FString PinnedVersionDisplay = FString::Printf(TEXT("GDK Pinned Version : %s"), *PinnedVersionString);
+
+		CustomRow.CustomWidget()
+			.NameContent()
+			[
+				ChildProperty->CreatePropertyNameWidget()
+			]
+		.ValueContent()
+			[
+				SNew(SHorizontalBox)
+				+ SHorizontalBox::Slot()
+			.HAlign(HAlign_Left)
+			.AutoWidth()
+			[
+				ChildProperty->CreatePropertyValueWidget()
+			]
+		+ SHorizontalBox::Slot()
+			.Padding(5)
+			.HAlign(HAlign_Center)
+			.AutoWidth()
+			[
+				SNew(STextBlock)
+				.Text(FText::FromString(PinnedVersionDisplay))
+			]
+			];
+	}
+}

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -233,7 +233,7 @@ namespace ESpatialOSRuntimeVariant
 	enum Type
 	{
 		Standard,
-		CompatabilityMode
+		CompatibilityMode
 	};
 }
 
@@ -324,7 +324,7 @@ public:
 	FRuntimeVariantVersion StandardRuntimeVersion;
 
 	UPROPERTY(EditAnywhere, config, Category = "Runtime", AdvancedDisplay)
-	FRuntimeVariantVersion CompatabilityModeRuntimeVersion;
+	FRuntimeVariantVersion CompatibilityModeRuntimeVersion;
 
 private:
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialRuntimeVersionCustomization.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialRuntimeVersionCustomization.h
@@ -1,0 +1,17 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "IPropertyTypeCustomization.h"
+
+class FSpatialRuntimeVersionCustomization :public IPropertyTypeCustomization
+{
+public:
+
+	static TSharedRef<IPropertyTypeCustomization> MakeInstance();
+
+	/** IPropertyTypeCustomization interface */
+	virtual void CustomizeHeader(TSharedRef<class IPropertyHandle> StructPropertyHandle, class FDetailWidgetRow& HeaderRow, IPropertyTypeCustomizationUtils& StructCustomizationUtils) override;
+	virtual void CustomizeChildren(TSharedRef<class IPropertyHandle> StructPropertyHandle, class IDetailChildrenBuilder& StructBuilder, IPropertyTypeCustomizationUtils& StructCustomizationUtils) override;
+};

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -885,8 +885,19 @@ void FSpatialGDKEditorToolbarModule::StopSpatialDeploymentButtonClicked()
 
 void FSpatialGDKEditorToolbarModule::LaunchInspectorWebpageButtonClicked()
 {
+	// Get the runtime variant currently being used as this affects which Inspector to use.
+	FString InspectorURL;
+	if (GetDefault<USpatialGDKEditorSettings>()->GetSpatialOSRuntimeVariant() == ESpatialOSRuntimeVariant::Standard)
+	{
+		InspectorURL = TEXT("http://localhost:31000/inspector-v2");
+	}
+	else
+	{
+		InspectorURL = TEXT("http://localhost:31000/inspector");
+	}
+
 	FString WebError;
-	FPlatformProcess::LaunchURL(TEXT("http://localhost:31000/inspector"), TEXT(""), &WebError);
+	FPlatformProcess::LaunchURL(*InspectorURL, TEXT(""), &WebError);
 	if (!WebError.IsEmpty())
 	{
 		FNotificationInfo Info(FText::FromString(WebError));

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -822,7 +822,7 @@ void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment()
 
 	const FString LaunchFlags = SpatialGDKEditorSettings->GetSpatialOSCommandLineLaunchFlags();
 	const FString SnapshotName = SpatialGDKEditorSettings->GetSpatialOSSnapshotToLoad();
-	const FString RuntimeVersion = SpatialGDKEditorSettings->GetSpatialOSRuntimeVersionForLocal();
+	const FString RuntimeVersion = SpatialGDKEditorSettings->GetSelectedRuntimeVariantVersion().GetVersionForLocal();
 
 	AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [this, LaunchConfig, LaunchFlags, SnapshotName, RuntimeVersion]
 	{

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -735,13 +735,13 @@ void SSpatialGDKSimulatedPlayerDeployment::OnPrimaryDeploymentNameCommited(const
 void SSpatialGDKSimulatedPlayerDeployment::OnCheckedUsePinnedVersion(ECheckBoxState NewCheckedState)
 {
 	USpatialGDKEditorSettings* SpatialGDKSettings = GetMutableDefault<USpatialGDKEditorSettings>();
-	SpatialGDKSettings->SetUseGDKPinnedRuntimeVersion(NewCheckedState == ECheckBoxState::Checked);
+	SpatialGDKSettings->SetUseGDKPinnedRuntimeVersion(SpatialGDKSettings->RuntimeVariant, NewCheckedState == ECheckBoxState::Checked);
 }
 
 void SSpatialGDKSimulatedPlayerDeployment::OnRuntimeCustomVersionCommited(const FText& InText, ETextCommit::Type InCommitType)
 {
 	USpatialGDKEditorSettings* SpatialGDKSettings = GetMutableDefault<USpatialGDKEditorSettings>();
-	SpatialGDKSettings->SetCustomCloudSpatialOSRuntimeVersion(InText.ToString());
+	SpatialGDKSettings->SetCustomCloudSpatialOSRuntimeVersion(SpatialGDKSettings->RuntimeVariant, InText.ToString());
 }
 
 void SSpatialGDKSimulatedPlayerDeployment::OnSnapshotPathPicked(const FString& PickedPath)
@@ -900,20 +900,24 @@ ECheckBoxState SSpatialGDKSimulatedPlayerDeployment::IsSimulatedPlayersEnabled()
 ECheckBoxState SSpatialGDKSimulatedPlayerDeployment::IsUsingGDKPinnedRuntimeVersion() const
 {
 	const USpatialGDKEditorSettings* SpatialGDKSettings = GetDefault<USpatialGDKEditorSettings>();
-	return SpatialGDKSettings->GetUseGDKPinnedRuntimeVersion() ? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
+	const FRuntimeVariantVersion& RuntimeVersion = SpatialGDKSettings->GetSelectedRuntimeVariantVersion();
+	return RuntimeVersion.GetUseGDKPinnedRuntimeVersion() ? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
 }
 
 bool SSpatialGDKSimulatedPlayerDeployment::IsUsingCustomRuntimeVersion() const
 {
 	const USpatialGDKEditorSettings* SpatialGDKSettings = GetDefault<USpatialGDKEditorSettings>();
-	return !SpatialGDKSettings->GetUseGDKPinnedRuntimeVersion();
+	const FRuntimeVariantVersion& RuntimeVersion = SpatialGDKSettings->GetSelectedRuntimeVariantVersion();
+	return !RuntimeVersion.GetUseGDKPinnedRuntimeVersion();
 }
 
 FText SSpatialGDKSimulatedPlayerDeployment::GetSpatialOSRuntimeVersionToUseText() const
 {
 	const USpatialGDKEditorSettings* SpatialGDKSettings = GetDefault<USpatialGDKEditorSettings>();
-	const FString& RuntimeVersion = SpatialGDKSettings->bUseGDKPinnedRuntimeVersion ? SpatialGDKServicesConstants::SpatialOSRuntimePinnedVersion : SpatialGDKSettings->CloudRuntimeVersion;
-	return FText::FromString(RuntimeVersion);
+	const FRuntimeVariantVersion& RuntimeVersion = SpatialGDKSettings->GetSelectedRuntimeVariantVersion();
+	const FString& RuntimeVersionString =
+		RuntimeVersion.GetUseGDKPinnedRuntimeVersion() ? RuntimeVersion.GetPinnedVersion() : RuntimeVersion.GetVersionForCloud();
+	return FText::FromString(RuntimeVersionString);
 }
 
 FReply SSpatialGDKSimulatedPlayerDeployment::OnGenerateConfigFromCurrentMap()

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -25,7 +25,7 @@ DEFINE_LOG_CATEGORY(LogSpatialDeploymentManager);
 
 #define LOCTEXT_NAMESPACE "FLocalDeploymentManager"
 
-static const FString SpatialServiceVersion(TEXT("20200526.163759.18e41b5703"));
+static const FString SpatialServiceVersion(TEXT("20200527.151213.8a5a38401e"));
 
 FLocalDeploymentManager::FLocalDeploymentManager()
 	: bLocalDeploymentRunning(false)

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -25,7 +25,7 @@ DEFINE_LOG_CATEGORY(LogSpatialDeploymentManager);
 
 #define LOCTEXT_NAMESPACE "FLocalDeploymentManager"
 
-static const FString SpatialServiceVersion(TEXT("20200311.145308.ef0fc31004"));
+static const FString SpatialServiceVersion(TEXT("20200526.163759.18e41b5703"));
 
 FLocalDeploymentManager::FLocalDeploymentManager()
 	: bLocalDeploymentRunning(false)

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesConstants.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesConstants.h
@@ -29,7 +29,8 @@ namespace SpatialGDKServicesConstants
 	const FString SpotExe = CreateExePath(GDKProgramPath, TEXT("spot"));
 	const FString SchemaCompilerExe = CreateExePath(GDKProgramPath, TEXT("schema_compiler"));
 	const FString SpatialOSDirectory = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectDir(), TEXT("/../spatial/")));
-	const FString SpatialOSRuntimePinnedVersion("14.5.1");
+	const FString SpatialOSRuntimePinnedStandardVersion("0.4.0-preview-1");
+	const FString SpatialOSRuntimePinnedCompatbilityModeVersion("14.5.1");
 	const FString SpatialOSConfigFileName = TEXT("spatialos.json");
 	const FString ChinaEnvironmentArgument = TEXT(" --environment=cn-production");
 }

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKServices/LocalDeploymentManager/LocalDeploymentManagerUtilities.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKServices/LocalDeploymentManager/LocalDeploymentManagerUtilities.cpp
@@ -61,7 +61,7 @@ bool FStartDeployment::Update()
 		const FString LaunchConfig = FPaths::Combine(FPaths::ConvertRelativePathToFull(FPaths::ProjectIntermediateDir()), AutomationLaunchConfig);
 		const FString LaunchFlags = SpatialGDKSettings->GetSpatialOSCommandLineLaunchFlags();
 		const FString SnapshotName = SpatialGDKSettings->GetSpatialOSSnapshotToLoad();
-		const FString RuntimeVersion = SpatialGDKSettings->GetSpatialOSRuntimeVersionForLocal();
+		const FString RuntimeVersion = SpatialGDKSettings->GetSelectedRuntimeVariantVersion().GetVersionForLocal();
 
 		AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [LocalDeploymentManager, LaunchConfig, LaunchFlags, SnapshotName, RuntimeVersion]
 		{


### PR DESCRIPTION
#### Description
This PR adds support for the new runtime and has the appropriate switches where required.

This involves:
- Switch for choosing which runtime variant to use
- Switching which inspector to use based on runtime.
- Disabling secure connections for editor builds (new runtime forbids this locally)
- Disabling new runtime on MacOS (not yet supported)
- (Todo) Changing how we handle some logs based on runtime variant
- Updating spatiald version to support new runtime

#### Release note
- Added support for the new runtime! There is now a drop-down in SpatialGDKEditorSettings which allows you to choose whether to use the new runtime or the old (compatibility-mode) variant.
- Inspector V2 is now the default for the new runtime!
- Secure connections are no longer supported for editor builds


#### Primary reviewers
