### PR TITLE
Add class override to Default layer

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -747,6 +747,12 @@ void USpatialNetDriver::SpatialProcessServerTravel(const FString& URL, bool bAbs
 		return;
 	}
 
+	if (NetDriver->LoadBalanceStrategy->GetMinimumRequiredWorkers() > 1)
+	{
+		UE_LOG(LogGameMode, Warning, TEXT("Server travel is not supported on a deployment with multiple workers."));
+		return;
+	}
+
 	NetDriver->GlobalStateManager->ResetGSM();
 
 	GameMode->StartToLeaveMap();

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -747,12 +747,6 @@ void USpatialNetDriver::SpatialProcessServerTravel(const FString& URL, bool bAbs
 		return;
 	}
 
-	if (NetDriver->LoadBalanceStrategy->GetMinimumRequiredWorkers() > 1)
-	{
-		UE_LOG(LogGameMode, Warning, TEXT("Server travel is not supported on a deployment with multiple workers."));
-		return;
-	}
-
 	NetDriver->GlobalStateManager->ResetGSM();
 
 	GameMode->StartToLeaveMap();

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
@@ -70,6 +70,18 @@ void ULayeredLBStrategy::Init()
 	{
 		UAbstractLBStrategy* DefaultLBStrategy = NewObject<UAbstractLBStrategy>(this, WorldSettings->DefaultLayerLoadBalanceStrategy);
 		AddStrategyForLayer(SpatialConstants::DefaultLayer, DefaultLBStrategy);
+		for (const TSoftClassPtr<AActor>& ClassPtr : WorldSettings->DefaultActorClasses)
+		{
+			if (ClassPtr.IsValid())
+			{
+				UE_LOG(LogLayeredLBStrategy, Log, TEXT(" - Adding class %s."), *ClassPtr->GetName());
+				ClassPathToLayer.Add(ClassPtr, SpatialConstants::DefaultLayer);
+			}
+			else
+			{
+				UE_LOG(LogLayeredLBStrategy, Log, TEXT(" - Invalid class not added %s"), *ClassPtr.GetAssetName());
+			}
+		}
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
@@ -82,7 +82,7 @@ void ULayeredLBStrategy::Init()
 			}
 			else
 			{
-				UE_LOG(LogLayeredLBStrategy, Log, TEXT(" - Invalid class not added %s"), *ClassPtr.GetAssetName());
+				UE_LOG(LogLayeredLBStrategy, Log, TEXT(" - Invalid class not added to default layer %s"), *ClassPtr.GetAssetName());
 			}
 		}
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
@@ -70,7 +70,10 @@ void ULayeredLBStrategy::Init()
 	{
 		UAbstractLBStrategy* DefaultLBStrategy = NewObject<UAbstractLBStrategy>(this, WorldSettings->DefaultLayerLoadBalanceStrategy);
 		AddStrategyForLayer(SpatialConstants::DefaultLayer, DefaultLBStrategy);
-		for (const TSoftClassPtr<AActor>& ClassPtr : WorldSettings->DefaultActorClasses)
+
+		// Any class not specified on one of the other layers will be on the default layer. However, some games may have a class hierarchy with
+		// some parts of the hierarchy on different layers. This provides a way to specify that.
+		for (const TSoftClassPtr<AActor>& ClassPtr : WorldSettings->ExplicitDefaultActorClasses)
 		{
 			if (ClassPtr.IsValid())
 			{

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
@@ -77,7 +77,7 @@ void ULayeredLBStrategy::Init()
 		{
 			if (ClassPtr.IsValid())
 			{
-				UE_LOG(LogLayeredLBStrategy, Log, TEXT(" - Adding class %s."), *ClassPtr->GetName());
+				UE_LOG(LogLayeredLBStrategy, Log, TEXT(" - Adding class to default layer %s."), *ClassPtr->GetName());
 				ClassPathToLayer.Add(ClassPtr, SpatialConstants::DefaultLayer);
 			}
 			else

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialWorldSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialWorldSettings.h
@@ -30,6 +30,9 @@ public:
 	UPROPERTY(EditAnywhere, Config, Category = "Multi-Worker", meta = (EditCondition = "bEnableMultiWorker"))
 	TSubclassOf<UAbstractLockingPolicy> DefaultLayerLockingPolicy;
 
+	UPROPERTY(EditAnywhere, Category = "Multi-Worker")
+	TSet<TSoftClassPtr<AActor>> DefaultActorClasses;
+
 	/** Layer configuration. */
 	UPROPERTY(EditAnywhere, Config, Category = "Multi-Worker", meta = (EditCondition = "bEnableMultiWorker"))
 	TMap<FName, FLayerInfo> WorkerLayers;

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialWorldSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialWorldSettings.h
@@ -30,8 +30,12 @@ public:
 	UPROPERTY(EditAnywhere, Config, Category = "Multi-Worker", meta = (EditCondition = "bEnableMultiWorker"))
 	TSubclassOf<UAbstractLockingPolicy> DefaultLayerLockingPolicy;
 
+	/**
+	  * Any classes not specified on another layer will be handled by the default layer, but this also gives a way
+	  * to force classes to be on the default layer.
+	  */
 	UPROPERTY(EditAnywhere, Category = "Multi-Worker")
-	TSet<TSoftClassPtr<AActor>> DefaultActorClasses;
+	TSet<TSoftClassPtr<AActor>> ExplicitDefaultActorClasses;
 
 	/** Layer configuration. */
 	UPROPERTY(EditAnywhere, Config, Category = "Multi-Worker", meta = (EditCondition = "bEnableMultiWorker"))

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialWorldSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialWorldSettings.h
@@ -34,7 +34,7 @@ public:
 	  * Any classes not specified on another layer will be handled by the default layer, but this also gives a way
 	  * to force classes to be on the default layer.
 	  */
-	UPROPERTY(EditAnywhere, Category = "Multi-Worker")
+	UPROPERTY(EditAnywhere, Category = "Multi-Worker", meta = (EditCondition = "bEnableMultiWorker"))
 	TSet<TSoftClassPtr<AActor>> ExplicitDefaultActorClasses;
 
 	/** Layer configuration. */


### PR DESCRIPTION
#### Description
If a game has a class inheritance hierarchy such as the following:
    Foo
   /   \
FooBar  Foo2 , Foo3, Foo4, Foo5...

and they want FooBar on the Default layer but all the other Foo's on the FooLayer, they were not able to specify that without explicitly adding all FooX to the Layer's actor classes. 

This PR adds an explicit ActorClass list to the Default layer, so that the developer could put FooBar on the default layer and Foo on the FooLayer.


#### Release note
N/A

#### Tests
Use the offloading gym and set up a class hierarchy as the one above.

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
