### PR TITLE
Added the overflow case to PushOverflowedRPCs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed the SpatialGDK Setting bEnableMultiWorker to private, to enforce usage of IsMultiWorkerEnabled which respects the `-OverrideMultiWorker` flag.
 - No longer assert when SpatialStatics::GetActorEntityId() is passed a nullptr, return SpatialConstants::INVALID_ENTITY_ID instead.
 - Removed the `EditorWorkerController`, because it is not required anymore for running consecutive PIE sessions.
+- Fixed a crash that occured when overflowed RPCs remained overflowed after trying to flush them.
 
 ## [`0.10.0`] - 2020-07-08
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialRPCService.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialRPCService.cpp
@@ -158,15 +158,24 @@ void SpatialRPCService::PushOverflowedRPCs()
 			case EPushRPCResult::Success:
 				NumProcessed++;
 				break;
+			case EPushRPCResult::QueueOverflowed:
+				UE_LOG(LogSpatialRPCService, Log,
+					TEXT("SpatialRPCService::PushOverflowedRPCs: Sent some but not all overflowed RPCs. RPCs sent %d, RPCs still overflowed: %d, Entity: %lld, RPC type: %s"),
+					NumProcessed, OverflowedRPCArray.Num() - NumProcessed, EntityId, *SpatialConstants::RPCTypeToString(Type));
+				break;
 			case EPushRPCResult::DropOverflowed:
 				checkf(false, TEXT("Shouldn't be able to drop on overflow for RPC type that was previously queued."));
 				break;
 			case EPushRPCResult::HasAckAuthority:
-				UE_LOG(LogSpatialRPCService, Warning, TEXT("SpatialRPCService::PushOverflowedRPCs: Gained authority over ack component for RPC type that was overflowed. Entity: %lld, RPC type: %s"), EntityId, *SpatialConstants::RPCTypeToString(Type));
+				UE_LOG(LogSpatialRPCService, Warning,
+					TEXT("SpatialRPCService::PushOverflowedRPCs: Gained authority over ack component for RPC type that was overflowed. Entity: %lld, RPC type: %s"),
+					EntityId, *SpatialConstants::RPCTypeToString(Type));
 				bShouldDrop = true;
 				break;
 			case EPushRPCResult::NoRingBufferAuthority:
-				UE_LOG(LogSpatialRPCService, Warning, TEXT("SpatialRPCService::PushOverflowedRPCs: Lost authority over ring buffer component for RPC type that was overflowed. Entity: %lld, RPC type: %s"), EntityId, *SpatialConstants::RPCTypeToString(Type));
+				UE_LOG(LogSpatialRPCService, Warning,
+					TEXT("SpatialRPCService::PushOverflowedRPCs: Lost authority over ring buffer component for RPC type that was overflowed. Entity: %lld, RPC type: %s"),
+					EntityId, *SpatialConstants::RPCTypeToString(Type));
 				bShouldDrop = true;
 				break;
 			default:


### PR DESCRIPTION
#### Description
Fixed a crash in the RPC service where we don't correctly deal with the case where stuff is still overflowed.

#### Release note
Fixed a crash that occured when overflowed RPCs remained overflowed after trying to flush them.