### PR TITLE
Histogram metrics and upload worker metrics to Grafana 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Entering an invalid IP into the `Exposed local runtime IP address` field in the editor settings will trigger a warning popup and reset the value to an empty string.
 - Fixed bug causing this error to fire: "ResolveObjectReferences: Removed unresolved reference: AbsOffset >= MaxAbsOffset"
 - SpatialMetrics::WorkerMetricsRecieved is no longer static and the function signature now also receives histogram metrics
+
 ## [`0.10.0`] - 2020-07-08
 
 ### New Known Issues:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Features:
 - You can now change the GDK Editor Setting `Stop local deployment on stop play in editor` in order to automatically stop deployment when you stop playing in editor.
 
+### Breaking Changes:
+- SpatialMetrics::WorkerMetricsRecieved is no longer static and the function signature now also receives histogram metrics
+
 ## [`0.10.0`] - 2020-06-15
 
 ### New Known Issues:

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetrics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetrics.cpp
@@ -353,7 +353,7 @@ void USpatialMetrics::HandleWorkerMetrics(Worker_Op* Op)
 {
 	int32 NumGaugeMetrics = Op->op.metrics.metrics.gauge_metric_count;
 	int32 NumHistogramMetrics = Op->op.metrics.metrics.histogram_metric_count;
-	if (NumGaugeMetrics > 0 || NumHistogramMetrics > 0)
+	if (NumGaugeMetrics > 0 || NumHistogramMetrics > 0) // We store these here so we can forward them with our metrics submission
 	{
 		FString StringTmp;
 		StringTmp.Reserve(128);
@@ -379,7 +379,10 @@ void USpatialMetrics::HandleWorkerMetrics(Worker_Op* Op)
 			}
 		}
 
