### PR TITLE
Feature/unr 3315 connect local server to cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features:
 - You can now change the GDK Editor Setting `Stop local deployment on stop play in editor` in order to automatically stop deployment when you stop playing in editor.
+- Added the `Connect local server worker to the cloud deployment` checkbox in **SpatialOS Editor Settings**, that enables/disables the option to start and connect a local server to the cloud deployment when `Connect to cloud deployment` is enabled.
 
 ### Bug fixes:
 - `Cloud Deployment Name` field in the dropdown now refers to the same property as `Deployment Name` in the Cloud Deployment Configuration window, so the `Start Deployment` toolbar button will now use the name specified in the dropdown when quickly starting the new deployment without going through the Cloud Deployment Configuration window.

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
@@ -173,13 +173,21 @@ void USpatialConnectionManager::Connect(bool bInitAsClient, uint32 PlayInEditorI
 	bConnectAsClient = bInitAsClient;
 
 	const ISpatialGDKEditorModule* SpatialGDKEditorModule = FModuleManager::GetModulePtr<ISpatialGDKEditorModule>("SpatialGDKEditor");
-	if (SpatialGDKEditorModule != nullptr && SpatialGDKEditorModule->ShouldConnectToCloudDeployment() && bInitAsClient)
+	if (SpatialGDKEditorModule != nullptr && SpatialGDKEditorModule->ShouldConnectToCloudDeployment())
 	{
-		DevAuthConfig.Deployment = SpatialGDKEditorModule->GetSpatialOSCloudDeploymentName();
-		DevAuthConfig.WorkerType = SpatialConstants::DefaultClientWorkerType.ToString();
-		DevAuthConfig.UseExternalIp = true;
-		StartDevelopmentAuth(SpatialGDKEditorModule->GetDevAuthToken());
-		return;
+		if (bInitAsClient)
+		{
+			DevAuthConfig.Deployment = SpatialGDKEditorModule->GetSpatialOSCloudDeploymentName();
+			DevAuthConfig.WorkerType = SpatialConstants::DefaultClientWorkerType.ToString();
+			DevAuthConfig.UseExternalIp = true;
+			StartDevelopmentAuth(SpatialGDKEditorModule->GetDevAuthToken());
+			return;
+		}
+
+		if(SpatialGDKEditorModule->ShouldStartLocalServer())
+		{
+			ReceptionistConfig.UseExternalIp = true;
+		}
 	}
 
 	switch (GetConnectionType())

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
@@ -183,8 +183,7 @@ void USpatialConnectionManager::Connect(bool bInitAsClient, uint32 PlayInEditorI
 			StartDevelopmentAuth(SpatialGDKEditorModule->GetDevAuthToken());
 			return;
 		}
-
-		if(SpatialGDKEditorModule->ShouldStartLocalServer())
+		else if(SpatialGDKEditorModule->ShouldStartLocalServer())
 		{
 			ReceptionistConfig.UseExternalIp = true;
 		}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
@@ -183,7 +183,7 @@ void USpatialConnectionManager::Connect(bool bInitAsClient, uint32 PlayInEditorI
 			StartDevelopmentAuth(SpatialGDKEditorModule->GetDevAuthToken());
 			return;
 		}
-		else if(SpatialGDKEditorModule->ShouldStartLocalServer())
+		else if (SpatialGDKEditorModule->ShouldConnectServerToCloud())
 		{
 			ReceptionistConfig.UseExternalIp = true;
 		}

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -269,6 +269,8 @@ inline float GetCommandRetryWaitTimeSeconds(uint32 NumAttempts)
 const FString LOCAL_HOST   = TEXT("127.0.0.1");
 const uint16  DEFAULT_PORT = 7777;
 
+const uint16  DEFAULT_SERVER_RECEPTIONIST_PROXY_PORT = 7777;
+
 const float ENTITY_QUERY_RETRY_WAIT_SECONDS = 3.0f;
 
 const Worker_ComponentId MIN_EXTERNAL_SCHEMA_ID = 1000;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/EngineVersionCheck.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/EngineVersionCheck.h
@@ -7,7 +7,7 @@
 // GDK Version to be updated with SPATIAL_ENGINE_VERSION
 // when breaking changes are made to the engine that requires
 // changes to the GDK to remain compatible
-#define SPATIAL_GDK_VERSION 22
+#define SPATIAL_GDK_VERSION 23
 
 // Check if GDK is compatible with the current version of Unreal Engine
 // SPATIAL_ENGINE_VERSION is incremented in engine when breaking changes

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -101,11 +101,11 @@ bool FSpatialGDKEditorModule::TryStartLocalReceptionistProxyServer() const
 		
 		if (bSuccess)
 		{
-			UE_LOG(LogSpatialGDKEditorModule, Log, TEXT("%s"), *LOCTEXT("ProxyStartedSuccessfully", "Successfully started local receptionist proxy server!").ToString());
+			UE_LOG(LogSpatialGDKEditorModule, Log, TEXT("Successfully started local receptionist proxy server!"));
 		}
 		else
 		{
-			UE_LOG(LogSpatialGDKEditorModule, Error, TEXT("%s"), *LOCTEXT("FailedToStartProxy", "Failed to start local receptionist proxy server").ToString());
+			UE_LOG(LogSpatialGDKEditorModule, Error, TEXT("Failed to start local receptionist proxy server"));
 		}
 
 		return bSuccess;

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -213,7 +213,7 @@ bool FSpatialGDKEditorModule::ShouldStartLocalServer() const
 		// Start the PIE server(s) if we're connecting to a local deployment.
 		return true;
 	}
-	if (ShouldConnectToLocalDeployment() && ShouldConnectServerToCloud())
+	if (ShouldConnectToCloudDeployment() && ShouldConnectServerToCloud())
 	{
 		// Start the PIE server(s) if we're connecting to a cloud deployment and using receptionist proxy for the server(s).
 		return true;

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -84,27 +84,27 @@ FString FSpatialGDKEditorModule::GetSpatialOSCloudDeploymentName() const
 	return GetDefault<USpatialGDKEditorSettings>()->GetPrimaryDeploymentName();
 }
 
-bool FSpatialGDKEditorModule::ShouldStartLocalServer() const
+bool FSpatialGDKEditorModule::ShouldConnectServerToCloud() const
 {
-	return GetDefault<USpatialGDKEditorSettings>()->IsStartLocalServerWorkerEnabled();
+	return GetDefault<USpatialGDKEditorSettings>()->IsConnectServerToCloudEnabled();
 }
 
 bool FSpatialGDKEditorModule::TryStartLocalReceptionistProxyServer() const
 {
-	if(ShouldConnectToCloudDeployment() && ShouldStartLocalServer())
+	if (ShouldConnectToCloudDeployment() && ShouldConnectServerToCloud())
 	{
-			bool bSuccess = LocalReceptionistProxyServerManager->TryStartReceptionistProxyServer(GetDefault<USpatialGDKSettings>()->IsRunningInChina(), GetDefault<USpatialGDKEditorSettings>()->DevelopmentDeploymentToConnect, GetDefault<USpatialGDKEditorSettings>()->ListeningAddress, GetDefault<USpatialGDKEditorSettings>()->LocalReceptionistPort);
+		bool bSuccess = LocalReceptionistProxyServerManager->TryStartReceptionistProxyServer(GetDefault<USpatialGDKSettings>()->IsRunningInChina(), GetDefault<USpatialGDKEditorSettings>()->DevelopmentDeploymentToConnect, GetDefault<USpatialGDKEditorSettings>()->ListeningAddress, GetDefault<USpatialGDKEditorSettings>()->LocalReceptionistPort);
 
-			if (bSuccess)
-			{
-				UE_LOG(LogTemp, Log, TEXT("%s"), *LOCTEXT("ProxyStartedSuccessfully", "Successfully started local receptionist proxy server!").ToString());
-			}
-			else
-			{
-				UE_LOG(LogTemp, Error, TEXT("%s"), *LOCTEXT("FailedToStartProxy", "Failed to start local receptionist proxy server").ToString());
-			}
+		if (bSuccess)
+		{
+			UE_LOG(LogTemp, Log, TEXT("%s"), *LOCTEXT("ProxyStartedSuccessfully", "Successfully started local receptionist proxy server!").ToString());
+		}
+		else
+		{
+			UE_LOG(LogTemp, Error, TEXT("%s"), *LOCTEXT("FailedToStartProxy", "Failed to start local receptionist proxy server").ToString());
+		}
 
-			return bSuccess;
+		return bSuccess;
 	}
 
 	return true;
@@ -194,6 +194,16 @@ FString FSpatialGDKEditorModule::GetMobileClientCommandLineArgs() const
 bool FSpatialGDKEditorModule::ShouldPackageMobileCommandLineArgs() const
 {
 	return GetDefault<USpatialGDKEditorSettings>()->bPackageMobileCommandLineArgs;
+}
+
+bool FSpatialGDKEditorModule::ShouldStartLocalServer() const
+{
+	if (!GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking())
+	{
+		return true;
+	}
+
+	return ShouldConnectToLocalDeployment() || (ShouldConnectToLocalDeployment() && ShouldConnectServerToCloud());
 }
 
 void FSpatialGDKEditorModule::RegisterSettings()

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -208,7 +208,17 @@ bool FSpatialGDKEditorModule::ShouldStartLocalServer() const
 		return true;
 	}
 
-	return ShouldConnectToLocalDeployment() || (ShouldConnectToLocalDeployment() && ShouldConnectServerToCloud());
+	if (ShouldConnectToLocalDeployment())
+	{
+		// Start the PIE server(s) if we're connecting to a local deployment.
+		return true;
+	}
+	if (ShouldConnectToLocalDeployment() && ShouldConnectServerToCloud())
+	{
+		// Start the PIE server(s) if we're connecting to a cloud deployment and using receptionist proxy for the server(s).
+		return true;
+	}
+	return false;
 }
 
 void FSpatialGDKEditorModule::RegisterSettings()

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -97,7 +97,7 @@ bool FSpatialGDKEditorModule::TryStartLocalReceptionistProxyServer() const
 	if (ShouldConnectToCloudDeployment() && ShouldConnectServerToCloud())
 	{
 		const USpatialGDKEditorSettings* EditorSettings = GetDefault<USpatialGDKEditorSettings>();
-		bool bSuccess = LocalReceptionistProxyServerManager->TryStartReceptionistProxyServer(GetDefault<USpatialGDKSettings>()->IsRunningInChina(), EditorSettings->DevelopmentDeploymentToConnect, EditorSettings->ListeningAddress, EditorSettings->LocalReceptionistPort);
+		bool bSuccess = LocalReceptionistProxyServerManager->TryStartReceptionistProxyServer(GetDefault<USpatialGDKSettings>()->IsRunningInChina(), EditorSettings->GetPrimaryDeploymentName(), EditorSettings->ListeningAddress, EditorSettings->LocalReceptionistPort);
 		
 		if (bSuccess)
 		{

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -105,7 +105,7 @@ bool FSpatialGDKEditorModule::TryStartLocalReceptionistProxyServer() const
 		}
 		else
 		{
-			UE_LOG(LogSpatialGDKEditorModule, Error, TEXT("Failed to start local receptionist proxy server"));
+			FMessageDialog::Open(EAppMsgType::Ok, LOCTEXT("ReceptionistProxyFailure", "Failed to start local receptionist proxy server. See the logs for more information."));
 		}
 
 		return bSuccess;

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -58,6 +58,7 @@ USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& O
 	, AssemblyBuildConfiguration(TEXT("Development"))
 	, SimulatedPlayerDeploymentRegionCode(ERegionCode::US)
 	, bPackageMobileCommandLineArgs(false)
+	, bStartLocalServerWorker(false)
 	, bStartPIEClientsWithLocalLaunchOnDevice(false)
 	, SpatialOSNetFlowType(ESpatialOSNetFlow::LocalDeployment)
 {

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -59,6 +59,8 @@ USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& O
 	, SimulatedPlayerDeploymentRegionCode(ERegionCode::US)
 	, bPackageMobileCommandLineArgs(false)
 	, bStartLocalServerWorker(false)
+	, LocalReceptionistPort(SpatialConstants::DEFAULT_SERVER_RECEPTIONIST_PROXY_PORT)
+	, ListeningAddress(SpatialConstants::LOCAL_HOST)
 	, bStartPIEClientsWithLocalLaunchOnDevice(false)
 	, SpatialOSNetFlowType(ESpatialOSNetFlow::LocalDeployment)
 {

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -56,11 +56,11 @@ USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& O
 	, SimulatedPlayerLaunchConfigPath(FSpatialGDKServicesModule::GetSpatialGDKPluginDirectory(TEXT("SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/SpatialConfig/cloud_launch_sim_player_deployment.json")))
 	, bBuildAndUploadAssembly(true)
 	, AssemblyBuildConfiguration(TEXT("Development"))
-	, SimulatedPlayerDeploymentRegionCode(ERegionCode::US)
-	, bPackageMobileCommandLineArgs(false)
-	, bStartLocalServerWorker(false)
+	, bConnectServerToCloud(false)
 	, LocalReceptionistPort(SpatialConstants::DEFAULT_SERVER_RECEPTIONIST_PROXY_PORT)
 	, ListeningAddress(SpatialConstants::LOCAL_HOST)
+	, SimulatedPlayerDeploymentRegionCode(ERegionCode::US)
+	, bPackageMobileCommandLineArgs(false)
 	, bStartPIEClientsWithLocalLaunchOnDevice(false)
 	, SpatialOSNetFlowType(ESpatialOSNetFlow::LocalDeployment)
 {
@@ -269,9 +269,9 @@ void USpatialGDKEditorSettings::SetBuildClientWorker(bool bBuild)
 	SaveConfig();
 }
 
-void USpatialGDKEditorSettings::SetStartLocalServerWorker(bool bIsEnabled)
+void USpatialGDKEditorSettings::SetConnectServerToCloud(bool bIsEnabled)
 {
-	bStartLocalServerWorker = bIsEnabled;
+	bConnectServerToCloud = bIsEnabled;
 	SaveConfig();
 }
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
@@ -8,7 +8,7 @@
 class FLBStrategyEditorExtensionManager;
 class FSpatialGDKEditor;
 class FSpatialGDKEditorCommandLineArgsManager;
-class  FLocalReceptionistProxyServerManager;
+class FLocalReceptionistProxyServerManager;
 
 class FSpatialGDKEditorModule : public ISpatialGDKEditorModule
 {

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
@@ -8,6 +8,7 @@
 class FLBStrategyEditorExtensionManager;
 class FSpatialGDKEditor;
 class FSpatialGDKEditorCommandLineArgsManager;
+class  FLocalReceptionistProxyServerManager;
 
 class FSpatialGDKEditorModule : public ISpatialGDKEditorModule
 {
@@ -41,6 +42,7 @@ private:
 	virtual FString GetDevAuthToken() const override;
 	virtual FString GetSpatialOSCloudDeploymentName() const override;
 	virtual bool ShouldStartLocalServer() const override;
+	virtual bool TryStartLocalReceptionistProxyServer() const override;
 
 	virtual bool CanExecuteLaunch() const override;
 	virtual bool CanStartPlaySession(FText& OutErrorMessage) const override;
@@ -61,4 +63,6 @@ private:
 	TUniquePtr<FLBStrategyEditorExtensionManager> ExtensionManager;
 	TSharedPtr<FSpatialGDKEditor> SpatialGDKEditorInstance;
 	TUniquePtr<FSpatialGDKEditorCommandLineArgsManager> CommandLineArgsManager;
+
+	FLocalReceptionistProxyServerManager* LocalReceptionistProxyServerManager;
 };

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
@@ -10,6 +10,8 @@ class FSpatialGDKEditor;
 class FSpatialGDKEditorCommandLineArgsManager;
 class FLocalReceptionistProxyServerManager;
 
+DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKEditorModule, Log, All);
+
 class FSpatialGDKEditorModule : public ISpatialGDKEditorModule
 {
 public:

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
@@ -54,6 +54,7 @@ private:
 	virtual bool ShouldPackageMobileCommandLineArgs() const override;
 
 	virtual bool ShouldStartLocalServer() const override;
+
 private:
 	void RegisterSettings();
 	void UnregisterSettings();

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
@@ -41,7 +41,7 @@ private:
 	virtual bool ShouldConnectToCloudDeployment() const override;
 	virtual FString GetDevAuthToken() const override;
 	virtual FString GetSpatialOSCloudDeploymentName() const override;
-	virtual bool ShouldStartLocalServer() const override;
+	virtual bool ShouldConnectServerToCloud() const override;
 	virtual bool TryStartLocalReceptionistProxyServer() const override;
 
 	virtual bool CanExecuteLaunch() const override;
@@ -51,6 +51,7 @@ private:
 	virtual FString GetMobileClientCommandLineArgs() const override;
 	virtual bool ShouldPackageMobileCommandLineArgs() const override;
 
+	virtual bool ShouldStartLocalServer() const override;
 private:
 	void RegisterSettings();
 	void UnregisterSettings();

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -435,6 +435,13 @@ public:
 	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection", meta = (DisplayName = "Connect local server worker to the cloud deployment"))
 	bool bStartLocalServerWorker;
 
+	/** Port on which the receptionist proxy will be available.*/
+	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection", meta = (EditCondition = "bStartLocalServerWorker", DisplayName = "Local Receptionist Port"))
+	int32 LocalReceptionistPort = 7777;
+
+	/**Network interface to bind the receptionist proxy to.*/
+	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection", meta = (EditCondition = "bStartLocalServerWorker", DisplayName = "Listening Address"))
+	FString ListeningAddress = "127.0.0.1";
 private:
 	UPROPERTY(config)
 	TEnumAsByte<ERegionCode::Type> SimulatedPlayerDeploymentRegionCode;

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -431,7 +431,7 @@ public:
 	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection")
 	FString DevelopmentDeploymentToConnect;
 
-	/** Whether to start local server worker when connecting to cloud deployment*/
+	/** Whether to start local server worker when connecting to cloud deployment. If selected, make sure that the cloud deployment you want to connect to is not automatically launching Server-workers. (That your workers are "manual_connection_only" type)*/
 	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection", meta = (DisplayName = "Connect local server worker to the cloud deployment"))
 	bool bStartLocalServerWorker;
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -437,11 +437,11 @@ public:
 
 	/** Port on which the receptionist proxy will be available.*/
 	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection", meta = (EditCondition = "bStartLocalServerWorker", DisplayName = "Local Receptionist Port"))
-	int32 LocalReceptionistPort = 7777;
+	int32 LocalReceptionistPort = SpatialConstants::DEFAULT_SERVER_RECEPTIONIST_PROXY_PORT;
 
-	/**Network interface to bind the receptionist proxy to.*/
+	/**Network address to bind the receptionist proxy to.*/
 	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection", meta = (EditCondition = "bStartLocalServerWorker", DisplayName = "Listening Address"))
-	FString ListeningAddress = "127.0.0.1";
+	FString ListeningAddress = SpatialConstants::LOCAL_HOST;
 private:
 	UPROPERTY(config)
 	TEnumAsByte<ERegionCode::Type> SimulatedPlayerDeploymentRegionCode;

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -435,13 +435,13 @@ public:
 	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection", meta = (DisplayName = "Connect local server worker to the cloud deployment"))
 	bool bConnectServerToCloud;
 
-	/** Port on which the receptionist proxy will be available.*/
+	/** Port on which the receptionist proxy will be available. */
 	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection", meta = (EditCondition = "bConnectServerToCloud", DisplayName = "Local Receptionist Port"))
-		int32 LocalReceptionistPort;
+	int32 LocalReceptionistPort;
 
 	/** Network address to bind the receptionist proxy to. */
 	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection", meta = (EditCondition = "bConnectServerToCloud", DisplayName = "Listening Address"))
-		FString ListeningAddress;
+	FString ListeningAddress;
 private:
 	UPROPERTY(config)
 	TEnumAsByte<ERegionCode::Type> SimulatedPlayerDeploymentRegionCode;

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -436,11 +436,11 @@ public:
 	bool bConnectServerToCloud;
 
 	/** Port on which the receptionist proxy will be available.*/
-	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection", meta = (EditCondition = "bStartLocalServerWorker", DisplayName = "Local Receptionist Port"))
+	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection", meta = (EditCondition = "bConnectServerToCloud", DisplayName = "Local Receptionist Port"))
 		int32 LocalReceptionistPort;
 
 	/** Network address to bind the receptionist proxy to. */
-	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection", meta = (EditCondition = "bStartLocalServerWorker", DisplayName = "Listening Address"))
+	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection", meta = (EditCondition = "bConnectServerToCloud", DisplayName = "Listening Address"))
 		FString ListeningAddress;
 private:
 	UPROPERTY(config)

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -431,8 +431,8 @@ public:
 	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection")
 	FString DevelopmentDeploymentToConnect;
 
-	/** Whether to start Local Server Worker when connecting to cloud deployment*/
-	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection", meta = (DisplayName = "Start Local Server Worker"))
+	/** Whether to start local server worker when connecting to cloud deployment*/
+	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection", meta = (DisplayName = "Connect local server worker to the cloud deployment"))
 	bool bStartLocalServerWorker;
 
 private:

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -427,10 +427,6 @@ public:
 	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection")
 	FString DevelopmentAuthenticationToken;
 
-	/** The deployment to connect to when using the Development Authentication Flow. If left empty, it uses the first available one (order not guaranteed when there are multiple items). The deployment needs to be tagged with 'dev_login'. */
-	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection")
-	FString DevelopmentDeploymentToConnect;
-
 	/** Whether to start local server worker when connecting to cloud deployment. If selected, make sure that the cloud deployment you want to connect to is not automatically launching Server-workers. (That your workers have "manual_connection_only" enabled) */
 	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection", meta = (DisplayName = "Connect local server worker to the cloud deployment"))
 	bool bConnectServerToCloud;

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -433,7 +433,7 @@ public:
 
 	/** Whether to start local server worker when connecting to cloud deployment. If selected, make sure that the cloud deployment you want to connect to is not automatically launching Server-workers. (That your workers are "manual_connection_only" type)*/
 	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection", meta = (DisplayName = "Connect local server worker to the cloud deployment"))
-	bool bStartLocalServerWorker;
+	bool bConnectServerToCloud;
 
 	/** Port on which the receptionist proxy will be available.*/
 	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection", meta = (EditCondition = "bStartLocalServerWorker", DisplayName = "Local Receptionist Port"))
@@ -686,10 +686,10 @@ public:
 		return SimulatedPlayerDeploymentName;
 	}
 
-	void SetStartLocalServerWorker(bool bIsEnabled);
-	FORCEINLINE bool IsStartLocalServerWorkerEnabled() const
+	void SetConnectServerToCloud(bool bIsEnabled);
+	FORCEINLINE bool IsConnectServerToCloudEnabled() const
 	{
-		return bStartLocalServerWorker;
+		return bConnectServerToCloud;
 	}
 
 	void SetSimulatedPlayerCluster(const FString& NewCluster);

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -431,7 +431,7 @@ public:
 	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection")
 	FString DevelopmentDeploymentToConnect;
 
-	/** Whether to start local server worker when connecting to cloud deployment. If selected, make sure that the cloud deployment you want to connect to is not automatically launching Server-workers. (That your workers are "manual_connection_only" type)*/
+	/** Whether to start local server worker when connecting to cloud deployment. If selected, make sure that the cloud deployment you want to connect to is not automatically launching Server-workers. (That your workers have "manual_connection_only" enabled)*/
 	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection", meta = (DisplayName = "Connect local server worker to the cloud deployment"))
 	bool bConnectServerToCloud;
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -437,11 +437,11 @@ public:
 
 	/** Port on which the receptionist proxy will be available.*/
 	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection", meta = (EditCondition = "bStartLocalServerWorker", DisplayName = "Local Receptionist Port"))
-	int32 LocalReceptionistPort = SpatialConstants::DEFAULT_SERVER_RECEPTIONIST_PROXY_PORT;
+		int32 LocalReceptionistPort;
 
-	/**Network address to bind the receptionist proxy to.*/
+	/** Network address to bind the receptionist proxy to. */
 	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection", meta = (EditCondition = "bStartLocalServerWorker", DisplayName = "Listening Address"))
-	FString ListeningAddress = SpatialConstants::LOCAL_HOST;
+		FString ListeningAddress;
 private:
 	UPROPERTY(config)
 	TEnumAsByte<ERegionCode::Type> SimulatedPlayerDeploymentRegionCode;

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -431,7 +431,7 @@ public:
 	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection")
 	FString DevelopmentDeploymentToConnect;
 
-	/** Whether to start local server worker when connecting to cloud deployment. If selected, make sure that the cloud deployment you want to connect to is not automatically launching Server-workers. (That your workers have "manual_connection_only" enabled)*/
+	/** Whether to start local server worker when connecting to cloud deployment. If selected, make sure that the cloud deployment you want to connect to is not automatically launching Server-workers. (That your workers have "manual_connection_only" enabled) */
 	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection", meta = (DisplayName = "Connect local server worker to the cloud deployment"))
 	bool bConnectServerToCloud;
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -118,6 +118,8 @@ void FSpatialGDKEditorToolbarModule::StartupModule()
 	});
 
 	LocalDeploymentManager->Init(GetOptionalExposedRuntimeIP());
+	LocalReceptionistProxyServerManager->Init();
+
 	SpatialGDKEditorInstance = FModuleManager::GetModuleChecked<FSpatialGDKEditorModule>("SpatialGDKEditor").GetSpatialGDKEditorInstance();
 }
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -1099,6 +1099,10 @@ void FSpatialGDKEditorToolbarModule::OnPropertyChanged(UObject* ObjectBeingModif
 		{
 			OnAutoStartLocalDeploymentChanged();
 		}
+		else if(PropertyName.ToString() == TEXT("bStartLocalServerWorker"))
+		{
+			OnAutoStartLocalReceptionistProxyServer();
+		}
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -96,7 +96,6 @@ void FSpatialGDKEditorToolbarModule::StartupModule()
 	LocalReceptionistProxyServerManager = GDKServices.GetLocalReceptionistProxyServerManager();
 
 	OnAutoStartLocalDeploymentChanged();
-	OnAutoStartLocalReceptionistProxyServer();
 
 	FEditorDelegates::PreBeginPIE.AddLambda([this](bool bIsSimulatingInEditor)
 	{
@@ -866,22 +865,6 @@ void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment()
 	});
 }
 
