### PR TITLE
SpatialStatics::GetActorEntityId() - Remove assert and return INVALID_ENTITY_ID instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SpatialMetrics::WorkerMetricsRecieved is no longer static and the function signature now also receives histogram metrics
 - Log an error including Position when GridBasedLBStrategy can't locate a worker to take authority over an Actor.
 - Changed the SpatialGDK Setting bEnableMultiWorker to private, to enforce usage of IsMultiWorkerEnabled which respects the `-OverrideMultiWorker` flag.
+- No longer assert when SpatialStatics::GetActorEntityId() is passed a nullptr, return SpatialConstants::INVALID_ENTITY_ID instead.
 
 ## [`0.10.0`] - 2020-07-08
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
@@ -151,7 +151,8 @@ int64 USpatialStatics::GetActorEntityId(const AActor* Actor)
 	{
 		return static_cast<int64>(SpatialNetDriver->PackageMap->GetEntityIdFromObject(Actor));
 	}
-	return 0;
+
+	return SpatialConstants::INVALID_ENTITY_ID;
 }
 
 FString USpatialStatics::EntityIdToString(int64 EntityId)

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
@@ -142,7 +142,11 @@ void USpatialStatics::PrintTextSpatial(UObject* WorldContextObject, const FText 
 
 int64 USpatialStatics::GetActorEntityId(const AActor* Actor)
 {
-	check(Actor);
+	if (Actor == nullptr)
+	{
+		return SpatialConstants::INVALID_ENTITY_ID;
+	}
+
 	if (const USpatialNetDriver* SpatialNetDriver = Cast<USpatialNetDriver>(Actor->GetNetDriver()))
 	{
 		return static_cast<int64>(SpatialNetDriver->PackageMap->GetEntityIdFromObject(Actor));


### PR DESCRIPTION
#### Description
SpatialStatics::GetActorEntityId() - Remove assert and return INVALID_ENTITY_ID instead.  This will prevent the debug method from taking down a server if it is called with nullptr somewhere.

#### Release note
Release note added.

#### Tests
Verified with event tracing prototype (https://github.com/spatialos/UnrealGDK/tree/feature/GSE-1012-spike-structured-logs), which calls the method above from multiple places, that the server is no longer taken down.

STRONGLY SUGGESTED: How can this be verified by QA?

#### Documentation
Release note.

#### Reminders (IMPORTANT)
If your change relies on a breaking engine change:
* Increment `SPATIAL_ENGINE_VERSION` in `Engine\Source\Runtime\Launch\Resources\SpatialVersion.h` (in the engine fork) as well as `SPATIAL_GDK_VERSION` in `SpatialGDK\Source\SpatialGDK\Public\Utils\EngineVersionCheck.h`. This helps others by providing a more helpful message during compilation to make sure the GDK and the Engine are up to date.

If your change updates `Setup.bat`, `Setup.sh`, core SDK version, any C# tools in `SpatialGDK\Build\Programs\Improbable.Unreal.Scripts`, or hand-written schema in `SpatialGDK\Extras\schema`:
* Increment the number in `RequireSetup`. This will automatically run `Setup.bat` or `Setup.sh` when the GDK is next pulled.

#### Primary reviewers
@spatialos/develop-unreal 
