### PR TITLE
Create a marker file to indicate services region

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Build/Build.csproj.user
 _ReSharper.caches
 
 **/.DS_Store
+
+# File to indicate services region, created by Setup script
+UseChinaServicesRegion

--- a/RequireSetup
+++ b/RequireSetup
@@ -1,4 +1,4 @@
 Increment the below number whenever it is required to run Setup.bat as part of a new commit.
 Our git hooks will detect this file has been updated and automatically run Setup.bat on pull.
 
-58
+59

--- a/Setup.bat
+++ b/Setup.bat
@@ -67,6 +67,20 @@ call :MarkStartOfBlock "Setup variables"
     )
 call :MarkEndOfBlock "Setup variables"
 
+call :MarkStartOfBlock "Setup services region"
+    set USE_CHINA_SERVICES_REGION=
+    for %%A in (%*) do (
+        if "%%A"=="--china" set USE_CHINA_SERVICES_REGION=True
+    )
+
+    rem Create or remove an empty file in the plugin directory indicating whether to use China services region.
+    if defined USE_CHINA_SERVICES_REGION (
+        echo. 2> UseChinaServicesRegion
+    ) else (
+        if exist UseChinaServicesRegion del UseChinaServicesRegion
+    )
+call :MarkEndOfBlock "Setup services region"
+
 call :MarkStartOfBlock "Clean folders"
     rd /s /q "%CORE_SDK_DIR%"           2>nul
     rd /s /q "%WORKER_SDK_DIR%"         2>nul

--- a/Setup.sh
+++ b/Setup.sh
@@ -20,11 +20,14 @@ SCHEMA_COPY_DIR="$(pwd)/../../../spatial/schema/unreal/gdk"
 SCHEMA_STD_COPY_DIR="$(pwd)/../../../spatial/build/dependencies/schema/standard_library"
 SPATIAL_DIR="$(pwd)/../../../spatial"
 DOWNLOAD_MOBILE=
+USE_CHINA_SERVICES_REGION=
 
 while test $# -gt 0
 do
     case "$1" in
-        --china) DOMAIN_ENVIRONMENT_VAR="--environment cn-production"
+        --china)
+            DOMAIN_ENVIRONMENT_VAR="--environment cn-production"
+            USE_CHINA_SERVICES_REGION=true
             ;;
         --mobile) DOWNLOAD_MOBILE=true
             ;;
@@ -46,6 +49,15 @@ if [[ -e .git/hooks ]]; then
 
     # Add git hook to run Setup.sh when RequireSetup file has been updated.
     cp "$(pwd)/SpatialGDK/Extras/git/post-merge" "$(pwd)/.git/hooks"
+fi
+
+# Create or remove an empty file in the plugin directory indicating whether to use China services region.
+if [[ -n "${USE_CHINA_SERVICES_REGION}" ]]; then
+    touch UseChinaServicesRegion
+else
+    if [[ -e UseChinaServicesRegion ]]; then
+        rm -f UseChinaServicesRegion
+    fi
 fi
 
 echo "Clean folders"

--- a/Setup.sh
+++ b/Setup.sh
@@ -55,9 +55,7 @@ fi
 if [[ -n "${USE_CHINA_SERVICES_REGION}" ]]; then
     touch UseChinaServicesRegion
 else
-    if [[ -e UseChinaServicesRegion ]]; then
-        rm -f UseChinaServicesRegion
-    fi
+    rm -f UseChinaServicesRegion
 fi
 
 echo "Clean folders"

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -224,6 +224,8 @@ public:
 private:
 #if WITH_EDITOR
 	bool CanEditChange(const UProperty* InProperty) const override;
+
+	void UpdateServicesRegionFile();
 #endif
 
 	UPROPERTY(EditAnywhere, Config, Category = "Replication", meta = (DisplayName = "Use RPC Ring Buffers"))
@@ -272,6 +274,8 @@ public:
 	float RPCQueueWarningDefaultTimeout;
 
 	FORCEINLINE bool IsRunningInChina() const { return ServicesRegion == EServicesRegion::CN; }
+
+	void SetServicesRegion(EServicesRegion::Type NewRegion);
 
 	/** Enable to use the new net cull distance component tagging form of interest */
 	UPROPERTY(EditAnywhere, Config, Category = "Interest")

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -84,6 +84,10 @@ void FSpatialGDKEditorToolbarModule::StartupModule()
 	OnPropertyChangedDelegateHandle = FCoreUObjectDelegates::OnObjectPropertyChanged.AddRaw(this, &FSpatialGDKEditorToolbarModule::OnPropertyChanged);
 	bStopSpatialOnExit = SpatialGDKEditorSettings->bStopSpatialOnExit;
 
+	// Check for UseChinaServicesRegion file in the plugin directory to determine the services region.
+	bool bUseChinaServicesRegion = FPaths::FileExists(FSpatialGDKServicesModule::GetSpatialGDKPluginDirectory(SpatialGDKServicesConstants::UseChinaServicesRegionFilename));
+	GetMutableDefault<USpatialGDKSettings>()->SetServicesRegion(bUseChinaServicesRegion ? EServicesRegion::CN : EServicesRegion::Default);
+
 	FSpatialGDKServicesModule& GDKServices = FModuleManager::GetModuleChecked<FSpatialGDKServicesModule>("SpatialGDKServices");
 	LocalDeploymentManager = GDKServices.GetLocalDeploymentManager();
 	LocalDeploymentManager->PreInit(GetDefault<USpatialGDKSettings>()->IsRunningInChina());

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesConstants.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesConstants.h
@@ -44,4 +44,6 @@ namespace SpatialGDKServicesConstants
 	const FString PinnedChinaCompatibilityModeRuntimeTemplate = TEXT("m5xlarge_ssd40_r0500");
 	
 	const FString DevLoginDeploymentTag = TEXT("dev_login");
+
+	const FString UseChinaServicesRegionFilename = TEXT("UseChinaServicesRegion");
 }


### PR DESCRIPTION
#### Description
When using the UnrealGDK in China, you need to run the `Setup` script with `--china`. We can use this to indicate to the GDK whether to use the CN services region.
Running `Setup.bat` (or `Setup.sh` or Mac) will create or delete a file `UseChinaServicesRegion` in the plugin directory. On module startup, the GDK will check the existence of that file to set its services region. Changing the services region from the GDK settings will also create or delete the file.

#### Primary reviewers
@jayprobable @jessicafalk 
