### PR TITLE
Add flush and sleep after resetting begin play in gsm

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
@@ -355,6 +355,11 @@ void UGlobalStateManager::BeginDestroy()
 		{
 			// Reset the BeginPlay flag so Startup Actors are properly managed.
 			SendCanBeginPlayUpdate(false);
+
+			// Flush the connection and wait a moment to allow the message to propagate.
+			// TODO: UNR-3697 - This needs to be handled more correctly
+			NetDriver->Connection->Flush();
+			FPlatformProcess::Sleep(0.1f);
 		}
 	}
 #endif


### PR DESCRIPTION
#### Description
Found that it was possible for the call to reset `Can_Begin_Play` on editor shutdown could not complete if run with a fast/slow enough PC. This was encountered previously in the RC and fixed similarly with a flush+sleep.

This is a stop-gap solution until we better organise entity cleanup on worker shutdown - UNR-3697

#### Tests
Restarted the empty gym map 900 times

#### Primary reviewers
@mironec 