### PR TITLE
UNR-3675 Add Auto Generate Launch Configuration Checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **注意**：自虚幻引擎开发套件 v0.8.0 版本起，其日志提供中英文两个版本。每个日志的中文版本都置于英文版本之后。
 
 ## [`x.y.z`] - Unreleased
+- Replaced the "Generate From Current Map" button  from the "Cloud Deployment Configuration" window by "Automatically Generate Configuration" checkbox that if ticked, generates an up to date configuration from the current map every time a cloud deployment is started.
+
 
 ### New Known Issues:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **注意**：自虚幻引擎开发套件 v0.8.0 版本起，其日志提供中英文两个版本。每个日志的中文版本都置于英文版本之后。
 
 ## [`x.y.z`] - Unreleased
-- Replaced the "Generate From Current Map" button  from the "Cloud Deployment Configuration" window by "Automatically Generate Configuration" checkbox that if ticked, generates an up to date configuration from the current map every time a cloud deployment is started.
+- Replaced the **Generate From Current Map** button  from the **Cloud Deployment Configuration** window by **Automatically Generate Launch Configuration** checkbox. If ticked, it generates an up to date configuration from the current map when selecting the **Start Deployment** button.
 
 
 ### New Known Issues:

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -233,6 +233,12 @@ void USpatialGDKEditorSettings::SetSimulatedPlayersEnabledState(bool IsEnabled)
 	SaveConfig();
 }
 
+void USpatialGDKEditorSettings::SetAutoGenerateConfigEnabledState(bool IsEnabled)
+{
+	bIsAutoGenerateConfigEnabled = IsEnabled;
+	SaveConfig();
+}
+
 void USpatialGDKEditorSettings::SetBuildAndUploadAssembly(bool bBuildAndUpload)
 {
 	bBuildAndUploadAssembly = bBuildAndUpload;
@@ -388,7 +394,7 @@ bool USpatialGDKEditorSettings::IsDeploymentConfigurationValid() const
 		UE_LOG(LogSpatialEditorSettings, Error, TEXT("Snapshot path cannot be empty."));
 		bValid = false;
 	}
-	if (GetPrimaryLaunchConfigPath().IsEmpty())
+	if (GetPrimaryLaunchConfigPath().IsEmpty() && !bIsAutoGenerateConfigEnabled)
 	{
 		UE_LOG(LogSpatialEditorSettings, Error, TEXT("Launch config path cannot be empty."));
 		bValid = false;

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -233,9 +233,9 @@ void USpatialGDKEditorSettings::SetSimulatedPlayersEnabledState(bool IsEnabled)
 	SaveConfig();
 }
 
-void USpatialGDKEditorSettings::SetAutoGenerateConfigEnabledState(bool IsEnabled)
+void USpatialGDKEditorSettings::SetAutoGenerateCloudLaunchConfigEnabledState(bool IsEnabled)
 {
-	bIsAutoGenerateConfigEnabled = IsEnabled;
+	bIsAutoGenerateCloudConfigEnabled = IsEnabled;
 	SaveConfig();
 }
 
@@ -394,7 +394,7 @@ bool USpatialGDKEditorSettings::IsDeploymentConfigurationValid() const
 		UE_LOG(LogSpatialEditorSettings, Error, TEXT("Snapshot path cannot be empty."));
 		bValid = false;
 	}
-	if (GetPrimaryLaunchConfigPath().IsEmpty() && !bIsAutoGenerateConfigEnabled)
+	if (GetPrimaryLaunchConfigPath().IsEmpty() && !bIsAutoGenerateCloudConfigEnabled)
 	{
 		UE_LOG(LogSpatialEditorSettings, Error, TEXT("Launch config path cannot be empty."));
 		bValid = false;

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -378,6 +378,9 @@ private:
 	UPROPERTY(EditAnywhere, config, Category = "Cloud", meta = (DisplayName = "Deployment tags"))
 	FString DeploymentTags;
 
+	UPROPERTY(EditAnywhere, config, Category = "Cloud", meta = (DisplayName = "Auto generate configuration from current map"))
+	bool bIsAutoGenerateConfigEnabled;
+
 	const FString SimulatedPlayerLaunchConfigPath;
 
 public:
@@ -624,6 +627,12 @@ public:
 	FORCEINLINE bool IsSimulatedPlayersEnabled() const
 	{
 		return bSimulatedPlayersIsEnabled;
+	}
+
+	void SetAutoGenerateConfigEnabledState(bool IsEnabled);
+	FORCEINLINE bool IsAutoGenerateConfigEnabled() const
+	{
+		return bIsAutoGenerateConfigEnabled;
 	}
 
 	void SetBuildAndUploadAssembly(bool bBuildAndUpload);

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -378,8 +378,8 @@ private:
 	UPROPERTY(EditAnywhere, config, Category = "Cloud", meta = (DisplayName = "Deployment tags"))
 	FString DeploymentTags;
 
-	UPROPERTY(EditAnywhere, config, Category = "Cloud", meta = (DisplayName = "Auto generate configuration from current map"))
-	bool bIsAutoGenerateConfigEnabled;
+	UPROPERTY(config)
+	bool bIsAutoGenerateCloudConfigEnabled;
 
 	const FString SimulatedPlayerLaunchConfigPath;
 
@@ -629,10 +629,10 @@ public:
 		return bSimulatedPlayersIsEnabled;
 	}
 