-void FSpatialGDKEditorToolbarModule::StartLocalReceptionistProxyServer()
-{
-	OnShowTaskStartNotification(TEXT("Start local receptionist proxy server"));
-
-	bool bSuccess = LocalReceptionistProxyServerManager->TryStartReceptionistProxyServer(GetDefault<USpatialGDKSettings>()->IsRunningInChina(), GetDefault<USpatialGDKEditorSettings>()->GetPrimaryDeploymentName(), GetDefault<USpatialGDKEditorSettings>()->ListeningAddress, GetDefault<USpatialGDKEditorSettings>()->LocalReceptionistPort);
-
-	if (bSuccess)
-	{
-		OnShowSuccessNotification(TEXT("Successfully started local receptionist proxy server"));
-	}
-	else
-	{
-		OnShowFailedNotification(TEXT("Failed to start local receptionist proxy server"));
-	}
-}
-
 void FSpatialGDKEditorToolbarModule::StartLocalSpatialDeploymentButtonClicked()
 {
 	VerifyAndStartDeployment();
@@ -1042,7 +1025,7 @@ void FSpatialGDKEditorToolbarModule::LocalDeploymentClicked()
 
 	OnAutoStartLocalDeploymentChanged();
 
-	OnAutoStartLocalReceptionistProxyServer();
+	LocalReceptionistProxyServerManager->TryStopReceptionistProxyServer();
 }
 
 void FSpatialGDKEditorToolbarModule::CloudDeploymentClicked()
@@ -1054,8 +1037,6 @@ void FSpatialGDKEditorToolbarModule::CloudDeploymentClicked()
 	DevAuthTokenGenerator->AsyncGenerateDevAuthToken();
 
 	OnAutoStartLocalDeploymentChanged();
-
-	OnAutoStartLocalReceptionistProxyServer();
 }
 
 bool FSpatialGDKEditorToolbarModule::IsLocalDeploymentIPEditable()
@@ -1083,7 +1064,7 @@ void FSpatialGDKEditorToolbarModule::OnPropertyChanged(UObject* ObjectBeingModif
 				? PropertyChangedEvent.Property->GetFName()
 				: NAME_None;
 		FString PropertyNameStr = PropertyName.ToString();
-		if (PropertyNameStr == TEXT("bStopSpatialOnExit"))
+		if (PropertyName == GET_MEMBER_NAME_CHECKED(USpatialGDKEditorSettings, bStopSpatialOnExit))
 		{
 			/*
 			* This updates our own local copy of bStopSpatialOnExit as Settings change.
@@ -1093,17 +1074,17 @@ void FSpatialGDKEditorToolbarModule::OnPropertyChanged(UObject* ObjectBeingModif
 			*/
 			bStopSpatialOnExit = Settings->bStopSpatialOnExit;
 		}
-		else if (PropertyNameStr == TEXT("bStopLocalDeploymentOnEndPIE"))
+		else if (PropertyName == GET_MEMBER_NAME_CHECKED(USpatialGDKEditorSettings, bStopLocalDeploymentOnEndPIE))
 		{
 			bStopLocalDeploymentOnEndPIE = Settings->bStopLocalDeploymentOnEndPIE;
 		}
-		else if (PropertyNameStr == TEXT("bAutoStartLocalDeployment"))
+		else if (PropertyName == GET_MEMBER_NAME_CHECKED(USpatialGDKEditorSettings, bAutoStartLocalDeployment))
 		{
 			OnAutoStartLocalDeploymentChanged();
 		}
-		else if(PropertyName.ToString() == TEXT("bStartLocalServerWorker"))
+		else if(PropertyName == GET_MEMBER_NAME_CHECKED(USpatialGDKEditorSettings, bStartLocalServerWorker))
 		{
-			OnAutoStartLocalReceptionistProxyServer();
+			LocalReceptionistProxyServerManager->TryStopReceptionistProxyServer();
 		}
 	}
 }
@@ -1258,6 +1239,7 @@ void FSpatialGDKEditorToolbarModule::OnAutoStartLocalDeploymentChanged()
 	}
 }
 
+<<<<<<< HEAD
 
 void FSpatialGDKEditorToolbarModule::GenerateConfigFromCurrentMap()
 {
@@ -1304,6 +1286,8 @@ void FSpatialGDKEditorToolbarModule::OnAutoStartLocalReceptionistProxyServer()
 		}
 	}
 }
+=======
+>>>>>>> Move StartLocalReceptionist logic to the editor module
 
 FReply FSpatialGDKEditorToolbarModule::OnStartCloudDeployment()
 {

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -1239,8 +1239,6 @@ void FSpatialGDKEditorToolbarModule::OnAutoStartLocalDeploymentChanged()
 	}
 }
 
-<<<<<<< HEAD
-
 void FSpatialGDKEditorToolbarModule::GenerateConfigFromCurrentMap()
 {
 	USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetMutableDefault<USpatialGDKEditorSettings>();
@@ -1258,36 +1256,6 @@ void FSpatialGDKEditorToolbarModule::GenerateConfigFromCurrentMap()
 
 	SpatialGDKEditorSettings->SetPrimaryLaunchConfigPath(LaunchConfig);
 }
-
-void FSpatialGDKEditorToolbarModule::OnAutoStartLocalReceptionistProxyServer()
-{
-	const USpatialGDKEditorSettings* Settings = GetDefault<USpatialGDKEditorSettings>();
-	bool bShouldAutoStartLocalReceptionistProxyServer = (Settings->bStartLocalServerWorker && Settings->SpatialOSNetFlowType == ESpatialOSNetFlow::CloudDeployment);
-
-	if (bShouldAutoStartLocalReceptionistProxyServer)
-	{
-		if (!UEditorEngine::TryStartLocalReceptionistProxyServer.IsBound())
-		{
-			// Bind the TryStartSpatialDeployment delegate if autostart is enabled.
-			UEditorEngine::TryStartLocalReceptionistProxyServer.BindLambda([this]
-			{
-				StartLocalReceptionistProxyServer();
-			});
-		}
-	}
-	else
-	{
-		if (UEditorEngine::TryStartLocalReceptionistProxyServer.IsBound())
-		{
-			// Unbind the TryStartLocalReceptionistProxyServer if autostart is disabled.
-			UEditorEngine::TryStartLocalReceptionistProxyServer.Unbind();
-
-			LocalReceptionistProxyServerManager->TryStopReceptionistProxyServer();
-		}
-	}
-}
-=======
->>>>>>> Move StartLocalReceptionist logic to the editor module
 
 FReply FSpatialGDKEditorToolbarModule::OnStartCloudDeployment()
 {

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -1083,7 +1083,7 @@ void FSpatialGDKEditorToolbarModule::OnPropertyChanged(UObject* ObjectBeingModif
 		{
 			OnAutoStartLocalDeploymentChanged();
 		}
-		else if(PropertyName == GET_MEMBER_NAME_CHECKED(USpatialGDKEditorSettings, bConnectServerToCloud))
+		else if (PropertyName == GET_MEMBER_NAME_CHECKED(USpatialGDKEditorSettings, bConnectServerToCloud))
 		{
 			LocalReceptionistProxyServerManager->TryStopReceptionistProxyServer();
 		}

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -868,17 +868,17 @@ void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment()
 
 void FSpatialGDKEditorToolbarModule::StartLocalReceptionistProxyServer()
 {
-	OnShowTaskStartNotification(TEXT("StartLocalReceptionistProxyServer"));
+	OnShowTaskStartNotification(TEXT("Start local receptionist proxy server"));
 
 	bool bSuccess = LocalReceptionistProxyServerManager->TryStartReceptionistProxyServer(GetDefault<USpatialGDKSettings>()->IsRunningInChina(), GetDefault<USpatialGDKEditorSettings>()->GetPrimaryDeploymentName());
 
 	if (bSuccess)
 	{
-		OnShowSuccessNotification(TEXT("Successfully Started Local Receptionist Proxy Server"));
+		OnShowSuccessNotification(TEXT("Successfully started local receptionist proxy server"));
 	}
 	else
 	{
-		OnShowFailedNotification(TEXT("Failed to Start Local Receptionist Proxy Server!"));
+		OnShowFailedNotification(TEXT("Failed to start local receptionist proxy server"));
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -89,6 +89,7 @@ void FSpatialGDKEditorToolbarModule::StartupModule()
 	bool bUseChinaServicesRegion = FPaths::FileExists(FSpatialGDKServicesModule::GetSpatialGDKPluginDirectory(SpatialGDKServicesConstants::UseChinaServicesRegionFilename));
 	GetMutableDefault<USpatialGDKSettings>()->SetServicesRegion(bUseChinaServicesRegion ? EServicesRegion::CN : EServicesRegion::Default);
 
+	// This is relying on the module loading phase - SpatialGDKServices module should be already loaded
 	FSpatialGDKServicesModule& GDKServices = FModuleManager::GetModuleChecked<FSpatialGDKServicesModule>("SpatialGDKServices");
 	LocalDeploymentManager = GDKServices.GetLocalDeploymentManager();
 	LocalDeploymentManager->PreInit(GetDefault<USpatialGDKSettings>()->IsRunningInChina());

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -118,7 +118,7 @@ void FSpatialGDKEditorToolbarModule::StartupModule()
 	});
 
 	LocalDeploymentManager->Init(GetOptionalExposedRuntimeIP());
-	LocalReceptionistProxyServerManager->Init();
+	LocalReceptionistProxyServerManager->Init(GetDefault<USpatialGDKEditorSettings>()->LocalReceptionistPort);
 
 	SpatialGDKEditorInstance = FModuleManager::GetModuleChecked<FSpatialGDKEditorModule>("SpatialGDKEditor").GetSpatialGDKEditorInstance();
 }
@@ -870,7 +870,7 @@ void FSpatialGDKEditorToolbarModule::StartLocalReceptionistProxyServer()
 {
 	OnShowTaskStartNotification(TEXT("Start local receptionist proxy server"));
 
-	bool bSuccess = LocalReceptionistProxyServerManager->TryStartReceptionistProxyServer(GetDefault<USpatialGDKSettings>()->IsRunningInChina(), GetDefault<USpatialGDKEditorSettings>()->GetPrimaryDeploymentName());
+	bool bSuccess = LocalReceptionistProxyServerManager->TryStartReceptionistProxyServer(GetDefault<USpatialGDKSettings>()->IsRunningInChina(), GetDefault<USpatialGDKEditorSettings>()->GetPrimaryDeploymentName(), GetDefault<USpatialGDKEditorSettings>()->ListeningAddress, GetDefault<USpatialGDKEditorSettings>()->LocalReceptionistPort);
 
 	if (bSuccess)
 	{

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -247,12 +247,6 @@ void FSpatialGDKEditorToolbarModule::MapActions(TSharedPtr<class FUICommandList>
 		FIsActionChecked::CreateRaw(this, &FSpatialGDKEditorToolbarModule::IsSimulatedPlayersEnabled));
 
 	InPluginCommands->MapAction(
-		FSpatialGDKEditorToolbarCommands::Get().EnableStartLocalServerWorker,
-		FExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::OnCheckedStartLocalServerWorker),
-		FCanExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::AreCloudDeploymentPropertiesEditable),
-		FIsActionChecked::CreateRaw(this, &FSpatialGDKEditorToolbarModule::IsStartLocalServerWorkerEnabled));
-
-	InPluginCommands->MapAction(
 		FSpatialGDKEditorToolbarCommands::Get().OpenCloudDeploymentWindowAction,
 		FExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::ShowCloudDeploymentDialog),
 		FCanExecuteAction());
