### PR TITLE
[UNR-3545] Add cookloadonly flag for cookandgenerateschema

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/CookAndGenerateSchemaCommandlet.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/CookAndGenerateSchemaCommandlet.cpp
@@ -7,6 +7,8 @@
 #include "SpatialGDKEditorSettings.h"
 #include "SpatialGDKServicesConstants.h"
 
+#include "Misc/CommandLine.h"
+
 using namespace SpatialGDKEditor::Schema;
 
 DEFINE_LOG_CATEGORY(LogCookAndGenerateSchemaCommandlet);
@@ -103,7 +105,13 @@ int32 UCookAndGenerateSchemaCommandlet::Main(const FString& CmdLineParams)
 	}
 
 	UE_LOG(LogCookAndGenerateSchemaCommandlet, Display, TEXT("Starting Cook Command."));
-	int32 CookResult = Super::Main(CmdLineParams);
+
+	const FString AdditionalCookParam(TEXT(" -cookloadonly"));
+	FString NewCmdLine = CmdLineParams;
+	NewCmdLine.Append(AdditionalCookParam);
+	FCommandLine::Append(*AdditionalCookParam);
+
+	int32 CookResult = Super::Main(NewCmdLine);
 	UE_LOG(LogCookAndGenerateSchemaCommandlet, Display, TEXT("Cook Command Completed."));
 
 	UE_LOG(LogCookAndGenerateSchemaCommandlet, Display, TEXT("Discovered %d Classes during cook."), ReferencedClasses.Num());


### PR DESCRIPTION
#### Description
Add cookloadonly flag to the cooking command, in order to speed up schema generation.
Engine PR : https://github.com/improbableio/UnrealEngine/pull/553

Timings for scavengers, cooking Cascade.
Original time : 18 min.
Time without saving packages : 10 min
Time without saving or caching cooked data : 7.5 min (cookloadonly flag)
Time with cookloadonly and GC threshold set to 32 GB (instead of 16) : 5 min.
Time with cookloadonly and no GC : 4 min.

#### Release note

#### Tests

#### Documentation

#### Primary reviewers
