### PR TITLE
UNR-3550 Restore dynamic worker flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the `Connect local server worker to the cloud deployment` checkbox in **SpatialOS Editor Settings**, that enables/disables the option to start and connect a local server to the cloud deployment when `Connect to cloud deployment` is enabled.
 - Added the ability to suppress RPC warnings of the form "Executed RPC <RPCName> with unresolved references" by RPC Type using new SpatialGDKSetting RPCTypeAllowUnresolvedParamMap.
 - Decoupled QueuedIncomingRPCWaitTime from reprocessing flush time with new parameter QueuedIncomingRPCRetryTime (default value 1.0s).  This enables independent control over how long to wait for queued RPCs to resolve parameters, as well as how frequently to check if the parameters are resolved.
+- Dynamic Worker Flags are once again supported with the Standard Runtime Variant. 
+- Simulated Player deployments started with the DeploymentLauncher now startup faster thanks to Dynamic Worker Flags. DeploymentLauncher `createsim` usage has been updated to include the new boolean argument `<auto-connect>` which will automatically connect your sim players to your deployment when it is ready.  
 
 ### Bug fixes:
 - The example worker configuration for the simulated player coordinator has been updated to be compatible with the previously updated authentication flow.

--- a/RequireSetup
+++ b/RequireSetup
@@ -1,4 +1,4 @@
 Increment the below number whenever it is required to run Setup.bat as part of a new commit.
 Our git hooks will detect this file has been updated and automatically run Setup.bat on pull.
 
-60
+61

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/DeploymentLauncher/DeploymentLauncher.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/DeploymentLauncher/DeploymentLauncher.cs
@@ -20,6 +20,7 @@ namespace Improbable
     {
         private const string SIM_PLAYER_DEPLOYMENT_TAG = "simulated_players";
         private const string DEPLOYMENT_LAUNCHED_BY_LAUNCHER_TAG = "unreal_deployment_launcher";
+        private const string TARGET_DEPLOYMENT_READY_TAG = "target_deployment_ready";
 
         private const string CoordinatorWorkerName = "SimulatedPlayerCoordinator";
 
@@ -204,7 +205,7 @@ namespace Improbable
                 // Update coordinator worker flag for simulated player deployment to notify target deployment is ready.
                 simPlayerDeployment.WorkerFlags.Add(new WorkerFlag
                 {
-                    Key = "target_deployment_ready",
+                    Key = TARGET_DEPLOYMENT_READY_TAG,
                     Value = "true",
                     WorkerType = CoordinatorWorkerName
                 });
@@ -287,7 +288,7 @@ namespace Improbable
                 // Update coordinator worker flag for simulated player deployment to notify target deployment is ready.
                 simPlayerDeployment.WorkerFlags.Add(new WorkerFlag
                 {
-                    Key = "target_deployment_ready",
+                    Key = TARGET_DEPLOYMENT_READY_TAG,
                     Value = autoConnect.ToString(),
                     WorkerType = CoordinatorWorkerName
                 });

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/DeploymentLauncher/DeploymentLauncher.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/DeploymentLauncher/DeploymentLauncher.cs
@@ -254,7 +254,7 @@ namespace Improbable
             }
 
             var autoConnect = false;
-            if (!Boolean.TryParse(args[10], out autoConnect))
+            if (!Boolean.TryParse(args[11], out autoConnect))
             {
                 Console.WriteLine("Cannot parse the auto-connect flag.");
                 return 1;
@@ -293,7 +293,10 @@ namespace Improbable
                 });
                 deploymentServiceClient.UpdateDeployment(new UpdateDeploymentRequest { Deployment = simPlayerDeployment });
 
-                Console.WriteLine("Done! Simulated players will start to connect to your deployment");
+                if (autoConnect)
+                {
+                    Console.WriteLine("Done! Simulated players will start to connect to your deployment");
+                }
             }
             catch (Grpc.Core.RpcException e)
             {
@@ -669,7 +672,7 @@ namespace Improbable
             Console.WriteLine("Usage:");
             Console.WriteLine("DeploymentLauncher create <project-name> <assembly-name> <runtime-version> <main-deployment-name> <main-deployment-json> <main-deployment-snapshot> <main-deployment-region> <main-deployment-cluster> <main-deployment-tags> [<sim-deployment-name> <sim-deployment-json> <sim-deployment-region> <sim-deployment-cluster> <num-sim-players>]");
             Console.WriteLine($"  Starts a cloud deployment, with optionally a simulated player deployment. The deployments can be started in different regions ('EU', 'US', 'AP' and 'CN').");
-            Console.WriteLine("DeploymentLauncher createsim <project-name> <assembly-name> <runtime-version> <target-deployment-name> <sim-deployment-name> <sim-deployment-json> <sim-deployment-region> <sim-deployment-cluster> <sim-deployment-snapshot-path> <num-sim-players>");
+            Console.WriteLine("DeploymentLauncher createsim <project-name> <assembly-name> <runtime-version> <target-deployment-name> <sim-deployment-name> <sim-deployment-json> <sim-deployment-region> <sim-deployment-cluster> <sim-deployment-snapshot-path> <num-sim-players> <auto-connect>");
             Console.WriteLine($"  Starts a simulated player deployment. Can be started in a different region from the target deployment ('EU', 'US', 'AP' and 'CN').");
             Console.WriteLine("DeploymentLauncher stop <project-name> [deployment-id]");
             Console.WriteLine("  Stops the specified deployment within the project.");
@@ -691,7 +694,7 @@ namespace Improbable
 
             if (args.Length == 0 ||
                 (args[0] == "create" && (args.Length != 15 && args.Length != 10)) ||
-                (args[0] == "createsim" && args.Length != 11) ||
+                (args[0] == "createsim" && args.Length != 12) ||
                 (args[0] == "stop" && (args.Length != 2 && args.Length != 3)) ||
                 (args[0] == "list" && args.Length != 2))
             {

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/ManagedWorkerCoordinator.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/ManagedWorkerCoordinator.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Improbable.Collections;
 using Improbable.Worker;
 
@@ -123,7 +124,11 @@ namespace Improbable.WorkerCoordinator
             int deploymentTotalNumSimulatedPlayers = int.Parse(GetWorkerFlagOrDefault(connection, DeploymentTotalNumSimulatedPlayersWorkerFlag, "100"));
 
             Logger.WriteLog("Waiting for target deployment to become ready.");
-            WaitForTargetDeploymentReady(connection);
+            var deploymentReadyTask = Task.Run(() => WaitForTargetDeploymentReady(connection));
+            if (!deploymentReadyTask.Wait(TimeSpan.FromMinutes(15)))
+            {
+                throw new TimeoutException("Timed out waiting for the deployment to be ready. Waited 15 minutes.");
+            } 
 
             Logger.WriteLog($"Target deployment is ready. Starting {NumSimulatedPlayersToStart} simulated players.");
             Thread.Sleep(InitialStartDelayMillis);

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/GDKPropertyMacros.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/GDKPropertyMacros.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
-#include "Launch/Resources/Version.h"
 #include "UObject/UnrealType.h"
+#include "Runtime/Launch/Resources/Version.h"
 
 #if ENGINE_MINOR_VERSION <= 24
 	#define GDK_PROPERTY(Type) U##Type


### PR DESCRIPTION
#### Description
Re-add dynamic worker flags to SimPlayer launching as this is now supported again in runtime 0.4.0+
This speeds up deployment launch time.

#### Primary reviewers
@improbable-valentyn @improbable-andreaskrugersen 