@@ -454,7 +448,6 @@ void OnCloudDeploymentNameChanged(const FText& InText, ETextCommit::Type InCommi
 	SpatialGDKEditorSettings->SetPrimaryDeploymentName(InputDeploymentName);
 
 	UE_LOG(LogSpatialGDKEditorToolbar, Display, TEXT("Setting cloud deployment name to %s"), *InputDeploymentName);
-
 }
 
 TSharedRef<SWidget> FSpatialGDKEditorToolbarModule::CreateStartDropDownMenuContent()
@@ -496,7 +489,6 @@ TSharedRef<SWidget> FSpatialGDKEditorToolbarModule::CreateStartDropDownMenuConte
 		);
 		MenuBuilder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().EnableBuildClientWorker);
 		MenuBuilder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().EnableBuildSimulatedPlayer);
-		MenuBuilder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().EnableStartLocalServerWorker);
 	}
 	MenuBuilder.EndSection();
 
@@ -1241,7 +1233,6 @@ void FSpatialGDKEditorToolbarModule::OnAutoStartLocalDeploymentChanged()
 
 	if (bShouldAutoStartLocalDeployment)
 	{
-
 		if (!UEditorEngine::TryStartSpatialDeployment.IsBound())
 		{
 			// Bind the TryStartSpatialDeployment delegate if autostart is enabled.
@@ -1283,11 +1274,7 @@ void FSpatialGDKEditorToolbarModule::GenerateConfigFromCurrentMap()
 void FSpatialGDKEditorToolbarModule::OnAutoStartLocalReceptionistProxyServer()
 {
 	const USpatialGDKEditorSettings* Settings = GetDefault<USpatialGDKEditorSettings>();
-
 	bool bShouldAutoStartLocalReceptionistProxyServer = (Settings->bStartLocalServerWorker && Settings->SpatialOSNetFlowType == ESpatialOSNetFlow::CloudDeployment);
-
-	// TODO: UNR-1776 Workaround for SpatialNetDriver requiring editor settings.
-	//LocalDeploymentManager->SetAutoDeploy(bShouldAutoStartLocalDeployment);
 
 	if (bShouldAutoStartLocalReceptionistProxyServer)
 	{
@@ -1302,13 +1289,13 @@ void FSpatialGDKEditorToolbarModule::OnAutoStartLocalReceptionistProxyServer()
 	}
 	else
 	{
-	if (UEditorEngine::TryStartLocalReceptionistProxyServer.IsBound())
-	{
-		// Unbind the TryStartLocalReceptionistProxyServer if autostart is disabled.
-		UEditorEngine::TryStartLocalReceptionistProxyServer.Unbind();
+		if (UEditorEngine::TryStartLocalReceptionistProxyServer.IsBound())
+		{
+			// Unbind the TryStartLocalReceptionistProxyServer if autostart is disabled.
+			UEditorEngine::TryStartLocalReceptionistProxyServer.Unbind();
 
-		LocalReceptionistProxyServerManager->TryStopReceptionistProxyServer();
-	}
+			LocalReceptionistProxyServerManager->TryStopReceptionistProxyServer();
+		}
 	}
 }
 
@@ -1448,18 +1435,6 @@ bool FSpatialGDKEditorToolbarModule::IsSimulatedPlayersEnabled() const
 void FSpatialGDKEditorToolbarModule::OnCheckedSimulatedPlayers()
 {
 	GetMutableDefault<USpatialGDKEditorSettings>()->SetSimulatedPlayersEnabledState(!IsSimulatedPlayersEnabled());
-}
-
-bool FSpatialGDKEditorToolbarModule::IsStartLocalServerWorkerEnabled() const
-{
-	return GetDefault<USpatialGDKEditorSettings>()->IsStartLocalServerWorkerEnabled();
-}
-
-void FSpatialGDKEditorToolbarModule::OnCheckedStartLocalServerWorker()
-{
-	GetMutableDefault<USpatialGDKEditorSettings>()->SetStartLocalServerWorker(!IsStartLocalServerWorkerEnabled());
-
-	OnAutoStartLocalReceptionistProxyServer();
 }
 
 bool FSpatialGDKEditorToolbarModule::IsBuildClientWorkerEnabled() const

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -1082,7 +1082,7 @@ void FSpatialGDKEditorToolbarModule::OnPropertyChanged(UObject* ObjectBeingModif
 		{
 			OnAutoStartLocalDeploymentChanged();
 		}
-		else if(PropertyName == GET_MEMBER_NAME_CHECKED(USpatialGDKEditorSettings, bStartLocalServerWorker))
+		else if(PropertyName == GET_MEMBER_NAME_CHECKED(USpatialGDKEditorSettings, bConnectServerToCloud))
 		{
 			LocalReceptionistProxyServerManager->TryStopReceptionistProxyServer();
 		}

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarCommands.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarCommands.cpp
@@ -19,7 +19,6 @@ void FSpatialGDKEditorToolbarCommands::RegisterCommands()
 	UI_COMMAND(OpenLaunchConfigurationEditorAction, "Create Launch Configuration", "Opens an editor to create SpatialOS Launch configurations", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(EnableBuildClientWorker, "Build Client Worker", "If checked, an UnrealClient worker will be built and uploaded before launching the cloud deployment.", EUserInterfaceActionType::ToggleButton, FInputChord());
 	UI_COMMAND(EnableBuildSimulatedPlayer, "Build Simulated Player", "If checked, a SimulatedPlayer worker will be built and uploaded before launching the cloud deployment.", EUserInterfaceActionType::ToggleButton, FInputChord());
-	UI_COMMAND(EnableStartLocalServerWorker, "Start Local Server Worker", "If checked, an UnrealWorker will start and automatically connect to a cloud deployment", EUserInterfaceActionType::ToggleButton, FInputChord());
 	UI_COMMAND(StartSpatialService, "Start Service", "Starts the Spatial service daemon.", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(StopSpatialService, "Stop Service", "Stops the Spatial service daemon.", EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(EnableSpatialNetworking, "SpatialOS Networking", "If checked, the SpatialOS networking is used. Otherwise, native Unreal networking is used.", EUserInterfaceActionType::ToggleButton, FInputChord());

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -61,6 +61,7 @@ public:
 	bool IsSimulatedPlayersEnabled() const;
 	/** Delegate called when the user either clicks the simulated players checkbox */
 	void OnCheckedSimulatedPlayers();
+
 	bool IsBuildClientWorkerEnabled() const;
 	void OnCheckedBuildClientWorker();
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -72,7 +72,6 @@ private:
 	void AddMenuExtension(FMenuBuilder& Builder);
 
 	void VerifyAndStartDeployment();
-	void StartLocalReceptionistProxyServer();
 
 	void StartLocalSpatialDeploymentButtonClicked();
 	void StopSpatialDeploymentButtonClicked();

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -65,9 +65,6 @@ public:
 	bool IsBuildClientWorkerEnabled() const;
 	void OnCheckedBuildClientWorker();
 
-	bool IsStartLocalServerWorkerEnabled() const;
-	void OnCheckedStartLocalServerWorker();
-
 private:
 	void MapActions(TSharedPtr<FUICommandList> PluginCommands);
 	void SetupToolbar(TSharedPtr<FUICommandList> PluginCommands);
@@ -165,7 +162,7 @@ private:
 	// This should be called whenever the settings determining whether a local deployment should be automatically started have changed.
 	void OnAutoStartLocalDeploymentChanged();
 
-	//This should be called whenever the setting determining whether a local receptionist proxy server should be automatically started have changed. .
+	//This should be called whenever the setting determining whether a local receptionist proxy server should be automatically started has changed.
 	void OnAutoStartLocalReceptionistProxyServer();
 
 	TSharedPtr<FUICommandList> PluginCommands;

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -161,9 +161,6 @@ private:
 	// This should be called whenever the settings determining whether a local deployment should be automatically started have changed.
 	void OnAutoStartLocalDeploymentChanged();
 
-	//This should be called whenever the setting determining whether a local receptionist proxy server should be automatically started has changed.
-	void OnAutoStartLocalReceptionistProxyServer();
-
 	TSharedPtr<FUICommandList> PluginCommands;
 	FDelegateHandle OnPropertyChangedDelegateHandle;
 	bool bStopSpatialOnExit;

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -61,7 +61,6 @@ public:
 	bool IsSimulatedPlayersEnabled() const;
 	/** Delegate called when the user either clicks the simulated players checkbox */
 	void OnCheckedSimulatedPlayers();
-	
 	bool IsBuildClientWorkerEnabled() const;
 	void OnCheckedBuildClientWorker();
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbarCommands.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbarCommands.h
@@ -34,7 +34,6 @@ public:
 	TSharedPtr<FUICommandInfo> OpenLaunchConfigurationEditorAction;
 	TSharedPtr<FUICommandInfo> EnableBuildClientWorker;
 	TSharedPtr<FUICommandInfo> EnableBuildSimulatedPlayer;
-	TSharedPtr<FUICommandInfo> EnableStartLocalServerWorker;
 
 	TSharedPtr<FUICommandInfo> StartSpatialService;
 	TSharedPtr<FUICommandInfo> StopSpatialService;

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -211,13 +211,13 @@ bool FLocalDeploymentManager::CheckIfPortIsBound(int32 Port)
 
 bool FLocalDeploymentManager::KillProcessBlockingPort(int32 Port)
 {
-	FString Pid;
+	FString PID;
 	FString State;
 
-	bool bSuccess = SpatialCommandUtils::GetProcessInfoFromPort(Port, Pid, State);
+	bool bSuccess = SpatialCommandUtils::GetProcessInfoFromPort(Port, PID, State);
 	if (bSuccess)
 	{
-		bSuccess = SpatialCommandUtils::TryKillProcessWithPID(Pid);
+		bSuccess = SpatialCommandUtils::TryKillProcessWithPID(PID);
 	}
 
 	return bSuccess;

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -211,46 +211,13 @@ bool FLocalDeploymentManager::CheckIfPortIsBound(int32 Port)
 
 bool FLocalDeploymentManager::KillProcessBlockingPort(int32 Port)
 {
-	bool bSuccess = true;
+	FString Pid;
+	FString State;
 
-	const FString NetStatCmd = FString::Printf(TEXT("netstat"));
-
-	// -a display active tcp/udp connections, -o include PID for each connection, -n don't resolve hostnames
-	const FString NetStatArgs = TEXT("-n -o -a");
-	FString NetStatResult;
-	int32 ExitCode;
-	FString StdErr;
-	bSuccess = FPlatformProcess::ExecProcess(*NetStatCmd, *NetStatArgs, &ExitCode, &NetStatResult, &StdErr);
-
-	if (ExitCode == ExitCodeSuccess && bSuccess)
+	bool bSuccess = SpatialCommandUtils::GetProcessInfoFromPort(Port, Pid, State);
+	if (bSuccess)
 	{
-		// Get the line of the netstat output that contains the port we're looking for.
-		FRegexPattern PidMatcherPattern(FString::Printf(TEXT("(.*?:%i.)(.*)( [0-9]+)"), RequiredRuntimePort));
-		FRegexMatcher PidMatcher(PidMatcherPattern, NetStatResult);
-		if (PidMatcher.FindNext())
-		{
-			FString Pid = PidMatcher.GetCaptureGroup(3 /* Get the PID, which is the third group. */);
-
-			const FString TaskKillCmd = TEXT("taskkill");
-			const FString TaskKillArgs = FString::Printf(TEXT("/F /PID %s"), *Pid);
-			FString TaskKillResult;
-			bSuccess = FPlatformProcess::ExecProcess(*TaskKillCmd, *TaskKillArgs, &ExitCode, &TaskKillResult, &StdErr);
-			bSuccess = bSuccess && ExitCode == ExitCodeSuccess;
-			if (!bSuccess)
-			{
-				UE_LOG(LogSpatialDeploymentManager, Error, TEXT("Failed to kill process blocking required port. Error: %s"), *StdErr);
-			}
-		}
-		else
-		{
-			bSuccess = false;
-			UE_LOG(LogSpatialDeploymentManager, Error, TEXT("Failed to find PID of the process that is blocking the runtime port."));
-		}
-	}
-	else
-	{
-		bSuccess = false;
-		UE_LOG(LogSpatialDeploymentManager, Error, TEXT("Failed to find the process that is blocking required port. Error: %s"), *StdErr);
+		bSuccess = SpatialCommandUtils::TryKillProcessWithPID(Pid);
 	}
 
 	return bSuccess;

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -213,8 +213,9 @@ bool FLocalDeploymentManager::KillProcessBlockingPort(int32 Port)
 {
 	FString PID;
 	FString State;
+	FString ProcessName;
 
-	bool bSuccess = SpatialCommandUtils::GetProcessInfoFromPort(Port, PID, State);
+	bool bSuccess = SpatialCommandUtils::GetProcessInfoFromPort(Port, PID, State, ProcessName);
 	if (bSuccess)
 	{
 		bSuccess = SpatialCommandUtils::TryKillProcessWithPID(PID);

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
@@ -130,7 +130,7 @@ bool FLocalReceptionistProxyServerManager::LocalReceptionistProxyServerPreRunChe
 			return false;
 		}
 
-		UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("%s"), *OutLogMessage.ToString());
+		UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("%s :'%s'"), *LOCTEXT("KilledBlockingPortProcess", "Succesfully killed").ToString(), *OutLogMessage.ToString());
 		return true;
 	}
 

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
@@ -172,7 +172,6 @@ bool FLocalReceptionistProxyServerManager::TryStartReceptionistProxyServer(bool 
 {
 	FString StartResult;
 	int32 ExitCode;
-	bool bSuccess = false;
 
 	// Do not restart the same proxy if you have already a proxy running for the same cloud deployment
 	if (bProxyIsRunning && ProxyServerProcHandle.IsValid() && RunningCloudDeploymentName == CloudDeploymentName && RunningProxyListeningAddress == ListeningAddress && RunningProxyReceptionistPort == ReceptionistPort)
@@ -195,12 +194,10 @@ bool FLocalReceptionistProxyServerManager::TryStartReceptionistProxyServer(bool 
 		UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("%s"),*LOCTEXT("SucceededToStopPreviousServerProxy", "Stopped previous proxy server!").ToString());
 	}
 
-	bool bProxyStartSuccess = false;
-	ProxyServerProcHandle = SpatialCommandUtils::StartLocalReceptionistProxyServer(bIsRunningInChina, CloudDeploymentName, ListeningAddress, ReceptionistPort, StartResult, ExitCode, bProxyStartSuccess);
+	ProxyServerProcHandle = SpatialCommandUtils::StartLocalReceptionistProxyServer(bIsRunningInChina, CloudDeploymentName, ListeningAddress, ReceptionistPort, StartResult, ExitCode);
 
 	// Check if process run successfully
-	bSuccess = ProxyServerProcHandle.IsValid();
-	if (!bSuccess || !bProxyStartSuccess)
+	if (!ProxyServerProcHandle.IsValid())
 	{
 		const FText WarningMessage = FText::Format(LOCTEXT("FailedToStartProxyServer", "Starting the local receptionist proxy server failed. Error Code: {0}, Error Message: {1}"), ExitCode, FText::FromString(StartResult));
 		UE_LOG(LogLocalReceptionistProxyServerManager, Warning, TEXT("%s"), *WarningMessage.ToString());

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
@@ -17,10 +17,10 @@ FLocalReceptionistProxyServerManager::FLocalReceptionistProxyServerManager()
 {
 }
 
-bool FLocalReceptionistProxyServerManager::GetProcessName()
+FString FLocalReceptionistProxyServerManager::GetProcessName()
 {
 	bool bSuccess = false;
-
+	FString ProcessName = "";
 	const FString TaskListCmd = FString::Printf(TEXT("tasklist"));
 
 	//get the task list for 
@@ -35,15 +35,15 @@ bool FLocalReceptionistProxyServerManager::GetProcessName()
 		FRegexMatcher ProcessNameMatcher(ProcessNamePattern, TaskListResult);
 		if (ProcessNameMatcher.FindNext())
 		{
-			BlockingProcess.Name = ProcessNameMatcher.GetCaptureGroup(1 /* Get the Name of the process, which is the first group. */);
+			ProcessName = ProcessNameMatcher.GetCaptureGroup(1 /* Get the Name of the process, which is the first group. */);
 
-			return true;
+			return ProcessName;
 		}
 	}
 
 	UE_LOG(LogLocalReceptionistProxyServerManager, Warning, TEXT("Failed to get the name of process that is blocking required port."));
 	
-	return false;
+	return ProcessName;
 }
 
 bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound()
@@ -71,10 +71,10 @@ bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound()
 			{
 				
 				BlockingProcess.Pid = PidMatcher.GetCaptureGroup(3 /* Get the PID, which is the third group. */);
-				if (GetProcessName())
-				{
-					UE_LOG(LogLocalReceptionistProxyServerManager, Warning, TEXT("Process %s with PID:%s is blocking required port."), *BlockingProcess.Name, *BlockingProcess.Pid);
-				}
+				BlockingProcess.Name = GetProcessName();
+				
+				UE_LOG(LogLocalReceptionistProxyServerManager, Warning, TEXT("Process %s with PID:%s is blocking required port."), *BlockingProcess.Name, *BlockingProcess.Pid);
+				
 				return true;
 			}
 		}

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
@@ -241,7 +241,7 @@ bool FLocalReceptionistProxyServerManager::TryStartReceptionistProxyServer(bool 
 	// Check if process run successfully
 	if (!ProxyServerProcHandle.IsValid())
 	{
-		UE_LOG(LogLocalReceptionistProxyServerManager, Warning, TEXT("Starting the local receptionist proxy server failed. Error Code: %s, Error Message: %s"), ExitCode, StartResult);
+		UE_LOG(LogLocalReceptionistProxyServerManager, Warning, TEXT("Starting the local receptionist proxy server failed. Error Code: %s, Error Message: %s"), ExitCode, *StartResult);
 		return false;
 	}
 

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
@@ -5,19 +5,21 @@
 #include "Internationalization/Regex.h"
 #include "Sockets.h"
 #include "SocketSubsystem.h"
-#include "SpatialCommandUtils.h"
 #include "UObject/CoreNet.h"
+
+#include "SpatialCommandUtils.h"
 
 DEFINE_LOG_CATEGORY(LogLocalReceptionistProxyServerManager);
 
 #define LOCTEXT_NAMESPACE "FLocalReceptionistProxyServerManager"
+
 namespace
 {
 	static const int32 ExitCodeSuccess = 0;
 }
 
 FLocalReceptionistProxyServerManager::FLocalReceptionistProxyServerManager()
-: RunningCloudDeploymentName("")
+: RunningCloudDeploymentName(TEXT(""))
 {
 }
 
@@ -149,7 +151,6 @@ void FLocalReceptionistProxyServerManager::Init(int32 Port)
 	{
 		LocalReceptionistProxyServerPreRunChecks(Port);
 	}
-	return;
 }
 
 

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
@@ -21,7 +21,7 @@ FString FLocalReceptionistProxyServerManager::GetProcessName()
 {
 	bool bSuccess = false;
 	FString ProcessName = "";
-	const FString TaskListCmd = FString::Printf(TEXT("tasklist"));
+	const FString TaskListCmd = TEXT("tasklist");
 
 	// get the task list line for the process with Pid 
 	const FString TaskListArgs = FString::Printf(TEXT(" /fi \"PID eq %s\" /nh /fo:csv"), *BlockingProcess.Pid);
@@ -41,14 +41,14 @@ FString FLocalReceptionistProxyServerManager::GetProcessName()
 		}
 	}
 
-	UE_LOG(LogLocalReceptionistProxyServerManager, Warning, TEXT("Failed to get the name of the process that is blocking the required port."));
+	UE_LOG(LogLocalReceptionistProxyServerManager, Warning, TEXT("%s"), *LOCTEXT("FailedToGetBlockingProcessName", "Failed to get the name of the process that is blocking the required port.").ToString());
 	
 	return ProcessName;
 }
 
 bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound(int32 Port)
 {
-	const FString NetStatCmd = FString::Printf(TEXT("netstat"));
+	const FString NetStatCmd = TEXT("netstat");
 
 	// -a display active tcp/udp connections, -o include PID for each connection, -n don't resolve hostnames
 	const FString NetStatArgs = TEXT("-n -o -a");
@@ -70,7 +70,7 @@ bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound(int32 Port)
 				
 				BlockingProcess.Pid = PidMatcher.GetCaptureGroup(3 /* Get the PID, which is the third group. */);
 				BlockingProcess.Name = GetProcessName();
-				
+				const FString WarningMsg = LOCTEXT("FailedToGetBlockingProcessName", "Failed to get the name of the process that is blocking the required port.").ToString();
 				UE_LOG(LogLocalReceptionistProxyServerManager, Warning, TEXT("Process %s with PID:%s is blocking required port."), *BlockingProcess.Name, *BlockingProcess.Pid);
 				
 				return true;
@@ -82,7 +82,8 @@ bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound(int32 Port)
 		UE_LOG(LogLocalReceptionistProxyServerManager, Error, TEXT("Failed to check if any process is blocking required port. Error: %s"), *StdErr);
 	}
 
-	UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("No Process is blocking the runtime port."));
+	
+	UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("%s"), *LOCTEXT("NoProcessBlockingProxyPort", "No Process is blocking the required port.").ToString());
 
 	return false;
 }
@@ -102,7 +103,8 @@ bool FLocalReceptionistProxyServerManager::TryKillBlockingPortProcess()
 	bSuccess = bSuccess && ExitCode == ExitCodeSuccess;
 	if (!bSuccess)
 	{
-		UE_LOG(LogLocalReceptionistProxyServerManager, Error, TEXT("Failed to kill process blocking required port. Error: %s"), *StdErr);
+		const FText ErrorMessage = FText::Format(LOCTEXT("FailedToKillBlockingProcess", "Failed to kill process blocking required port. Error: '{0}'"), FText::FromString(StdErr));
+		UE_LOG(LogLocalReceptionistProxyServerManager, Error, TEXT("%s"),*ErrorMessage.ToString());
 	}
 
 	return bSuccess;
@@ -160,7 +162,8 @@ bool FLocalReceptionistProxyServerManager::TryStartReceptionistProxyServer(bool 
 	//Do not restart the same proxy if you have already a proxy running for the same cloud deployment
 	if (bProxyIsRunning && ProxyServerProcHandle.IsValid() && RunningCloudDeploymentName == CloudDeploymentName)
 	{
-		UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("The local receptionist proxy server is already running!"));
+		UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("%s"), *LOCTEXT("ServerProxyAlreadyRunning", "The local receptionist proxy server is already running!").ToString());
+
 		return true;
 	}
 
