### PR TITLE
Fix layered lb memory management

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
@@ -17,14 +17,6 @@ ULayeredLBStrategy::ULayeredLBStrategy()
 {
 }
 
-ULayeredLBStrategy::~ULayeredLBStrategy()
-{
-	for (const auto& Elem : LayerNameToLBStrategy)
-	{
-		Elem.Value->RemoveFromRoot();
-	}
-}
-
 void ULayeredLBStrategy::Init()
 {
 	Super::Init();
@@ -73,6 +65,7 @@ void ULayeredLBStrategy::Init()
 	{
 		UAbstractLBStrategy* DefaultLBStrategy = NewObject<UAbstractLBStrategy>(this, WorldSettings->DefaultLayerLoadBalanceStrategy);
 		AddStrategyForLayer(SpatialConstants::DefaultLayer, DefaultLBStrategy);
+		UE_LOG(LogLayeredLBStrategy, Log, TEXT("Added LBStrategy %lld for the Default Layer."), DefaultLBStrategy);
 	}
 }
 
@@ -293,7 +286,6 @@ FName ULayeredLBStrategy::GetLayerNameForActor(const AActor& Actor) const
 
 void ULayeredLBStrategy::AddStrategyForLayer(const FName& LayerName, UAbstractLBStrategy* LBStrategy)
 {
-	LBStrategy->AddToRoot();
 	LayerNameToLBStrategy.Add(LayerName, LBStrategy);
 	LayerNameToLBStrategy[LayerName]->Init();
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
@@ -65,7 +65,6 @@ void ULayeredLBStrategy::Init()
 	{
 		UAbstractLBStrategy* DefaultLBStrategy = NewObject<UAbstractLBStrategy>(this, WorldSettings->DefaultLayerLoadBalanceStrategy);
 		AddStrategyForLayer(SpatialConstants::DefaultLayer, DefaultLBStrategy);
-		UE_LOG(LogLayeredLBStrategy, Log, TEXT("Added LBStrategy %lld for the Default Layer."), DefaultLBStrategy);
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LayeredLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LayeredLBStrategy.h
@@ -47,7 +47,6 @@ class SPATIALGDK_API ULayeredLBStrategy : public UAbstractLBStrategy
 
 public:
 	ULayeredLBStrategy();
-	~ULayeredLBStrategy();
 
 	/* UAbstractLBStrategy Interface */
 	virtual void Init() override;
@@ -84,6 +83,7 @@ private:
 
 	TMap<VirtualWorkerId, FName> VirtualWorkerIdToLayerName;
 
+	UPROPERTY()
 	TMap<FName, UAbstractLBStrategy* > LayerNameToLBStrategy;
 
 	// Returns the name of the first Layer that contains this, or a parent of this class,


### PR DESCRIPTION
#### Description

The layer strategies in the LayeredLB were being added to root when put in a local map instead of using a UProperty for the map. This meant that things weren't being cleaned at the right time.

#### Release note
N/A

#### Tests
Run the offloading test gym. Start and restart the PiE instance without stopping the deployment. Run in DebugEditor and check that the editor doesn't crash on exit.

#### Documentation
N/A

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
