### PR TITLE
[UNR-3617] Delay actor hierarchy migration by one frame.

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -444,7 +444,7 @@ void USpatialActorChannel::GetLatestAuthorityChangeFromHierarchy(const AActor* H
 
 void USpatialActorChannel::MarkActorHierarchyForMigration(USpatialNetDriver* NetDriver, VirtualWorkerId NewAuthVirtualWorkerId, AActor* HierarchyActor)
 {
-	if (HierarchyActor->GetIsReplicated())
+	if (HierarchyActor->GetIsReplicated() && HierarchyActor->HasAuthority())
 	{
 		if (USpatialActorChannel* Channel = NetDriver->GetOrCreateSpatialActorChannel(HierarchyActor))
 		{

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -472,7 +472,7 @@ void USpatialActorChannel::DropActorHierarchyMigration(USpatialNetDriver* NetDri
 
 	for (AActor* Child : HierarchyActor->Children)
 	{
-		DropActorHierarchyMigration(Child);
+		DropActorHierarchyMigration(NetDriver, Child);
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/OwnershipLockingPolicy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/OwnershipLockingPolicy.cpp
@@ -43,7 +43,7 @@ ActorLockToken UOwnershipLockingPolicy::AcquireLock(AActor* Actor, FString Debug
 			Actor->OnDestroyed.AddDynamic(this, &UOwnershipLockingPolicy::OnExplicitlyLockedActorDeleted);
 		}
 
-		AActor* OwnershipHierarchyRoot = SpatialGDK::GetHierarchyRoot(Actor);
+		AActor* OwnershipHierarchyRoot = SpatialGDK::GetTopmostOwner(Actor);
 		AddOwnershipHierarchyRootInformation(OwnershipHierarchyRoot, Actor);
 		
 		ActorToLockingState.Add(Actor, MigrationLockElement{ 1, OwnershipHierarchyRoot });
@@ -107,7 +107,7 @@ bool UOwnershipLockingPolicy::IsLocked(const AActor* Actor) const
 	}
 
 	// Is the hierarchy root of this Actor explicitly locked or on a locked hierarchy ownership path.
-	if (AActor* HierarchyRoot = SpatialGDK::GetHierarchyRoot(Actor))
+	if (AActor* HierarchyRoot = SpatialGDK::GetTopmostOwner(Actor))
 	{
 		return IsExplicitlyLocked(HierarchyRoot) || IsLockedHierarchyRoot(HierarchyRoot);
 	}
@@ -171,7 +171,7 @@ void UOwnershipLockingPolicy::OnOwnerUpdated(const AActor* Actor, const AActor* 
 	// recalculate ownership hierarchies of all explicitly locked Actors in that hierarchy.
 	else if (OldOwner != nullptr)
 	{
-		const AActor* OldHierarchyRoot = OldOwner->GetOwner() != nullptr ? SpatialGDK::GetHierarchyRoot(OldOwner) : OldOwner;
+		const AActor* OldHierarchyRoot = OldOwner->GetOwner() != nullptr ? SpatialGDK::GetTopmostOwner(OldOwner) : OldOwner;
 		if (IsLockedHierarchyRoot(OldHierarchyRoot))
 		{
 			RecalculateAllExplicitlyLockedActorsInThisHierarchy(OldHierarchyRoot);
@@ -223,7 +223,7 @@ void UOwnershipLockingPolicy::RecalculateLockedActorOwnershipHierarchyInformatio
 	RemoveOwnershipHierarchyRootInformation(OldHierarchyRoot, ExplicitlyLockedActor);
 
 	// For the new ownership path, update ownership path Actor mapping to explicitly locked Actors to include this Actor.
-	AActor* NewOwnershipHierarchyRoot = SpatialGDK::GetHierarchyRoot(ExplicitlyLockedActor);
+	AActor* NewOwnershipHierarchyRoot = SpatialGDK::GetTopmostOwner(ExplicitlyLockedActor);
 	ActorToLockingState.FindChecked(ExplicitlyLockedActor).HierarchyRoot = NewOwnershipHierarchyRoot;
 	AddOwnershipHierarchyRootInformation(NewOwnershipHierarchyRoot, ExplicitlyLockedActor);
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -275,9 +275,9 @@ private:
 	void InitializeHandoverShadowData(TArray<uint8>& ShadowData, UObject* Object);
 	FHandoverChangeState GetHandoverChangeList(TArray<uint8>& ShadowData, UObject* Object);
 
-	void GetLatestAuthorityChangeFromHierarchy(const AActor* HierarchyActor, uint64& OutTimestamp);
-
-	static void MarkActorHierarchyForMigration(USpatialNetDriver* NetDriver, VirtualWorkerId NewAuthVirtualWorkerId, AActor* HierarchyActor);
+	static void GetLatestAuthorityChangeFromHierarchy(USpatialNetDriver* NetDriver, const AActor* HierarchyActor, uint64& OutTimestamp);
+	static void MarkActorHierarchyForMigration(USpatialNetDriver* NetDriver, AActor* HierarchyActor);
+	static void SetActorHierarchyMigrationDestination(USpatialNetDriver* NetDriver, VirtualWorkerId NewAuthVirtualWorkerId, AActor* HierarchyActor);
 	static void DropActorHierarchyMigration(USpatialNetDriver* NetDriver, AActor* HierarchyActor);
 
 public:
@@ -352,5 +352,7 @@ private:
 	uint32 MigrationFrame;
 
 	// WorkerId to migrate to.
-	VirtualWorkerId MigrationVirtualWorkerId = SpatialConstants::INVALID_VIRTUAL_WORKER_ID;
+	// Optional is valid if a migration was deemed necessary (LoadBalancingStrategy->ShouldHaveAuthority == false)
+	// but will contain an invalid ID until the frame where migration will happen and WhoShouldHaveAuthority will be evaluated for the entire hierarchy.
+	TOptional<VirtualWorkerId> MigrationVirtualWorkerId;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -279,6 +279,7 @@ private:
 	static void MarkActorHierarchyForMigration(USpatialNetDriver* NetDriver, AActor* HierarchyActor);
 	static void SetActorHierarchyMigrationDestination(USpatialNetDriver* NetDriver, VirtualWorkerId NewAuthVirtualWorkerId, AActor* HierarchyActor);
 	static void DropActorHierarchyMigration(USpatialNetDriver* NetDriver, AActor* HierarchyActor);
+	void HandleActorLoadBalancing();
 
 public:
 	// If this actor channel is responsible for creating a new entity, this will be set to true once the entity creation request is issued.
@@ -349,7 +350,7 @@ private:
 	// Contains the frame at which the actor hierarchy was marked to be migrated to another worker.
 	// Used to delay the hierarchy's migration by one frame, to allow all actors in the hierarchy to go through
 	// the regular replication loop (to run Pre-Replication events for instance) before being migrated together.
-	uint32 MigrationFrame;
+	uint32 MigrationInitiatedFrame;
 
 	// WorkerId to migrate to.
 	// Optional is valid if a migration was deemed necessary (LoadBalancingStrategy->ShouldHaveAuthority == false)

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -278,6 +278,7 @@ private:
 	void GetLatestAuthorityChangeFromHierarchy(const AActor* HierarchyActor, uint64& OutTimestamp);
 
 	static void MarkActorHierarchyForMigration(USpatialNetDriver* NetDriver, VirtualWorkerId NewAuthVirtualWorkerId, AActor* HierarchyActor);
+	static void DropActorHierarchyMigration(USpatialNetDriver* NetDriver, AActor* HierarchyActor);
 
 public:
 	// If this actor channel is responsible for creating a new entity, this will be set to true once the entity creation request is issued.
@@ -345,8 +346,9 @@ private:
 	// Using this timestamp, we can back off attempting migrations for a while.
 	uint64 AuthorityReceivedTimestamp;
 
-	// Contains the frame at which the actor (or its owner) was seen outside its worker's authoritative region.
-	// Used to delay migration by one frame, to allow Pre-Replication events to take place in the regular replication loop.
+	// Contains the frame at which the actor hierarchy was marked to be migrated to another worker.
+	// Used to delay the hierarchy's migration by one frame, to allow all actors in the hierarchy to go through
+	// the regular replication loop (to run Pre-Replication events for instance) before being migrated together.
 	uint32 MigrationFrame;
 
 	// WorkerId to migrate to.

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -277,6 +277,8 @@ private:
 
 	void GetLatestAuthorityChangeFromHierarchy(const AActor* HierarchyActor, uint64& OutTimestamp);
 
+	static void MarkActorHierarchyForMigration(USpatialNetDriver* NetDriver, VirtualWorkerId NewAuthVirtualWorkerId, AActor* HierarchyActor);
+
 public:
 	// If this actor channel is responsible for creating a new entity, this will be set to true once the entity creation request is issued.
 	bool bCreatedEntity;
@@ -342,4 +344,11 @@ private:
 	// before the actor holding the position for all the hierarchy, it can immediately attempt to migrate back.
 	// Using this timestamp, we can back off attempting migrations for a while.
 	uint64 AuthorityReceivedTimestamp;
+
+	// Contains the frame at which the actor (or its owner) was seen outside its worker's authoritative region.
+	// Used to delay migration by one frame, to allow Pre-Replication events to take place in the regular replication loop.
+	uint32 MigrationFrame;
+
+	// WorkerId to migrate to.
+	VirtualWorkerId MigrationVirtualWorkerId = SpatialConstants::INVALID_VIRTUAL_WORKER_ID;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialActorUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialActorUtils.h
@@ -37,7 +37,7 @@ inline AActor* GetTopmostOwner(const AActor* Actor)
 inline AActor* GetHierarchyRoot(const AActor* Actor)
 {
 	AActor* TopmostOwner = GetTopmostOwner(Actor);
-	return TopmostOwner ? TopmostOwner : Actor;
+	return TopmostOwner ? TopmostOwner : const_cast<AActor*>(Actor);
 }
 
 inline FString GetConnectionOwningWorkerId(const AActor* Actor)

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialActorUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialActorUtils.h
@@ -16,7 +16,7 @@
 namespace SpatialGDK
 {
 
-inline AActor* GetHierarchyRoot(const AActor* Actor)
+inline AActor* GetTopmostOwner(const AActor* Actor)
 {
 	check(Actor != nullptr);
 
@@ -32,6 +32,12 @@ inline AActor* GetHierarchyRoot(const AActor* Actor)
 	}
 
 	return Owner;
+}
+
+inline AActor* GetHierarchyRoot(const AActor* Actor)
+{
+	AActor* TopmostOwner = GetTopmostOwner(Actor);
+	return TopmostOwner ? TopmostOwner : Actor;
 }
 
 inline FString GetConnectionOwningWorkerId(const AActor* Actor)

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialActorUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialActorUtils.h
@@ -37,7 +37,7 @@ inline AActor* GetTopmostOwner(const AActor* Actor)
 inline AActor* GetHierarchyRoot(const AActor* Actor)
 {
 	AActor* TopmostOwner = GetTopmostOwner(Actor);
-	return TopmostOwner ? TopmostOwner : const_cast<AActor*>(Actor);
+	return TopmostOwner != nullptr ? TopmostOwner : const_cast<AActor*>(Actor);
 }
 
 inline FString GetConnectionOwningWorkerId(const AActor* Actor)
@@ -48,6 +48,23 @@ inline FString GetConnectionOwningWorkerId(const AActor* Actor)
 	}
 
 	return FString();
+}
+
+template <typename Functor>
+void ForeachReplicatedActorInHierarchy(AActor* HierarchyActor, Functor&& InFunctor)
+{
+	if (HierarchyActor)
+	{
+		if (HierarchyActor->GetIsReplicated())
+		{
+			InFunctor(HierarchyActor);
+		}
+
+		for (AActor* Child : HierarchyActor->Children)
+		{
+			ForeachReplicatedActorInHierarchy(Child, InFunctor);
+		}
+	}
 }
 
 inline FVector GetActorSpatialPosition(const AActor* InActor)


### PR DESCRIPTION
#### Description
Actor hierarchy migration happened synchronously through recursive call from USpatialActorChannel::ReplicateActor. While simple, this bypassed the regular replication loop in the net driver.
This caused some pre-replication events to be skipped, namely one which copied actor location to replicated movement data. Symptoms were being pulled back to the actor's origin position after teleport for instance.
This change marks actors for migration instead, in order for them to go through a regular replication frame before being migrated.

#### Release note

#### Tests

#### Documentation

#### Primary reviewers

