### PR TITLE
Remove enable multi worker flag in gdk settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `OnConnected` and `OnConnectionFailed` on `SpatialGameInstance` have been renamed to `OnSpatialConnected` and `OnSpatialConnectionFailed`. They are now also blueprint-assignable.
 - The GenerateSchema and GenerateSchemaAndSnapshots commandlet will not generate Schema anymore and has been deprecated in favor of CookAndGenerateSchemaCommandlet (GenerateSchemaAndSnapshots still works with the -SkipSchema option).
 - Settings for Offloading and Load Balancing have been combined and moved from the Editor and Runtime settings to instead be per map in the SpatialWorldSettings. For a detailed explanation please see the Load Balancing documentation.
+- Command line arguments `OverrideSpatialOffloading` and `OverrideLoadBalancer` have been removed and UnrealGDK Load balancing is always enabled. To override a map's load balancing config and run single worker, use the command line flag `OverrideLoadBalancing`
 - Running with result types (previously default enabled) is now mandatory. The Runtime setting `bEnableResultTypes` has been removed to reflect this.
 - Removed `QueuedOutgoingRPCWaitTime`, all RPC failure cases are now correctly queued or dropped.
 - Removed `Max connection capacity limit` and `Login rate limit` from generated worker configurations as no longer supported.

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
@@ -286,7 +286,7 @@ void USpatialGameInstance::CleanupLevelInitializedNetworkActors(ULevel* LoadedLe
 			continue;
 		}
 
