### PR TITLE
Add a checkbox to build and upload assembly

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/CloudDeploymentConfiguration.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/CloudDeploymentConfiguration.cpp
@@ -24,6 +24,7 @@ void FCloudDeploymentConfiguration::InitFromSettings()
 	SimulatedPlayerCluster = Settings->GetSimulatedPlayerCluster();
 	NumberOfSimulatedPlayers = Settings->GetNumberOfSimulatedPlayers();
 
+	bBuildAndUploadAssembly = Settings->ShouldBuildAndUploadAssembly();
 	bGenerateSchema = Settings->IsGenerateSchemaEnabled();
 	bGenerateSnapshot = Settings->IsGenerateSnapshotEnabled();
 	BuildConfiguration = Settings->GetAssemblyBuildConfiguration().ToString();

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -32,6 +32,7 @@ USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& O
 	, CookAndGenerateAdditionalArguments("-cookall -unversioned")
 	, PrimaryDeploymentRegionCode(ERegionCode::US)
 	, SimulatedPlayerLaunchConfigPath(FSpatialGDKServicesModule::GetSpatialGDKPluginDirectory(TEXT("SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/SpatialConfig/cloud_launch_sim_player_deployment.json")))
+	, bBuildAndUploadAssembly(true)
 	, AssemblyBuildConfiguration(TEXT("Development"))
 	, SimulatedPlayerDeploymentRegionCode(ERegionCode::US)
 	, bStartPIEClientsWithLocalLaunchOnDevice(false)
@@ -191,6 +192,12 @@ void USpatialGDKEditorSettings::SetSimulatedPlayerCluster(const FString& NewClus
 void USpatialGDKEditorSettings::SetSimulatedPlayersEnabledState(bool IsEnabled)
 {
 	bSimulatedPlayersIsEnabled = IsEnabled;
+	SaveConfig();
+}
+
+void USpatialGDKEditorSettings::SetBuildAndUploadAssembly(bool bBuildAndUpload)
+{
+	bBuildAndUploadAssembly = bBuildAndUpload;
 	SaveConfig();
 }
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/CloudDeploymentConfiguration.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/CloudDeploymentConfiguration.h
@@ -28,6 +28,7 @@ struct SPATIALGDKEDITOR_API FCloudDeploymentConfiguration
 	FString SimulatedPlayerCluster;
 	uint32 NumberOfSimulatedPlayers = 0;
 
+	bool bBuildAndUploadAssembly = false;
 	bool bGenerateSchema = false;
 	bool bGenerateSnapshot = false;
 	FString BuildConfiguration;

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -323,6 +323,10 @@ private:
 	const FString SimulatedPlayerLaunchConfigPath;
 
 public:
+	/** Whether to build and upload the assembly when starting the cloud deployment. */
+	UPROPERTY(EditAnywhere, config, Category = "Assembly", meta = (DisplayName = "Build and Upload Assembly"))
+	bool bBuildAndUploadAssembly;
+
 	/** The build configuration to use when creating workers for the assembly, e.g. Development */
 	UPROPERTY(EditAnywhere, config, Category = "Assembly", meta = (DisplayName = "Build Configuration"))
 	FString AssemblyBuildConfiguration;
@@ -554,6 +558,12 @@ public:
 	FORCEINLINE bool IsSimulatedPlayersEnabled() const
 	{
 		return bSimulatedPlayersIsEnabled;
+	}
+
+	void SetBuildAndUploadAssembly(bool bBuildAndUpload);
+	FORCEINLINE bool ShouldBuildAndUploadAssembly() const
+	{
+		return bBuildAndUploadAssembly;
 	}
 
 	void SetForceAssemblyOverwrite(bool bForce);

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKCloudDeploymentConfiguration.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKCloudDeploymentConfiguration.cpp
@@ -526,7 +526,28 @@ void SSpatialGDKCloudDeploymentConfiguration::Construct(const FArguments& InArgs
 							.HAlign(HAlign_Center)
 							[
 								SNew(STextBlock)
-								.Text(FText::FromString(FString(TEXT("Build and Upload Assembly"))))
+								.Text(FText::FromString(FString(TEXT("Assembly Configuration"))))
+							]
+							// Build and Upload Assembly
+							+ SVerticalBox::Slot()
+							.AutoHeight()
+							.Padding(2.0f)
+							[
+								SNew(SHorizontalBox)
+								+ SHorizontalBox::Slot()
+								.FillWidth(1.0f)
+								[
+									SNew(STextBlock)
+									.Text(FText::FromString(FString(TEXT("Build and Upload Assembly"))))
+									.ToolTipText(FText::FromString(FString(TEXT("Whether to build and upload the assembly when starting the cloud deployment."))))
+								]
+								+ SHorizontalBox::Slot()
+								.FillWidth(1.0f)
+								[
+									SNew(SCheckBox)
+									.IsChecked(this, &SSpatialGDKCloudDeploymentConfiguration::IsBuildAndUploadAssemblyEnabled)
+									.OnCheckStateChanged(this, &SSpatialGDKCloudDeploymentConfiguration::OnCheckedBuildAndUploadAssembly)
+								]
 							]
 							// Generate Schema
 							+ SVerticalBox::Slot()
@@ -547,6 +568,7 @@ void SSpatialGDKCloudDeploymentConfiguration::Construct(const FArguments& InArgs
 									SNew(SCheckBox)
 									.IsChecked(this, &SSpatialGDKCloudDeploymentConfiguration::IsGenerateSchemaEnabled)
 									.OnCheckStateChanged(this, &SSpatialGDKCloudDeploymentConfiguration::OnCheckedGenerateSchema)
+									.IsEnabled_UObject(SpatialGDKSettings, &USpatialGDKEditorSettings::ShouldBuildAndUploadAssembly)
 								]
 							]
 							// Generate Snapshot
@@ -568,6 +590,7 @@ void SSpatialGDKCloudDeploymentConfiguration::Construct(const FArguments& InArgs
 									SNew(SCheckBox)
 									.IsChecked(this, &SSpatialGDKCloudDeploymentConfiguration::IsGenerateSnapshotEnabled)
 									.OnCheckStateChanged(this, &SSpatialGDKCloudDeploymentConfiguration::OnCheckedGenerateSnapshot)
+									.IsEnabled_UObject(SpatialGDKSettings, &USpatialGDKEditorSettings::ShouldBuildAndUploadAssembly)
 								]
 							]
 							// Build Configuration
