### PR TITLE
UNR-3555 Enable editing SpatialOS project name from Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Start` is now called `Start Deployment`
   - `Deploy` is now called `Configure`
 - Required fields in the Cloud Deployment Configuration window are now marked with an asterisk.
+- When changing the project name via the `Cloud Deployment` dialog the development authentication token will automatically be regenerated.
+- The SpatialOS project name can now be modified via the **SpatialOS Editor Settings**.
 
 ## Bug fixes:
 - Fix problem where load balanced cloud deploys could fail to start while under heavy load.

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
@@ -344,6 +344,12 @@ bool FSpatialGDKEditor::FullScanRequired()
 	return !Schema::GeneratedSchemaFolderExists() || !Schema::GeneratedSchemaDatabaseExists();
 }
 
+void FSpatialGDKEditor::SetProjectName(const FString& InProjectName)
+{
+	FSpatialGDKServicesModule::SetProjectName(InProjectName);
+	SpatialGDKDevAuthTokenGeneratorInstance->AsyncGenerateDevAuthToken();
+}
+
 void FSpatialGDKEditor::RemoveEditorAssetLoadedCallback()
 {
 	if (OnAssetLoadedHandle.IsValid())

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
@@ -6,8 +6,8 @@
 #include "DetailLayoutBuilder.h"
 #include "DetailWidgetRow.h"
 #include "Widgets/Input/SButton.h"
-#include "Widgets/Notifications/SPopupErrorText.h"
 #include "Widgets/Input/SEditableTextBox.h"
+#include "Widgets/Notifications/SPopupErrorText.h"
 #include "Widgets/Text/STextBlock.h"
 
 #include "SpatialCommandUtils.h"

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorLayoutDetails.cpp
@@ -11,7 +11,9 @@
 #include "Widgets/Text/STextBlock.h"
 
 #include "SpatialCommandUtils.h"
+#include "SpatialGDKEditor.h"
 #include "SpatialGDKEditorCommandLineArgsManager.h"
+#include "SpatialGDKEditorModule.h"
 #include "SpatialGDKEditorSettings.h"
 #include "SpatialGDKServicesConstants.h"
 #include "SpatialGDKSettings.h"
@@ -170,5 +172,6 @@ void FSpatialGDKEditorLayoutDetails::OnProjectNameCommitted(const FText& InText,
 	}
 	ProjectNameInputErrorReporting->SetError(TEXT(""));
 
-	FSpatialGDKServicesModule::SetProjectName(NewProjectName);
+	TSharedPtr<FSpatialGDKEditor> SpatialGDKEditorInstance = FModuleManager::GetModuleChecked<FSpatialGDKEditorModule>("SpatialGDKEditor").GetSpatialGDKEditorInstance();
+	SpatialGDKEditorInstance->SetProjectName(NewProjectName);
 }

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditor.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditor.h
@@ -33,6 +33,8 @@ public:
 	bool IsSchemaGeneratorRunning() { return bSchemaGeneratorRunning; }
 	bool FullScanRequired();
 
+	void SetProjectName(const FString& InProjectName);
+
 	TSharedRef<FSpatialGDKDevAuthTokenGenerator> GetDevAuthTokenGeneratorRef();
 	TSharedRef<FSpatialGDKPackageAssembly> GetPackageAssemblyRef();
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorLayoutDetails.h
@@ -5,6 +5,8 @@
 #include "CoreMinimal.h"
 #include "IDetailCustomization.h"
 
+class IErrorReportingWidget;
+
 class FSpatialGDKEditorLayoutDetails : public IDetailCustomization
 {
 public:
@@ -16,4 +18,8 @@ private:
 
 private:
 	IDetailLayoutBuilder* CurrentLayout = nullptr;
+	TSharedPtr<IErrorReportingWidget> ProjectNameInputErrorReporting;
+
+	/** Delegate to commit project name */
+	void OnProjectNameCommitted(const FText& InText, ETextCommit::Type InCommitType);
 };

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKCloudDeploymentConfiguration.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKCloudDeploymentConfiguration.cpp
@@ -773,11 +773,9 @@ void SSpatialGDKCloudDeploymentConfiguration::OnProjectNameCommitted(const FText
 	}
 	ProjectNameInputErrorReporting->SetError(TEXT(""));
 
-	FSpatialGDKServicesModule::SetProjectName(NewProjectName);
 	if (SpatialGDKEditorPtr.IsValid())
 	{
-		TSharedRef<FSpatialGDKDevAuthTokenGenerator> DevAuthTokenGenerator = SpatialGDKEditorPtr.Pin()->GetDevAuthTokenGeneratorRef();
-		DevAuthTokenGenerator->AsyncGenerateDevAuthToken();
+		SpatialGDKEditorPtr.Pin()->SetProjectName(NewProjectName);
 	}
 }
 


### PR DESCRIPTION
#### Description
Add the ability to update the SpatialOS project name via the settings dialog. The primary purpose is to support updating this value on Mac which will not display the "Cloud Deployment" dialog since it is not possible to compile a linux serverworker on Mac currently.

#### Release note
The SpatialOS project name can now be modified via the **Spatial Editor Settings**

#### Tests
I ran the editor and modified the value in the Cloud Deployment and Settings dialogs to confirm the changes were persisted and displayed properly by both.

QA: Edit the project name via the editor then review the spatial.json file to see what project name is in the json.

#### Documentation
release note

![Uploading image.png…]()
