### PR TITLE
[UNR-3768] Give better error reporting with incorrect worker layer setup

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
@@ -40,7 +40,17 @@ void ULayeredLBStrategy::Init()
 		const FName& LayerName = Layer.Key;
 		const FLayerInfo& LayerInfo = Layer.Value;
 
-		UAbstractLBStrategy* LBStrategy = NewObject<UAbstractLBStrategy>(this, LayerInfo.LoadBalanceStrategy);
+		UAbstractLBStrategy* LBStrategy;
+		if (LayerInfo.LoadBalanceStrategy == nullptr)
+		{
+			UE_LOG(LogLayeredLBStrategy, Error, TEXT("WorkerLayer %s does not specify a loadbalancing strategy (or it cannot be resolved). Using a 1x1 grid."), *LayerName.ToString());
+			LBStrategy = NewObject<UGridBasedLBStrategy>(this);
+		}
+		else
+		{
+			LBStrategy = NewObject<UAbstractLBStrategy>(this, LayerInfo.LoadBalanceStrategy);
+		}
+
 		AddStrategyForLayer(LayerName, LBStrategy);
 
 		UE_LOG(LogLayeredLBStrategy, Log, TEXT("Creating LBStrategy for Layer %s."), *LayerName.ToString());

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
@@ -149,7 +149,12 @@ uint32 GetWorkerCountFromWorldSettings(const UWorld& World)
 
 		UAbstractRuntimeLoadBalancingStrategy* LoadBalancingStrat = nullptr;
 		FIntPoint Dimension;
-		if (!EditorModule.GetLBStrategyExtensionManager().GetDefaultLaunchConfiguration(LayerInfo.LoadBalanceStrategy->GetDefaultObject<UAbstractLBStrategy>(), LoadBalancingStrat, Dimension))
+		if (LayerInfo.LoadBalanceStrategy == nullptr)
+		{
+			UE_LOG(LogSpatialGDKDefaultLaunchConfigGenerator, Error, TEXT("Missing Load balancing strategy on layer %s"), *LayerKey.ToString());
+			NumWorkers += 1;
+		}
+		else if (!EditorModule.GetLBStrategyExtensionManager().GetDefaultLaunchConfiguration(LayerInfo.LoadBalanceStrategy->GetDefaultObject<UAbstractLBStrategy>(), LoadBalancingStrat, Dimension))
 		{
 			UE_LOG(LogSpatialGDKDefaultLaunchConfigGenerator, Error, TEXT("Could not get the SpatialOS Load balancing strategy for layer %s"), *LayerKey.ToString());
 			NumWorkers += 1;

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/TestGridBasedLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/TestGridBasedLBStrategy.h
@@ -9,7 +9,7 @@
 /**
  * This class is for testing purposes only.
  */
-UCLASS(HideDropdown)
+UCLASS(HideDropdown, NotBlueprintable)
 class SPATIALGDKTESTS_API UTestGridBasedLBStrategy : public UGridBasedLBStrategy
 {
 	GENERATED_BODY()

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/LayeredLBStrategy/TestLayeredLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/LayeredLBStrategy/TestLayeredLBStrategy.h
@@ -12,7 +12,7 @@
 /**
  * This class is for testing purposes only.
  */
-UCLASS(HideDropdown)
+UCLASS(HideDropdown, NotBlueprintable)
 class SPATIALGDKTESTS_API UTwoByFourLBGridStrategy : public UGridBasedLBStrategy 
 {
 	GENERATED_BODY()


### PR DESCRIPTION
#### Description
Give better error reporting and a failsafe, if a worker layer has a nullptr LoadBalancing Strategy.
Also makes the TestGridLBStrategy (and TwoByFour...) not blueprintable, so users do not choose it in error, since they are not available in non-editor builds.

#### Release note
N/A

#### Tests
Tested manually.

#### Documentation
N/A

#### Primary reviewers
@jennifer-at-improbable-io @alastairdglennie 