@@ -594,6 +617,7 @@ void SSpatialGDKCloudDeploymentConfiguration::Construct(const FArguments& InArgs
 										SNew(STextBlock)
 										.Text_UObject(SpatialGDKSettings, &USpatialGDKEditorSettings::GetAssemblyBuildConfiguration)
 									]
+									.IsEnabled_UObject(SpatialGDKSettings, &USpatialGDKEditorSettings::ShouldBuildAndUploadAssembly)
 								]
 							]
 							// Enable/Disable Build Client Worker
@@ -615,6 +639,7 @@ void SSpatialGDKCloudDeploymentConfiguration::Construct(const FArguments& InArgs
 									SNew(SCheckBox)
 									.IsChecked(this, &SSpatialGDKCloudDeploymentConfiguration::IsBuildClientWorkerEnabled)
 									.OnCheckStateChanged(this, &SSpatialGDKCloudDeploymentConfiguration::OnCheckedBuildClientWorker)
+									.IsEnabled_UObject(SpatialGDKSettings, &USpatialGDKEditorSettings::ShouldBuildAndUploadAssembly)
 								]
 							]
 							// Force Overwrite on Upload
@@ -636,6 +661,7 @@ void SSpatialGDKCloudDeploymentConfiguration::Construct(const FArguments& InArgs
 									SNew(SCheckBox)
 									.IsChecked(this, &SSpatialGDKCloudDeploymentConfiguration::ForceAssemblyOverwrite)
 									.OnCheckStateChanged(this, &SSpatialGDKCloudDeploymentConfiguration::OnCheckedForceAssemblyOverwrite)
+									.IsEnabled_UObject(SpatialGDKSettings, &USpatialGDKEditorSettings::ShouldBuildAndUploadAssembly)
 								]
 							]
 							// Separator
@@ -895,6 +921,18 @@ void SSpatialGDKCloudDeploymentConfiguration::OnCheckedSimulatedPlayers(ECheckBo
 {
 	USpatialGDKEditorSettings* SpatialGDKSettings = GetMutableDefault<USpatialGDKEditorSettings>();
 	SpatialGDKSettings->SetSimulatedPlayersEnabledState(NewCheckedState == ECheckBoxState::Checked);
+}
+
+ECheckBoxState SSpatialGDKCloudDeploymentConfiguration::IsBuildAndUploadAssemblyEnabled() const
+{
+	const USpatialGDKEditorSettings* SpatialGDKSettings = GetDefault<USpatialGDKEditorSettings>();
+	return SpatialGDKSettings->ShouldBuildAndUploadAssembly() ? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
+}
+
+void SSpatialGDKCloudDeploymentConfiguration::OnCheckedBuildAndUploadAssembly(ECheckBoxState NewCheckedState)
+{
+	USpatialGDKEditorSettings* SpatialGDKSettings = GetMutableDefault<USpatialGDKEditorSettings>();
+	SpatialGDKSettings->SetBuildAndUploadAssembly(NewCheckedState == ECheckBoxState::Checked);
 }
 
 ECheckBoxState SSpatialGDKCloudDeploymentConfiguration::IsSimulatedPlayersEnabled() const

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKCloudDeploymentConfiguration.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKCloudDeploymentConfiguration.h
@@ -108,6 +108,9 @@ private:
 	/** Delegate called when the user either clicks the simulated players checkbox */
 	void OnCheckedSimulatedPlayers(ECheckBoxState NewCheckedState);
 
+	ECheckBoxState IsBuildAndUploadAssemblyEnabled() const;
+	void OnCheckedBuildAndUploadAssembly(ECheckBoxState NewCheckedState);
+
 	TSharedRef<SWidget> OnGetBuildConfiguration();
 	void OnBuildConfigurationPicked(FString Configuration);
 


### PR DESCRIPTION
#### Description
Starting a cloud deployment can fail after build and upload succeeds, so add a checkbox to skip the build and upload stage.

![image](https://user-images.githubusercontent.com/32096431/83676853-3b4ff600-a5d3-11ea-9b64-f18770589496.png)

#### Primary reviewers
@jessicafalk @jayprobable 
