### PR TITLE
Cleanup race conditions in initialization code

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
@@ -25,6 +25,11 @@
 
 DEFINE_LOG_CATEGORY(LogSpatialGameInstance);
 
+USpatialGameInstance::USpatialGameInstance()
+	: Super()
+	, bIsSpatialNetDriverReady(false)
+{}
+
 bool USpatialGameInstance::HasSpatialNetDriver() const
 {
 	bool bHasSpatialNetDriver = false;
@@ -265,8 +270,7 @@ void USpatialGameInstance::OnLevelInitializedNetworkActors(ULevel* LoadedLevel, 
 		return;
 	}
 
-	check(SpatialConnectionManager != nullptr);
-	if (SpatialConnectionManager->IsConnected())
+	if (bIsSpatialNetDriverReady)
 	{
 		CleanupLevelInitializedNetworkActors(LoadedLevel);
 	}
@@ -276,8 +280,9 @@ void USpatialGameInstance::OnLevelInitializedNetworkActors(ULevel* LoadedLevel, 
 	}
 }
 
-void USpatialGameInstance::CleanupLevelInitializedNetworkActors(ULevel* LoadedLevel) const
+void USpatialGameInstance::CleanupLevelInitializedNetworkActors(ULevel* LoadedLevel)
 {
+	bIsSpatialNetDriverReady = true;
 	for (int32 ActorIndex = 0; ActorIndex < LoadedLevel->Actors.Num(); ActorIndex++)
 	{
 		AActor* Actor = LoadedLevel->Actors[ActorIndex];

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -2568,11 +2568,10 @@ void USpatialNetDriver::TrackTombstone(const Worker_EntityId EntityId)
 }
 #endif
 
-bool USpatialNetDriver::IsReady()
+bool USpatialNetDriver::IsReady() const
 {
 	return bIsReadyToStart;
 }
-
 
 // This should only be called once on each client, in the SpatialDebugger constructor after the class is replicated to each client.
 void USpatialNetDriver::SetSpatialDebugger(ASpatialDebugger* InSpatialDebugger)

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -603,11 +603,17 @@ void USpatialNetDriver::OnActorSpawned(AActor* Actor)
 	if (!Actor->GetIsReplicated() ||
 		Actor->GetLocalRole() != ROLE_Authority ||
 		!Actor->GetClass()->HasAnySpatialClassFlags(SPATIALCLASS_SpatialType) ||
-		!IsReady() ||
-		USpatialStatics::IsActorGroupOwnerForActor(Actor))
+		(IsReady() && USpatialStatics::IsActorGroupOwnerForActor(Actor)))
 	{
 		// We only want to delete actors which are replicated and we somehow gain local authority over,
 		// when they should be in a different Layer.
+		return;
+	}
+
+	if (!IsReady())
+	{
+		UE_LOG(LogSpatialOSNetDriver, Warning, TEXT("Spawned replicated actor %s (owner: %s) before the NetDriver was ready. This is not supported. Actors should only be spawned after BeginPlay is called."),
+			*GetNameSafe(Actor), *GetNameSafe(Actor->GetOwner()));
 		return;
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialGameInstance.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialGameInstance.h
@@ -24,6 +24,8 @@ class SPATIALGDK_API USpatialGameInstance : public UGameInstance
 	GENERATED_BODY()
 
 public:
+	USpatialGameInstance();
+
 #if WITH_EDITOR
 	virtual FGameInstancePIEResult StartPlayInEditorGameInstance(ULocalPlayer* LocalPlayer, const FGameInstancePIEParameters& Params) override;
 #endif
@@ -70,7 +72,7 @@ public:
 	void SetFirstConnectionToSpatialOSAttempted() { bFirstConnectionToSpatialOSAttempted = true; };
 	bool GetFirstConnectionToSpatialOSAttempted() const { return bFirstConnectionToSpatialOSAttempted; };
 
-	void CleanupLevelInitializedNetworkActors(ULevel* LoadedLevel) const;
+	void CleanupLevelInitializedNetworkActors(ULevel* LoadedLevel);
 
 protected:
 	// Checks whether the current net driver is a USpatialNetDriver.
@@ -101,4 +103,7 @@ private:
 
 	UFUNCTION()
 	void OnLevelInitializedNetworkActors(ULevel* LoadedLevel, UWorld* OwningWorld);
+
+	// Boolean for whether or not the Spatial connection is ready for normal operations.
+	bool bIsSpatialNetDriverReady;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -182,6 +182,10 @@ public:
 	void TrackTombstone(const Worker_EntityId EntityId);
 #endif
 
+	// IsReady evaluates the GSM, Load Balancing system, and others to get a holistic
+	// view of whether the SpatialNetDriver is ready to assume normal operations.
+	bool IsReady();
+
 private:
 
 	TUniquePtr<SpatialDispatcher> Dispatcher;

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -184,7 +184,7 @@ public:
 
 	// IsReady evaluates the GSM, Load Balancing system, and others to get a holistic
 	// view of whether the SpatialNetDriver is ready to assume normal operations.
-	bool IsReady();
+	bool IsReady() const;
 
 private:
 


### PR DESCRIPTION
#### Description
NWX has run into two problems with the startup ordering and an IsReady check in the LayeredLBStrategy. This fixes both and adds a bit more debugging info.

1. There was a race where the SpatialConnectionManager has made the connection to Spatial but the LoadBalancing system isn't ready yet. If a map loads before the LBStrategy is ready, it could start processing the network initialized actors early. The fix for that is in SpatialGameInstance.

2. NWX is seeing issues with LevelActors being spawned before the NetDriver is ready (specifically before the LBStrategy is ready). The fix for this is in SpatialNetDriver.

#### Release note
REQUIRED: Add a release note to the `##Unreleased` section of CHANGELOG.md. You can find guidance for writing useful release notes [here](../SpatialGDK/Extras/internal-documentation/how-to-write-good-release-notes.md). Documentation changes are exempt from this requirement.

#### Tests
How did you test these changes prior to submitting this pull request?
What automated tests are included in this PR?

STRONGLY SUGGESTED: How can this be verified by QA?

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
