### PR TITLE
Fix up usages of bEnableMultiWorker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed bug causing this error to fire: "ResolveObjectReferences: Removed unresolved reference: AbsOffset >= MaxAbsOffset"
 - SpatialMetrics::WorkerMetricsRecieved is no longer static and the function signature now also receives histogram metrics
 - Log an error including Position when GridBasedLBStrategy can't locate a worker to take authority over an Actor.
+- Changed the SpatialGDK Setting bEnableMultiWorker to private, to enforce usage of IsMultiWorkerEnabled which respects the `-OverrideMultiWorker` flag.
 
 ## [`0.10.0`] - 2020-07-08
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialWorldSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialWorldSettings.h
@@ -53,7 +53,6 @@ public:
 	}
 
 private:
-
 	/** Enable running different server worker types to split the simulation. */
 	UPROPERTY(EditAnywhere, Config, Category = "Multi-Worker")
 	bool bEnableMultiWorker;

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialWorldSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialWorldSettings.h
@@ -20,10 +20,6 @@ class SPATIALGDK_API ASpatialWorldSettings : public AWorldSettings
 	GENERATED_BODY()
 
 public:
-	/** Enable running different server worker types to split the simulation. */
-	UPROPERTY(EditAnywhere, Config, Category = "Multi-Worker")
-	bool bEnableMultiWorker;
-
 	UPROPERTY(EditAnywhere, Config, Category = "Multi-Worker", meta = (EditCondition = "bEnableMultiWorker"))
 	TSubclassOf<UAbstractLBStrategy> DefaultLayerLoadBalanceStrategy;
 
@@ -50,4 +46,15 @@ public:
 		}
 		return bEnableMultiWorker;
 	}
+
+	void SetMultiWorkerEnabled(bool IsEnabled)
+	{
+		bEnableMultiWorker = IsEnabled;
+	}
+
+private:
+
+	/** Enable running different server worker types to split the simulation. */
+	UPROPERTY(EditAnywhere, Config, Category = "Multi-Worker")
+	bool bEnableMultiWorker;
 };

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
@@ -115,7 +115,7 @@ uint32 GetWorkerCountFromWorldSettings(const UWorld& World)
 		return 1;
 	}
 
-	if (WorldSettings->bEnableMultiWorker == false)
+	if (WorldSettings->IsMultiWorkerEnabled() == false)
 	{
 		return 1;
 	}
@@ -172,7 +172,7 @@ bool TryGetLoadBalancingStrategyFromWorldSettings(const UWorld& World, UAbstract
 {
 	const ASpatialWorldSettings* WorldSettings = Cast<ASpatialWorldSettings>(World.GetWorldSettings());
 
-	if (WorldSettings == nullptr || !WorldSettings->bEnableMultiWorker)
+	if (WorldSettings == nullptr || !WorldSettings->IsMultiWorkerEnabled())
 	{
 		UE_LOG(LogSpatialGDKDefaultLaunchConfigGenerator, Log, TEXT("No SpatialWorldSettings on map %s"), *World.GetMapName());
 		return false;

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/LayeredLBStrategy/LayeredLBStrategyTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/LayeredLBStrategy/LayeredLBStrategyTest.cpp
@@ -112,7 +112,7 @@ bool FSetupStrategy::Update()
 {
 	ASpatialWorldSettings* WorldSettings = Cast<ASpatialWorldSettings>(TestData->TestWorld->GetWorldSettings());
 	WorldSettings->DefaultLayerLoadBalanceStrategy = UGridBasedLBStrategy::StaticClass();
-	WorldSettings->bEnableMultiWorker = true;
+	WorldSettings->SetMultiWorkerEnabled(true);
 
 	auto& Strat = TestData->Strat;
 	Strat->Init();


### PR DESCRIPTION
#### Description
Replaced the direct usages of  `bEnableMultiWorker` with  `bool IsMultiWorkerEnabled()` in `SpatialGDKDefaultLaunchConfigGenerator` and  `LayeredLBStrategyTest` file.

Made  `bEnableMultiWorker` private and added a setter function for it.

#### Release note
Added release note.

#### Tests
No tests required.

#### Documentation
No documentation required.