@@ -169,11 +172,12 @@ bool FLocalReceptionistProxyServerManager::TryStartReceptionistProxyServer(bool 
 	{
 		if(!TryStopReceptionistProxyServer())
 		{
-			UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("Failed to stop previous proxy server!"))
+			UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("%s"),*LOCTEXT("FailedToStopPreviousServerProxy", "Failed to stop previous proxy server!").ToString());
+		
 			return false;
 		}
 
-		UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("Stopped previous proxy server!"));
+		UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("%s"),*LOCTEXT("SucceededToStopPreviousServerProxy", "Stopped previous proxy server!").ToString());
 	}
 
 	bool bProxyStartSuccess = false;
@@ -190,7 +194,7 @@ bool FLocalReceptionistProxyServerManager::TryStartReceptionistProxyServer(bool 
 	RunningCloudDeploymentName = CloudDeploymentName;
 	bProxyIsRunning = true;
 
-	UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("Local receptionist proxy server started sucessfully!"));
+	UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("%s"),*LOCTEXT("SuccesfullyStartedServerProxy", "Local receptionist proxy server started sucessfully!").ToString());
 
 	return true;
 }

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
@@ -148,12 +148,12 @@ TSharedPtr<FJsonObject> FLocalReceptionistProxyServerManager::ParsePIDFile()
 		}
 		else
 		{
-			UE_LOG(LogLocalReceptionistProxyServerManager, Error, TEXT("Json parsing of proxyInfo.json failed. Can't get proxy's PID."));
+			UE_LOG(LogLocalReceptionistProxyServerManager, Error, TEXT("Json parsing of %s failed. Can't get proxy's PID."), *ProxyInfoFilePath);
 		}
 	}
 	else
 	{
-		UE_LOG(LogLocalReceptionistProxyServerManager, Error, TEXT("Loading proxyInfo.json failed. Can't get proxy's PID."));
+		UE_LOG(LogLocalReceptionistProxyServerManager, Error, TEXT("Loading %s failed. Can't get proxy's PID."), *ProxyInfoFilePath);
 	}
 
 	return nullptr;
@@ -176,7 +176,7 @@ void FLocalReceptionistProxyServerManager::SetPIDInJson(const FString& PID)
 		return;
 	}
 
-	JsonParsedProxyInfoFile->SetStringField("PID", PID);
+	JsonParsedProxyInfoFile->SetStringField("pid", PID);
 
 	TSharedRef<TJsonWriter<>> JsonWriter = TJsonWriterFactory<>::Create(&ProxyInfoFileResult);
 	if (!FJsonSerializer::Serialize(JsonParsedProxyInfoFile.ToSharedRef(), JsonWriter))
@@ -184,7 +184,7 @@ void FLocalReceptionistProxyServerManager::SetPIDInJson(const FString& PID)
 		UE_LOG(LogLocalReceptionistProxyServerManager, Error, TEXT("Failed to write PID to parsed proxy info file. Unable to serialize content to json file."));
 		return;
 	}
-	if (!FFileHelper::SaveStringToFile(ProxyInfoFileResult, *FPaths::Combine(SpatialGDKServicesConstants::ProxyFileDirectory, SpatialGDKServicesConstants::ProxyInfoFilename)))
+	if (!FFileHelper::SaveStringToFile(ProxyInfoFileResult, *ProxyInfoFilePath))
 	{
 		UE_LOG(LogLocalReceptionistProxyServerManager, Error, TEXT("Failed to write file content to %s"), *SpatialGDKServicesConstants::ProxyInfoFilename);
 	}
@@ -200,10 +200,8 @@ FString FLocalReceptionistProxyServerManager::GetPreviousReceptionistProxyPID()
 		{
 			return PID;
 		}
-		else
-		{
-			UE_LOG(LogLocalReceptionistProxyServerManager, Error, TEXT("'pid' does not exist in proxyInfo.json. Can't read proxy's PID."));
-		}
+
+		UE_LOG(LogLocalReceptionistProxyServerManager, Error, TEXT("'pid' does not exist in %s. Can't read proxy's PID."), *ProxyInfoFilePath);
 	}
 
 	PID.Empty();
@@ -242,6 +240,7 @@ bool FLocalReceptionistProxyServerManager::TryStartReceptionistProxyServer(bool 
 	if (!ProxyServerProcHandle.IsValid())
 	{
 		UE_LOG(LogLocalReceptionistProxyServerManager, Warning, TEXT("Starting the local receptionist proxy server failed. Error Code: %s, Error Message: %s"), ExitCode, *StartResult);
+		ProxyServerProcHandle.Reset();
 		return false;
 	}
 

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
@@ -108,7 +108,7 @@ bool FLocalReceptionistProxyServerManager::TryKillBlockingPortProcess()
 	return bSuccess;
 }
 
-bool FLocalReceptionistProxyServerManager::LocalReceptionistProxyServerPreRunChecks(const int32& ReceptionistPort)
+bool FLocalReceptionistProxyServerManager::LocalReceptionistProxyServerPreRunChecks(int32 ReceptionistPort)
 {
 	//Check if any process is blocking the receptionist port
 	if(CheckIfPortIsBound(ReceptionistPort))
@@ -127,7 +127,7 @@ bool FLocalReceptionistProxyServerManager::LocalReceptionistProxyServerPreRunChe
 	return true;
 }
 
-void FLocalReceptionistProxyServerManager::Init(const int32& Port)
+void FLocalReceptionistProxyServerManager::Init(int32 Port)
 {
 	if (!IsRunningCommandlet())
 	{
@@ -151,7 +151,7 @@ bool FLocalReceptionistProxyServerManager::TryStopReceptionistProxyServer()
 
 
 
-bool FLocalReceptionistProxyServerManager::TryStartReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, const FString& ListeningAddress, const int32& ReceptionistPort)
+bool FLocalReceptionistProxyServerManager::TryStartReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, const FString& ListeningAddress, const int32 ReceptionistPort)
 {
 	FString StartResult;
 	int32 ExitCode;

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
@@ -108,7 +108,7 @@ bool FLocalReceptionistProxyServerManager::TryKillBlockingPortProcess()
 	return bSuccess;
 }
 
-bool FLocalReceptionistProxyServerManager::LocalReceptionistProxyServerPreRunChecks()
+bool FLocalReceptionistProxyServerManager::LocalReceptionistProxyServerPreRunChecks(const int32& ReceptionistPort)
 {
 	//Check if any process is blocking the receptionist port
 	if(CheckIfPortIsBound(ReceptionistPort))
@@ -127,11 +127,11 @@ bool FLocalReceptionistProxyServerManager::LocalReceptionistProxyServerPreRunChe
 	return true;
 }
 
-void FLocalReceptionistProxyServerManager::Init()
+void FLocalReceptionistProxyServerManager::Init(const int32& Port)
 {
 	if (!IsRunningCommandlet())
 	{
-		LocalReceptionistProxyServerPreRunChecks();
+		LocalReceptionistProxyServerPreRunChecks(Port);
 	}
 	return;
 }
@@ -151,7 +151,7 @@ bool FLocalReceptionistProxyServerManager::TryStopReceptionistProxyServer()
 
 
 
-bool FLocalReceptionistProxyServerManager::TryStartReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName)
+bool FLocalReceptionistProxyServerManager::TryStartReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, const FString& ListeningAddress, const int32& ReceptionistPort)
 {
 	FString StartResult;
 	int32 ExitCode;

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
@@ -126,7 +126,7 @@ bool FLocalReceptionistProxyServerManager::LocalReceptionistProxyServerPreRunChe
 	FString PID;
 
 	//Check if any process is blocking the receptionist port
-	if(CheckIfPortIsBound(ReceptionistPort, PID, OutLogMessage))
+	if (CheckIfPortIsBound(ReceptionistPort, PID, OutLogMessage))
 	{
 		//Try killing the process that blocks the receptionist port 
 		bool bProcessKilled = TryKillBlockingPortProcess(PID);
@@ -185,7 +185,7 @@ bool FLocalReceptionistProxyServerManager::TryStartReceptionistProxyServer(bool 
 	//Stop receptionist proxy server if it is for a different cloud deployment, port or listening address
 	if (bProxyIsRunning && ProxyServerProcHandle.IsValid())
 	{
-		if(!TryStopReceptionistProxyServer())
+		if (!TryStopReceptionistProxyServer())
 		{
 			UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("%s"),*LOCTEXT("FailedToStopPreviousServerProxy", "Failed to stop previous proxy server!").ToString());
 		

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
@@ -170,14 +170,14 @@ bool FLocalReceptionistProxyServerManager::TryStartReceptionistProxyServer(bool 
 	bool bSuccess = false;
 
 	//Do not restart the same proxy if you have already a proxy running for the same cloud deployment
-	if (bProxyIsRunning && ProxyServerProcHandle.IsValid() && RunningCloudDeploymentName == CloudDeploymentName)
+	if (bProxyIsRunning && ProxyServerProcHandle.IsValid() && RunningCloudDeploymentName == CloudDeploymentName && RunningProxyListeningAddress ==ListeningAddress && RunningProxyReceptionistPort==ReceptionistPort)
 	{
 		UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("%s"), *LOCTEXT("ServerProxyAlreadyRunning", "The local receptionist proxy server is already running!").ToString());
 
 		return true;
 	}
 
-	//Stop receptionist proxy server if it is for a different cloud deployment
+	//Stop receptionist proxy server if it is for a different cloud deployment, port or listening address
 	if (bProxyIsRunning && ProxyServerProcHandle.IsValid())
 	{
 		if(!TryStopReceptionistProxyServer())
@@ -193,7 +193,7 @@ bool FLocalReceptionistProxyServerManager::TryStartReceptionistProxyServer(bool 
 	bool bProxyStartSuccess = false;
 	ProxyServerProcHandle = SpatialCommandUtils::StartLocalReceptionistProxyServer(bIsRunningInChina, CloudDeploymentName, ListeningAddress, ReceptionistPort, StartResult, ExitCode, bProxyStartSuccess);
 
-	//check if process run successfully
+	//Check if process run successfully
 	bSuccess = ProxyServerProcHandle.IsValid();
 	if (!bSuccess || !bProxyStartSuccess)
 	{
@@ -203,6 +203,8 @@ bool FLocalReceptionistProxyServerManager::TryStartReceptionistProxyServer(bool 
 	}
 
 	RunningCloudDeploymentName = CloudDeploymentName;
+	RunningProxyListeningAddress = ListeningAddress;
+	RunningProxyReceptionistPort = ReceptionistPort;
 	bProxyIsRunning = true;
 
 	UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("%s"),*LOCTEXT("SuccesfullyStartedServerProxy", "Local receptionist proxy server started sucessfully!").ToString());

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
@@ -80,7 +80,7 @@ bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound(int32 Port, FStrin
 					return true;
 				}
 
-				LogMsg= FText::Format(LOCTEXT("ProcessBlockingPort", "Unknown process with PID:{1}."), FText::FromString(PID));
+				LogMsg = FText::Format(LOCTEXT("ProcessBlockingPort", "Unknown process with PID:{1}."), FText::FromString(PID));
 			
 				return true;
 			}

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
@@ -148,10 +148,6 @@ TSharedPtr<FJsonObject> FLocalReceptionistProxyServerManager::ParsePIDFile()
 			UE_LOG(LogLocalReceptionistProxyServerManager, Error, TEXT("Json parsing of %s failed. Can't get proxy's PID."), *SpatialGDKServicesConstants::ProxyInfoFilePath);
 		}
 	}
-	else
-	{
-		UE_LOG(LogLocalReceptionistProxyServerManager, Error, TEXT("Loading %s failed. Can't get proxy's PID."), *SpatialGDKServicesConstants::ProxyInfoFilePath);
-	}
 
 	return nullptr;
 }

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
@@ -72,11 +72,11 @@ bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound(int32 Port, FStrin
 				PID = PidMatcher.GetCaptureGroup(3 /* Get the PID, which is the third group. */);
 				if (GetProcessName(PID, ProcessName))
 				{
-					LogMsg = FText::Format(LOCTEXT("ProcessBlockingPort", "Process {0} with PID : {1} is blocking required port."), FText::FromString(ProcessName), FText::FromString(PID));
+					LogMsg = FText::Format(LOCTEXT("ProcessBlockingPort", "{0} process with PID:{1}."), FText::FromString(ProcessName), FText::FromString(PID));
 					return true;
 				}
 
-				LogMsg= FText::Format(LOCTEXT("ProcessBlockingPort", "Unknown Process with PID : {1} is blocking required port."), FText::FromString(PID));
+				LogMsg= FText::Format(LOCTEXT("ProcessBlockingPort", "Unknown process with PID:{1}."), FText::FromString(PID));
 			
 				return true;
 			}
@@ -84,7 +84,7 @@ bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound(int32 Port, FStrin
 	}
 	else
 	{
-		LogMsg = FText::Format(LOCTEXT("ProcessBlockingPort", "Failed to check if any process is blocking required port. Error: {0}"), FText::FromString(StdErr));
+		LogMsg = FText::Format(LOCTEXT("ProcessBlockingPort", "Failed to check if any process is blocking required port. Error:{0}"), FText::FromString(StdErr));
 	}
 
 	LogMsg = LOCTEXT("NoProcessBlockingProxyPort", "No Process is blocking the required port.");
@@ -126,15 +126,15 @@ bool FLocalReceptionistProxyServerManager::LocalReceptionistProxyServerPreRunChe
 		bool bProcessKilled = TryKillBlockingPortProcess(PID);
 		if (!bProcessKilled)
 		{
-			UE_LOG(LogLocalReceptionistProxyServerManager, Warning, TEXT("%s : '%s'"), *LOCTEXT("FailedToKillBlockingPortProcess", "Failed to kill the process that is blocking the port.").ToString(),*OutLogMessage.ToString());
+			UE_LOG(LogLocalReceptionistProxyServerManager, Warning, TEXT("%s %s!"), *LOCTEXT("FailedToKillBlockingPortProcess", "Failed to kill the process that is blocking the port.").ToString(),*OutLogMessage.ToString());
 			return false;
 		}
 
-		UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("%s :'%s'"), *LOCTEXT("KilledBlockingPortProcess", "Succesfully killed").ToString(), *OutLogMessage.ToString());
+		UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("%s %s."), *LOCTEXT("KilledBlockingPortProcess", "Succesfully killed").ToString(), *OutLogMessage.ToString());
 		return true;
 	}
 
