### PR TITLE
[UNR-3680][MS] Spatial connection manager created from spatial net driver

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
@@ -124,11 +124,14 @@ bool USpatialGameInstance::TryStartSpatialConnection()
 	if (!bHasPreviouslyConnectedToSpatial &&
 		HasSpatialNetDriver())
 	{
-		// If we are using spatial networking then prepare a spatial connection.
 		// Ensure that any connections attempting to using command line arguments have a valid locater host in the command line.
 		InjectSpatialLocatorIntoCommandLine();
+
+		// If we are using spatial networking then prepare a spatial connection.
 		CreateNewSpatialConnectionManager();
+
 		bHasPreviouslyConnectedToSpatial = true;
+
 		return true;
 	}
 #if TRACE_LIB_ACTIVE

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
@@ -119,7 +119,7 @@ FGameInstancePIEResult USpatialGameInstance::StartPlayInEditorGameInstance(ULoca
 }
 #endif
 
-void USpatialGameInstance::TryStartSpatialConnection()
+bool USpatialGameInstance::TryStartSpatialConnection()
 {
 	if (!bHasPreviouslyConnectedToSpatial &&
 		HasSpatialNetDriver())
@@ -129,6 +129,7 @@ void USpatialGameInstance::TryStartSpatialConnection()
 		InjectSpatialLocatorIntoCommandLine();
 		CreateNewSpatialConnectionManager();
 		bHasPreviouslyConnectedToSpatial = true;
+		return true;
 	}
 #if TRACE_LIB_ACTIVE
 	else
@@ -138,6 +139,7 @@ void USpatialGameInstance::TryStartSpatialConnection()
 		SpatialLatencyTracer->SetWorkerId(WorkerName);
 	}
 #endif
+	return false;
 }
 
 void USpatialGameInstance::InjectSpatialLocatorIntoCommandLine()

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -224,9 +224,10 @@ void USpatialNetDriver::InitiateConnectionToSpatialOS(const FURL& URL)
 
 	// This will create a Spatial Connection Manager if it is our first time connection.
 	// It will also inject a command line locater.
-	GameInstance->TryStartSpatialConnection();
+	bool bCreatedNewNetDriver = GameInstance->TryStartSpatialConnection();
 
-	if (!bPersistSpatialConnection)
+	if (!bCreatedNewNetDriver &&
+		!bPersistSpatialConnection)
 	{
 		GameInstance->DestroySpatialConnectionManager();
 		GameInstance->CreateNewSpatialConnectionManager();

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -224,9 +224,9 @@ void USpatialNetDriver::InitiateConnectionToSpatialOS(const FURL& URL)
 
 	// This will create a Spatial Connection Manager if it is our first time connection.
 	// It will also inject a command line locater.
-	bool bCreatedNewNetDriver = GameInstance->TryStartSpatialConnection();
+	bool bCreatedNewConnectionManager = GameInstance->TryStartSpatialConnection();
 
-	if (!bCreatedNewNetDriver &&
+	if (!bCreatedNewConnectionManager &&
 		!bPersistSpatialConnection)
 	{
 		GameInstance->DestroySpatialConnectionManager();

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -222,6 +222,10 @@ void USpatialNetDriver::InitiateConnectionToSpatialOS(const FURL& URL)
 		bPersistSpatialConnection = URL.HasOption(*SpatialConstants::ClientsStayConnectedURLOption);
 	}
 
+	// This will create a Spatial Connection Manager if it is our first time connection.
+	// It will also inject a command line locater.
+	GameInstance->TryStartSpatialConnection();
+
 	if (!bPersistSpatialConnection)
 	{
 		GameInstance->DestroySpatialConnectionManager();
@@ -240,9 +244,6 @@ void USpatialNetDriver::InitiateConnectionToSpatialOS(const FURL& URL)
 	// If arguments can not be found we will use the regular flow of loading from the input URL.
 
 	FString SpatialWorkerType = GameInstance->GetSpatialWorkerType().ToString();
-
-	// Ensures that any connections attempting to using command line arguments have a valid locater host in the command line.
-	GameInstance->TryInjectSpatialLocatorIntoCommandLine();
 
 	UE_LOG(LogSpatialOSNetDriver, Log, TEXT("Attempting connection to SpatialOS"));
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialGameInstance.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialGameInstance.h
@@ -70,7 +70,8 @@ public:
 	void DisableShouldConnectUsingCommandLineArgs() { bShouldConnectUsingCommandLineArgs = false; }
 	bool GetShouldConnectUsingCommandLineArgs() const { return bShouldConnectUsingCommandLineArgs; }
 
-	void TryInjectSpatialLocatorIntoCommandLine();
+	// Initializes the Spatial connection manager if Spatial networking is enabled, otherwise does nothing.
+	void TryStartSpatialConnection();
 
 	void CleanupLevelInitializedNetworkActors(ULevel* LoadedLevel);
 
@@ -102,11 +103,7 @@ private:
 	UPROPERTY()
 	TSet<ULevel*> CachedLevelsForNetworkIntialize;
 
-	// Initializes the Spatial connection manager if Spatial networking is enabled, otherwise does nothing.
-	void StartSpatialConnection();
-
-	void SetHasPreviouslyConnectedToSpatial() { bHasPreviouslyConnectedToSpatial = true; }
-	bool HasPreviouslyConnectedToSpatial() const { return bHasPreviouslyConnectedToSpatial; }
+	void InjectSpatialLocatorIntoCommandLine();
 
 	UFUNCTION()
 	void OnLevelInitializedNetworkActors(ULevel* LoadedLevel, UWorld* OwningWorld);

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialGameInstance.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialGameInstance.h
@@ -71,7 +71,7 @@ public:
 	bool GetShouldConnectUsingCommandLineArgs() const { return bShouldConnectUsingCommandLineArgs; }
 
 	// Initializes the Spatial connection manager if Spatial networking is enabled, otherwise does nothing.
-	void TryStartSpatialConnection();
+	bool TryStartSpatialConnection();
 
 	void CleanupLevelInitializedNetworkActors(ULevel* LoadedLevel);
 


### PR DESCRIPTION
If the AutoPreventCloudConnection setting is enabled on clients it is possible that the first connection will be attempted without a connection manager if bPersistSpatialConnection is true. We now attempt to "StartSpatalConnection" from the netdriver which itself will create a connection manager and inject the a locator into the command line arguments.