### PR TITLE
Enable SpatialGDK Tests on MacOS

### DIFF
--- a/SpatialGDK/Source/SpatialGDKServices/Private/SSpatialOutputLog.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SSpatialOutputLog.cpp
@@ -125,6 +125,14 @@ void SSpatialOutputLog::OnLogDirectoryChanged(const TArray<FFileChangeData>& Fil
 	{
 		if (FileChange.Action == FFileChangeData::FCA_Added)
 		{
+#if PLATFORM_MAC
+			// Unreal does not support IDirectoryWatcher::WatchOptions::IgnoreChangesInSubtree for macOS.
+			// We need to double-check whether the current file really is a directory.
+			if (!FPaths::DirectoryExists(FileChange.Filename))
+			{
+				continue;
+			}
+#endif
 			// Now we can start reading the new log file in the new log folder.
 			ResetPollingLogFile(FPaths::Combine(FileChange.Filename, LaunchLogFilename));
 			return;

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/SpatialOSDispatcherInterface/SpatialOSDispatcherSpy.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/SpatialOSDispatcherInterface/SpatialOSDispatcherSpy.cpp
@@ -1,7 +1,5 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
-#pragma once
-
 #include "SpatialOSDispatcherSpy.h"
 
 SpatialOSDispatcherSpy::SpatialOSDispatcherSpy()

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/OwnershipLockingPolicy/OwnershipLockingPolicyTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/OwnershipLockingPolicy/OwnershipLockingPolicyTest.cpp
@@ -158,9 +158,9 @@ bool FAcquireLock::Update()
 		for (const TPair<AActor*, TArray<LockingTokenAndDebugString>>& ActorLockingTokenAndDebugStrings : Data->TestActorToLockingTokenAndDebugStrings)
 		{
 			const TArray<LockingTokenAndDebugString>& LockingTokensAndDebugStrings = ActorLockingTokenAndDebugStrings.Value;
-			bool TokenAlreadyExists = LockingTokensAndDebugStrings.ContainsByPredicate([Token](const LockingTokenAndDebugString& Data)
+			bool TokenAlreadyExists = LockingTokensAndDebugStrings.ContainsByPredicate([Token](const LockingTokenAndDebugString& InnerData)
 			{
-				return Token == Data.Key;
+				return Token == InnerData.Key;
 			});
 			if (TokenAlreadyExists)
 			{
@@ -196,9 +196,9 @@ bool FReleaseLock::Update()
 		return true;
 	}
 
-	int32 TokenIndex = LockTokenAndDebugStrings->IndexOfByPredicate([this](const LockingTokenAndDebugString& Data)
+	int32 TokenIndex = LockTokenAndDebugStrings->IndexOfByPredicate([this](const LockingTokenAndDebugString& InnerData)
 	{
-		return Data.Value == LockDebugString;
+		return InnerData.Value == LockDebugString;
 	});
 	Test->TestTrue("Found valid lock token", TokenIndex != INDEX_NONE);
 

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Utils/Misc/SpatialActivationFlagsTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Utils/Misc/SpatialActivationFlagsTest.cpp
@@ -67,7 +67,7 @@ struct SpatialActivationFlagTestFixture
 {
 	SpatialActivationFlagTestFixture(FAutomationTestBase& Test)
 	{
-		ProjectPath = FPaths::GetProjectFilePath();
+		ProjectPath = FPaths::ConvertRelativePathToFull(FPaths::GetProjectFilePath());
 		CommandLineArgs = ProjectPath;
 		CommandLineArgs.Append(TEXT(" -ExecCmds=\"Automation RunTests SpatialGDKSlow.Core.UGeneralProjectSettings.SpatialActivationReport; Quit\""));
 		CommandLineArgs.Append(TEXT(" -TestExit=\"Automation Test Queue Empty\""));

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
@@ -293,7 +293,6 @@ private:
 		FString Content = SchemaContent;
 		Content.ReplaceInline(TEXT("\r"), TEXT(""));
 		Content.ReplaceInline(TEXT("\n"), TEXT(""));
-		Content.ReplaceInline(TEXT(" "), TEXT(""));
 		return Content;
 	}
 };

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
@@ -54,13 +54,13 @@ ComponentNamesAndIds ParseAvailableNamesAndIdsFromSchemaFile(const TArray<FStrin
 
 	for (const auto& SchemaLine : LoadedSchema)
 	{
-		FRegexPattern IdPattern = TEXT("(\tid = )([0-9]+)(;)");
+		FRegexPattern IdPattern(TEXT("(\tid = )([0-9]+)(;)"));
 		FRegexMatcher IdRegMatcher(IdPattern, SchemaLine);
 
-		FRegexPattern NamePattern = TEXT("(^component )(.+)( \\{)");
+		FRegexPattern NamePattern(TEXT("(^component )(.+)( \\{)"));
 		FRegexMatcher NameRegMatcher(NamePattern, SchemaLine);
 
-		FRegexPattern SubobjectNamePattern = TEXT("(\tUnrealObjectRef )(.+)( = )([0-9]+)(;)");
+		FRegexPattern SubobjectNamePattern(TEXT("(\tUnrealObjectRef )(.+)( = )([0-9]+)(;)"));
 		FRegexMatcher SubobjectNameRegMatcher(SubobjectNamePattern, SchemaLine);
 
 		if (IdRegMatcher.FindNext())
@@ -263,7 +263,7 @@ public:
 		FString ExpectedContent;
 		FFileHelper::LoadFileToString(ExpectedContent, *ExpectedContentFullPath);
 		ExpectedContent.ReplaceInline(TEXT("{{id}}"), *FString::FromInt(GetNextFreeId()));
-		return (GeneratedSchemaContent.Compare(ExpectedContent) == 0);
+		return (CleanSchema(GeneratedSchemaContent).Compare(CleanSchema(ExpectedContent)) == 0);
 	}
 
 	bool ValidateGeneratedSchemaForClass(const FString& FileContent, const UClass* CurrentClass)
@@ -285,6 +285,17 @@ private:
 	}
 
 	int FreeId = 10000;
+
+	// This is needed to ensure the schema generated is the same for both Windows and macOS.
+	// The new-line characters differ which will fail the tests when running it on macOS.
+	FString CleanSchema(const FString& SchemaContent)
+	{
+		FString Content = SchemaContent;
+		Content.ReplaceInline(TEXT("\r"), TEXT(""));
+		Content.ReplaceInline(TEXT("\n"), TEXT(""));
+		Content.ReplaceInline(TEXT(" "), TEXT(""));
+		return Content;
+	}
 };
 
 class SchemaTestFixture

--- a/SpatialGDK/SpatialGDK.uplugin
+++ b/SpatialGDK/SpatialGDK.uplugin
@@ -70,7 +70,8 @@
       "Type": "Editor",
       "LoadingPhase": "PreLoadingScreen",
       "WhitelistPlatforms": [
-        "Win64"
+        "Win64",
+        "Mac"
       ]
     },
     {

--- a/ci/cleanup.sh
+++ b/ci/cleanup.sh
@@ -3,7 +3,7 @@
 pushd "$(dirname "$0")"
 
     UNREAL_PATH="${1:-"$(pwd)/../../UnrealEngine"}"
-    BUILD_PROJECT="${2:-NetworkTestProject}"
+    BUILD_PROJECT="${2:-GDKTestGyms}"
 
     PROJECT_ABSOLUTE_PATH="$(pwd)/../../${BUILD_PROJECT}"
     GDK_IN_TEST_REPO="${PROJECT_ABSOLUTE_PATH}/Game/Plugins/UnrealGDK"

--- a/ci/generate-and-upload-build-steps.sh
+++ b/ci/generate-and-upload-build-steps.sh
@@ -73,6 +73,10 @@ generate_build_configuration_steps () {
             done
         fi
     else
+        if [[ -n "${SLOW_NETWORKING_TESTS:-}" ]]; then
+            export SLOW_NETWORKING_TESTS
+        fi
+
         if [[ -z "${BUILD_ALL_CONFIGURATIONS+x}" ]]; then
             # MacOS Development Editor build configuration
             upload_build_configuration_step "${ENGINE_COMMIT_HASH}" "Mac" "Editor" "Development"

--- a/ci/run-tests.sh
+++ b/ci/run-tests.sh
@@ -32,7 +32,9 @@ pushd "$(dirname "$0")"
                 -unattended \
                 -nullRHI \
                 -run=CookAndGenerateSchema \
-                -cookall
+                -map="${TEST_REPO_MAP}" \
+                -targetplatform=MacNoEditor \
+                -cooksinglepackage
                 
             "${UNREAL_EDITOR_PATH}" \
                 "${UPROJECT_PATH}" \

--- a/ci/run-tests.sh
+++ b/ci/run-tests.sh
@@ -32,9 +32,9 @@ pushd "$(dirname "$0")"
                 -unattended \
                 -nullRHI \
                 -run=CookAndGenerateSchema \
-                -map="${TEST_REPO_MAP}" \
                 -targetplatform=MacNoEditor \
-                -cooksinglepackage
+                -cookall \
+            || true
                 
             "${UNREAL_EDITOR_PATH}" \
                 "${UPROJECT_PATH}" \

--- a/ci/setup-build-test-gdk.sh
+++ b/ci/setup-build-test-gdk.sh
@@ -13,12 +13,20 @@ pushd "$(dirname "$0")"
     BUILD_HOME="${3:-"$(pwd)/../.."}"
 
     UNREAL_PATH="${BUILD_HOME}/UnrealEngine"
+<<<<<<< HEAD
     TEST_UPROJECT_NAME="UnrealGDKTestGyms"
     TEST_REPO_URL="git@github.com:spatialos/UnrealGDKTestGyms.git"
     TEST_REPO_MAP="SpatialNetworkingMap"
     TEST_PROJECT_NAME="GDKTestGyms"
     CHOSEN_TEST_REPO_BRANCH="${TEST_REPO_BRANCH:-master}" 
     SLOW_NETWORKING_TESTS=false
+=======
+    TEST_UPROJECT_NAME="GDKTestGyms"
+    TEST_REPO_URL="git@github.com:spatialos/UnrealGDKTestGyms.git"
+    TEST_REPO_MAP="EmptyGym"
+    TEST_PROJECT_NAME="GDKTestGyms"
+    CHOSEN_TEST_REPO_BRANCH="${TEST_REPO_BRANCH:-master}"
+>>>>>>> update ci scripts to run tests and use test gyms
 
     # Download Unreal Engine
     echo "--- get-unreal-engine"
@@ -45,26 +53,25 @@ pushd "$(dirname "$0")"
         "${BUILD_STATE}" \
         "${TEST_UPROJECT_NAME}${BUILD_TARGET}"
 
-    # TODO UNR-3164 - re-enable tests after we made sure they work for Mac; note: test execution changed, see .ps script
-    # echo "--- run-fast-tests"
-    # "${GDK_HOME}/ci/run-tests.sh" \
-    #     "${UNREAL_PATH}" \
-    #     "${TEST_PROJECT_NAME}" \
-    #     "${UPROJECT_PATH}" \
-    #     "FastTestResults" \
-    #     "NetworkingMap" \
-    #     "SpatialGDK+/Game/SpatialNetworkingMap" \
-    #     "True"
+    echo "--- run-fast-tests"
+    "${GDK_HOME}/ci/run-tests.sh" \
+        "${UNREAL_PATH}" \
+        "${TEST_PROJECT_NAME}" \
+        "${UPROJECT_PATH}" \
+        "TestResults" \
+        "${TEST_REPO_MAP}" \
+        ".SpatialGDK" \
+        "True"
 
-    # if [[ -n "${SLOW_NETWORKING_TESTS}" ]]; then
-    #     echo "--- run-slow-networking-tests"
-    #     "${GDK_HOME}/ci/run-tests.sh" \
-    #         "${UNREAL_PATH}" \
-    #         "${TEST_PROJECT_NAME}" \
-    #         "${UPROJECT_PATH}" \
-    #         "VanillaTestResults" \
-    #         "NetworkingMap" \
-    #         "+/Game/NetworkingMap" \
-    #         ""
-    # fi
+    if [[ -n "${SLOW_NETWORKING_TESTS}" ]]; then
+        echo "--- run-slow-networking-tests"
+        "${GDK_HOME}/ci/run-tests.sh" \
+            "${UNREAL_PATH}" \
+            "${TEST_PROJECT_NAME}" \
+            "${UPROJECT_PATH}" \
+            "SlowTestResults" \
+            "${TEST_REPO_MAP}" \
+            "+SpatialGDKSlow." \
+            "True"
+    fi
 popd

--- a/ci/setup-build-test-gdk.sh
+++ b/ci/setup-build-test-gdk.sh
@@ -60,7 +60,7 @@ pushd "$(dirname "$0")"
         "${UPROJECT_PATH}" \
         "TestResults" \
         "${TEST_REPO_MAP}" \
-        ".SpatialGDK" \
+        "SpatialGDK." \
         "True"
 
     if [[ -n "${SLOW_NETWORKING_TESTS}" ]]; then
@@ -71,7 +71,7 @@ pushd "$(dirname "$0")"
             "${UPROJECT_PATH}" \
             "SlowTestResults" \
             "${TEST_REPO_MAP}" \
-            "+SpatialGDKSlow." \
+            "SpatialGDKSlow." \
             "True"
     fi
 popd

--- a/ci/setup-build-test-gdk.sh
+++ b/ci/setup-build-test-gdk.sh
@@ -13,20 +13,11 @@ pushd "$(dirname "$0")"
     BUILD_HOME="${3:-"$(pwd)/../.."}"
 
     UNREAL_PATH="${BUILD_HOME}/UnrealEngine"
-<<<<<<< HEAD
-    TEST_UPROJECT_NAME="UnrealGDKTestGyms"
-    TEST_REPO_URL="git@github.com:spatialos/UnrealGDKTestGyms.git"
-    TEST_REPO_MAP="SpatialNetworkingMap"
-    TEST_PROJECT_NAME="GDKTestGyms"
-    CHOSEN_TEST_REPO_BRANCH="${TEST_REPO_BRANCH:-master}" 
-    SLOW_NETWORKING_TESTS=false
-=======
     TEST_UPROJECT_NAME="GDKTestGyms"
     TEST_REPO_URL="git@github.com:spatialos/UnrealGDKTestGyms.git"
     TEST_REPO_MAP="EmptyGym"
     TEST_PROJECT_NAME="GDKTestGyms"
     CHOSEN_TEST_REPO_BRANCH="${TEST_REPO_BRANCH:-master}"
->>>>>>> update ci scripts to run tests and use test gyms
 
     # Download Unreal Engine
     echo "--- get-unreal-engine"


### PR DESCRIPTION
#### Description
enabling SpatialGDK tests for macOS CI and also moved the test repo to be the GDKTestGyms instead for macOS. 

#### Tests
corresponding build: https://buildkite.com/improbable/unrealgdk-premerge/builds/14995#_