-	OutLogMessage = LOCTEXT("NoProcessBlockingPort", "The required Port is not blocked!");
+	OutLogMessage = LOCTEXT("NoProcessBlockingPort", "The required port is not blocked!");
 	UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("%s"), *OutLogMessage.ToString());
 	return true;
 }

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
@@ -31,7 +31,7 @@ bool FLocalReceptionistProxyServerManager::KillProcessBlockingPort()
 	if (ExitCode == ExitCodeSuccess && bSuccess)
 	{
 		// Get the line of the netstat output that contains the port we're looking for.
-		FRegexPattern PidMatcherPattern(FString::Printf(TEXT("(.*?:%i.)(.*)( [0-9]+)"), RequiredRuntimePort));
+		FRegexPattern PidMatcherPattern(FString::Printf(TEXT("(.*?:%i.)(.*)( [0-9]+)"), ReceptionistPort));
 		FRegexMatcher PidMatcher(PidMatcherPattern, NetStatResult);
 		if (PidMatcher.FindNext())
 		{

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
@@ -11,6 +11,10 @@
 DEFINE_LOG_CATEGORY(LogLocalReceptionistProxyServerManager);
 
 #define LOCTEXT_NAMESPACE "FLocalReceptionistProxyServerManager"
+namespace
+{
+	static const int32 ExitCodeSuccess = 0;
+}
 
 FLocalReceptionistProxyServerManager::FLocalReceptionistProxyServerManager()
 : RunningCloudDeploymentName("")
@@ -20,7 +24,7 @@ FLocalReceptionistProxyServerManager::FLocalReceptionistProxyServerManager()
 bool FLocalReceptionistProxyServerManager::GetProcessName(const FString& PID, FString& ProcessName)
 {
 	bool bSuccess = false;
-	ProcessName = "";
+	ProcessName = TEXT("");
 	const FString TaskListCmd = TEXT("tasklist");
 
 	// get the task list line for the process with Pid 
@@ -170,7 +174,7 @@ bool FLocalReceptionistProxyServerManager::TryStartReceptionistProxyServer(bool 
 	bool bSuccess = false;
 
 	//Do not restart the same proxy if you have already a proxy running for the same cloud deployment
-	if (bProxyIsRunning && ProxyServerProcHandle.IsValid() && RunningCloudDeploymentName == CloudDeploymentName && RunningProxyListeningAddress ==ListeningAddress && RunningProxyReceptionistPort==ReceptionistPort)
+	if (bProxyIsRunning && ProxyServerProcHandle.IsValid() && RunningCloudDeploymentName == CloudDeploymentName && RunningProxyListeningAddress == ListeningAddress && RunningProxyReceptionistPort == ReceptionistPort)
 	{
 		UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("%s"), *LOCTEXT("ServerProxyAlreadyRunning", "The local receptionist proxy server is already running!").ToString());
 

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
@@ -17,14 +17,14 @@ FLocalReceptionistProxyServerManager::FLocalReceptionistProxyServerManager()
 {
 }
 
-FString FLocalReceptionistProxyServerManager::GetProcessName()
+bool FLocalReceptionistProxyServerManager::GetProcessName(const FString& PID, FString& ProcessName)
 {
 	bool bSuccess = false;
-	FString ProcessName = "";
+	ProcessName = "";
 	const FString TaskListCmd = TEXT("tasklist");
 
 	// get the task list line for the process with Pid 
-	const FString TaskListArgs = FString::Printf(TEXT(" /fi \"PID eq %s\" /nh /fo:csv"), *BlockingProcess.Pid);
+	const FString TaskListArgs = FString::Printf(TEXT(" /fi \"PID eq %s\" /nh /fo:csv"), *PID);
 	FString TaskListResult;
 	int32 ExitCode;
 	FString StdErr;
@@ -37,16 +37,16 @@ FString FLocalReceptionistProxyServerManager::GetProcessName()
 		{
 			ProcessName = ProcessNameMatcher.GetCaptureGroup(1 /* Get the Name of the process, which is the first group. */);
 
-			return ProcessName;
+			return true;
 		}
 	}
 
 	UE_LOG(LogLocalReceptionistProxyServerManager, Warning, TEXT("%s"), *LOCTEXT("FailedToGetBlockingProcessName", "Failed to get the name of the process that is blocking the required port.").ToString());
 	
-	return ProcessName;
+	return false;
 }
 
-bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound(int32 Port)
+bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound(int32 Port, FString& PID, FText& LogMsg)
 {
 	const FString NetStatCmd = TEXT("netstat");
 
@@ -55,6 +55,7 @@ bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound(int32 Port)
 	FString NetStatResult;
 	int32 ExitCode;
 	FString StdErr;
+	FString ProcessName;
 	bool bSuccess = FPlatformProcess::ExecProcess(*NetStatCmd, *NetStatArgs, &ExitCode, &NetStatResult, &StdErr);
 
 	if (ExitCode == ExitCodeSuccess && bSuccess)
@@ -68,31 +69,31 @@ bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound(int32 Port)
 			if (State.Contains("LISTENING"))
 			{
 				
-				BlockingProcess.Pid = PidMatcher.GetCaptureGroup(3 /* Get the PID, which is the third group. */);
-				BlockingProcess.Name = GetProcessName();
+				PID = PidMatcher.GetCaptureGroup(3 /* Get the PID, which is the third group. */);
+				if (GetProcessName(PID, ProcessName))
+				{
+					LogMsg = FText::Format(LOCTEXT("ProcessBlockingPort", "Process {0} with PID : {1} is blocking required port."), FText::FromString(ProcessName), FText::FromString(PID));
+					return true;
+				}
 
-				const FText WarningMsg = FText::Format(LOCTEXT("ProcessBlockingPort", "Process {0} with PID : {1} is blocking required port."), FText::FromString(BlockingProcess.Name), FText::FromString(BlockingProcess.Pid));
-				UE_LOG(LogLocalReceptionistProxyServerManager, Warning, TEXT("%s"), *WarningMsg.ToString());
-				
+				LogMsg= FText::Format(LOCTEXT("ProcessBlockingPort", "Unknown Process with PID : {1} is blocking required port."), FText::FromString(PID));
+			
 				return true;
 			}
 		}
 	}
 	else
 	{
-		const FText ErrorMsg = FText::Format(LOCTEXT("ProcessBlockingPort", "Failed to check if any process is blocking required port. Error: {0}"), FText::FromString(StdErr));
-		UE_LOG(LogLocalReceptionistProxyServerManager, Error, TEXT("%s"), *ErrorMsg.ToString());
-	
+		LogMsg = FText::Format(LOCTEXT("ProcessBlockingPort", "Failed to check if any process is blocking required port. Error: {0}"), FText::FromString(StdErr));
 	}
 
-	
-	UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("%s"), *LOCTEXT("NoProcessBlockingProxyPort", "No Process is blocking the required port.").ToString());
+	LogMsg = LOCTEXT("NoProcessBlockingProxyPort", "No Process is blocking the required port.");
 
 	return false;
 }
 
 
-bool FLocalReceptionistProxyServerManager::TryKillBlockingPortProcess()
+bool FLocalReceptionistProxyServerManager::TryKillBlockingPortProcess(const FString& PID)
 {
 	bool bSuccess = false;
 
@@ -100,7 +101,7 @@ bool FLocalReceptionistProxyServerManager::TryKillBlockingPortProcess()
 	FString StdErr;
 
 	const FString TaskKillCmd = TEXT("taskkill");
-	const FString TaskKillArgs = FString::Printf(TEXT("/F /PID %s"), *BlockingProcess.Pid);
+	const FString TaskKillArgs = FString::Printf(TEXT("/F /PID %s"), *PID);
 	FString TaskKillResult;
 	bSuccess = FPlatformProcess::ExecProcess(*TaskKillCmd, *TaskKillArgs, &ExitCode, &TaskKillResult, &StdErr);
 	bSuccess = bSuccess && ExitCode == ExitCodeSuccess;
@@ -115,23 +116,26 @@ bool FLocalReceptionistProxyServerManager::TryKillBlockingPortProcess()
 
 bool FLocalReceptionistProxyServerManager::LocalReceptionistProxyServerPreRunChecks(int32 ReceptionistPort)
 {
-	FText LogMessage;
+	FText OutLogMessage;
+	FString PID;
+
 	//Check if any process is blocking the receptionist port
-	if(CheckIfPortIsBound(ReceptionistPort))
+	if(CheckIfPortIsBound(ReceptionistPort, PID, OutLogMessage))
 	{
 		//Try killing the process that blocks the receptionist port 
-		bool bProcessKilled = TryKillBlockingPortProcess();
+		bool bProcessKilled = TryKillBlockingPortProcess(PID);
 		if (!bProcessKilled)
 		{
-			LogMessage = FText::Format(LOCTEXT("FailedToKillBlockingPortProcess", "Failed to kill the process '{0}' that is blocking the port."), FText::FromString(BlockingProcess.Name));
-			UE_LOG(LogLocalReceptionistProxyServerManager, Warning, TEXT("%s"), *LogMessage.ToString());
+			UE_LOG(LogLocalReceptionistProxyServerManager, Warning, TEXT("%s : '%s'"), *LOCTEXT("FailedToKillBlockingPortProcess", "Failed to kill the process that is blocking the port.").ToString(),*OutLogMessage.ToString());
 			return false;
 		}
 
-		LogMessage = FText::Format(LOCTEXT("SucceededToKillBlockingPortProcess", "Succesfully killed {0} process that was blocking {1} port."), FText::FromString(BlockingProcess.Name), ReceptionistPort);
-		UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("%s"), *LogMessage.ToString());
+		UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("%s"), *OutLogMessage.ToString());
+		return true;
 	}
 
+	OutLogMessage = LOCTEXT("NoProcessBlockingPort", "The required Port is not blocked!");
+	UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("%s"), *OutLogMessage.ToString());
 	return true;
 }
 

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
@@ -152,7 +152,7 @@ TSharedPtr<FJsonObject> FLocalReceptionistProxyServerManager::ParsePIDFile()
 	return nullptr;
 }
 
-void FLocalReceptionistProxyServerManager::SetPIDInJson(const FString& PID)
+void FLocalReceptionistProxyServerManager::SavePIDInJson(const FString& PID)
 {
 	FString ProxyInfoFileResult;
 	TSharedPtr<FJsonObject> JsonParsedProxyInfoFile = MakeShareable(new FJsonObject());
@@ -237,7 +237,7 @@ bool FLocalReceptionistProxyServerManager::TryStartReceptionistProxyServer(bool 
 	// Save the server receptionist proxy process's PID in a Json file
 	if (SpatialCommandUtils::GetProcessInfoFromPort(ReceptionistPort, PID, State))
 	{
-		SetPIDInJson(PID);
+		SavePIDInJson(PID);
 	}
 
 	RunningCloudDeploymentName = CloudDeploymentName;

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
@@ -46,7 +46,7 @@ FString FLocalReceptionistProxyServerManager::GetProcessName()
 	return ProcessName;
 }
 
-bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound()
+bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound(int32 Port)
 {
 	const FString NetStatCmd = FString::Printf(TEXT("netstat"));
 
@@ -60,7 +60,7 @@ bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound()
 	if (ExitCode == ExitCodeSuccess && bSuccess)
 	{
 		// Get the line of the netstat output that contains the port we're looking for.
-		FRegexPattern PidMatcherPattern(FString::Printf(TEXT("(.*?:%i.)(.*)( [0-9]+)"), ReceptionistPort));
+		FRegexPattern PidMatcherPattern(FString::Printf(TEXT("(.*?:%i.)(.*)( [0-9]+)"), Port));
 		FRegexMatcher PidMatcher(PidMatcherPattern, NetStatResult);
 		if (PidMatcher.FindNext())
 		{
@@ -110,10 +110,10 @@ bool FLocalReceptionistProxyServerManager::TryKillBlockingPortProcess()
 
 bool FLocalReceptionistProxyServerManager::LocalReceptionistProxyServerPreRunChecks()
 {
-	//Check if any process is blocking the 7777 port
-	if(CheckIfPortIsBound())
+	//Check if any process is blocking the receptionist port
+	if(CheckIfPortIsBound(ReceptionistPort))
 	{
-		//Try killing the process that blocks the 7777 port 
+		//Try killing the process that blocks the receptionist port 
 		bool bProcessKilled = TryKillBlockingPortProcess();
 		if (!bProcessKilled)
 		{
@@ -177,7 +177,7 @@ bool FLocalReceptionistProxyServerManager::TryStartReceptionistProxyServer(bool 
 	}
 
 	bool bProxyStartSuccess = false;
-	ProxyServerProcHandle = SpatialCommandUtils::StartLocalReceptionistProxyServer(bIsRunningInChina, CloudDeploymentName, StartResult, ExitCode, bProxyStartSuccess);
+	ProxyServerProcHandle = SpatialCommandUtils::StartLocalReceptionistProxyServer(bIsRunningInChina, CloudDeploymentName, ListeningAddress, ReceptionistPort, StartResult, ExitCode, bProxyStartSuccess);
 
 	//check if process run successfully
 	bSuccess = ProxyServerProcHandle.IsValid();

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
@@ -53,12 +53,12 @@ bool FLocalReceptionistProxyServerManager::GetProcessName(const FString& PID, FS
 		}
 	}
 
-	UE_LOG(LogLocalReceptionistProxyServerManager, Warning, TEXT("%s"), *LOCTEXT("FailedToGetBlockingProcessName", "Failed to get the name of the process that is blocking the required port.").ToString());
+	UE_LOG(LogLocalReceptionistProxyServerManager, Warning, TEXT("Failed to get the name of the process that is blocking the required port."));
 	
 	return false;
 }
 
-bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound(int32 Port, FString& OutPID, FText& OutLogMsg)
+bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound(int32 Port, FString& OutPID, FString& OutLogMsg)
 {
 	FString State;
 	FString ProcessName;
@@ -69,23 +69,23 @@ bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound(int32 Port, FStrin
 		{
 			if (GetProcessName(OutPID, ProcessName))
 			{
-				OutLogMsg = FText::Format(LOCTEXT("ProcessBlockingPort", "{0} process with PID:{1}."), FText::FromString(ProcessName), FText::FromString(OutPID));
+				OutLogMsg = TEXT("%s process with PID: %s"), ProcessName, OutPID;
 				return true;
 			}
 
-			OutLogMsg = FText::Format(LOCTEXT("ProcessBlockingPort", "Unknown process with PID:{1}."), FText::FromString(OutPID));
+			OutLogMsg = TEXT("Unknown process with PID: %s."), *OutPID;
 
 			return true;
 		}
 	}
-	OutLogMsg = LOCTEXT("NoProcessBlockingProxyPort", "No Process is blocking the required port.");
+	OutLogMsg = TEXT("No Process is blocking the required port.");
 
 	return false;
 }
 
 bool FLocalReceptionistProxyServerManager::LocalReceptionistProxyServerPreRunChecks(int32 ReceptionistPort)
 {
-	FText OutLogMessage;
+	FString OutLogMessage;
 	FString PID;
 
 	// Check if any process is blocking the receptionist port
@@ -97,11 +97,11 @@ bool FLocalReceptionistProxyServerManager::LocalReceptionistProxyServerPreRunChe
 			bool bProcessKilled = SpatialCommandUtils::TryKillProcessWithPID(PID);
 			if (!bProcessKilled)
 			{
-				UE_LOG(LogLocalReceptionistProxyServerManager, Warning, TEXT("%s %s!"), *LOCTEXT("FailedToKillBlockingPortProcess", "Failed to kill the process that is blocking the port.").ToString(), *OutLogMessage.ToString());
+				UE_LOG(LogLocalReceptionistProxyServerManager, Warning, TEXT("Failed to kill the process that is blocking the port. %s"), *OutLogMessage);
 				return false;
 			}
 
-			UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("%s %s."), *LOCTEXT("KilledBlockingPortProcess", "Succesfully killed").ToString(), *OutLogMessage.ToString());
+			UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("Succesfully killed %s"), *OutLogMessage);
 			return true;
 		}
 
@@ -109,8 +109,7 @@ bool FLocalReceptionistProxyServerManager::LocalReceptionistProxyServerPreRunChe
 		return false;
 	}
 
-	OutLogMessage = LOCTEXT("NoProcessBlockingPort", "The required port is not blocked!");
-	UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("%s"), *OutLogMessage.ToString());
+	UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("The required port is not blocked!"));
 	return true;
 }
 
@@ -219,7 +218,7 @@ bool FLocalReceptionistProxyServerManager::TryStartReceptionistProxyServer(bool 
 	// Do not restart the same proxy if you have already a proxy running for the same cloud deployment
 	if (bProxyIsRunning && ProxyServerProcHandle.IsValid() && RunningCloudDeploymentName == CloudDeploymentName && RunningProxyListeningAddress == ListeningAddress && RunningProxyReceptionistPort == ReceptionistPort)
 	{
-		UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("%s"), *LOCTEXT("ServerProxyAlreadyRunning", "The local receptionist proxy server is already running!").ToString());
+		UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("The local receptionist proxy server is already running!"));
 
 		return true;
 	}
@@ -229,12 +228,12 @@ bool FLocalReceptionistProxyServerManager::TryStartReceptionistProxyServer(bool 
 	{
 		if (!TryStopReceptionistProxyServer())
 		{
-			UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("%s"),*LOCTEXT("FailedToStopPreviousServerProxy", "Failed to stop previous proxy server!").ToString());
+			UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("Failed to stop previous proxy server!"));
 		
 			return false;
 		}
 
-		UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("%s"),*LOCTEXT("SucceededToStopPreviousServerProxy", "Stopped previous proxy server!").ToString());
+		UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("Stopped previous proxy server sucessfully!"));
 	}
 
 	ProxyServerProcHandle = SpatialCommandUtils::StartLocalReceptionistProxyServer(bIsRunningInChina, CloudDeploymentName, ListeningAddress, ReceptionistPort, StartResult, ExitCode);
@@ -242,8 +241,7 @@ bool FLocalReceptionistProxyServerManager::TryStartReceptionistProxyServer(bool 
 	// Check if process run successfully
 	if (!ProxyServerProcHandle.IsValid())
 	{
-		const FText WarningMessage = FText::Format(LOCTEXT("FailedToStartProxyServer", "Starting the local receptionist proxy server failed. Error Code: {0}, Error Message: {1}"), ExitCode, FText::FromString(StartResult));
-		UE_LOG(LogLocalReceptionistProxyServerManager, Warning, TEXT("%s"), *WarningMessage.ToString());
+		UE_LOG(LogLocalReceptionistProxyServerManager, Warning, TEXT("Starting the local receptionist proxy server failed. Error Code: %s, Error Message: %s"), ExitCode, StartResult);
 		return false;
 	}
 
@@ -261,7 +259,7 @@ bool FLocalReceptionistProxyServerManager::TryStartReceptionistProxyServer(bool 
 	RunningProxyReceptionistPort = ReceptionistPort;
 	bProxyIsRunning = true;
 
-	UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("%s"),*LOCTEXT("SuccesfullyStartedServerProxy", "Local receptionist proxy server started sucessfully!").ToString());
+	UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("Local receptionist proxy server started sucessfully!"));
 
 	return true;
 }

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
@@ -64,11 +64,11 @@ bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound(int32 Port, FStrin
 		{
 			if (GetProcessName(OutPID, ProcessName))
 			{
-				OutLogMsg = TEXT("%s process with PID: %s"), ProcessName, OutPID;
+				OutLogMsg = FString::Printf(TEXT("%s process with PID: %s"), *ProcessName, *OutPID);
 				return true;
 			}
 
-			OutLogMsg = TEXT("Unknown process with PID: %s."), *OutPID;
+			OutLogMsg = FString::Printf(TEXT("Unknown process with PID: %s."), *OutPID);
 
 			return true;
 		}
@@ -102,12 +102,9 @@ bool FLocalReceptionistProxyServerManager::LocalReceptionistProxyServerPreRunChe
 				UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("Successfully killed %s"), *OutLogMessage);
 				return true;
 			}
-
-			UE_LOG(LogLocalReceptionistProxyServerManager, Error, TEXT("The required port is blocked from a different process with PID: %s"), *PID);
-			return false;
 		}
 
