### PR TITLE
Remove 'No automatic connection' option

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -212,7 +212,6 @@ namespace ESpatialOSNetFlow
 {
 	enum Type
 	{
-		NoAutomaticConnection,
 		LocalDeployment,
 		CloudDeployment
 	};

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -198,13 +198,6 @@ void FSpatialGDKEditorToolbarModule::MapActions(TSharedPtr<class FUICommandList>
 		FIsActionButtonVisible::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartNativeIsVisible));
 
 	InPluginCommands->MapAction(
-		FSpatialGDKEditorToolbarCommands::Get().StartNoAutomaticConnection,
-		FExecuteAction(),
-		FCanExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartNoAutomaticConnectionCanExecute),
-		FIsActionChecked(),
-		FIsActionButtonVisible::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartNoAutomaticConnectionIsVisible));
-
-	InPluginCommands->MapAction(
 		FSpatialGDKEditorToolbarCommands::Get().StartLocalSpatialDeployment,
 		FExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartLocalSpatialDeploymentButtonClicked),
 		FCanExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartLocalSpatialDeploymentCanExecute),
@@ -324,7 +317,6 @@ void FSpatialGDKEditorToolbarModule::AddMenuExtension(FMenuBuilder& Builder)
 		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().CreateSpatialGDKSchema);
 		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().CreateSpatialGDKSnapshot);
 		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().StartNative);
-		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().StartNoAutomaticConnection);
 		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().StartLocalSpatialDeployment);
 		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().StartCloudSpatialDeployment);
 		Builder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().StopSpatialDeployment);
@@ -352,7 +344,6 @@ void FSpatialGDKEditorToolbarModule::AddToolbarExtension(FToolBarBuilder& Builde
 	);
 	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().CreateSpatialGDKSnapshot);
 	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().StartNative);
-	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().StartNoAutomaticConnection);
 	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().StartLocalSpatialDeployment);
 	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().StartCloudSpatialDeployment);
 	Builder.AddToolBarButton(FSpatialGDKEditorToolbarCommands::Get().StopSpatialDeployment);
@@ -900,16 +891,6 @@ bool FSpatialGDKEditorToolbarModule::StartNativeCanExecute() const
 	return false;
 }
 
-bool FSpatialGDKEditorToolbarModule::StartNoAutomaticConnectionIsVisible() const
-{
-	return GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking() && GetDefault<USpatialGDKEditorSettings>()->SpatialOSNetFlowType == ESpatialOSNetFlow::NoAutomaticConnection;
-}
-
-bool FSpatialGDKEditorToolbarModule::StartNoAutomaticConnectionCanExecute() const
-{
-	return false;
-}
-
 bool FSpatialGDKEditorToolbarModule::StartLocalSpatialDeploymentIsVisible() const
 {
 	return !LocalDeploymentManager->IsLocalDeploymentRunning() && GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking() && GetDefault<USpatialGDKEditorSettings>()->SpatialOSNetFlowType == ESpatialOSNetFlow::LocalDeployment;
@@ -987,12 +968,6 @@ void FSpatialGDKEditorToolbarModule::GDKEditorSettingsClicked() const
 void FSpatialGDKEditorToolbarModule::GDKRuntimeSettingsClicked() const
 {
 	FModuleManager::LoadModuleChecked<ISettingsModule>("Settings").ShowViewer("Project", "SpatialGDKEditor", "Runtime Settings");
-}
-
-bool FSpatialGDKEditorToolbarModule::IsNoAutomaticConnectionSelected() const
-{
-	const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>();
-	return SpatialGDKEditorSettings->SpatialOSNetFlowType == ESpatialOSNetFlow::NoAutomaticConnection;
 }
 
 bool FSpatialGDKEditorToolbarModule::IsLocalDeploymentSelected() const

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarCommands.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarCommands.cpp
@@ -11,7 +11,6 @@ void FSpatialGDKEditorToolbarCommands::RegisterCommands()
 	UI_COMMAND(DeleteSchemaDatabase, "Delete schema database", "Deletes the schema database file", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(CreateSpatialGDKSnapshot, "Snapshot", "Creates SpatialOS Unreal GDK snapshot.", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(StartNative, "Native", "Use native Unreal networking", EUserInterfaceActionType::Button, FInputGesture());
-	UI_COMMAND(StartNoAutomaticConnection, "None", "Doesn't automatically connect to SpatialOS", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(StartLocalSpatialDeployment, "Local", "Start a local deployment", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(StartCloudSpatialDeployment, "Cloud", "Start a cloud deployment (Windows-only)", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(StopSpatialDeployment, "Stop", "Stops SpatialOS.", EUserInterfaceActionType::Button, FInputGesture());

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarStyle.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarStyle.cpp
@@ -67,12 +67,6 @@ TSharedRef<FSlateStyleSet> FSpatialGDKEditorToolbarStyle::Create()
 	Style->Set("SpatialGDKEditorToolbar.StartNative.Small",
 		new IMAGE_BRUSH(TEXT("None@0.5x"), Icon20x20));
 
-	Style->Set("SpatialGDKEditorToolbar.StartNoAutomaticConnection",
-		new IMAGE_BRUSH(TEXT("None"), Icon40x40));
-
-	Style->Set("SpatialGDKEditorToolbar.StartNoAutomaticConnection.Small",
-		new IMAGE_BRUSH(TEXT("None@0.5x"), Icon20x20));
-
 	Style->Set("SpatialGDKEditorToolbar.StartLocalSpatialDeployment",
 		new IMAGE_BRUSH(TEXT("StartLocal"), Icon40x40));
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -80,9 +80,6 @@ private:
 	bool StartNativeIsVisible() const;
 	bool StartNativeCanExecute() const;
 
-	bool StartNoAutomaticConnectionIsVisible() const;
-	bool StartNoAutomaticConnectionCanExecute() const;
-
 	bool StartLocalSpatialDeploymentIsVisible() const;
 	bool StartLocalSpatialDeploymentCanExecute() const;
 
@@ -104,7 +101,6 @@ private:
 	void GDKEditorSettingsClicked() const;
 	void GDKRuntimeSettingsClicked() const;
 
-	bool IsNoAutomaticConnectionSelected() const;
 	bool IsLocalDeploymentSelected() const;
 	bool IsCloudDeploymentSelected() const;
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbarCommands.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbarCommands.h
@@ -25,7 +25,6 @@ public:
 	TSharedPtr<FUICommandInfo> DeleteSchemaDatabase;
 	TSharedPtr<FUICommandInfo> CreateSpatialGDKSnapshot;
 	TSharedPtr<FUICommandInfo> StartNative;
-	TSharedPtr<FUICommandInfo> StartNoAutomaticConnection;
 	TSharedPtr<FUICommandInfo> StartLocalSpatialDeployment;
 	TSharedPtr<FUICommandInfo> StartCloudSpatialDeployment;
 	TSharedPtr<FUICommandInfo> StopSpatialDeployment;


### PR DESCRIPTION
#### Description
'No automatic connection' flow was first added to support the use case of custom authentication flow. However, we don't have a reference implementation of this use case that we can test this flow against. Additionally, there is already an existing way to disable automatic connection by running in offline mode (via advanced networking settings).
So instead of supporting an incomplete feature in this release, we should first implement a reference use case and add this back when we can properly test it.

I also added a ticket to add it back together with the reference use case: https://improbableio.atlassian.net/browse/UNR-3583

#### Primary reviewers
@jessicafalk @jayprobable 