-	void SetAutoGenerateConfigEnabledState(bool IsEnabled);
-	FORCEINLINE bool IsAutoGenerateConfigEnabled() const
+	void SetAutoGenerateCloudLaunchConfigEnabledState(bool IsEnabled);
+	FORCEINLINE bool ShouldAutoGenerateCloudLaunchConfig() const
 	{
-		return bIsAutoGenerateConfigEnabled;
+		return bIsAutoGenerateCloudConfigEnabled;
 	}
 
 	void SetBuildAndUploadAssembly(bool bBuildAndUpload);

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKCloudDeploymentConfiguration.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKCloudDeploymentConfiguration.cpp
@@ -178,7 +178,7 @@ void SSpatialGDKCloudDeploymentConfiguration::Construct(const FArguments& InArgs
 									.Text(FText::FromString(FString(TEXT("Use GDK Pinned Version For Cloud"))))
 									.ToolTipText(FText::FromString(FString(TEXT("Whether to use the SpatialOS Runtime version associated to the current GDK version for cloud deployments"))))
 								]
-							+ SHorizontalBox::Slot()
+								+ SHorizontalBox::Slot()
 								.FillWidth(1.0f)
 								[
 									SNew(SCheckBox)
@@ -198,7 +198,7 @@ void SSpatialGDKCloudDeploymentConfiguration::Construct(const FArguments& InArgs
 									.Text(FText::FromString(FString(TEXT("Runtime Version"))))
 									.ToolTipText(FText::FromString(FString(TEXT("User supplied version of the SpatialOS runtime to use"))))
 								]
-							+ SHorizontalBox::Slot()
+								+ SHorizontalBox::Slot()
 								.FillWidth(1.0f)
 								[
 									SNew(SEditableTextBox)
@@ -289,49 +289,48 @@ void SSpatialGDKCloudDeploymentConfiguration::Construct(const FArguments& InArgs
 									.FilePath_UObject(SpatialGDKSettings, &USpatialGDKEditorSettings::GetPrimaryLaunchConfigPath)
 									.FileTypeFilter(TEXT("Launch configuration files (*.json)|*.json"))
 									.OnPathPicked(this, &SSpatialGDKCloudDeploymentConfiguration::OnPrimaryLaunchConfigPathPicked)
-									.IsEnabled(this, &SSpatialGDKCloudDeploymentConfiguration::IsUsingAutoGenerateConfig)
+									.IsEnabled(this, &SSpatialGDKCloudDeploymentConfiguration::CanPickOrEditCloudLaunchConfig)
 								]
 							]
 							+ SVerticalBox::Slot()
-								.AutoHeight()
-								.Padding(2.0f)
-								[
-									SNew(SHorizontalBox)
-									+ SHorizontalBox::Slot()
+							.AutoHeight()
+							.Padding(2.0f)
+							[
+								SNew(SHorizontalBox)
+								+ SHorizontalBox::Slot()
 								.FillWidth(1.0f)
 								[
 									SNew(STextBlock)
 									.Text(FText::FromString(FString(TEXT(""))))
-								.ToolTipText(FText::FromString(FString(TEXT(""))))
+									.ToolTipText(FText::FromString(FString(TEXT(""))))
 								]
-							+ SHorizontalBox::Slot()
+								+ SHorizontalBox::Slot()
 								.FillWidth(1.0f)
 								[
 									SNew(SButton)
 									.Text(FText::FromString(FString(TEXT("Open Launch Configuration editor"))))
-								.OnClicked(this, &SSpatialGDKCloudDeploymentConfiguration::OnOpenLaunchConfigEditor)
-								.IsEnabled(this, &SSpatialGDKCloudDeploymentConfiguration::IsUsingAutoGenerateConfig)
+									.OnClicked(this, &SSpatialGDKCloudDeploymentConfiguration::OnOpenLaunchConfigEditor)
+									.IsEnabled(this, &SSpatialGDKCloudDeploymentConfiguration::CanPickOrEditCloudLaunchConfig)
 								]
-								]
+							]
 							+ SVerticalBox::Slot()
-								.AutoHeight()
-								.Padding(2.0f)
-								[
-									SNew(SHorizontalBox)
-									+ SHorizontalBox::Slot()
+							.AutoHeight()
+							.Padding(2.0f)
+							[
+								SNew(SHorizontalBox)
+								+ SHorizontalBox::Slot()
 								.FillWidth(1.0f)
 								[
 									SNew(STextBlock)
-									.Text(FText::FromString(FString(TEXT("Automatically Generate Configuration"))))
-								.ToolTipText(FText::FromString(FString(TEXT("Whether to automatically generate the configuration from the current map every time a cloud deployment is started."))))
+									.Text(FText::FromString(FString(TEXT("Automatically Generate Launch Configuration"))))
+									.ToolTipText(FText::FromString(FString(TEXT("Whether to automatically generate the launch configuration from the current map when a cloud deployment is started."))))
 								]
-
 								+ SHorizontalBox::Slot()
 								.FillWidth(1.0f)
 								[
 									SNew(SCheckBox)
-									.IsChecked(this, &SSpatialGDKCloudDeploymentConfiguration::IsAutoGenerateConfigEnabled)
-								.OnCheckStateChanged(this, &SSpatialGDKCloudDeploymentConfiguration::OnCheckedAutoGenerateConfig)
+									.IsChecked(this, &SSpatialGDKCloudDeploymentConfiguration::IsAutoGenerateCloudLaunchConfigEnabled)
+									.OnCheckStateChanged(this, &SSpatialGDKCloudDeploymentConfiguration::OnCheckedAutoGenerateCloudLaunchConfig)
 								]
 							]
 							// Primary Deployment Region Picker
@@ -1019,23 +1018,22 @@ FText SSpatialGDKCloudDeploymentConfiguration::GetSpatialOSRuntimeVersionToUseTe
 	return FText::FromString(RuntimeVersionString);
 }
 
-
-bool SSpatialGDKCloudDeploymentConfiguration::IsUsingAutoGenerateConfig() const
+bool SSpatialGDKCloudDeploymentConfiguration::CanPickOrEditCloudLaunchConfig() const
 {
 	const USpatialGDKEditorSettings* SpatialGKDSettings = GetDefault<USpatialGDKEditorSettings>();
-	return !SpatialGKDSettings->IsAutoGenerateConfigEnabled();
+	return !SpatialGKDSettings->ShouldAutoGenerateCloudLaunchConfig();
 }
 
-ECheckBoxState SSpatialGDKCloudDeploymentConfiguration::IsAutoGenerateConfigEnabled() const
+ECheckBoxState SSpatialGDKCloudDeploymentConfiguration::IsAutoGenerateCloudLaunchConfigEnabled() const
 {
 	const USpatialGDKEditorSettings* SpatialGKDSettings = GetDefault<USpatialGDKEditorSettings>();
-	return SpatialGKDSettings->IsAutoGenerateConfigEnabled() ? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
+	return SpatialGKDSettings->ShouldAutoGenerateCloudLaunchConfig() ? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
 }
 
-void SSpatialGDKCloudDeploymentConfiguration::OnCheckedAutoGenerateConfig(ECheckBoxState NewCheckedState)
+void SSpatialGDKCloudDeploymentConfiguration::OnCheckedAutoGenerateCloudLaunchConfig(ECheckBoxState NewCheckedState)
 {
 	USpatialGDKEditorSettings* SpatialGDKSettings = GetMutableDefault<USpatialGDKEditorSettings>();
-	SpatialGDKSettings->SetAutoGenerateConfigEnabledState(NewCheckedState == ECheckBoxState::Checked);
+	SpatialGDKSettings->SetAutoGenerateCloudLaunchConfigEnabledState(NewCheckedState == ECheckBoxState::Checked);
 }
 
 FReply SSpatialGDKCloudDeploymentConfiguration::OnOpenLaunchConfigEditor()

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -1217,7 +1217,6 @@ void FSpatialGDKEditorToolbarModule::GenerateConfigFromCurrentMap()
 	GenerateLaunchConfig(LaunchConfig, &LaunchConfiguration, ServerWorkerConfig);
 
 	SpatialGDKEditorSettings->SetPrimaryLaunchConfigPath(LaunchConfig);
-
 }
 
 FReply FSpatialGDKEditorToolbarModule::OnStartCloudDeployment()
