### PR TITLE
Prevent enum value error for CN when loading config

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -146,6 +146,13 @@ bool USpatialGDKEditorSettings::IsDeploymentNameValid(const FString& Name)
 
 bool USpatialGDKEditorSettings::IsRegionCodeValid(const ERegionCode::Type RegionCode)
 {
+	// Selecting CN region code in the Cloud Deployment Configuration window has been deprecated.
+	// It will now be automatically determined based on the services region.
+	if (RegionCode == ERegionCode::CN)
+	{
+		return false;
+	}
+
 	UEnum* pEnum = FindObject<UEnum>(ANY_PACKAGE, TEXT("ERegionCode"), true);
 
 	return pEnum != nullptr && pEnum->IsValidEnumValue(RegionCode);

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -197,7 +197,8 @@ namespace ERegionCode
 	{
 		US = 1,
 		EU,
-		AP
+		AP,
+		CN UMETA(Hidden)
 	};
 }
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKCloudDeploymentConfiguration.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKCloudDeploymentConfiguration.cpp
@@ -833,11 +833,14 @@ TSharedRef<SWidget> SSpatialGDKCloudDeploymentConfiguration::OnGetPrimaryDeploym
 
 	if (pEnum != nullptr)
 	{
-		for (int32 i = 0; i < pEnum->NumEnums() - 1; i++)
+		for (int32 EnumIdx = 0; EnumIdx < pEnum->NumEnums() - 1; EnumIdx++)
 		{
-			int64 CurrentEnumValue = pEnum->GetValueByIndex(i);
-			FUIAction ItemAction(FExecuteAction::CreateSP(this, &SSpatialGDKCloudDeploymentConfiguration::OnPrimaryDeploymentRegionCodePicked, CurrentEnumValue));
-			MenuBuilder.AddMenuEntry(pEnum->GetDisplayNameTextByValue(CurrentEnumValue), TAttribute<FText>(), FSlateIcon(), ItemAction);
+			if (!pEnum->HasMetaData(TEXT("Hidden"), EnumIdx))
+			{
+				int64 CurrentEnumValue = pEnum->GetValueByIndex(EnumIdx);
+				FUIAction ItemAction(FExecuteAction::CreateSP(this, &SSpatialGDKCloudDeploymentConfiguration::OnPrimaryDeploymentRegionCodePicked, CurrentEnumValue));
+				MenuBuilder.AddMenuEntry(pEnum->GetDisplayNameTextByValue(CurrentEnumValue), TAttribute<FText>(), FSlateIcon(), ItemAction);
+			}
 		}
 	}
 


### PR DESCRIPTION
#### Description
https://github.com/spatialos/UnrealGDK/pull/2204 has removed `CN` from the `ERegionCode` enum values, which can cause an error when upgrading. Instead, we should hide the enum value for now.
```
Error: LoadConfig (/Script/SpatialGDKEditor.Default__SpatialGDKEditorSettings): import failed for PrimaryDeploymentRegionCode in: CN
```

#### Primary reviewers
@jayprobable @jessicafalk 