### PR TITLE
removing DevelopmentDeploymentToConnect

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
@@ -232,9 +232,9 @@ bool FSpatialGDKEditorCommandLineArgsManager::TryConstructMobileCommandLineArgum
 		}
 
 		SpatialOSOptions += FString::Printf(TEXT(" -devauthToken %s"), *(SpatialGDKSettings->DevelopmentAuthenticationToken));
-		if (!SpatialGDKSettings->DevelopmentDeploymentToConnect.IsEmpty())
+		if (!SpatialGDKSettings->GetPrimaryDeploymentName().IsEmpty())
 		{
-			SpatialOSOptions += FString::Printf(TEXT(" -deployment %s"), *(SpatialGDKSettings->DevelopmentDeploymentToConnect));
+			SpatialOSOptions += FString::Printf(TEXT(" -deployment %s"), *(SpatialGDKSettings->GetPrimaryDeploymentName()));
 		}
 	}
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -77,7 +77,7 @@ FString FSpatialGDKEditorModule::GetDevAuthToken() const
 
 FString FSpatialGDKEditorModule::GetSpatialOSCloudDeploymentName() const
 {
-	return GetDefault<USpatialGDKEditorSettings>()->DevelopmentDeploymentToConnect;
+	return GetDefault<USpatialGDKEditorSettings>()->GetPrimaryDeploymentName();
 }
 
 bool FSpatialGDKEditorModule::CanExecuteLaunch() const
@@ -103,7 +103,7 @@ bool FSpatialGDKEditorModule::CanStartSession(FText& OutErrorMessage) const
 
 		const USpatialGDKEditorSettings* Settings = GetDefault<USpatialGDKEditorSettings>();
 		bool bIsRunningInChina = GetDefault<USpatialGDKSettings>()->IsRunningInChina();
-		if (!Settings->DevelopmentDeploymentToConnect.IsEmpty() && !SpatialCommandUtils::HasDevLoginTag(Settings->DevelopmentDeploymentToConnect, bIsRunningInChina, OutErrorMessage))
+		if (!Settings->GetPrimaryDeploymentName().IsEmpty() && !SpatialCommandUtils::HasDevLoginTag(Settings->GetPrimaryDeploymentName(), bIsRunningInChina, OutErrorMessage))
 		{
 			return false;
 		}

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -447,12 +447,6 @@ void USpatialGDKEditorSettings::SetDevelopmentAuthenticationToken(const FString&
 	SaveConfig();
 }
 
-void USpatialGDKEditorSettings::SetDevelopmentDeploymentToConnect(const FString& Deployment)
-{
-	DevelopmentDeploymentToConnect = Deployment;
-	SaveConfig();
-}
-
 void USpatialGDKEditorSettings::SetExposedRuntimeIP(const FString& RuntimeIP)
 {
 	ExposedRuntimeIP = RuntimeIP;

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -424,10 +424,6 @@ public:
 	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection")
 	FString DevelopmentAuthenticationToken;
 
-	/** The deployment to connect to when using the Development Authentication Flow. If left empty, it uses the first available one (order not guaranteed when there are multiple items). The deployment needs to be tagged with 'dev_login'. */
-	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection")
-	FString DevelopmentDeploymentToConnect;
-
 private:
 	UPROPERTY(config)
 	TEnumAsByte<ERegionCode::Type> SimulatedPlayerDeploymentRegionCode;
@@ -697,8 +693,6 @@ public:
 	bool IsDeploymentConfigurationValid() const;
 
 	void SetDevelopmentAuthenticationToken(const FString& Token);
-	void SetDevelopmentDeploymentToConnect(const FString& Deployment);
-
 	void SetExposedRuntimeIP(const FString& RuntimeIP);
 
 	void SetSpatialOSNetFlowType(ESpatialOSNetFlow::Type NetFlowType);

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -441,7 +441,7 @@ void OnCloudDeploymentNameChanged(const FText& InText, ETextCommit::Type InCommi
 	}
 
 	USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetMutableDefault<USpatialGDKEditorSettings>();
-	SpatialGDKEditorSettings->SetDevelopmentDeploymentToConnect(InputDeploymentName);
+	SpatialGDKEditorSettings->SetPrimaryDeploymentName(InputDeploymentName);
 
 	UE_LOG(LogSpatialGDKEditorToolbar, Display, TEXT("Setting cloud deployment name to %s"), *InputDeploymentName);
 }
@@ -478,7 +478,7 @@ TSharedRef<SWidget> FSpatialGDKEditorToolbarModule::CreateStartDropDownMenuConte
 
 		MenuBuilder.AddWidget(SNew(SEditableText)
 			.OnTextCommitted_Static(OnCloudDeploymentNameChanged)
-			.Text(FText::FromString(SpatialGDKEditorSettings->DevelopmentDeploymentToConnect))
+			.Text(FText::FromString(SpatialGDKEditorSettings->GetPrimaryDeploymentName()))
 			.SelectAllTextWhenFocused(true)
 			.ColorAndOpacity(FLinearColor::White * 0.8f)
 			.IsEnabled_Raw(this, &FSpatialGDKEditorToolbarModule::AreCloudDeploymentPropertiesEditable)
@@ -1240,7 +1240,6 @@ FReply FSpatialGDKEditorToolbarModule::OnStartCloudDeployment()
 	CloudDeploymentConfiguration.InitFromSettings();
 
 	const FString& DeploymentName = CloudDeploymentConfiguration.PrimaryDeploymentName;
-	GetMutableDefault<USpatialGDKEditorSettings>()->SetDevelopmentDeploymentToConnect(DeploymentName);
 	UE_LOG(LogSpatialGDKEditorToolbar, Display, TEXT("Setting deployment to connect to %s"), *DeploymentName);
 
 	if (CloudDeploymentConfiguration.bBuildAndUploadAssembly)


### PR DESCRIPTION
#### Description
We currently have `DevelopmentDeploymentToConnect` and `PrimaryDeploymentName`. One is used to identify which cloud deployment to connect, the other one is used to identify which name the cloud deployment we want to start should have.
After some chats this seems confusing to people and maybe it actually makes more sense to just have one cloud deployment field that is used for both.

e.g. if I change the **Cloud Deployment Name** field in th**e Start Deployment** dropdown and the click **Start Deployment**, I would expect the deployment  that starts to have the name I just entered. This doesn't happen at the moment. However, when we start a cloud deployment, we do enter the deployment into the **Cloud Deployment Name** field.

#### Tests
only tested it in the Editor whether the value gets stored correctly. Currently starting up a cloud deployment to test.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@improbable-valentyn @MatthewSandfordImprobable 
