### PR TITLE
Modify error message to include position, which is typically necessar…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Local Deployment IP` and `Cloud Deployment Name` labels now get grayed out correctly when the edit box is disabled.
 - Entering an invalid IP into the `Exposed local runtime IP address` field in the editor settings will trigger a warning popup and reset the value to an empty string.
 - Fixed bug causing this error to fire: "ResolveObjectReferences: Removed unresolved reference: AbsOffset >= MaxAbsOffset"
+- Error logged when LoadBalancingStrategy can't locate a worker to take authority over an Actor has been improved to include the Spatial Position of the Actor.
 
 ## [`0.10.0`] - 2020-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Local Deployment IP` and `Cloud Deployment Name` labels now get grayed out correctly when the edit box is disabled.
 - Entering an invalid IP into the `Exposed local runtime IP address` field in the editor settings will trigger a warning popup and reset the value to an empty string.
 - Fixed bug causing this error to fire: "ResolveObjectReferences: Removed unresolved reference: AbsOffset >= MaxAbsOffset"
-- Error logged when LoadBalancingStrategy can't locate a worker to take authority over an Actor has been improved to include the Spatial Position of the Actor.
+- Log an error including Position when GridBasedLBStrategy can't locate a worker to take authority over an Actor.
 
 ## [`0.10.0`] - 2020-07-08
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -770,7 +770,8 @@ int64 USpatialActorChannel::ReplicateActor()
 				const VirtualWorkerId NewAuthVirtualWorkerId = NetDriver->LoadBalanceStrategy->WhoShouldHaveAuthority(*Actor);
 				if (NewAuthVirtualWorkerId == SpatialConstants::INVALID_VIRTUAL_WORKER_ID)
 				{
-					UE_LOG(LogSpatialActorChannel, Error, TEXT("Load Balancing Strategy returned invalid virtual worker for actor %s"), *Actor->GetName());
+					const FVector SpatialPosition = SpatialGDK::GetActorSpatialPosition(Actor);
+					UE_LOG(LogSpatialActorChannel, Error, TEXT("Load Balancing Strategy returned invalid virtual worker for actor %s (Spatial position: %s)"), *GetNameSafe(Actor), *SpatialPosition.ToString());
 				}
 				else
 				{

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -770,8 +770,7 @@ int64 USpatialActorChannel::ReplicateActor()
 				const VirtualWorkerId NewAuthVirtualWorkerId = NetDriver->LoadBalanceStrategy->WhoShouldHaveAuthority(*Actor);
 				if (NewAuthVirtualWorkerId == SpatialConstants::INVALID_VIRTUAL_WORKER_ID)
 				{
-					const FVector SpatialPosition = SpatialGDK::GetActorSpatialPosition(Actor);
-					UE_LOG(LogSpatialActorChannel, Error, TEXT("Load Balancing Strategy returned invalid virtual worker for actor %s (Spatial position: %s)"), *GetNameSafe(Actor), *SpatialPosition.ToString());
+					UE_LOG(LogSpatialActorChannel, Error, TEXT("Load Balancing Strategy returned invalid virtual worker for actor %s"), *GetNameSafe(Actor));
 				}
 				else
 				{

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
@@ -113,11 +113,12 @@ VirtualWorkerId UGridBasedLBStrategy::WhoShouldHaveAuthority(const AActor& Actor
 	{
 		if (IsInside(WorkerCells[i], Actor2DLocation))
 		{
-			UE_LOG(LogGridBasedLBStrategy, Log, TEXT("Actor: %s, grid %d, worker %d for position %f, %f"), *AActor::GetDebugName(&Actor), i, VirtualWorkerIds[i], Actor2DLocation.X, Actor2DLocation.Y);
+			UE_LOG(LogGridBasedLBStrategy, Log, TEXT("Actor: %s, grid %d, worker %d for position %s"), *AActor::GetDebugName(&Actor), i, VirtualWorkerIds[i], *Actor2DLocation.ToString());
 			return VirtualWorkerIds[i];
 		}
 	}
 
+	UE_LOG(LogGridBasedLBStrategy, Error, TEXT("GridBasedLBStrategy couldn't determine virtual worker for Actor %s at position %s"), *AActor::GetDebugName(&Actor), *Actor2DLocation.ToString());
 	return SpatialConstants::INVALID_VIRTUAL_WORKER_ID;
 }
 


### PR DESCRIPTION
…y to track down why no workers claimed authority, at least in the current commonly used LB strategy

#### Description
Modified the following error message:

"Load Balancing Strategy returned invalid virtual worker for actor <actor_name>"

to this:

"Load Balancing Strategy returned invalid virtual worker for actor <actor_name> (Spatial position: <position>)"

#### Release note
Release note added.

#### Tests
Verified the new error message prints correctly on our project

STRONGLY SUGGESTED: How can this be verified by QA?
Place an actor outside the authority area of all server workers for a given level

#### Documentation
Release note


#### Primary reviewers
@spatialos/develop-unreal 