### PR TITLE
Feature/enforce tests default actor tick every frame

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
@@ -20,6 +20,8 @@ ASpatialFunctionalTest::ASpatialFunctionalTest()
 	NetUpdateFrequency = 100.0f;
 	
 	bAlwaysRelevant = true;
+
+	PrimaryActorTick.TickInterval = 0.0f;
 }
 
 void ASpatialFunctionalTest::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestFlowController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestFlowController.cpp
@@ -12,7 +12,8 @@ ASpatialFunctionalTestFlowController::ASpatialFunctionalTestFlowController(const
 {	
 	bReplicates = true;
 	bAlwaysRelevant = true;
-	
+
+	PrimaryActorTick.TickInterval = 0.0f;
 	PrimaryActorTick.bCanEverTick = true;
 	PrimaryActorTick.bStartWithTickEnabled = false;
 	PrimaryActorTick.bTickEvenWhenPaused = true;


### PR DESCRIPTION
#### Description

Setting Test and FlowControllers to have a default tick of every frame. This is to make sure tests run properly in projects that have altered the default settings on AActor.