### PR TITLE
[UNR-3684] Show error message dialog if full schema scan is required

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -1223,6 +1223,13 @@ FReply FSpatialGDKEditorToolbarModule::OnStartCloudDeployment()
 	{
 		if (CloudDeploymentConfiguration.bGenerateSchema)
 		{
+			if (SpatialGDKEditorInstance->FullScanRequired())
+			{
+				FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("A full schema generation is required before being able to start a cloud deployment. Please press the Schema button before starting a cloud deployment.")));
+				OnShowSingleFailureNotification(TEXT("Generate schema failed."));
+				return FReply::Unhandled();
+			}
+
 			if (!SpatialGDKEditorInstance->GenerateSchema(FSpatialGDKEditor::InMemoryAsset))
 			{
 				OnShowSingleFailureNotification(TEXT("Generate schema failed."));

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -1225,7 +1225,7 @@ FReply FSpatialGDKEditorToolbarModule::OnStartCloudDeployment()
 		{
 			if (SpatialGDKEditorInstance->FullScanRequired())
 			{
-				FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("A full schema generation is required before being able to start a cloud deployment. Please press the Schema button before starting a cloud deployment.")));
+				FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("A full schema generation is required at least once before you can start a cloud deployment. Press the Schema button before starting a cloud deployment.")));
 				OnShowSingleFailureNotification(TEXT("Generate schema failed."));
 				return FReply::Unhandled();
 			}


### PR DESCRIPTION
#### Description
When starting a cloud deployment you have the option to generate schema. 
This fails if you don't have generated schema before you start your cloud deployment. because we only try to do an iterative schema scan.