@@ -1231,9 +1230,9 @@ FReply FSpatialGDKEditorToolbarModule::OnStartCloudDeployment()
 		return FReply::Unhandled();
 	}
 
-	if (SpatialGDKSettings->IsAutoGenerateConfigEnabled())
+	if (SpatialGDKSettings->ShouldAutoGenerateCloudLaunchConfig())
 	{
-		this->GenerateConfigFromCurrentMap();
+		GenerateConfigFromCurrentMap();
 	}
 
 	AddDeploymentTagIfMissing(SpatialConstants::DEV_LOGIN_TAG);
@@ -1329,7 +1328,7 @@ bool FSpatialGDKEditorToolbarModule::IsDeploymentConfigurationValid() const
 		&& !SpatialGDKSettings->GetPrimaryDeploymentName().IsEmpty()
 		&& !SpatialGDKSettings->GetAssemblyName().IsEmpty()
 		&& !SpatialGDKSettings->GetSnapshotPath().IsEmpty()
-		&& (!SpatialGDKSettings->GetPrimaryLaunchConfigPath().IsEmpty() || SpatialGDKSettings->IsAutoGenerateConfigEnabled());
+		&& (!SpatialGDKSettings->GetPrimaryLaunchConfigPath().IsEmpty() || SpatialGDKSettings->ShouldAutoGenerateCloudLaunchConfig());
 }
 
 bool FSpatialGDKEditorToolbarModule::CanBuildAndUpload() const

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKCloudDeploymentConfiguration.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKCloudDeploymentConfiguration.h
@@ -131,9 +131,9 @@ private:
 	bool IsUsingCustomRuntimeVersion() const;
 	FText GetSpatialOSRuntimeVersionToUseText() const;
 
