### PR TITLE
Ensure worker entity is cleaned up on shutdown

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -831,7 +831,7 @@ void USpatialNetDriver::BeginDestroy()
 			Connection->SendDeleteEntityRequest(WorkerEntityId);
 		}
 		// Flush the connection and wait a moment to allow the message to propagate.
-		// This is a workaround and needs to be handled more smoothly : UNR-3694
+		// TODO: UNR-3697 - This needs to be handled more correctly
 		Connection->Flush();
 		FPlatformProcess::Sleep(0.1f);
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -830,6 +830,10 @@ void USpatialNetDriver::BeginDestroy()
 		{
 			Connection->SendDeleteEntityRequest(WorkerEntityId);
 		}
+		// Flush the connection and wait a moment to allow the message to propagate.
+		// This is a workaround and needs to be handled more smoothly : UNR-3694
+		Connection->Flush();
+		FPlatformProcess::Sleep(0.1f);
 
 		// Destroy the connection to disconnect from SpatialOS if we aren't meant to persist it.
 		if (!bPersistSpatialConnection)


### PR DESCRIPTION
#### Description
Stop-gap fix for UNR-3694
Server worker entity isn't given enough time to delete when running locally with squid.

#### Primary reviewers
@samiwh @joshuahuburn @mironec 