-		UE_LOG(LogLocalReceptionistProxyServerManager, Error, TEXT("The required port is blocked from an unidentified process with PID: %s"), *PID);
+		UE_LOG(LogLocalReceptionistProxyServerManager, Error, TEXT("The required port is blocked from %s."), *OutLogMessage);
 		return false;
 	}
 
@@ -193,7 +190,7 @@ bool FLocalReceptionistProxyServerManager::GetPreviousReceptionistProxyPID(FStri
 	UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("Local Receptionist Proxy is not running."));
 
 	OutPID.Empty();
-	return true;
+	return false;
 }
 
 void FLocalReceptionistProxyServerManager::DeletePIDFile()
@@ -234,7 +231,7 @@ bool FLocalReceptionistProxyServerManager::TryStartReceptionistProxyServer(bool 
 	// Check if process run successfully
 	if (!ProxyServerProcHandle.IsValid())
 	{
-		UE_LOG(LogLocalReceptionistProxyServerManager, Warning, TEXT("Starting the local receptionist proxy server failed. Error Code: %s, Error Message: %s"), ExitCode, *StartResult);
+		UE_LOG(LogLocalReceptionistProxyServerManager, Warning, TEXT("Starting the local receptionist proxy server failed. Error Code: %d, Error Message: %s"), ExitCode, *StartResult);
 		ProxyServerProcHandle.Reset();
 		return false;
 	}

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
@@ -158,10 +158,9 @@ TSharedPtr<FJsonObject> FLocalReceptionistProxyServerManager::ParsePIDFile()
 		{
 			return JsonParsedProxyInfoFile;
 		}
-		else
-		{
-			UE_LOG(LogLocalReceptionistProxyServerManager, Error, TEXT("Json parsing of %s failed. Can't get proxy's PID."), *SpatialGDKServicesConstants::ProxyInfoFilePath);
-		}
+
+		UE_LOG(LogLocalReceptionistProxyServerManager, Error, TEXT("Json parsing of %s failed. Can't get proxy's PID."), *SpatialGDKServicesConstants::ProxyInfoFilePath);
+
 	}
 
 	return nullptr;

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
@@ -36,12 +36,9 @@ bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound(int32 Port, FStrin
 			OutLogMsg = FString::Printf(TEXT("%s process with PID: %s"), *ProcessName, *OutPID);
 			return true;
 		}
-
-		OutLogMsg = TEXT("No Process is blocking the required port.");
-		return false;
 	}
 
-	OutLogMsg = TEXT("Failed to check if a process is blocking the required port.");
+	OutLogMsg = TEXT("No Process is blocking the required port or Failed to check if process is blocked.");
 	return false;
 }
 
@@ -54,7 +51,7 @@ bool FLocalReceptionistProxyServerManager::LocalReceptionistProxyServerPreRunChe
 	// Check if any process is blocking the receptionist port
 	if (!CheckIfPortIsBound(ReceptionistPort, PID, OutLogMessage))
 	{
-		UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("The required port is not blocked! %s"), *OutLogMessage);
+		UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("The required port is not blocked: %s"), *OutLogMessage);
 		return true;
 	}
 

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
@@ -29,13 +29,10 @@ bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound(int32 Port, FStrin
 	FString State;
 	FString ProcessName;
 	bool bSuccess = SpatialCommandUtils::GetProcessInfoFromPort(Port, OutPID, State, ProcessName);
-	if (bSuccess)
+	if (bSuccess && State.Contains("LISTEN"))
 	{
-		if (State.Contains("LISTEN"))
-		{
-			OutLogMsg = FString::Printf(TEXT("%s process with PID: %s"), *ProcessName, *OutPID);
-			return true;
-		}
+		OutLogMsg = FString::Printf(TEXT("%s process with PID: %s"), *ProcessName, *OutPID);
+		return true;
 	}
 
 	OutLogMsg = TEXT("No Process is blocking the required port or Failed to check if process is blocked.");
@@ -117,7 +114,6 @@ TSharedPtr<FJsonObject> FLocalReceptionistProxyServerManager::ParsePIDFile()
 		}
 
 		UE_LOG(LogLocalReceptionistProxyServerManager, Error, TEXT("Json parsing of %s failed. Can't get proxy's PID."), *SpatialGDKServicesConstants::ProxyInfoFilePath);
-
 	}
 
 	return nullptr;
