### PR TITLE
Possible SpatialActorChannel.cpp changes

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -1242,22 +1242,6 @@ void USpatialActorChannel::UpdateSpatialPosition()
 		return;
 	}
 
-	// When we update an Actor's position, we want to update the position of all the children of this Actor.
-	// If this Actor is a PlayerController, we want to update all of its children and its possessed Pawn.
-	// That means if this Actor has an Owner or has a NetConnection and is NOT a PlayerController
-	// we want to defer updating position until we reach the highest parent.
-	AActor* ActorOwner = Actor->GetOwner();
-
-	if ((ActorOwner != nullptr || Actor->GetNetConnection() != nullptr) && !Actor->IsA<APlayerController>())
-	{
-		// If this Actor's owner is not replicated (e.g. parent = AI Controller), the actor will not have it's spatial
-		// position updated as this code will never be run for the parent.
-		if (!(Actor->GetNetConnection() == nullptr && ActorOwner != nullptr && !ActorOwner->GetIsReplicated()))
-		{
-			return;
-		}
-	}
-
 	// Check that the Actor has moved sufficiently far to be updated
 	const float SpatialPositionThresholdSquared = FMath::Square(GetDefault<USpatialGDKSettings>()->PositionDistanceThreshold);
 	FVector ActorSpatialPosition = SpatialGDK::GetActorSpatialPosition(Actor);
@@ -1270,14 +1254,6 @@ void USpatialActorChannel::UpdateSpatialPosition()
 	TimeWhenPositionLastUpdated = NetDriver->GetElapsedTime();
 
 	SendPositionUpdate(Actor, EntityId, LastPositionSinceUpdate);
-
-	if (APlayerController* PlayerController = Cast<APlayerController>(Actor))
-	{
-		if (APawn* Pawn = PlayerController->GetPawn())
-		{
-			SendPositionUpdate(Pawn, NetDriver->PackageMap->GetEntityIdFromObject(Pawn), LastPositionSinceUpdate);
-		}
-	}
 }
 
 void USpatialActorChannel::SendPositionUpdate(AActor* InActor, Worker_EntityId InEntityId, const FVector& NewPosition)


### PR DESCRIPTION
#### Description
This PR is to open a discussion about possible issues inside the `USpatialActorChannel::UpdateSpatialPosition()` method.

Currently, if an Actor is the child of another Actor, the Child will send position updates based on the Parent's update frequency, is this the behaviour we desire after adding per Class position update frequencies?

The second block of code treats the Pawn that is possesed by the PlayerController as a special case, is that necessary? 



