### PR TITLE
Improve the connection flow dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Features:
 - You can now change the GDK Editor Setting `Stop local deployment on stop play in editor` in order to automatically stop deployment when you stop playing in editor.
 
+### Bug fixes:
+- `Cloud Deployment Name` field in the dropdown now refers to the same property as `Deployment Name` in the Cloud Deployment Configuration window, so the `Start Deployment` toolbar button will now use the name specified in the dropdown when quickly starting the new deployment without going through the Cloud Deployment Configuration window.
+- `Local Deployment IP` and `Cloud Deployment Name` labels now get grayed out correctly when the edit box is disabled.
+- Entering an invalid IP into the `Exposed local runtime IP address` field in the editor settings will trigger a warning popup and reset the value to an empty string.
+
 ## [`0.10.0`] - 2020-06-15
 
 ### New Known Issues:
@@ -75,7 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The SpatialOS project name can now be modified via the **SpatialOS Editor Settings**.
 - Replaced the `Generate From Current Map` button from the `Cloud Deployment Configuration` window by `Automatically Generate Launch Configuration` checkbox. If ticked, it generates an up to date configuration from the current map when selecting the `Start Deployment` button.
 
-## Bug fixes:
+### Bug fixes:
 - Fix problem where load balanced cloud deploys could fail to start while under heavy load.
 - Fix to avoid using packages still being processed in the async loading thread.
 - Fixed a bug when running GDK setup scripts fail to unzip dependencies sometimes.
