### PR TITLE
Feature/unr 3794 setspatialmetricsdisplay update

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -2573,7 +2573,12 @@ void USpatialNetDriver::SelectiveProcessOps(TArray<Worker_Op*> FoundOps)
 // This should only be called once on each client, in the SpatialMetricsDisplay constructor after the class is replicated to each client.
 void USpatialNetDriver::SetSpatialMetricsDisplay(ASpatialMetricsDisplay* InSpatialMetricsDisplay)
 {
-	check(SpatialMetricsDisplay == nullptr);
+	check(!IsServer());
+	if (SpatialMetricsDisplay != nullptr)
+	{
+		UE_LOG(LogSpatialOSNetDriver, Error, TEXT("SpatialMetricsDisplay should only be set once on each client!"));
+		return;
+	}
 	SpatialMetricsDisplay = InSpatialMetricsDisplay;
 }
 


### PR DESCRIPTION
#### Description

This check has fired at least once on NWX, with undetermined cause as of yet.  Converting the code so that SpatialMetricsDisplay follows the same pattern as SetSpatialDebugger, and the assert doesn't take out clients.  I'm going to follow this up with some tests to see if these methods can be replaced by spawning these 2 singletons from SpatialNetDriver on the client now that "Singleton" keyword is removed (the changes to UnrealObjectRef may allow this to work correctly now).  If that isn't possible, we'll continue investigating what caused the assert to fire.

#### Release note
No release note added b/c this change should be transparent to users.

#### Tests
Tested on our project.