-	ECheckBoxState IsAutoGenerateConfigEnabled() const;
-	bool IsUsingAutoGenerateConfig() const;
-	void OnCheckedAutoGenerateConfig(ECheckBoxState NewCheckedState);
+	ECheckBoxState IsAutoGenerateCloudLaunchConfigEnabled() const;
+	bool CanPickOrEditCloudLaunchConfig() const;
+	void OnCheckedAutoGenerateCloudLaunchConfig(ECheckBoxState NewCheckedState);
 
 	FReply OnOpenLaunchConfigEditor();
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKCloudDeploymentConfiguration.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKCloudDeploymentConfiguration.h
@@ -131,7 +131,9 @@ private:
 	bool IsUsingCustomRuntimeVersion() const;
 	FText GetSpatialOSRuntimeVersionToUseText() const;
 
-	FReply OnGenerateConfigFromCurrentMap();
+	ECheckBoxState IsAutoGenerateConfigEnabled() const;
+	bool IsUsingAutoGenerateConfig() const;
+	void OnCheckedAutoGenerateConfig(ECheckBoxState NewCheckedState);
 
 	FReply OnOpenLaunchConfigEditor();
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -182,4 +182,6 @@ private:
 	FCloudDeploymentConfiguration CloudDeploymentConfiguration;
 
 	bool bStartingCloudDeployment;
+
+	void GenerateConfigFromCurrentMap();
 };


### PR DESCRIPTION
#### Description

Replaced the "Generate From Current Map" button  from the "Cloud Deployment Configuration" window by "Automatically Generate Configuration" checkbox that if ticked, generates an up to date configuration from the current map every time a cloud deployment is started. Also, checking the box prevents the user from clicking "Open Launch Configuration editor" and from manually picking the "Launch Config File". 

Below are two images to make the change easier to visualize, the first one shows the menu before the change, the second shows it after the change: 

![Before](https://user-images.githubusercontent.com/66263711/85150519-8a8c5c80-b24a-11ea-8127-f68cb34bba5b.png)
![After](https://user-images.githubusercontent.com/66263711/85150525-8ceeb680-b24a-11ea-892d-3b5605edda7e.png)

#### Release note
Added under ##Unreleased .

#### Tests
Only manual testing, verifying that having the checkbox checked provides the stated functionality, and that the conditions for starting a deployment are updated by this addition.  

#### Documentation
Documented by the release note.

#### Primary reviewers
@ImprobableNic @improbable-valentyn @jessicafalk 