@@ -151,7 +156,7 @@ Usage: `DeploymentLauncher createsim <project-name> <assembly-name> <target-depl
 - Added `OnClientOwnershipGained` and `OnClientOwnershipLost` events on Actors and Actor Components. These events trigger when an Actor is added to or removed from the ownership hierarchy of a client's PlayerController.
 - Automatically remove UE4CommandLine.txt after finishing a Launch on device session on an Android device (only UnrealEngine 4.24 or above). This is done to prevent the launch session command line from overriding the one built into the APK.
 
-## Bug fixes:
+### Bug fixes:
 - Queued RPCs no longer spam logs when an entity is deleted.
 - We now take the `OverrideSpatialNetworking` command line argument into account as early as possible (previously, `LocalDeploymentManager` queried `bSpatialNetworking` before the command line was parsed).
 - Servers now maintain interest in `AlwaysRelevant` Actors.

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
@@ -232,9 +232,9 @@ bool FSpatialGDKEditorCommandLineArgsManager::TryConstructMobileCommandLineArgum
 		}
 
 		SpatialOSOptions += FString::Printf(TEXT(" -devauthToken %s"), *(SpatialGDKSettings->DevelopmentAuthenticationToken));
-		if (!SpatialGDKSettings->DevelopmentDeploymentToConnect.IsEmpty())
+		if (!SpatialGDKSettings->GetPrimaryDeploymentName().IsEmpty())
 		{
-			SpatialOSOptions += FString::Printf(TEXT(" -deployment %s"), *(SpatialGDKSettings->DevelopmentDeploymentToConnect));
+			SpatialOSOptions += FString::Printf(TEXT(" -deployment %s"), *(SpatialGDKSettings->GetPrimaryDeploymentName()));
 		}
 	}
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -77,7 +77,7 @@ FString FSpatialGDKEditorModule::GetDevAuthToken() const
 
 FString FSpatialGDKEditorModule::GetSpatialOSCloudDeploymentName() const
 {
-	return GetDefault<USpatialGDKEditorSettings>()->DevelopmentDeploymentToConnect;
+	return GetDefault<USpatialGDKEditorSettings>()->GetPrimaryDeploymentName();
 }
 
 bool FSpatialGDKEditorModule::CanExecuteLaunch() const
@@ -103,7 +103,7 @@ bool FSpatialGDKEditorModule::CanStartSession(FText& OutErrorMessage) const
 
 		const USpatialGDKEditorSettings* Settings = GetDefault<USpatialGDKEditorSettings>();
 		bool bIsRunningInChina = GetDefault<USpatialGDKSettings>()->IsRunningInChina();
-		if (!Settings->DevelopmentDeploymentToConnect.IsEmpty() && !SpatialCommandUtils::HasDevLoginTag(Settings->DevelopmentDeploymentToConnect, bIsRunningInChina, OutErrorMessage))
+		if (!Settings->GetPrimaryDeploymentName().IsEmpty() && !SpatialCommandUtils::HasDevLoginTag(Settings->GetPrimaryDeploymentName(), bIsRunningInChina, OutErrorMessage))
 		{
 			return false;
 		}

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -427,10 +427,6 @@ public:
 	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection")
 	FString DevelopmentAuthenticationToken;
 
-	/** The deployment to connect to when using the Development Authentication Flow. If left empty, it uses the first available one (order not guaranteed when there are multiple items). The deployment needs to be tagged with 'dev_login'. */
-	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection")
-	FString DevelopmentDeploymentToConnect;
-
 private:
 	UPROPERTY(config)
 	TEnumAsByte<ERegionCode::Type> SimulatedPlayerDeploymentRegionCode;
@@ -700,8 +696,8 @@ public:
 	bool IsDeploymentConfigurationValid() const;
 
 	void SetDevelopmentAuthenticationToken(const FString& Token);
-	void SetDevelopmentDeploymentToConnect(const FString& Deployment);
 
+	static bool IsValidIP(const FString& IP);
 	void SetExposedRuntimeIP(const FString& RuntimeIP);
 
 	void SetSpatialOSNetFlowType(ESpatialOSNetFlow::Type NetFlowType);

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKCloudDeploymentConfiguration.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKCloudDeploymentConfiguration.cpp
@@ -227,7 +227,7 @@ void SSpatialGDKCloudDeploymentConfiguration::Construct(const FArguments& InArgs
 								.FillWidth(1.0f)
 								[
 									SNew(SEditableTextBox)
-									.Text(FText::FromString(SpatialGDKSettings->GetPrimaryDeploymentName()))
+									.Text(this, &SSpatialGDKCloudDeploymentConfiguration::GetPrimaryDeploymentNameText)
 									.ToolTipText(FText::FromString(FString(TEXT("The name of the cloud deployment. Must be unique."))))
 									.OnTextCommitted(this, &SSpatialGDKCloudDeploymentConfiguration::OnPrimaryDeploymentNameCommited)
 									.ErrorReporting(DeploymentNameInputErrorReporting)
@@ -767,6 +767,12 @@ void SSpatialGDKCloudDeploymentConfiguration::OnDeploymentAssemblyCommited(const
 
 	USpatialGDKEditorSettings* SpatialGDKSettings = GetMutableDefault<USpatialGDKEditorSettings>();
 	SpatialGDKSettings->SetAssemblyName(InputAssemblyName);
+}
+
+FText SSpatialGDKCloudDeploymentConfiguration::GetPrimaryDeploymentNameText() const
+{
+	const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>();
+	return FText::FromString(SpatialGDKEditorSettings->GetPrimaryDeploymentName());
 }
 
 void SSpatialGDKCloudDeploymentConfiguration::OnProjectNameCommitted(const FText& InText, ETextCommit::Type InCommitType)

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKCloudDeploymentConfiguration.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKCloudDeploymentConfiguration.h
@@ -54,6 +54,8 @@ private:
 	/** Delegate to commit assembly name */
 	void OnDeploymentAssemblyCommited(const FText& InText, ETextCommit::Type InCommitType);
 
+	FText GetPrimaryDeploymentNameText() const;
+
 	/** Delegate to commit primary deployment name */
 	void OnPrimaryDeploymentNameCommited(const FText& InText, ETextCommit::Type InCommitType);
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -4,6 +4,7 @@
 
 #include "Async/Future.h"
 #include "CoreMinimal.h"
+#include "Framework/SlateDelegates.h"
 #include "Modules/ModuleManager.h"
 #include "Serialization/JsonWriter.h"
 #include "Templates/SharedPointer.h"
@@ -109,8 +110,8 @@ private:
 	void LocalDeploymentClicked();
 	void CloudDeploymentClicked();
 
-	bool IsLocalDeploymentIPEditable() const;
-	bool AreCloudDeploymentPropertiesEditable() const;
+	static bool IsLocalDeploymentIPEditable();
+	static bool AreCloudDeploymentPropertiesEditable();
 
 	void LaunchInspectorWebpageButtonClicked();
 	void CreateSnapshotButtonClicked();
@@ -139,6 +140,9 @@ private:
 	TSharedRef<SWidget> CreateGenerateSchemaMenuContent();
 	TSharedRef<SWidget> CreateLaunchDeploymentMenuContent();
 	TSharedRef<SWidget> CreateStartDropDownMenuContent();
+
+	using IsEnabledFunc = bool();
+	TSharedRef<SWidget> CreateBetterEditableTextWidget(const FText& Label, const FText& Text, FOnTextCommitted::TFuncType OnTextCommitted, IsEnabledFunc IsEnabled);
 
 	void ShowSingleFailureNotification(const FString& NotificationText);
 	void ShowTaskStartNotification(const FString& NotificationText);


### PR DESCRIPTION
#### Description
I combined https://github.com/spatialos/UnrealGDK/pull/2290 with the Connection Flow dropdown improvements suggested in https://improbableio.atlassian.net/browse/UNR-3746:
- `Cloud Deployment Name` field in the dropdown now refers to the same property as `Deployment Name` in the Cloud Deployment Configuration window, so the `Start Deployment` toolbar button will now use the name specified in the dropdown when quickly starting the new deployment without going through the Cloud Deployment Configuration window.
- `Local Deployment IP` and `Cloud Deployment Name` labels now get grayed out correctly when the edit box is disabled.
- Entering an invalid IP into the `Exposed local runtime IP address` field in the editor settings will trigger a warning popup and reset the value to an empty string.

#### Primary reviewers
@jessicafalk @MatthewSandfordImprobable 
