### PR TITLE
Allow (temporarily) setting snapshot path to empty in Cloud deployment window

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -187,7 +187,8 @@ void USpatialGDKEditorSettings::SetPrimaryLaunchConfigPath(const FString& Path)
 
 void USpatialGDKEditorSettings::SetSnapshotPath(const FString& Path)
 {
-	SnapshotPath.FilePath = FPaths::ConvertRelativePathToFull(Path);
+	// If a non-empty path is specified, convert it to full, otherwise just empty the field.
+	SnapshotPath.FilePath = Path.IsEmpty() ? TEXT("") : FPaths::ConvertRelativePathToFull(Path);
 	SaveConfig();
 }
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -62,6 +62,7 @@ USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& O
 	SpatialOSLaunchConfig.FilePath = GetSpatialOSLaunchConfig();
 	SpatialOSSnapshotToSave = GetSpatialOSSnapshotToSave();
 	SpatialOSSnapshotToLoad = GetSpatialOSSnapshotToLoad();
+	SnapshotPath.FilePath = GetSpatialOSSnapshotToSavePath();
 }
 
 FRuntimeVariantVersion& USpatialGDKEditorSettings::GetRuntimeVariantVersion(ESpatialOSRuntimeVariant::Type Variant)

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -565,10 +565,7 @@ public:
 	void SetSnapshotPath(const FString& Path);
 	FORCEINLINE FString GetSnapshotPath() const
 	{
-		const USpatialGDKEditorSettings* SpatialEditorSettings = GetDefault<USpatialGDKEditorSettings>();
-		return SnapshotPath.FilePath.IsEmpty()
-			? SpatialEditorSettings->GetSpatialOSSnapshotToSavePath()
-			: SnapshotPath.FilePath;
+		return SnapshotPath.FilePath;
 	}
 
 	void SetPrimaryRegionCode(const ERegionCode::Type RegionCode);


### PR DESCRIPTION
#### Description
Allow the user to set the snapshot field to empty in the Cloud Deployment Configuration window to make the user experience more consistent (previously it would get automatically assigned to `.../Engine/Binaries/Win64` as a result of converting a relative empty path to full, which was confusing). The user would still not be able to start the deployment until they specify a snapshot path.
![image](https://user-images.githubusercontent.com/32096431/85401631-3e932d80-b552-11ea-9cb9-11cbe20bef06.png)


#### Primary reviewers
@jessicafalk @oblm 
