### PR TITLE
Do not override default settings for manual connection

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -169,12 +169,7 @@ struct FSpatialLaunchConfigDescription
 	FSpatialLaunchConfigDescription()
 		: Template(TEXT("w2_r0500_e5"))
 		, World()
-	{
-		FWorkerTypeLaunchSection UnrealWorkerDefaultSetting;
-		UnrealWorkerDefaultSetting.bManualWorkerConnectionOnly = true;
-
-		ServerWorkerConfig = UnrealWorkerDefaultSetting;
-	}
+	{}
 
 	/** Deployment template. */
 	UPROPERTY(Category = "SpatialGDK", EditAnywhere, config)


### PR DESCRIPTION
#### Description
The default value for ManualWorkerConnectionOnly is set in FWorkerTypeLaunchSection, but then is overridden when a FSpatialLaunchConfigDescription is created. This removes the override.

The side effect is that by default the settings set ManualWorkerConnection to false, as intended.

#### Release note
REQUIRED: Add a release note to the `##Unreleased` section of CHANGELOG.md. You can find guidance for writing useful release notes [here](../SpatialGDK/Extras/internal-documentation/how-to-write-good-release-notes.md). Documentation changes are exempt from this requirement.

#### Tests
How did you test these changes prior to submitting this pull request?
What automated tests are included in this PR?

STRONGLY SUGGESTED: How can this be verified by QA?

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
