### PR TITLE
UNR-3635 Cloud deployment configuration window refresh DEV token when it's not necessary.

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
@@ -353,8 +353,11 @@ bool FSpatialGDKEditor::FullScanRequired()
 
 void FSpatialGDKEditor::SetProjectName(const FString& InProjectName)
 {
-	FSpatialGDKServicesModule::SetProjectName(InProjectName);
-	SpatialGDKDevAuthTokenGeneratorInstance->AsyncGenerateDevAuthToken();
+	if (!FSpatialGDKServicesModule::GetProjectName().Equals(InProjectName))
+	{
+		FSpatialGDKServicesModule::SetProjectName(InProjectName);
+		SpatialGDKDevAuthTokenGeneratorInstance->AsyncGenerateDevAuthToken();
+	}
 }
 
 void FSpatialGDKEditor::RemoveEditorAssetLoadedCallback()


### PR DESCRIPTION
#### Description
Only new deployment name is different with the previous one in cloud deployment window, it will write it in config file and refresh the DEV token.