### PR TITLE
Check if service is actually running before erroring

### DIFF
--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -274,7 +274,7 @@ bool FLocalDeploymentManager::LocalDeploymentPreRunChecks()
 		}
 	}
 
-	if (!bSpatialServiceInProjectDirectory)
+	if (!bSpatialServiceInProjectDirectory && bSpatialServiceRunning)
 	{
 		if (FMessageDialog::Open(EAppMsgType::YesNo, LOCTEXT("StopSpatialServiceFromDifferentProject", "An instance of the SpatialOS Runtime is running with another project. Would you like to stop it and start the Runtime for this project?")) == EAppReturnType::Yes)
 		{


### PR DESCRIPTION
## Description
If checking the spatial service is in the correct project, first make sure it's actually running. This was really annoying me because it will 100% give you the pop-up dialogue for no reason if the service is stopped. 