-		if (USpatialStatics::IsSpatialOffloadingEnabled())
+		if (USpatialStatics::IsSpatialOffloadingEnabled(GetWorld()))
 		{
 			if (!USpatialStatics::IsActorGroupOwnerForActor(Actor))
 			{

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -382,10 +382,7 @@ void USpatialNetDriver::CreateAndInitializeCoreClasses()
 	}
 #endif
 
-	if (SpatialSettings->bEnableMultiWorker)
-	{
-		CreateAndInitializeLoadBalancingClasses();
-	}
+	CreateAndInitializeLoadBalancingClasses();
 
 	if (SpatialSettings->UseRPCRingBuffer())
 	{
@@ -435,7 +432,10 @@ void USpatialNetDriver::CreateAndInitializeLoadBalancingClasses()
 
 		if (WorldSettings == nullptr || WorldSettings->DefaultLayerLockingPolicy == nullptr)
 		{
-			UE_LOG(LogSpatialOSNetDriver, Error, TEXT("If EnableMultiWorker is set, there must be a Locking Policy set. Using default policy."));
+			if (WorldSettings->DefaultLayerLoadBalanceStrategy != nullptr)
+			{
+				UE_LOG(LogSpatialOSNetDriver, Error, TEXT("If a Load balancing strategy is set, there must be a Locking Policy set. Using default policy."));
+			}
 			LockingPolicy = NewObject<UOwnershipLockingPolicy>(this);
 		}
 		else
@@ -694,16 +694,9 @@ void USpatialNetDriver::OnLevelAddedToWorld(ULevel* LoadedLevel, UWorld* OwningW
 		return;
 	}
 
-	const bool bLoadBalancingEnabled = GetDefault<USpatialGDKSettings>()->bEnableMultiWorker;
 	const bool bHaveGSMAuthority = StaticComponentView->HasAuthority(SpatialConstants::INITIAL_GLOBAL_STATE_MANAGER_ENTITY_ID, SpatialConstants::STARTUP_ACTOR_MANAGER_COMPONENT_ID);
 
-	if (!bLoadBalancingEnabled && !bHaveGSMAuthority)
-	{
-		// If load balancing is disabled and this worker is not GSM authoritative then exit early.
-		return;
-	}
-
-	if (bLoadBalancingEnabled && !LoadBalanceStrategy->IsReady())
+	if (!LoadBalanceStrategy->IsReady())
 	{
 		// Load balancer isn't ready, this should only occur when servers are loading composition levels on startup, before connecting to spatial.
 		return;
@@ -715,7 +708,7 @@ void USpatialNetDriver::OnLevelAddedToWorld(ULevel* LoadedLevel, UWorld* OwningW
 		// otherwise, load balancing is enabled, so check the lb strategy.
 		if (Actor->GetIsReplicated())
 		{
-			const bool bRoleAuthoritative = !bLoadBalancingEnabled || LoadBalanceStrategy->ShouldHaveAuthority(*Actor);
+			const bool bRoleAuthoritative = LoadBalanceStrategy->ShouldHaveAuthority(*Actor);
 			Actor->Role = bRoleAuthoritative ? ROLE_Authority : ROLE_SimulatedProxy;
 			Actor->RemoteRole = bRoleAuthoritative ? ROLE_SimulatedProxy : ROLE_Authority;
 		}
@@ -2343,11 +2336,8 @@ void USpatialNetDriver::HandleStartupOpQueueing(const TArray<Worker_OpList*>& In
 			// Process levels which were loaded before the connection to Spatial was ready.
 			GetGameInstance()->CleanupCachedLevelsAfterConnection();
 
-			if (GetDefault<USpatialGDKSettings>()->bEnableMultiWorker)
-			{
-				// We know at this point that we have all the information to set the worker's interest query.
-				Sender->UpdateServerWorkerEntityInterestAndPosition();
-			}
+			// We know at this point that we have all the information to set the worker's interest query.
+			Sender->UpdateServerWorkerEntityInterestAndPosition();
 
 			// We've found and dispatched all ops we need for startup,
 			// trigger BeginPlay() on the GSM and process the queued ops.

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -430,12 +430,13 @@ void USpatialNetDriver::CreateAndInitializeLoadBalancingClasses()
 	{
 		LoadBalanceEnforcer = MakeUnique<SpatialLoadBalanceEnforcer>(Connection->GetWorkerId(), StaticComponentView, VirtualWorkerTranslator.Get());
 
-		if (WorldSettings == nullptr || WorldSettings->DefaultLayerLockingPolicy == nullptr)
+		if (WorldSettings == nullptr || !WorldSettings->bEnableMultiWorker)
 		{
-			if (WorldSettings->DefaultLayerLoadBalanceStrategy != nullptr)
-			{
-				UE_LOG(LogSpatialOSNetDriver, Error, TEXT("If a Load balancing strategy is set, there must be a Locking Policy set. Using default policy."));
-			}
+			LockingPolicy = NewObject<UOwnershipLockingPolicy>(this);
+		}
+		else if (WorldSettings->DefaultLayerLockingPolicy == nullptr)
+		{
+			UE_LOG(LogSpatialOSNetDriver, Error, TEXT("If Load balancing is enabled, there must be a Locking Policy set. Using default policy."));
 			LockingPolicy = NewObject<UOwnershipLockingPolicy>(this);
 		}
 		else

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
@@ -359,28 +359,6 @@ void UGlobalStateManager::BeginDestroy()
 #endif
 }
 
-void UGlobalStateManager::BecomeAuthoritativeOverAllActors()
-{
-	// This logic is not used in offloading.
-	if (USpatialStatics::IsSpatialOffloadingEnabled())
-	{
-		return;
-	}
-
-	for (TActorIterator<AActor> It(NetDriver->World); It; ++It)
-	{
-		AActor* Actor = *It;
-		if (Actor != nullptr && !Actor->IsPendingKill())
-		{
-			if (Actor->GetIsReplicated())
-			{
-				Actor->Role = ROLE_Authority;
-				Actor->RemoteRole = ROLE_SimulatedProxy;
-			}
-		}
-	}
-}
-
 void UGlobalStateManager::SetAllActorRolesBasedOnLBStrategy()
 {
 	for (TActorIterator<AActor> It(NetDriver->World); It; ++It)
@@ -412,14 +390,7 @@ void UGlobalStateManager::TriggerBeginPlay()
 	// If we're loading from a snapshot, we shouldn't try and call BeginPlay with authority.
 	if (bCanSpawnWithAuthority)
 	{
-		if (GetDefault<USpatialGDKSettings>()->bEnableMultiWorker)
-		{
-			SetAllActorRolesBasedOnLBStrategy();
-		}
-		else
-		{
-			BecomeAuthoritativeOverAllActors();
-		}
+		SetAllActorRolesBasedOnLBStrategy();
 	}
 
 	NetDriver->World->GetWorldSettings()->SetGSMReadyForPlay();

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
@@ -276,15 +276,9 @@ bool USpatialClassInfoManager::ShouldTrackHandoverProperties() const
 
 	const USpatialGDKSettings* Settings = GetDefault<USpatialGDKSettings>();
 
-	if (Settings->bEnableMultiWorker)
-	{
-		const UAbstractLBStrategy* Strategy = NetDriver->LoadBalanceStrategy;
-		if (ensure(Strategy != nullptr))
-		{
-			return Strategy->RequiresHandoverData() || Settings->bEnableHandover;
-		}
-	}
-	return Settings->bEnableHandover;
+	const UAbstractLBStrategy* Strategy = NetDriver->LoadBalanceStrategy;
+	check(Strategy != nullptr);
+	return Strategy->RequiresHandoverData() || Settings->bEnableHandover;
 }
 
 void USpatialClassInfoManager::TryCreateClassInfoForComponentId(Worker_ComponentId ComponentId)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -704,13 +704,6 @@ FRPCErrorInfo USpatialSender::SendRPC(const FPendingRPCParams& Params)
 
 	return SendLegacyRPC(TargetObject, Function, Params.Payload, Channel, Params.ObjectRef);
 }
-#if !UE_BUILD_SHIPPING
-void USpatialSender::TrackRPC(AActor* Actor, UFunction* Function, const RPCPayload& Payload, const ERPCType RPCType)
-{
-	NETWORK_PROFILER(GNetworkProfiler.TrackSendRPC(Actor, Function, 0, Payload.CountDataBits(), 0, NetDriver->GetSpatialOSNetConnection()));
-	NetDriver->SpatialMetrics->TrackSentRPC(Function, RPCType, Payload.PayloadData.Num());
-}
-#endif
 
 void USpatialSender::SendOnEntityCreationRPC(UObject* TargetObject, UFunction* Function, const SpatialGDK::RPCPayload& Payload, USpatialActorChannel* Channel, const FUnrealObjectRef& TargetObjectRef)
 {
@@ -850,7 +843,7 @@ bool USpatialSender::WillHaveAuthorityOverActor(AActor* TargetActor, Worker_Enti
 		}
 	}
 
-	return SendLegacyRPC(TargetObject, Function, Params.Payload, Channel, Params.ObjectRef);
+	return WillHaveAuthorityOverActor;
 }
 
 void USpatialSender::EnqueueRetryRPC(TSharedRef<FReliableRPCForRetry> RetryRPC)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -716,16 +716,13 @@ bool USpatialSender::WillHaveAuthorityOverActor(AActor* TargetActor, Worker_Enti
 {
 	bool WillHaveAuthorityOverActor = true;
 
-	if (GetDefault<USpatialGDKSettings>()->bEnableMultiWorker)
+	if (NetDriver->VirtualWorkerTranslator != nullptr)
 	{
-		if (NetDriver->VirtualWorkerTranslator != nullptr)
+		if (const SpatialGDK::AuthorityIntent* AuthorityIntentComponent = StaticComponentView->GetComponentData<SpatialGDK::AuthorityIntent>(TargetEntity))
 		{
-			if (const SpatialGDK::AuthorityIntent* AuthorityIntentComponent = StaticComponentView->GetComponentData<SpatialGDK::AuthorityIntent>(TargetEntity))
+			if (AuthorityIntentComponent->VirtualWorkerId != NetDriver->VirtualWorkerTranslator->GetLocalVirtualWorkerId())
 			{
-				if (AuthorityIntentComponent->VirtualWorkerId != NetDriver->VirtualWorkerTranslator->GetLocalVirtualWorkerId())
-				{
-					WillHaveAuthorityOverActor = false;
-				}
+				WillHaveAuthorityOverActor = false;
 			}
 		}
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -696,9 +696,14 @@ FRPCErrorInfo USpatialSender::SendRPC(const FPendingRPCParams& Params)
 		return FRPCErrorInfo{ TargetObject, Function, ERPCResult::Success };
 	}
 
-	return FRPCErrorInfo{ TargetObject, Function, Result, false };
-}
+	if (Channel->bCreatingNewEntity && Function->HasAnyFunctionFlags(FUNC_NetClient))
+	{
+		SendOnEntityCreationRPC(TargetObject, Function, Params.Payload, Channel, Params.ObjectRef);
+		return FRPCErrorInfo{ TargetObject, Function, ERPCResult::Success };
+	}
 
+	return SendLegacyRPC(TargetObject, Function, Params.Payload, Channel, Params.ObjectRef);
+}
 #if !UE_BUILD_SHIPPING
 void USpatialSender::TrackRPC(AActor* Actor, UFunction* Function, const RPCPayload& Payload, const ERPCType RPCType)
 {

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
@@ -34,7 +34,7 @@ void ULayeredLBStrategy::Init()
 	const USpatialGDKSettings* SpatialGDKSettings = GetDefault<USpatialGDKSettings>();
 	const ASpatialWorldSettings* WorldSettings = GetWorld() ? Cast<ASpatialWorldSettings>(GetWorld()->GetWorldSettings()) : nullptr;
 
-	if (SpatialGDKSettings->bOverrideLoadBalancing || WorldSettings == nullptr)
+	if (SpatialGDKSettings->bOverrideLoadBalancing || WorldSettings == nullptr || !WorldSettings->bEnableMultiWorker)
 	{
 		UAbstractLBStrategy* DefaultLBStrategy = NewObject<UGridBasedLBStrategy>(this);
 		AddStrategyForLayer(SpatialConstants::DefaultLayer, DefaultLBStrategy);

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
@@ -31,14 +31,10 @@ void ULayeredLBStrategy::Init()
 
 	VirtualWorkerId CurrentVirtualWorkerId = SpatialConstants::INVALID_VIRTUAL_WORKER_ID + 1;
 
-	const USpatialGDKSettings* Settings = GetDefault<USpatialGDKSettings>();
-	check(Settings->bEnableMultiWorker);
-
 	const ASpatialWorldSettings* WorldSettings = GetWorld() ? Cast<ASpatialWorldSettings>(GetWorld()->GetWorldSettings()) : nullptr;
 
 	if (WorldSettings == nullptr)
 	{
-		UE_LOG(LogLayeredLBStrategy, Error, TEXT("If EnableMultiWorker is set, WorldSettings should inherit from SpatialWorldSettings to get the load balancing strategy."));
 		UAbstractLBStrategy* DefaultLBStrategy = NewObject<UGridBasedLBStrategy>(this);
 		AddStrategyForLayer(SpatialConstants::DefaultLayer, DefaultLBStrategy);
 		return;

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
@@ -31,9 +31,10 @@ void ULayeredLBStrategy::Init()
 
 	VirtualWorkerId CurrentVirtualWorkerId = SpatialConstants::INVALID_VIRTUAL_WORKER_ID + 1;
 
+	const USpatialGDKSettings* SpatialGDKSettings = GetDefault<USpatialGDKSettings>();
 	const ASpatialWorldSettings* WorldSettings = GetWorld() ? Cast<ASpatialWorldSettings>(GetWorld()->GetWorldSettings()) : nullptr;
 
-	if (WorldSettings == nullptr)
+	if (SpatialGDKSettings->bOverrideLoadBalancing || WorldSettings == nullptr)
 	{
 		UAbstractLBStrategy* DefaultLBStrategy = NewObject<UGridBasedLBStrategy>(this);
 		AddStrategyForLayer(SpatialConstants::DefaultLayer, DefaultLBStrategy);

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -79,6 +79,7 @@ USpatialGDKSettings::USpatialGDKSettings(const FObjectInitializer& ObjectInitial
 	, bUseSecureServerConnection(false)
 	, bEnableClientQueriesOnServer(false)
 	, bUseSpatialView(false)
+	, bOverrideLoadBalancing(false)
 {
 	DefaultReceptionistHost = SpatialConstants::LOCAL_HOST;
 }
@@ -89,9 +90,8 @@ void USpatialGDKSettings::PostInitProperties()
 
 	// Check any command line overrides for using QBI, Offloading (after reading the config value):
 	const TCHAR* CommandLine = FCommandLine::Get();
-	// CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideSpatialOffloading"), TEXT("Offloading"), bEnableMultiWorker);
 	CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideHandover"), TEXT("Handover"), bEnableHandover);
-	// CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideLoadBalancer"), TEXT("Load balancer"), bEnableMultiWorker);
+	CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideLoadBalancing"), TEXT("Load balancing"), bOverrideLoadBalancing);
 	CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideRPCRingBuffers"), TEXT("RPC ring buffers"), bUseRPCRingBuffers);
 	CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideSpatialWorkerConnectionOnGameThread"), TEXT("Spatial worker connection on game thread"), bRunSpatialWorkerConnectionOnGameThread);
 	CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideResultTypes"), TEXT("Result types"), bEnableResultTypes);

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -60,7 +60,6 @@ USpatialGDKSettings::USpatialGDKSettings(const FObjectInitializer& ObjectInitial
 	, bEnableResultTypes(true)
 	, ServicesRegion(EServicesRegion::Default)
 	, WorkerLogLevel(ESettingsWorkerLogVerbosity::Warning)
-	, bEnableMultiWorker(false)
 	, bRunSpatialWorkerConnectionOnGameThread(false)
 	, bUseRPCRingBuffers(true)
 	, DefaultRPCRingBufferSize(32)
@@ -90,9 +89,9 @@ void USpatialGDKSettings::PostInitProperties()
 
 	// Check any command line overrides for using QBI, Offloading (after reading the config value):
 	const TCHAR* CommandLine = FCommandLine::Get();
-	CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideSpatialOffloading"), TEXT("Offloading"), bEnableMultiWorker);
+	// CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideSpatialOffloading"), TEXT("Offloading"), bEnableMultiWorker);
 	CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideHandover"), TEXT("Handover"), bEnableHandover);
-	CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideLoadBalancer"), TEXT("Load balancer"), bEnableMultiWorker);
+	// CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideLoadBalancer"), TEXT("Load balancer"), bEnableMultiWorker);
 	CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideRPCRingBuffers"), TEXT("RPC ring buffers"), bUseRPCRingBuffers);
 	CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideSpatialWorkerConnectionOnGameThread"), TEXT("Spatial worker connection on game thread"), bRunSpatialWorkerConnectionOnGameThread);
 	CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideResultTypes"), TEXT("Result types"), bEnableResultTypes);
@@ -135,11 +134,6 @@ bool USpatialGDKSettings::CanEditChange(const UProperty* InProperty) const
 
 	const FName Name = InProperty->GetFName();
 
-	if (Name == GET_MEMBER_NAME_CHECKED(USpatialGDKSettings, bUseRPCRingBuffers))
-	{
-		return !bEnableMultiWorker;
-	}
-
 	if (Name == GET_MEMBER_NAME_CHECKED(USpatialGDKSettings, DefaultRPCRingBufferSize)
 	 || Name == GET_MEMBER_NAME_CHECKED(USpatialGDKSettings, RPCRingBufferSizeMap)
 	 || Name == GET_MEMBER_NAME_CHECKED(USpatialGDKSettings, MaxRPCRingBufferSize))
@@ -166,7 +160,7 @@ uint32 USpatialGDKSettings::GetRPCRingBufferSize(ERPCType RPCType) const
 bool USpatialGDKSettings::UseRPCRingBuffer() const
 {
 	// RPC Ring buffer are necessary in order to do RPC handover, something legacy RPC does not handle.
-	return bUseRPCRingBuffers || bEnableMultiWorker;
+	return bUseRPCRingBuffers;
 }
 
 float USpatialGDKSettings::GetSecondsBeforeWarning(const ERPCResult Result) const

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -63,7 +63,7 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 
 	// Add Load Balancer Attribute. If this is a single worker deployment, this will be just be the single worker.
 	WorkerAttributeSet WorkerAttributeOrSpecificWorker = SpatialConstants::UnrealServerAttributeSet;
-	VirtualWorkerId IntendedVirtualWorkerId = NetDriver->LoadBalanceStrategy->GetLocalVirtualWorkerId();
+	const VirtualWorkerId IntendedVirtualWorkerId = NetDriver->LoadBalanceStrategy->GetLocalVirtualWorkerId();
 	if (IntendedVirtualWorkerId != SpatialConstants::INVALID_VIRTUAL_WORKER_ID)
 	{
 		const PhysicalWorkerName* IntendedAuthoritativePhysicalWorkerName = NetDriver->VirtualWorkerTranslator->GetPhysicalWorkerForVirtualWorker(IntendedVirtualWorkerId);

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -61,28 +61,17 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 
 	const FClassInfo& Info = ClassInfoManager->GetOrCreateClassInfoByClass(Class);
 
-	const USpatialGDKSettings* SpatialSettings = GetDefault<USpatialGDKSettings>();
-
+	// Add Load Balancer Attribute. If this is a single worker deployment, this will be just be the single worker.
 	WorkerAttributeSet WorkerAttributeOrSpecificWorker = SpatialConstants::UnrealServerAttributeSet;
-	VirtualWorkerId IntendedVirtualWorkerId = SpatialConstants::INVALID_VIRTUAL_WORKER_ID;
-
-	// Add Load Balancer Attribute if we are using the load balancer.
-	bool bEnableMultiWorker = SpatialSettings->bEnableMultiWorker;
-	if (bEnableMultiWorker)
+	VirtualWorkerId IntendedVirtualWorkerId = NetDriver->LoadBalanceStrategy->GetLocalVirtualWorkerId();
+	if (IntendedVirtualWorkerId != SpatialConstants::INVALID_VIRTUAL_WORKER_ID)
 	{
-		const UAbstractLBStrategy* LBStrategy = NetDriver->LoadBalanceStrategy;
-		check(LBStrategy != nullptr);
-
-		IntendedVirtualWorkerId = LBStrategy->GetLocalVirtualWorkerId();
-		if (IntendedVirtualWorkerId != SpatialConstants::INVALID_VIRTUAL_WORKER_ID)
-		{
-			const PhysicalWorkerName* IntendedAuthoritativePhysicalWorkerName = NetDriver->VirtualWorkerTranslator->GetPhysicalWorkerForVirtualWorker(IntendedVirtualWorkerId);
-			WorkerAttributeOrSpecificWorker = { FString::Format(TEXT("workerId:{0}"), { *IntendedAuthoritativePhysicalWorkerName }) };
-		}
-		else
-		{
-			UE_LOG(LogEntityFactory, Error, TEXT("Load balancing strategy provided invalid local virtual worker ID during Actor spawn. Actor: %s. Strategy: %s"), *Actor->GetName(), *LBStrategy->GetName());
-		}
+		const PhysicalWorkerName* IntendedAuthoritativePhysicalWorkerName = NetDriver->VirtualWorkerTranslator->GetPhysicalWorkerForVirtualWorker(IntendedVirtualWorkerId);
+		WorkerAttributeOrSpecificWorker = { FString::Format(TEXT("workerId:{0}"), { *IntendedAuthoritativePhysicalWorkerName }) };
+	}
+	else
+	{
+		UE_LOG(LogEntityFactory, Error, TEXT("Load balancing strategy provided invalid local virtual worker ID during Actor spawn. Actor: %s. Strategy: %s"), *Actor->GetName(), *NetDriver->LoadBalanceStrategy->GetName());
 	}
 
 	const WorkerRequirementSet AuthoritativeWorkerRequirementSet = { WorkerAttributeOrSpecificWorker };
@@ -110,7 +99,9 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 	ComponentWriteAcl.Add(SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID, AuthoritativeWorkerRequirementSet);
 	ComponentWriteAcl.Add(SpatialConstants::NET_OWNING_CLIENT_WORKER_COMPONENT_ID, AuthoritativeWorkerRequirementSet);
 	ComponentWriteAcl.Add(SpatialConstants::ENTITY_ACL_COMPONENT_ID, AnyServerRequirementSet);
+	ComponentWriteAcl.Add(SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID, AuthoritativeWorkerRequirementSet);
 
+	const USpatialGDKSettings* SpatialSettings = GetDefault<USpatialGDKSettings>();
 	if (SpatialSettings->UseRPCRingBuffer() && RPCService != nullptr)
 	{
 		ComponentWriteAcl.Add(SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID, OwningClientOnlyRequirementSet);
@@ -128,11 +119,6 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 		{
 			ComponentWriteAcl.Add(SpatialConstants::RPCS_ON_ENTITY_CREATION_ID, AuthoritativeWorkerRequirementSet);
 		}
-	}
-
-	if (bEnableMultiWorker)
-	{
-		ComponentWriteAcl.Add(SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID, AuthoritativeWorkerRequirementSet);
 	}
 
 	if (Actor->IsNetStartupActor())
@@ -223,34 +209,26 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 	ComponentDatas.Add(SpawnData(Actor).CreateSpawnDataData());
 	ComponentDatas.Add(UnrealMetadata(StablyNamedObjectRef, Class->GetPathName(), bNetStartup).CreateUnrealMetadataData());
 	ComponentDatas.Add(NetOwningClientWorker(GetConnectionOwningWorkerId(Channel->Actor)).CreateNetOwningClientWorkerData());
+	ComponentDatas.Add(AuthorityIntent::CreateAuthorityIntentData(IntendedVirtualWorkerId));
 
 	if (!Class->HasAnySpatialClassFlags(SPATIALCLASS_NotPersistent))
 	{
 		ComponentDatas.Add(Persistence().CreatePersistenceData());
 	}
 
-	if (bEnableMultiWorker)
-	{
-		ComponentDatas.Add(AuthorityIntent::CreateAuthorityIntentData(IntendedVirtualWorkerId));
-	}
-
 #if !UE_BUILD_SHIPPING
 	if (NetDriver->SpatialDebugger != nullptr)
 	{
-		if (bEnableMultiWorker)
-		{
-			check(NetDriver->VirtualWorkerTranslator != nullptr);
+		check(NetDriver->VirtualWorkerTranslator != nullptr);
 
-			const PhysicalWorkerName* PhysicalWorkerName = NetDriver->VirtualWorkerTranslator->GetPhysicalWorkerForVirtualWorker(IntendedVirtualWorkerId);
-			FColor InvalidServerTintColor = NetDriver->SpatialDebugger->InvalidServerTintColor;
-			FColor IntentColor = PhysicalWorkerName != nullptr ? SpatialGDK::GetColorForWorkerName(*PhysicalWorkerName) : InvalidServerTintColor;
+		const PhysicalWorkerName* PhysicalWorkerName = NetDriver->VirtualWorkerTranslator->GetPhysicalWorkerForVirtualWorker(IntendedVirtualWorkerId);
+		FColor InvalidServerTintColor = NetDriver->SpatialDebugger->InvalidServerTintColor;
+		FColor IntentColor = PhysicalWorkerName != nullptr ? SpatialGDK::GetColorForWorkerName(*PhysicalWorkerName) : InvalidServerTintColor;
 
-			const bool bIsLocked = NetDriver->LockingPolicy->IsLocked(Actor);
+		const bool bIsLocked = NetDriver->LockingPolicy->IsLocked(Actor);
 
-			SpatialDebugging DebuggingInfo(SpatialConstants::INVALID_VIRTUAL_WORKER_ID, InvalidServerTintColor, IntendedVirtualWorkerId, IntentColor, bIsLocked);
-			ComponentDatas.Add(DebuggingInfo.CreateSpatialDebuggingData());
-		}
-
+		SpatialDebugging DebuggingInfo(SpatialConstants::INVALID_VIRTUAL_WORKER_ID, InvalidServerTintColor, IntendedVirtualWorkerId, IntentColor, bIsLocked);
+		ComponentDatas.Add(DebuggingInfo.CreateSpatialDebuggingData());
 		ComponentWriteAcl.Add(SpatialConstants::SPATIAL_DEBUGGING_COMPONENT_ID, AuthoritativeWorkerRequirementSet);
 	}
 #endif

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -125,8 +125,8 @@ Interest InterestFactory::CreateServerWorkerInterest(const UAbstractLBStrategy* 
 
 	Constraint = AlwaysRelevantConstraint;
 
-	// If we are using the unreal load balancer, we also add the server worker interest defined by the load balancing strategy.
-	if (SpatialGDKSettings->bEnableMultiWorker)
+	// Also add the server worker interest defined by the load balancing strategy if there is more than one worker.
+	if (LBStrategy->GetMinimumRequiredWorkers() > 1)
 	{
 		check(LBStrategy != nullptr);
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
@@ -5,6 +5,7 @@
 #include "Engine/World.h"
 #include "EngineClasses/SpatialNetDriver.h"
 #include "EngineClasses/SpatialPackageMapClient.h"
+#include "EngineClasses/SpatialWorldSettings.h"
 #include "GeneralProjectSettings.h"
 #include "Interop/SpatialWorkerFlags.h"
 #include "Kismet/KismetSystemLibrary.h"
@@ -65,10 +66,15 @@ FColor USpatialStatics::GetInspectorColorForWorkerName(const FString& WorkerName
 	return SpatialGDK::GetColorForWorkerName(WorkerName);
 }
 
-bool USpatialStatics::IsSpatialOffloadingEnabled()
+bool USpatialStatics::IsSpatialOffloadingEnabled(const UWorld* World)
 {
-	return IsSpatialNetworkingEnabled()
-		&& GetDefault<USpatialGDKSettings>()->bEnableMultiWorker;
+	if (World != nullptr)
+	{
+		const ASpatialWorldSettings* WorldSettings = Cast<ASpatialWorldSettings>(World->GetWorldSettings());
+		return IsSpatialNetworkingEnabled() && WorldSettings->WorkerLayers.Num() > 0;
+	}
+
+	return false;
 }
 
 bool USpatialStatics::IsActorGroupOwnerForActor(const AActor* Actor)

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -137,7 +137,7 @@ public:
 		if (EntityId != SpatialConstants::INVALID_ENTITY_ID)
 		{
 			// If the entity already exists, make sure we have spatial authority before we replicate with Offloading, because we pretend to have local authority
-			if (USpatialStatics::IsSpatialOffloadingEnabled() && !bCreatingNewEntity && !NetDriver->StaticComponentView->HasAuthority(EntityId, SpatialConstants::POSITION_COMPONENT_ID))
+			if (USpatialStatics::IsSpatialOffloadingEnabled(GetWorld()) && !bCreatingNewEntity && !NetDriver->StaticComponentView->HasAuthority(EntityId, SpatialConstants::POSITION_COMPONENT_ID))
 			{
 				return false;
 			}

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -315,4 +315,6 @@ public:
 	/** Experimental feature to use SpatialView layer when communicating with the Worker */
 	UPROPERTY(Config)
 	bool bUseSpatialView;
+
+	bool bOverrideLoadBalancing;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -305,5 +305,9 @@ public:
 	UPROPERTY(Config)
 	bool bUseSpatialView;
 
+	/**
+	  * By default, load balancing config will be read from the WorldSettings, but this can be toggled to override
+	  * the map's config with a 1x1 grid.
+	  */
 	bool bOverrideLoadBalancing;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -221,10 +221,6 @@ public:
 	UPROPERTY(EditAnywhere, config, Category = "Debug", meta = (MetaClass = "SpatialDebugger"))
 	TSubclassOf<ASpatialDebugger> SpatialDebugger;
 
-	/** EXPERIMENTAL: Disable runtime load balancing and use a worker to do it instead. */
-	UPROPERTY(EditAnywhere, Config, Category = "Multi-Worker")
-	bool bEnableMultiWorker;
-
 	/** EXPERIMENTAL: Run SpatialWorkerConnection on Game Thread. */
 	UPROPERTY(Config)
 	bool bRunSpatialWorkerConnectionOnGameThread;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialStatics.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialStatics.h
@@ -34,7 +34,7 @@ public:
     * Returns true if SpatialOS Offloading is enabled.
     */
     UFUNCTION(BlueprintPure, Category = "SpatialOS|Offloading")
-    static bool IsSpatialOffloadingEnabled();
+    static bool IsSpatialOffloadingEnabled(const UWorld* World);
 
 	/**
 	 * Returns true if the current Worker Type owns the Actor Group this Actor belongs to.

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/LayeredLBStrategy/LayeredLBStrategyTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/LayeredLBStrategy/LayeredLBStrategyTest.cpp
@@ -27,15 +27,12 @@ struct TestData {
 	TMap<FName, AActor*> TestActors{};
 
 	TestData()
-	{
-		Cast<USpatialGDKSettings>(USpatialGDKSettings::StaticClass()->GetDefaultObject())->bEnableMultiWorker = true;
-	}
+	{}
 
 	~TestData()
 	{
 		ASpatialWorldSettings* WorldSettings = Cast<ASpatialWorldSettings>(TestWorld->GetWorldSettings());
 		WorldSettings->WorkerLayers.Empty();
-		Cast<USpatialGDKSettings>(USpatialGDKSettings::StaticClass()->GetDefaultObject())->bEnableMultiWorker = false;
 	}
 };
 


### PR DESCRIPTION
#### Description
Remove the bEnableMultiWorker flag from GDKSettings. The SpatialNetDriver will now always create a LayeredLBStrategy, even if it just has one layer with a 1x1 grid. 

Some places where we used to check if bEnabledMultiWorker, we now just always execute. Others, we check for whether there are multiple layers enabled.

One breaking change is that I added a World parameter to SpatialStatics::IsOffloadingEnabled, because we don't know anymore until we've connected to the deployment. 

#### Release note
REQUIRED: Add a release note to the `##Unreleased` section of CHANGELOG.md. You can find guidance for writing useful release notes [here](../SpatialGDK/Extras/internal-documentation/how-to-write-good-release-notes.md). Documentation changes are exempt from this requirement.

#### Tests
How did you test these changes prior to submitting this pull request?
What automated tests are included in this PR?

STRONGLY SUGGESTED: How can this be verified by QA?

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
