### PR TITLE
Added an accessor to the LayeredLB to get the Default strategy.

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -14,6 +14,7 @@
 #include "Interop/Connection/SpatialWorkerConnection.h"
 #include "Interop/GlobalStateManager.h"
 #include "Interop/SpatialReceiver.h"
+#include "LoadBalancing/AbstractLBStrategy.h"
 #include "Net/NetworkProfiler.h"
 #include "Schema/AuthorityIntent.h"
 #include "Schema/ClientRPCEndpointLegacy.h"

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
@@ -239,6 +239,14 @@ bool ULayeredLBStrategy::CouldHaveAuthority(const TSubclassOf<AActor> Class) con
 	return *VirtualWorkerIdToLayerName.Find(LocalVirtualWorkerId) == GetLayerNameForClass(Class);
 }
 
+UAbstractLBStrategy* ULayeredLBStrategy::GetLBStrategyForVisualRendering() const
+{
+	// The default strategy is guaranteed to exist as long as the strategy is ready.
+	check(IsReady());
+	return LayerNameToLBStrategy[SpatialConstants::DefaultLayer];
+}
+
+
 FName ULayeredLBStrategy::GetLayerNameForClass(const TSubclassOf<AActor> Class) const
 {
 	if (Class == nullptr)

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
@@ -246,7 +246,6 @@ UAbstractLBStrategy* ULayeredLBStrategy::GetLBStrategyForVisualRendering() const
 	return LayerNameToLBStrategy[SpatialConstants::DefaultLayer];
 }
 
-
 FName ULayeredLBStrategy::GetLayerNameForClass(const TSubclassOf<AActor> Class) const
 {
 	if (Class == nullptr)

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
@@ -6,6 +6,8 @@
 #include "Interop/SpatialReceiver.h"
 #include "Interop/SpatialSender.h"
 #include "Interop/SpatialStaticComponentView.h"
+#include "LoadBalancing/GridBasedLBStrategy.h"
+#include "LoadBalancing/LayeredLBStrategy.h"
 #include "LoadBalancing/WorkerRegion.h"
 #include "Schema/AuthorityIntent.h"
 #include "Schema/SpatialDebugging.h"
@@ -143,7 +145,14 @@ void ASpatialDebugger::OnAuthorityGained()
 {
 	if (NetDriver->LoadBalanceStrategy)
 	{
-		if (const UGridBasedLBStrategy* GridBasedLBStrategy = Cast<UGridBasedLBStrategy>(NetDriver->LoadBalanceStrategy))
+		const ULayeredLBStrategy* LayeredLBStrategy = Cast<ULayeredLBStrategy>(NetDriver->LoadBalanceStrategy);
+		if (LayeredLBStrategy == nullptr)
+		{
+			UE_LOG(LogSpatialDebugger, Warning, TEXT("SpatialDebugger enabled but unable to get LayeredLBStrategy."));
+			return;
+		}
+
+		if (const UGridBasedLBStrategy* GridBasedLBStrategy = Cast<UGridBasedLBStrategy>(LayeredLBStrategy->GetLBStrategyForVisualRendering()))
 		{
 			const UGridBasedLBStrategy::LBStrategyRegions LBStrategyRegions = GridBasedLBStrategy->GetLBStrategyRegions();
 			WorkerRegions.SetNum(LBStrategyRegions.Num());

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LayeredLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LayeredLBStrategy.h
@@ -73,6 +73,10 @@ public:
 	// switch to Load Balancing. 
 	bool CouldHaveAuthority(TSubclassOf<AActor> Class) const;
 
+	// This returns the LBStrategy which should be rendered in the SpatialDebugger.
+	// Currently, this is just the default strategy.
+	UAbstractLBStrategy* GetLBStrategyForVisualRendering() const;
+
 private:
 	TArray<VirtualWorkerId> VirtualWorkerIds;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialDebugger.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialDebugger.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "LoadBalancing/GridBasedLBStrategy.h"
 #include "LoadBalancing/WorkerRegion.h"
 #include "SpatialCommonTypes.h"
 


### PR DESCRIPTION
#### Description
This fixes the SpatialDebugger region display. This is a short term solution. The long term solution would be to allow the WorldSettings to specify which layer should be displayed, but in the short term, most developers will want to display the default layer, so that's what this defaults to.

#### Release note
N/A

#### Tests
Run the OffloadingGym in GDKTestGyms and verify that you see 4 colored quadrants, but that the offloaded cube is displayed as a different color.

STRONGLY SUGGESTED: How can this be verified by QA?

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
