### PR TITLE
[GSE-1244] Add functional test step API refactor

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
@@ -118,7 +118,7 @@ bool ASpatialFunctionalTest::IsReady_Implementation()
 	{
 		if (FlowController->IsReadyToRunTest()) // Check if the owner already finished initialization
 		{
-			if (FlowController->ControllerType == ESpatialFunctionalTestFlowControllerType::Server)
+			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Server)
 			{
 				++NumRegisteredServers;
 			}
@@ -168,7 +168,7 @@ int ASpatialFunctionalTest::GetNumberOfServerWorkers()
 	int Counter = 0;
 	for (ASpatialFunctionalTestFlowController* FlowController : FlowControllers)
 	{
-		if (FlowController != nullptr && FlowController->ControllerType == ESpatialFunctionalTestFlowControllerType::Server)
+		if (FlowController != nullptr && FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Server)
 		{
 			++Counter;
 		}
@@ -181,7 +181,7 @@ int ASpatialFunctionalTest::GetNumberOfClientWorkers()
 	int Counter = 0;
 	for (ASpatialFunctionalTestFlowController* FlowController : FlowControllers)
 	{
-		if (FlowController != nullptr && FlowController->ControllerType == ESpatialFunctionalTestFlowControllerType::Client)
+		if (FlowController != nullptr && FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
 		{
 			++Counter;
 		}
@@ -286,7 +286,7 @@ void ASpatialFunctionalTest::RegisterFlowController(ASpatialFunctionalTestFlowCo
 		return;
 	}
 
-	if (FlowController->ControllerType == ESpatialFunctionalTestFlowControllerType::Client)
+	if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
 	{
 		// Since Clients can spawn on any worker we need to centralize the assignment of their ids to the Test Authority.
 		FlowControllerSpawner.AssignClientFlowControllerId(FlowController);
@@ -335,17 +335,17 @@ void ASpatialFunctionalTest::StartStep(const int StepIndex)
 
 		for (const FWorkerDefinition& Worker : StepDefinition.Workers)
 		{
-			ESpatialFunctionalTestFlowControllerType WorkerType = Worker.Type;
+			ESpatialFunctionalTestWorkerType WorkerType = Worker.Type;
 			int WorkerId = Worker.Id;
-			if (NumExpectedServers == 1 && WorkerType == ESpatialFunctionalTestFlowControllerType::Server)
+			if (NumExpectedServers == 1 && WorkerType == ESpatialFunctionalTestWorkerType::Server)
 			{
 				// make sure that tests made for multi server also run on single server
 				WorkerId = 1;
 			}
 			for (auto* FlowController : FlowControllers)
 			{
-				if (WorkerType == ESpatialFunctionalTestFlowControllerType::All
-					|| ( FlowController->ControllerType == WorkerType && (WorkerId <= FWorkerDefinition::ALL_WORKERS_ID || FlowController->ControllerInstanceId == WorkerId)))
+				if (WorkerType == ESpatialFunctionalTestWorkerType::All
+					|| ( FlowController->WorkerDefinition.Type == WorkerType && (WorkerId <= FWorkerDefinition::ALL_WORKERS_ID || FlowController->WorkerDefinition.Id == WorkerId)))
 				{
 					FlowControllersExecutingStep.AddUnique(FlowController);
 				}
@@ -408,11 +408,11 @@ FSpatialFunctionalTestStepDefinition& ASpatialFunctionalTest::AddStep(const FStr
 }
 
 
-ASpatialFunctionalTestFlowController* ASpatialFunctionalTest::GetFlowController(ESpatialFunctionalTestFlowControllerType ControllerType, int InstanceId)
+ASpatialFunctionalTestFlowController* ASpatialFunctionalTest::GetFlowController(ESpatialFunctionalTestWorkerType ControllerType, int InstanceId)
 {
 	for (auto* FlowController : FlowControllers)
 	{
-		if (FlowController->ControllerType == ControllerType && FlowController->ControllerInstanceId == InstanceId)
+		if (FlowController->WorkerDefinition.Type == ControllerType && FlowController->WorkerDefinition.Id == InstanceId)
 		{
 			return FlowController;
 		}
@@ -451,7 +451,7 @@ void ASpatialFunctionalTest::OnReplicated_CurrentStepIndex()
 			if (AuxLocalFlowController != nullptr)
 			{
 				AuxLocalFlowController->OnTestFinished();
-				if (AuxLocalFlowController->ControllerType == ESpatialFunctionalTestFlowControllerType::Server)
+				if (AuxLocalFlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Server)
 				{
 					ISpatialFunctionalTestLBDelegationInterface* DelegationInterface = GetDelegationInterface();
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
@@ -306,7 +306,7 @@ ASpatialFunctionalTestFlowController* ASpatialFunctionalTest::GetLocalFlowContro
 
 // Add Steps for Blueprints
 
-void ASpatialFunctionalTest::AddStepBlueprint(const FString& StepName, ESpatialFunctionalTestFlowControllerType WorkerType, int WorkerId, const FStepIsReadyDelegate& IsReadyEvent, const FStepStartDelegate& StartEvent, const FStepTickDelegate& TickEvent, float StepTimeLimit /*= 0.0f*/)
+void ASpatialFunctionalTest::AddStepBlueprint(const FString& StepName, const FWorkerDefinition& Worker, const FStepIsReadyDelegate& IsReadyEvent, const FStepStartDelegate& StartEvent, const FStepTickDelegate& TickEvent, float StepTimeLimit /*= 0.0f*/)
 {
 	FSpatialFunctionalTestStepDefinition StepDefinition;
 	StepDefinition.bIsNativeDefinition = false;
@@ -316,7 +316,7 @@ void ASpatialFunctionalTest::AddStepBlueprint(const FString& StepName, ESpatialF
 	StepDefinition.TickEvent = TickEvent;
 	StepDefinition.TimeLimit = StepTimeLimit;
 
-	StepDefinition.Workers.Add(FWorkerDefinition{ WorkerType, WorkerId });
+	StepDefinition.Workers.Add(Worker);
 
 	StepDefinitions.Add(StepDefinition);
 }
@@ -338,8 +338,8 @@ void ASpatialFunctionalTest::StartStep(const int StepIndex)
 
 		for (const FWorkerDefinition& Worker : StepDefinition.Workers)
 		{
-			ESpatialFunctionalTestFlowControllerType WorkerType = Worker.ControllerType;
-			int WorkerId = Worker.WorkerId;
+			ESpatialFunctionalTestFlowControllerType WorkerType = Worker.Type;
+			int WorkerId = Worker.Id;
 			if (NumExpectedServers == 1 && WorkerType == ESpatialFunctionalTestFlowControllerType::Server)
 			{
 				// make sure that tests made for multi server also run on single server
@@ -384,7 +384,7 @@ void ASpatialFunctionalTest::StartStep(const int StepIndex)
 
 // Add Steps for C++
 
-FSpatialFunctionalTestStepDefinition& ASpatialFunctionalTest::AddStep(const FString& StepName, ESpatialFunctionalTestFlowControllerType WorkerType, int WorkerId, FIsReadyEventFunc IsReadyEvent /*= nullptr*/, FStartEventFunc StartEvent /*= nullptr*/, FTickEventFunc TickEvent /*= nullptr*/, float StepTimeLimit /*= 0.0f*/)
+FSpatialFunctionalTestStepDefinition& ASpatialFunctionalTest::AddStep(const FString& StepName, const FWorkerDefinition& Worker, FIsReadyEventFunc IsReadyEvent /*= nullptr*/, FStartEventFunc StartEvent /*= nullptr*/, FTickEventFunc TickEvent /*= nullptr*/, float StepTimeLimit /*= 0.0f*/)
 {
 	FSpatialFunctionalTestStepDefinition StepDefinition;
 	StepDefinition.bIsNativeDefinition = true;
@@ -403,7 +403,7 @@ FSpatialFunctionalTestStepDefinition& ASpatialFunctionalTest::AddStep(const FStr
 	}
 	StepDefinition.TimeLimit = StepTimeLimit;
 
-	StepDefinition.Workers.Add(FWorkerDefinition{ WorkerType, WorkerId });
+	StepDefinition.Workers.Add(Worker);
 
 	StepDefinitions.Add(StepDefinition);
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
@@ -306,7 +306,7 @@ ASpatialFunctionalTestFlowController* ASpatialFunctionalTest::GetLocalFlowContro
 
 // Add Steps for Blueprints
 
-void ASpatialFunctionalTest::AddStep(const FString& StepName, ESpatialFunctionalTestFlowControllerType WorkerType, int WorkerId, const FStepIsReadyDelegate& IsReadyEvent, const FStepStartDelegate& StartEvent, const FStepTickDelegate& TickEvent, float StepTimeLimit /*= 0.0f*/)
+void ASpatialFunctionalTest::AddStepBlueprint(const FString& StepName, ESpatialFunctionalTestFlowControllerType WorkerType, int WorkerId, const FStepIsReadyDelegate& IsReadyEvent, const FStepStartDelegate& StartEvent, const FStepTickDelegate& TickEvent, float StepTimeLimit /*= 0.0f*/)
 {
 	FSpatialFunctionalTestStepDefinition StepDefinition;
 	StepDefinition.bIsNativeDefinition = false;

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestFlowController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestFlowController.cpp
@@ -32,8 +32,7 @@ void ASpatialFunctionalTestFlowController::GetLifetimeReplicatedProps(TArray< FL
 	DOREPLIFETIME(ASpatialFunctionalTestFlowController, bReadyToRegisterWithTest);
 	DOREPLIFETIME(ASpatialFunctionalTestFlowController, bIsReadyToRunTest);
 	DOREPLIFETIME(ASpatialFunctionalTestFlowController, OwningTest);
-	DOREPLIFETIME(ASpatialFunctionalTestFlowController, ControllerType);
-	DOREPLIFETIME(ASpatialFunctionalTestFlowController, ControllerInstanceId);
+	DOREPLIFETIME(ASpatialFunctionalTestFlowController, WorkerDefinition);
 }
 
 void ASpatialFunctionalTestFlowController::OnAuthorityGained()
@@ -50,9 +49,9 @@ void ASpatialFunctionalTestFlowController::Tick(float DeltaSeconds)
 	}
 }
 
-void ASpatialFunctionalTestFlowController::CrossServerSetControllerInstanceId_Implementation(int NewControllerInstanceId)
+void ASpatialFunctionalTestFlowController::CrossServerSetWorkerId_Implementation(int NewWorkerId)
 {
-	ControllerInstanceId = NewControllerInstanceId;
+	WorkerDefinition.Id = NewWorkerId;
 }
 
 void ASpatialFunctionalTestFlowController::OnReadyToRegisterWithTest()
@@ -66,7 +65,7 @@ void ASpatialFunctionalTestFlowController::OnReadyToRegisterWithTest()
 
 	if (IsLocalController())
 	{
-		if (ControllerType == ESpatialFunctionalTestFlowControllerType::Server)
+		if (WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Server)
 		{
 			bIsReadyToRunTest = true;
 		}
@@ -84,7 +83,7 @@ void ASpatialFunctionalTestFlowController::ServerSetReadyToRunTest_Implementatio
 
 void ASpatialFunctionalTestFlowController::CrossServerStartStep_Implementation(int StepIndex)
 {
-	if (ControllerType == ESpatialFunctionalTestFlowControllerType::Server)
+	if (WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Server)
 	{
 		StartStepInternal(StepIndex);
 	}
@@ -99,7 +98,7 @@ void ASpatialFunctionalTestFlowController::NotifyStepFinished()
 	ensureMsgf(CurrentStep.bIsRunning, TEXT("Trying to Notify Step Finished when it wasn't running. Either the Test ended prematurely or it's logic is calling FinishStep multiple times"));
 	if (CurrentStep.bIsRunning)
 	{
-		if (ControllerType == ESpatialFunctionalTestFlowControllerType::Server)
+		if (WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Server)
 		{
 			CrossServerNotifyStepFinished();
 		}
@@ -139,7 +138,7 @@ void ASpatialFunctionalTestFlowController::NotifyFinishTest(EFunctionalTestResul
 {
 	StopStepInternal();
 
-	if (ControllerType == ESpatialFunctionalTestFlowControllerType::Server)
+	if (WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Server)
 	{
 		ServerNotifyFinishTestInternal(TestResult, Message);
 	}
@@ -151,7 +150,7 @@ void ASpatialFunctionalTestFlowController::NotifyFinishTest(EFunctionalTestResul
 
 const FString ASpatialFunctionalTestFlowController::GetDisplayName()
 {
-	return FString::Printf(TEXT("[%s:%d]"), (ControllerType == ESpatialFunctionalTestFlowControllerType::Server ? TEXT("Server") : TEXT("Client")), ControllerInstanceId);
+	return FString::Printf(TEXT("[%s:%d]"), (WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Server ? TEXT("Server") : TEXT("Client")), WorkerDefinition.Id);
 }
 
 void ASpatialFunctionalTestFlowController::OnTestFinished()

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestStep.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestStep.cpp
@@ -8,7 +8,7 @@
 #include "SpatialFunctionalTestFlowController.h"
 #include "SpatialFunctionalTest.h"
 
-const FWorkerDefinition FWorkerDefinition::AllWorkers = FWorkerDefinition{ ESpatialFunctionalTestFlowControllerType::All, 0 };
+const FWorkerDefinition FWorkerDefinition::AllWorkers = FWorkerDefinition{ ESpatialFunctionalTestFlowControllerType::All, FWorkerDefinition::ALL_WORKERS_ID };
 const FWorkerDefinition FWorkerDefinition::AllServers = FWorkerDefinition{ ESpatialFunctionalTestFlowControllerType::Server, FWorkerDefinition::ALL_WORKERS_ID };
 const FWorkerDefinition FWorkerDefinition::AllClients = FWorkerDefinition{ ESpatialFunctionalTestFlowControllerType::Client, FWorkerDefinition::ALL_WORKERS_ID };
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestStep.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestStep.cpp
@@ -8,6 +8,20 @@
 #include "SpatialFunctionalTestFlowController.h"
 #include "SpatialFunctionalTest.h"
 
+const FWorkerDefinition FWorkerDefinition::AllWorkers = FWorkerDefinition{ ESpatialFunctionalTestFlowControllerType::All, 0 };
+const FWorkerDefinition FWorkerDefinition::AllServers = FWorkerDefinition{ ESpatialFunctionalTestFlowControllerType::Server, FWorkerDefinition::ALL_WORKERS_ID };
+const FWorkerDefinition FWorkerDefinition::AllClients = FWorkerDefinition{ ESpatialFunctionalTestFlowControllerType::Client, FWorkerDefinition::ALL_WORKERS_ID };
+
+FWorkerDefinition FWorkerDefinition::Server(int ServerId)
+{
+	return FWorkerDefinition{ESpatialFunctionalTestFlowControllerType::Server, ServerId};
+}
+
+FWorkerDefinition FWorkerDefinition::Client(int ClientId)
+{
+	return FWorkerDefinition{ ESpatialFunctionalTestFlowControllerType::Client, ClientId };
+}
+
 SpatialFunctionalTestStep::SpatialFunctionalTestStep()
 	: bIsRunning(false)
 	, bIsReady(false)

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestStep.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestStep.cpp
@@ -8,18 +8,18 @@
 #include "SpatialFunctionalTestFlowController.h"
 #include "SpatialFunctionalTest.h"
 
-const FWorkerDefinition FWorkerDefinition::AllWorkers = FWorkerDefinition{ ESpatialFunctionalTestFlowControllerType::All, FWorkerDefinition::ALL_WORKERS_ID };
-const FWorkerDefinition FWorkerDefinition::AllServers = FWorkerDefinition{ ESpatialFunctionalTestFlowControllerType::Server, FWorkerDefinition::ALL_WORKERS_ID };
-const FWorkerDefinition FWorkerDefinition::AllClients = FWorkerDefinition{ ESpatialFunctionalTestFlowControllerType::Client, FWorkerDefinition::ALL_WORKERS_ID };
+const FWorkerDefinition FWorkerDefinition::AllWorkers = FWorkerDefinition{ ESpatialFunctionalTestWorkerType::All, FWorkerDefinition::ALL_WORKERS_ID };
+const FWorkerDefinition FWorkerDefinition::AllServers = FWorkerDefinition{ ESpatialFunctionalTestWorkerType::Server, FWorkerDefinition::ALL_WORKERS_ID };
+const FWorkerDefinition FWorkerDefinition::AllClients = FWorkerDefinition{ ESpatialFunctionalTestWorkerType::Client, FWorkerDefinition::ALL_WORKERS_ID };
 
 FWorkerDefinition FWorkerDefinition::Server(int ServerId)
 {
-	return FWorkerDefinition{ESpatialFunctionalTestFlowControllerType::Server, ServerId};
+	return FWorkerDefinition{ESpatialFunctionalTestWorkerType::Server, ServerId};
 }
 
 FWorkerDefinition FWorkerDefinition::Client(int ClientId)
 {
-	return FWorkerDefinition{ ESpatialFunctionalTestFlowControllerType::Client, ClientId };
+	return FWorkerDefinition{ ESpatialFunctionalTestWorkerType::Client, ClientId };
 }
 
 SpatialFunctionalTestStep::SpatialFunctionalTestStep()

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
@@ -91,8 +91,8 @@ public:
 
 	// Add Steps for Blueprints
 	
-	UFUNCTION(BlueprintCallable, Category = "Spatial Functional Test", meta = (AutoCreateRefTerm = "IsReadyEvent,StartEvent,TickEvent", WorkerId = "1", ToolTip = "Adds a Test Step. You can define if you want to run on Server, Client of All.\n\nWorker Ids start from 1.\nIf you pass 0 it will run on all the Servers / Clients (there's also a convenience function GetAllWorkersId())\n\nIf you choose WorkerType 'All' it runs on all Servers and Clients (hence WorkerId is ignored)."))
-	void AddStep(const FString& StepName, ESpatialFunctionalTestFlowControllerType WorkerType, int WorkerId, const FStepIsReadyDelegate& IsReadyEvent, const FStepStartDelegate& StartEvent, const FStepTickDelegate& TickEvent, float StepTimeLimit = 0.0f);
+	UFUNCTION(BlueprintCallable, Category = "Spatial Functional Test", meta = (DisplayName = "Add Step", AutoCreateRefTerm = "IsReadyEvent,StartEvent,TickEvent", WorkerId = "1", ToolTip = "Adds a Test Step. You can define if you want to run on Server, Client of All.\n\nWorker Ids start from 1.\nIf you pass 0 it will run on all the Servers / Clients (there's also a convenience function GetAllWorkersId())\n\nIf you choose WorkerType 'All' it runs on all Servers and Clients (hence WorkerId is ignored)."))
+	void AddStepBlueprint(const FString& StepName, ESpatialFunctionalTestFlowControllerType WorkerType, int WorkerId, const FStepIsReadyDelegate& IsReadyEvent, const FStepStartDelegate& StartEvent, const FStepTickDelegate& TickEvent, float StepTimeLimit = 0.0f);
 
 	UFUNCTION(BlueprintCallable, Category = "Spatial Functional Test")
 	void AddGenericStep(const FSpatialFunctionalTestStepDefinition& StepDefinition);

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
@@ -100,8 +100,9 @@ public:
 	// Add Steps for C++
 	/**
 	 * Adds a Step to the Test. You can define if you want to run on Server, Client or All.
-	 * Worker Ids start from 1. If you pass FWorkerDefinition::ALL_WORKERS_ID (GetAllWorkersId()) it will run on all the Servers / Clients.
-	 * If you pass WorkerType 'All' it runs on all Servers and Clients (hence WorkerId is ignored).
+	 * There's helpers in FWorkerDefinition to make it easier / more concise. If you want to make a FWorkerDefinition from scratch,
+	 * keep in mind that Worker Ids start from 1. If you pass FWorkerDefinition::ALL_WORKERS_ID (GetAllWorkersId()) it will
+	 * run on all the Servers / Clients. If you pass WorkerType 'All' it runs on all Servers and Clients (hence WorkerId is ignored).
 	 */
 	FSpatialFunctionalTestStepDefinition& AddStep(const FString& StepName, const FWorkerDefinition& Worker, FIsReadyEventFunc IsReadyEvent = nullptr, FStartEventFunc StartEvent = nullptr, FTickEventFunc TickEvent = nullptr, float StepTimeLimit = 0.0f);
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
@@ -130,7 +130,7 @@ public:
 	UFUNCTION(BlueprintPure, meta = (ToolTip = "Returns the Id (0) that represents all Workers (ie Server / Client), useful for when you want to have a Server / Client Step run on all of them"), Category = "Spatial Functional Test")
 	int GetAllWorkersId() { return FWorkerDefinition::ALL_WORKERS_ID; }
 
-	UFUNCTION(BlueprintPure, meta=(ToolTip = "Returns a Worker Defnition that represents all of the Servers and Clients"), Category = "Spatial Functional Test")
+	UFUNCTION(BlueprintPure, meta = (ToolTip = "Returns a Worker Defnition that represents all of the Servers and Clients"), Category = "Spatial Functional Test")
 	FWorkerDefinition GetAllWorkers() { return FWorkerDefinition::AllWorkers; }
 
 	UFUNCTION(BlueprintPure, meta = (ToolTip = "Returns a Worker Defnition that represents all of the Servers"), Category = "Spatial Functional Test")

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
@@ -91,13 +91,18 @@ public:
 
 	// Add Steps for Blueprints
 	
-	UFUNCTION(BlueprintCallable, Category = "Spatial Functional Test", meta = (AutoCreateRefTerm = "IsReadyEvent,StartEvent,TickEvent", WorkerId = "1", ToolTip = "Adds a Step that runs on Servers. Server Worker Ids start from 1.\n\nIf you pass 0 it will run on All the Servers (there's also a convenience function GetAllWorkersId())"))
+	UFUNCTION(BlueprintCallable, Category = "Spatial Functional Test", meta = (AutoCreateRefTerm = "IsReadyEvent,StartEvent,TickEvent", WorkerId = "1", ToolTip = "Adds a Test Step. You can define if you want to run on Server, Client of All.\n\nWorker Ids start from 1.\nIf you pass 0 it will run on all the Servers / Clients (there's also a convenience function GetAllWorkersId())\n\nIf you choose WorkerType 'All' it runs on all Servers and Clients (hence WorkerId is ignored)."))
 	void AddStep(const FString& StepName, ESpatialFunctionalTestFlowControllerType WorkerType, int WorkerId, const FStepIsReadyDelegate& IsReadyEvent, const FStepStartDelegate& StartEvent, const FStepTickDelegate& TickEvent, float StepTimeLimit = 0.0f);
 
 	UFUNCTION(BlueprintCallable, Category = "Spatial Functional Test")
 	void AddGenericStep(const FSpatialFunctionalTestStepDefinition& StepDefinition);
 
 	// Add Steps for C++
+	/**
+	 * Adds a Step to the Test. You can define if you want to run on Server, Client or All.
+	 * Worker Ids start from 1. If you pass FWorkerDefinition::ALL_WORKERS_ID (GetAllWorkersId()) it will run on all the Servers / Clients.
+	 * If you pass WorkerType 'All' it runs on all Servers and Clients (hence WorkerId is ignored).
+	 */
 	FSpatialFunctionalTestStepDefinition& AddStep(const FString& StepName, ESpatialFunctionalTestFlowControllerType WorkerType, int WorkerId, FIsReadyEventFunc IsReadyEvent = nullptr, FStartEventFunc StartEvent = nullptr, FTickEventFunc TickEvent = nullptr, float StepTimeLimit = 0.0f);
 
 	// Start Running a Step

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
@@ -91,24 +91,14 @@ public:
 
 	// Add Steps for Blueprints
 	
-	UFUNCTION(BlueprintCallable, Category = "Spatial Functional Test", meta = (AutoCreateRefTerm = "IsReadyEvent,StartEvent,TickEvent", ToolTip = "Adds a Step that runs on All Clients and Servers"))
-	void AddUniversalStep(const FString& StepName, const FStepIsReadyDelegate& IsReadyEvent, const FStepStartDelegate& StartEvent, const FStepTickDelegate& TickEvent, float StepTimeLimit = 0.0f);
-
-	UFUNCTION(BlueprintCallable, Category = "Spatial Functional Test", meta = (AutoCreateRefTerm = "IsReadyEvent,StartEvent,TickEvent", ClientId = "1", ToolTip = "Adds a Step that runs on Clients. Client Worker Ids start from 1.\n\nIf you pass 0 it will run on All the Clients (there's also a convenience function GetAllWorkersId())"))
-	void AddClientStep(const FString& StepName, int ClientId, const FStepIsReadyDelegate& IsReadyEvent, const FStepStartDelegate& StartEvent, const FStepTickDelegate& TickEvent, float StepTimeLimit = 0.0f);
-
-	UFUNCTION(BlueprintCallable, Category = "Spatial Functional Test", meta = (AutoCreateRefTerm = "IsReadyEvent,StartEvent,TickEvent", ServerId = "1", ToolTip = "Adds a Step that runs on Servers. Server Worker Ids start from 1.\n\nIf you pass 0 it will run on All the Servers (there's also a convenience function GetAllWorkersId())"))
-	void AddServerStep(const FString& StepName, int ServerId, const FStepIsReadyDelegate& IsReadyEvent, const FStepStartDelegate& StartEvent, const FStepTickDelegate& TickEvent, float StepTimeLimit = 0.0f);
+	UFUNCTION(BlueprintCallable, Category = "Spatial Functional Test", meta = (AutoCreateRefTerm = "IsReadyEvent,StartEvent,TickEvent", WorkerId = "1", ToolTip = "Adds a Step that runs on Servers. Server Worker Ids start from 1.\n\nIf you pass 0 it will run on All the Servers (there's also a convenience function GetAllWorkersId())"))
+	void AddStep(const FString& StepName, ESpatialFunctionalTestFlowControllerType WorkerType, int WorkerId, const FStepIsReadyDelegate& IsReadyEvent, const FStepStartDelegate& StartEvent, const FStepTickDelegate& TickEvent, float StepTimeLimit = 0.0f);
 
 	UFUNCTION(BlueprintCallable, Category = "Spatial Functional Test")
 	void AddGenericStep(const FSpatialFunctionalTestStepDefinition& StepDefinition);
 
 	// Add Steps for C++
-	FSpatialFunctionalTestStepDefinition& AddUniversalStep(const FString& StepName, FIsReadyEventFunc IsReadyEvent = nullptr, FStartEventFunc StartEvent = nullptr, FTickEventFunc TickEvent = nullptr, float StepTimeLimit = 0.0f);
-
-	FSpatialFunctionalTestStepDefinition& AddClientStep(const FString& StepName, int ClientId, FIsReadyEventFunc IsReadyEvent = nullptr, FStartEventFunc StartEvent = nullptr, FTickEventFunc TickEvent = nullptr, float StepTimeLimit = 0.0f);
-
-	FSpatialFunctionalTestStepDefinition& AddServerStep(const FString& StepName, int ServerId, FIsReadyEventFunc IsReadyEvent = nullptr, FStartEventFunc StartEvent = nullptr, FTickEventFunc TickEvent = nullptr, float StepTimeLimit = 0.0f);
+	FSpatialFunctionalTestStepDefinition& AddStep(const FString& StepName, ESpatialFunctionalTestFlowControllerType WorkerType, int WorkerId, FIsReadyEventFunc IsReadyEvent = nullptr, FStartEventFunc StartEvent = nullptr, FTickEventFunc TickEvent = nullptr, float StepTimeLimit = 0.0f);
 
 	// Start Running a Step
 	void StartStep(const int StepIndex);

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
@@ -82,7 +82,7 @@ public:
 	const TArray<ASpatialFunctionalTestFlowController*>& GetFlowControllers() const { return FlowControllers; }
 
 	UFUNCTION(BlueprintPure, Category = "Spatial Functional Test")
-	ASpatialFunctionalTestFlowController* GetFlowController(ESpatialFunctionalTestFlowControllerType ControllerType, int InstanceId);
+	ASpatialFunctionalTestFlowController* GetFlowController(ESpatialFunctionalTestWorkerType ControllerType, int InstanceId);
 
 	// Get the FlowController that is Local to this instance
 	UFUNCTION(BlueprintPure, Category = "Spatial Functional Test")

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
@@ -92,7 +92,7 @@ public:
 
 	// Add Steps for Blueprints
 	
-	UFUNCTION(BlueprintCallable, Category = "Spatial Functional Test", meta = (DisplayName = "Add Step", AutoCreateRefTerm = "IsReadyEvent,StartEvent,TickEvent", ToolTip = "Adds a Test Step. Check GetAllWorkers(), GetAllServerWorkers() and GetAllClientWorkers() for convenience.\n\nIf you split the Worker pin you can define if you want to run on Server, Client of All.\n\nWorker Ids start from 1.\nIf you pass 0 it will run on all the Servers / Clients (there's also a convenience function GetAllWorkersId())\n\nIf you choose WorkerType 'All' it runs on all Servers and Clients (hence WorkerId is ignored)."))
+	UFUNCTION(BlueprintCallable, Category = "Spatial Functional Test", meta = (DisplayName = "Add Step", AutoCreateRefTerm = "IsReadyEvent,StartEvent,TickEvent", ToolTip = "Adds a Test Step. Check GetAllWorkers(), GetAllServerWorkers() and GetAllClientWorkers() for convenience.\n\nIf you split the Worker pin you can define if you want to run on Server, Client or All.\n\nWorker Ids start from 1.\nIf you pass 0 it will run on all the Servers / Clients (there's also a convenience function GetAllWorkersId())\n\nIf you choose WorkerType 'All' it runs on all Servers and Clients (hence WorkerId is ignored)."))
 	void AddStepBlueprint(const FString& StepName, const FWorkerDefinition& Worker, const FStepIsReadyDelegate& IsReadyEvent, const FStepStartDelegate& StartEvent, const FStepTickDelegate& TickEvent, float StepTimeLimit = 0.0f);
 
 	UFUNCTION(BlueprintCallable, Category = "Spatial Functional Test")

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
@@ -91,8 +91,8 @@ public:
 
 	// Add Steps for Blueprints
 	
-	UFUNCTION(BlueprintCallable, Category = "Spatial Functional Test", meta = (DisplayName = "Add Step", AutoCreateRefTerm = "IsReadyEvent,StartEvent,TickEvent", WorkerId = "1", ToolTip = "Adds a Test Step. You can define if you want to run on Server, Client of All.\n\nWorker Ids start from 1.\nIf you pass 0 it will run on all the Servers / Clients (there's also a convenience function GetAllWorkersId())\n\nIf you choose WorkerType 'All' it runs on all Servers and Clients (hence WorkerId is ignored)."))
-	void AddStepBlueprint(const FString& StepName, ESpatialFunctionalTestFlowControllerType WorkerType, int WorkerId, const FStepIsReadyDelegate& IsReadyEvent, const FStepStartDelegate& StartEvent, const FStepTickDelegate& TickEvent, float StepTimeLimit = 0.0f);
+	UFUNCTION(BlueprintCallable, Category = "Spatial Functional Test", meta = (DisplayName = "Add Step", AutoCreateRefTerm = "IsReadyEvent,StartEvent,TickEvent", ToolTip = "Adds a Test Step. Check GetAllWorkers(), GetAllServerWorkers() and GetAllClientWorkers() for convenience.\n\nIf you split the Worker pin you can define if you want to run on Server, Client of All.\n\nWorker Ids start from 1.\nIf you pass 0 it will run on all the Servers / Clients (there's also a convenience function GetAllWorkersId())\n\nIf you choose WorkerType 'All' it runs on all Servers and Clients (hence WorkerId is ignored)."))
+	void AddStepBlueprint(const FString& StepName, const FWorkerDefinition& Worker, const FStepIsReadyDelegate& IsReadyEvent, const FStepStartDelegate& StartEvent, const FStepTickDelegate& TickEvent, float StepTimeLimit = 0.0f);
 
 	UFUNCTION(BlueprintCallable, Category = "Spatial Functional Test")
 	void AddGenericStep(const FSpatialFunctionalTestStepDefinition& StepDefinition);
@@ -103,7 +103,7 @@ public:
 	 * Worker Ids start from 1. If you pass FWorkerDefinition::ALL_WORKERS_ID (GetAllWorkersId()) it will run on all the Servers / Clients.
 	 * If you pass WorkerType 'All' it runs on all Servers and Clients (hence WorkerId is ignored).
 	 */
-	FSpatialFunctionalTestStepDefinition& AddStep(const FString& StepName, ESpatialFunctionalTestFlowControllerType WorkerType, int WorkerId, FIsReadyEventFunc IsReadyEvent = nullptr, FStartEventFunc StartEvent = nullptr, FTickEventFunc TickEvent = nullptr, float StepTimeLimit = 0.0f);
+	FSpatialFunctionalTestStepDefinition& AddStep(const FString& StepName, const FWorkerDefinition& Worker, FIsReadyEventFunc IsReadyEvent = nullptr, FStartEventFunc StartEvent = nullptr, FTickEventFunc TickEvent = nullptr, float StepTimeLimit = 0.0f);
 
 	// Start Running a Step
 	void StartStep(const int StepIndex);
@@ -127,6 +127,15 @@ public:
 	// Convenience function that returns the Id used for executing steps on all Servers / Clients
 	UFUNCTION(BlueprintPure, meta = (ToolTip = "Returns the Id (0) that represents all Workers (ie Server / Client), useful for when you want to have a Server / Client Step run on all of them"), Category = "Spatial Functional Test")
 	int GetAllWorkersId() { return FWorkerDefinition::ALL_WORKERS_ID; }
+
+	UFUNCTION(BlueprintPure, meta=(ToolTip = "Returns a Worker Defnition that represents all of the Servers and Clients"), Category = "Spatial Functional Test")
+	FWorkerDefinition GetAllWorkers() { return FWorkerDefinition::AllWorkers; }
+
+	UFUNCTION(BlueprintPure, meta = (ToolTip = "Returns a Worker Defnition that represents all of the Servers"), Category = "Spatial Functional Test")
+	FWorkerDefinition GetAllServers() { return FWorkerDefinition::AllServers; }
+
+	UFUNCTION(BlueprintPure, meta = (ToolTip = "Returns a Worker Defnition that represents all of the Clients"), Category = "Spatial Functional Test")
+	FWorkerDefinition GetAllClients() { return FWorkerDefinition::AllClients; }
 
 	// # Actor Delegation APIs
 	UFUNCTION(CrossServer, Reliable, BlueprintCallable, Category = "Spatial Functional Test", meta=(ToolTip="Allows you to delegate authority over this Actor to a specific Server Worker. \n\nKeep in mind that currently this functionality only works in single layer Load Balancing Strategies, and your Default Load Balancing Strategy needs to implement ISpatialFunctionalTestLBDelegationInterface."))

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTestFlowController.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTestFlowController.h
@@ -47,11 +47,10 @@ public:
 	UPROPERTY(Replicated)
 	ASpatialFunctionalTest* OwningTest;
 
+	// Holds WorkerType and WorkerId. Type should be only Server or Client, and Id >= 1 (after registered)
+	// The Client WorkerId will be given out in the order they connect; the Server one matches its VirtualWorkerId
 	UPROPERTY(Replicated)
-	ESpatialFunctionalTestFlowControllerType ControllerType;
-
-	UPROPERTY(Replicated)
-	int ControllerInstanceId; //client defined by login order; server maps to virtual worker
+	FWorkerDefinition WorkerDefinition;
 
 	// Prettier way to display type+id combo since it can be quite useful
 	const FString GetDisplayName();
@@ -60,12 +59,15 @@ public:
 	void OnTestFinished();
 
 	// Returns if the data regarding the FlowControllers has been replicated to their owners
-	bool IsReadyToRunTest() { return ControllerInstanceId != INVALID_FLOW_CONTROLLER_ID && bIsReadyToRunTest; }
+	bool IsReadyToRunTest() { return WorkerDefinition.Id != INVALID_FLOW_CONTROLLER_ID && bIsReadyToRunTest; }
 
 	// Each server worker will assign local client ids, this function will be used by
 	// the Test owner server worker to guarantee they are all unique
 	UFUNCTION(CrossServer, Reliable)
-	void CrossServerSetControllerInstanceId(int NewControllerInstanceId);
+	void CrossServerSetWorkerId(int NewWorkerId);
+
+	UFUNCTION(BlueprintPure, Category = "Spatial Functional Test")
+	FWorkerDefinition GetWorkerDefinition() { return WorkerDefinition; }
 
 private:
 	// Current Step being executed

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTestStep.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTestStep.h
@@ -25,7 +25,7 @@ enum class ESpatialFunctionalTestFlowControllerType : uint8
 {
 	Server,
 	Client,
-	All
+	All		// Special type that allows you to reference all the Servers and Clients
 };
 
 
@@ -34,12 +34,31 @@ struct FWorkerDefinition
 {
 	GENERATED_BODY()
 
+	// Type of Worker, usually Server or Client.
 	UPROPERTY(BlueprintReadWrite, Category="Spatial Functional Test")
-	ESpatialFunctionalTestFlowControllerType ControllerType;
-	UPROPERTY(BlueprintReadWrite, Category = "Spatial Functional Test")
-	int WorkerId;
+	ESpatialFunctionalTestFlowControllerType Type = ESpatialFunctionalTestFlowControllerType::Server;
 
+	// Ids of Workers start from 1.
+	UPROPERTY(BlueprintReadWrite, Category = "Spatial Functional Test")
+	int Id = 1;
+
+	// Id that represents all workers, useful when you want to run a Step on all Clients or Servers.
 	static const int ALL_WORKERS_ID = 0;
+
+	// Definition that represents all workers (both Client and Server).
+	static const FWorkerDefinition AllWorkers;
+
+	// Definition that represents all Server workers
+	static const FWorkerDefinition AllServers;
+
+	// Definition that represents all Client workers
+	static const FWorkerDefinition AllClients;
+
+	// Helper for Server Worker Definition
+	static FWorkerDefinition Server(int ServerId);
+
+	// Helper for Client Worker Definition
+	static FWorkerDefinition Client(int ClientId);
 };
 
 USTRUCT(BlueprintType)
@@ -53,11 +72,15 @@ struct FSpatialFunctionalTestStepDefinition
 	{
 	}
 
+	// Description so that in the logs you can clearly identify Test Steps
 	UPROPERTY()
 	FString StepName;
 
+	// Given that we support different delegate types for C++ and BP
+	// this is a variable to distinguish what kind you're running
 	bool bIsNativeDefinition;
 
+	// BP Delegates
 	UPROPERTY()
 	FStepIsReadyDelegate IsReadyEvent;
 	UPROPERTY()
@@ -65,13 +88,16 @@ struct FSpatialFunctionalTestStepDefinition
 	UPROPERTY()
 	FStepTickDelegate TickEvent;
 
+	// C++ Delegates
 	FNativeStepIsReadyDelegate NativeIsReadyEvent;
 	FNativeStepStartDelegate NativeStartEvent;
 	FNativeStepTickDelegate NativeTickEvent;
 
+	// Workers the Test Step should run on
 	UPROPERTY()
 	TArray<FWorkerDefinition> Workers;
 
+	// Maximum time it can take to finish this Step; if <= 0 it fallback to the time limit of the whole Test
 	UPROPERTY()
 	float TimeLimit;
 };

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTestStep.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTestStep.h
@@ -21,7 +21,7 @@ DECLARE_DELEGATE_OneParam(FNativeStepStartDelegate, ASpatialFunctionalTest*);
 DECLARE_DELEGATE_TwoParams(FNativeStepTickDelegate, ASpatialFunctionalTest*, float /*DeltaTime*/);
 
 UENUM()
-enum class ESpatialFunctionalTestFlowControllerType : uint8
+enum class ESpatialFunctionalTestWorkerType : uint8
 {
 	Server,
 	Client,
@@ -35,11 +35,11 @@ struct FWorkerDefinition
 	GENERATED_BODY()
 
 	// Type of Worker, usually Server or Client.
-	UPROPERTY(BlueprintReadWrite, Category="Spatial Functional Test")
-	ESpatialFunctionalTestFlowControllerType Type = ESpatialFunctionalTestFlowControllerType::Server;
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Spatial Functional Test")
+	ESpatialFunctionalTestWorkerType Type = ESpatialFunctionalTestWorkerType::Server;
 
 	// Ids of Workers start from 1.
-	UPROPERTY(BlueprintReadWrite, Category = "Spatial Functional Test")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Spatial Functional Test")
 	int Id = 1;
 
 	// Id that represents all workers, useful when you want to run a Step on all Clients or Servers.
@@ -59,6 +59,16 @@ struct FWorkerDefinition
 
 	// Helper for Client Worker Definition
 	static FWorkerDefinition Client(int ClientId);
+
+	bool operator == (const FWorkerDefinition& Other)
+	{
+		return Type == Other.Type && Id == Other.Id;
+	};
+
+	bool operator != (const FWorkerDefinition& Other)
+	{
+		return Type != Other.Type || Id != Other.Id;
+	};
 };
 
 USTRUCT(BlueprintType)

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTestStep.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTestStep.h
@@ -97,7 +97,7 @@ struct FSpatialFunctionalTestStepDefinition
 	UPROPERTY()
 	TArray<FWorkerDefinition> Workers;
 
-	// Maximum time it can take to finish this Step; if <= 0 it fallback to the time limit of the whole Test
+	// Maximum time it can take to finish this Step; if <= 0 it falls back to the time limit of the whole Test
 	UPROPERTY()
 	float TimeLimit;
 };
@@ -122,4 +122,3 @@ public:
 	
 	FSpatialFunctionalTestStepDefinition StepDefinition;
 };
-

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTestStep.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTestStep.h
@@ -24,7 +24,8 @@ UENUM()
 enum class ESpatialFunctionalTestFlowControllerType : uint8
 {
 	Server,
-	Client
+	Client,
+	All
 };
 
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAndClientOrchestrationTest/CrossServerAndClientOrchestrationFlowController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAndClientOrchestrationTest/CrossServerAndClientOrchestrationFlowController.cpp
@@ -8,5 +8,5 @@
 void ACrossServerAndClientOrchestrationFlowController::ServerClientReadValueAck_Implementation()
 {
 	ACrossServerAndClientOrchestrationTest* Test = Cast<ACrossServerAndClientOrchestrationTest>(OwningTest);
-	Test->CrossServerSetTestValue(ESpatialFunctionalTestFlowControllerType::Client, ControllerInstanceId);
+	Test->CrossServerSetTestValue(ESpatialFunctionalTestWorkerType::Client, WorkerDefinition.Id);
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAndClientOrchestrationTest/CrossServerAndClientOrchestrationTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAndClientOrchestrationTest/CrossServerAndClientOrchestrationTest.cpp
@@ -40,7 +40,7 @@ void ACrossServerAndClientOrchestrationTest::BeginPlay()
 			//Send CrossServer RPC to Test actor to set the flag for this server flow controller instance
 			ACrossServerAndClientOrchestrationTest* CrossServerTest = Cast<ACrossServerAndClientOrchestrationTest>(NetTest);
 			ASpatialFunctionalTestFlowController* FlowController = CrossServerTest->GetLocalFlowController();
-			CrossServerTest->CrossServerSetTestValue(FlowController->ControllerType, FlowController->ControllerInstanceId);
+			CrossServerTest->CrossServerSetTestValue(FlowController->WorkerDefinition.Type, FlowController->WorkerDefinition.Id);
 			CrossServerTest->FinishStep();
 			});
 	}
@@ -115,10 +115,10 @@ void ACrossServerAndClientOrchestrationTest::BeginPlay()
 	}
 }
 
-void ACrossServerAndClientOrchestrationTest::CrossServerSetTestValue_Implementation(ESpatialFunctionalTestFlowControllerType ControllerType, uint8 ChangedInstance)
+void ACrossServerAndClientOrchestrationTest::CrossServerSetTestValue_Implementation(ESpatialFunctionalTestWorkerType ControllerType, uint8 ChangedInstance)
 {
 	uint8 FlagIndex = ChangedInstance - 1;
-	if(ControllerType == ESpatialFunctionalTestFlowControllerType::Client)
+	if(ControllerType == ESpatialFunctionalTestWorkerType::Client)
 	{
 		if(FlagIndex >= ClientWorkerSetValues.Num())
 		{
@@ -158,7 +158,7 @@ void ACrossServerAndClientOrchestrationTest::Assert_ServerStepIsRunningInExpecte
 	InstanceToRunIn = GetNumExpectedServers() == 1 ? 1 : InstanceToRunIn;
 	
 	// Check Step is running in expected controller instance
-	AssertEqual_Int(FlowController->ControllerInstanceId, InstanceToRunIn, TEXT("Step executing in expected FlowController instance"), this);
+	AssertEqual_Int(FlowController->WorkerDefinition.Id, InstanceToRunIn, TEXT("Step executing in expected FlowController instance"), this);
 
 	// Check Step is running in expected worker instance
 	AssertEqual_Int(LocalWorkerId, InstanceToRunIn, TEXT("Step executing in expected Worker instance"), this);
@@ -168,7 +168,7 @@ void ACrossServerAndClientOrchestrationTest::Assert_ClientStepIsRunningInExpecte
 {
 	// Check Step is running in expected controller instance
 	// We can't check against clients as clients don't have natural logical IDs, Controllers are mapped by login order
-	AssertEqual_Int(FlowController->ControllerInstanceId, InstanceToRunIn, TEXT("Step executing in expected FlowController instance"), this);
+	AssertEqual_Int(FlowController->WorkerDefinition.Id, InstanceToRunIn, TEXT("Step executing in expected FlowController instance"), this);
 }
 
 bool ACrossServerAndClientOrchestrationTest::CheckAllValuesHaveBeenSetAndCanBeLocallyRead()

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAndClientOrchestrationTest/CrossServerAndClientOrchestrationTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAndClientOrchestrationTest/CrossServerAndClientOrchestrationTest.cpp
@@ -36,7 +36,7 @@ void ACrossServerAndClientOrchestrationTest::BeginPlay()
 
 	{
 		//Step 1 - Set all server values
-		AddServerStep(TEXT("Servers_SetupSetValue"), FWorkerDefinition::ALL_WORKERS_ID, nullptr, [](ASpatialFunctionalTest* NetTest) {
+		AddStep(TEXT("Servers_SetupSetValue"), ESpatialFunctionalTestFlowControllerType::Server, FWorkerDefinition::ALL_WORKERS_ID, nullptr, [](ASpatialFunctionalTest* NetTest) {
 			//Send CrossServer RPC to Test actor to set the flag for this server flow controller instance
 			ACrossServerAndClientOrchestrationTest* CrossServerTest = Cast<ACrossServerAndClientOrchestrationTest>(NetTest);
 			ASpatialFunctionalTestFlowController* FlowController = CrossServerTest->GetLocalFlowController();
@@ -46,7 +46,7 @@ void ACrossServerAndClientOrchestrationTest::BeginPlay()
 	}
 	{
 		//Step 2 - Set all client values
-		AddClientStep(TEXT("Clients_SetupSetValue"), FWorkerDefinition::ALL_WORKERS_ID, nullptr, [](ASpatialFunctionalTest* NetTest) {
+		AddStep(TEXT("Clients_SetupSetValue"), ESpatialFunctionalTestFlowControllerType::Client, FWorkerDefinition::ALL_WORKERS_ID, nullptr, [](ASpatialFunctionalTest* NetTest) {
 			//Send Server RPC via flow controller to set the Test actor flag for this client flow controller instance
 			ACrossServerAndClientOrchestrationFlowController* FlowController = Cast<ACrossServerAndClientOrchestrationFlowController>(NetTest->GetLocalFlowController());
 			FlowController->ServerClientReadValueAck();
@@ -55,7 +55,7 @@ void ACrossServerAndClientOrchestrationTest::BeginPlay()
 	}
 	{
 		//Step 3 - Verify steps for server 1 run in right context and can read all values set in test by other workers
-		AddServerStep(TEXT("Server1_Validate"), 1, nullptr, 
+		AddStep(TEXT("Server1_Validate"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr,
 			[](ASpatialFunctionalTest* NetTest) {
 				ACrossServerAndClientOrchestrationTest* CrossServerTest = Cast<ACrossServerAndClientOrchestrationTest>(NetTest);
 				CrossServerTest->Assert_ServerStepIsRunningInExpectedEnvironment(1, CrossServerTest->GetLocalFlowController());
@@ -70,7 +70,7 @@ void ACrossServerAndClientOrchestrationTest::BeginPlay()
 	}
 	{
 		//Step 4 - Verify steps for server 2 run in right context and can read all values set in test by other workers
-		AddServerStep(TEXT("Server2_Validate"), 2, nullptr,
+		AddStep(TEXT("Server2_Validate"), ESpatialFunctionalTestFlowControllerType::Server, 2, nullptr,
 			[](ASpatialFunctionalTest* NetTest) {
 				ACrossServerAndClientOrchestrationTest* CrossServerTest = Cast<ACrossServerAndClientOrchestrationTest>(NetTest);
 				CrossServerTest->Assert_ServerStepIsRunningInExpectedEnvironment(2, CrossServerTest->GetLocalFlowController());
@@ -85,7 +85,7 @@ void ACrossServerAndClientOrchestrationTest::BeginPlay()
 	}
 	{
 		//Step 5 - Verify steps for client 1 run in right context and can read all values set in test by other workers
-		AddClientStep(TEXT("Client1_Validate"), 1, nullptr, 
+		AddStep(TEXT("Client1_Validate"), ESpatialFunctionalTestFlowControllerType::Client, 1, nullptr,
 			[](ASpatialFunctionalTest* NetTest) {
 				ACrossServerAndClientOrchestrationTest* CrossServerTest = Cast<ACrossServerAndClientOrchestrationTest>(NetTest);
 				CrossServerTest->Assert_ClientStepIsRunningInExpectedEnvironment(1, CrossServerTest->GetLocalFlowController());
@@ -100,7 +100,7 @@ void ACrossServerAndClientOrchestrationTest::BeginPlay()
 	}
 	{
 		//Step 6 - Verify steps for client 2 run in right context and can read all values set in test by other workers
-		AddClientStep(TEXT("Client2_Validate"), 2, nullptr, 
+		AddStep(TEXT("Client2_Validate"), ESpatialFunctionalTestFlowControllerType::Client, 2, nullptr,
 			[](ASpatialFunctionalTest* NetTest) {
 				ACrossServerAndClientOrchestrationTest* CrossServerTest = Cast<ACrossServerAndClientOrchestrationTest>(NetTest);
 				CrossServerTest->Assert_ClientStepIsRunningInExpectedEnvironment(2, CrossServerTest->GetLocalFlowController());

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAndClientOrchestrationTest/CrossServerAndClientOrchestrationTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAndClientOrchestrationTest/CrossServerAndClientOrchestrationTest.cpp
@@ -36,7 +36,7 @@ void ACrossServerAndClientOrchestrationTest::BeginPlay()
 
 	{
 		//Step 1 - Set all server values
-		AddStep(TEXT("Servers_SetupSetValue"), ESpatialFunctionalTestFlowControllerType::Server, FWorkerDefinition::ALL_WORKERS_ID, nullptr, [](ASpatialFunctionalTest* NetTest) {
+		AddStep(TEXT("Servers_SetupSetValue"), FWorkerDefinition::AllServers, nullptr, [](ASpatialFunctionalTest* NetTest) {
 			//Send CrossServer RPC to Test actor to set the flag for this server flow controller instance
 			ACrossServerAndClientOrchestrationTest* CrossServerTest = Cast<ACrossServerAndClientOrchestrationTest>(NetTest);
 			ASpatialFunctionalTestFlowController* FlowController = CrossServerTest->GetLocalFlowController();
@@ -46,7 +46,7 @@ void ACrossServerAndClientOrchestrationTest::BeginPlay()
 	}
 	{
 		//Step 2 - Set all client values
-		AddStep(TEXT("Clients_SetupSetValue"), ESpatialFunctionalTestFlowControllerType::Client, FWorkerDefinition::ALL_WORKERS_ID, nullptr, [](ASpatialFunctionalTest* NetTest) {
+		AddStep(TEXT("Clients_SetupSetValue"), FWorkerDefinition::AllClients, nullptr, [](ASpatialFunctionalTest* NetTest) {
 			//Send Server RPC via flow controller to set the Test actor flag for this client flow controller instance
 			ACrossServerAndClientOrchestrationFlowController* FlowController = Cast<ACrossServerAndClientOrchestrationFlowController>(NetTest->GetLocalFlowController());
 			FlowController->ServerClientReadValueAck();
@@ -55,7 +55,7 @@ void ACrossServerAndClientOrchestrationTest::BeginPlay()
 	}
 	{
 		//Step 3 - Verify steps for server 1 run in right context and can read all values set in test by other workers
-		AddStep(TEXT("Server1_Validate"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr,
+		AddStep(TEXT("Server1_Validate"), FWorkerDefinition::Server(1), nullptr,
 			[](ASpatialFunctionalTest* NetTest) {
 				ACrossServerAndClientOrchestrationTest* CrossServerTest = Cast<ACrossServerAndClientOrchestrationTest>(NetTest);
 				CrossServerTest->Assert_ServerStepIsRunningInExpectedEnvironment(1, CrossServerTest->GetLocalFlowController());
@@ -70,7 +70,7 @@ void ACrossServerAndClientOrchestrationTest::BeginPlay()
 	}
 	{
 		//Step 4 - Verify steps for server 2 run in right context and can read all values set in test by other workers
-		AddStep(TEXT("Server2_Validate"), ESpatialFunctionalTestFlowControllerType::Server, 2, nullptr,
+		AddStep(TEXT("Server2_Validate"), FWorkerDefinition::Server(2), nullptr,
 			[](ASpatialFunctionalTest* NetTest) {
 				ACrossServerAndClientOrchestrationTest* CrossServerTest = Cast<ACrossServerAndClientOrchestrationTest>(NetTest);
 				CrossServerTest->Assert_ServerStepIsRunningInExpectedEnvironment(2, CrossServerTest->GetLocalFlowController());
@@ -85,7 +85,7 @@ void ACrossServerAndClientOrchestrationTest::BeginPlay()
 	}
 	{
 		//Step 5 - Verify steps for client 1 run in right context and can read all values set in test by other workers
-		AddStep(TEXT("Client1_Validate"), ESpatialFunctionalTestFlowControllerType::Client, 1, nullptr,
+		AddStep(TEXT("Client1_Validate"), FWorkerDefinition::Client(1), nullptr,
 			[](ASpatialFunctionalTest* NetTest) {
 				ACrossServerAndClientOrchestrationTest* CrossServerTest = Cast<ACrossServerAndClientOrchestrationTest>(NetTest);
 				CrossServerTest->Assert_ClientStepIsRunningInExpectedEnvironment(1, CrossServerTest->GetLocalFlowController());
@@ -100,7 +100,7 @@ void ACrossServerAndClientOrchestrationTest::BeginPlay()
 	}
 	{
 		//Step 6 - Verify steps for client 2 run in right context and can read all values set in test by other workers
-		AddStep(TEXT("Client2_Validate"), ESpatialFunctionalTestFlowControllerType::Client, 2, nullptr,
+		AddStep(TEXT("Client2_Validate"), FWorkerDefinition::Client(2), nullptr,
 			[](ASpatialFunctionalTest* NetTest) {
 				ACrossServerAndClientOrchestrationTest* CrossServerTest = Cast<ACrossServerAndClientOrchestrationTest>(NetTest);
 				CrossServerTest->Assert_ClientStepIsRunningInExpectedEnvironment(2, CrossServerTest->GetLocalFlowController());

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAndClientOrchestrationTest/CrossServerAndClientOrchestrationTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAndClientOrchestrationTest/CrossServerAndClientOrchestrationTest.h
@@ -25,7 +25,7 @@ public:
 	TArray<bool> ClientWorkerSetValues;
 
 	UFUNCTION(CrossServer, Reliable)
-	void CrossServerSetTestValue(ESpatialFunctionalTestFlowControllerType ControllerType, uint8 ChangedInstance);
+	void CrossServerSetTestValue(ESpatialFunctionalTestWorkerType ControllerType, uint8 ChangedInstance);
 
 	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const;
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/DormancyAndTombstoneTest/DormancyAndTombstoneTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/DormancyAndTombstoneTest/DormancyAndTombstoneTest.cpp
@@ -32,7 +32,7 @@ void ADormancyAndTombstoneTest::BeginPlay()
 	Super::BeginPlay();
 
 	{	// Step 1 - Set TestIntProp to 1.
-		AddStep(TEXT("ServerSetTestIntPropTo1"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, [](ASpatialFunctionalTest* NetTest) {
+		AddStep(TEXT("ServerSetTestIntPropTo1"), FWorkerDefinition::Server(1), nullptr, [](ASpatialFunctionalTest* NetTest) {
 			int Counter = 0;
 			int ExpectedDormancyActors = 1;
 			for (TActorIterator<ADormancyTestActor> Iter(NetTest->GetWorld()); Iter; ++Iter)
@@ -47,7 +47,7 @@ void ADormancyAndTombstoneTest::BeginPlay()
 			});
 	}
 	{	// Step 2 - Observe TestIntProp on client should still be 0.
-		AddStep(TEXT("ClientCheckValue"), ESpatialFunctionalTestFlowControllerType::Client, FWorkerDefinition::ALL_WORKERS_ID, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
+		AddStep(TEXT("ClientCheckValue"), FWorkerDefinition::AllClients, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
 
 			bool bPassesChecks = true;
 
@@ -72,7 +72,7 @@ void ADormancyAndTombstoneTest::BeginPlay()
 	}
 
 	{	// Step 3 - Delete the test actor on the server.
-		AddStep(TEXT("ServerDeleteActor"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, [](ASpatialFunctionalTest* NetTest) {
+		AddStep(TEXT("ServerDeleteActor"), FWorkerDefinition::Server(1), nullptr, [](ASpatialFunctionalTest* NetTest) {
 			int Counter = 0;
 			int ExpectedDormancyActors = 1;
 			for (TActorIterator<ADormancyTestActor> Iter(NetTest->GetWorld()); Iter; ++Iter)
@@ -87,7 +87,7 @@ void ADormancyAndTombstoneTest::BeginPlay()
 	}
 
 	{	// Step 4 - Observe the test actor has been deleted on the client.
-		AddStep(TEXT("ClientCheckActorDestroyed"), ESpatialFunctionalTestFlowControllerType::Client, FWorkerDefinition::ALL_WORKERS_ID, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
+		AddStep(TEXT("ClientCheckActorDestroyed"), FWorkerDefinition::AllClients, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
 			int Counter = 0;
 			int ExpectedDormancyActors = 0;
 			for (TActorIterator<ADormancyTestActor> Iter(NetTest->GetWorld()); Iter; ++Iter)

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/DormancyAndTombstoneTest/DormancyAndTombstoneTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/DormancyAndTombstoneTest/DormancyAndTombstoneTest.cpp
@@ -32,7 +32,7 @@ void ADormancyAndTombstoneTest::BeginPlay()
 	Super::BeginPlay();
 
 	{	// Step 1 - Set TestIntProp to 1.
-		AddServerStep(TEXT("ServerSetTestIntPropTo1"), 1, nullptr, [](ASpatialFunctionalTest* NetTest) {
+		AddStep(TEXT("ServerSetTestIntPropTo1"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, [](ASpatialFunctionalTest* NetTest) {
 			int Counter = 0;
 			int ExpectedDormancyActors = 1;
 			for (TActorIterator<ADormancyTestActor> Iter(NetTest->GetWorld()); Iter; ++Iter)
@@ -47,7 +47,7 @@ void ADormancyAndTombstoneTest::BeginPlay()
 			});
 	}
 	{	// Step 2 - Observe TestIntProp on client should still be 0.
-		AddClientStep(TEXT("ClientCheckValue"), 0, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
+		AddStep(TEXT("ClientCheckValue"), ESpatialFunctionalTestFlowControllerType::Client, FWorkerDefinition::ALL_WORKERS_ID, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
 
 			bool bPassesChecks = true;
 
@@ -72,7 +72,7 @@ void ADormancyAndTombstoneTest::BeginPlay()
 	}
 
 	{	// Step 3 - Delete the test actor on the server.
-		AddServerStep(TEXT("ServerDeleteActor"), 1, nullptr, [](ASpatialFunctionalTest* NetTest) {
+		AddStep(TEXT("ServerDeleteActor"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, [](ASpatialFunctionalTest* NetTest) {
 			int Counter = 0;
 			int ExpectedDormancyActors = 1;
 			for (TActorIterator<ADormancyTestActor> Iter(NetTest->GetWorld()); Iter; ++Iter)
@@ -87,7 +87,7 @@ void ADormancyAndTombstoneTest::BeginPlay()
 	}
 
 	{	// Step 4 - Observe the test actor has been deleted on the client.
-		AddClientStep(TEXT("ClientCheckActorDestroyed"), 0, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
+		AddStep(TEXT("ClientCheckActorDestroyed"), ESpatialFunctionalTestFlowControllerType::Client, FWorkerDefinition::ALL_WORKERS_ID, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
 			int Counter = 0;
 			int ExpectedDormancyActors = 0;
 			for (TActorIterator<ADormancyTestActor> Iter(NetTest->GetWorld()); Iter; ++Iter)

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/RegisterAutoDestroyActorsTest/RegisterAutoDestroyActorsTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/RegisterAutoDestroyActorsTest/RegisterAutoDestroyActorsTest.cpp
@@ -17,7 +17,7 @@ void ARegisterAutoDestroyActorsTestPart1::BeginPlay()
 {
 	Super::BeginPlay();
 	{ // Step 1 - Spawn Actor On Auth 
-		AddStep(TEXT("SERVER_1_Spawn"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, [](ASpatialFunctionalTest* NetTest){
+		AddStep(TEXT("SERVER_1_Spawn"), FWorkerDefinition::Server(1), nullptr, [](ASpatialFunctionalTest* NetTest){
 			UWorld* World = NetTest->GetWorld();
 			int NumVirtualWorkers = NetTest->GetNumberOfServerWorkers();
 
@@ -37,7 +37,7 @@ void ARegisterAutoDestroyActorsTestPart1::BeginPlay()
 	}
 
 	{ // Step 2 - Check If Clients have it
-		AddStep(TEXT("CLIENT_ALL_CheckActorsSpawned"), ESpatialFunctionalTestFlowControllerType::Client, FWorkerDefinition::ALL_WORKERS_ID, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime){
+		AddStep(TEXT("CLIENT_ALL_CheckActorsSpawned"), FWorkerDefinition::AllClients, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime){
 				int NumCharactersFound = 0;
 				int NumCharactersExpected = NetTest->GetNumberOfServerWorkers();
 				UWorld* World = NetTest->GetWorld();
@@ -54,7 +54,7 @@ void ARegisterAutoDestroyActorsTestPart1::BeginPlay()
 	}
 
 	{ // Step 3 - Destroy by second server that doesn't have authority
-		AddStep(TEXT("SERVER_2_RegisterAutoDestroyActors"), ESpatialFunctionalTestFlowControllerType::Server, 2, [](ASpatialFunctionalTest* NetTest) -> bool {
+		AddStep(TEXT("SERVER_2_RegisterAutoDestroyActors"), FWorkerDefinition::Server(2), [](ASpatialFunctionalTest* NetTest) -> bool {
 			int NumCharactersFound = 0;
 			int NumCharactersExpected = NetTest->GetNumberOfServerWorkers();
 			UWorld* World = NetTest->GetWorld();
@@ -91,8 +91,8 @@ void ARegisterAutoDestroyActorsTestPart2::BeginPlay()
 		FSpatialFunctionalTestStepDefinition StepDefinition;
 		StepDefinition.bIsNativeDefinition = true;
 		StepDefinition.TimeLimit = 0.0f;
-		StepDefinition.Workers.Add(FWorkerDefinition{ESpatialFunctionalTestFlowControllerType::Server, FWorkerDefinition::ALL_WORKERS_ID});
-		StepDefinition.Workers.Add(FWorkerDefinition{ESpatialFunctionalTestFlowControllerType::Client, FWorkerDefinition::ALL_WORKERS_ID});
+		StepDefinition.Workers.Add(FWorkerDefinition::AllServers);
+		StepDefinition.Workers.Add(FWorkerDefinition::AllClients);
 		StepDefinition.NativeStartEvent.BindLambda([](ASpatialFunctionalTest* NetTest) {
 			UWorld* World = NetTest->GetWorld();
 			TActorIterator<ACharacter> It(World);

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/RegisterAutoDestroyActorsTest/RegisterAutoDestroyActorsTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/RegisterAutoDestroyActorsTest/RegisterAutoDestroyActorsTest.cpp
@@ -17,7 +17,7 @@ void ARegisterAutoDestroyActorsTestPart1::BeginPlay()
 {
 	Super::BeginPlay();
 	{ // Step 1 - Spawn Actor On Auth 
-		AddServerStep(TEXT("SERVER_1_Spawn"), 1, nullptr, [](ASpatialFunctionalTest* NetTest){
+		AddStep(TEXT("SERVER_1_Spawn"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, [](ASpatialFunctionalTest* NetTest){
 			UWorld* World = NetTest->GetWorld();
 			int NumVirtualWorkers = NetTest->GetNumberOfServerWorkers();
 
@@ -37,7 +37,7 @@ void ARegisterAutoDestroyActorsTestPart1::BeginPlay()
 	}
 
 	{ // Step 2 - Check If Clients have it
-		AddClientStep(TEXT("CLIENT_ALL_CheckActorsSpawned"), FWorkerDefinition::ALL_WORKERS_ID, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime){
+		AddStep(TEXT("CLIENT_ALL_CheckActorsSpawned"), ESpatialFunctionalTestFlowControllerType::Client, FWorkerDefinition::ALL_WORKERS_ID, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime){
 				int NumCharactersFound = 0;
 				int NumCharactersExpected = NetTest->GetNumberOfServerWorkers();
 				UWorld* World = NetTest->GetWorld();
@@ -54,7 +54,7 @@ void ARegisterAutoDestroyActorsTestPart1::BeginPlay()
 	}
 
 	{ // Step 3 - Destroy by second server that doesn't have authority
-		AddServerStep(TEXT("SERVER_2_RegisterAutoDestroyActors"), 2, [](ASpatialFunctionalTest* NetTest) -> bool {
+		AddStep(TEXT("SERVER_2_RegisterAutoDestroyActors"), ESpatialFunctionalTestFlowControllerType::Server, 2, [](ASpatialFunctionalTest* NetTest) -> bool {
 			int NumCharactersFound = 0;
 			int NumCharactersExpected = NetTest->GetNumberOfServerWorkers();
 			UWorld* World = NetTest->GetWorld();

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/RegisterAutoDestroyActorsTest/RegisterAutoDestroyActorsTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/RegisterAutoDestroyActorsTest/RegisterAutoDestroyActorsTest.cpp
@@ -29,7 +29,7 @@ void ARegisterAutoDestroyActorsTestPart1::BeginPlay()
 			for (int i = 0; i != NumVirtualWorkers; ++i)
 			{
 				ACharacter* Character = World->SpawnActor<ACharacter>(SpawnPosition, FRotator::ZeroRotator);
-				NetTest->AssertTrue(IsValid(Character), FString::Printf(TEXT("Spawned ACharacter %s in worker %s"), *(Character->GetName()), *NetTest->GetFlowController(ESpatialFunctionalTestFlowControllerType::Server, i + 1)->GetDisplayName()));
+				NetTest->AssertTrue(IsValid(Character), FString::Printf(TEXT("Spawned ACharacter %s in worker %s"), *GetNameSafe(Character), *NetTest->GetFlowController(ESpatialFunctionalTestWorkerType::Server, i + 1)->GetDisplayName()));
 				SpawnPosition = SpawnPositionRotator.RotateVector(SpawnPosition);
 			}
 			
@@ -58,7 +58,7 @@ void ARegisterAutoDestroyActorsTestPart1::BeginPlay()
 	}
 
 	{ // Step 3 - Destroy by all servers that have authority
-		AddStep(TEXT("SERVER_ALL_RegisterAutoDestroyActors"), FWorkerDefinition::AllWorkers, [](ASpatialFunctionalTest* NetTest) -> bool {
+		AddStep(TEXT("SERVER_ALL_RegisterAutoDestroyActors"), FWorkerDefinition::AllServers, [](ASpatialFunctionalTest* NetTest) -> bool {
 			int NumCharactersFound = 0;
 			int NumCharactersExpected = 1;
 			UWorld* World = NetTest->GetWorld();
@@ -78,7 +78,7 @@ void ARegisterAutoDestroyActorsTestPart1::BeginPlay()
 			{
 				if (It->HasAuthority())
 				{
-					NetTest->AssertTrue(IsValid(*It), FString::Printf(TEXT("Registering ACharacter for destruction: %s"), *((*It)->GetName())));
+					NetTest->AssertTrue(IsValid(*It), FString::Printf(TEXT("Registering ACharacter for destruction: %s"), *GetNameSafe(*It)));
 					NetTest->RegisterAutoDestroyActor(*It);
 				}
 			}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestCharacterMovement/SpatialTestCharacterMovement.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestCharacterMovement/SpatialTestCharacterMovement.cpp
@@ -75,7 +75,7 @@ void ASpatialTestCharacterMovement::BeginPlay()
 
 		for (ASpatialFunctionalTestFlowController* FlowController : NetTest->GetFlowControllers())
 		{
-			if (FlowController->ControllerType == ESpatialFunctionalTestFlowControllerType::Server)
+			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Server)
 			{
 				continue;
 			}
@@ -85,7 +85,7 @@ void ASpatialTestCharacterMovement::BeginPlay()
 
 			checkf(PlayerCharacter, TEXT("Client did not receive a TestMovementCharacter"));
 
-			if (FlowController->ControllerInstanceId == 1)
+			if (FlowController->WorkerDefinition.Id == 1)
 			{
 				PlayerCharacter->SetActorLocation(FVector(0.0f, 0.0f, 50.0f));
 			}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestCharacterMovement/SpatialTestCharacterMovement.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestCharacterMovement/SpatialTestCharacterMovement.cpp
@@ -51,7 +51,7 @@ void ASpatialTestCharacterMovement::BeginPlay()
 	Super::BeginPlay();
 
 	// Universal setup step to create the TriggerBox and to set the 2 helper variables
-	AddUniversalStep(TEXT("UniversalSetupStep"), nullptr, [](ASpatialFunctionalTest* NetTest) {
+	AddStep(TEXT("UniversalSetupStep"), ESpatialFunctionalTestFlowControllerType::All, 0, nullptr, [](ASpatialFunctionalTest* NetTest) {
 		ASpatialTestCharacterMovement* Test = Cast<ASpatialTestCharacterMovement>(NetTest);
 		Test->bCharacterReachedDestination = false;
 		Test->ElapsedTime = 0.0f;
@@ -70,7 +70,7 @@ void ASpatialTestCharacterMovement::BeginPlay()
 		});
 
 	// The server checks if the clients received a TestCharacterMovement and moves them to the mentioned locations
-	AddServerStep(TEXT("SpatialTestCharacterMovementServerSetupStep"), 1, nullptr, [this](ASpatialFunctionalTest* NetTest) {
+	AddStep(TEXT("SpatialTestCharacterMovementServerSetupStep"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, [this](ASpatialFunctionalTest* NetTest) {
 		ASpatialTestCharacterMovement* Test = Cast<ASpatialTestCharacterMovement>(NetTest);
 
 		for (ASpatialFunctionalTestFlowController* FlowController : NetTest->GetFlowControllers())
@@ -99,7 +99,7 @@ void ASpatialTestCharacterMovement::BeginPlay()
 		});
 
 	// Client 1 moves his character and asserts that it reached the Destination locally.
-	AddClientStep(TEXT("SpatialTestCharacterMovementClient1Move"), 1,
+	AddStep(TEXT("SpatialTestCharacterMovementClient1Move"), ESpatialFunctionalTestFlowControllerType::Client, 1,
 		[](ASpatialFunctionalTest* NetTest) -> bool {
 			AController* PlayerController = Cast<AController>(NetTest->GetLocalFlowController()->GetOwner());
 			// Since the character is simulating gravity, it will drop from the original position close to (0, 0, 40), depending on the size of the CapsuleComponent in the TestMovementCharacter
@@ -126,7 +126,7 @@ void ASpatialTestCharacterMovement::BeginPlay()
 		});
 
 	// Server asserts that the character of client 1 has reached the Destination.
-	AddServerStep(TEXT("SpatialTestChracterMovementServerCheckMovementVisibility"), 1, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
+	AddStep(TEXT("SpatialTestChracterMovementServerCheckMovementVisibility"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
 		ASpatialTestCharacterMovement* Test = Cast<ASpatialTestCharacterMovement>(NetTest);
 
 		Test->AssertTrue(Test->bCharacterReachedDestination, TEXT("Player character has reached the destination on the server."));
@@ -135,7 +135,7 @@ void ASpatialTestCharacterMovement::BeginPlay()
 		});
 
 	// Client 2 asserts that the character of client 1 has reached the Destination.
-	AddClientStep(TEXT("SpatialTestCharacterMovementClient2CheckMovementVisibility"), 2, nullptr, [](ASpatialFunctionalTest* NetTest) {
+	AddStep(TEXT("SpatialTestCharacterMovementClient2CheckMovementVisibility"), ESpatialFunctionalTestFlowControllerType::Client, 2, nullptr, [](ASpatialFunctionalTest* NetTest) {
 		ASpatialTestCharacterMovement* Test = Cast<ASpatialTestCharacterMovement>(NetTest);
 
 		Test->AssertTrue(Test->bCharacterReachedDestination, TEXT("Player character has reached the destination on the simulated proxy"));
@@ -145,7 +145,7 @@ void ASpatialTestCharacterMovement::BeginPlay()
 
 
 	// Universal clean-up step to delete the TriggerBox from all connected clients and servers		
-	AddUniversalStep(TEXT("SpatialTestCharacterMovementUniversalCleanUp"), nullptr, [](ASpatialFunctionalTest* NetTest) {
+	AddStep(TEXT("SpatialTestCharacterMovementUniversalCleanUp"), ESpatialFunctionalTestFlowControllerType::Server, 0, nullptr, [](ASpatialFunctionalTest* NetTest) {
 		TArray<AActor*> FoundTriggers;
 		UGameplayStatics::GetAllActorsOfClass(NetTest->GetWorld(), ATriggerBox::StaticClass(), FoundTriggers);
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestCharacterMovement/SpatialTestCharacterMovement.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestCharacterMovement/SpatialTestCharacterMovement.cpp
@@ -51,7 +51,7 @@ void ASpatialTestCharacterMovement::BeginPlay()
 	Super::BeginPlay();
 
 	// Universal setup step to create the TriggerBox and to set the 2 helper variables
-	AddStep(TEXT("UniversalSetupStep"), ESpatialFunctionalTestFlowControllerType::All, 0, nullptr, [](ASpatialFunctionalTest* NetTest) {
+	AddStep(TEXT("UniversalSetupStep"), FWorkerDefinition::AllWorkers, nullptr, [](ASpatialFunctionalTest* NetTest) {
 		ASpatialTestCharacterMovement* Test = Cast<ASpatialTestCharacterMovement>(NetTest);
 		Test->bCharacterReachedDestination = false;
 		Test->ElapsedTime = 0.0f;
@@ -70,7 +70,7 @@ void ASpatialTestCharacterMovement::BeginPlay()
 		});
 
 	// The server checks if the clients received a TestCharacterMovement and moves them to the mentioned locations
-	AddStep(TEXT("SpatialTestCharacterMovementServerSetupStep"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, [this](ASpatialFunctionalTest* NetTest) {
+	AddStep(TEXT("SpatialTestCharacterMovementServerSetupStep"), FWorkerDefinition::Server(1), nullptr, [this](ASpatialFunctionalTest* NetTest) {
 		ASpatialTestCharacterMovement* Test = Cast<ASpatialTestCharacterMovement>(NetTest);
 
 		for (ASpatialFunctionalTestFlowController* FlowController : NetTest->GetFlowControllers())
@@ -99,7 +99,7 @@ void ASpatialTestCharacterMovement::BeginPlay()
 		});
 
 	// Client 1 moves his character and asserts that it reached the Destination locally.
-	AddStep(TEXT("SpatialTestCharacterMovementClient1Move"), ESpatialFunctionalTestFlowControllerType::Client, 1,
+	AddStep(TEXT("SpatialTestCharacterMovementClient1Move"), FWorkerDefinition::Client(1),
 		[](ASpatialFunctionalTest* NetTest) -> bool {
 			AController* PlayerController = Cast<AController>(NetTest->GetLocalFlowController()->GetOwner());
 			// Since the character is simulating gravity, it will drop from the original position close to (0, 0, 40), depending on the size of the CapsuleComponent in the TestMovementCharacter
@@ -126,7 +126,7 @@ void ASpatialTestCharacterMovement::BeginPlay()
 		});
 
 	// Server asserts that the character of client 1 has reached the Destination.
-	AddStep(TEXT("SpatialTestChracterMovementServerCheckMovementVisibility"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
+	AddStep(TEXT("SpatialTestChracterMovementServerCheckMovementVisibility"), FWorkerDefinition::Server(1), nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
 		ASpatialTestCharacterMovement* Test = Cast<ASpatialTestCharacterMovement>(NetTest);
 
 		Test->AssertTrue(Test->bCharacterReachedDestination, TEXT("Player character has reached the destination on the server."));
@@ -135,7 +135,7 @@ void ASpatialTestCharacterMovement::BeginPlay()
 		});
 
 	// Client 2 asserts that the character of client 1 has reached the Destination.
-	AddStep(TEXT("SpatialTestCharacterMovementClient2CheckMovementVisibility"), ESpatialFunctionalTestFlowControllerType::Client, 2, nullptr, [](ASpatialFunctionalTest* NetTest) {
+	AddStep(TEXT("SpatialTestCharacterMovementClient2CheckMovementVisibility"), FWorkerDefinition::Client(2), nullptr, [](ASpatialFunctionalTest* NetTest) {
 		ASpatialTestCharacterMovement* Test = Cast<ASpatialTestCharacterMovement>(NetTest);
 
 		Test->AssertTrue(Test->bCharacterReachedDestination, TEXT("Player character has reached the destination on the simulated proxy"));
@@ -145,7 +145,7 @@ void ASpatialTestCharacterMovement::BeginPlay()
 
 
 	// Universal clean-up step to delete the TriggerBox from all connected clients and servers		
-	AddStep(TEXT("SpatialTestCharacterMovementUniversalCleanUp"), ESpatialFunctionalTestFlowControllerType::Server, 0, nullptr, [](ASpatialFunctionalTest* NetTest) {
+	AddStep(TEXT("SpatialTestCharacterMovementUniversalCleanUp"), FWorkerDefinition::AllServers, nullptr, [](ASpatialFunctionalTest* NetTest) {
 		TArray<AActor*> FoundTriggers;
 		UGameplayStatics::GetAllActorsOfClass(NetTest->GetWorld(), ATriggerBox::StaticClass(), FoundTriggers);
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestCharacterMovement/SpatialTestCharacterMovement.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestCharacterMovement/SpatialTestCharacterMovement.cpp
@@ -145,7 +145,7 @@ void ASpatialTestCharacterMovement::BeginPlay()
 
 
 	// Universal clean-up step to delete the TriggerBox from all connected clients and servers		
-	AddStep(TEXT("SpatialTestCharacterMovementUniversalCleanUp"), FWorkerDefinition::AllServers, nullptr, [](ASpatialFunctionalTest* NetTest) {
+	AddStep(TEXT("SpatialTestCharacterMovementUniversalCleanUp"), FWorkerDefinition::AllWorkers, nullptr, [](ASpatialFunctionalTest* NetTest) {
 		TArray<AActor*> FoundTriggers;
 		UGameplayStatics::GetAllActorsOfClass(NetTest->GetWorld(), ATriggerBox::StaticClass(), FoundTriggers);
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestCharacterMovement/SpatialTestCharacterMovement.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestCharacterMovement/SpatialTestCharacterMovement.cpp
@@ -51,7 +51,7 @@ void ASpatialTestCharacterMovement::BeginPlay()
 	Super::BeginPlay();
 
 	// Universal setup step to create the TriggerBox and to set the helper variable
-	AddUniversalStep(TEXT("UniversalSetupStep"), nullptr, [this](ASpatialFunctionalTest* NetTest)
+	AddStep(TEXT("UniversalSetupStep"), FWorkerDefinition::AllWorkers, nullptr, [this](ASpatialFunctionalTest* NetTest)
 		{
 			bCharacterReachedDestination = false;
 
@@ -70,11 +70,11 @@ void ASpatialTestCharacterMovement::BeginPlay()
 		});
 
 	// The server checks if the clients received a TestCharacterMovement and moves them to the mentioned locations
-	AddServerStep(TEXT("SpatialTestCharacterMovementServerSetupStep"), 1, nullptr, [this](ASpatialFunctionalTest* NetTest)
+	AddStep(TEXT("SpatialTestCharacterMovementServerSetupStep"), FWorkerDefinition::Server(1), nullptr, [this](ASpatialFunctionalTest* NetTest)
 		{
 			for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
 			{
-				if (FlowController->ControllerType == ESpatialFunctionalTestFlowControllerType::Server)
+				if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Server)
 				{
 					continue;
 				}
@@ -84,7 +84,7 @@ void ASpatialTestCharacterMovement::BeginPlay()
 
 				checkf(PlayerCharacter, TEXT("Client did not receive a TestMovementCharacter"));
 
-				int FlowControllerId = FlowController->ControllerInstanceId;
+				int FlowControllerId = FlowController->WorkerDefinition.Id;
 
 				if (FlowControllerId == 1)
 				{
@@ -100,7 +100,7 @@ void ASpatialTestCharacterMovement::BeginPlay()
 		});
 
 	// Client 1 moves his character and asserts that it reached the Destination locally.
-	AddClientStep(TEXT("SpatialTestCharacterMovementClient1Move"), 1,
+	AddStep(TEXT("SpatialTestCharacterMovementClient1Move"), FWorkerDefinition::Client(1),
 		[](ASpatialFunctionalTest* NetTest) -> bool
 		{
 			AController* PlayerController = Cast<AController>(NetTest->GetLocalFlowController()->GetOwner());
@@ -125,7 +125,7 @@ void ASpatialTestCharacterMovement::BeginPlay()
 		}, 3.0f);
 
 	// Server asserts that the character of client 1 has reached the Destination.
-	AddServerStep(TEXT("SpatialTestChracterMovementServerCheckMovementVisibility"), 1, nullptr, nullptr, [this](ASpatialFunctionalTest* NetTest, float DeltaTime)
+	AddStep(TEXT("SpatialTestChracterMovementServerCheckMovementVisibility"), FWorkerDefinition::Server(1), nullptr, nullptr, [this](ASpatialFunctionalTest* NetTest, float DeltaTime)
 		{
 			if (bCharacterReachedDestination)
 			{
@@ -135,7 +135,7 @@ void ASpatialTestCharacterMovement::BeginPlay()
 		}, 1.0f);
 
 	// Client 2 asserts that the character of client 1 has reached the Destination.
-	AddClientStep(TEXT("SpatialTestCharacterMovementClient2CheckMovementVisibility"), 2, nullptr, nullptr, [this](ASpatialFunctionalTest* NetTest, float DeltaTime)
+	AddStep(TEXT("SpatialTestCharacterMovementClient2CheckMovementVisibility"), FWorkerDefinition::Client(2), nullptr, nullptr, [this](ASpatialFunctionalTest* NetTest, float DeltaTime)
 		{
 			if (bCharacterReachedDestination)
 			{

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestPossession.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestPossession.cpp
@@ -40,7 +40,7 @@ void ASpatialTestPossession::BeginPlay()
 
 		for (ASpatialFunctionalTestFlowController* FlowController : Test->GetFlowControllers())
 		{
-			if (FlowController->ControllerType == ESpatialFunctionalTestFlowControllerType::Server)
+			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Server)
 			{
 				continue;
 			}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestPossession.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestPossession.cpp
@@ -32,7 +32,7 @@ void ASpatialTestPossession::BeginPlay()
 {
 	Super::BeginPlay();
 
-	AddStep(TEXT("SpatialTestPossessionServerSetupStep"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
+	AddStep(TEXT("SpatialTestPossessionServerSetupStep"), FWorkerDefinition::Server(1), nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
 		ASpatialTestPossession* Test = Cast<ASpatialTestPossession>(NetTest);
 
 		float YToSpawnAt = -60.0f;
@@ -62,7 +62,7 @@ void ASpatialTestPossession::BeginPlay()
 		Test->FinishStep();
 		});
 
-	AddStep(TEXT("SpatialTestPossessionClientCheckStep"), ESpatialFunctionalTestFlowControllerType::Client, FWorkerDefinition::ALL_WORKERS_ID,
+	AddStep(TEXT("SpatialTestPossessionClientCheckStep"), FWorkerDefinition::AllClients,
 		[](ASpatialFunctionalTest* NetTest) -> bool {
 			AController* PlayerController = Cast<AController>(NetTest->GetLocalFlowController()->GetOwner());
 			return IsValid(PlayerController->GetPawn());
@@ -79,7 +79,7 @@ void ASpatialTestPossession::BeginPlay()
 			Test->FinishStep();
 		});
 
-	AddStep(TEXT("SpatialTestPossessionServerPossessOldPawns"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
+	AddStep(TEXT("SpatialTestPossessionServerPossessOldPawns"), FWorkerDefinition::Server(1), nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
 		ASpatialTestPossession* Test = Cast<ASpatialTestPossession>(NetTest);
 		for (const auto& OriginalPawnPair : Test->OriginalPawns)
 		{

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestPossession.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestPossession.cpp
@@ -32,7 +32,7 @@ void ASpatialTestPossession::BeginPlay()
 {
 	Super::BeginPlay();
 
-	AddServerStep(TEXT("SpatialTestPossessionServerSetupStep"), 1, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
+	AddStep(TEXT("SpatialTestPossessionServerSetupStep"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
 		ASpatialTestPossession* Test = Cast<ASpatialTestPossession>(NetTest);
 
 		float YToSpawnAt = -60.0f;
@@ -62,7 +62,7 @@ void ASpatialTestPossession::BeginPlay()
 		Test->FinishStep();
 		});
 
-	AddClientStep(TEXT("SpatialTestPossessionClientCheckStep"), 0,
+	AddStep(TEXT("SpatialTestPossessionClientCheckStep"), ESpatialFunctionalTestFlowControllerType::Client, FWorkerDefinition::ALL_WORKERS_ID,
 		[](ASpatialFunctionalTest* NetTest) -> bool {
 			AController* PlayerController = Cast<AController>(NetTest->GetLocalFlowController()->GetOwner());
 			return IsValid(PlayerController->GetPawn());
@@ -79,7 +79,7 @@ void ASpatialTestPossession::BeginPlay()
 			Test->FinishStep();
 		});
 
-	AddServerStep(TEXT("SpatialTestPossessionServerPossessOldPawns"), 1, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
+	AddStep(TEXT("SpatialTestPossessionServerPossessOldPawns"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
 		ASpatialTestPossession* Test = Cast<ASpatialTestPossession>(NetTest);
 		for (const auto& OriginalPawnPair : Test->OriginalPawns)
 		{

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRepossession.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRepossession.cpp
@@ -40,7 +40,7 @@ void ASpatialTestRepossession::BeginPlay()
 
 		for (ASpatialFunctionalTestFlowController* FlowController : Test->GetFlowControllers())
 		{
-			if (FlowController->ControllerType == ESpatialFunctionalTestFlowControllerType::Server)
+			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Server)
 			{
 				continue;
 			}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRepossession.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRepossession.cpp
@@ -27,7 +27,7 @@ void ASpatialTestRepossession::BeginPlay()
 {
 	Super::BeginPlay();
 
-	AddServerStep(TEXT("SpatialTestRepossessionServerSetupStep"), 1, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
+	AddStep(TEXT("SpatialTestRepossessionServerSetupStep"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
 		ASpatialTestRepossession* Test = Cast<ASpatialTestRepossession>(NetTest);
 		ASpatialFunctionalTestFlowController* LocalFlowController = Test->GetLocalFlowController();
 		checkf(LocalFlowController, TEXT("Can't be running test without valid FlowControl."));
@@ -85,13 +85,13 @@ void ASpatialTestRepossession::BeginPlay()
 		}
 	};
 
-	AddClientStep(TEXT("SpatialTestRepossessionClientCheckPossessionStep"), 0, [](ASpatialFunctionalTest* NetTest) -> bool {
+	AddStep(TEXT("SpatialTestRepossessionClientCheckPossessionStep"), ESpatialFunctionalTestFlowControllerType::Client, FWorkerDefinition::ALL_WORKERS_ID, [](ASpatialFunctionalTest* NetTest) -> bool {
 		ASpatialTestRepossession* Test = Cast<ASpatialTestRepossession>(NetTest);
 		int NumClients = Test->GetNumRequiredClients();
 		return Test->Controllers.Num() == NumClients && Test->TestPawns.Num() == NumClients;
 		}, nullptr, ClientCheckPossessionTickLambda);
 
-	AddServerStep(TEXT("SpatialTestRepossessionServerSwitchStep"), 1, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
+	AddStep(TEXT("SpatialTestRepossessionServerSwitchStep"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
 		ASpatialTestRepossession* Test = Cast<ASpatialTestRepossession>(NetTest);
 		ASpatialFunctionalTestFlowController* LocalFlowController = Test->GetLocalFlowController();
 		checkf(LocalFlowController, TEXT("Can't be running test without valid FlowControl."));
@@ -112,9 +112,9 @@ void ASpatialTestRepossession::BeginPlay()
 		Test->FinishStep();
 		});
 
-	AddClientStep(TEXT("SpatialTestRepossessionClientCheckRepossessionStep"), 0, nullptr, nullptr, ClientCheckPossessionTickLambda);
+	AddStep(TEXT("SpatialTestRepossessionClientCheckRepossessionStep"), ESpatialFunctionalTestFlowControllerType::Client, FWorkerDefinition::ALL_WORKERS_ID, nullptr, nullptr, ClientCheckPossessionTickLambda);
 
-	AddServerStep(TEXT("SpatialTestRepossessionClientCheckRepossessionStep"), 1, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
+	AddStep(TEXT("SpatialTestRepossessionServerPossessOriginalPawn"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
 		ASpatialTestRepossession* Test = Cast<ASpatialTestRepossession>(NetTest);
 		for (const auto& OriginalPawnPair : Test->OriginalPawns)
 		{

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRepossession.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRepossession.cpp
@@ -27,7 +27,7 @@ void ASpatialTestRepossession::BeginPlay()
 {
 	Super::BeginPlay();
 
-	AddStep(TEXT("SpatialTestRepossessionServerSetupStep"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
+	AddStep(TEXT("SpatialTestRepossessionServerSetupStep"), FWorkerDefinition::Server(1), nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
 		ASpatialTestRepossession* Test = Cast<ASpatialTestRepossession>(NetTest);
 		ASpatialFunctionalTestFlowController* LocalFlowController = Test->GetLocalFlowController();
 		checkf(LocalFlowController, TEXT("Can't be running test without valid FlowControl."));
@@ -85,13 +85,13 @@ void ASpatialTestRepossession::BeginPlay()
 		}
 	};
 
-	AddStep(TEXT("SpatialTestRepossessionClientCheckPossessionStep"), ESpatialFunctionalTestFlowControllerType::Client, FWorkerDefinition::ALL_WORKERS_ID, [](ASpatialFunctionalTest* NetTest) -> bool {
+	AddStep(TEXT("SpatialTestRepossessionClientCheckPossessionStep"), FWorkerDefinition::AllClients, [](ASpatialFunctionalTest* NetTest) -> bool {
 		ASpatialTestRepossession* Test = Cast<ASpatialTestRepossession>(NetTest);
 		int NumClients = Test->GetNumRequiredClients();
 		return Test->Controllers.Num() == NumClients && Test->TestPawns.Num() == NumClients;
 		}, nullptr, ClientCheckPossessionTickLambda);
 
-	AddStep(TEXT("SpatialTestRepossessionServerSwitchStep"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
+	AddStep(TEXT("SpatialTestRepossessionServerSwitchStep"), FWorkerDefinition::Server(1), nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
 		ASpatialTestRepossession* Test = Cast<ASpatialTestRepossession>(NetTest);
 		ASpatialFunctionalTestFlowController* LocalFlowController = Test->GetLocalFlowController();
 		checkf(LocalFlowController, TEXT("Can't be running test without valid FlowControl."));
@@ -112,9 +112,9 @@ void ASpatialTestRepossession::BeginPlay()
 		Test->FinishStep();
 		});
 
-	AddStep(TEXT("SpatialTestRepossessionClientCheckRepossessionStep"), ESpatialFunctionalTestFlowControllerType::Client, FWorkerDefinition::ALL_WORKERS_ID, nullptr, nullptr, ClientCheckPossessionTickLambda);
+	AddStep(TEXT("SpatialTestRepossessionClientCheckRepossessionStep"), FWorkerDefinition::AllClients, nullptr, nullptr, ClientCheckPossessionTickLambda);
 
-	AddStep(TEXT("SpatialTestRepossessionServerPossessOriginalPawn"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
+	AddStep(TEXT("SpatialTestRepossessionServerPossessOriginalPawn"), FWorkerDefinition::Server(1), nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
 		ASpatialTestRepossession* Test = Cast<ASpatialTestRepossession>(NetTest);
 		for (const auto& OriginalPawnPair : Test->OriginalPawns)
 		{

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3066/OwnerOnlyPropertyReplication.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3066/OwnerOnlyPropertyReplication.cpp
@@ -46,7 +46,7 @@ void AOwnerOnlyPropertyReplication::BeginPlay()
 	Super::BeginPlay();
 
 	{	// Step 1 - Set TestIntProp to 42.
-		AddServerStep(TEXT("ServerCreateActor"), 1, nullptr, [](ASpatialFunctionalTest* NetTest) {
+		AddStep(TEXT("ServerCreateActor"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, [](ASpatialFunctionalTest* NetTest) {
 			AOwnerOnlyPropertyReplication* Test = Cast<AOwnerOnlyPropertyReplication>(NetTest);
 			Test->Pawn = Test->GetWorld()->SpawnActor<AOwnerOnlyTestPawn>(FVector::ZeroVector, FRotator::ZeroRotator);
 			Test->Pawn->SetReplicates(true);
@@ -57,7 +57,7 @@ void AOwnerOnlyPropertyReplication::BeginPlay()
 			});
 	}
 	{	// Step 2 - Check on client that TestInt didn't replicate.
-		AddClientStep(TEXT("ClientNoReplicationBeforePossess"), 0, 
+		AddStep(TEXT("ClientNoReplicationBeforePossess"), ESpatialFunctionalTestFlowControllerType::Client, FWorkerDefinition::ALL_WORKERS_ID,
 			[](ASpatialFunctionalTest* NetTest) -> bool {
 				AOwnerOnlyPropertyReplication* Test = Cast<AOwnerOnlyPropertyReplication>(NetTest);
 				return IsValid(Test->Pawn);
@@ -74,7 +74,7 @@ void AOwnerOnlyPropertyReplication::BeginPlay()
 			});
 	}
 	{	// Step 3 - Possess actor.
-		AddServerStep(TEXT("ServerPossessActor"), 1, nullptr, [](ASpatialFunctionalTest* NetTest) {
+		AddStep(TEXT("ServerPossessActor"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, [](ASpatialFunctionalTest* NetTest) {
 			AOwnerOnlyPropertyReplication* Test = Cast<AOwnerOnlyPropertyReplication>(NetTest);
 			if (Test->Pawn)
 			{
@@ -90,7 +90,7 @@ void AOwnerOnlyPropertyReplication::BeginPlay()
 			});
 	}
 	{	// Step 4 - Check on client that TestInt did replicate now on owning client.
-		AddClientStep(TEXT("ClientCheckReplicationAfterPossess"), 0,
+		AddStep(TEXT("ClientCheckReplicationAfterPossess"), ESpatialFunctionalTestFlowControllerType::Client, FWorkerDefinition::ALL_WORKERS_ID,
 			[](ASpatialFunctionalTest* NetTest) -> bool {
 				AOwnerOnlyPropertyReplication* Test = Cast<AOwnerOnlyPropertyReplication>(NetTest);
 				return IsValid(Test->Pawn);
@@ -125,7 +125,7 @@ void AOwnerOnlyPropertyReplication::BeginPlay()
 			});
 	}
 	{	// Step 5 - Change value on server.
-		AddServerStep(TEXT("ServerChangeValue"), 1, nullptr, [](ASpatialFunctionalTest* NetTest) {
+		AddStep(TEXT("ServerChangeValue"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, [](ASpatialFunctionalTest* NetTest) {
 			AOwnerOnlyPropertyReplication* Test = Cast<AOwnerOnlyPropertyReplication>(NetTest);
 			if (Test->Pawn)
 			{
@@ -136,7 +136,7 @@ void AOwnerOnlyPropertyReplication::BeginPlay()
 			});
 	}
 	{	// Step 6 - Check that value was replicated on owning client.
-		AddClientStep(TEXT("ClientCheckReplicationAfterChange"), 0, nullptr, nullptr, 
+		AddStep(TEXT("ClientCheckReplicationAfterChange"), ESpatialFunctionalTestFlowControllerType::Server, FWorkerDefinition::ALL_WORKERS_ID, nullptr, nullptr,
 			[](ASpatialFunctionalTest* NetTest, float DeltaTime) {
 				AOwnerOnlyPropertyReplication* Test = Cast<AOwnerOnlyPropertyReplication>(NetTest);
 				const FSpatialFunctionalTestStepDefinition StepDefinition = Test->GetStepDefinition(Test->GetCurrentStepIndex());
@@ -166,7 +166,7 @@ void AOwnerOnlyPropertyReplication::BeginPlay()
 			});
 	}
 	{ // Step 7 - Put back original Pawns
-		AddServerStep(TEXT("ServerPossessOriginalPawns"), 1, nullptr, [](ASpatialFunctionalTest* NetTest) {
+		AddStep(TEXT("ServerPossessOriginalPawns"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, [](ASpatialFunctionalTest* NetTest) {
 			AOwnerOnlyPropertyReplication* Test = Cast<AOwnerOnlyPropertyReplication>(NetTest);
 			for (const auto& OriginalPawnPair : Test->OriginalPawns)
 			{

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3066/OwnerOnlyPropertyReplication.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3066/OwnerOnlyPropertyReplication.cpp
@@ -46,7 +46,7 @@ void AOwnerOnlyPropertyReplication::BeginPlay()
 	Super::BeginPlay();
 
 	{	// Step 1 - Set TestIntProp to 42.
-		AddStep(TEXT("ServerCreateActor"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, [](ASpatialFunctionalTest* NetTest) {
+		AddStep(TEXT("ServerCreateActor"), FWorkerDefinition::Server(1), nullptr, [](ASpatialFunctionalTest* NetTest) {
 			AOwnerOnlyPropertyReplication* Test = Cast<AOwnerOnlyPropertyReplication>(NetTest);
 			Test->Pawn = Test->GetWorld()->SpawnActor<AOwnerOnlyTestPawn>(FVector::ZeroVector, FRotator::ZeroRotator);
 			Test->Pawn->SetReplicates(true);
@@ -57,7 +57,7 @@ void AOwnerOnlyPropertyReplication::BeginPlay()
 			});
 	}
 	{	// Step 2 - Check on client that TestInt didn't replicate.
-		AddStep(TEXT("ClientNoReplicationBeforePossess"), ESpatialFunctionalTestFlowControllerType::Client, FWorkerDefinition::ALL_WORKERS_ID,
+		AddStep(TEXT("ClientNoReplicationBeforePossess"), FWorkerDefinition::AllClients,
 			[](ASpatialFunctionalTest* NetTest) -> bool {
 				AOwnerOnlyPropertyReplication* Test = Cast<AOwnerOnlyPropertyReplication>(NetTest);
 				return IsValid(Test->Pawn);
@@ -74,7 +74,7 @@ void AOwnerOnlyPropertyReplication::BeginPlay()
 			});
 	}
 	{	// Step 3 - Possess actor.
-		AddStep(TEXT("ServerPossessActor"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, [](ASpatialFunctionalTest* NetTest) {
+		AddStep(TEXT("ServerPossessActor"), FWorkerDefinition::Server(1), nullptr, [](ASpatialFunctionalTest* NetTest) {
 			AOwnerOnlyPropertyReplication* Test = Cast<AOwnerOnlyPropertyReplication>(NetTest);
 			if (Test->Pawn)
 			{
@@ -90,7 +90,7 @@ void AOwnerOnlyPropertyReplication::BeginPlay()
 			});
 	}
 	{	// Step 4 - Check on client that TestInt did replicate now on owning client.
-		AddStep(TEXT("ClientCheckReplicationAfterPossess"), ESpatialFunctionalTestFlowControllerType::Client, FWorkerDefinition::ALL_WORKERS_ID,
+		AddStep(TEXT("ClientCheckReplicationAfterPossess"), FWorkerDefinition::AllClients,
 			[](ASpatialFunctionalTest* NetTest) -> bool {
 				AOwnerOnlyPropertyReplication* Test = Cast<AOwnerOnlyPropertyReplication>(NetTest);
 				return IsValid(Test->Pawn);
@@ -125,7 +125,7 @@ void AOwnerOnlyPropertyReplication::BeginPlay()
 			});
 	}
 	{	// Step 5 - Change value on server.
-		AddStep(TEXT("ServerChangeValue"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, [](ASpatialFunctionalTest* NetTest) {
+		AddStep(TEXT("ServerChangeValue"), FWorkerDefinition::Server(1), nullptr, [](ASpatialFunctionalTest* NetTest) {
 			AOwnerOnlyPropertyReplication* Test = Cast<AOwnerOnlyPropertyReplication>(NetTest);
 			if (Test->Pawn)
 			{
@@ -136,7 +136,7 @@ void AOwnerOnlyPropertyReplication::BeginPlay()
 			});
 	}
 	{	// Step 6 - Check that value was replicated on owning client.
-		AddStep(TEXT("ClientCheckReplicationAfterChange"), ESpatialFunctionalTestFlowControllerType::Server, FWorkerDefinition::ALL_WORKERS_ID, nullptr, nullptr,
+		AddStep(TEXT("ClientCheckReplicationAfterChange"), FWorkerDefinition::AllServers, nullptr, nullptr,
 			[](ASpatialFunctionalTest* NetTest, float DeltaTime) {
 				AOwnerOnlyPropertyReplication* Test = Cast<AOwnerOnlyPropertyReplication>(NetTest);
 				const FSpatialFunctionalTestStepDefinition StepDefinition = Test->GetStepDefinition(Test->GetCurrentStepIndex());
@@ -166,7 +166,7 @@ void AOwnerOnlyPropertyReplication::BeginPlay()
 			});
 	}
 	{ // Step 7 - Put back original Pawns
-		AddStep(TEXT("ServerPossessOriginalPawns"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, [](ASpatialFunctionalTest* NetTest) {
+		AddStep(TEXT("ServerPossessOriginalPawns"), FWorkerDefinition::Server(1), nullptr, [](ASpatialFunctionalTest* NetTest) {
 			AOwnerOnlyPropertyReplication* Test = Cast<AOwnerOnlyPropertyReplication>(NetTest);
 			for (const auto& OriginalPawnPair : Test->OriginalPawns)
 			{

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3066/OwnerOnlyPropertyReplication.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3066/OwnerOnlyPropertyReplication.cpp
@@ -136,7 +136,7 @@ void AOwnerOnlyPropertyReplication::BeginPlay()
 			});
 	}
 	{	// Step 6 - Check that value was replicated on owning client.
-		AddStep(TEXT("ClientCheckReplicationAfterChange"), FWorkerDefinition::AllServers, nullptr, nullptr,
+		AddStep(TEXT("ClientCheckReplicationAfterChange"), FWorkerDefinition::AllClients, nullptr, nullptr,
 			[](ASpatialFunctionalTest* NetTest, float DeltaTime) {
 				AOwnerOnlyPropertyReplication* Test = Cast<AOwnerOnlyPropertyReplication>(NetTest);
 				const FSpatialFunctionalTestStepDefinition StepDefinition = Test->GetStepDefinition(Test->GetCurrentStepIndex());

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3066/OwnerOnlyPropertyReplication.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3066/OwnerOnlyPropertyReplication.cpp
@@ -78,7 +78,7 @@ void AOwnerOnlyPropertyReplication::BeginPlay()
 			AOwnerOnlyPropertyReplication* Test = Cast<AOwnerOnlyPropertyReplication>(NetTest);
 			if (Test->Pawn)
 			{
-				ASpatialFunctionalTestFlowController* FlowController = Test->GetFlowController(ESpatialFunctionalTestFlowControllerType::Client, 1);
+				ASpatialFunctionalTestFlowController* FlowController = Test->GetFlowController(ESpatialFunctionalTestWorkerType::Client, 1);
 				APlayerController* PlayerController = Cast<APlayerController>(FlowController->GetOwner());
 
 				Test->OriginalPawns.Add(TPair<AController*, APawn*>(PlayerController, PlayerController->GetPawn()));
@@ -101,7 +101,7 @@ void AOwnerOnlyPropertyReplication::BeginPlay()
 				if (Test->Pawn)
 				{
 					ASpatialFunctionalTestFlowController* FlowController = Test->GetLocalFlowController();
-					if (FlowController->ControllerInstanceId == 1)
+					if (FlowController->WorkerDefinition.Id == 1)
 					{
 						if (Test->Pawn->GetController() == FlowController->GetOwner() && Test->Pawn->TestInt == 42)
 						{
@@ -144,7 +144,7 @@ void AOwnerOnlyPropertyReplication::BeginPlay()
 				if (Test->Pawn)
 				{
 					ASpatialFunctionalTestFlowController* FlowController = Test->GetLocalFlowController();
-					if (FlowController->ControllerInstanceId == 1)
+					if (FlowController->WorkerDefinition.Id == 1)
 					{
 						if (Test->Pawn->TestInt == 666)
 						{

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3157/RPCInInterfaceTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3157/RPCInInterfaceTest.cpp
@@ -23,7 +23,7 @@ void ARPCInInterfaceTest::BeginPlay()
 	Super::BeginPlay();
 
 	{	// Step 1 - Create actor
-		AddStep(TEXT("ServerCreateActor"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, [](ASpatialFunctionalTest* NetTest) {
+		AddStep(TEXT("ServerCreateActor"), FWorkerDefinition::Server(1), nullptr, [](ASpatialFunctionalTest* NetTest) {
 			ARPCInInterfaceTest* Test = Cast<ARPCInInterfaceTest>(NetTest);
 
 			ASpatialFunctionalTestFlowController* Client1FlowController = Test->GetFlowController(ESpatialFunctionalTestFlowControllerType::Client, 1);
@@ -40,7 +40,7 @@ void ARPCInInterfaceTest::BeginPlay()
 			});
 	}
 	{ // Step 2 - Make sure client has ownership of Actor
-		AddStep(TEXT("ClientCheckOwnership"), ESpatialFunctionalTestFlowControllerType::Client, 1, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
+		AddStep(TEXT("ClientCheckOwnership"), FWorkerDefinition::Client(1), nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
 			ARPCInInterfaceTest* Test = Cast<ARPCInInterfaceTest>(NetTest);
 			if (IsValid(Test->TestActor) && Test->TestActor->GetOwner() == Test->GetLocalFlowController()->GetOwner())
 			{
@@ -49,7 +49,7 @@ void ARPCInInterfaceTest::BeginPlay()
 			});
 	}
 	{	// Step 3 - Call client RPC on interface
-		AddStep(TEXT("ServerCallRPC"), ESpatialFunctionalTestFlowControllerType::Server, 1, [](ASpatialFunctionalTest* NetTest) -> bool {
+		AddStep(TEXT("ServerCallRPC"), FWorkerDefinition::Server(1), [](ASpatialFunctionalTest* NetTest) -> bool {
 			ARPCInInterfaceTest* Test = Cast<ARPCInInterfaceTest>(NetTest);
 				return IsValid(Test->TestActor);
 			}, [](ASpatialFunctionalTest* NetTest) {
@@ -59,7 +59,7 @@ void ARPCInInterfaceTest::BeginPlay()
 			});
 	}
 	{	// Step 4 - Check RPC was received on client
-		AddStep(TEXT("ClientCheckRPC"), ESpatialFunctionalTestFlowControllerType::Client, FWorkerDefinition::ALL_WORKERS_ID, [](ASpatialFunctionalTest* NetTest) -> bool {
+		AddStep(TEXT("ClientCheckRPC"), FWorkerDefinition::AllClients, [](ASpatialFunctionalTest* NetTest) -> bool {
 				ARPCInInterfaceTest* Test = Cast<ARPCInInterfaceTest>(NetTest);
 				return IsValid(Test->TestActor);
 			}, 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3157/RPCInInterfaceTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3157/RPCInInterfaceTest.cpp
@@ -26,7 +26,7 @@ void ARPCInInterfaceTest::BeginPlay()
 		AddStep(TEXT("ServerCreateActor"), FWorkerDefinition::Server(1), nullptr, [](ASpatialFunctionalTest* NetTest) {
 			ARPCInInterfaceTest* Test = Cast<ARPCInInterfaceTest>(NetTest);
 
-			ASpatialFunctionalTestFlowController* Client1FlowController = Test->GetFlowController(ESpatialFunctionalTestFlowControllerType::Client, 1);
+			ASpatialFunctionalTestFlowController* Client1FlowController = Test->GetFlowController(ESpatialFunctionalTestWorkerType::Client, 1);
 
 			Test->TestActor = Test->GetWorld()->SpawnActor<ARPCInInterfaceActor>();
 			Test->AssertIsValid(Test->TestActor, "Actor exists", Test);

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3157/RPCInInterfaceTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3157/RPCInInterfaceTest.cpp
@@ -23,7 +23,7 @@ void ARPCInInterfaceTest::BeginPlay()
 	Super::BeginPlay();
 
 	{	// Step 1 - Create actor
-		AddServerStep(TEXT("ServerCreateActor"), 1, nullptr, [](ASpatialFunctionalTest* NetTest) {
+		AddStep(TEXT("ServerCreateActor"), ESpatialFunctionalTestFlowControllerType::Server, 1, nullptr, [](ASpatialFunctionalTest* NetTest) {
 			ARPCInInterfaceTest* Test = Cast<ARPCInInterfaceTest>(NetTest);
 
 			ASpatialFunctionalTestFlowController* Client1FlowController = Test->GetFlowController(ESpatialFunctionalTestFlowControllerType::Client, 1);
@@ -40,7 +40,7 @@ void ARPCInInterfaceTest::BeginPlay()
 			});
 	}
 	{ // Step 2 - Make sure client has ownership of Actor
-		AddClientStep(TEXT("ClientCheckOwnership"), 1, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
+		AddStep(TEXT("ClientCheckOwnership"), ESpatialFunctionalTestFlowControllerType::Client, 1, nullptr, nullptr, [](ASpatialFunctionalTest* NetTest, float DeltaTime) {
 			ARPCInInterfaceTest* Test = Cast<ARPCInInterfaceTest>(NetTest);
 			if (IsValid(Test->TestActor) && Test->TestActor->GetOwner() == Test->GetLocalFlowController()->GetOwner())
 			{
@@ -49,7 +49,7 @@ void ARPCInInterfaceTest::BeginPlay()
 			});
 	}
 	{	// Step 3 - Call client RPC on interface
-		AddServerStep(TEXT("ServerCallRPC"), 1, [](ASpatialFunctionalTest* NetTest) -> bool {
+		AddStep(TEXT("ServerCallRPC"), ESpatialFunctionalTestFlowControllerType::Server, 1, [](ASpatialFunctionalTest* NetTest) -> bool {
 			ARPCInInterfaceTest* Test = Cast<ARPCInInterfaceTest>(NetTest);
 				return IsValid(Test->TestActor);
 			}, [](ASpatialFunctionalTest* NetTest) {
@@ -59,7 +59,7 @@ void ARPCInInterfaceTest::BeginPlay()
 			});
 	}
 	{	// Step 4 - Check RPC was received on client
-		AddClientStep(TEXT("ClientCheckRPC"), 0, [](ASpatialFunctionalTest* NetTest) -> bool {
+		AddStep(TEXT("ClientCheckRPC"), ESpatialFunctionalTestFlowControllerType::Client, FWorkerDefinition::ALL_WORKERS_ID, [](ASpatialFunctionalTest* NetTest) -> bool {
 				ARPCInInterfaceTest* Test = Cast<ARPCInInterfaceTest>(NetTest);
 				return IsValid(Test->TestActor);
 			}, 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestNetReference/SpatialTestNetReference.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestNetReference/SpatialTestNetReference.cpp
@@ -55,7 +55,7 @@ void ASpatialTestNetReference::BeginPlay()
 
 	PreviousPositionUpdateFrequency = GetDefault<USpatialGDKSettings>()->PositionUpdateFrequency;
 
-	AddServerStep(TEXT("SpatialTestNetReferenceServerSetup"), 1, nullptr, [this](ASpatialFunctionalTest* NetTest) {
+	AddStep(TEXT("SpatialTestNetReferenceServerSetup"), FWorkerDefinition::Server(1), nullptr, [this](ASpatialFunctionalTest* NetTest) {
 		// Set up the cubes' spawn locations
 		TArray<FVector> CubeLocations;
 		CubeLocations.Add(FVector(0.0f, -11000.0f, 40.0f));
@@ -93,7 +93,7 @@ void ASpatialTestNetReference::BeginPlay()
 		// Spawn the TestMovementCharacter actor for client 1 to possess.
 		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
 		{
-			if (FlowController->ControllerType == ESpatialFunctionalTestFlowControllerType::Client && FlowController->ControllerInstanceId == 1)
+			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client && FlowController->WorkerDefinition.Id == 1)
 			{
 				ATestMovementCharacter* TestCharacter = GetWorld()->SpawnActor<ATestMovementCharacter>(FVector::ZeroVector, FRotator::ZeroRotator, FActorSpawnParameters());
 				APlayerController* PlayerController = Cast<APlayerController>(FlowController->GetOwner());
@@ -113,9 +113,9 @@ void ASpatialTestNetReference::BeginPlay()
 		// The mod is required since the test goes over each test location twice 
 		int CurrentMoveIndex = i % TestLocations.Num();
 
-		AddServerStep(TEXT("SpatialTestNetReferenceServerMove"), 1, nullptr, [this, CurrentMoveIndex](ASpatialFunctionalTest* NetTest)
+		AddStep(TEXT("SpatialTestNetReferenceServerMove"), FWorkerDefinition::Server(1), nullptr, [this, CurrentMoveIndex](ASpatialFunctionalTest* NetTest)
 			{
-				ASpatialFunctionalTestFlowController* FlowController = GetFlowController(ESpatialFunctionalTestFlowControllerType::Client, 1);
+				ASpatialFunctionalTestFlowController* FlowController = GetFlowController(ESpatialFunctionalTestWorkerType::Client, 1);
 				APlayerController* PlayerController = Cast<APlayerController>(FlowController->GetOwner());
 				ATestMovementCharacter* PlayerCharacter = Cast<ATestMovementCharacter>(PlayerController->GetPawn());
 
@@ -128,7 +128,7 @@ void ASpatialTestNetReference::BeginPlay()
 				FinishStep();
 			});
 
-		AddClientStep(TEXT("SpatialTestNetReferenceClientCheckMovement"), 1, nullptr, nullptr, [this, CurrentMoveIndex](ASpatialFunctionalTest* NetTest, float DeltaTime)
+		AddStep(TEXT("SpatialTestNetReferenceClientCheckMovement"), FWorkerDefinition::Client(1), nullptr, nullptr, [this, CurrentMoveIndex](ASpatialFunctionalTest* NetTest, float DeltaTime)
 			{
 				AController* PlayerController = Cast<AController>(GetLocalFlowController()->GetOwner());
 				ATestMovementCharacter* PlayerCharacter = Cast<ATestMovementCharacter>(PlayerController->GetPawn());
@@ -140,7 +140,7 @@ void ASpatialTestNetReference::BeginPlay()
 
 			}, 5.0f);
 
-		AddClientStep(TEXT("SpatialTestNetReferenceClientCheckNumberOfReferences"), 1, nullptr, nullptr, [this, CurrentMoveIndex](ASpatialFunctionalTest* NetTest, float DeltaTime)
+		AddStep(TEXT("SpatialTestNetReferenceClientCheckNumberOfReferences"), FWorkerDefinition::Client(1), nullptr, nullptr, [this, CurrentMoveIndex](ASpatialFunctionalTest* NetTest, float DeltaTime)
 			{
 				TArray<AActor*> CubesWithReferences;
 				UGameplayStatics::GetAllActorsOfClass(GetWorld(), ACubeWithReferences::StaticClass(), CubesWithReferences);
@@ -154,7 +154,7 @@ void ASpatialTestNetReference::BeginPlay()
 				}
 			}, 5.0f);
 
-		AddClientStep(TEXT("SpatialTestNetReferenceClientCheckReferences"), 1, nullptr, nullptr, [this, CurrentMoveIndex](ASpatialFunctionalTest* NetTest, float DeltaTime)
+		AddStep(TEXT("SpatialTestNetReferenceClientCheckReferences"), FWorkerDefinition::Client(1), nullptr, nullptr, [this, CurrentMoveIndex](ASpatialFunctionalTest* NetTest, float DeltaTime)
 			{
 				TArray<AActor*> CubesWithReferences;
 				UGameplayStatics::GetAllActorsOfClass(GetWorld(), ACubeWithReferences::StaticClass(), CubesWithReferences);
@@ -213,7 +213,7 @@ void ASpatialTestNetReference::BeginPlay()
 			}, 5.0f);
 	}
 	
-	AddServerStep(TEXT("SpatialTestNetReferenceServerCleanup"), 1, nullptr, [this](ASpatialFunctionalTest* NetTest) {
+	AddStep(TEXT("SpatialTestNetReferenceServerCleanup"), FWorkerDefinition::Server(1), nullptr, [this](ASpatialFunctionalTest* NetTest) {
 		// Possess the original pawn, so that the spawned character can get destroyed correctly
 		OriginalPawn.Key->Possess(OriginalPawn.Value);
 


### PR DESCRIPTION
#### Description
Refactored AddServerStep / AddClientStep / AddUniversalStep into just AddStep.
Refactored AddStep function for BP to be AddStepBlueprint (to make it easier for c++ test makers, will still show as AddStep in blueprints)
Added ESpatialFunctionalTestFlowControllerType::All which allows you to run on all workers

NOTE: Because of making only 1 function for each like people were suggesting, if 'All' is passed WorkerId is ignored. It's ok in BP but a bit ugly in c++ since you still need to pass an int. I have a suggestion to it, maybe we have FWorkerDefinition passed in c++ instead of the enum + int, and so I can create some consts to help, thoughts?

#### Testing
 There's another CL for the gyms that will be pushed if this one is approved.