### PR TITLE
Bugfix/unr 3792 propagate uarrayproperty deletions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OwnerOnly components are now properly replicated when gaining authority over an actor. Previously, they were sometimes only replicated when a value on them changed after already being authoritative.
 - Fixed a rare server crash that could occur when closing an actor channel right after attaching a dynamic subobject to that actor.
 - Fixed a defect in `InstallGDK.bat` which sometimes caused it to incorrectly report `Error: Could not clone...` when repositories had been cloned correctly.
+- Fix bug causing this this error to fire: "ResolveObjectReferences: Removed unresolved reference: AbsOffset >= MaxAbsOffset"
 
 ### Internal:
 Features listed in this section are not ready to use. However, in the spirit of open development, we record every change that we make to the GDK.

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
@@ -507,20 +507,12 @@ void ComponentReader::ApplyArray(Schema_Object* Object, Schema_FieldId FieldId, 
 	int Count = GetPropertyCount(Object, FieldId, Property->Inner);
 	ArrayHelper.Resize(Count);
 
+	ArrayObjectReferences->Empty(Count);
+
 	for (int i = 0; i < Count; i++)
 	{
 		int32 ElementOffset = i * Property->Inner->ElementSize;
 		ApplyProperty(Object, FieldId, *ArrayObjectReferences, i, Property->Inner, ArrayHelper.GetRawPtr(i), ElementOffset, ElementOffset, ParentIndex, bOutReferencesChanged);
-	}
-
-	const int32 MaxOffset = Count * Property->Inner->ElementSize;
-
-	for (auto It = ArrayObjectReferences->CreateIterator(); It; ++It)
-	{
-		if (It.Key() >= MaxOffset)
-		{
-			It.RemoveCurrent();
-		}
 	}
 
 	if (ArrayObjectReferences->Num() > 0)

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
@@ -513,6 +513,16 @@ void ComponentReader::ApplyArray(Schema_Object* Object, Schema_FieldId FieldId, 
 		ApplyProperty(Object, FieldId, *ArrayObjectReferences, i, Property->Inner, ArrayHelper.GetRawPtr(i), ElementOffset, ElementOffset, ParentIndex, bOutReferencesChanged);
 	}
 
+	const int32 MaxOffset = Count * Property->Inner->ElementSize;
+
+	for (auto It = ArrayObjectReferences->CreateIterator(); It; ++It)
+	{
+		if (It.Key() >= MaxOffset)
+		{
+			It.RemoveCurrent();
+		}
+	}
+
 	if (ArrayObjectReferences->Num() > 0)
 	{
 		if (bNewArrayMap)


### PR DESCRIPTION
#### Description
Fix one cause of this error firing: "ResolveObjectReferences: removed unresolved reference: absoffset >= maxabsoffset: #".  The problem is caused by a sequence of updates to a UArrayProperty sent over the wire.  If the array ever gets smaller as a result of an update, the stored FObjectReferencesMap will have an entry containing a key offset >= the MaxOffset possible for that UArrayProperty.  The next time an object arrives over the wire that the array depends on for object resolution, SpatialReceiver::ResolveObjectReferences will throw this error.

The fix is to remove any elements from the FObjectReferencesMap whose key is beyond the last element of the UArrayProperty immediately after receiving the update to the array in ComponentReader::ApplyArray.

#### Release note
Release note added to changelog.

#### Tests
Verified that the error no longer fires on our project with this fix.

STRONGLY SUGGESTED: How can this be verified by QA?

#### Documentation
Release note.

#### Primary reviewers
Alex.
