### PR TITLE
Fix 4.25 UNetDriver::Time deprecation warnings

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -210,7 +210,7 @@ USpatialActorChannel::USpatialActorChannel(const FObjectInitializer& ObjectIniti
 	, bNetOwned(false)
 	, NetDriver(nullptr)
 	, LastPositionSinceUpdate(FVector::ZeroVector)
-	, TimeWhenPositionLastUpdated(0.0f)
+	, TimeWhenPositionLastUpdated(0.0)
 {
 }
 
@@ -227,7 +227,7 @@ void USpatialActorChannel::Init(UNetConnection* InConnection, int32 ChannelIndex
 	bIsAuthClient = false;
 	bIsAuthServer = false;
 	LastPositionSinceUpdate = FVector::ZeroVector;
-	TimeWhenPositionLastUpdated = 0.0f;
+	TimeWhenPositionLastUpdated = 0.0;
 	AuthorityReceivedTimestamp = 0;
 
 	PendingDynamicSubobjects.Empty();
@@ -390,7 +390,7 @@ void USpatialActorChannel::UpdateShadowData()
 void USpatialActorChannel::UpdateSpatialPositionWithFrequencyCheck()
 {
 	// Check that there has been a sufficient amount of time since the last update.
-	if ((NetDriver->Time - TimeWhenPositionLastUpdated) >= (1.0f / GetDefault<USpatialGDKSettings>()->PositionUpdateFrequency))
+	if ((NetDriver->GetElapsedTime() - TimeWhenPositionLastUpdated) >= (1.0f / GetDefault<USpatialGDKSettings>()->PositionUpdateFrequency))
 	{
 		UpdateSpatialPosition();
 	}
@@ -807,7 +807,7 @@ int64 USpatialActorChannel::ReplicateActor()
 #endif
 
 	// If we evaluated everything, mark LastUpdateTime, even if nothing changed.
-	LastUpdateTime = Connection->Driver->Time;
+	LastUpdateTime = NetDriver->GetElapsedTime();
 
 	MemMark.Pop();
 
@@ -1267,7 +1267,7 @@ void USpatialActorChannel::UpdateSpatialPosition()
 	}
 
 	LastPositionSinceUpdate = ActorSpatialPosition;
-	TimeWhenPositionLastUpdated = NetDriver->Time;
+	TimeWhenPositionLastUpdated = NetDriver->GetElapsedTime();
 
 	SendPositionUpdate(Actor, EntityId, LastPositionSinceUpdate);
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1119,7 +1119,7 @@ int32 USpatialNetDriver::ServerReplicateActors_PrepConnections(const float Delta
 		AActor* OwningActor = SpatialConnection->OwningActor;
 
 		//SpatialGDK: We allow a connection without an owner to process if it's meant to be the connection to the fake SpatialOS client.
-		if ((SpatialConnection->bReliableSpatialConnection || OwningActor != NULL) && SpatialConnection->State == USOCK_Open && (SpatialConnection->Driver->Time - SpatialConnection->LastReceiveTime < 1.5f))
+		if ((SpatialConnection->bReliableSpatialConnection || OwningActor != NULL) && SpatialConnection->State == USOCK_Open && (SpatialConnection->Driver->GetElapsedTime() - SpatialConnection->LastReceiveTime < 1.5f))
 		{
 			check(SpatialConnection->bReliableSpatialConnection || World == OwningActor->GetWorld());
 
@@ -1191,7 +1191,7 @@ int32 USpatialNetDriver::ServerReplicateActors_PrioritizeActors(UNetConnection* 
 			}
 
 			// See of actor wants to try and go dormant
-			if (ShouldActorGoDormant(Actor, ConnectionViewers, Channel, Time, bLowNetBandwidth))
+			if (ShouldActorGoDormant(Actor, ConnectionViewers, Channel, GetElapsedTime(), bLowNetBandwidth))
 			{
 				// Channel is marked to go dormant now once all properties have been replicated (but is not dormant yet)
 				Channel->StartBecomingDormant();
@@ -1317,7 +1317,7 @@ void USpatialNetDriver::ServerReplicateActors_ProcessPrioritizedActors(UNetConne
 			// SpatialGDK: Here, Unreal would check (again) whether an actor is relevant. Removed such checks.
 			// only check visibility on already visible actors every 1.0 + 0.5R seconds
 			// bTearOff actors should never be checked
-			if (!Actor->GetTearOff() && (!Channel || Time - Channel->RelevantTime > 1.f))
+			if (!Actor->GetTearOff() && (!Channel || GetElapsedTime() - Channel->RelevantTime > 1.f))
 			{
 				if (DebugRelevantActors)
 				{
@@ -1344,7 +1344,7 @@ void USpatialNetDriver::ServerReplicateActors_ProcessPrioritizedActors(UNetConne
 			}
 
 			// If the actor is now relevant or was recently relevant.
-			const bool bIsRecentlyRelevant = bIsRelevant || (Channel && Time - Channel->RelevantTime < RelevantTimeout);
+			const bool bIsRecentlyRelevant = bIsRelevant || (Channel && GetElapsedTime() - Channel->RelevantTime < RelevantTimeout);
 
 			if (bIsRecentlyRelevant)
 			{
@@ -1374,7 +1374,7 @@ void USpatialNetDriver::ServerReplicateActors_ProcessPrioritizedActors(UNetConne
 				if (Channel && bIsRelevant)
 				{
 					// If it is relevant then mark the channel as relevant for a short amount of time.
-					Channel->RelevantTime = Time + 0.5f * FMath::SRand();
+					Channel->RelevantTime = GetElapsedTime() + 0.5f * FMath::SRand();
 
 					// If the channel isn't saturated.
 					if (Channel->IsNetReady(0))
@@ -1628,7 +1628,7 @@ void USpatialNetDriver::TickDispatch(float DeltaTime)
 
 		if (SpatialMetrics != nullptr && SpatialGDKSettings->bEnableMetrics)
 		{
-			SpatialMetrics->TickMetrics(Time);
+			SpatialMetrics->TickMetrics(GetElapsedTime());
 		}
 
 		if (LoadBalanceEnforcer.IsValid())
@@ -1776,9 +1776,9 @@ void USpatialNetDriver::TickFlush(float DeltaTime)
 
 		if (SpatialGDKSettings->bBatchSpatialPositionUpdates && Sender != nullptr)
 		{
-			if ((Time - TimeWhenPositionLastUpdated) >= (1.0f / SpatialGDKSettings->PositionUpdateFrequency))
+			if ((GetElapsedTime() - TimeWhenPositionLastUpdated) >= (1.0f / SpatialGDKSettings->PositionUpdateFrequency))
 			{
-				TimeWhenPositionLastUpdated = Time;
+				TimeWhenPositionLastUpdated = GetElapsedTime();
 
 				Sender->ProcessPositionUpdates();
 			}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1119,7 +1119,7 @@ int32 USpatialNetDriver::ServerReplicateActors_PrepConnections(const float Delta
 		AActor* OwningActor = SpatialConnection->OwningActor;
 
 		//SpatialGDK: We allow a connection without an owner to process if it's meant to be the connection to the fake SpatialOS client.
-		if ((SpatialConnection->bReliableSpatialConnection || OwningActor != NULL) && SpatialConnection->State == USOCK_Open && (SpatialConnection->Driver->GetElapsedTime() - SpatialConnection->LastReceiveTime < 1.5f))
+		if ((SpatialConnection->bReliableSpatialConnection || OwningActor != NULL) && SpatialConnection->State == USOCK_Open && (GetElapsedTime() - SpatialConnection->LastReceiveTime < 1.5f))
 		{
 			check(SpatialConnection->bReliableSpatialConnection || World == OwningActor->GetWorld());
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetricsDisplay.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetricsDisplay.cpp
@@ -195,12 +195,12 @@ void ASpatialMetricsDisplay::Tick(float DeltaSeconds)
 	// Cleanup stats entries for workers that have not reported stats for awhile
 	if (Role == ROLE_Authority)
 	{
-		const float CurrentTime = SpatialNetDriver->Time;
+		const float CurrentTime = SpatialNetDriver->GetElapsedTime();
 		TArray<FWorkerStats> WorkerStatsToRemove;
 
 		for (const FWorkerStats& OneWorkerStats : WorkerStats)
 		{
-			if (ShouldRemoveStats(SpatialNetDriver->Time, OneWorkerStats))
+			if (ShouldRemoveStats(SpatialNetDriver->GetElapsedTime(), OneWorkerStats))
 			{
 				WorkerStatsToRemove.Add(OneWorkerStats);
 			}
@@ -251,7 +251,7 @@ void ASpatialMetricsDisplay::Tick(float DeltaSeconds)
 	}
 #endif // USE_SERVER_PERF_COUNTERS
 
-	ServerUpdateWorkerStats(SpatialNetDriver->Time, Stats);
+	ServerUpdateWorkerStats(SpatialNetDriver->GetElapsedTime(), Stats);
 
 #endif // !UE_BUILD_SHIPPING
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -318,7 +318,7 @@ private:
 	class USpatialReceiver* Receiver;
 
 	FVector LastPositionSinceUpdate;
-	float TimeWhenPositionLastUpdated;
+	double TimeWhenPositionLastUpdated;
 
 	uint8 FramesTillDormancyAllowed = 0;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -189,6 +189,10 @@ public:
 
 	SpatialGDK::SpatialRPCService* GetRPCService() const { return RPCService.Get(); }
 
+#if ENGINE_MINOR_VERSION <= 24
+	float GetElapsedTime() { return Time; }
+#endif
+
 private:
 
 	TUniquePtr<SpatialDispatcher> Dispatcher;


### PR DESCRIPTION
#### Description
In 4.25, `UNetDriver::Time` is deprecated, and `GetElapsedTime()` should be used instead. Instead of doing `#if ENGINE_MINOR_VERSION <= 24` for every time we used `Time`, we can instead define `GetElapsedTime` in 4.24 to return `Time` and have the call sites consistent for 4.24 and 4.25.

#### Primary reviewers
@jessicafalk @mironec
