### PR TITLE
Player spawner retry crash

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialPlayerSpawner.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialPlayerSpawner.cpp
@@ -390,8 +390,8 @@ void USpatialPlayerSpawner::RetryForwardSpawnPlayerRequest(const Worker_EntityId
 		return;
 	}
 
-	Schema_CommandRequest* OldRequest = OutgoingForwardPlayerSpawnRequests.FindAndRemoveChecked(RequestId).Get();
-	Schema_Object* OldRequestPayload = Schema_GetCommandRequestObject(OldRequest);
+	const auto OldRequest = OutgoingForwardPlayerSpawnRequests.FindAndRemoveChecked(RequestId);
+	Schema_Object* OldRequestPayload = Schema_GetCommandRequestObject(OldRequest.Get());
 
 	// If the chosen PlayerStart is deleted or being deleted, we will pick another.
 	const FUnrealObjectRef PlayerStartRef = GetObjectRefFromSchema(OldRequestPayload, SpatialConstants::FORWARD_SPAWN_PLAYER_START_ACTOR_ID);
@@ -406,9 +406,9 @@ void USpatialPlayerSpawner::RetryForwardSpawnPlayerRequest(const Worker_EntityId
 	}
 
 	// Resend the ForwardSpawnPlayer request.
-	Worker_CommandRequest ForwardSpawnPlayerRequest = ServerWorker::CreateForwardPlayerSpawnRequest(Schema_CopyCommandRequest(OldRequest));
+	Worker_CommandRequest ForwardSpawnPlayerRequest = ServerWorker::CreateForwardPlayerSpawnRequest(Schema_CopyCommandRequest(OldRequest.Get()));
 	const Worker_RequestId NewRequestId = NetDriver->Connection->SendCommandRequest(EntityId, &ForwardSpawnPlayerRequest, SpatialConstants::SERVER_WORKER_FORWARD_SPAWN_REQUEST_COMMAND_ID);
 
 	// Move the request data from the old request ID map entry across to the new ID entry.
-	OutgoingForwardPlayerSpawnRequests.Add(NewRequestId, TUniquePtr<Schema_CommandRequest, ForwardSpawnRequestDeleter>(OldRequest));
+	OutgoingForwardPlayerSpawnRequests.Add(NewRequestId, TUniquePtr<Schema_CommandRequest, ForwardSpawnRequestDeleter>(OldRequest.Get()));
 }


### PR DESCRIPTION
#### Description
Fix a bug where we delete a unique pointer immediately before using the value it points to.
Seems to almost never crash unless you put a breakpoint in or use SpatialView.

#### Tests
Run the handover gym and put a breakpoint on the offending line (or run with the experimental-up-to-date SpatialView for some reason I haven't worked out. Presumably more schema shenanigans has some knock on effect on exactly when memory gets cleared :shrug:).

STRONGLY SUGGESTED: How can this be verified by QA?

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

#### Primary reviewers
@alastairdglennie 