-		WorkerMetricsUpdated.Broadcast(WorkerSDKGaugeMetrics, WorkerSDKHistogramMetrics);
+		if (WorkerMetricsUpdated.IsBound())
+		{
+			WorkerMetricsUpdated.Broadcast(WorkerSDKGaugeMetrics, WorkerSDKHistogramMetrics);
+		}
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetrics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetrics.cpp
@@ -92,7 +92,6 @@ void USpatialMetrics::TickMetrics(float NetDriverTime)
 	}
 	for (const TPair<FString, WorkerHistogramValues>& Metric : WorkerHistogramMetricsToForward)
 	{
-
 		SpatialGDK::HistogramMetric SpatialMetric;
 		SpatialMetric.Key = TCHAR_TO_UTF8(*Metric.Key);
 		SpatialMetric.Buckets.Reserve(Metric.Value.Buckets.Num());

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetrics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetrics.cpp
@@ -11,8 +11,6 @@
 
 DEFINE_LOG_CATEGORY(LogSpatialMetrics);
 
-USpatialMetrics::WorkerMetricsDelegate USpatialMetrics::WorkerMetricsRecieved;
-
 void USpatialMetrics::Init(USpatialWorkerConnection* InConnection, float InNetServerMaxTickRate, bool bInIsServer)
 {
 	Connection = InConnection;

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetrics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetrics.cpp
@@ -83,25 +83,28 @@ void USpatialMetrics::TickMetrics(float NetDriverTime)
 	TimeOfLastReport = NetDriverTime;
 	FramesSinceLastReport = 0;
 
-	for (const TPair<FString, double>& Metric : WorkerGuageMetricsToForward)
+	if (bIsServer) // Server only for now
 	{
-		SpatialGDK::GaugeMetric SpatialMetric;
-		SpatialMetric.Key = TCHAR_TO_UTF8(*Metric.Key);
-		SpatialMetric.Value = Metric.Value;
-		Metrics.GaugeMetrics.Add(SpatialMetric);
-	}
-	for (const TPair<FString, WorkerHistogramValues>& Metric : WorkerHistogramMetricsToForward)
-	{
-		SpatialGDK::HistogramMetric SpatialMetric;
-		SpatialMetric.Key = TCHAR_TO_UTF8(*Metric.Key);
-		SpatialMetric.Buckets.Reserve(Metric.Value.Buckets.Num());
-		SpatialMetric.Sum = Metric.Value.Sum;
-		for (const TPair<double, uint32>& Bucket : Metric.Value.Buckets)
+		for (const TPair<FString, double>& Metric : WorkerGuageMetricsToForward)
 		{
-			SpatialGDK::HistogramMetricBucket SpatialBucket;
-			SpatialBucket.UpperBound = Bucket.Key;
-			SpatialBucket.Samples = Bucket.Value;
-			SpatialMetric.Buckets.Push(SpatialBucket);
+			SpatialGDK::GaugeMetric SpatialMetric;
+			SpatialMetric.Key = TCHAR_TO_UTF8(*Metric.Key);
+			SpatialMetric.Value = Metric.Value;
+			Metrics.GaugeMetrics.Add(SpatialMetric);
+		}
+		for (const TPair<FString, WorkerHistogramValues>& Metric : WorkerHistogramMetricsToForward)
+		{
+			SpatialGDK::HistogramMetric SpatialMetric;
+			SpatialMetric.Key = TCHAR_TO_UTF8(*Metric.Key);
+			SpatialMetric.Buckets.Reserve(Metric.Value.Buckets.Num());
+			SpatialMetric.Sum = Metric.Value.Sum;
+			for (const TPair<double, uint32>& Bucket : Metric.Value.Buckets)
+			{
+				SpatialGDK::HistogramMetricBucket SpatialBucket;
+				SpatialBucket.UpperBound = Bucket.Key;
+				SpatialBucket.Samples = Bucket.Value;
+				SpatialMetric.Buckets.Push(SpatialBucket);
+			}
 		}
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetrics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetrics.cpp
@@ -46,7 +46,6 @@ void USpatialMetrics::TickMetrics(float NetDriverTime)
 	}
 
 	AverageFPS = FramesSinceLastReport / TimeSinceLastReport;
-
 	if (WorkerLoadDelegate.IsBound())
 	{
 		WorkerLoad = WorkerLoadDelegate.Execute();

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetrics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetrics.cpp
@@ -351,14 +351,14 @@ void USpatialMetrics::TrackSentRPC(UFunction* Function, ERPCType RPCType, int Pa
 
 void USpatialMetrics::HandleWorkerMetrics(Worker_Op* Op)
 {
-	int32 NumGuageMetrics = Op->op.metrics.metrics.gauge_metric_count;
+	int32 NumGaugeMetrics = Op->op.metrics.metrics.gauge_metric_count;
 	int32 NumHistogramMetrics = Op->op.metrics.metrics.histogram_metric_count;
-	if (NumGuageMetrics > 0 || NumHistogramMetrics > 0)
+	if (NumGaugeMetrics > 0 || NumHistogramMetrics > 0)
 	{
 		FString StringTmp;
 		StringTmp.Reserve(128);
 
-		for (int32 i = 0; i < NumGuageMetrics; i++)
+		for (int32 i = 0; i < NumGaugeMetrics; i++)
 		{
 			const Worker_GaugeMetric& WorkerMetric = Op->op.metrics.metrics.gauge_metrics[i];
 			StringTmp = WorkerMetric.key;

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetrics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetrics.cpp
@@ -86,14 +86,14 @@ void USpatialMetrics::TickMetrics(float NetDriverTime)
 		for (const TPair<FString, double>& Metric : WorkerGuageMetricsToForward)
 		{
 			SpatialGDK::GaugeMetric SpatialMetric;
-			SpatialMetric.Key = TCHAR_TO_UTF8(*Metric.Key);
+			SpatialMetric.Key = TCHAR_TO_UTF8(*(FString("unreal_worker_") + Metric.Key));
 			SpatialMetric.Value = Metric.Value;
 			Metrics.GaugeMetrics.Add(SpatialMetric);
 		}
 		for (const TPair<FString, WorkerHistogramValues>& Metric : WorkerHistogramMetricsToForward)
 		{
 			SpatialGDK::HistogramMetric SpatialMetric;
-			SpatialMetric.Key = TCHAR_TO_UTF8(*Metric.Key);
+			SpatialMetric.Key = TCHAR_TO_UTF8(*(FString("unreal_worker_") + Metric.Key));
 			SpatialMetric.Buckets.Reserve(Metric.Value.Buckets.Num());
 			SpatialMetric.Sum = Metric.Value.Sum;
 			for (const TPair<double, uint32>& Bucket : Metric.Value.Buckets)

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetrics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetrics.cpp
@@ -360,20 +360,22 @@ void USpatialMetrics::HandleWorkerMetrics(Worker_Op* Op)
 
 		for (int32 i = 0; i < NumGuageMetrics; i++)
 		{
-			StringTmp = Op->op.metrics.metrics.gauge_metrics[i].key;
-			WorkerSDKGaugeMetrics.FindOrAdd(StringTmp) = Op->op.metrics.metrics.gauge_metrics[i].value;
+			const Worker_GaugeMetric& WorkerMetric = Op->op.metrics.metrics.gauge_metrics[i];
+			StringTmp = WorkerMetric.key;
+			WorkerSDKGaugeMetrics.FindOrAdd(StringTmp) = WorkerMetric.value;
 		}
 
 		for (int32 i = 0; i < NumHistogramMetrics; i++)
 		{
-			StringTmp = Op->op.metrics.metrics.histogram_metrics[i].key;
-			WorkerHistogramValues& HistogramMetrics =  WorkerSDKHistogramMetrics.FindOrAdd(StringTmp);
-			HistogramMetrics.Sum = Op->op.metrics.metrics.histogram_metrics[i].sum;
-			int32 NumBuckets = Op->op.metrics.metrics.histogram_metrics[i].bucket_count;
+			const Worker_HistogramMetric& WorkerMetric = Op->op.metrics.metrics.histogram_metrics[i];
+			StringTmp = WorkerMetric.key;
+			WorkerHistogramValues& HistogramMetrics = WorkerSDKHistogramMetrics.FindOrAdd(StringTmp);
+			HistogramMetrics.Sum = WorkerMetric.sum;
+			int32 NumBuckets = WorkerMetric.bucket_count;
 			HistogramMetrics.Buckets.SetNum(NumBuckets);
 			for (int32 j = 0; j < NumBuckets; j++)
 			{
-				HistogramMetrics.Buckets[j] = TTuple<double, uint32>{ Op->op.metrics.metrics.histogram_metrics[i].buckets[j].upper_bound, Op->op.metrics.metrics.histogram_metrics[i].buckets[j].samples };
+				HistogramMetrics.Buckets[j] = TTuple<double, uint32>{ WorkerMetric.buckets[j].upper_bound, WorkerMetric.buckets[j].samples };
 			}
 		}
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetrics.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetrics.h
@@ -56,8 +56,8 @@ public:
 		double Sum;
 	};
 	typedef TMap<FString, WorkerHistogramValues> WorkerHistogramMetrics;
-	DECLARE_MULTICAST_DELEGATE_TwoParams(WorkerMetricsDelegate, WorkerGuageMetric, WorkerHistogramMetrics);
-	static WorkerMetricsDelegate WorkerMetricsRecieved;
+	DECLARE_MULTICAST_DELEGATE_TwoParams(WorkerMetricsDelegate, const WorkerGuageMetric&, const WorkerHistogramMetrics&);
+	WorkerMetricsDelegate WorkerMetricsUpdated; 
 
 	// Delegate used to poll for the current player controller's reference
 	DECLARE_DELEGATE_RetVal(FUnrealObjectRef, FControllerRefProviderDelegate);
@@ -68,9 +68,9 @@ public:
 	void RemoveCustomMetric(const FString& Metric);
 private:
 
-	// These will be stored and pushed to Grafana
-	WorkerGuageMetric WorkerGuageMetricsToForward;
-	WorkerHistogramMetrics WorkerHistogramMetricsToForward;
+	// Worker SDK metrics
+	WorkerGuageMetric WorkerSDKGaugeMetrics;
+	WorkerHistogramMetrics WorkerSDKHistogramMetrics;
 
 	UPROPERTY()
 	USpatialWorkerConnection* Connection;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetrics.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetrics.h
@@ -49,9 +49,18 @@ public:
 	void HandleWorkerMetrics(Worker_Op* Op);
 
 	// The user can bind their own delegate to handle worker metrics.
-	typedef TMap<FString, double> WorkerMetrics;
-	DECLARE_MULTICAST_DELEGATE_OneParam(WorkerMetricsDelegate, WorkerMetrics);
+	typedef TMap<FString, double> WorkerGuageMetric;
+	struct WorkerHistogramValues
+	{
+		TArray<TPair<double, uint32>> Buckets; // upper-bound, count
+		double Sum;
+	};
+	typedef TMap<FString, WorkerHistogramValues> WorkerHistogramMetrics;
+	DECLARE_MULTICAST_DELEGATE_TwoParams(WorkerMetricsDelegate, WorkerGuageMetric, WorkerHistogramMetrics);
 	static WorkerMetricsDelegate WorkerMetricsRecieved;
+
+	WorkerGuageMetric WorkerGuageMetricsToForward;
+	WorkerHistogramMetrics WorkerHistogramMetricsToForward;
 
 	// Delegate used to poll for the current player controller's reference
 	DECLARE_DELEGATE_RetVal(FUnrealObjectRef, FControllerRefProviderDelegate);

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetrics.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetrics.h
@@ -59,9 +59,6 @@ public:
 	DECLARE_MULTICAST_DELEGATE_TwoParams(WorkerMetricsDelegate, WorkerGuageMetric, WorkerHistogramMetrics);
 	WorkerMetricsDelegate WorkerMetricsRecieved;
 
-	WorkerGuageMetric WorkerGuageMetricsToForward;
-	WorkerHistogramMetrics WorkerHistogramMetricsToForward;
-
 	// Delegate used to poll for the current player controller's reference
 	DECLARE_DELEGATE_RetVal(FUnrealObjectRef, FControllerRefProviderDelegate);
 	FControllerRefProviderDelegate ControllerRefProvider;
@@ -70,6 +67,10 @@ public:
 	void SetCustomMetric(const FString& Metric, const UserSuppliedMetric& Delegate);
 	void RemoveCustomMetric(const FString& Metric);
 private:
+
+	// These will be stored and pushed to Grafana
+	WorkerGuageMetric WorkerGuageMetricsToForward;
+	WorkerHistogramMetrics WorkerHistogramMetricsToForward;
 
 	UPROPERTY()
 	USpatialWorkerConnection* Connection;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetrics.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetrics.h
@@ -49,14 +49,14 @@ public:
 	void HandleWorkerMetrics(Worker_Op* Op);
 
 	// The user can bind their own delegate to handle worker metrics.
-	typedef TMap<FString, double> WorkerGuageMetric;
+	typedef TMap<FString, double> WorkerGaugeMetric;
 	struct WorkerHistogramValues
 	{
 		TArray<TPair<double, uint32>> Buckets; // upper-bound, count
 		double Sum;
 	};
 	typedef TMap<FString, WorkerHistogramValues> WorkerHistogramMetrics;
-	DECLARE_MULTICAST_DELEGATE_TwoParams(WorkerMetricsDelegate, const WorkerGuageMetric&, const WorkerHistogramMetrics&);
+	DECLARE_MULTICAST_DELEGATE_TwoParams(WorkerMetricsDelegate, const WorkerGaugeMetric&, const WorkerHistogramMetrics&);
 	WorkerMetricsDelegate WorkerMetricsUpdated; 
 
 	// Delegate used to poll for the current player controller's reference
@@ -69,7 +69,7 @@ public:
 private:
 
 	// Worker SDK metrics
-	WorkerGuageMetric WorkerSDKGaugeMetrics;
+	WorkerGaugeMetric WorkerSDKGaugeMetrics;
 	WorkerHistogramMetrics WorkerSDKHistogramMetrics;
 
 	UPROPERTY()

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetrics.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetrics.h
@@ -57,7 +57,7 @@ public:
 	};
 	typedef TMap<FString, WorkerHistogramValues> WorkerHistogramMetrics;
 	DECLARE_MULTICAST_DELEGATE_TwoParams(WorkerMetricsDelegate, WorkerGuageMetric, WorkerHistogramMetrics);
-	static WorkerMetricsDelegate WorkerMetricsRecieved;
+	WorkerMetricsDelegate WorkerMetricsRecieved;
 
 	WorkerGuageMetric WorkerGuageMetricsToForward;
 	WorkerHistogramMetrics WorkerHistogramMetricsToForward;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetrics.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetrics.h
@@ -57,7 +57,7 @@ public:
 	};
 	typedef TMap<FString, WorkerHistogramValues> WorkerHistogramMetrics;
 	DECLARE_MULTICAST_DELEGATE_TwoParams(WorkerMetricsDelegate, WorkerGuageMetric, WorkerHistogramMetrics);
-	WorkerMetricsDelegate WorkerMetricsRecieved;
+	static WorkerMetricsDelegate WorkerMetricsRecieved;
 
 	// Delegate used to poll for the current player controller's reference
 	DECLARE_DELEGATE_RetVal(FUnrealObjectRef, FControllerRefProviderDelegate);


### PR DESCRIPTION
#### Description
Metrics received by the WorkerSDK can be forwarded to Prometheus/Grafana for display in dashboards (approved projects only until SVP) 

#### Release note
Breaking interface change, note added 

#### Tests
Tested manually, can be viewed in NFR project metrics or binding to the delegate and surfacing metrics locally


#### Primary reviewers
@m-samiec 
