### PR TITLE
Separate tracer utils and data

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
@@ -131,6 +131,7 @@ void USpatialGameInstance::StartSpatialConnection()
 	else
 	{
 		// In native, setup worker name here as we don't get a HandleOnConnected() callback
+		// This needs to be done after UGameInstance::Init() is called where SpatialWorkerType is set
 		FString WorkerName = FString::Printf(TEXT("%s:%s"), *SpatialWorkerType.ToString(), *FGuid::NewGuid().ToString(EGuidFormats::Digits));
 		SpatialLatencyTracer->SetWorkerId(WorkerName);
 	}
@@ -225,8 +226,7 @@ void USpatialGameInstance::HandleOnConnected()
 	SpatialLatencyTracer->SetWorkerId(SpatialWorkerId);
 
 	USpatialWorkerConnection* WorkerConnection = SpatialConnectionManager->GetWorkerConnection();
-	WorkerConnection->OnEnqueueMessage.AddUObject(SpatialLatencyTracer, &USpatialLatencyTracer::OnEnqueueMessage);
-	WorkerConnection->OnDequeueMessage.AddUObject(SpatialLatencyTracer, &USpatialLatencyTracer::OnDequeueMessage);
+	WorkerConnection->BindLatencyTracer(SpatialLatencyTracer->GetTracer());
 #endif
 
 	OnSpatialConnected.Broadcast();

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslationManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslationManager.cpp
@@ -24,7 +24,7 @@ void SpatialVirtualWorkerTranslationManager::SetNumberOfVirtualWorkers(const uin
 	UE_LOG(LogSpatialVirtualWorkerTranslationManager, Log, TEXT("TranslationManager is configured to look for %d workers"), NumVirtualWorkers);
 
 	// Currently, this should only be called once on startup. In the future we may allow for more
-	// flexibility. 
+	// flexibility.
 	for (uint32 i = 1; i <= NumVirtualWorkers; i++)
 	{
 		UnassignedVirtualWorkers.Enqueue(i);
@@ -116,13 +116,13 @@ void SpatialVirtualWorkerTranslationManager::SendVirtualWorkerMappingUpdate()
 
 	WriteMappingToSchema(UpdateObject);
 
-	check(Connection != nullptr);
-	Connection->SendComponentUpdate(SpatialConstants::INITIAL_VIRTUAL_WORKER_TRANSLATOR_ENTITY_ID, &Update);
-
 	// The Translator on the worker which hosts the manager won't get the component update notification,
 	// so send it across directly.
 	check(Translator != nullptr);
 	Translator->ApplyVirtualWorkerManagerData(UpdateObject);
+
+	check(Connection != nullptr);
+	Connection->SendComponentUpdate(SpatialConstants::INITIAL_VIRTUAL_WORKER_TRANSLATOR_ENTITY_ID, &Update);
 }
 
 void SpatialVirtualWorkerTranslationManager::QueryForServerWorkerEntities()

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialRPCService.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialRPCService.cpp
@@ -13,7 +13,7 @@ DEFINE_LOG_CATEGORY(LogSpatialRPCService);
 namespace SpatialGDK
 {
 
-SpatialRPCService::SpatialRPCService(ExtractRPCDelegate ExtractRPCCallback, const USpatialStaticComponentView* View, USpatialLatencyTracer* SpatialLatencyTracer)
+SpatialRPCService::SpatialRPCService(ExtractRPCDelegate ExtractRPCCallback, const USpatialStaticComponentView* View, SpatialGDK::TracerSharedPtr SpatialLatencyTracer)
 	: ExtractRPCCallback(ExtractRPCCallback)
 	, View(View)
 	, SpatialLatencyTracer(SpatialLatencyTracer)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -421,7 +421,7 @@ void USpatialSender::SendComponentUpdates(UObject* Object, const FClassInfo& Inf
 
 	UE_LOG(LogSpatialSender, Verbose, TEXT("Sending component update (object: %s, entity: %lld)"), *Object->GetName(), EntityId);
 
-	USpatialLatencyTracer* Tracer = USpatialLatencyTracer::GetTracer(Object);
+	TracerSharedPtr Tracer = USpatialLatencyTracer::GetTracer(Object);
 	ComponentFactory UpdateFactory(Channel->GetInterestDirty(), NetDriver, Tracer);
 
 	TArray<FWorkerComponentUpdate> ComponentUpdates = UpdateFactory.CreateComponentUpdates(Object, Info, EntityId, RepChanges, HandoverChanges, OutBytesWritten);

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
@@ -16,7 +16,6 @@
 #include "SpatialConstants.h"
 #include "Utils/InterestFactory.h"
 #include "Utils/RepLayoutUtils.h"
-#include "Utils/SpatialLatencyTracer.h"
 
 DEFINE_LOG_CATEGORY(LogComponentFactory);
 
@@ -38,7 +37,7 @@ namespace
 namespace SpatialGDK
 {
 
-ComponentFactory::ComponentFactory(bool bInterestDirty, USpatialNetDriver* InNetDriver, USpatialLatencyTracer* InLatencyTracer)
+ComponentFactory::ComponentFactory(bool bInterestDirty, USpatialNetDriver* InNetDriver, SpatialGDK::TracerSharedPtr InLatencyTracer)
 	: NetDriver(InNetDriver)
 	, PackageMap(InNetDriver->PackageMap)
 	, ClassInfoManager(InNetDriver->ClassInfoManager)

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -252,7 +252,7 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 		ComponentDatas.Add(Heartbeat().CreateHeartbeatData());
 	}
 
-	USpatialLatencyTracer* Tracer = USpatialLatencyTracer::GetTracer(Actor);
+	TracerSharedPtr Tracer = USpatialLatencyTracer::GetTracer(Actor);
 
 	ComponentFactory DataFactory(false, NetDriver, Tracer);
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
@@ -5,16 +5,8 @@
 #include "Async/Async.h"
 #include "Engine/World.h"
 #include "EngineClasses/SpatialGameInstance.h"
-#include "GeneralProjectSettings.h"
-#include "Interop/Connection/OutgoingMessages.h"
-#include "Utils/SchemaUtils.h"
 
 #include <sstream>
-
-DEFINE_LOG_CATEGORY(LogSpatialLatencyTracing);
-
-DECLARE_CYCLE_STAT(TEXT("ContinueLatencyTraceRPC_Internal"), STAT_ContinueLatencyTraceRPC_Internal, STATGROUP_SpatialNet);
-DECLARE_CYCLE_STAT(TEXT("BeginLatencyTraceRPC_Internal"), STAT_BeginLatencyTraceRPC_Internal, STATGROUP_SpatialNet);
 
 namespace
 {
@@ -36,26 +28,12 @@ namespace
 	};
 
 	UEStream UStream;
-
-#if TRACE_LIB_ACTIVE
-	improbable::trace::SpanContext ReadSpanContext(const void* TraceBytes, const void* SpanBytes)
-	{
-		improbable::trace::TraceId _TraceId;
-		memcpy(&_TraceId[0], TraceBytes, sizeof(improbable::trace::TraceId));
-
-		improbable::trace::SpanId _SpanId;
-		memcpy(&_SpanId[0], SpanBytes, sizeof(improbable::trace::SpanId));
-
-		return improbable::trace::SpanContext(_TraceId, _SpanId);
-	}
-#endif
 }  // anonymous namespace
 
 USpatialLatencyTracer::USpatialLatencyTracer()
 {
 #if TRACE_LIB_ACTIVE
-	ResetWorkerId();
-	FParse::Value(FCommandLine::Get(), TEXT("traceMetadata"), TraceMetadata);
+	Tracer = MakeShared<SpatialGDK::SpatialLatencyTracerData, ESPMode::ThreadSafe>();
 #endif
 }
 
@@ -79,7 +57,7 @@ void USpatialLatencyTracer::RegisterProject(UObject* WorldContextObject, const F
 bool USpatialLatencyTracer::SetTraceMetadata(UObject* WorldContextObject, const FString& NewTraceMetadata)
 {
 #if TRACE_LIB_ACTIVE
-	if (USpatialLatencyTracer* Tracer = GetTracer(WorldContextObject))
+	if (SpatialGDK::TracerSharedPtr Tracer = GetTracer(WorldContextObject))
 	{
 		Tracer->TraceMetadata = NewTraceMetadata;
 		return true;
@@ -91,7 +69,7 @@ bool USpatialLatencyTracer::SetTraceMetadata(UObject* WorldContextObject, const 
 bool USpatialLatencyTracer::BeginLatencyTrace(UObject* WorldContextObject, const FString& TraceDesc, FSpatialLatencyPayload& OutLatencyPayload)
 {
 #if TRACE_LIB_ACTIVE
-	if (USpatialLatencyTracer* Tracer = GetTracer(WorldContextObject))
+	if (SpatialGDK::TracerSharedPtr Tracer = GetTracer(WorldContextObject))
 	{
 		return Tracer->BeginLatencyTrace_Internal(TraceDesc, OutLatencyPayload);
 	}
@@ -102,7 +80,7 @@ bool USpatialLatencyTracer::BeginLatencyTrace(UObject* WorldContextObject, const
 bool USpatialLatencyTracer::ContinueLatencyTraceRPC(UObject* WorldContextObject, const AActor* Actor, const FString& FunctionName, const FString& TraceDesc, const FSpatialLatencyPayload& LatencyPayload, FSpatialLatencyPayload& OutContinuedLatencyPayload)
 {
 #if TRACE_LIB_ACTIVE
-	if (USpatialLatencyTracer* Tracer = GetTracer(WorldContextObject))
+	if (SpatialGDK::TracerSharedPtr Tracer = GetTracer(WorldContextObject))
 	{
 		return Tracer->ContinueLatencyTrace_Internal(Actor, FunctionName, ETraceType::RPC, TraceDesc, LatencyPayload, OutContinuedLatencyPayload);
 	}
@@ -113,7 +91,7 @@ bool USpatialLatencyTracer::ContinueLatencyTraceRPC(UObject* WorldContextObject,
 bool USpatialLatencyTracer::ContinueLatencyTraceProperty(UObject* WorldContextObject, const AActor* Actor, const FString& PropertyName, const FString& TraceDesc, const FSpatialLatencyPayload& LatencyPayload, FSpatialLatencyPayload& OutContinuedLatencyPayload)
 {
 #if TRACE_LIB_ACTIVE
-	if (USpatialLatencyTracer* Tracer = GetTracer(WorldContextObject))
+	if (SpatialGDK::TracerSharedPtr Tracer = GetTracer(WorldContextObject))
 	{
 		return Tracer->ContinueLatencyTrace_Internal(Actor, PropertyName, ETraceType::Property, TraceDesc, LatencyPayload, OutContinuedLatencyPayload);
 	}
@@ -124,7 +102,7 @@ bool USpatialLatencyTracer::ContinueLatencyTraceProperty(UObject* WorldContextOb
 bool USpatialLatencyTracer::ContinueLatencyTraceTagged(UObject* WorldContextObject, const AActor* Actor, const FString& Tag, const FString& TraceDesc, const FSpatialLatencyPayload& LatencyPayload, FSpatialLatencyPayload& OutContinuedLatencyPayload)
 {
 #if TRACE_LIB_ACTIVE
-	if (USpatialLatencyTracer* Tracer = GetTracer(WorldContextObject))
+	if (SpatialGDK::TracerSharedPtr Tracer = GetTracer(WorldContextObject))
 	{
 		return Tracer->ContinueLatencyTrace_Internal(Actor, Tag, ETraceType::Tagged, TraceDesc, LatencyPayload, OutContinuedLatencyPayload);
 	}
@@ -135,7 +113,7 @@ bool USpatialLatencyTracer::ContinueLatencyTraceTagged(UObject* WorldContextObje
 bool USpatialLatencyTracer::EndLatencyTrace(UObject* WorldContextObject, const FSpatialLatencyPayload& LatencyPayload)
 {
 #if TRACE_LIB_ACTIVE
-	if (USpatialLatencyTracer* Tracer = GetTracer(WorldContextObject))
+	if (SpatialGDK::TracerSharedPtr Tracer = GetTracer(WorldContextObject))
 	{
 		return Tracer->EndLatencyTrace_Internal(LatencyPayload);
 	}
@@ -146,7 +124,7 @@ bool USpatialLatencyTracer::EndLatencyTrace(UObject* WorldContextObject, const F
 FSpatialLatencyPayload USpatialLatencyTracer::RetrievePayload(UObject* WorldContextObject, const AActor* Actor, const FString& Tag)
 {
 #if TRACE_LIB_ACTIVE
-	if (USpatialLatencyTracer* Tracer = GetTracer(WorldContextObject))
+	if (SpatialGDK::TracerSharedPtr Tracer = GetTracer(WorldContextObject))
 	{
 		return Tracer->RetrievePayload_Internal(Actor, Tag);
 	}
@@ -154,7 +132,7 @@ FSpatialLatencyPayload USpatialLatencyTracer::RetrievePayload(UObject* WorldCont
 	return FSpatialLatencyPayload{};
 }
 
-USpatialLatencyTracer* USpatialLatencyTracer::GetTracer(UObject* WorldContextObject)
+SpatialGDK::TracerSharedPtr USpatialLatencyTracer::GetTracer(UObject* WorldContextObject)
 {
 #if TRACE_LIB_ACTIVE
 	UWorld* World = GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::ReturnNull);
@@ -165,425 +143,16 @@ USpatialLatencyTracer* USpatialLatencyTracer::GetTracer(UObject* WorldContextObj
 
 	if (USpatialGameInstance* GameInstance = World->GetGameInstance<USpatialGameInstance>())
 	{
-		return GameInstance->GetSpatialLatencyTracer();
+		return GameInstance->GetSpatialLatencyTracer()->Tracer;
 	}
 #endif
 	return nullptr;
 }
 
-#if TRACE_LIB_ACTIVE
-bool USpatialLatencyTracer::IsValidKey(const TraceKey Key)
+SpatialGDK::TracerSharedPtr USpatialLatencyTracer::GetTracer()
 {
-	FScopeLock Lock(&Mutex);
-	return (TraceMap.Find(Key) != nullptr);
+	return Tracer;
 }
-
-TraceKey USpatialLatencyTracer::RetrievePendingTrace(const UObject* Obj, const UFunction* Function)
-{
-	FScopeLock Lock(&Mutex);
-
-	ActorFuncKey FuncKey{ Cast<AActor>(Obj), Function };
-	TraceKey ReturnKey = InvalidTraceKey;
-	TrackingRPCs.RemoveAndCopyValue(FuncKey, ReturnKey);
-	return ReturnKey;
-}
-
-TraceKey USpatialLatencyTracer::RetrievePendingTrace(const UObject* Obj, const UProperty* Property)
-{
-	FScopeLock Lock(&Mutex);
-
-	ActorPropertyKey PropKey{ Cast<AActor>(Obj), Property };
-	TraceKey ReturnKey = InvalidTraceKey;
-	TrackingProperties.RemoveAndCopyValue(PropKey, ReturnKey);
-	return ReturnKey;
-}
-
-TraceKey USpatialLatencyTracer::RetrievePendingTrace(const UObject* Obj, const FString& Tag)
-{
-	FScopeLock Lock(&Mutex);
-
-	ActorTagKey EventKey{ Cast<AActor>(Obj), Tag };
-	TraceKey ReturnKey = InvalidTraceKey;
-	TrackingTags.RemoveAndCopyValue(EventKey, ReturnKey);
-	return ReturnKey;
-}
-
-void USpatialLatencyTracer::WriteToLatencyTrace(const TraceKey Key, const FString& TraceDesc)
-{
-	FScopeLock Lock(&Mutex);
-
-	if (TraceSpan* Trace = TraceMap.Find(Key))
-	{
-		WriteKeyFrameToTrace(Trace, TraceDesc);
-	}
-}
-
-void USpatialLatencyTracer::WriteAndEndTrace(const TraceKey Key, const FString& TraceDesc, bool bOnlyEndIfTraceRootIsRemote)
-{
-	FScopeLock Lock(&Mutex);
-
-	if (TraceSpan* Trace = TraceMap.Find(Key))
-	{
-		WriteKeyFrameToTrace(Trace, TraceDesc);
-
-		// Check RootTraces to verify if this trace was started locally. If it was, we don't End the trace yet, but
-		// wait for an explicit call to EndLatencyTrace.
-		if (!bOnlyEndIfTraceRootIsRemote || RootTraces.Find(Key) == nullptr)
-		{
-			Trace->End();
-			TraceMap.Remove(Key);
-		}
-	}
-}
-
-void USpatialLatencyTracer::WriteTraceToSchemaObject(const TraceKey Key, Schema_Object* Obj, const Schema_FieldId FieldId)
-{
-	FScopeLock Lock(&Mutex);
-
-	if (TraceSpan* Trace = TraceMap.Find(Key))
-	{
-		Schema_Object* TraceObj = Schema_AddObject(Obj, FieldId);
-
-		const improbable::trace::SpanContext& TraceContext = Trace->context();
-		improbable::trace::TraceId _TraceId = TraceContext.trace_id();
-		improbable::trace::SpanId _SpanId = TraceContext.span_id();
-
-		SpatialGDK::AddBytesToSchema(TraceObj, SpatialConstants::UNREAL_RPC_TRACE_ID, &_TraceId[0], _TraceId.size());
-		SpatialGDK::AddBytesToSchema(TraceObj, SpatialConstants::UNREAL_RPC_SPAN_ID, &_SpanId[0], _SpanId.size());
-	}
-}
-
-TraceKey USpatialLatencyTracer::ReadTraceFromSchemaObject(Schema_Object* Obj, const Schema_FieldId FieldId)
-{
-	FScopeLock Lock(&Mutex);
-
-	if (Schema_GetObjectCount(Obj, FieldId) > 0)
-	{
-		Schema_Object* TraceData = Schema_IndexObject(Obj, FieldId, 0);
-
-		const uint8* TraceBytes = Schema_GetBytes(TraceData, SpatialConstants::UNREAL_RPC_TRACE_ID);
-		const uint8* SpanBytes = Schema_GetBytes(TraceData, SpatialConstants::UNREAL_RPC_SPAN_ID);
-
-		improbable::trace::SpanContext DestContext = ReadSpanContext(TraceBytes, SpanBytes);
-
-		TraceKey Key = InvalidTraceKey;
-
-		for (const auto& TracePair : TraceMap)
-		{
-			const TraceKey& _Key = TracePair.Key;
-			const TraceSpan& Span = TracePair.Value;
-
-			if (Span.context().trace_id() == DestContext.trace_id())
-			{
-				Key = _Key;
-				break;
-			}
-		}
-
-		if (Key != InvalidTraceKey)
-		{
-			TraceSpan* Span = TraceMap.Find(Key);
-
-			WriteKeyFrameToTrace(Span, TEXT("Local Trace - Schema Obj Read"));
-		}
-		else
-		{
-			FString SpanMsg = FormatMessage(TEXT("Remote Parent Trace - Schema Obj Read"));
-			TraceSpan RetrieveTrace = improbable::trace::Span::StartSpanWithRemoteParent(TCHAR_TO_UTF8(*SpanMsg), DestContext);
-
-			Key = GenerateNewTraceKey();
-			TraceMap.Add(Key, MoveTemp(RetrieveTrace));
-		}
-
-		return Key;
-	}
-
-	return InvalidTraceKey;
-}
-
-FSpatialLatencyPayload USpatialLatencyTracer::RetrievePayload_Internal(const UObject* Obj, const FString& Tag)
-{
-	FScopeLock Lock(&Mutex);
-
-	 TraceKey Key = RetrievePendingTrace(Obj, Tag);
-	 if (Key != InvalidTraceKey)
-	 {
-		 if (const TraceSpan* Span = TraceMap.Find(Key))
-		 {
-			 const improbable::trace::SpanContext& TraceContext = Span->context();
-
-			 TArray<uint8> TraceBytes = TArray<uint8_t>((const uint8_t*)&TraceContext.trace_id()[0], sizeof(improbable::trace::TraceId));
-			 TArray<uint8> SpanBytes = TArray<uint8_t>((const uint8_t*)&TraceContext.span_id()[0], sizeof(improbable::trace::SpanId));
-			 return FSpatialLatencyPayload(MoveTemp(TraceBytes), MoveTemp(SpanBytes), Key);
-		 }
-	 }
-	 return {};
-}
-
-void USpatialLatencyTracer::ResetWorkerId()
-{
-	WorkerId = TEXT("DeviceId_") + FPlatformMisc::GetDeviceId();
-}
-
-void USpatialLatencyTracer::OnEnqueueMessage(const SpatialGDK::FOutgoingMessage* Message)
-{
-	if (Message->Type == SpatialGDK::EOutgoingMessageType::ComponentUpdate)
-	{
-		const SpatialGDK::FComponentUpdate* ComponentUpdate = static_cast<const SpatialGDK::FComponentUpdate*>(Message);
-		WriteToLatencyTrace(ComponentUpdate->Update.Trace, TEXT("Moved componentUpdate to Worker queue"));
-	}
-	else if (Message->Type == SpatialGDK::EOutgoingMessageType::AddComponent)
-	{
-		const SpatialGDK::FAddComponent* ComponentAdd = static_cast<const SpatialGDK::FAddComponent*>(Message);
-		WriteToLatencyTrace(ComponentAdd->Data.Trace, TEXT("Moved componentAdd to Worker queue"));
-	}
-	else if (Message->Type == SpatialGDK::EOutgoingMessageType::CreateEntityRequest)
-	{
-		const SpatialGDK::FCreateEntityRequest* CreateEntityRequest = static_cast<const SpatialGDK::FCreateEntityRequest*>(Message);
-		for (auto& Component : CreateEntityRequest->Components)
-		{
-			WriteToLatencyTrace(Component.Trace, TEXT("Moved createEntityRequest to Worker queue"));
-		}
-	}
-}
-
-void USpatialLatencyTracer::OnDequeueMessage(const SpatialGDK::FOutgoingMessage* Message)
-{
-	if (Message->Type == SpatialGDK::EOutgoingMessageType::ComponentUpdate)
-	{
-		const SpatialGDK::FComponentUpdate* ComponentUpdate = static_cast<const SpatialGDK::FComponentUpdate*>(Message);
-		WriteAndEndTrace(ComponentUpdate->Update.Trace, TEXT("Sent componentUpdate to Worker SDK"), true);
-	}
-	else if (Message->Type == SpatialGDK::EOutgoingMessageType::AddComponent)
-	{
-		const SpatialGDK::FAddComponent* ComponentAdd = static_cast<const SpatialGDK::FAddComponent*>(Message);
-		WriteAndEndTrace(ComponentAdd->Data.Trace, TEXT("Sent componentAdd to Worker SDK"), true);
-	}
-	else if (Message->Type == SpatialGDK::EOutgoingMessageType::CreateEntityRequest)
-	{
-		const SpatialGDK::FCreateEntityRequest* CreateEntityRequest = static_cast<const SpatialGDK::FCreateEntityRequest*>(Message);
-		for (auto& Component : CreateEntityRequest->Components)
-		{
-			WriteAndEndTrace(Component.Trace, TEXT("Sent createEntityRequest to Worker SDK"), true);
-		}
-	}
-}
-
-bool USpatialLatencyTracer::BeginLatencyTrace_Internal(const FString& TraceDesc, FSpatialLatencyPayload& OutLatencyPayload)
-{	 
-	// TODO: UNR-2787 - Improve mutex-related latency
-	// This functions might spike because of the Mutex below
-	SCOPE_CYCLE_COUNTER(STAT_BeginLatencyTraceRPC_Internal);
-	FScopeLock Lock(&Mutex);
-
-	FString SpanMsg = FormatMessage(TraceDesc, true);
-	TraceSpan NewTrace = improbable::trace::Span::StartSpan(TCHAR_TO_UTF8(*SpanMsg), nullptr);
-
-	// Construct payload data from trace
-	const improbable::trace::SpanContext& TraceContext = NewTrace.context();
-
-	{
-		TArray<uint8> TraceBytes = TArray<uint8_t>((const uint8_t*)&TraceContext.trace_id()[0], sizeof(improbable::trace::TraceId));
-		TArray<uint8> SpanBytes = TArray<uint8_t>((const uint8_t*)&TraceContext.span_id()[0], sizeof(improbable::trace::SpanId));
-		OutLatencyPayload = FSpatialLatencyPayload(MoveTemp(TraceBytes), MoveTemp(SpanBytes), GenerateNewTraceKey());
-	}
-
-	// Add to internal tracking
-	TraceMap.Add(OutLatencyPayload.Key, MoveTemp(NewTrace));
-
-	// Store traces started on this worker, so we can persist them until they've been round trip returned.
-	RootTraces.Add(OutLatencyPayload.Key);
-
-	return true;
-}
-
-bool USpatialLatencyTracer::ContinueLatencyTrace_Internal(const AActor* Actor, const FString& Target, ETraceType::Type Type, const FString& TraceDesc, const FSpatialLatencyPayload& LatencyPayload, FSpatialLatencyPayload& OutLatencyPayload)
-{
-	// TODO: UNR-2787 - Improve mutex-related latency
-	// This functions might spike because of the Mutex below
-	SCOPE_CYCLE_COUNTER(STAT_ContinueLatencyTraceRPC_Internal);
-	if (Actor == nullptr)
-	{
-		return false;
-	}
-
-	// We do minimal internal tracking for native rpcs/properties
-	const bool bInternalTracking = GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking() || Type == ETraceType::Tagged;
-
-	FScopeLock Lock(&Mutex);
-
-	OutLatencyPayload = LatencyPayload;
-	if (OutLatencyPayload.Key == InvalidTraceKey)
-	{
-		ResolveKeyInLatencyPayload(OutLatencyPayload);
-	}
-
-	const TraceKey Key = OutLatencyPayload.Key;
-	const TraceSpan* ActiveTrace = TraceMap.Find(Key);
-	if (ActiveTrace == nullptr)
-	{
-		UE_LOG(LogSpatialLatencyTracing, Warning, TEXT("(%s) : No active trace to continue (%s)"), *WorkerId, *TraceDesc);
-		return false;
-	}
-
-	if (bInternalTracking)
-	{
-		if (!AddTrackingInfo(Actor, Target, Type, Key))
-		{
-			UE_LOG(LogSpatialLatencyTracing, Warning, TEXT("(%s) : Failed to create Actor/Func trace (%s)"), *WorkerId, *TraceDesc);
-			return false;
-		}
-	}
-
-	WriteKeyFrameToTrace(ActiveTrace, FString::Printf(TEXT("Continue [%s] %s - %s"), *TraceDesc, *UEnum::GetValueAsString(Type), *Target));
-
-	// If we're not doing any further tracking, end the trace
-	if (!bInternalTracking)
-	{
-		WriteAndEndTrace(Key, TEXT("Native - End of Tracking"), true);
-	}
-
-	return true;
-}
-
-bool USpatialLatencyTracer::EndLatencyTrace_Internal(const FSpatialLatencyPayload& LatencyPayload)
-{
-	FScopeLock Lock(&Mutex);
-
-	// Create temp payload to resolve key
-	FSpatialLatencyPayload LocalLatencyPayload = LatencyPayload;
-	if (LocalLatencyPayload.Key == InvalidTraceKey)
-	{
-		ResolveKeyInLatencyPayload(LocalLatencyPayload);
-	}
-
-	const TraceKey Key = LocalLatencyPayload.Key;
-	const TraceSpan* ActiveTrace = TraceMap.Find(Key);
-	if (ActiveTrace == nullptr)
-	{
-		UE_LOG(LogSpatialLatencyTracing, Warning, TEXT("(%s) : No active trace to end"), *WorkerId);
-		return false;
-	}
-
-	WriteKeyFrameToTrace(ActiveTrace, TEXT("End"));
-
-	ActiveTrace->End();
-
-	TraceMap.Remove(Key);
-	RootTraces.Remove(Key);
-
-	return true;
-}
-
-bool USpatialLatencyTracer::AddTrackingInfo(const AActor* Actor, const FString& Target, const ETraceType::Type Type, const TraceKey Key)
-{
-	if (Actor == nullptr)
-	{
-		return false;
-	}
-
-	if (UClass* ActorClass = Actor->GetClass())
-	{
-		switch (Type)
-		{
-		case ETraceType::RPC:
-			if (const UFunction* Function = ActorClass->FindFunctionByName(*Target))
-			{
-				ActorFuncKey AFKey{ Actor, Function };
-				if (TrackingRPCs.Find(AFKey) == nullptr)
-				{
-					TrackingRPCs.Add(AFKey, Key);
-					return true;
-				}
-				UE_LOG(LogSpatialLatencyTracing, Warning, TEXT("(%s) : ActorFunc already exists for trace"), *WorkerId);
-			}
-			break;
-		case ETraceType::Property:
-			if (const UProperty* Property = ActorClass->FindPropertyByName(*Target))
-			{
-				ActorPropertyKey APKey{ Actor, Property };
-				if (TrackingProperties.Find(APKey) == nullptr)
-				{
-					TrackingProperties.Add(APKey, Key);
-					return true;
-				}
-				UE_LOG(LogSpatialLatencyTracing, Warning, TEXT("(%s) : ActorProperty already exists for trace"), *WorkerId);
-			}
-			break;
-		case ETraceType::Tagged:
-			{
-				ActorTagKey ATKey{ Actor, Target };
-				if (TrackingTags.Find(ATKey) == nullptr)
-				{
-					TrackingTags.Add(ATKey, Key);
-					return true;
-				}
-				UE_LOG(LogSpatialLatencyTracing, Warning, TEXT("(%s) : ActorTag already exists for trace"), *WorkerId);
-			}
-			break;
-		}
-	}
-
-	return false;
-}
-
-TraceKey USpatialLatencyTracer::GenerateNewTraceKey()
-{
-	return NextTraceKey++;
-}
-
-void USpatialLatencyTracer::ResolveKeyInLatencyPayload(FSpatialLatencyPayload& Payload)
-{
-	// Key isn't set, so attempt to find it in the trace map
-	for (const auto& TracePair : TraceMap)
-	{
-		const TraceKey& Key = TracePair.Key;
-		const TraceSpan& Span = TracePair.Value;
-
-		if (memcmp(Span.context().trace_id().data(), Payload.TraceId.GetData(), Payload.TraceId.Num()) == 0)
-		{
-			WriteKeyFrameToTrace(&Span, TEXT("Local Trace - Payload Obj Read"));
-			Payload.Key = Key;
-			break;
-		}
-	}
-
-	if (Payload.Key == InvalidTraceKey)
-	{
-		// Uninitialized key, generate and add to map
-		Payload.Key = GenerateNewTraceKey();
-
-		improbable::trace::SpanContext DestContext = ReadSpanContext(Payload.TraceId.GetData(), Payload.SpanId.GetData());
-
-		FString SpanMsg = FormatMessage(TEXT("Remote Parent Trace - Payload Obj Read"));
-		TraceSpan RetrieveTrace = improbable::trace::Span::StartSpanWithRemoteParent(TCHAR_TO_UTF8(*SpanMsg), DestContext);
-
-		TraceMap.Add(Payload.Key, MoveTemp(RetrieveTrace));
-	}
-}
-
-void USpatialLatencyTracer::WriteKeyFrameToTrace(const TraceSpan* Trace, const FString& TraceDesc)
-{
-	if (Trace != nullptr)
-	{
-		FString TraceMsg = FormatMessage(TraceDesc);
-		improbable::trace::Span::StartSpan(TCHAR_TO_UTF8(*TraceMsg), Trace).End();
-	}
-}
-
-FString USpatialLatencyTracer::FormatMessage(const FString& Message, bool bIncludeMetadata) const
-{
-	if (bIncludeMetadata)
-	{
-		return FString::Printf(TEXT("%s (%s : %s)"), *Message, *TraceMetadata, *WorkerId.Left(18));
-	}
-	else
-	{
-		return FString::Printf(TEXT("%s (%s)"), *Message, *WorkerId.Left(18));
-	}
-}
-
-#endif // TRACE_LIB_ACTIVE
 
 void USpatialLatencyTracer::Debug_SendTestTrace()
 {
@@ -625,5 +194,25 @@ void USpatialLatencyTracer::Debug_SendTestTrace()
 			SubSpan3.End();
 		}
 	});
+#endif // TRACE_LIB_ACTIVE
+}
+
+void USpatialLatencyTracer::SetWorkerId(const FString& NewWorkerId)
+{
+#if TRACE_LIB_ACTIVE
+	if (Tracer.IsValid())
+	{
+		Tracer->SetWorkerId(NewWorkerId);
+	}
+#endif // TRACE_LIB_ACTIVE
+}
+
+void USpatialLatencyTracer::ResetWorkerId()
+{
+#if TRACE_LIB_ACTIVE
+	if (Tracer.IsValid())
+	{
+		Tracer->ResetWorkerId();
+	}
 #endif // TRACE_LIB_ACTIVE
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracerData.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracerData.cpp
@@ -1,0 +1,463 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "Utils/SpatialLatencyTracerData.h"
+
+#include "Async/Async.h"
+#include "Engine/World.h"
+#include "EngineClasses/SpatialGameInstance.h"
+#include "GeneralProjectSettings.h"
+#include "Interop/Connection/OutgoingMessages.h"
+#include "Utils/SchemaUtils.h"
+
+#include <sstream>
+
+DEFINE_LOG_CATEGORY(LogSpatialLatencyTracing);
+
+DECLARE_CYCLE_STAT(TEXT("ContinueLatencyTraceRPC_Internal"), STAT_ContinueLatencyTraceRPC_Internal, STATGROUP_SpatialNet);
+DECLARE_CYCLE_STAT(TEXT("BeginLatencyTraceRPC_Internal"), STAT_BeginLatencyTraceRPC_Internal, STATGROUP_SpatialNet);
+
+namespace
+{
+#if TRACE_LIB_ACTIVE
+	improbable::trace::SpanContext ReadSpanContext(const void* TraceBytes, const void* SpanBytes)
+	{
+		improbable::trace::TraceId _TraceId;
+		memcpy(&_TraceId[0], TraceBytes, sizeof(improbable::trace::TraceId));
+
+		improbable::trace::SpanId _SpanId;
+		memcpy(&_SpanId[0], SpanBytes, sizeof(improbable::trace::SpanId));
+
+		return improbable::trace::SpanContext(_TraceId, _SpanId);
+	}
+#endif
+}  // anonymous namespace
+
+#if TRACE_LIB_ACTIVE
+namespace SpatialGDK
+{
+
+SpatialLatencyTracerData::SpatialLatencyTracerData()
+{
+	ResetWorkerId();
+	FParse::Value(FCommandLine::Get(), TEXT("traceMetadata"), TraceMetadata);
+}
+
+TraceKey SpatialLatencyTracerData::RetrievePendingTrace(const UObject* Obj, const UFunction* Function)
+{
+	FScopeLock Lock(&Mutex);
+
+	ActorFuncKey FuncKey{ Cast<AActor>(Obj), Function };
+	TraceKey ReturnKey = InvalidTraceKey;
+	TrackingRPCs.RemoveAndCopyValue(FuncKey, ReturnKey);
+	return ReturnKey;
+}
+
+TraceKey SpatialLatencyTracerData::RetrievePendingTrace(const UObject* Obj, const UProperty* Property)
+{
+	FScopeLock Lock(&Mutex);
+
+	ActorPropertyKey PropKey{ Cast<AActor>(Obj), Property };
+	TraceKey ReturnKey = InvalidTraceKey;
+	TrackingProperties.RemoveAndCopyValue(PropKey, ReturnKey);
+	return ReturnKey;
+}
+
+TraceKey SpatialLatencyTracerData::RetrievePendingTrace(const UObject* Obj, const FString& Tag)
+{
+	FScopeLock Lock(&Mutex);
+
+	ActorTagKey EventKey{ Cast<AActor>(Obj), Tag };
+	TraceKey ReturnKey = InvalidTraceKey;
+	TrackingTags.RemoveAndCopyValue(EventKey, ReturnKey);
+	return ReturnKey;
+}
+
+void SpatialLatencyTracerData::WriteToLatencyTrace(const TraceKey Key, const FString& TraceDesc)
+{
+	FScopeLock Lock(&Mutex);
+
+	if (TraceSpan* Trace = TraceMap.Find(Key))
+	{
+		WriteKeyFrameToTrace(Trace, TraceDesc);
+	}
+}
+
+void SpatialLatencyTracerData::WriteAndEndTrace(const TraceKey Key, const FString& TraceDesc, bool bOnlyEndIfTraceRootIsRemote)
+{
+	FScopeLock Lock(&Mutex);
+
+	if (TraceSpan* Trace = TraceMap.Find(Key))
+	{
+		WriteKeyFrameToTrace(Trace, TraceDesc);
+
+		// Check RootTraces to verify if this trace was started locally. If it was, we don't End the trace yet, but
+		// wait for an explicit call to EndLatencyTrace.
+		if (!bOnlyEndIfTraceRootIsRemote || RootTraces.Find(Key) == nullptr)
+		{
+			Trace->End();
+			TraceMap.Remove(Key);
+		}
+	}
+}
+
+void SpatialLatencyTracerData::WriteTraceToSchemaObject(const TraceKey Key, Schema_Object* Obj, const Schema_FieldId FieldId)
+{
+	FScopeLock Lock(&Mutex);
+
+	if (TraceSpan* Trace = TraceMap.Find(Key))
+	{
+		Schema_Object* TraceObj = Schema_AddObject(Obj, FieldId);
+
+		const improbable::trace::SpanContext& TraceContext = Trace->context();
+		improbable::trace::TraceId _TraceId = TraceContext.trace_id();
+		improbable::trace::SpanId _SpanId = TraceContext.span_id();
+
+		AddBytesToSchema(TraceObj, SpatialConstants::UNREAL_RPC_TRACE_ID, &_TraceId[0], _TraceId.size());
+		AddBytesToSchema(TraceObj, SpatialConstants::UNREAL_RPC_SPAN_ID, &_SpanId[0], _SpanId.size());
+	}
+}
+
+TraceKey SpatialLatencyTracerData::ReadTraceFromSchemaObject(Schema_Object* Obj, const Schema_FieldId FieldId)
+{
+	FScopeLock Lock(&Mutex);
+
+	if (Schema_GetObjectCount(Obj, FieldId) > 0)
+	{
+		Schema_Object* TraceData = Schema_IndexObject(Obj, FieldId, 0);
+
+		const uint8* TraceBytes = Schema_GetBytes(TraceData, SpatialConstants::UNREAL_RPC_TRACE_ID);
+		const uint8* SpanBytes = Schema_GetBytes(TraceData, SpatialConstants::UNREAL_RPC_SPAN_ID);
+
+		improbable::trace::SpanContext DestContext = ReadSpanContext(TraceBytes, SpanBytes);
+
+		TraceKey Key = InvalidTraceKey;
+
+		for (const auto& TracePair : TraceMap)
+		{
+			const TraceKey& _Key = TracePair.Key;
+			const TraceSpan& Span = TracePair.Value;
+
+			if (Span.context().trace_id() == DestContext.trace_id())
+			{
+				Key = _Key;
+				break;
+			}
+		}
+
+		if (Key != InvalidTraceKey)
+		{
+			TraceSpan* Span = TraceMap.Find(Key);
+
+			WriteKeyFrameToTrace(Span, TEXT("Local Trace - Schema Obj Read"));
+		}
+		else
+		{
+			FString SpanMsg = FormatMessage(TEXT("Remote Parent Trace - Schema Obj Read"));
+			TraceSpan RetrieveTrace = improbable::trace::Span::StartSpanWithRemoteParent(TCHAR_TO_UTF8(*SpanMsg), DestContext);
+
+			Key = GenerateNewTraceKey();
+			TraceMap.Add(Key, MoveTemp(RetrieveTrace));
+		}
+
+		return Key;
+	}
+
+	return InvalidTraceKey;
+}
+
+FSpatialLatencyPayload SpatialLatencyTracerData::RetrievePayload_Internal(const UObject* Obj, const FString& Tag)
+{
+	FScopeLock Lock(&Mutex);
+
+	 TraceKey Key = RetrievePendingTrace(Obj, Tag);
+	 if (Key != InvalidTraceKey)
+	 {
+		 if (const TraceSpan* Span = TraceMap.Find(Key))
+		 {
+			 const improbable::trace::SpanContext& TraceContext = Span->context();
+
+			 TArray<uint8> TraceBytes = TArray<uint8_t>((const uint8_t*)&TraceContext.trace_id()[0], sizeof(improbable::trace::TraceId));
+			 TArray<uint8> SpanBytes = TArray<uint8_t>((const uint8_t*)&TraceContext.span_id()[0], sizeof(improbable::trace::SpanId));
+			 return FSpatialLatencyPayload(MoveTemp(TraceBytes), MoveTemp(SpanBytes), Key);
+		 }
+	 }
+	 return {};
+}
+
+void SpatialLatencyTracerData::ResetWorkerId()
+{
+	WorkerId = TEXT("DeviceId_") + FPlatformMisc::GetDeviceId();
+}
+
+void SpatialLatencyTracerData::OnEnqueueMessage(const FOutgoingMessage* Message)
+{
+	if (Message->Type == EOutgoingMessageType::ComponentUpdate)
+	{
+		const FComponentUpdate* ComponentUpdate = static_cast<const FComponentUpdate*>(Message);
+		WriteToLatencyTrace(ComponentUpdate->Update.Trace, TEXT("Moved componentUpdate to Worker queue"));
+
+		FScopeLock Lock(&Mutex);
+
+		if (TraceSpan* Trace = TraceMap.Find(ComponentUpdate->Update.Trace))
+		{
+			UE_LOG(LogSpatialLatencyTracing, Warning, TEXT("MCS: Enqueue called for %d"), ComponentUpdate->Update.Trace);
+		}
+	}
+	else if (Message->Type == EOutgoingMessageType::AddComponent)
+	{
+		const FAddComponent* ComponentAdd = static_cast<const FAddComponent*>(Message);
+		WriteToLatencyTrace(ComponentAdd->Data.Trace, TEXT("Moved componentAdd to Worker queue"));
+	}
+	else if (Message->Type == EOutgoingMessageType::CreateEntityRequest)
+	{
+		const FCreateEntityRequest* CreateEntityRequest = static_cast<const FCreateEntityRequest*>(Message);
+		for (auto& Component : CreateEntityRequest->Components)
+		{
+			WriteToLatencyTrace(Component.Trace, TEXT("Moved createEntityRequest to Worker queue"));
+		}
+	}
+}
+
+void SpatialLatencyTracerData::OnDequeueMessage(const FOutgoingMessage* Message)
+{
+	if (Message->Type == EOutgoingMessageType::ComponentUpdate)
+	{
+		const FComponentUpdate* ComponentUpdate = static_cast<const FComponentUpdate*>(Message);
+
+		if (TraceSpan* Trace = TraceMap.Find(ComponentUpdate->Update.Trace))
+		{
+			UE_LOG(LogSpatialLatencyTracing, Warning, TEXT("MCS: Dequeue called for %d"), ComponentUpdate->Update.Trace);
+		}
+
+		WriteAndEndTrace(ComponentUpdate->Update.Trace, TEXT("Sent componentUpdate to Worker SDK"), true);
+	}
+	else if (Message->Type == EOutgoingMessageType::AddComponent)
+	{
+		const FAddComponent* ComponentAdd = static_cast<const FAddComponent*>(Message);
+		WriteAndEndTrace(ComponentAdd->Data.Trace, TEXT("Sent componentAdd to Worker SDK"), true);
+	}
+	else if (Message->Type == EOutgoingMessageType::CreateEntityRequest)
+	{
+		const FCreateEntityRequest* CreateEntityRequest = static_cast<const FCreateEntityRequest*>(Message);
+		for (auto& Component : CreateEntityRequest->Components)
+		{
+			WriteAndEndTrace(Component.Trace, TEXT("Sent createEntityRequest to Worker SDK"), true);
+		}
+	}
+}
+
+bool SpatialLatencyTracerData::BeginLatencyTrace_Internal(const FString& TraceDesc, FSpatialLatencyPayload& OutLatencyPayload)
+{	 
+	// TODO: UNR-2787 - Improve mutex-related latency
+	// This functions might spike because of the Mutex below
+	SCOPE_CYCLE_COUNTER(STAT_BeginLatencyTraceRPC_Internal);
+	FScopeLock Lock(&Mutex);
+
+	FString SpanMsg = FormatMessage(TraceDesc, true);
+	TraceSpan NewTrace = improbable::trace::Span::StartSpan(TCHAR_TO_UTF8(*SpanMsg), nullptr);
+
+	// Construct payload data from trace
+	const improbable::trace::SpanContext& TraceContext = NewTrace.context();
+
+	{
+		TArray<uint8> TraceBytes = TArray<uint8_t>((const uint8_t*)&TraceContext.trace_id()[0], sizeof(improbable::trace::TraceId));
+		TArray<uint8> SpanBytes = TArray<uint8_t>((const uint8_t*)&TraceContext.span_id()[0], sizeof(improbable::trace::SpanId));
+		OutLatencyPayload = FSpatialLatencyPayload(MoveTemp(TraceBytes), MoveTemp(SpanBytes), GenerateNewTraceKey());
+	}
+
+	// Add to internal tracking
+	TraceMap.Add(OutLatencyPayload.Key, MoveTemp(NewTrace));
+
+	// Store traces started on this worker, so we can persist them until they've been round trip returned.
+	RootTraces.Add(OutLatencyPayload.Key);
+
+	return true;
+}
+
+bool SpatialLatencyTracerData::ContinueLatencyTrace_Internal(const AActor* Actor, const FString& Target, ETraceType::Type Type, const FString& TraceDesc, const FSpatialLatencyPayload& LatencyPayload, FSpatialLatencyPayload& OutLatencyPayload)
+{
+	// TODO: UNR-2787 - Improve mutex-related latency
+	// This functions might spike because of the Mutex below
+	SCOPE_CYCLE_COUNTER(STAT_ContinueLatencyTraceRPC_Internal);
+	if (Actor == nullptr)
+	{
+		return false;
+	}
+
+	// We do minimal internal tracking for native rpcs/properties
+	const bool bInternalTracking = GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking() || Type == ETraceType::Tagged;
+
+	FScopeLock Lock(&Mutex);
+
+	OutLatencyPayload = LatencyPayload;
+	if (OutLatencyPayload.Key == InvalidTraceKey)
+	{
+		ResolveKeyInLatencyPayload(OutLatencyPayload);
+	}
+
+	const TraceKey Key = OutLatencyPayload.Key;
+	const TraceSpan* ActiveTrace = TraceMap.Find(Key);
+	if (ActiveTrace == nullptr)
+	{
+		UE_LOG(LogSpatialLatencyTracing, Warning, TEXT("(%s) : No active trace to continue (%s)"), *WorkerId, *TraceDesc);
+		return false;
+	}
+
+	if (bInternalTracking)
+	{
+		if (!AddTrackingInfo(Actor, Target, Type, Key))
+		{
+			UE_LOG(LogSpatialLatencyTracing, Warning, TEXT("(%s) : Failed to create Actor/Func trace (%s)"), *WorkerId, *TraceDesc);
+			return false;
+		}
+	}
+
+	WriteKeyFrameToTrace(ActiveTrace, FString::Printf(TEXT("Continue [%s] %s - %s"), *TraceDesc, *UEnum::GetValueAsString(Type), *Target));
+
+	// If we're not doing any further tracking, end the trace
+	if (!bInternalTracking)
+	{
+		WriteAndEndTrace(Key, TEXT("Native - End of Tracking"), true);
+	}
+
+	return true;
+}
+
+bool SpatialLatencyTracerData::EndLatencyTrace_Internal(const FSpatialLatencyPayload& LatencyPayload)
+{
+	FScopeLock Lock(&Mutex);
+
+	// Create temp payload to resolve key
+	FSpatialLatencyPayload LocalLatencyPayload = LatencyPayload;
+	if (LocalLatencyPayload.Key == InvalidTraceKey)
+	{
+		ResolveKeyInLatencyPayload(LocalLatencyPayload);
+	}
+
+	const TraceKey Key = LocalLatencyPayload.Key;
+	const TraceSpan* ActiveTrace = TraceMap.Find(Key);
+	if (ActiveTrace == nullptr)
+	{
+		UE_LOG(LogSpatialLatencyTracing, Warning, TEXT("(%s) : No active trace to end"), *WorkerId);
+		return false;
+	}
+
+	WriteKeyFrameToTrace(ActiveTrace, TEXT("End"));
+
+	ActiveTrace->End();
+
+	TraceMap.Remove(Key);
+	RootTraces.Remove(Key);
+
+	return true;
+}
+
+bool SpatialLatencyTracerData::AddTrackingInfo(const AActor* Actor, const FString& Target, const ETraceType::Type Type, const TraceKey Key)
+{
+	if (Actor == nullptr)
+	{
+		return false;
+	}
+
+	if (UClass* ActorClass = Actor->GetClass())
+	{
+		switch (Type)
+		{
+		case ETraceType::RPC:
+			if (const UFunction* Function = ActorClass->FindFunctionByName(*Target))
+			{
+				ActorFuncKey AFKey{ Actor, Function };
+				if (TrackingRPCs.Find(AFKey) == nullptr)
+				{
+					TrackingRPCs.Add(AFKey, Key);
+					return true;
+				}
+				UE_LOG(LogSpatialLatencyTracing, Warning, TEXT("(%s) : ActorFunc already exists for trace"), *WorkerId);
+			}
+			break;
+		case ETraceType::Property:
+			if (const UProperty* Property = ActorClass->FindPropertyByName(*Target))
+			{
+				ActorPropertyKey APKey{ Actor, Property };
+				if (TrackingProperties.Find(APKey) == nullptr)
+				{
+					TrackingProperties.Add(APKey, Key);
+					return true;
+				}
+				UE_LOG(LogSpatialLatencyTracing, Warning, TEXT("(%s) : ActorProperty already exists for trace"), *WorkerId);
+			}
+			break;
+		case ETraceType::Tagged:
+			{
+				ActorTagKey ATKey{ Actor, Target };
+				if (TrackingTags.Find(ATKey) == nullptr)
+				{
+					TrackingTags.Add(ATKey, Key);
+					return true;
+				}
+				UE_LOG(LogSpatialLatencyTracing, Warning, TEXT("(%s) : ActorTag already exists for trace"), *WorkerId);
+			}
+			break;
+		}
+	}
+
+	return false;
+}
+
+TraceKey SpatialLatencyTracerData::GenerateNewTraceKey()
+{
+	return NextTraceKey++;
+}
+
+void SpatialLatencyTracerData::ResolveKeyInLatencyPayload(FSpatialLatencyPayload& Payload)
+{
+	// Key isn't set, so attempt to find it in the trace map
+	for (const auto& TracePair : TraceMap)
+	{
+		const TraceKey& Key = TracePair.Key;
+		const TraceSpan& Span = TracePair.Value;
+
+		if (memcmp(Span.context().trace_id().data(), Payload.TraceId.GetData(), Payload.TraceId.Num()) == 0)
+		{
+			WriteKeyFrameToTrace(&Span, TEXT("Local Trace - Payload Obj Read"));
+			Payload.Key = Key;
+			break;
+		}
+	}
+
+	if (Payload.Key == InvalidTraceKey)
+	{
+		// Uninitialized key, generate and add to map
+		Payload.Key = GenerateNewTraceKey();
+
+		improbable::trace::SpanContext DestContext = ReadSpanContext(Payload.TraceId.GetData(), Payload.SpanId.GetData());
+
+		FString SpanMsg = FormatMessage(TEXT("Remote Parent Trace - Payload Obj Read"));
+		TraceSpan RetrieveTrace = improbable::trace::Span::StartSpanWithRemoteParent(TCHAR_TO_UTF8(*SpanMsg), DestContext);
+
+		TraceMap.Add(Payload.Key, MoveTemp(RetrieveTrace));
+	}
+}
+
+void SpatialLatencyTracerData::WriteKeyFrameToTrace(const TraceSpan* Trace, const FString& TraceDesc)
+{
+	if (Trace != nullptr)
+	{
+		FString TraceMsg = FormatMessage(TraceDesc);
+		improbable::trace::Span::StartSpan(TCHAR_TO_UTF8(*TraceMsg), Trace).End();
+	}
+}
+
+FString SpatialLatencyTracerData::FormatMessage(const FString& Message, bool bIncludeMetadata) const
+{
+	if (bIncludeMetadata)
+	{
+		return FString::Printf(TEXT("%s (%s : %s)"), *Message, *TraceMetadata, *WorkerId.Left(18));
+	}
+	else
+	{
+		return FString::Printf(TEXT("%s (%s)"), *Message, *WorkerId.Left(18));
+	}
+}
+} // namespace SpatialGDK
+#endif // TRACE_LIB_ACTIVE

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialWorkerConnection.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialWorkerConnection.h
@@ -48,11 +48,7 @@ public:
 	PhysicalWorkerName GetWorkerId() const;
 	const TArray<FString>& GetWorkerAttributes() const;
 
-	DECLARE_MULTICAST_DELEGATE_OneParam(FOnEnqueueMessage, const SpatialGDK::FOutgoingMessage*);
-	FOnEnqueueMessage OnEnqueueMessage;
-
-	DECLARE_MULTICAST_DELEGATE_OneParam(FOnDequeueMessage, const SpatialGDK::FOutgoingMessage*);
-	FOnDequeueMessage OnDequeueMessage;
+	void BindLatencyTracer(SpatialGDK::TracerSharedPtr Tracer);
 
 	void QueueLatestOpList();
 	void ProcessOutgoingMessages();
@@ -87,4 +83,7 @@ private:
 
 	// Coordinates the async worker ops thread.
 	TOptional<WorkerConnectionCoordinator> ThreadWaitCondition;
+
+	// Used to coordinate logging tracer events
+	SpatialGDK::TracerSharedPtr Tracer;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialRPCService.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialRPCService.h
@@ -7,13 +7,13 @@
 #include "Schema/RPCPayload.h"
 #include "SpatialView/EntityComponentId.h"
 #include "Utils/RPCRingBuffer.h"
+#include "Utils/SpatialLatencyTracerData.h"
 
 #include <WorkerSDK/improbable/c_schema.h>
 #include <WorkerSDK/improbable/c_worker.h>
 
 DECLARE_LOG_CATEGORY_EXTERN(LogSpatialRPCService, Log, All);
 
-class USpatialLatencyTracer;
 class USpatialStaticComponentView;
 struct RPCRingBuffer;
 
@@ -57,7 +57,7 @@ enum class EPushRPCResult : uint8
 class SPATIALGDK_API SpatialRPCService
 {
 public:
-	SpatialRPCService(ExtractRPCDelegate ExtractRPCCallback, const USpatialStaticComponentView* View, USpatialLatencyTracer* SpatialLatencyTracer);
+	SpatialRPCService(ExtractRPCDelegate ExtractRPCCallback, const USpatialStaticComponentView* View, SpatialGDK::TracerSharedPtr SpatialLatencyTracer);
 
 	EPushRPCResult PushRPC(Worker_EntityId EntityId, ERPCType Type, RPCPayload Payload, bool bCreatedEntity);
 	void PushOverflowedRPCs();
@@ -101,7 +101,7 @@ private:
 private:
 	ExtractRPCDelegate ExtractRPCCallback;
 	const USpatialStaticComponentView* View;
-	USpatialLatencyTracer* SpatialLatencyTracer;
+	SpatialGDK::TracerSharedPtr SpatialLatencyTracer;
 
 	// This is local, not written into schema.
 	TMap<Worker_EntityId_Key, uint64> LastSeenMulticastRPCIds;

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/RPCPayload.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/RPCPayload.h
@@ -31,7 +31,7 @@ struct RPCPayload
 		PayloadData = SpatialGDK::GetBytesFromSchema(RPCObject, SpatialConstants::UNREAL_RPC_PAYLOAD_RPC_PAYLOAD_ID);
 
 #if TRACE_LIB_ACTIVE
-		if (USpatialLatencyTracer* Tracer = USpatialLatencyTracer::GetTracer(nullptr))
+		if (TracerSharedPtr Tracer = USpatialLatencyTracer::GetTracer(nullptr))
 		{
 			Trace = Tracer->ReadTraceFromSchemaObject(RPCObject, SpatialConstants::UNREAL_RPC_PAYLOAD_TRACE_ID);
 		}
@@ -48,7 +48,7 @@ struct RPCPayload
 		WriteToSchemaObject(RPCObject, Offset, Index, PayloadData.GetData(), PayloadData.Num());
 
 #if TRACE_LIB_ACTIVE
-		if (USpatialLatencyTracer* Tracer = USpatialLatencyTracer::GetTracer(nullptr))
+		if (TracerSharedPtr Tracer = USpatialLatencyTracer::GetTracer(nullptr))
 		{
 			Tracer->WriteTraceToSchemaObject(Trace, RPCObject, SpatialConstants::UNREAL_RPC_PAYLOAD_TRACE_ID);
 		}

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/ComponentFactory.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/ComponentFactory.h
@@ -5,6 +5,7 @@
 #include "Interop/SpatialClassInfoManager.h"
 #include "Schema/Interest.h"
 #include "Utils/RepDataUtils.h"
+#include "Utils/SpatialLatencyTracerData.h"
 
 #include <WorkerSDK/improbable/c_schema.h>
 #include <WorkerSDK/improbable/c_worker.h>
@@ -14,7 +15,6 @@ DECLARE_LOG_CATEGORY_EXTERN(LogComponentFactory, Log, All);
 class USpatialNetDriver;
 class USpatialPackageMap;
 class USpatialClassInfoManager;
-class USpatialLatencyTracer;
 class USpatialPackageMapClient;
 
 class UNetDriver;
@@ -28,7 +28,7 @@ namespace SpatialGDK
 class SPATIALGDK_API ComponentFactory
 {
 public:
-	ComponentFactory(bool bInterestDirty, USpatialNetDriver* InNetDriver, USpatialLatencyTracer* LatencyTracer);
+	ComponentFactory(bool bInterestDirty, USpatialNetDriver* InNetDriver, SpatialGDK::TracerSharedPtr LatencyTracer);
 
 	TArray<FWorkerComponentData> CreateComponentDatas(UObject* Object, const FClassInfo& Info, const FRepChangeState& RepChangeState, const FHandoverChangeState& HandoverChangeState, uint32& OutBytesWritten);
 	TArray<FWorkerComponentUpdate> CreateComponentUpdates(UObject* Object, const FClassInfo& Info, Worker_EntityId EntityId, const FRepChangeState* RepChangeState, const FHandoverChangeState* HandoverChangeState, uint32& OutBytesWritten);
@@ -55,7 +55,7 @@ private:
 
 	bool bInterestHasChanged;
 
-	USpatialLatencyTracer* LatencyTracer;
+	SpatialGDK::TracerSharedPtr LatencyTracer;
 };
 
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracer.h
@@ -5,40 +5,12 @@
 #include "CoreMinimal.h"
 
 #include "SpatialConstants.h"
-#include "Containers/Map.h"
-#include "Containers/StaticArray.h"
 #include "SpatialLatencyPayload.h"
-
-#if TRACE_LIB_ACTIVE
-#include "WorkerSDK/improbable/trace.h"
-#endif
+#include "SpatialLatencyTracerData.h"
 
 #include "SpatialLatencyTracer.generated.h"
 
-DECLARE_LOG_CATEGORY_EXTERN(LogSpatialLatencyTracing, Log, All);
-
 class AActor;
-class UFunction;
-class USpatialGameInstance;
-
-namespace SpatialGDK
-{
-	struct FOutgoingMessage;
-}  // namespace SpatialGDK
-
-/**
- * Enum that maps Unreal's log verbosity to allow use in settings.
-**/
-UENUM()
-namespace ETraceType
-{
-	enum Type
-	{
-		RPC,
-		Property,
-		Tagged
-	};
-}
 
 UCLASS()
 class SPATIALGDK_API USpatialLatencyTracer : public UObject
@@ -121,67 +93,16 @@ public:
 	static FSpatialLatencyPayload RetrievePayload(UObject* WorldContextObject, const AActor* Actor, const FString& Tag);
 
 	// Internal GDK usage, shouldn't be used by game code
-	static USpatialLatencyTracer* GetTracer(UObject* WorldContextObject);
-
-#if TRACE_LIB_ACTIVE
-
-	bool IsValidKey(TraceKey Key);
-	TraceKey RetrievePendingTrace(const UObject* Obj, const UFunction* Function);
-	TraceKey RetrievePendingTrace(const UObject* Obj, const UProperty* Property);
-	TraceKey RetrievePendingTrace(const UObject* Obj, const FString& Tag);
-
-	void WriteToLatencyTrace(const TraceKey Key, const FString& TraceDesc);
-	void WriteAndEndTrace(const TraceKey Key, const FString& TraceDesc, bool bOnlyEndIfTraceRootIsRemote);
-
-	void WriteTraceToSchemaObject(const TraceKey Key, Schema_Object* Obj, const Schema_FieldId FieldId);
-	TraceKey ReadTraceFromSchemaObject(Schema_Object* Obj, const Schema_FieldId FieldId);
-
-	void SetWorkerId(const FString& NewWorkerId) { WorkerId = NewWorkerId; }
-	void ResetWorkerId();
-
-	void OnEnqueueMessage(const SpatialGDK::FOutgoingMessage*);
-	void OnDequeueMessage(const SpatialGDK::FOutgoingMessage*);
-
-private:
-
-	using ActorFuncKey = TPair<const AActor*, const UFunction*>;
-	using ActorPropertyKey = TPair<const AActor*, const UProperty*>;
-	using ActorTagKey = TPair<const AActor*, FString>;
-	using TraceSpan = improbable::trace::Span;
-
-	bool BeginLatencyTrace_Internal(const FString& TraceDesc, FSpatialLatencyPayload& OutLatencyPayload);
-	bool ContinueLatencyTrace_Internal(const AActor* Actor, const FString& Target, ETraceType::Type Type, const FString& TraceDesc, const FSpatialLatencyPayload& LatencyPayload, FSpatialLatencyPayload& OutLatencyPayload);
-	bool EndLatencyTrace_Internal(const FSpatialLatencyPayload& LatencyPayload);
-
-	FSpatialLatencyPayload RetrievePayload_Internal(const UObject* Actor, const FString& Key);
-
-	bool AddTrackingInfo(const AActor* Actor, const FString& Target, const ETraceType::Type Type, const TraceKey Key);
-
-	TraceKey GenerateNewTraceKey();
-	void ResolveKeyInLatencyPayload(FSpatialLatencyPayload& Payload);
-
-	void WriteKeyFrameToTrace(const TraceSpan* Trace, const FString& TraceDesc);
-	FString FormatMessage(const FString& Message, bool bIncludeMetadata = false) const;
-
-	FString WorkerId;
-	FString TraceMetadata;
-
-	TraceKey NextTraceKey = 1;
-
-	FCriticalSection Mutex; // This mutex is to protect modifications to the containers below
-
-	TMap<ActorFuncKey, TraceKey> TrackingRPCs;
-	TMap<ActorPropertyKey, TraceKey> TrackingProperties;
-	TMap<ActorTagKey, TraceKey> TrackingTags;
-	TMap<TraceKey, TraceSpan> TraceMap;
-
-	TSet<TraceKey> RootTraces;
-
-public:
-
-#endif // TRACE_LIB_ACTIVE
+	static SpatialGDK::TracerSharedPtr GetTracer(UObject* WorldContextObject);
+	SpatialGDK::TracerSharedPtr GetTracer();
 
 	// Used for testing trace functionality, will send a debug trace in three parts from this worker
 	UFUNCTION(BlueprintCallable, Category = "SpatialOS")
 	static void Debug_SendTestTrace();
+
+	void SetWorkerId(const FString& NewWorkerId);
+	void ResetWorkerId();
+
+	// Thread-safe tracer data
+	SpatialGDK::TracerSharedPtr Tracer;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracerData.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracerData.h
@@ -1,0 +1,107 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+#include "SpatialConstants.h"
+#include "Containers/Map.h"
+#include "SpatialLatencyPayload.h"
+
+#if TRACE_LIB_ACTIVE
+#include "WorkerSDK/improbable/trace.h"
+#endif
+
+#include "SpatialLatencyTracerData.generated.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogSpatialLatencyTracing, Log, All);
+
+class AActor;
+class UFunction;
+class USpatialLatencyTracer;
+
+/**
+ * Enum that defined the each of the types a trace can be attached to
+**/
+UENUM()
+namespace ETraceType
+{
+	enum Type
+	{
+		RPC,
+		Property,
+		Tagged
+	};
+}
+
+namespace SpatialGDK
+{
+struct FOutgoingMessage;
+
+class SPATIALGDK_API SpatialLatencyTracerData
+{
+	friend class USpatialLatencyTracer;
+
+public:
+
+#if TRACE_LIB_ACTIVE
+
+	SpatialLatencyTracerData();
+
+	TraceKey RetrievePendingTrace(const UObject* Obj, const UFunction* Function);
+	TraceKey RetrievePendingTrace(const UObject* Obj, const UProperty* Property);
+	TraceKey RetrievePendingTrace(const UObject* Obj, const FString& Tag);
+
+	void WriteToLatencyTrace(const TraceKey Key, const FString& TraceDesc);
+	void WriteAndEndTrace(const TraceKey Key, const FString& TraceDesc, bool bOnlyEndIfTraceRootIsRemote);
+
+	void WriteTraceToSchemaObject(const TraceKey Key, Schema_Object* Obj, const Schema_FieldId FieldId);
+	TraceKey ReadTraceFromSchemaObject(Schema_Object* Obj, const Schema_FieldId FieldId);
+
+	void SetWorkerId(const FString& NewWorkerId) { WorkerId = NewWorkerId; }
+	void ResetWorkerId();
+
+	void OnEnqueueMessage(const FOutgoingMessage*);
+	void OnDequeueMessage(const FOutgoingMessage*);
+
+private:
+
+	using ActorFuncKey = TPair<const AActor*, const UFunction*>;
+	using ActorPropertyKey = TPair<const AActor*, const UProperty*>;
+	using ActorTagKey = TPair<const AActor*, FString>;
+	using TraceSpan = improbable::trace::Span;
+
+	bool BeginLatencyTrace_Internal(const FString& TraceDesc, FSpatialLatencyPayload& OutLatencyPayload);
+	bool ContinueLatencyTrace_Internal(const AActor* Actor, const FString& Target, ETraceType::Type Type, const FString& TraceDesc, const FSpatialLatencyPayload& LatencyPayload, FSpatialLatencyPayload& OutLatencyPayload);
+	bool EndLatencyTrace_Internal(const FSpatialLatencyPayload& LatencyPayload);
+
+	FSpatialLatencyPayload RetrievePayload_Internal(const UObject* Actor, const FString& Key);
+
+	bool AddTrackingInfo(const AActor* Actor, const FString& Target, const ETraceType::Type Type, const TraceKey Key);
+
+	TraceKey GenerateNewTraceKey();
+	void ResolveKeyInLatencyPayload(FSpatialLatencyPayload& Payload);
+
+	void WriteKeyFrameToTrace(const TraceSpan* Trace, const FString& TraceDesc);
+	FString FormatMessage(const FString& Message, bool bIncludeMetadata = false) const;
+
+	FString WorkerId;
+	FString TraceMetadata;
+
+	TraceKey NextTraceKey = 1;
+
+	FCriticalSection Mutex; // This mutex is to protect modifications to the containers below
+
+	TMap<ActorFuncKey, TraceKey> TrackingRPCs;
+	TMap<ActorPropertyKey, TraceKey> TrackingProperties;
+	TMap<ActorTagKey, TraceKey> TrackingTags;
+	TMap<TraceKey, TraceSpan> TraceMap;
+
+	TSet<TraceKey> RootTraces;
+
+#endif // TRACE_LIB_ACTIVE
+};
+
+using TracerSharedPtr = TSharedPtr<SpatialLatencyTracerData, ESPMode::ThreadSafe>;
+
+}  // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracerData.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracerData.h
@@ -40,7 +40,7 @@ struct FOutgoingMessage;
 
 class SPATIALGDK_API SpatialLatencyTracerData
 {
-	friend class USpatialLatencyTracer;
+	friend class ::USpatialLatencyTracer;
 
 public:
 


### PR DESCRIPTION
#### Description
Attempting to call delegates from not the game thread led to all sorts of problems.
This PR separates the data and core functionality into an object that is wrapped in a thread-safe pointer.
The remaining api functions have been kept the same, so as to not break existing usage.

#### Primary reviewers
@improbable-danny 
