### PR TITLE
[UNR-3772] Fix authority for non-replicated offloaded actors

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
@@ -266,7 +266,6 @@ void USpatialGameInstance::OnLevelInitializedNetworkActors(ULevel* LoadedLevel, 
 {
 	if (OwningWorld != GetWorld()
 		|| !OwningWorld->IsServer()
-		|| OwningWorld->NetDriver == nullptr
 		|| !GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking()
 		|| (OwningWorld->WorldType != EWorldType::PIE
 			&& OwningWorld->WorldType != EWorldType::Game


### PR DESCRIPTION
#### Description
Non-replicated offloaded actors in old offloading were LocalRole == Role_NONE, but in new offloading, they had authority.
This restores the functionality of CleanupLevelInitializedNetworkActors, which does the swap based on the LBStrategy (though this does now happen later than previously).

Engine PRs:
https://github.com/improbableio/UnrealEngine/pull/563
https://github.com/improbableio/UnrealEngine/pull/564

#### Release note
Should have worked. N/A

#### Tests
Example project offloading tutorial.

#### Documentation
N/A

#### Primary reviewers
@m-samiec @MatthewSandfordImprobable @joshuahuburn 
