### PR TITLE
UNR-3431 Regenerate Dev Auth Token when Project Name changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new icons for the toolbar.
 - The port is now respected when travelling via URL, translating to the receptionist port. The `-receptionistPort` command-line argument will still be used for the first connection.
 - Running BuildWorker.bat with <game-name>Client will build the Client target of your project.
+- When changing the project name via the `Cloud Deployment` dialog the development authentication token will automatically be regenerated.
 
 ## Bug fixes:
 - Fix problem where load balanced cloud deploys could fail to start while under heavy load.

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKSimulatedPlayerDeployment.cpp
@@ -36,6 +36,7 @@
 #include "SpatialCommandUtils.h"
 #include "SpatialConstants.h"
 #include "SpatialGDKDefaultLaunchConfigGenerator.h"
+#include "SpatialGDKDevAuthTokenGenerator.h"
 #include "SpatialGDKEditorSettings.h"
 #include "SpatialGDKEditorToolbar.h"
 #include "SpatialGDKEditorPackageAssembly.h"
@@ -716,6 +717,11 @@ void SSpatialGDKSimulatedPlayerDeployment::OnProjectNameCommitted(const FText& I
 	ProjectNameInputErrorReporting->SetError(TEXT(""));
 
 	FSpatialGDKServicesModule::SetProjectName(NewProjectName);
+	if (SpatialGDKEditorPtr.IsValid())
+	{
+		TSharedRef<FSpatialGDKDevAuthTokenGenerator> DevAuthTokenGenerator = SpatialGDKEditorPtr.Pin()->GetDevAuthTokenGeneratorRef();
+		DevAuthTokenGenerator->AsyncGenerateDevAuthToken();
+	}
 }
 
 void SSpatialGDKSimulatedPlayerDeployment::OnPrimaryDeploymentNameCommited(const FText& InText, ETextCommit::Type InCommitType)


### PR DESCRIPTION
#### Description
Whenever the project name is changed through the Cloud Deployment window, automatically generate a new dev auth token.

#### Release note
When changing the project name via the `Cloud Deployment` dialog the development authentication token will automatically be regenerated.

#### Tests
I ran the editor and changed the project name through the Cloud Deployment dialog, toasts for dev auth generation popped-up, and I saw the token value in the settings was different.

#### Documentation
Release note
