### PR TITLE
Better player start forwarding logic for offloading multi-worker

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialPlayerSpawner.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialPlayerSpawner.h
@@ -61,7 +61,7 @@ private:
 
 	// Authoritative server worker
 	void FindPlayerStartAndProcessPlayerSpawn(Schema_Object* Request, const PhysicalWorkerName& ClientWorkerId);
-	void ForwardSpawnRequestToOtherServer(const Schema_Object* OriginalPlayerSpawnRequest, AActor* PlayerStart, const PhysicalWorkerName& ClientWorkerId, const VirtualWorkerId SpawningVirtualWorker);
+	void ForwardSpawnRequestToStrategizedServer(const Schema_Object* OriginalPlayerSpawnRequest, AActor* PlayerStart, const PhysicalWorkerName& ClientWorkerId, const VirtualWorkerId SpawningVirtualWorker);
 	void RetryForwardSpawnPlayerRequest(const Worker_EntityId EntityId, const Worker_RequestId RequestId, const bool bShouldTryDifferentPlayerStart = false);
 
 	// Any server

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialPlayerSpawner.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialPlayerSpawner.h
@@ -61,11 +61,11 @@ private:
 
 	// Authoritative server worker
 	void FindPlayerStartAndProcessPlayerSpawn(Schema_Object* Request, const PhysicalWorkerName& ClientWorkerId);
-	bool ForwardSpawnRequestToStrategizedServer(const Schema_Object* OriginalPlayerSpawnRequest, AActor* PlayerStart, const PhysicalWorkerName& ClientWorkerId);
+	void ForwardSpawnRequestToOtherServer(const Schema_Object* OriginalPlayerSpawnRequest, AActor* PlayerStart, const PhysicalWorkerName& ClientWorkerId, const VirtualWorkerId SpawningVirtualWorker);
 	void RetryForwardSpawnPlayerRequest(const Worker_EntityId EntityId, const Worker_RequestId RequestId, const bool bShouldTryDifferentPlayerStart = false);
 
 	// Any server
-	void PassSpawnRequestToNetDriver(Schema_Object* PlayerSpawnData, AActor* PlayerStart);
+	void PassSpawnRequestToNetDriver(const Schema_Object* PlayerSpawnData, AActor* PlayerStart);
 
 	UPROPERTY()
 	USpatialNetDriver* NetDriver;


### PR DESCRIPTION
It's conceivable that the worker authoritative over the PlayerSpawner snapshot entity doesn't correctly find PlayerStarts Actors, e.g. if the PlayerSpawner authoritative worker is the wrong layer / has decided to delete PlayerStarts / FindPlayerStart_Implementation doesn't work correctly on this worker type. In this case, we attempt to route to a worker of the correct layer instead of failing outright. This is a short-term mitigation. The long-term fix is better control over which worker gains auth over PlayerSpawner component.