@@ -193,7 +189,7 @@ bool FLocalReceptionistProxyServerManager::TryStartReceptionistProxyServer(bool 
 	{
 		if (!TryStopReceptionistProxyServer())
 		{
-			UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("Failed to stop previous proxy server!"));
+			UE_LOG(LogLocalReceptionistProxyServerManager, Error, TEXT("Failed to stop previous proxy server!"));
 			return false;
 		}
 

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
@@ -57,11 +57,12 @@ bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound(int32 Port, FStrin
 {
 	FString State;
 	FString ProcessName;
-	bool bSuccess = SpatialCommandUtils::GetProcessInfoFromPort(Port, OutPID, State);
+	bool bSuccess = SpatialCommandUtils::GetProcessInfoFromPort(Port, OutPID, State, ProcessName);
 	if (bSuccess)
 	{
-		if (State.Contains("LISTENING"))
+		if (State.Contains("LISTEN"))
 		{
+#if PLATFORM_WINDOWS
 			if (GetProcessName(OutPID, ProcessName))
 			{
 				OutLogMsg = FString::Printf(TEXT("%s process with PID: %s"), *ProcessName, *OutPID);
@@ -69,7 +70,11 @@ bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound(int32 Port, FStrin
 			}
 
 			OutLogMsg = FString::Printf(TEXT("Unknown process with PID: %s."), *OutPID);
+#endif
 
+#if PLATFORM_MAC
+			OutLogMsg = FString::Printf(TEXT("%s process with PID: %s"), *ProcessName, *OutPID);
+#endif
 			return true;
 		}
 	}
@@ -251,9 +256,10 @@ bool FLocalReceptionistProxyServerManager::TryStartReceptionistProxyServer(bool 
 
 	FString PID;
 	FString State;
+	FString ProcessName;
 
 	// Save the server receptionist proxy process's PID in a Json file
-	if (SpatialCommandUtils::GetProcessInfoFromPort(ReceptionistPort, PID, State))
+	if (SpatialCommandUtils::GetProcessInfoFromPort(ReceptionistPort, PID, State, ProcessName))
 	{
 		SavePIDInJson(PID);
 	}

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
@@ -24,7 +24,6 @@ FLocalReceptionistProxyServerManager::FLocalReceptionistProxyServerManager()
 {
 }
 
-
 bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound(int32 Port, FString& OutPID, FString& OutLogMsg)
 {
 	FString State;
@@ -34,19 +33,15 @@ bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound(int32 Port, FStrin
 	{
 		if (State.Contains("LISTEN"))
 		{
-
 			OutLogMsg = FString::Printf(TEXT("%s process with PID: %s"), *ProcessName, *OutPID);
 			return true;
 		}
-	}
-	else
-	{
-		OutLogMsg = TEXT("Failed to check if a process is blocking the required port.");
+
+		OutLogMsg = TEXT("No Process is blocking the required port.");
 		return false;
 	}
 
-	OutLogMsg = TEXT("No Process is blocking the required port.");
-
+	OutLogMsg = TEXT("Failed to check if a process is blocking the required port.");
 	return false;
 }
 
@@ -59,12 +54,12 @@ bool FLocalReceptionistProxyServerManager::LocalReceptionistProxyServerPreRunChe
 	// Check if any process is blocking the receptionist port
 	if (!CheckIfPortIsBound(ReceptionistPort, PID, OutLogMessage))
 	{
-		UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("The required port is not blocked!"));
+		UE_LOG(LogLocalReceptionistProxyServerManager, Log, TEXT("The required port is not blocked! %s"), *OutLogMessage);
 		return true;
 	}
 
-	// Get the previous running proxy's
-	if(GetPreviousReceptionistProxyPID(PreviousPID))
+	// Get the previous running proxy's PID
+	if (GetPreviousReceptionistProxyPID(PreviousPID))
 	{
 		// Try killing the process that blocks the receptionist port if the process blocking the port is a previously running proxy.
 		if (FCString::Atoi(*PID) == FCString::Atoi(*PreviousPID))

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
@@ -73,6 +73,12 @@ bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound(int32 Port, FStrin
 			return true;
 		}
 	}
+	else
+	{
+		OutLogMsg = TEXT("Failed to check if a process is blocking the required port.");
+		return false;
+	}
+
 	OutLogMsg = TEXT("No Process is blocking the required port.");
 
 	return false;
@@ -205,6 +211,13 @@ bool FLocalReceptionistProxyServerManager::TryStartReceptionistProxyServer(bool 
 {
 	FString StartResult;
 	int32 ExitCode;
+
+	// Do not start receptionist proxy if the cloud deployment name is not specified
+	if (CloudDeploymentName.IsEmpty())
+	{
+		UE_LOG(LogLocalReceptionistProxyServerManager, Error, TEXT("No deployment name has been specified."));
+		return false;
+	}
 
 	// Do not restart the same proxy if you have already a proxy running for the same cloud deployment
 	if (bProxyIsRunning && ProxyServerProcHandle.IsValid() && RunningCloudDeploymentName == CloudDeploymentName && RunningProxyListeningAddress == ListeningAddress && RunningProxyReceptionistPort == ReceptionistPort)

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
@@ -280,7 +280,7 @@ bool SpatialCommandUtils::HasDevLoginTag(const FString& DeploymentName, bool bIs
 	return false;
 }
 
-FProcHandle SpatialCommandUtils::StartLocalReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, FString &OutResult, int32 &OutExitCode)
+FProcHandle SpatialCommandUtils::StartLocalReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, FString &OutResult, int32 &OutExitCode, bool &bProcessSucessed)
 {
 	FString Command = TEXT("cloud connect external ");
 
@@ -299,7 +299,7 @@ FProcHandle SpatialCommandUtils::StartLocalReceptionistProxyServer(bool bIsRunni
 
 	ProcHandle = FPlatformProcess::CreateProc(*SpatialGDKServicesConstants::SpatialExe, *Command, false, true, true, nullptr, 1 /*PriorityModifer*/, *SpatialGDKServicesConstants::SpatialOSDirectory, WritePipe);
 
-	bool bProcessSucessed = false;
+	bProcessSucessed = false;
 	bool bProcessFinished = false;
 	if (ProcHandle.IsValid())
 	{

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
@@ -280,7 +280,7 @@ bool SpatialCommandUtils::HasDevLoginTag(const FString& DeploymentName, bool bIs
 	return false;
 }
 
-FProcHandle SpatialCommandUtils::StartLocalReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, const FString& ListeningAddress, const int32 Port , FString &OutResult, int32 &OutExitCode, bool &bProcessSucceeded)
+FProcHandle SpatialCommandUtils::StartLocalReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, const FString& ListeningAddress, const int32 Port , FString &OutResult, int32 &OutExitCode)
 {
 	FString Command = FString::Printf(TEXT("cloud connect external %s --listening_address %s --local_receptionist_port %i"), *CloudDeploymentName, *ListeningAddress, Port);
 
@@ -297,7 +297,7 @@ FProcHandle SpatialCommandUtils::StartLocalReceptionistProxyServer(bool bIsRunni
 
 	ProcHandle = FPlatformProcess::CreateProc(*SpatialGDKServicesConstants::SpatialExe, *Command, false, true, true, nullptr, 1 /*PriorityModifer*/, *SpatialGDKServicesConstants::SpatialOSDirectory, WritePipe);
 
-	bProcessSucceeded = false;
+	bool bProcessSucceeded = false;
 	bool bProcessFinished = false;
 	if (ProcHandle.IsValid())
 	{
@@ -314,6 +314,11 @@ FProcHandle SpatialCommandUtils::StartLocalReceptionistProxyServer(bool bIsRunni
 	else
 	{
 		UE_LOG(LogSpatialCommandUtils, Error, TEXT("%s"), *FText::Format(LOCTEXT( "CloudConnectExternalExecutionFailed","Execution failed. '{0}' with arguments '{1}' in directory '{2}' "), FText::FromString(SpatialGDKServicesConstants::SpatialExe), FText::FromString(Command), FText::FromString(SpatialGDKServicesConstants::SpatialOSDirectory)).ToString());
+	}
+
+	if(!bProcessSucceeded)
+	{
+		FPlatformProcess::TerminateProc(ProcHandle, true);
 	}
 
 	FPlatformProcess::ClosePipe(0, ReadPipe);

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
@@ -280,9 +280,9 @@ bool SpatialCommandUtils::HasDevLoginTag(const FString& DeploymentName, bool bIs
 	return false;
 }
 
-FProcHandle SpatialCommandUtils::StartLocalReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, FString &OutResult, int32 &OutExitCode, bool &bProcessSucceeded)
+FProcHandle SpatialCommandUtils::StartLocalReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, const FString& ListeningAddress, const int32& Port , FString &OutResult, int32 &OutExitCode, bool &bProcessSucceeded)
 {
-	FString Command = FString::Printf(TEXT("cloud connect external %s"), *CloudDeploymentName);
+	FString Command = FString::Printf(TEXT("cloud connect external %s --listening_address %s --local_receptionist_port %i"), *CloudDeploymentName, *ListeningAddress, Port);
 
 	if (bIsRunningInChina)
 	{

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
@@ -302,7 +302,7 @@ FProcHandle SpatialCommandUtils::StartLocalReceptionistProxyServer(bool bIsRunni
 	bool bProcessFinished = false;
 	if (ProcHandle.IsValid())
 	{
-		while(!bProcessFinished && !bProcessSucceeded)
+		while (!bProcessFinished && !bProcessSucceeded)
 		{
 			bProcessFinished = FPlatformProcess::GetProcReturnCode(ProcHandle, &OutExitCode);
 
@@ -314,10 +314,10 @@ FProcHandle SpatialCommandUtils::StartLocalReceptionistProxyServer(bool bIsRunni
 	}
 	else
 	{
-		UE_LOG(LogSpatialCommandUtils, Error, TEXT("Execution failed. '%s' with arguments '%s' in directory '%s' "), *SpatialGDKServicesConstants::SpatialExe, *Command, *SpatialGDKServicesConstants::SpatialOSDirectory);
+		UE_LOG(LogSpatialCommandUtils, Error, TEXT("Execution failed. '%s' with arguments '%s' in directory '%s'"), *SpatialGDKServicesConstants::SpatialExe, *Command, *SpatialGDKServicesConstants::SpatialOSDirectory);
 	}
 
-	if(!bProcessSucceeded)
+	if (!bProcessSucceeded)
 	{
 		FPlatformProcess::TerminateProc(ProcHandle, true);
 	}
@@ -336,7 +336,7 @@ void SpatialCommandUtils::StopLocalReceptionistProxyServer(FProcHandle& ProcHand
 	}
 }
 
-bool SpatialCommandUtils::TryKillProcessWithPID(const FString & PID)
+bool SpatialCommandUtils::TryKillProcessWithPID(const FString& PID)
 {
 	int32 ExitCode;
 	FString StdErr;
@@ -348,7 +348,7 @@ bool SpatialCommandUtils::TryKillProcessWithPID(const FString & PID)
 	bSuccess = bSuccess && ExitCode == 0;
 	if (!bSuccess)
 	{
-		UE_LOG(LogSpatialCommandUtils, Error, TEXT("Failed to kill process blocking required port. Error: %s"), *StdErr);
+		UE_LOG(LogSpatialCommandUtils, Error, TEXT("Failed to kill process with PID %s. Error: %s"), *PID, *StdErr);
 	}
 
 	return bSuccess;
@@ -391,6 +391,5 @@ bool SpatialCommandUtils::GetProcessInfoFromPort(int32 Port, FString& OutPid, FS
 
 	return bSuccess;
 }
-
 
 #undef LOCTEXT_NAMESPACE

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
@@ -280,7 +280,7 @@ bool SpatialCommandUtils::HasDevLoginTag(const FString& DeploymentName, bool bIs
 	return false;
 }
 
-FProcHandle SpatialCommandUtils::StartLocalReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, const FString& ListeningAddress, const int32& Port , FString &OutResult, int32 &OutExitCode, bool &bProcessSucceeded)
+FProcHandle SpatialCommandUtils::StartLocalReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, const FString& ListeningAddress, const int32 Port , FString &OutResult, int32 &OutExitCode, bool &bProcessSucceeded)
 {
 	FString Command = FString::Printf(TEXT("cloud connect external %s --listening_address %s --local_receptionist_port %i"), *CloudDeploymentName, *ListeningAddress, Port);
 

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
@@ -313,7 +313,7 @@ FProcHandle SpatialCommandUtils::StartLocalReceptionistProxyServer(bool bIsRunni
 	}
 	else
 	{
-		UE_LOG(LogSpatialCommandUtils, Error, TEXT("Execution failed. '%s' with arguments '%s' in directory '%s' "), *SpatialGDKServicesConstants::SpatialExe, *Command, *SpatialGDKServicesConstants::SpatialOSDirectory);
+		UE_LOG(LogSpatialCommandUtils, Error, TEXT("%s"), *FText::Format(LOCTEXT( "CloudConnectExternalExecutionFailed","Execution failed. '{0}' with arguments '{1}' in directory '{2}' "), FText::FromString(SpatialGDKServicesConstants::SpatialExe), FText::FromString(Command), FText::FromString(SpatialGDKServicesConstants::SpatialOSDirectory)).ToString());
 	}
 
 	FPlatformProcess::ClosePipe(0, ReadPipe);

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
@@ -280,11 +280,9 @@ bool SpatialCommandUtils::HasDevLoginTag(const FString& DeploymentName, bool bIs
 	return false;
 }
 
-FProcHandle SpatialCommandUtils::StartLocalReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, FString &OutResult, int32 &OutExitCode, bool &bProcessSucessed)
+FProcHandle SpatialCommandUtils::StartLocalReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, FString &OutResult, int32 &OutExitCode, bool &bProcessSucceeded)
 {
-	FString Command = TEXT("cloud connect external ");
-
-	Command += CloudDeploymentName;
+	FString Command = FString::Printf(TEXT("cloud connect external %s"), *CloudDeploymentName);
 
 	if (bIsRunningInChina)
 	{
@@ -299,16 +297,16 @@ FProcHandle SpatialCommandUtils::StartLocalReceptionistProxyServer(bool bIsRunni
 
 	ProcHandle = FPlatformProcess::CreateProc(*SpatialGDKServicesConstants::SpatialExe, *Command, false, true, true, nullptr, 1 /*PriorityModifer*/, *SpatialGDKServicesConstants::SpatialOSDirectory, WritePipe);
 
-	bProcessSucessed = false;
+	bProcessSucceeded = false;
 	bool bProcessFinished = false;
 	if (ProcHandle.IsValid())
 	{
-		while(!bProcessFinished && !bProcessSucessed)
+		while(!bProcessFinished && !bProcessSucceeded)
 		{
 			bProcessFinished = FPlatformProcess::GetProcReturnCode(ProcHandle, &OutExitCode);
 
 			OutResult = OutResult.Append(FPlatformProcess::ReadPipe(ReadPipe));
-			bProcessSucessed = OutResult.Contains("The receptionist proxy is available");
+			bProcessSucceeded = OutResult.Contains("The receptionist proxy is available");
 
 			FPlatformProcess::Sleep(0.01f);
 		}

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
@@ -314,7 +314,7 @@ FProcHandle SpatialCommandUtils::StartLocalReceptionistProxyServer(bool bIsRunni
 	}
 	else
 	{
-		UE_LOG(LogSpatialCommandUtils, Error, TEXT("%s"), *FText::Format(LOCTEXT( "CloudConnectExternalExecutionFailed","Execution failed. '{0}' with arguments '{1}' in directory '{2}' "), FText::FromString(SpatialGDKServicesConstants::SpatialExe), FText::FromString(Command), FText::FromString(SpatialGDKServicesConstants::SpatialOSDirectory)).ToString());
+		UE_LOG(LogSpatialCommandUtils, Error, TEXT("Execution failed. '%s' with arguments '%s' in directory '%s' "), *SpatialGDKServicesConstants::SpatialExe, *Command, *SpatialGDKServicesConstants::SpatialOSDirectory);
 	}
 
 	if(!bProcessSucceeded)

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
@@ -320,6 +320,7 @@ FProcHandle SpatialCommandUtils::StartLocalReceptionistProxyServer(bool bIsRunni
 	if (!bProcessSucceeded)
 	{
 		FPlatformProcess::TerminateProc(ProcHandle, true);
+		ProcHandle.Reset();
 	}
 
 	FPlatformProcess::ClosePipe(0, ReadPipe);

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
@@ -359,8 +359,6 @@ bool SpatialCommandUtils::TryKillProcessWithPID(const FString& PID)
 #if PLATFORM_WINDOWS
 	const FString KillCmd = TEXT("taskkill");
 	const FString KillArgs = FString::Printf(TEXT("/F /PID %s"), *PID);
-#endif
-
 #elif PLATFORM_MAC
 	const FString KillCmd = FPaths::Combine(SpatialGDKServicesConstants::KillCmdFilePath, TEXT("kill"));
 	const FString KillArgs = FString::Printf(TEXT("%s"), *PID);

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
@@ -431,7 +431,7 @@ bool SpatialCommandUtils::GetProcessInfoFromPortMacOs(int32 Port, FString& OutPi
 
 	if (ExitCode == 0 && bSuccess)
 	{
-		FRegexPattern PidMatcherPattern(FString::Printf(TEXT("(\\S+)( \\d+).*(\\(\\S+\\))")));
+		FRegexPattern PidMatcherPattern(FString::Printf(TEXT("(\\S+)( *\\d+).*(\\(\\S+\\))")));
 		FRegexMatcher PidMatcher(PidMatcherPattern, LsofResult);
 		if (PidMatcher.FindNext())
 		{

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
@@ -339,12 +339,10 @@ void SpatialCommandUtils::StopLocalReceptionistProxyServer(FProcHandle& ProcHand
 
 bool SpatialCommandUtils::GetProcessName(const FString& PID, FString& OutProcessName)
 {
-
 #if PLATFORM_MAC
 	UE_LOG(LogSpatialCommandUtils, Warning, TEXT("Failed to get the name of the process that is blocking the required port. To get the name of the process in MacOS you need to use SpatialCommandUtils::GetProcessInfoFromPort."));
 	return false;
-#endif 
-
+#else
 	bool bSuccess = false;
 	OutProcessName = TEXT("");
 	const FString TaskListCmd = TEXT("tasklist");
@@ -369,6 +367,7 @@ bool SpatialCommandUtils::GetProcessName(const FString& PID, FString& OutProcess
 	UE_LOG(LogSpatialCommandUtils, Warning, TEXT("Failed to get the name of the process that is blocking the required port."));
 
 	return false;
+#endif
 }
 
 bool SpatialCommandUtils::TryKillProcessWithPID(const FString& PID)
@@ -420,7 +419,7 @@ bool SpatialCommandUtils::GetProcessInfoFromPort(int32 Port, FString& OutPid, FS
 		FRegexPattern PidMatcherPattern(FString::Printf(TEXT("(.*?:%i.)(.*)( [0-9]+)"), Port));
 #elif PLATFORM_MAC
 		// Get the line that contains the name, pid and state of the process.
-		FRegexPattern PidMatcherPattern(FString::Printf(TEXT("(\\S+)( *\\d+).*(\\(\\S+\\))")));
+		FRegexPattern PidMatcherPattern(TEXT("(\\S+)( *\\d+).*(\\(\\S+\\))"));
 #endif
 		FRegexMatcher PidMatcher(PidMatcherPattern, Result);
 		if (PidMatcher.FindNext())
@@ -431,7 +430,7 @@ bool SpatialCommandUtils::GetProcessInfoFromPort(int32 Port, FString& OutPid, FS
 			OutPid = PidMatcher.GetCaptureGroup(3 /* Get the PID, which is the third group. */);
 			if (!GetProcessName(OutPid, OutProcessName))
 			{
-				OutProcessName = "Unknown";
+				OutProcessName = TEXT("Unknown");
 			}
 #elif PLATFORM_MAC
 			OutProcessName = PidMatcher.GetCaptureGroup(1 /* Get the Name of the process, which is the first group. */);

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
@@ -339,6 +339,12 @@ void SpatialCommandUtils::StopLocalReceptionistProxyServer(FProcHandle& ProcHand
 
 bool SpatialCommandUtils::GetProcessName(const FString& PID, FString& OutProcessName)
 {
+
+#if PLATFORM_MAC
+	UE_LOG(LogSpatialCommandUtils, Warning, TEXT("Failed to get the name of the process that is blocking the required port. To get the name of the process in MacOS you need to use SpatialCommandUtils::GetProcessInfoFromPort."));
+	return false;
+#endif 
+
 	bool bSuccess = false;
 	OutProcessName = TEXT("");
 	const FString TaskListCmd = TEXT("tasklist");
@@ -356,7 +362,6 @@ bool SpatialCommandUtils::GetProcessName(const FString& PID, FString& OutProcess
 		if (ProcessNameMatcher.FindNext())
 		{
 			OutProcessName = ProcessNameMatcher.GetCaptureGroup(1 /* Get the Name of the process, which is the first group. */);
-
 			return true;
 		}
 	}
@@ -444,7 +449,7 @@ bool SpatialCommandUtils::GetProcessInfoFromPort(int32 Port, FString& OutPid, FS
 	}
 
 #if PLATFORM_MAC
-	if (bSuccess && StdErr.IsEmpty())
+	if (bSuccess && ExitCode == 1 && StdErr.IsEmpty())
 	{
 		UE_LOG(LogSpatialCommandUtils, Log, TEXT("The required port %i is not blocked!"), Port);
 		return false;

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
@@ -392,7 +392,7 @@ bool SpatialCommandUtils::GetProcessInfoFromPortWindows(int32 Port, FString& Out
 
 	if (ExitCode == 0 && bSuccess)
 	{
-		// Get the line of the netstat output that contains the port we're looking for. 
+		// Get the line of the netstat output that contains the port we're looking for.
 		FRegexPattern PidMatcherPattern(FString::Printf(TEXT("(.*?:%i.)(.*)( [0-9]+)"), Port));
 		FRegexMatcher PidMatcher(PidMatcherPattern, NetStatResult);
 		if (PidMatcher.FindNext())

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
@@ -361,7 +361,7 @@ bool SpatialCommandUtils::TryKillProcessWithPID(const FString& PID)
 	const FString KillArgs = FString::Printf(TEXT("/F /PID %s"), *PID);
 #endif
 
-#if PLATFORM_MAC
+#elif PLATFORM_MAC
 	const FString KillCmd = FPaths::Combine(SpatialGDKServicesConstants::KillCmdFilePath, TEXT("kill"));
 	const FString KillArgs = FString::Printf(TEXT("%s"), *PID);
 #endif
@@ -447,6 +447,11 @@ bool SpatialCommandUtils::GetProcessInfoFromPortMacOs(int32 Port, FString& OutPi
 	}
 	else
 	{
+		if (bSuccess && StdErr.IsEmpty())
+		{
+			UE_LOG(LogSpatialCommandUtils, Log, TEXT("The required port is not blocked!"));
+		}
+
 		bSuccess = false;
 		UE_LOG(LogSpatialCommandUtils, Error, TEXT("Failed to find the process that is blocking required port. Error: %s"), *StdErr);
 	}

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
@@ -399,7 +399,7 @@ bool SpatialCommandUtils::GetProcessInfoFromPort(int32 Port, FString& OutPid, FS
 #elif PLATFORM_MAC
 	const FString Command = FPaths::Combine(SpatialGDKServicesConstants::LsofCmdFilePath, TEXT("lsof"));
 	// -i:Port list the processes that are running on Port
-	const FString Args = FString::Printf(TEXT("-i:%d"), Port);
+	const FString Args = FString::Printf(TEXT("-i:%i"), Port);
 #endif
 
 	FString Result;
@@ -437,7 +437,7 @@ bool SpatialCommandUtils::GetProcessInfoFromPort(int32 Port, FString& OutPid, FS
 		}
 
 #if PLATFORM_WINDOWS
-		UE_LOG(LogSpatialCommandUtils, Log, TEXT("The required port is not blocked!"), Port);
+		UE_LOG(LogSpatialCommandUtils, Log, TEXT("The required port %i is not blocked!"), Port);
 		return false;
 #endif
 		 
@@ -446,7 +446,7 @@ bool SpatialCommandUtils::GetProcessInfoFromPort(int32 Port, FString& OutPid, FS
 #if PLATFORM_MAC
 	if (bSuccess && StdErr.IsEmpty())
 	{
-		UE_LOG(LogSpatialCommandUtils, Log, TEXT("The required port is not blocked!"));
+		UE_LOG(LogSpatialCommandUtils, Log, TEXT("The required port %i is not blocked!"), Port);
 		return false;
 	}
 #endif

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
@@ -28,7 +28,5 @@ private:
 	int32 RunningProxyReceptionistPort;
 	FString RunningProxyListeningAddress;
 
-	static const int32 ExitCodeSuccess = 0;
-
 	bool bProxyIsRunning = false;
 };

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
@@ -11,11 +11,11 @@ class FLocalReceptionistProxyServerManager
 public:
 	FLocalReceptionistProxyServerManager();
 
-	bool CheckIfPortIsBound(int32 Port, FString& PID, FText& LogMessages);
+	bool CheckIfPortIsBound(int32 Port, FString& OutPID, FText& OutLogMessages);
 	bool TryKillBlockingPortProcess(const FString& PID);
 	bool LocalReceptionistProxyServerPreRunChecks(int32 ReceptionistPort);
 
-	bool GetProcessName(const FString& PID, FString& ProcessName);
+	bool GetProcessName(const FString& PID, FString& OutProcessName);
 
 	void SPATIALGDKSERVICES_API Init(int32 ReceptionistPort);
 	bool SPATIALGDKSERVICES_API TryStartReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, const FString& ListeningAddress, int32 ReceptionistPort);

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
@@ -21,9 +21,9 @@ public:
 	bool SPATIALGDKSERVICES_API TryStopReceptionistProxyServer();
 	
 private:
-	static TSharedPtr<FJsonObject> ParsePidFile();
-	static void SetPidInJson(const FString & Pid);
-	static FString ParsePid();
+	static TSharedPtr<FJsonObject> ParsePIDFile();
+	static void SetPIDInJson(const FString& PID);
+	static FString GetPreviousReceptionistProxyPID();
 
 	FProcHandle ProxyServerProcHandle;
 	FString RunningCloudDeploymentName;

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
@@ -13,12 +13,12 @@ public:
 
 	bool CheckIfPortIsBound(int32 Port);
 	bool TryKillBlockingPortProcess();
-	bool LocalReceptionistProxyServerPreRunChecks(const int32& ReceptionistPort);
+	bool LocalReceptionistProxyServerPreRunChecks(int32 ReceptionistPort);
 
 	FString GetProcessName();
 
-	void SPATIALGDKSERVICES_API Init(const int32& ReceptionistPort);
-	bool SPATIALGDKSERVICES_API TryStartReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, const FString& ListeningAddress, const int32& ReceptionistPort);
+	void SPATIALGDKSERVICES_API Init(int32 ReceptionistPort);
+	bool SPATIALGDKSERVICES_API TryStartReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, const FString& ListeningAddress, int32 ReceptionistPort);
 	bool SPATIALGDKSERVICES_API TryStopReceptionistProxyServer();
 	
 private:

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
@@ -11,15 +11,26 @@ class FLocalReceptionistProxyServerManager
 public:
 	FLocalReceptionistProxyServerManager();
 
-	bool CheckIfPortIsBound(int32 Port);
-	bool KillProcessBlockingPort();
+	bool CheckIfPortIsBound();
+	bool KillBlockingPortProcess();
 	bool LocalReceptionistProxyServerPreRunChecks();
+
+	bool GetProcessName();
 
 	void SPATIALGDKSERVICES_API Init();
 	bool SPATIALGDKSERVICES_API TryStartReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName);
 	bool SPATIALGDKSERVICES_API TryStopReceptionistProxyServer();
 	
 private:
+
+	struct BlockingPortProcess
+	{
+		FString Pid = "";
+		FString Name = "";
+	};
+
+	BlockingPortProcess BlockingProcess;
+
 	FProcHandle ProxyServerProcHandle;
 	FString RunningCloudDeploymentName;
 

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
@@ -25,6 +25,8 @@ private:
 
 	FProcHandle ProxyServerProcHandle;
 	FString RunningCloudDeploymentName;
+	int32 RunningProxyReceptionistPort;
+	FString RunningProxyListeningAddress;
 
 	static const int32 ExitCodeSuccess = 0;
 

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
@@ -23,7 +23,7 @@ public:
 private:
 	static TSharedPtr<FJsonObject> ParsePIDFile();
 	static void SavePIDInJson(const FString& PID);
-	static FString GetPreviousReceptionistProxyPID();
+	static bool GetPreviousReceptionistProxyPID(FString& OutPID);
 	static void DeletePIDFile();
 
 	FProcHandle ProxyServerProcHandle;

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
@@ -11,7 +11,7 @@ class FLocalReceptionistProxyServerManager
 public:
 	FLocalReceptionistProxyServerManager();
 
-	bool CheckIfPortIsBound(int32 Port, FString& OutPID, FText& OutLogMessages);
+	bool CheckIfPortIsBound(int32 Port, FString& OutPID, FString& OutLogMessages);
 	bool LocalReceptionistProxyServerPreRunChecks(int32 ReceptionistPort);
 
 	bool GetProcessName(const FString& PID, FString& OutProcessName);

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
@@ -22,9 +22,9 @@ public:
 	
 private:
 	static TSharedPtr<FJsonObject> ParsePIDFile();
-	static void SetPIDInJson(const FString& PID);
+	static void SavePIDInJson(const FString& PID);
 	static FString GetPreviousReceptionistProxyPID();
-	void DeletePIDFile();
+	static void DeletePIDFile();
 
 	FProcHandle ProxyServerProcHandle;
 	FString RunningCloudDeploymentName;

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
@@ -12,7 +12,6 @@ public:
 	FLocalReceptionistProxyServerManager();
 
 	bool CheckIfPortIsBound(int32 Port, FString& OutPID, FText& OutLogMessages);
-	bool TryKillBlockingPortProcess(const FString& PID);
 	bool LocalReceptionistProxyServerPreRunChecks(int32 ReceptionistPort);
 
 	bool GetProcessName(const FString& PID, FString& OutProcessName);

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
@@ -21,6 +21,9 @@ public:
 	bool SPATIALGDKSERVICES_API TryStopReceptionistProxyServer();
 	
 private:
+	static TSharedPtr<FJsonObject> ParsePidFile();
+	static void SetPidInJson(const FString & Pid);
+	static FString ParsePid();
 
 	FProcHandle ProxyServerProcHandle;
 	FString RunningCloudDeploymentName;

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
@@ -11,7 +11,7 @@ class FLocalReceptionistProxyServerManager
 public:
 	FLocalReceptionistProxyServerManager();
 
-	bool CheckIfPortIsBound();
+	bool CheckIfPortIsBound(int32 Port);
 	bool TryKillBlockingPortProcess();
 	bool LocalReceptionistProxyServerPreRunChecks();
 
@@ -36,6 +36,7 @@ private:
 
 	static const int32 ExitCodeSuccess = 0;
 	static const int32 ReceptionistPort = 7777;
+	const FString ListeningAddress = TEXT("127.0.0.1");
 
 	bool bProxyIsRunning = false;
 };

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
@@ -21,7 +21,7 @@ private:
 	FString RunningCloudDeploymentName;
 
 	static const int32 ExitCodeSuccess = 0;
-	static const int32 RequiredRuntimePort = 7777;
+	static const int32 ReceptionistPort = 7777;
 
 	bool bProxyIsRunning = false;
 };

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
@@ -12,7 +12,7 @@ public:
 	FLocalReceptionistProxyServerManager();
 
 	bool CheckIfPortIsBound();
-	bool KillBlockingPortProcess();
+	bool TryKillBlockingPortProcess();
 	bool LocalReceptionistProxyServerPreRunChecks();
 
 	FString GetProcessName();
@@ -25,8 +25,8 @@ private:
 
 	struct BlockingPortProcess
 	{
-		FString Pid = "";
-		FString Name = "";
+		FString Pid = TEXT("");
+		FString Name = TEXT("");
 	};
 
 	BlockingPortProcess BlockingProcess;

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
@@ -13,12 +13,12 @@ public:
 
 	bool CheckIfPortIsBound(int32 Port);
 	bool TryKillBlockingPortProcess();
-	bool LocalReceptionistProxyServerPreRunChecks();
+	bool LocalReceptionistProxyServerPreRunChecks(const int32& ReceptionistPort);
 
 	FString GetProcessName();
 
-	void SPATIALGDKSERVICES_API Init();
-	bool SPATIALGDKSERVICES_API TryStartReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName);
+	void SPATIALGDKSERVICES_API Init(const int32& ReceptionistPort);
+	bool SPATIALGDKSERVICES_API TryStartReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, const FString& ListeningAddress, const int32& ReceptionistPort);
 	bool SPATIALGDKSERVICES_API TryStopReceptionistProxyServer();
 	
 private:
@@ -35,8 +35,6 @@ private:
 	FString RunningCloudDeploymentName;
 
 	static const int32 ExitCodeSuccess = 0;
-	static const int32 ReceptionistPort = 7777;
-	const FString ListeningAddress = TEXT("127.0.0.1");
 
 	bool bProxyIsRunning = false;
 };

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
@@ -24,6 +24,7 @@ private:
 	static TSharedPtr<FJsonObject> ParsePIDFile();
 	static void SetPIDInJson(const FString& PID);
 	static FString GetPreviousReceptionistProxyPID();
+	void DeletePIDFile();
 
 	FProcHandle ProxyServerProcHandle;
 	FString RunningCloudDeploymentName;

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
@@ -6,7 +6,6 @@
 
 DECLARE_LOG_CATEGORY_EXTERN(LogLocalReceptionistProxyServerManager, Log, All);
 
-
 class FLocalReceptionistProxyServerManager
 {
 public:

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
@@ -11,25 +11,17 @@ class FLocalReceptionistProxyServerManager
 public:
 	FLocalReceptionistProxyServerManager();
 
-	bool CheckIfPortIsBound(int32 Port);
-	bool TryKillBlockingPortProcess();
+	bool CheckIfPortIsBound(int32 Port, FString& PID, FText& LogMessages);
+	bool TryKillBlockingPortProcess(const FString& PID);
 	bool LocalReceptionistProxyServerPreRunChecks(int32 ReceptionistPort);
 
-	FString GetProcessName();
+	bool GetProcessName(const FString& PID, FString& ProcessName);
 
 	void SPATIALGDKSERVICES_API Init(int32 ReceptionistPort);
 	bool SPATIALGDKSERVICES_API TryStartReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, const FString& ListeningAddress, int32 ReceptionistPort);
 	bool SPATIALGDKSERVICES_API TryStopReceptionistProxyServer();
 	
 private:
-
-	struct BlockingPortProcess
-	{
-		FString Pid = TEXT("");
-		FString Name = TEXT("");
-	};
-
-	BlockingPortProcess BlockingProcess;
 
 	FProcHandle ProxyServerProcHandle;
 	FString RunningCloudDeploymentName;

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
@@ -11,11 +11,14 @@ class FLocalReceptionistProxyServerManager
 public:
 	FLocalReceptionistProxyServerManager();
 
+	bool CheckIfPortIsBound(int32 Port);
 	bool KillProcessBlockingPort();
+	bool LocalReceptionistProxyServerPreRunChecks();
 
+	void SPATIALGDKSERVICES_API Init();
 	bool SPATIALGDKSERVICES_API TryStartReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName);
 	bool SPATIALGDKSERVICES_API TryStopReceptionistProxyServer();
-
+	
 private:
 	FProcHandle ProxyServerProcHandle;
 	FString RunningCloudDeploymentName;

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
@@ -15,7 +15,7 @@ public:
 	bool KillBlockingPortProcess();
 	bool LocalReceptionistProxyServerPreRunChecks();
 
-	bool GetProcessName();
+	FString GetProcessName();
 
 	void SPATIALGDKSERVICES_API Init();
 	bool SPATIALGDKSERVICES_API TryStartReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName);

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
@@ -14,8 +14,6 @@ public:
 	bool CheckIfPortIsBound(int32 Port, FString& OutPID, FString& OutLogMessages);
 	bool LocalReceptionistProxyServerPreRunChecks(int32 ReceptionistPort);
 
-	bool GetProcessName(const FString& PID, FString& OutProcessName);
-
 	void SPATIALGDKSERVICES_API Init(int32 ReceptionistPort);
 	bool SPATIALGDKSERVICES_API TryStartReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, const FString& ListeningAddress, int32 ReceptionistPort);
 	bool SPATIALGDKSERVICES_API TryStopReceptionistProxyServer();

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
@@ -16,9 +16,9 @@ public:
 	SPATIALGDKSERVICES_API static bool StopSpatialService(bool bIsRunningInChina, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode);
 	SPATIALGDKSERVICES_API static bool BuildWorkerConfig(bool bIsRunningInChina, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode);
 	SPATIALGDKSERVICES_API static FProcHandle LocalWorkerReplace(const FString& ServicePort, const FString& OldWorker, const FString& NewWorker, bool bIsRunningInChina, uint32* OutProcessID);
-	SPATIALGDKSERVICES_API static bool GenerateDevAuthToken(bool bIsRunningInChina, FString& OutTokenSecret, FText& OutErrorMessage);
-	SPATIALGDKSERVICES_API static bool HasDevLoginTag(const FString& DeploymentName, bool bIsRunningInChinat, FText& OutErrorMessage);
-	SPATIALGDKSERVICES_API static FProcHandle StartLocalReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, FString &OutResult, int32 &ExitCode, bool &bProcessSucceeded);
+	SPATIALGDKSERVICES_API static bool GenerateDevAuthToken(bool bIsRunningInChina, FString& OutTokenSecret, FString& OutErrorMessage);
+	SPATIALGDKSERVICES_API static bool HasDevLoginTag(const FString& DeploymentName, bool bIsRunningInChina, FText& OutErrorMessage);
+	SPATIALGDKSERVICES_API static FProcHandle StartLocalReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, const FString& ListeningAddress, const int32& ReceptionistPort, FString &OutResult, int32 &OutExitCode, bool &bProcessSucceeded);
 	SPATIALGDKSERVICES_API static void StopLocalReceptionistProxyServer(FProcHandle& ProcessHandle);
 
 };

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
@@ -20,5 +20,6 @@ public:
 	SPATIALGDKSERVICES_API static bool HasDevLoginTag(const FString& DeploymentName, bool bIsRunningInChina, FText& OutErrorMessage);
 	SPATIALGDKSERVICES_API static FProcHandle StartLocalReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, const FString& ListeningAddress, const int32 ReceptionistPort, FString &OutResult, int32 &OutExitCode);
 	SPATIALGDKSERVICES_API static void StopLocalReceptionistProxyServer(FProcHandle& ProcessHandle);
-
+	SPATIALGDKSERVICES_API static bool GetProcessInfoFromPort(int32 Port, FString& OutPid, FString& OutState);
+	SPATIALGDKSERVICES_API static bool TryKillProcessWithPID(const FString& PID);
 };

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
@@ -18,7 +18,7 @@ public:
 	SPATIALGDKSERVICES_API static FProcHandle LocalWorkerReplace(const FString& ServicePort, const FString& OldWorker, const FString& NewWorker, bool bIsRunningInChina, uint32* OutProcessID);
 	SPATIALGDKSERVICES_API static bool GenerateDevAuthToken(bool bIsRunningInChina, FString& OutTokenSecret, FString& OutErrorMessage);
 	SPATIALGDKSERVICES_API static bool HasDevLoginTag(const FString& DeploymentName, bool bIsRunningInChina, FText& OutErrorMessage);
-	SPATIALGDKSERVICES_API static FProcHandle StartLocalReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, const FString& ListeningAddress, const int32 ReceptionistPort, FString &OutResult, int32 &OutExitCode);
+	SPATIALGDKSERVICES_API static FProcHandle StartLocalReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, const FString& ListeningAddress, const int32 ReceptionistPort, FString& OutResult, int32& OutExitCode);
 	SPATIALGDKSERVICES_API static void StopLocalReceptionistProxyServer(FProcHandle& ProcessHandle);
 	SPATIALGDKSERVICES_API static bool GetProcessInfoFromPort(int32 Port, FString& OutPid, FString& OutState);
 	SPATIALGDKSERVICES_API static bool TryKillProcessWithPID(const FString& PID);

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
@@ -18,7 +18,7 @@ public:
 	SPATIALGDKSERVICES_API static FProcHandle LocalWorkerReplace(const FString& ServicePort, const FString& OldWorker, const FString& NewWorker, bool bIsRunningInChina, uint32* OutProcessID);
 	SPATIALGDKSERVICES_API static bool GenerateDevAuthToken(bool bIsRunningInChina, FString& OutTokenSecret, FText& OutErrorMessage);
 	SPATIALGDKSERVICES_API static bool HasDevLoginTag(const FString& DeploymentName, bool bIsRunningInChinat, FText& OutErrorMessage);
-	SPATIALGDKSERVICES_API static FProcHandle StartLocalReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, FString &OutResult, int32 &ExitCode);
+	SPATIALGDKSERVICES_API static FProcHandle StartLocalReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, FString &OutResult, int32 &ExitCode, bool &bProcessSucessed);
 	SPATIALGDKSERVICES_API static void StopLocalReceptionistProxyServer(FProcHandle& ProcessHandle);
 
 };

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
@@ -18,7 +18,7 @@ public:
 	SPATIALGDKSERVICES_API static FProcHandle LocalWorkerReplace(const FString& ServicePort, const FString& OldWorker, const FString& NewWorker, bool bIsRunningInChina, uint32* OutProcessID);
 	SPATIALGDKSERVICES_API static bool GenerateDevAuthToken(bool bIsRunningInChina, FString& OutTokenSecret, FString& OutErrorMessage);
 	SPATIALGDKSERVICES_API static bool HasDevLoginTag(const FString& DeploymentName, bool bIsRunningInChina, FText& OutErrorMessage);
-	SPATIALGDKSERVICES_API static FProcHandle StartLocalReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, const FString& ListeningAddress, const int32& ReceptionistPort, FString &OutResult, int32 &OutExitCode, bool &bProcessSucceeded);
+	SPATIALGDKSERVICES_API static FProcHandle StartLocalReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, const FString& ListeningAddress, const int32 ReceptionistPort, FString &OutResult, int32 &OutExitCode, bool &bProcessSucceeded);
 	SPATIALGDKSERVICES_API static void StopLocalReceptionistProxyServer(FProcHandle& ProcessHandle);
 
 };

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
@@ -16,12 +16,11 @@ public:
 	SPATIALGDKSERVICES_API static bool StopSpatialService(bool bIsRunningInChina, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode);
 	SPATIALGDKSERVICES_API static bool BuildWorkerConfig(bool bIsRunningInChina, const FString& DirectoryToRun, FString& OutResult, int32& OutExitCode);
 	SPATIALGDKSERVICES_API static FProcHandle LocalWorkerReplace(const FString& ServicePort, const FString& OldWorker, const FString& NewWorker, bool bIsRunningInChina, uint32* OutProcessID);
-	SPATIALGDKSERVICES_API static bool GenerateDevAuthToken(bool bIsRunningInChina, FString& OutTokenSecret, FString& OutErrorMessage);
+	SPATIALGDKSERVICES_API static bool GenerateDevAuthToken(bool bIsRunningInChina, FString& OutTokenSecret, FText& OutErrorMessage);
 	SPATIALGDKSERVICES_API static bool HasDevLoginTag(const FString& DeploymentName, bool bIsRunningInChina, FText& OutErrorMessage);
 	SPATIALGDKSERVICES_API static FProcHandle StartLocalReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, const FString& ListeningAddress, const int32 ReceptionistPort, FString& OutResult, int32& OutExitCode);
 	SPATIALGDKSERVICES_API static void StopLocalReceptionistProxyServer(FProcHandle& ProcessHandle);
 	SPATIALGDKSERVICES_API static bool GetProcessInfoFromPort(int32 Port, FString& OutPid, FString& OutState, FString& OutProcessName);
-	SPATIALGDKSERVICES_API static bool GetProcessInfoFromPortWindows(int32 Port, FString& OutPid, FString& OutState);
-	SPATIALGDKSERVICES_API static bool GetProcessInfoFromPortMacOs(int32 Port, FString& OutPid, FString& OutState, FString& OutProcessName);
+	SPATIALGDKSERVICES_API static bool GetProcessName(const FString& PID, FString& OutProcessName);
 	SPATIALGDKSERVICES_API static bool TryKillProcessWithPID(const FString& PID);
 };

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
@@ -18,7 +18,7 @@ public:
 	SPATIALGDKSERVICES_API static FProcHandle LocalWorkerReplace(const FString& ServicePort, const FString& OldWorker, const FString& NewWorker, bool bIsRunningInChina, uint32* OutProcessID);
 	SPATIALGDKSERVICES_API static bool GenerateDevAuthToken(bool bIsRunningInChina, FString& OutTokenSecret, FString& OutErrorMessage);
 	SPATIALGDKSERVICES_API static bool HasDevLoginTag(const FString& DeploymentName, bool bIsRunningInChina, FText& OutErrorMessage);
-	SPATIALGDKSERVICES_API static FProcHandle StartLocalReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, const FString& ListeningAddress, const int32 ReceptionistPort, FString &OutResult, int32 &OutExitCode, bool &bProcessSucceeded);
+	SPATIALGDKSERVICES_API static FProcHandle StartLocalReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, const FString& ListeningAddress, const int32 ReceptionistPort, FString &OutResult, int32 &OutExitCode);
 	SPATIALGDKSERVICES_API static void StopLocalReceptionistProxyServer(FProcHandle& ProcessHandle);
 
 };

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
@@ -20,6 +20,8 @@ public:
 	SPATIALGDKSERVICES_API static bool HasDevLoginTag(const FString& DeploymentName, bool bIsRunningInChina, FText& OutErrorMessage);
 	SPATIALGDKSERVICES_API static FProcHandle StartLocalReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, const FString& ListeningAddress, const int32 ReceptionistPort, FString& OutResult, int32& OutExitCode);
 	SPATIALGDKSERVICES_API static void StopLocalReceptionistProxyServer(FProcHandle& ProcessHandle);
