### PR TITLE
Disable testing against 4.23 on master

### DIFF
--- a/ci/unreal-engine.version
+++ b/ci/unreal-engine.version
@@ -1,2 +1,1 @@
 HEAD 4.24-SpatialOSUnrealGDK
-HEAD 4.23-SpatialOSUnrealGDK


### PR DESCRIPTION
#### Description
As we are dropping support for 4.23 in the next release, we no longer need to test against 4.23 on master.

#### Primary reviewers
@mironec @m-samiec 
