### PR TITLE
Set deployment to connect as soon as 'Start deployment' is clicked

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -1219,6 +1219,10 @@ FReply FSpatialGDKEditorToolbarModule::OnStartCloudDeployment()
 
 	CloudDeploymentConfiguration.InitFromSettings();
 
+	const FString& DeploymentName = CloudDeploymentConfiguration.PrimaryDeploymentName;
+	GetMutableDefault<USpatialGDKEditorSettings>()->SetDevelopmentDeploymentToConnect(DeploymentName);
+	UE_LOG(LogSpatialGDKEditorToolbar, Display, TEXT("Setting deployment to connect to %s"), *DeploymentName);
+
 	if (CloudDeploymentConfiguration.bBuildAndUploadAssembly)
 	{
 		if (CloudDeploymentConfiguration.bGenerateSchema)
@@ -1262,10 +1266,6 @@ void FSpatialGDKEditorToolbarModule::OnBuildSuccess()
 			FSimpleDelegate::CreateLambda([this]()
 			{
 				OnShowSuccessNotification("Successfully started cloud deployment.");
-				USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetMutableDefault<USpatialGDKEditorSettings>();
-				const FString& DeploymentName = SpatialGDKEditorSettings->GetPrimaryDeploymentName();
-				SpatialGDKEditorSettings->SetDevelopmentDeploymentToConnect(DeploymentName);
-				UE_LOG(LogSpatialGDKEditorToolbar, Display, TEXT("Setting deployment to connect to %s"), *DeploymentName)
 			}),
 			FSimpleDelegate::CreateLambda([this]()
 			{


### PR DESCRIPTION
#### Description
Set deployment to connect to the one being started as soon as 'Start Deployment' is clicked. This aims to improve the user experience together with @jessicafalk's PR https://github.com/spatialos/UnrealGDK/pull/2206, where clicking on Play or Launch will first check whether the deployment is running before attempting to start a session.

#### Primary reviewers
@jessicafalk @MatthewSandfordImprobable 
