### PR TITLE
UNR-3483 Do not connect automatically

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -23,6 +23,7 @@
 #include "EngineClasses/SpatialPackageMapClient.h"
 #include "EngineClasses/SpatialPendingNetGame.h"
 #include "EngineClasses/SpatialWorldSettings.h"
+#include "Improbable/SpatialGDKSettingsBridge.h"
 #include "Interop/Connection/SpatialConnectionManager.h"
 #include "Interop/Connection/SpatialWorkerConnection.h"
 #include "Interop/GlobalStateManager.h"
@@ -185,9 +186,15 @@ bool USpatialNetDriver::InitBase(bool bInitAsClient, FNetworkNotify* InNotify, c
 
 	TombstonedEntities.Reserve(EDITOR_TOMBSTONED_ENTITY_TRACKING_RESERVATION_COUNT);
 #endif
-
-	InitiateConnectionToSpatialOS(URL);
-
+	bool AutoConnect = true;
+	if (const ISpatialGDKEditorModule* GDKEditorModule = FModuleManager::GetModulePtr<ISpatialGDKEditorModule>("SpatialGDKEditor"))
+	{
+		AutoConnect = GDKEditorModule->ShouldConnectToLocalDeployment() || GDKEditorModule->ShouldConnectToCloudDeployment();
+	}
+	if (AutoConnect)
+	{
+		InitiateConnectionToSpatialOS(URL);
+	}
 	return true;
 }
 


### PR DESCRIPTION
This change enables preventing automatic connection when the No Automatic Connection option is selected.

![image](https://user-images.githubusercontent.com/49975160/83376132-d09c9000-a403-11ea-9196-b87a816ab63d.png)

![image](https://user-images.githubusercontent.com/49975160/83376149-e0b46f80-a403-11ea-812e-c7ebe5563468.png)

What this means is that the game developer is expected to manage their connection logic, an example case would be once they have a custom authentication solution their auth flow would be executed and then the client connection to the SpatialOS runtime would be initiated.

This change should not be applied until [UNR-3314](https://github.com/improbableio/UnrealEngine/pull/488) is merged, because that change ensures that a server instance will not be started if No Automatic Connect is enabled.

#### Tests
I selected this option and confirmed that the spatial networking connection code path was not invoked by placing breakpoints.

Without direct inspection via a debugger I believe this is very challenging to confirm, as the expected behavior would depend on what the game developer has implemented.

COMMENT:
This particular code and this flow feels very underdeveloped to me, the whole custom authentication piece seems incomplete. There are multiple components here which worry me, foremost the settings are only in the editor, so for a stand alone client this will not work. Next, it seems there is not actually any specific support for a custom authentication flow, at least it doesn't appear to be a first class citizen in the UnrealGDK.

Going forward I believe this entire feature needs to be flushed out, that there should be first tier GDK support in the runtime, and that it needs to have better, clear and concise documentation.

I have not seen what NWX or Scavengers code looks like regarding custom auth, but I guess they have some solution? 