### PR TITLE
Check for world settings null

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
@@ -70,8 +70,7 @@ bool USpatialStatics::IsSpatialOffloadingEnabled(const UWorld* World)
 {
 	if (World != nullptr)
 	{
-		const ASpatialWorldSettings* WorldSettings = Cast<ASpatialWorldSettings>(World->GetWorldSettings());
-		if (WorldSettings != nullptr)
+		if (const ASpatialWorldSettings* WorldSettings = Cast<ASpatialWorldSettings>(World->GetWorldSettings()))
 		{
 			return IsSpatialNetworkingEnabled() && WorldSettings->WorkerLayers.Num() > 0;
 		}

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
@@ -71,7 +71,10 @@ bool USpatialStatics::IsSpatialOffloadingEnabled(const UWorld* World)
 	if (World != nullptr)
 	{
 		const ASpatialWorldSettings* WorldSettings = Cast<ASpatialWorldSettings>(World->GetWorldSettings());
-		return IsSpatialNetworkingEnabled() && WorldSettings->WorkerLayers.Num() > 0;
+		if (WorldSettings != nullptr)
+		{
+			return IsSpatialNetworkingEnabled() && WorldSettings->WorkerLayers.Num() > 0;
+		}
 	}
 
 	return false;


### PR DESCRIPTION
#### Description
Check for world settings null

Fix for https://improbableio.atlassian.net/browse/UNR-3688

#### Release note
REQUIRED: Add a release note to the `##Unreleased` section of CHANGELOG.md. You can find guidance for writing useful release notes [here](../SpatialGDK/Extras/internal-documentation/how-to-write-good-release-notes.md). Documentation changes are exempt from this requirement.

#### Tests
Use the repro in https://improbableio.atlassian.net/browse/UNR-3688 or start the offloading benchmark gym with no SpatialWorldSettings.


#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
