### PR TITLE
Allow overriding connection flow when pushing settings to mobile

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
@@ -191,18 +191,34 @@ bool FSpatialGDKEditorCommandLineArgsManager::TryConstructMobileCommandLineArgum
 	const FString MobileProjectPath = FString::Printf(TEXT("../../../%s/%s.uproject"), *ProjectName, *ProjectName);
 	FString TravelUrl;
 	FString SpatialOSOptions = FString::Printf(TEXT("-workerType %s"), *(SpatialGDKSettings->MobileWorkerType));
-	if (SpatialGDKSettings->bMobileConnectToLocalDeployment)
+
+	ESpatialOSNetFlow::Type ConnectionFlow = SpatialGDKSettings->SpatialOSNetFlowType;
+	if (SpatialGDKSettings->bMobileOverrideConnectionFlow)
 	{
-		if (SpatialGDKSettings->MobileRuntimeIP.IsEmpty())
+		ConnectionFlow = SpatialGDKSettings->MobileConnectionFlow;
+	}
+
+	if (ConnectionFlow == ESpatialOSNetFlow::LocalDeployment)
+	{
+		FString RuntimeIP = SpatialGDKSettings->ExposedRuntimeIP;
+		if (!SpatialGDKSettings->MobileRuntimeIPOverride.IsEmpty())
 		{
-			UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("The Runtime IP is currently not set. Please make sure to specify a Runtime IP."));
-			FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(FString::Printf(TEXT("The Runtime IP is currently not set. Please make sure to specify a Runtime IP."))));
+			RuntimeIP = SpatialGDKSettings->MobileRuntimeIPOverride;
+		}
+
+		if (RuntimeIP.IsEmpty())
+		{
+			const FString ErrorMessage = TEXT("The Runtime IP is currently not set. Please make sure to specify a Runtime IP.");
+			UE_LOG(LogSpatialGDKEditorCommandLineArgsManager, Error, TEXT("%s"), *ErrorMessage);
+			FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(ErrorMessage));
 			return false;
 		}
 
-		TravelUrl = SpatialGDKSettings->MobileRuntimeIP;
+		TravelUrl = RuntimeIP;
+
+		SpatialOSOptions += TEXT(" -useExternalIpForBridge true");
 	}
-	else
+	else if (ConnectionFlow == ESpatialOSNetFlow::CloudDeployment)
 	{
 		TravelUrl = TEXT("connect.to.spatialos");
 
@@ -215,10 +231,10 @@ bool FSpatialGDKEditorCommandLineArgsManager::TryConstructMobileCommandLineArgum
 			}
 		}
 
-		SpatialOSOptions += FString::Printf(TEXT(" +devauthToken %s"), *(SpatialGDKSettings->DevelopmentAuthenticationToken));
+		SpatialOSOptions += FString::Printf(TEXT(" -devauthToken %s"), *(SpatialGDKSettings->DevelopmentAuthenticationToken));
 		if (!SpatialGDKSettings->DevelopmentDeploymentToConnect.IsEmpty())
 		{
-			SpatialOSOptions += FString::Printf(TEXT(" +deployment %s"), *(SpatialGDKSettings->DevelopmentDeploymentToConnect));
+			SpatialOSOptions += FString::Printf(TEXT(" -deployment %s"), *(SpatialGDKSettings->DevelopmentDeploymentToConnect));
 		}
 	}
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -393,11 +393,17 @@ private:
 	static bool IsManualWorkerConnectionSet(const FString& LaunchConfigPath, TArray<FString>& OutWorkersManuallyLaunched);
 
 public:
-	UPROPERTY(EditAnywhere, config, Category = "Mobile", meta = (DisplayName = "Connect to a local deployment"))
-	bool bMobileConnectToLocalDeployment;
+	/** If checked, use the connection flow override below instead of the one selected in the editor when building the command line for mobile. */
+	UPROPERTY(EditAnywhere, config, Category = "Mobile", meta = (DisplayName = "Override Mobile Connection Flow (only for Push settings to device)"))
+	bool bMobileOverrideConnectionFlow;
 
-	UPROPERTY(EditAnywhere, config, Category = "Mobile", meta = (EditCondition = "bMobileConnectToLocalDeployment", DisplayName = "Runtime IP to local deployment"))
-	FString MobileRuntimeIP;
+	/** The connection flow that should be used when pushing command line to the mobile device. */
+	UPROPERTY(EditAnywhere, config, Category = "Mobile", meta = (EditCondition = "bMobileOverrideConnectionFlow", DisplayName = "Mobile Connection Flow"))
+	TEnumAsByte<ESpatialOSNetFlow::Type> MobileConnectionFlow;
+
+	/** If specified, use this IP instead of 'Exposed local runtime IP address' when building the command line to push to the mobile device. */
+	UPROPERTY(EditAnywhere, config, Category = "Mobile", meta = (DisplayName = "Local Runtime IP Override"))
+	FString MobileRuntimeIPOverride;
 
 	UPROPERTY(EditAnywhere, config, Category = "Mobile", meta = (DisplayName = "Mobile Client Worker Type"))
 	FString MobileWorkerType = SpatialConstants::DefaultClientWorkerType.ToString();


### PR DESCRIPTION
#### Description
Add a checkbox to override the connection flow that should be used to build the command line when pushing settings to a device.
If this is unchecked, use the connection flow selected in the editor.
If `Local Deployment` is selected, use `Local Runtime IP Override` as the URL if it's non-empty, otherwise use `Exposed local runtime IP address`.

![image](https://user-images.githubusercontent.com/32096431/83272136-b758d100-a1c2-11ea-932d-7e57ea1cb680.png)


#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
