### PR TITLE
Replace usages of FProperty with GDK_PROPERTY that expands to correct type

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -28,6 +28,7 @@
 #include "Schema/ServerRPCEndpointLegacy.h"
 #include "SpatialConstants.h"
 #include "SpatialGDKSettings.h"
+#include "Utils/GDKPropertyMacros.h"
 #include "Utils/RepLayoutUtils.h"
 #include "Utils/SpatialActorUtils.h"
 
@@ -1165,7 +1166,7 @@ FObjectReplicator* USpatialActorChannel::PreReceiveSpatialUpdate(UObject* Target
 	return &Replicator;
 }
 
-void USpatialActorChannel::PostReceiveSpatialUpdate(UObject* TargetObject, const TArray<UProperty*>& RepNotifies)
+void USpatialActorChannel::PostReceiveSpatialUpdate(UObject* TargetObject, const TArray<GDK_PROPERTY(Property)*>& RepNotifies)
 {
 	FObjectReplicator& Replicator = FindOrCreateReplicator(TargetObject).Get();
 	TargetObject->PostNetReceive();
@@ -1292,11 +1293,11 @@ void USpatialActorChannel::SendPositionUpdate(AActor* InActor, Worker_EntityId I
 	}
 }
 
-void USpatialActorChannel::RemoveRepNotifiesWithUnresolvedObjs(TArray<UProperty*>& RepNotifies, const FRepLayout& RepLayout, const FObjectReferencesMap& RefMap, UObject* Object)
+void USpatialActorChannel::RemoveRepNotifiesWithUnresolvedObjs(TArray<GDK_PROPERTY(Property)*>& RepNotifies, const FRepLayout& RepLayout, const FObjectReferencesMap& RefMap, UObject* Object)
 {
 	// Prevent rep notify callbacks from being issued when unresolved obj references exist inside UStructs.
 	// This prevents undefined behaviour when engine rep callbacks are issued where they don't expect unresolved objects in native flow.
-	RepNotifies.RemoveAll([&](UProperty* Property)
+	RepNotifies.RemoveAll([&](GDK_PROPERTY(Property)* Property)
 	{
 		for (auto& ObjRef : RefMap)
 		{
@@ -1313,7 +1314,7 @@ void USpatialActorChannel::RemoveRepNotifiesWithUnresolvedObjs(TArray<UProperty*
 			}
 
 			bool bIsSameRepNotify = RepLayout.Parents[ObjRef.Value.ParentIndex].Property == Property;
-			bool bIsArray = RepLayout.Parents[ObjRef.Value.ParentIndex].Property->ArrayDim > 1 || Cast<UArrayProperty>(Property) != nullptr;
+			bool bIsArray = RepLayout.Parents[ObjRef.Value.ParentIndex].Property->ArrayDim > 1 || GDK_CASTFIELD<GDK_PROPERTY(ArrayProperty)>(Property) != nullptr;
 			if (bIsSameRepNotify && !bIsArray)
 			{
 				UE_LOG(LogSpatialActorChannel, Verbose, TEXT("RepNotify %s on %s ignored due to unresolved Actor"), *Property->GetName(), *Object->GetName());

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialFastArrayNetSerialize.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialFastArrayNetSerialize.cpp
@@ -4,11 +4,12 @@
 
 #include "EngineClasses/SpatialNetBitReader.h"
 #include "EngineClasses/SpatialNetBitWriter.h"
+#include "Utils/GDKPropertyMacros.h"
 
 namespace SpatialGDK
 {
 
-bool FSpatialNetDeltaSerializeInfo::DeltaSerializeRead(USpatialNetDriver* NetDriver, FSpatialNetBitReader& Reader, UObject* Object, int32 ArrayIndex, UProperty* ParentProperty, UScriptStruct* NetDeltaStruct)
+bool FSpatialNetDeltaSerializeInfo::DeltaSerializeRead(USpatialNetDriver* NetDriver, FSpatialNetBitReader& Reader, UObject* Object, int32 ArrayIndex, GDK_PROPERTY(Property)* ParentProperty, UScriptStruct* NetDeltaStruct)
 {
 	FSpatialNetDeltaSerializeInfo NetDeltaInfo;
 
@@ -19,7 +20,7 @@ bool FSpatialNetDeltaSerializeInfo::DeltaSerializeRead(USpatialNetDriver* NetDri
 	NetDeltaInfo.NetSerializeCB = &SerializeCB;
 	NetDeltaInfo.Object = Object;
 
-	UStructProperty* ParentStruct = Cast<UStructProperty>(ParentProperty);
+	GDK_PROPERTY(StructProperty)* ParentStruct = GDK_CASTFIELD<GDK_PROPERTY(StructProperty)>(ParentProperty);
 	check(ParentStruct);
 	void* Destination = ParentStruct->ContainerPtrToValuePtr<void>(Object, ArrayIndex);
 
@@ -29,7 +30,7 @@ bool FSpatialNetDeltaSerializeInfo::DeltaSerializeRead(USpatialNetDriver* NetDri
 	return CppStructOps->NetDeltaSerialize(NetDeltaInfo, Destination);
 }
 
-bool FSpatialNetDeltaSerializeInfo::DeltaSerializeWrite(USpatialNetDriver* NetDriver, FSpatialNetBitWriter& Writer, UObject* Object, int32 ArrayIndex, UProperty* ParentProperty, UScriptStruct* NetDeltaStruct)
+bool FSpatialNetDeltaSerializeInfo::DeltaSerializeWrite(USpatialNetDriver* NetDriver, FSpatialNetBitWriter& Writer, UObject* Object, int32 ArrayIndex, GDK_PROPERTY(Property)* ParentProperty, UScriptStruct* NetDeltaStruct)
 {
 	FSpatialNetDeltaSerializeInfo NetDeltaInfo;
 
@@ -40,7 +41,7 @@ bool FSpatialNetDeltaSerializeInfo::DeltaSerializeWrite(USpatialNetDriver* NetDr
 	NetDeltaInfo.NetSerializeCB = &SerializeCB;
 	NetDeltaInfo.Object = Object;
 
-	UStructProperty* ParentStruct = Cast<UStructProperty>(ParentProperty);
+	GDK_PROPERTY(StructProperty)* ParentStruct = GDK_CASTFIELD<GDK_PROPERTY(StructProperty)>(ParentProperty);
 	check(ParentStruct);
 	void* Source = ParentStruct->ContainerPtrToValuePtr<void>(Object, ArrayIndex);
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -40,6 +40,7 @@
 #include "Utils/ComponentFactory.h"
 #include "Utils/EntityPool.h"
 #include "Utils/ErrorCodeRemapping.h"
+#include "Utils/GDKPropertyMacros.h"
 #include "Utils/InterestFactory.h"
 #include "Utils/OpUtils.h"
 #include "Utils/SpatialDebugger.h"
@@ -1693,7 +1694,7 @@ void USpatialNetDriver::ProcessRemoteFunction(
 	{
 		// Look for CPF_OutParm's, we'll need to copy these into the local parameter memory manually
 		// The receiving side will pull these back out when needed
-		for (TFieldIterator<UProperty> It(Function); It && (It->PropertyFlags & (CPF_Parm | CPF_ReturnParm)) == CPF_Parm; ++It)
+		for (TFieldIterator<GDK_PROPERTY(Property)> It(Function); It && (It->PropertyFlags & (CPF_Parm | CPF_ReturnParm)) == CPF_Parm; ++It)
 		{
 			if (It->HasAnyPropertyFlags(CPF_OutParm))
 			{
@@ -2070,9 +2071,9 @@ bool USpatialNetDriver::HandleNetDumpCrossServerRPCCommand(const TCHAR* Cmd, FOu
 
 				const FFieldNetCache * FieldCache = ClassCache->GetFromField(Function);
 
-				TArray< UProperty * > Parms;
+				TArray< GDK_PROPERTY(Property) * > Parms;
 
-				for (TFieldIterator<UProperty> It(Function); It && (It->PropertyFlags & (CPF_Parm | CPF_ReturnParm)) == CPF_Parm; ++It)
+				for (TFieldIterator<GDK_PROPERTY(Property)> It(Function); It && (It->PropertyFlags & (CPF_Parm | CPF_ReturnParm)) == CPF_Parm; ++It)
 				{
 					Parms.Add(*It);
 				}
@@ -2087,9 +2088,9 @@ bool USpatialNetDriver::HandleNetDumpCrossServerRPCCommand(const TCHAR* Cmd, FOu
 
 				for (int32 j = 0; j < Parms.Num(); j++)
 				{
-					if (Cast<UStructProperty>(Parms[j]))
+					if (GDK_CASTFIELD<GDK_PROPERTY(StructProperty)>(Parms[j]))
 					{
-						ParmString += Cast<UStructProperty>(Parms[j])->Struct->GetName();
+						ParmString += GDK_CASTFIELD<GDK_PROPERTY(StructProperty)>(Parms[j])->Struct->GetName();
 					}
 					else
 					{

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
@@ -19,6 +19,7 @@
 #include "EngineClasses/SpatialPackageMapClient.h"
 #include "EngineClasses/SpatialWorldSettings.h"
 #include "LoadBalancing/AbstractLBStrategy.h"
+#include "Utils/GDKPropertyMacros.h"
 #include "Utils/RepLayoutUtils.h"
 
 DEFINE_LOG_CATEGORY(LogSpatialClassInfoManager);
@@ -137,9 +138,9 @@ void USpatialClassInfoManager::CreateClassInfoForClass(UClass* Class)
 	}
 
 	const bool bTrackHandoverProperties = ShouldTrackHandoverProperties();
-	for (TFieldIterator<UProperty> PropertyIt(Class); PropertyIt; ++PropertyIt)
+	for (TFieldIterator<GDK_PROPERTY(Property)> PropertyIt(Class); PropertyIt; ++PropertyIt)
 	{
-		UProperty* Property = *PropertyIt;
+		GDK_PROPERTY(Property)* Property = *PropertyIt;
 
 		if (bTrackHandoverProperties && (Property->PropertyFlags & CPF_Handover))
 		{

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -5,7 +5,9 @@
 #include "Improbable/SpatialEngineConstants.h"
 #include "Misc/MessageDialog.h"
 #include "Misc/CommandLine.h"
+
 #include "SpatialConstants.h"
+#include "Utils/GDKPropertyMacros.h"
 
 #if WITH_EDITOR
 #include "HAL/PlatformFilemanager.h"
@@ -153,7 +155,7 @@ void USpatialGDKSettings::PostEditChangeProperty(struct FPropertyChangedEvent& P
 	}
 }
 
-bool USpatialGDKSettings::CanEditChange(const UProperty* InProperty) const
+bool USpatialGDKSettings::CanEditChange(const GDK_PROPERTY(Property)* InProperty) const
 {
 	if (!InProperty)
 	{
@@ -226,7 +228,7 @@ void USpatialGDKSettings::SetServicesRegion(EServicesRegion::Type NewRegion)
 	ServicesRegion = NewRegion;
 
 	// Save in default config so this applies for other platforms e.g. Linux, Android.
-	UProperty* ServicesRegionProperty = USpatialGDKSettings::StaticClass()->FindPropertyByName(FName("ServicesRegion"));
+	GDK_PROPERTY(Property)* ServicesRegionProperty = USpatialGDKSettings::StaticClass()->FindPropertyByName(FName("ServicesRegion"));
 	UpdateSinglePropertyInConfigFile(ServicesRegionProperty, GetDefaultConfigFilename());
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
@@ -245,17 +245,17 @@ void ComponentFactory::AddProperty(Schema_Object* Object, Schema_FieldId FieldId
 	{
 		Schema_AddUint32(Object, FieldId, (uint32)ByteProperty->GetPropertyValue(Data));
 	}
-	else if (GDK_PROPERTY(UInt16Property)* GDK_PROPERTY(Int16Property) = GDK_CASTFIELD<GDK_PROPERTY(UInt16Property)>(Property))
+	else if (GDK_PROPERTY(UInt16Property)* UInt16Property = GDK_CASTFIELD<GDK_PROPERTY(UInt16Property)>(Property))
 	{
-		Schema_AddUint32(Object, FieldId, (uint32)GDK_PROPERTY(Int16Property)->GetPropertyValue(Data));
+		Schema_AddUint32(Object, FieldId, (uint32)UInt16Property->GetPropertyValue(Data));
 	}
-	else if (GDK_PROPERTY(UInt32Property)* GDK_PROPERTY(Int32Property) = GDK_CASTFIELD<GDK_PROPERTY(UInt32Property)>(Property))
+	else if (GDK_PROPERTY(UInt32Property)* UInt32Property = GDK_CASTFIELD<GDK_PROPERTY(UInt32Property)>(Property))
 	{
-		Schema_AddUint32(Object, FieldId, GDK_PROPERTY(Int32Property)->GetPropertyValue(Data));
+		Schema_AddUint32(Object, FieldId, UInt32Property->GetPropertyValue(Data));
 	}
-	else if (GDK_PROPERTY(UInt64Property)* GDK_PROPERTY(Int64Property) = GDK_CASTFIELD<GDK_PROPERTY(UInt64Property)>(Property))
+	else if (GDK_PROPERTY(UInt64Property)* UInt64Property = GDK_CASTFIELD<GDK_PROPERTY(UInt64Property)>(Property))
 	{
-		Schema_AddUint64(Object, FieldId, GDK_PROPERTY(Int64Property)->GetPropertyValue(Data));
+		Schema_AddUint64(Object, FieldId, UInt64Property->GetPropertyValue(Data));
 	}
 	else if (GDK_PROPERTY(ObjectPropertyBase)* ObjectProperty = GDK_CASTFIELD<GDK_PROPERTY(ObjectPropertyBase)>(Property))
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
@@ -14,6 +14,7 @@
 #include "Net/NetworkProfiler.h"
 #include "Schema/Interest.h"
 #include "SpatialConstants.h"
+#include "Utils/GDKPropertyMacros.h"
 #include "Utils/InterestFactory.h"
 #include "Utils/RepLayoutUtils.h"
 #include "Utils/SpatialLatencyTracer.h"
@@ -96,7 +97,7 @@ uint32 ComponentFactory::FillSchemaObject(Schema_Object* ComponentObject, UObjec
 
 				if (Cmd.Type == ERepLayoutCmdType::DynamicArray)
 				{
-					UArrayProperty* ArrayProperty = Cast<UArrayProperty>(Cmd.Property);
+					GDK_PROPERTY(ArrayProperty)* ArrayProperty = GDK_CASTFIELD<GDK_PROPERTY(ArrayProperty)>(Cmd.Property);
 
 					// Check if this is a FastArraySerializer array and if so, call our custom delta serialization
 					if (UScriptStruct* NetDeltaStruct = GetFastArraySerializerProperty(ArrayProperty))
@@ -178,9 +179,9 @@ uint32 ComponentFactory::FillHandoverSchemaObject(Schema_Object* ComponentObject
 	return BytesEnd - BytesStart;
 }
 
-void ComponentFactory::AddProperty(Schema_Object* Object, Schema_FieldId FieldId, UProperty* Property, const uint8* Data, TArray<Schema_FieldId>* ClearedIds)
+void ComponentFactory::AddProperty(Schema_Object* Object, Schema_FieldId FieldId, GDK_PROPERTY(Property)* Property, const uint8* Data, TArray<Schema_FieldId>* ClearedIds)
 {
-	if (UStructProperty* StructProperty = Cast<UStructProperty>(Property))
+	if (GDK_PROPERTY(StructProperty)* StructProperty = GDK_CASTFIELD<GDK_PROPERTY(StructProperty)>(Property))
 	{
 		UScriptStruct* Struct = StructProperty->Struct;
 		FSpatialNetBitWriter ValueDataWriter(PackageMap);
@@ -212,53 +213,53 @@ void ComponentFactory::AddProperty(Schema_Object* Object, Schema_FieldId FieldId
 
 		AddBytesToSchema(Object, FieldId, ValueDataWriter);
 	}
-	else if (UBoolProperty* BoolProperty = Cast<UBoolProperty>(Property))
+	else if (GDK_PROPERTY(BoolProperty)* BoolProperty = GDK_CASTFIELD<GDK_PROPERTY(BoolProperty)>(Property))
 	{
 		Schema_AddBool(Object, FieldId, (uint8)BoolProperty->GetPropertyValue(Data));
 	}
-	else if (UFloatProperty* FloatProperty = Cast<UFloatProperty>(Property))
+	else if (GDK_PROPERTY(FloatProperty)* FloatProperty = GDK_CASTFIELD<GDK_PROPERTY(FloatProperty)>(Property))
 	{
 		Schema_AddFloat(Object, FieldId, FloatProperty->GetPropertyValue(Data));
 	}
-	else if (UDoubleProperty* DoubleProperty = Cast<UDoubleProperty>(Property))
+	else if (GDK_PROPERTY(DoubleProperty)* DoubleProperty = GDK_CASTFIELD<GDK_PROPERTY(DoubleProperty)>(Property))
 	{
 		Schema_AddDouble(Object, FieldId, DoubleProperty->GetPropertyValue(Data));
 	}
-	else if (UInt8Property* Int8Property = Cast<UInt8Property>(Property))
+	else if (GDK_PROPERTY(Int8Property)* Int8Property = GDK_CASTFIELD<GDK_PROPERTY(Int8Property)>(Property))
 	{
 		Schema_AddInt32(Object, FieldId, (int32)Int8Property->GetPropertyValue(Data));
 	}
-	else if (UInt16Property* Int16Property = Cast<UInt16Property>(Property))
+	else if (GDK_PROPERTY(Int16Property)* Int16Property = GDK_CASTFIELD<GDK_PROPERTY(Int16Property)>(Property))
 	{
 		Schema_AddInt32(Object, FieldId, (int32)Int16Property->GetPropertyValue(Data));
 	}
-	else if (UIntProperty* IntProperty = Cast<UIntProperty>(Property))
+	else if (GDK_PROPERTY(IntProperty)* IntProperty = GDK_CASTFIELD<GDK_PROPERTY(IntProperty)>(Property))
 	{
 		Schema_AddInt32(Object, FieldId, IntProperty->GetPropertyValue(Data));
 	}
-	else if (UInt64Property* Int64Property = Cast<UInt64Property>(Property))
+	else if (GDK_PROPERTY(Int64Property)* Int64Property = GDK_CASTFIELD<GDK_PROPERTY(Int64Property)>(Property))
 	{
 		Schema_AddInt64(Object, FieldId, Int64Property->GetPropertyValue(Data));
 	}
-	else if (UByteProperty* ByteProperty = Cast<UByteProperty>(Property))
+	else if (GDK_PROPERTY(ByteProperty)* ByteProperty = GDK_CASTFIELD<GDK_PROPERTY(ByteProperty)>(Property))
 	{
 		Schema_AddUint32(Object, FieldId, (uint32)ByteProperty->GetPropertyValue(Data));
 	}
-	else if (UUInt16Property* UInt16Property = Cast<UUInt16Property>(Property))
+	else if (GDK_PROPERTY(UInt16Property)* GDK_PROPERTY(Int16Property) = GDK_CASTFIELD<GDK_PROPERTY(UInt16Property)>(Property))
 	{
-		Schema_AddUint32(Object, FieldId, (uint32)UInt16Property->GetPropertyValue(Data));
+		Schema_AddUint32(Object, FieldId, (uint32)GDK_PROPERTY(Int16Property)->GetPropertyValue(Data));
 	}
-	else if (UUInt32Property* UInt32Property = Cast<UUInt32Property>(Property))
+	else if (GDK_PROPERTY(UInt32Property)* GDK_PROPERTY(Int32Property) = GDK_CASTFIELD<GDK_PROPERTY(UInt32Property)>(Property))
 	{
-		Schema_AddUint32(Object, FieldId, UInt32Property->GetPropertyValue(Data));
+		Schema_AddUint32(Object, FieldId, GDK_PROPERTY(Int32Property)->GetPropertyValue(Data));
 	}
-	else if (UUInt64Property* UInt64Property = Cast<UUInt64Property>(Property))
+	else if (GDK_PROPERTY(UInt64Property)* GDK_PROPERTY(Int64Property) = GDK_CASTFIELD<GDK_PROPERTY(UInt64Property)>(Property))
 	{
-		Schema_AddUint64(Object, FieldId, UInt64Property->GetPropertyValue(Data));
+		Schema_AddUint64(Object, FieldId, GDK_PROPERTY(Int64Property)->GetPropertyValue(Data));
 	}
-	else if (UObjectPropertyBase* ObjectProperty = Cast<UObjectPropertyBase>(Property))
+	else if (GDK_PROPERTY(ObjectPropertyBase)* ObjectProperty = GDK_CASTFIELD<GDK_PROPERTY(ObjectPropertyBase)>(Property))
 	{
-		if (Cast<USoftObjectProperty>(Property))
+		if (GDK_CASTFIELD<GDK_PROPERTY(SoftObjectProperty)>(Property))
 		{
 			const FSoftObjectPtr* ObjectPtr = reinterpret_cast<const FSoftObjectPtr*>(Data);
 
@@ -275,19 +276,19 @@ void ComponentFactory::AddProperty(Schema_Object* Object, Schema_FieldId FieldId
 			AddObjectRefToSchema(Object, FieldId, FUnrealObjectRef::FromObjectPtr(ObjectValue, PackageMap));
 		}
 	}
-	else if (UNameProperty* NameProperty = Cast<UNameProperty>(Property))
+	else if (GDK_PROPERTY(NameProperty)* NameProperty = GDK_CASTFIELD<GDK_PROPERTY(NameProperty)>(Property))
 	{
 		AddStringToSchema(Object, FieldId, NameProperty->GetPropertyValue(Data).ToString());
 	}
-	else if (UStrProperty* StrProperty = Cast<UStrProperty>(Property))
+	else if (GDK_PROPERTY(StrProperty)* StrProperty = GDK_CASTFIELD<GDK_PROPERTY(StrProperty)>(Property))
 	{
 		AddStringToSchema(Object, FieldId, StrProperty->GetPropertyValue(Data));
 	}
-	else if (UTextProperty* TextProperty = Cast<UTextProperty>(Property))
+	else if (GDK_PROPERTY(TextProperty)* TextProperty = GDK_CASTFIELD<GDK_PROPERTY(TextProperty)>(Property))
 	{
 		AddStringToSchema(Object, FieldId, TextProperty->GetPropertyValue(Data).ToString());
 	}
-	else if (UArrayProperty* ArrayProperty = Cast<UArrayProperty>(Property))
+	else if (GDK_PROPERTY(ArrayProperty)* ArrayProperty = GDK_CASTFIELD<GDK_PROPERTY(ArrayProperty)>(Property))
 	{
 		FScriptArrayHelper ArrayHelper(ArrayProperty, Data);
 		for (int i = 0; i < ArrayHelper.Num(); i++)
@@ -300,7 +301,7 @@ void ComponentFactory::AddProperty(Schema_Object* Object, Schema_FieldId FieldId
 			ClearedIds->Add(FieldId);
 		}
 	}
-	else if (UEnumProperty* EnumProperty = Cast<UEnumProperty>(Property))
+	else if (GDK_PROPERTY(EnumProperty)* EnumProperty = GDK_CASTFIELD<GDK_PROPERTY(EnumProperty)>(Property))
 	{
 		if (EnumProperty->ElementSize < 4)
 		{
@@ -311,15 +312,15 @@ void ComponentFactory::AddProperty(Schema_Object* Object, Schema_FieldId FieldId
 			AddProperty(Object, FieldId, EnumProperty->GetUnderlyingProperty(), Data, ClearedIds);
 		}
 	}
-	else if (Property->IsA<UDelegateProperty>() || Property->IsA<UMulticastDelegateProperty>() || Property->IsA<UInterfaceProperty>())
+	else if (Property->IsA<GDK_PROPERTY(DelegateProperty)>() || Property->IsA<GDK_PROPERTY(MulticastDelegateProperty)>() || Property->IsA<GDK_PROPERTY(InterfaceProperty)>())
 	{
 		// These properties can be set to replicate, but won't serialize across the network.
 	}
-	else if (Property->IsA<UMapProperty>())
+	else if (Property->IsA<GDK_PROPERTY(MapProperty)>())
 	{
 		UE_LOG(LogComponentFactory, Error, TEXT("Class %s with name %s in field %d: Replicated TMaps are not supported."), *Property->GetClass()->GetName(), *Property->GetName(), FieldId);
 	}
-	else if (Property->IsA<USetProperty>())
+	else if (Property->IsA<GDK_PROPERTY(SetProperty)>())
 	{
 		UE_LOG(LogComponentFactory, Error, TEXT("Class %s with name %s in field %d: Replicated TSets are not supported."), *Property->GetClass()->GetName(), *Property->GetName(), FieldId);
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
@@ -405,17 +405,17 @@ void ComponentReader::ApplyProperty(Schema_Object* Object, Schema_FieldId FieldI
 	{
 		ByteProperty->SetPropertyValue(Data, (uint8)Schema_IndexUint32(Object, FieldId, Index));
 	}
-	else if (GDK_PROPERTY(UInt16Property)* GDK_PROPERTY(Int16Property) = GDK_CASTFIELD<GDK_PROPERTY(UInt16Property)>(Property))
+	else if (GDK_PROPERTY(UInt16Property)* UInt16Property = GDK_CASTFIELD<GDK_PROPERTY(UInt16Property)>(Property))
 	{
-		GDK_PROPERTY(Int16Property)->SetPropertyValue(Data, (uint16)Schema_IndexUint32(Object, FieldId, Index));
+		UInt16Property->SetPropertyValue(Data, (uint16)Schema_IndexUint32(Object, FieldId, Index));
 	}
-	else if (GDK_PROPERTY(UInt32Property)* GDK_PROPERTY(Int32Property) = GDK_CASTFIELD<GDK_PROPERTY(UInt32Property)>(Property))
+	else if (GDK_PROPERTY(UInt32Property)* UInt32Property = GDK_CASTFIELD<GDK_PROPERTY(UInt32Property)>(Property))
 	{
-		GDK_PROPERTY(Int32Property)->SetPropertyValue(Data, Schema_IndexUint32(Object, FieldId, Index));
+		UInt32Property->SetPropertyValue(Data, Schema_IndexUint32(Object, FieldId, Index));
 	}
-	else if (GDK_PROPERTY(UInt64Property)* GDK_PROPERTY(Int64Property) = GDK_CASTFIELD<GDK_PROPERTY(UInt64Property)>(Property))
+	else if (GDK_PROPERTY(UInt64Property)* UInt64Property = GDK_CASTFIELD<GDK_PROPERTY(UInt64Property)>(Property))
 	{
-		GDK_PROPERTY(Int64Property)->SetPropertyValue(Data, Schema_IndexUint64(Object, FieldId, Index));
+		UInt64Property->SetPropertyValue(Data, Schema_IndexUint64(Object, FieldId, Index));
 	}
 	else if (GDK_PROPERTY(ObjectPropertyBase)* ObjectProperty = GDK_CASTFIELD<GDK_PROPERTY(ObjectPropertyBase)>(Property))
 	{
@@ -575,15 +575,15 @@ uint32 ComponentReader::GetPropertyCount(const Schema_Object* Object, Schema_Fie
 	{
 		return Schema_GetUint32Count(Object, FieldId);
 	}
-	else if (GDK_PROPERTY(UInt16Property)* GDK_PROPERTY(Int16Property) = GDK_CASTFIELD<GDK_PROPERTY(UInt16Property)>(Property))
+	else if (GDK_PROPERTY(UInt16Property)* UInt16Property = GDK_CASTFIELD<GDK_PROPERTY(UInt16Property)>(Property))
 	{
 		return Schema_GetUint32Count(Object, FieldId);
 	}
-	else if (GDK_PROPERTY(UInt32Property)* GDK_PROPERTY(Int32Property) = GDK_CASTFIELD<GDK_PROPERTY(UInt32Property)>(Property))
+	else if (GDK_PROPERTY(UInt32Property)* UInt32Property = GDK_CASTFIELD<GDK_PROPERTY(UInt32Property)>(Property))
 	{
 		return Schema_GetUint32Count(Object, FieldId);
 	}
-	else if (GDK_PROPERTY(UInt64Property)* GDK_PROPERTY(Int64Property) = GDK_CASTFIELD<GDK_PROPERTY(UInt64Property)>(Property))
+	else if (GDK_PROPERTY(UInt64Property)* UInt64Property = GDK_CASTFIELD<GDK_PROPERTY(UInt64Property)>(Property))
 	{
 		return Schema_GetUint64Count(Object, FieldId);
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
@@ -11,8 +11,9 @@
 #include "EngineClasses/SpatialNetBitReader.h"
 #include "Interop/SpatialConditionMapFilter.h"
 #include "SpatialConstants.h"
-#include "Utils/SchemaUtils.h"
+#include "Utils/GDKPropertyMacros.h"
 #include "Utils/RepLayoutUtils.h"
+#include "Utils/SchemaUtils.h"
 
 DEFINE_LOG_CATEGORY(LogSpatialComponentReader);
 
@@ -170,7 +171,7 @@ void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject&
 
 	FSpatialConditionMapFilter ConditionMap(&Channel, bIsClient);
 
-	TArray<UProperty*> RepNotifies;
+	TArray<GDK_PROPERTY(Property)*> RepNotifies;
 
 	{
 		// Scoped to exclude OnRep callbacks which are already tracked per OnRep function
@@ -213,7 +214,7 @@ void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject&
 
 				if (Cmd.Type == ERepLayoutCmdType::DynamicArray)
 				{
-					UArrayProperty* ArrayProperty = Cast<UArrayProperty>(Cmd.Property);
+					GDK_PROPERTY(ArrayProperty)* ArrayProperty = GDK_CASTFIELD<GDK_PROPERTY(ArrayProperty)>(Cmd.Property);
 					if (ArrayProperty == nullptr)
 					{
 						UE_LOG(LogSpatialComponentReader, Error, TEXT("Failed to apply Schema Object %s. One of it's properties is null"), *Object.GetName());
@@ -266,7 +267,7 @@ void ComponentReader::ApplySchemaObject(Schema_Object* ComponentObject, UObject&
 				{
 					// Downgrade role from AutonomousProxy to SimulatedProxy if we aren't authoritative over
 					// the client RPCs component.
-					UByteProperty* ByteProperty = Cast<UByteProperty>(Cmd.Property);
+					GDK_PROPERTY(ByteProperty)* ByteProperty = GDK_CASTFIELD<GDK_PROPERTY(ByteProperty)>(Cmd.Property);
 					if (!bIsAuthServer && !bAutonomousProxy && ByteProperty->GetPropertyValue(Data) == ROLE_AutonomousProxy)
 					{
 						ByteProperty->SetPropertyValue(Data, ROLE_SimulatedProxy);
@@ -328,7 +329,7 @@ void ComponentReader::ApplyHandoverSchemaObject(Schema_Object* ComponentObject, 
 
 		uint8* Data = (uint8*)&Object + PropertyInfo.Offset;
 
-		if (UArrayProperty* ArrayProperty = Cast<UArrayProperty>(PropertyInfo.Property))
+		if (GDK_PROPERTY(ArrayProperty)* ArrayProperty = GDK_CASTFIELD<GDK_PROPERTY(ArrayProperty)>(PropertyInfo.Property))
 		{
 			ApplyArray(ComponentObject, FieldId, RootObjectReferencesMap, ArrayProperty, Data, PropertyInfo.Offset, -1, -1, bOutReferencesChanged);
 		}
@@ -338,14 +339,14 @@ void ComponentReader::ApplyHandoverSchemaObject(Schema_Object* ComponentObject, 
 		}
 	}
 
-	Channel.PostReceiveSpatialUpdate(&Object, TArray<UProperty*>());
+	Channel.PostReceiveSpatialUpdate(&Object, TArray<GDK_PROPERTY(Property)*>());
 }
 
-void ComponentReader::ApplyProperty(Schema_Object* Object, Schema_FieldId FieldId, FObjectReferencesMap& InObjectReferencesMap, uint32 Index, UProperty* Property, uint8* Data, int32 Offset, int32 ShadowOffset, int32 ParentIndex, bool& bOutReferencesChanged)
+void ComponentReader::ApplyProperty(Schema_Object* Object, Schema_FieldId FieldId, FObjectReferencesMap& InObjectReferencesMap, uint32 Index, GDK_PROPERTY(Property)* Property, uint8* Data, int32 Offset, int32 ShadowOffset, int32 ParentIndex, bool& bOutReferencesChanged)
 {
 	SCOPE_CYCLE_COUNTER(STAT_ReaderApplyProperty);
 
-	if (UStructProperty* StructProperty = Cast<UStructProperty>(Property))
+	if (GDK_PROPERTY(StructProperty)* StructProperty = GDK_CASTFIELD<GDK_PROPERTY(StructProperty)>(Property))
 	{
 		TArray<uint8> ValueData = IndexBytesFromSchema(Object, FieldId, Index);
 		// A bit hacky, we should probably include the number of bits with the data instead.
@@ -372,56 +373,56 @@ void ComponentReader::ApplyProperty(Schema_Object* Object, Schema_FieldId FieldI
 			bOutReferencesChanged = true;
 		}
 	}
-	else if (UBoolProperty* BoolProperty = Cast<UBoolProperty>(Property))
+	else if (GDK_PROPERTY(BoolProperty)* BoolProperty = GDK_CASTFIELD<GDK_PROPERTY(BoolProperty)>(Property))
 	{
 		BoolProperty->SetPropertyValue(Data, Schema_IndexBool(Object, FieldId, Index) != 0);
 	}
-	else if (UFloatProperty* FloatProperty = Cast<UFloatProperty>(Property))
+	else if (GDK_PROPERTY(FloatProperty)* FloatProperty = GDK_CASTFIELD<GDK_PROPERTY(FloatProperty)>(Property))
 	{
 		FloatProperty->SetPropertyValue(Data, Schema_IndexFloat(Object, FieldId, Index));
 	}
-	else if (UDoubleProperty* DoubleProperty = Cast<UDoubleProperty>(Property))
+	else if (GDK_PROPERTY(DoubleProperty)* DoubleProperty = GDK_CASTFIELD<GDK_PROPERTY(DoubleProperty)>(Property))
 	{
 		DoubleProperty->SetPropertyValue(Data, Schema_IndexDouble(Object, FieldId, Index));
 	}
-	else if (UInt8Property* Int8Property = Cast<UInt8Property>(Property))
+	else if (GDK_PROPERTY(Int8Property)* Int8Property = GDK_CASTFIELD<GDK_PROPERTY(Int8Property)>(Property))
 	{
 		Int8Property->SetPropertyValue(Data, (int8)Schema_IndexInt32(Object, FieldId, Index));
 	}
-	else if (UInt16Property* Int16Property = Cast<UInt16Property>(Property))
+	else if (GDK_PROPERTY(Int16Property)* Int16Property = GDK_CASTFIELD<GDK_PROPERTY(Int16Property)>(Property))
 	{
 		Int16Property->SetPropertyValue(Data, (int16)Schema_IndexInt32(Object, FieldId, Index));
 	}
-	else if (UIntProperty* IntProperty = Cast<UIntProperty>(Property))
+	else if (GDK_PROPERTY(IntProperty)* IntProperty = GDK_CASTFIELD<GDK_PROPERTY(IntProperty)>(Property))
 	{
 		IntProperty->SetPropertyValue(Data, Schema_IndexInt32(Object, FieldId, Index));
 	}
-	else if (UInt64Property* Int64Property = Cast<UInt64Property>(Property))
+	else if (GDK_PROPERTY(Int64Property)* Int64Property = GDK_CASTFIELD<GDK_PROPERTY(Int64Property)>(Property))
 	{
 		Int64Property->SetPropertyValue(Data, Schema_IndexInt64(Object, FieldId, Index));
 	}
-	else if (UByteProperty* ByteProperty = Cast<UByteProperty>(Property))
+	else if (GDK_PROPERTY(ByteProperty)* ByteProperty = GDK_CASTFIELD<GDK_PROPERTY(ByteProperty)>(Property))
 	{
 		ByteProperty->SetPropertyValue(Data, (uint8)Schema_IndexUint32(Object, FieldId, Index));
 	}
-	else if (UUInt16Property* UInt16Property = Cast<UUInt16Property>(Property))
+	else if (GDK_PROPERTY(UInt16Property)* GDK_PROPERTY(Int16Property) = GDK_CASTFIELD<GDK_PROPERTY(UInt16Property)>(Property))
 	{
-		UInt16Property->SetPropertyValue(Data, (uint16)Schema_IndexUint32(Object, FieldId, Index));
+		GDK_PROPERTY(Int16Property)->SetPropertyValue(Data, (uint16)Schema_IndexUint32(Object, FieldId, Index));
 	}
-	else if (UUInt32Property* UInt32Property = Cast<UUInt32Property>(Property))
+	else if (GDK_PROPERTY(UInt32Property)* GDK_PROPERTY(Int32Property) = GDK_CASTFIELD<GDK_PROPERTY(UInt32Property)>(Property))
 	{
-		UInt32Property->SetPropertyValue(Data, Schema_IndexUint32(Object, FieldId, Index));
+		GDK_PROPERTY(Int32Property)->SetPropertyValue(Data, Schema_IndexUint32(Object, FieldId, Index));
 	}
-	else if (UUInt64Property* UInt64Property = Cast<UUInt64Property>(Property))
+	else if (GDK_PROPERTY(UInt64Property)* GDK_PROPERTY(Int64Property) = GDK_CASTFIELD<GDK_PROPERTY(UInt64Property)>(Property))
 	{
-		UInt64Property->SetPropertyValue(Data, Schema_IndexUint64(Object, FieldId, Index));
+		GDK_PROPERTY(Int64Property)->SetPropertyValue(Data, Schema_IndexUint64(Object, FieldId, Index));
 	}
-	else if (UObjectPropertyBase* ObjectProperty = Cast<UObjectPropertyBase>(Property))
+	else if (GDK_PROPERTY(ObjectPropertyBase)* ObjectProperty = GDK_CASTFIELD<GDK_PROPERTY(ObjectPropertyBase)>(Property))
 	{
 		FUnrealObjectRef ObjectRef = IndexObjectRefFromSchema(Object, FieldId, Index);
 		check(ObjectRef != FUnrealObjectRef::UNRESOLVED_OBJECT_REF);
 
-		if (Cast<USoftObjectProperty>(Property))
+		if (GDK_CASTFIELD<GDK_PROPERTY(SoftObjectProperty)>(Property))
 		{
 			FSoftObjectPtr* ObjectPtr = reinterpret_cast<FSoftObjectPtr*>(Data);
 			*ObjectPtr = FUnrealObjectRef::ToSoftObjectPath(ObjectRef);
@@ -455,19 +456,19 @@ void ComponentReader::ApplyProperty(Schema_Object* Object, Schema_FieldId FieldI
 			}
 		}
 	}
-	else if (UNameProperty* NameProperty = Cast<UNameProperty>(Property))
+	else if (GDK_PROPERTY(NameProperty)* NameProperty = GDK_CASTFIELD<GDK_PROPERTY(NameProperty)>(Property))
 	{
 		NameProperty->SetPropertyValue(Data, FName(*IndexStringFromSchema(Object, FieldId, Index)));
 	}
-	else if (UStrProperty* StrProperty = Cast<UStrProperty>(Property))
+	else if (GDK_PROPERTY(StrProperty)* StrProperty = GDK_CASTFIELD<GDK_PROPERTY(StrProperty)>(Property))
 	{
 		StrProperty->SetPropertyValue(Data, IndexStringFromSchema(Object, FieldId, Index));
 	}
-	else if (UTextProperty* TextProperty = Cast<UTextProperty>(Property))
+	else if (GDK_PROPERTY(TextProperty)* TextProperty = GDK_CASTFIELD<GDK_PROPERTY(TextProperty)>(Property))
 	{
 		TextProperty->SetPropertyValue(Data, FText::FromString(IndexStringFromSchema(Object, FieldId, Index)));
 	}
-	else if (UEnumProperty* EnumProperty = Cast<UEnumProperty>(Property))
+	else if (GDK_PROPERTY(EnumProperty)* EnumProperty = GDK_CASTFIELD<GDK_PROPERTY(EnumProperty)>(Property))
 	{
 		if (EnumProperty->ElementSize < 4)
 		{
@@ -484,7 +485,7 @@ void ComponentReader::ApplyProperty(Schema_Object* Object, Schema_FieldId FieldI
 	}
 }
 
-void ComponentReader::ApplyArray(Schema_Object* Object, Schema_FieldId FieldId, FObjectReferencesMap& InObjectReferencesMap, UArrayProperty* Property, uint8* Data, int32 Offset, int32 ShadowOffset, int32 ParentIndex, bool& bOutReferencesChanged)
+void ComponentReader::ApplyArray(Schema_Object* Object, Schema_FieldId FieldId, FObjectReferencesMap& InObjectReferencesMap, GDK_PROPERTY(ArrayProperty)* Property, uint8* Data, int32 Offset, int32 ShadowOffset, int32 ParentIndex, bool& bOutReferencesChanged)
 {
 	SCOPE_CYCLE_COUNTER(STAT_ReaderApplyArray);
 
@@ -536,77 +537,77 @@ void ComponentReader::ApplyArray(Schema_Object* Object, Schema_FieldId FieldId, 
 	}
 }
 
-uint32 ComponentReader::GetPropertyCount(const Schema_Object* Object, Schema_FieldId FieldId, UProperty* Property)
+uint32 ComponentReader::GetPropertyCount(const Schema_Object* Object, Schema_FieldId FieldId, GDK_PROPERTY(Property)* Property)
 {
-	if (UStructProperty* StructProperty = Cast<UStructProperty>(Property))
+	if (GDK_PROPERTY(StructProperty)* StructProperty = GDK_CASTFIELD<GDK_PROPERTY(StructProperty)>(Property))
 	{
 		return Schema_GetBytesCount(Object, FieldId);
 	}
-	else if (UBoolProperty* BoolProperty = Cast<UBoolProperty>(Property))
+	else if (GDK_PROPERTY(BoolProperty)* BoolProperty = GDK_CASTFIELD<GDK_PROPERTY(BoolProperty)>(Property))
 	{
 		return Schema_GetBoolCount(Object, FieldId);
 	}
-	else if (UFloatProperty* FloatProperty = Cast<UFloatProperty>(Property))
+	else if (GDK_PROPERTY(FloatProperty)* FloatProperty = GDK_CASTFIELD<GDK_PROPERTY(FloatProperty)>(Property))
 	{
 		return Schema_GetFloatCount(Object, FieldId);
 	}
-	else if (UDoubleProperty* DoubleProperty = Cast<UDoubleProperty>(Property))
+	else if (GDK_PROPERTY(DoubleProperty)* DoubleProperty = GDK_CASTFIELD<GDK_PROPERTY(DoubleProperty)>(Property))
 	{
 		return Schema_GetDoubleCount(Object, FieldId);
 	}
-	else if (UInt8Property* Int8Property = Cast<UInt8Property>(Property))
+	else if (GDK_PROPERTY(Int8Property)* Int8Property = GDK_CASTFIELD<GDK_PROPERTY(Int8Property)>(Property))
 	{
 		return Schema_GetInt32Count(Object, FieldId);
 	}
-	else if (UInt16Property* Int16Property = Cast<UInt16Property>(Property))
+	else if (GDK_PROPERTY(Int16Property)* Int16Property = GDK_CASTFIELD<GDK_PROPERTY(Int16Property)>(Property))
 	{
 		return Schema_GetInt32Count(Object, FieldId);
 	}
-	else if (UIntProperty* IntProperty = Cast<UIntProperty>(Property))
+	else if (GDK_PROPERTY(IntProperty)* IntProperty = GDK_CASTFIELD<GDK_PROPERTY(IntProperty)>(Property))
 	{
 		return Schema_GetInt32Count(Object, FieldId);
 	}
-	else if (UInt64Property* Int64Property = Cast<UInt64Property>(Property))
+	else if (GDK_PROPERTY(Int64Property)* Int64Property = GDK_CASTFIELD<GDK_PROPERTY(Int64Property)>(Property))
 	{
 		return Schema_GetInt64Count(Object, FieldId);
 	}
-	else if (UByteProperty* ByteProperty = Cast<UByteProperty>(Property))
+	else if (GDK_PROPERTY(ByteProperty)* ByteProperty = GDK_CASTFIELD<GDK_PROPERTY(ByteProperty)>(Property))
 	{
 		return Schema_GetUint32Count(Object, FieldId);
 	}
-	else if (UUInt16Property* UInt16Property = Cast<UUInt16Property>(Property))
+	else if (GDK_PROPERTY(UInt16Property)* GDK_PROPERTY(Int16Property) = GDK_CASTFIELD<GDK_PROPERTY(UInt16Property)>(Property))
 	{
 		return Schema_GetUint32Count(Object, FieldId);
 	}
-	else if (UUInt32Property* UInt32Property = Cast<UUInt32Property>(Property))
+	else if (GDK_PROPERTY(UInt32Property)* GDK_PROPERTY(Int32Property) = GDK_CASTFIELD<GDK_PROPERTY(UInt32Property)>(Property))
 	{
 		return Schema_GetUint32Count(Object, FieldId);
 	}
-	else if (UUInt64Property* UInt64Property = Cast<UUInt64Property>(Property))
+	else if (GDK_PROPERTY(UInt64Property)* GDK_PROPERTY(Int64Property) = GDK_CASTFIELD<GDK_PROPERTY(UInt64Property)>(Property))
 	{
 		return Schema_GetUint64Count(Object, FieldId);
 	}
-	else if (UObjectPropertyBase* ObjectProperty = Cast<UObjectPropertyBase>(Property))
+	else if (GDK_PROPERTY(ObjectPropertyBase)* ObjectProperty = GDK_CASTFIELD<GDK_PROPERTY(ObjectPropertyBase)>(Property))
 	{
 		return Schema_GetObjectCount(Object, FieldId);
 	}
-	else if (UNameProperty* NameProperty = Cast<UNameProperty>(Property))
+	else if (GDK_PROPERTY(NameProperty)* NameProperty = GDK_CASTFIELD<GDK_PROPERTY(NameProperty)>(Property))
 	{
 		return Schema_GetBytesCount(Object, FieldId);
 	}
-	else if (UStrProperty* StrProperty = Cast<UStrProperty>(Property))
+	else if (GDK_PROPERTY(StrProperty)* StrProperty = GDK_CASTFIELD<GDK_PROPERTY(StrProperty)>(Property))
 	{
 		return Schema_GetBytesCount(Object, FieldId);
 	}
-	else if (UTextProperty* TextProperty = Cast<UTextProperty>(Property))
+	else if (GDK_PROPERTY(TextProperty)* TextProperty = GDK_CASTFIELD<GDK_PROPERTY(TextProperty)>(Property))
 	{
 		return Schema_GetBytesCount(Object, FieldId);
 	}
-	else if (UArrayProperty* ArrayProperty = Cast<UArrayProperty>(Property))
+	else if (GDK_PROPERTY(ArrayProperty)* ArrayProperty = GDK_CASTFIELD<GDK_PROPERTY(ArrayProperty)>(Property))
 	{
 		return GetPropertyCount(Object, FieldId, ArrayProperty->Inner);
 	}
-	else if (UEnumProperty* EnumProperty = Cast<UEnumProperty>(Property))
+	else if (GDK_PROPERTY(EnumProperty)* EnumProperty = GDK_CASTFIELD<GDK_PROPERTY(EnumProperty)>(Property))
 	{
 		if (EnumProperty->ElementSize < 4)
 		{

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -10,6 +10,7 @@
 #include "LoadBalancing/AbstractLBStrategy.h"
 #include "SpatialConstants.h"
 #include "SpatialGDKSettings.h"
+#include "Utils/GDKPropertyMacros.h"
 #include "Utils/Interest/NetCullDistanceInterest.h"
 
 #include "Engine/World.h"
@@ -449,16 +450,16 @@ QueryConstraint InterestFactory::CreateAlwaysInterestedConstraint(const AActor* 
 	for (const FInterestPropertyInfo& PropertyInfo : InInfo.InterestProperties)
 	{
 		uint8* Data = (uint8*)InActor + PropertyInfo.Offset;
-		if (UObjectPropertyBase* ObjectProperty = Cast<UObjectPropertyBase>(PropertyInfo.Property))
+		if (GDK_PROPERTY(ObjectPropertyBase)* ObjectProperty = GDK_CASTFIELD<GDK_PROPERTY(ObjectPropertyBase)>(PropertyInfo.Property))
 		{
 			AddObjectToConstraint(ObjectProperty, Data, AlwaysInterestedConstraint);
 		}
-		else if (UArrayProperty* ArrayProperty = Cast<UArrayProperty>(PropertyInfo.Property))
+		else if (GDK_PROPERTY(ArrayProperty)* ArrayProperty = GDK_CASTFIELD<GDK_PROPERTY(ArrayProperty)>(PropertyInfo.Property))
 		{
 			FScriptArrayHelper ArrayHelper(ArrayProperty, Data);
 			for (int i = 0; i < ArrayHelper.Num(); i++)
 			{
-				AddObjectToConstraint(Cast<UObjectPropertyBase>(ArrayProperty->Inner), ArrayHelper.GetRawPtr(i), AlwaysInterestedConstraint);
+				AddObjectToConstraint(GDK_CASTFIELD<GDK_PROPERTY(ObjectPropertyBase)>(ArrayProperty->Inner), ArrayHelper.GetRawPtr(i), AlwaysInterestedConstraint);
 			}
 		}
 		else
@@ -525,7 +526,7 @@ QueryConstraint InterestFactory::CreateLevelConstraints(const AActor* InActor) c
 	return LevelConstraint;
 }
 
-void InterestFactory::AddObjectToConstraint(UObjectPropertyBase* Property, uint8* Data, QueryConstraint& OutConstraint) const
+void InterestFactory::AddObjectToConstraint(GDK_PROPERTY(ObjectPropertyBase)* Property, uint8* Data, QueryConstraint& OutConstraint) const
 {
 	UObject* ObjectOfInterest = Property->GetObjectPropertyValue(Data);
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
@@ -7,6 +7,7 @@
 #include "EngineClasses/SpatialGameInstance.h"
 #include "GeneralProjectSettings.h"
 #include "Interop/Connection/OutgoingMessages.h"
+#include "Utils/GDKPropertyMacros.h"
 #include "Utils/SchemaUtils.h"
 
 #include <sstream>
@@ -188,7 +189,7 @@ TraceKey USpatialLatencyTracer::RetrievePendingTrace(const UObject* Obj, const U
 	return ReturnKey;
 }
 
-TraceKey USpatialLatencyTracer::RetrievePendingTrace(const UObject* Obj, const UProperty* Property)
+TraceKey USpatialLatencyTracer::RetrievePendingTrace(const UObject* Obj, const GDK_PROPERTY(Property)* Property)
 {
 	FScopeLock Lock(&Mutex);
 
@@ -499,7 +500,7 @@ bool USpatialLatencyTracer::AddTrackingInfo(const AActor* Actor, const FString& 
 			}
 			break;
 		case ETraceType::Property:
-			if (const UProperty* Property = ActorClass->FindPropertyByName(*Target))
+			if (const GDK_PROPERTY(Property)* Property = ActorClass->FindPropertyByName(*Target))
 			{
 				ActorPropertyKey APKey{ Actor, Property };
 				if (TrackingProperties.Find(APKey) == nullptr)

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -13,6 +13,7 @@
 #include "Schema/RPCPayload.h"
 #include "SpatialCommonTypes.h"
 #include "SpatialGDKSettings.h"
+#include "Utils/GDKPropertyMacros.h"
 #include "Utils/RepDataUtils.h"
 #include "Utils/SpatialStatics.h"
 
@@ -38,7 +39,7 @@ struct FObjectReferences
 		, Property(Other.Property) {}
 
 	// Single property constructor
-	FObjectReferences(const FUnrealObjectRef& InObjectRef, bool bUnresolved, int32 InCmdIndex, int32 InParentIndex, UProperty* InProperty)
+	FObjectReferences(const FUnrealObjectRef& InObjectRef, bool bUnresolved, int32 InCmdIndex, int32 InParentIndex, GDK_PROPERTY(Property)* InProperty)
 		: bSingleProp(true), bFastArrayProp(false), ShadowOffset(InCmdIndex), ParentIndex(InParentIndex), Property(InProperty)
 	{
 		if (bUnresolved)
@@ -52,11 +53,11 @@ struct FObjectReferences
 	}
 
 	// Struct (memory stream) constructor
-	FObjectReferences(const TArray<uint8>& InBuffer, int32 InNumBufferBits, TSet<FUnrealObjectRef>&& InDynamicRefs, TSet<FUnrealObjectRef>&& InUnresolvedRefs, int32 InCmdIndex, int32 InParentIndex, UProperty* InProperty, bool InFastArrayProp = false)
+	FObjectReferences(const TArray<uint8>& InBuffer, int32 InNumBufferBits, TSet<FUnrealObjectRef>&& InDynamicRefs, TSet<FUnrealObjectRef>&& InUnresolvedRefs, int32 InCmdIndex, int32 InParentIndex, GDK_PROPERTY(Property)* InProperty, bool InFastArrayProp = false)
 		: MappedRefs(MoveTemp(InDynamicRefs)), UnresolvedRefs(MoveTemp(InUnresolvedRefs)), bSingleProp(false), bFastArrayProp(InFastArrayProp), Buffer(InBuffer), NumBufferBits(InNumBufferBits), ShadowOffset(InCmdIndex), ParentIndex(InParentIndex), Property(InProperty) {}
 
 	// Array constructor
-	FObjectReferences(FObjectReferencesMap* InArray, int32 InCmdIndex, int32 InParentIndex, UProperty* InProperty)
+	FObjectReferences(FObjectReferencesMap* InArray, int32 InCmdIndex, int32 InParentIndex, GDK_PROPERTY(Property)* InProperty)
 		: bSingleProp(false), bFastArrayProp(false), Array(InArray), ShadowOffset(InCmdIndex), ParentIndex(InParentIndex), Property(InProperty) {}
 
 	TSet<FUnrealObjectRef>				MappedRefs;
@@ -70,7 +71,7 @@ struct FObjectReferences
 	TUniquePtr<FObjectReferencesMap>	Array;
 	int32								ShadowOffset;
 	int32								ParentIndex;
-	UProperty*							Property;
+	GDK_PROPERTY(Property)*							Property;
 };
 
 struct FPendingSubobjectAttachment
@@ -237,11 +238,11 @@ public:
 	bool IsDynamicArrayHandle(UObject* Object, uint16 Handle);
 
 	FObjectReplicator* PreReceiveSpatialUpdate(UObject* TargetObject);
-	void PostReceiveSpatialUpdate(UObject* TargetObject, const TArray<UProperty*>& RepNotifies);
+	void PostReceiveSpatialUpdate(UObject* TargetObject, const TArray<GDK_PROPERTY(Property)*>& RepNotifies);
 
 	void OnCreateEntityResponse(const Worker_CreateEntityResponseOp& Op);
 
-	void RemoveRepNotifiesWithUnresolvedObjs(TArray<UProperty*>& RepNotifies, const FRepLayout& RepLayout, const FObjectReferencesMap& RefMap, UObject* Object);
+	void RemoveRepNotifiesWithUnresolvedObjs(TArray<GDK_PROPERTY(Property)*>& RepNotifies, const FRepLayout& RepLayout, const FObjectReferencesMap& RefMap, UObject* Object);
 
 	void UpdateShadowData();
 	void UpdateSpatialPositionWithFrequencyCheck();

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -71,7 +71,7 @@ struct FObjectReferences
 	TUniquePtr<FObjectReferencesMap>	Array;
 	int32								ShadowOffset;
 	int32								ParentIndex;
-	GDK_PROPERTY(Property)*							Property;
+	GDK_PROPERTY(Property)*				Property;
 };
 
 struct FPendingSubobjectAttachment

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialFastArrayNetSerialize.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialFastArrayNetSerialize.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 
+#include "Utils/GDKPropertyMacros.h"
 #include "Utils/RepLayoutUtils.h"
 
 class FSpatialNetBitReader;
@@ -40,8 +41,8 @@ struct FSpatialNetDeltaSerializeInfo : FNetDeltaSerializeInfo
 		bIsSpatialType = true;
 	}
 
-	static bool DeltaSerializeRead(USpatialNetDriver* NetDriver, FSpatialNetBitReader& Reader, UObject* Object, int32 ArrayIndex, UProperty* ParentProperty, UScriptStruct* NetDeltaStruct);
-	static bool DeltaSerializeWrite(USpatialNetDriver* NetDriver, FSpatialNetBitWriter& Writer, UObject* Object, int32 ArrayIndex, UProperty* ParentProperty, UScriptStruct* NetDeltaStruct);
+	static bool DeltaSerializeRead(USpatialNetDriver* NetDriver, FSpatialNetBitReader& Reader, UObject* Object, int32 ArrayIndex, GDK_PROPERTY(Property)* ParentProperty, UScriptStruct* NetDeltaStruct);
+	static bool DeltaSerializeWrite(USpatialNetDriver* NetDriver, FSpatialNetBitWriter& Writer, UObject* Object, int32 ArrayIndex, GDK_PROPERTY(Property)* ParentProperty, UScriptStruct* NetDeltaStruct);
 };
 
 PRAGMA_ENABLE_DEPRECATION_WARNINGS // TODO: UNR-2371 - Remove when we update our usage of FNetDeltaSerializeInfo

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialClassInfoManager.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialClassInfoManager.h
@@ -3,6 +3,8 @@
 #pragma once
 
 #include "CoreMinimal.h"
+
+#include "Utils/GDKPropertyMacros.h"
 #include "Utils/SchemaDatabase.h"
 
 #include <WorkerSDK/improbable/c_worker.h>
@@ -41,12 +43,12 @@ struct FHandoverPropertyInfo
 	uint16 Handle;
 	int32 Offset;
 	int32 ArrayIdx;
-	UProperty* Property;
+	GDK_PROPERTY(Property)* Property;
 };
 
 struct FInterestPropertyInfo
 {
-	UProperty* Property;
+	GDK_PROPERTY(Property)* Property;
 	int32 Offset;
 };
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -17,6 +17,7 @@
 #include "Schema/StandardLibrary.h"
 #include "Schema/UnrealObjectRef.h"
 #include "SpatialCommonTypes.h"
+#include "Utils/GDKPropertyMacros.h"
 #include "Utils/RPCContainer.h"
 
 #include <WorkerSDK/improbable/c_schema.h>
@@ -142,7 +143,7 @@ private:
 
 	void ResolveIncomingOperations(UObject* Object, const FUnrealObjectRef& ObjectRef);
 
-	void ResolveObjectReferences(FRepLayout& RepLayout, UObject* ReplicatedObject, FSpatialObjectRepState& RepState, FObjectReferencesMap& ObjectReferencesMap, uint8* RESTRICT StoredData, uint8* RESTRICT Data, int32 MaxAbsOffset, TArray<UProperty*>& RepNotifies, bool& bOutSomeObjectsWereMapped);
+	void ResolveObjectReferences(FRepLayout& RepLayout, UObject* ReplicatedObject, FSpatialObjectRepState& RepState, FObjectReferencesMap& ObjectReferencesMap, uint8* RESTRICT StoredData, uint8* RESTRICT Data, int32 MaxAbsOffset, TArray<GDK_PROPERTY(Property)*>& RepNotifies, bool& bOutSomeObjectsWereMapped);
 
 	void ProcessQueuedActorRPCsOnEntityCreation(Worker_EntityId EntityId, SpatialGDK::RPCsOnEntityCreation& QueuedRPCs);
 	void UpdateShadowData(Worker_EntityId EntityId);

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "Engine/EngineTypes.h"
 #include "Misc/Paths.h"
+#include "Utils/GDKPropertyMacros.h"
 #include "Utils/RPCContainer.h"
 
 #include "SpatialGDKSettings.generated.h"
@@ -223,7 +224,7 @@ public:
 
 private:
 #if WITH_EDITOR
-	bool CanEditChange(const UProperty* InProperty) const override;
+	bool CanEditChange(const GDK_PROPERTY(Property)* InProperty) const override;
 
 	void UpdateServicesRegionFile();
 #endif

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/ComponentFactory.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/ComponentFactory.h
@@ -4,6 +4,7 @@
 
 #include "Interop/SpatialClassInfoManager.h"
 #include "Schema/Interest.h"
+#include "Utils/GDKPropertyMacros.h"
 #include "Utils/RepDataUtils.h"
 
 #include <WorkerSDK/improbable/c_schema.h>
@@ -18,7 +19,6 @@ class USpatialLatencyTracer;
 class USpatialPackageMapClient;
 
 class UNetDriver;
-class UProperty;
 
 enum EReplicatedPropertyGroup : uint32;
 
@@ -47,7 +47,7 @@ private:
 
 	uint32 FillHandoverSchemaObject(Schema_Object* ComponentObject, UObject* Object, const FClassInfo& Info, const FHandoverChangeState& Changes, bool bIsInitialData, TraceKey* OutLatencyTraceId, TArray<Schema_FieldId>* ClearedIds = nullptr);
 
-	void AddProperty(Schema_Object* Object, Schema_FieldId FieldId, UProperty* Property, const uint8* Data, TArray<Schema_FieldId>* ClearedIds);
+	void AddProperty(Schema_Object* Object, Schema_FieldId FieldId, GDK_PROPERTY(Property)* Property, const uint8* Data, TArray<Schema_FieldId>* ClearedIds);
 
 	USpatialNetDriver* NetDriver;
 	USpatialPackageMapClient* PackageMap;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/ComponentReader.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/ComponentReader.h
@@ -4,6 +4,7 @@
 
 #include "EngineClasses/SpatialNetBitReader.h"
 #include "Interop/SpatialReceiver.h"
+#include "Utils/GDKPropertyMacros.h"
 
 DECLARE_LOG_CATEGORY_EXTERN(LogSpatialComponentReader, All, All);
 
@@ -22,10 +23,10 @@ private:
 	void ApplySchemaObject(Schema_Object* ComponentObject, UObject& Object, USpatialActorChannel& Channel, bool bIsInitialData, const TArray<Schema_FieldId>& UpdatedIds, Worker_ComponentId ComponentId, bool& bOutReferencesChanged);
 	void ApplyHandoverSchemaObject(Schema_Object* ComponentObject, UObject& Object, USpatialActorChannel& Channel, bool bIsInitialData, const TArray<Schema_FieldId>& UpdatedIds, Worker_ComponentId ComponentId, bool& bOutReferencesChanged);
 
-	void ApplyProperty(Schema_Object* Object, Schema_FieldId FieldId, FObjectReferencesMap& InObjectReferencesMap, uint32 Index, UProperty* Property, uint8* Data, int32 Offset, int32 CmdIndex, int32 ParentIndex, bool& bOutReferencesChanged);
-	void ApplyArray(Schema_Object* Object, Schema_FieldId FieldId, FObjectReferencesMap& InObjectReferencesMap, UArrayProperty* Property, uint8* Data, int32 Offset, int32 CmdIndex, int32 ParentIndex, bool& bOutReferencesChanged);
+	void ApplyProperty(Schema_Object* Object, Schema_FieldId FieldId, FObjectReferencesMap& InObjectReferencesMap, uint32 Index, GDK_PROPERTY(Property)* Property, uint8* Data, int32 Offset, int32 CmdIndex, int32 ParentIndex, bool& bOutReferencesChanged);
+	void ApplyArray(Schema_Object* Object, Schema_FieldId FieldId, FObjectReferencesMap& InObjectReferencesMap, GDK_PROPERTY(ArrayProperty)* Property, uint8* Data, int32 Offset, int32 CmdIndex, int32 ParentIndex, bool& bOutReferencesChanged);
 
-	uint32 GetPropertyCount(const Schema_Object* Object, Schema_FieldId Id, UProperty* Property);
+	uint32 GetPropertyCount(const Schema_Object* Object, Schema_FieldId Id, GDK_PROPERTY(Property)* Property);
 
 private:
 	class USpatialPackageMapClient* PackageMap;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/GDKPropertyMacros.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/GDKPropertyMacros.h
@@ -1,0 +1,14 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "Launch/Resources/Version.h"
+#include "UObject/UnrealType.h"
+
+#if ENGINE_MINOR_VERSION <= 24
+	#define GDK_PROPERTY(Type) U##Type
+	#define GDK_CASTFIELD Cast
+#else
+	#define GDK_PROPERTY(Type) F##Type
+	#define GDK_CASTFIELD CastField
+#endif

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/InterestFactory.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/InterestFactory.h
@@ -5,6 +5,8 @@
 #include "Interop/SpatialClassInfoManager.h"
 #include "Schema/Interest.h"
 
+#include "Utils/GDKPropertyMacros.h"
+
 #include <WorkerSDK/improbable/c_worker.h>
 
 /**
@@ -87,7 +89,7 @@ private:
 	// Only checkout entities that are in loaded sub-levels
 	QueryConstraint CreateLevelConstraints(const AActor* InActor) const;
 
-	void AddObjectToConstraint(UObjectPropertyBase* Property, uint8* Data, QueryConstraint& OutConstraint) const;
+	void AddObjectToConstraint(GDK_PROPERTY(ObjectPropertyBase)* Property, uint8* Data, QueryConstraint& OutConstraint) const;
 
 	USpatialClassInfoManager* ClassInfoManager;
 	USpatialPackageMapClient* PackageMap;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/RepLayoutUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/RepLayoutUtils.h
@@ -9,6 +9,7 @@
 #include "EngineClasses/SpatialNetBitWriter.h"
 #include "EngineClasses/SpatialNetDriver.h"
 #include "EngineClasses/SpatialPackageMapClient.h"
+#include "Utils/GDKPropertyMacros.h"
 
 namespace SpatialGDK
 {
@@ -31,7 +32,7 @@ inline void RepLayout_SerializeProperties_DynamicArray(FRepLayout& RepLayout, FA
 	// When loading, we may need to resize the array to properly fit the number of elements.
 	if (Ar.IsLoading() && OutArrayNum != Array->Num())
 	{
-		FScriptArrayHelper ArrayHelper((UArrayProperty*)Cmd.Property, Data);
+		FScriptArrayHelper ArrayHelper((GDK_PROPERTY(ArrayProperty)*)Cmd.Property, Data);
 		ArrayHelper.Resize(OutArrayNum);
 	}
 
@@ -84,7 +85,7 @@ inline void RepLayout_SendPropertiesForRPC(FRepLayout& RepLayout, FNetBitWriter&
 	{
 		bool bSend = true;
 
-		if (!Cast<UBoolProperty>(Parent.Property))
+		if (!GDK_CASTFIELD<GDK_PROPERTY(BoolProperty)>(Parent.Property))
 		{
 			// check for a complete match, including arrays
 			// (we're comparing against zero data here, since
@@ -115,7 +116,7 @@ inline void RepLayout_ReceivePropertiesForRPC(FRepLayout& RepLayout, FNetBitRead
 
 	for (auto& Parent : RepLayout.Parents)
 	{
-		if (Cast<UBoolProperty>(Parent.Property) || Reader.ReadBit())
+		if (GDK_CASTFIELD<GDK_PROPERTY(BoolProperty)>(Parent.Property) || Reader.ReadBit())
 		{
 			bool bHasUnmapped = false;
 
@@ -129,7 +130,7 @@ inline void RepLayout_ReceivePropertiesForRPC(FRepLayout& RepLayout, FNetBitRead
 	}
 }
 
-inline void ReadStructProperty(FSpatialNetBitReader& Reader, UStructProperty* Property, USpatialNetDriver* NetDriver, uint8* Data, bool& bOutHasUnmapped)
+inline void ReadStructProperty(FSpatialNetBitReader& Reader, GDK_PROPERTY(StructProperty)* Property, USpatialNetDriver* NetDriver, uint8* Data, bool& bOutHasUnmapped)
 {
 	UScriptStruct* Struct = Property->Struct;
 
@@ -202,7 +203,7 @@ inline TArray<UFunction*> GetClassRPCFunctions(const UClass* Class)
 	return RelevantClassFunctions;
 }
 
-inline UScriptStruct* GetFastArraySerializerProperty(UArrayProperty* Property)
+inline UScriptStruct* GetFastArraySerializerProperty(GDK_PROPERTY(ArrayProperty)* Property)
 {
 	// Check if this array property conforms to the pattern of what we expect for a FFastArraySerializer. We do
 	// this be ensuring that the owner struct has the NetDeltaSerialize flag, and that the array's internal item
@@ -211,7 +212,7 @@ inline UScriptStruct* GetFastArraySerializerProperty(UArrayProperty* Property)
 	{
 		if (OwnerProperty->StructFlags & STRUCT_NetDeltaSerializeNative)
 		{
-			if (UStructProperty* ArrayInnerProperty = Cast<UStructProperty>(Property->Inner))
+			if (GDK_PROPERTY(StructProperty)* ArrayInnerProperty = GDK_CASTFIELD<GDK_PROPERTY(StructProperty)>(Property->Inner))
 			{
 				if (ArrayInnerProperty->Struct->IsChildOf(FFastArraySerializerItem::StaticStruct()))
 				{

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracer.h
@@ -8,6 +8,7 @@
 #include "Containers/Map.h"
 #include "Containers/StaticArray.h"
 #include "SpatialLatencyPayload.h"
+#include "Utils/GDKPropertyMacros.h"
 
 #if TRACE_LIB_ACTIVE
 #include "WorkerSDK/improbable/trace.h"
@@ -127,7 +128,7 @@ public:
 
 	bool IsValidKey(TraceKey Key);
 	TraceKey RetrievePendingTrace(const UObject* Obj, const UFunction* Function);
-	TraceKey RetrievePendingTrace(const UObject* Obj, const UProperty* Property);
+	TraceKey RetrievePendingTrace(const UObject* Obj, const GDK_PROPERTY(Property)* Property);
 	TraceKey RetrievePendingTrace(const UObject* Obj, const FString& Tag);
 
 	void WriteToLatencyTrace(const TraceKey Key, const FString& TraceDesc);
@@ -145,7 +146,7 @@ public:
 private:
 
 	using ActorFuncKey = TPair<const AActor*, const UFunction*>;
-	using ActorPropertyKey = TPair<const AActor*, const UProperty*>;
+	using ActorPropertyKey = TPair<const AActor*, const GDK_PROPERTY(Property)*>;
 	using ActorTagKey = TPair<const AActor*, FString>;
 	using TraceSpan = improbable::trace::Span;
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SchemaGenerator.cpp
@@ -12,6 +12,7 @@
 #include "Utils/CodeWriter.h"
 #include "Utils/ComponentIdGenerator.h"
 #include "Utils/DataTypeUtilities.h"
+#include "Utils/GDKPropertyMacros.h"
 #include "SpatialGDKEditorSchemaGenerator.h"
 
 using namespace SpatialGDKEditor::Schema;
@@ -40,76 +41,76 @@ ESchemaComponentType PropertyGroupToSchemaComponentType(EReplicatedPropertyGroup
 
 // Given a RepLayout cmd type (a data type supported by the replication system). Generates the corresponding
 // type used in schema.
-FString PropertyToSchemaType(UProperty* Property)
+FString PropertyToSchemaType(GDK_PROPERTY(Property)* Property)
 {
 	FString DataType;
 
-	if (Property->IsA(UStructProperty::StaticClass()))
+	if (Property->IsA(GDK_PROPERTY(StructProperty)::StaticClass()))
 	{
-		UStructProperty* StructProp = Cast<UStructProperty>(Property);
+		GDK_PROPERTY(StructProperty)* StructProp = GDK_CASTFIELD<GDK_PROPERTY(StructProperty)>(Property);
 		UScriptStruct* Struct = StructProp->Struct;
 		DataType = TEXT("bytes");
 	}
-	else if (Property->IsA(UBoolProperty::StaticClass()))
+	else if (Property->IsA(GDK_PROPERTY(BoolProperty)::StaticClass()))
 	{
 		DataType = TEXT("bool");
 	}
-	else if (Property->IsA(UFloatProperty::StaticClass()))
+	else if (Property->IsA(GDK_PROPERTY(FloatProperty)::StaticClass()))
 	{
 		DataType = TEXT("float");
 	}
-	else if (Property->IsA(UDoubleProperty::StaticClass()))
+	else if (Property->IsA(GDK_PROPERTY(DoubleProperty)::StaticClass()))
 	{
 		DataType = TEXT("double");
 	}
-	else if (Property->IsA(UInt8Property::StaticClass()))
+	else if (Property->IsA(GDK_PROPERTY(Int8Property)::StaticClass()))
 	{
 		DataType = TEXT("int32");
 	}
-	else if (Property->IsA(UInt16Property::StaticClass()))
+	else if (Property->IsA(GDK_PROPERTY(Int16Property)::StaticClass()))
 	{
 		DataType = TEXT("int32");
 	}
-	else if (Property->IsA(UIntProperty::StaticClass()))
+	else if (Property->IsA(GDK_PROPERTY(IntProperty)::StaticClass()))
 	{
 		DataType = TEXT("int32");
 	}
-	else if (Property->IsA(UInt64Property::StaticClass()))
+	else if (Property->IsA(GDK_PROPERTY(Int64Property)::StaticClass()))
 	{
 		DataType = TEXT("int64");
 	}
-	else if (Property->IsA(UByteProperty::StaticClass()))
+	else if (Property->IsA(GDK_PROPERTY(ByteProperty)::StaticClass()))
 	{
 		DataType = TEXT("uint32"); // uint8 not supported in schema.
 	}
-	else if (Property->IsA(UUInt16Property::StaticClass()))
+	else if (Property->IsA(GDK_PROPERTY(UInt16Property)::StaticClass()))
 	{
 		DataType = TEXT("uint32");
 	}
-	else if (Property->IsA(UUInt32Property::StaticClass()))
+	else if (Property->IsA(GDK_PROPERTY(UInt32Property)::StaticClass()))
 	{
 		DataType = TEXT("uint32");
 	}
-	else if (Property->IsA(UUInt64Property::StaticClass()))
+	else if (Property->IsA(GDK_PROPERTY(UInt64Property)::StaticClass()))
 	{
 		DataType = TEXT("uint64");
 	}
-	else if (Property->IsA(UNameProperty::StaticClass()) || Property->IsA(UStrProperty::StaticClass()) || Property->IsA(UTextProperty::StaticClass()))
+	else if (Property->IsA(GDK_PROPERTY(NameProperty)::StaticClass()) || Property->IsA(GDK_PROPERTY(StrProperty)::StaticClass()) || Property->IsA(GDK_PROPERTY(TextProperty)::StaticClass()))
 	{
 		DataType = TEXT("string");
 	}
-	else if (Property->IsA(UObjectPropertyBase::StaticClass()))
+	else if (Property->IsA(GDK_PROPERTY(ObjectPropertyBase)::StaticClass()))
 	{
 		DataType = TEXT("UnrealObjectRef");
 	}
-	else if (Property->IsA(UArrayProperty::StaticClass()))
+	else if (Property->IsA(GDK_PROPERTY(ArrayProperty)::StaticClass()))
 	{
-		DataType = PropertyToSchemaType(Cast<UArrayProperty>(Property)->Inner);
+		DataType = PropertyToSchemaType(GDK_CASTFIELD<GDK_PROPERTY(ArrayProperty)>(Property)->Inner);
 		DataType = FString::Printf(TEXT("list<%s>"), *DataType);
 	}
-	else if (Property->IsA(UEnumProperty::StaticClass()))
+	else if (Property->IsA(GDK_PROPERTY(EnumProperty)::StaticClass()))
 	{
-		DataType = GetEnumDataType(Cast<UEnumProperty>(Property));
+		DataType = GetEnumDataType(GDK_CASTFIELD<GDK_PROPERTY(EnumProperty)>(Property));
 	}
 	else
 	{
@@ -212,8 +213,8 @@ void GenerateSubobjectSchemaForActorIncludes(FCodeWriter& Writer, TSharedPtr<FUn
 
 	for (auto& PropertyPair : TypeInfo->Properties)
 	{
-		UProperty* Property = PropertyPair.Key;
-		UObjectProperty* ObjectProperty = Cast<UObjectProperty>(Property);
+		GDK_PROPERTY(Property)* Property = PropertyPair.Key;
+		GDK_PROPERTY(ObjectProperty)* ObjectProperty = GDK_CASTFIELD<GDK_PROPERTY(ObjectProperty)>(Property);
 
 		TSharedPtr<FUnrealType>& PropertyTypeInfo = PropertyPair.Value->Type;
 
@@ -368,15 +369,15 @@ void GenerateSubobjectSchema(FComponentIdGenerator& IdGenerator, UClass* Class, 
 	{
 		for (auto& PropertyPair : PropertyGroup.Value)
 		{
-			UProperty* Property = PropertyPair.Value->Property;
-			if (Property->IsA<UObjectPropertyBase>())
+			GDK_PROPERTY(Property)* Property = PropertyPair.Value->Property;
+			if (Property->IsA<GDK_PROPERTY(ObjectPropertyBase)>())
 			{
 				bShouldIncludeCoreTypes = true;
 			}
 
-			if (Property->IsA<UArrayProperty>())
+			if (Property->IsA<GDK_PROPERTY(ArrayProperty)>())
 			{
-				if (Cast<UArrayProperty>(Property)->Inner->IsA<UObjectPropertyBase>())
+				if (GDK_CASTFIELD<GDK_PROPERTY(ArrayProperty)>(Property)->Inner->IsA<GDK_PROPERTY(ObjectPropertyBase)>())
 				{
 					bShouldIncludeCoreTypes = true;
 				}
@@ -404,7 +405,7 @@ void GenerateSubobjectSchema(FComponentIdGenerator& IdGenerator, UClass* Class, 
 		if (Group == REP_MultiClient && Class->IsChildOf<UActorComponent>())
 		{
 			TSharedPtr<FUnrealProperty> ExpectedReplicatesPropData = RepData[Group].FindRef(SpatialConstants::ACTOR_COMPONENT_REPLICATES_ID);
-			const UProperty* ReplicatesProp = UActorComponent::StaticClass()->FindPropertyByName("bReplicates");
+			const GDK_PROPERTY(Property)* ReplicatesProp = UActorComponent::StaticClass()->FindPropertyByName("bReplicates");
 
 			if (!(ExpectedReplicatesPropData.IsValid() && ExpectedReplicatesPropData->Property == ReplicatesProp))
 			{
@@ -563,7 +564,7 @@ void GenerateActorSchema(FComponentIdGenerator& IdGenerator, UClass* Class, TSha
 		if (Group == REP_MultiClient && Class->IsChildOf<AActor>())
 		{
 			TSharedPtr<FUnrealProperty> ExpectedReplicatesPropData = RepData[Group].FindRef(SpatialConstants::ACTOR_TEAROFF_ID);
-			const UProperty* ReplicatesProp = AActor::StaticClass()->FindPropertyByName("bTearOff");
+			const GDK_PROPERTY(Property)* ReplicatesProp = AActor::StaticClass()->FindPropertyByName("bTearOff");
 
 			if (!(ExpectedReplicatesPropData.IsValid() && ExpectedReplicatesPropData->Property == ReplicatesProp))
 			{

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/TypeStructure.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/TypeStructure.h
@@ -5,6 +5,8 @@
 #include "CoreMinimal.h"
 #include "Net/RepLayout.h"
 
+#include "Utils/GDKPropertyMacros.h"
+
 /*
 
 This file contains functions to generate an abstract syntax tree which is used by the code generating in
@@ -76,14 +78,14 @@ struct FUnrealType
 	UStruct* Type;
 	UObject* Object; // Actual instance of the object. Could be the CDO or a Subobject on the CDO/BlueprintGeneratedClass
 	FName Name; // Name for the object. This is either the name of the object itself, or the name of the property in the blueprint
-	TMultiMap<UProperty*, TSharedPtr<FUnrealProperty>> Properties;
+	TMultiMap<GDK_PROPERTY(Property)*, TSharedPtr<FUnrealProperty>> Properties;
 	TWeakPtr<FUnrealProperty> ParentProperty;
 };
 
 // A node which represents a single property.
 struct FUnrealProperty
 {
-	UProperty* Property;
+	GDK_PROPERTY(Property)* Property;
 	TSharedPtr<FUnrealType> Type; // Only set if strong reference to object/struct property.
 	TSharedPtr<FUnrealRepData> ReplicationData; // Only set if property is replicated.
 	TSharedPtr<FUnrealHandoverData> HandoverData; // Only set if property is marked for handover (and not replicated).
@@ -133,10 +135,10 @@ void VisitAllObjects(TSharedPtr<FUnrealType> TypeNode, TFunction<bool(TSharedPtr
 void VisitAllProperties(TSharedPtr<FUnrealType> TypeNode, TFunction<bool(TSharedPtr<FUnrealProperty>)> Visitor);
 
 // Generates a unique checksum for the Property that allows matching to Unreal's RepLayout Cmds.
-uint32 GenerateChecksum(UProperty* Property, uint32 ParentChecksum, int32 StaticArrayIndex);
+uint32 GenerateChecksum(GDK_PROPERTY(Property)* Property, uint32 ParentChecksum, int32 StaticArrayIndex);
 
 // Creates a new FUnrealProperty for the included UProperty, generates a checksum for it and then adds it to the TypeNode included.
-TSharedPtr<FUnrealProperty> CreateUnrealProperty(TSharedPtr<FUnrealType> TypeNode, UProperty* Property, uint32 ParentChecksum, uint32 StaticArrayIndex);
+TSharedPtr<FUnrealProperty> CreateUnrealProperty(TSharedPtr<FUnrealType> TypeNode, GDK_PROPERTY(Property)* Property, uint32 ParentChecksum, uint32 StaticArrayIndex);
 
 // Generates an AST from an Unreal UStruct or UClass.
 TSharedPtr<FUnrealType> CreateUnrealTypeInfo(UStruct* Type, uint32 ParentChecksum, int32 StaticArrayIndex);

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/Utils/DataTypeUtilities.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/Utils/DataTypeUtilities.cpp
@@ -4,12 +4,14 @@
 
 #include "Algo/Transform.h"
 #include "Internationalization/Regex.h"
+
 #include "SpatialGDKEditorSchemaGenerator.h"
+#include "Utils/GDKPropertyMacros.h"
 
 // Regex pattern matcher to match alphanumeric characters.
 const FRegexPattern AlphanumericPattern(TEXT("[A-Za-z0-9]"));
 
-FString GetEnumDataType(const UEnumProperty* EnumProperty)
+FString GetEnumDataType(const GDK_PROPERTY(EnumProperty)* EnumProperty)
 {
 	FString DataType;
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/Utils/DataTypeUtilities.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/Utils/DataTypeUtilities.h
@@ -5,11 +5,12 @@
 #include "CoreMinimal.h"
 
 #include "SchemaGenerator/TypeStructure.h"
+#include "Utils/GDKPropertyMacros.h"
 
 extern TMap<FString, FString> ClassPathToSchemaName;
 
 // Return the string representation of the underlying data type of an enum property
-FString GetEnumDataType(const UEnumProperty* EnumProperty);
+FString GetEnumDataType(const GDK_PROPERTY(EnumProperty)* EnumProperty);
 
 // Given a class or function name, generates the name used for naming schema components and types. Removes all non-alphanumeric characters.
 FString UnrealNameToSchemaName(const FString& UnrealName, bool bWarnAboutRename = false);

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/Utils/LaunchConfigurationEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/Utils/LaunchConfigurationEditor.cpp
@@ -13,6 +13,7 @@
 #include "SpatialGDKDefaultLaunchConfigGenerator.h"
 #include "SpatialGDKSettings.h"
 #include "SpatialRuntimeLoadBalancingStrategies.h"
+#include "Utils/GDKPropertyMacros.h"
 
 #define LOCTEXT_NAMESPACE "SpatialLaunchConfigurationEditor"
 
@@ -61,15 +62,18 @@ namespace
 	// Copied from FPropertyEditorModule::CreateFloatingDetailsView.
 	bool ShouldShowProperty(const FPropertyAndParent& PropertyAndParent, bool bHaveTemplate)
 	{
-		const UProperty& Property = PropertyAndParent.Property;
+		const GDK_PROPERTY(Property)& Property = PropertyAndParent.Property;
 
 		if (bHaveTemplate)
 		{
+#if ENGINE_MINOR_VERSION <= 24
 			const UClass* PropertyOwnerClass = Cast<const UClass>(Property.GetOuter());
+#else
+			const UClass* PropertyOwnerClass = Property.GetOwner<const UClass>();
+#endif
 			const bool bDisableEditOnTemplate = PropertyOwnerClass
 				&& PropertyOwnerClass->IsNative()
 				&& Property.HasAnyPropertyFlags(CPF_DisableEditOnTemplate);
-
 			if (bDisableEditOnTemplate)
 			{
 				return false;

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/Utils/TransientUObjectEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/Utils/TransientUObjectEditor.cpp
@@ -9,6 +9,7 @@
 #include "Widgets/Input/SButton.h"
 #include "Widgets/Layout/SBorder.h"
 
+#include "Utils/GDKPropertyMacros.h"
 
 namespace
 {
@@ -21,15 +22,18 @@ namespace
 	// Copied from FPropertyEditorModule::CreateFloatingDetailsView.
 	bool ShouldShowProperty(const FPropertyAndParent& PropertyAndParent, bool bHaveTemplate)
 	{
-		const UProperty& Property = PropertyAndParent.Property;
+		const GDK_PROPERTY(Property)& Property = PropertyAndParent.Property;
 
 		if (bHaveTemplate)
 		{
+#if ENGINE_MINOR_VERSION <= 24
 			const UClass* PropertyOwnerClass = Cast<const UClass>(Property.GetOuter());
+#else
+			const UClass* PropertyOwnerClass = Property.GetOwner<const UClass>();
+#endif
 			const bool bDisableEditOnTemplate = PropertyOwnerClass
 				&& PropertyOwnerClass->IsNative()
 				&& Property.HasAnyPropertyFlags(CPF_DisableEditOnTemplate);
-
 			if (bDisableEditOnTemplate)
 			{
 				return false;

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -47,6 +47,7 @@
 #include "SpatialGDKEditorToolbarStyle.h"
 #include "SpatialGDKCloudDeploymentConfiguration.h"
 #include "SpatialRuntimeLoadBalancingStrategies.h"
+#include "Utils/GDKPropertyMacros.h"
 #include "Utils/LaunchConfigurationEditor.h"
 
 DEFINE_LOG_CATEGORY(LogSpatialGDKEditorToolbar);
@@ -981,7 +982,7 @@ bool FSpatialGDKEditorToolbarModule::StopSpatialServiceIsVisible() const
 void FSpatialGDKEditorToolbarModule::OnToggleSpatialNetworking()
 {
 	UGeneralProjectSettings* GeneralProjectSettings = GetMutableDefault<UGeneralProjectSettings>();
-	UProperty* SpatialNetworkingProperty = UGeneralProjectSettings::StaticClass()->FindPropertyByName(FName("bSpatialNetworking"));
+	GDK_PROPERTY(Property)* SpatialNetworkingProperty = UGeneralProjectSettings::StaticClass()->FindPropertyByName(FName("bSpatialNetworking"));
 
 	GeneralProjectSettings->SetUsesSpatialNetworking(!GeneralProjectSettings->UsesSpatialNetworking());
 	GeneralProjectSettings->UpdateSinglePropertyInConfigFile(SpatialNetworkingProperty, GeneralProjectSettings->GetDefaultConfigFilename());

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Utils/Misc/SpatialActivationFlagsTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Utils/Misc/SpatialActivationFlagsTest.cpp
@@ -6,6 +6,8 @@
 #include "Tests/AutomationCommon.h"
 #include "Runtime/EngineSettings/Public/EngineSettings.h"
 
+#include "Utils/GDKPropertyMacros.h"
+
 namespace
 {
 	bool bEarliestFlag;
@@ -77,7 +79,7 @@ struct SpatialActivationFlagTestFixture
 		CommandLineArgs.Append(TEXT(" -nullRHI"));
 		CommandLineArgs.Append(TEXT(" -stdout"));
 
-		SpatialFlagProperty = Cast<UBoolProperty>(UGeneralProjectSettings::StaticClass()->FindPropertyByName("bSpatialNetworking"));
+		SpatialFlagProperty = GDK_CASTFIELD<GDK_PROPERTY(BoolProperty)>(UGeneralProjectSettings::StaticClass()->FindPropertyByName("bSpatialNetworking"));
 		Test.TestNotNull("Property existence", SpatialFlagProperty);
 
 		ProjectSettings = GetMutableDefault<UGeneralProjectSettings>();
@@ -104,7 +106,7 @@ struct SpatialActivationFlagTestFixture
 
 private:
 	FString ProjectPath;
-	UBoolProperty* SpatialFlagProperty;
+	GDK_PROPERTY(BoolProperty)* SpatialFlagProperty;
 	UGeneralProjectSettings* ProjectSettings;
 	void* SpatialFlagPtr;
 	bool bSavedFlagValue;


### PR DESCRIPTION
#### Description
In 4.25, `UProperty` was renamed to `FProperty`. To support both, we can use a macro that expands to `USomethingProperty` or `FSomethingProperty` depending on the engine version.

#### Primary reviewers
@m-samiec @joshuahuburn 