-	SPATIALGDKSERVICES_API static bool GetProcessInfoFromPort(int32 Port, FString& OutPid, FString& OutState);
+	SPATIALGDKSERVICES_API static bool GetProcessInfoFromPort(int32 Port, FString& OutPid, FString& OutState, FString& OutProcessName);
+	SPATIALGDKSERVICES_API static bool GetProcessInfoFromPortWindows(int32 Port, FString& OutPid, FString& OutState);
+	SPATIALGDKSERVICES_API static bool GetProcessInfoFromPortMacOs(int32 Port, FString& OutPid, FString& OutState, FString& OutProcessName);
 	SPATIALGDKSERVICES_API static bool TryKillProcessWithPID(const FString& PID);
 };

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
@@ -18,7 +18,7 @@ public:
 	SPATIALGDKSERVICES_API static FProcHandle LocalWorkerReplace(const FString& ServicePort, const FString& OldWorker, const FString& NewWorker, bool bIsRunningInChina, uint32* OutProcessID);
 	SPATIALGDKSERVICES_API static bool GenerateDevAuthToken(bool bIsRunningInChina, FString& OutTokenSecret, FText& OutErrorMessage);
 	SPATIALGDKSERVICES_API static bool HasDevLoginTag(const FString& DeploymentName, bool bIsRunningInChinat, FText& OutErrorMessage);
-	SPATIALGDKSERVICES_API static FProcHandle StartLocalReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, FString &OutResult, int32 &ExitCode, bool &bProcessSucessed);
+	SPATIALGDKSERVICES_API static FProcHandle StartLocalReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName, FString &OutResult, int32 &ExitCode, bool &bProcessSucceeded);
 	SPATIALGDKSERVICES_API static void StopLocalReceptionistProxyServer(FProcHandle& ProcessHandle);
 
 };

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesConstants.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesConstants.h
@@ -47,6 +47,6 @@ namespace SpatialGDKServicesConstants
 
 	const FString UseChinaServicesRegionFilename = TEXT("UseChinaServicesRegion");
 
-	const FString ProxyFileDirectory = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectDir(), TEXT("/../Game/Intermediate/")));
+	const FString ProxyFileDirectory = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectIntermediateDir(), TEXT("Improbable")));
 	const FString ProxyInfoFilename = TEXT("ServerReceptionistProxyInfo.json");
 }

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesConstants.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesConstants.h
@@ -46,4 +46,7 @@ namespace SpatialGDKServicesConstants
 	const FString DevLoginDeploymentTag = TEXT("dev_login");
 
 	const FString UseChinaServicesRegionFilename = TEXT("UseChinaServicesRegion");
+
+	const FString ProxyFileDirectory = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectDir(), TEXT("/../Game/Intermediate/")));
+	const FString ProxyInfoFilename = TEXT("ServerReceptionistProxyInfo.json");
 }

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesConstants.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesConstants.h
@@ -48,5 +48,5 @@ namespace SpatialGDKServicesConstants
 	const FString UseChinaServicesRegionFilename = TEXT("UseChinaServicesRegion");
 
 	const FString ProxyFileDirectory = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectIntermediateDir(), TEXT("Improbable")));
-	const FString ProxyInfoFilename = TEXT("ServerReceptionistProxyInfo.json");
+	const FString ProxyInfoFilePath = FPaths::Combine(ProxyFileDirectory, TEXT("ServerReceptionistProxyInfo.json"));
 }

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesConstants.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesConstants.h
@@ -50,6 +50,8 @@ namespace SpatialGDKServicesConstants
 	const FString ProxyFileDirectory = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectIntermediateDir(), TEXT("Improbable")));
 	const FString ProxyInfoFilePath = FPaths::Combine(ProxyFileDirectory, TEXT("ServerReceptionistProxyInfo.json"));
 
+#if PLATFORM_MAC
 	const FString LsofCmdFilePath = TEXT("/usr/sbin/");
 	const FString KillCmdFilePath = TEXT("/bin/");
+#endif
 }

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesConstants.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesConstants.h
@@ -49,4 +49,7 @@ namespace SpatialGDKServicesConstants
 
 	const FString ProxyFileDirectory = FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectIntermediateDir(), TEXT("Improbable")));
 	const FString ProxyInfoFilePath = FPaths::Combine(ProxyFileDirectory, TEXT("ServerReceptionistProxyInfo.json"));
+
+	const FString LsofCmdFilePath = TEXT("/usr/sbin/");
+	const FString KillCmdFilePath = TEXT("/bin/");
 }

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesModule.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesModule.h
@@ -38,7 +38,6 @@ public:
 	static void ExecuteAndReadOutput(const FString& Executable, const FString& Arguments, const FString& DirectoryToRun, FString& OutResult, int32& ExitCode);
 
 private:
-
 	FLocalDeploymentManager LocalDeploymentManager;
 	FLocalReceptionistProxyServerManager LocalReceptionistProxyServerManager;
 


### PR DESCRIPTION
Adding a new **Connect local server worker to the cloud deployment** checkbox, in Editor Setting under Cloud Connection:
![image](https://user-images.githubusercontent.com/56884490/85114237-9fe49500-b210-11ea-8528-3d2d3c59d44c.png)


In addition, added the option to select the port and the listening address of the server receptionist proxy if needed.

If  **Connect local server worker to the cloud deployment** is enabled when pressing play to connect to a Cloud Deployment both the Client and Server will start and connect to the Deployment.

If **Connect local server worker to the cloud deployment** is disabled, only the Client will start and connect to the Deployment.

The server is connecting via a receptionist proxy server that starts when you click the Play button.

No automated tests are included. Tested locally by running both local and cloud deployments.

To test : 
- Click Cloud in the SpatialOS Toolbar
- Select the default launch configuration file : **"manual_worker_connection_only"** option set to **true.**
- Start the cloud deployment
- Navigate to SpatialOS Settings> **Connect local server worker to the cloud deployment**  enable it
- Press play.
- You should see that both a UnrealClient and a UnrealWorker connected to the cloud deployment.

Good to test all different workflows,  enable /disable Connect local server worker to the cloud, local deployment, cloud deployment as we run a proxy that can block the local deployment too.

#### Documentation
Release Note, [Feature Documentation ](https://docs.google.com/document/d/1uxFe4JkISvoWZsLJPSsCjvDtF_S4yKxA1esQAt2vkM0/edit?usp=sharing)

