### PR TITLE
Save services region to default config

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -221,7 +221,10 @@ float USpatialGDKSettings::GetSecondsBeforeWarning(const ERPCResult Result) cons
 void USpatialGDKSettings::SetServicesRegion(EServicesRegion::Type NewRegion)
 {
 	ServicesRegion = NewRegion;
-	SaveConfig();
+
+	// Save in default config so this applies for other platforms e.g. Linux, Android.
+	UProperty* ServicesRegionProperty = USpatialGDKSettings::StaticClass()->FindPropertyByName(FName("ServicesRegion"));
+	UpdateSinglePropertyInConfigFile(ServicesRegionProperty, GetDefaultConfigFilename());
 }
 
 bool USpatialGDKSettings::GetPreventClientCloudDeploymentAutoConnect() const


### PR DESCRIPTION
#### Description
Save services region to default config when it's changed as a result of checking the marker file. This is necessary for the config value to apply to other platforms (Linux, Android, iOS), since before it was saved in `Saved\Config\Windows`.

#### Primary reviewers
@jayprobable @jessicafalk 