### PR TITLE
Worker layer hints

### DIFF
--- a/SpatialGDK/Extras/schema/server_worker.schema
+++ b/SpatialGDK/Extras/schema/server_worker.schema
@@ -18,5 +18,7 @@ component ServerWorker {
     id = 9974;
     string worker_name = 1;
     bool ready_to_begin_play = 2;
+    // Allow developers to pass a CLI flag to worker executables that expresses a preferred multiworker layer.
+    string layer_hint = 3;
     command ForwardSpawnPlayerResponse forward_spawn_player(ForwardSpawnPlayerRequest);
 }

--- a/SpatialGDK/Extras/schema/server_worker.schema
+++ b/SpatialGDK/Extras/schema/server_worker.schema
@@ -18,7 +18,9 @@ component ServerWorker {
     id = 9974;
     string worker_name = 1;
     bool ready_to_begin_play = 2;
-    // Allow developers to pass a CLI flag to worker executables that expresses a preferred multiworker layer.
+    // Used for workers to express a preferred multiworker layer. Thie will be used for the worker name.
+    // PIE single process workers will have this set automatically. Alternatively, a CLI flag can 
+    // be passed to server worker executables.
     string layer_hint = 3;
     command ForwardSpawnPlayerResponse forward_spawn_player(ForwardSpawnPlayerRequest);
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
@@ -112,6 +112,7 @@ void USpatialGameInstance::DestroySpatialConnectionManager()
 FGameInstancePIEResult USpatialGameInstance::StartPlayInEditorGameInstance(ULocalPlayer* LocalPlayer, const FGameInstancePIEParameters& Params)
 {
 	SpatialWorkerType = Params.SpatialWorkerType;
+	SpatialLayerHint = Params.SpatalLayerHint;
 	bIsSimulatedPlayer = Params.bIsSimulatedPlayer;
 
 	StartSpatialConnection();

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -248,7 +248,7 @@ void USpatialNetDriver::InitiateConnectionToSpatialOS(const FURL& URL)
 	// If this is the first connection try using the command line arguments to setup the config objects.
 	// If arguments can not be found we will use the regular flow of loading from the input URL.
 
-	FString SpatialWorkerType = GameInstance->GetSpatialWorkerType().ToString();
+	const FString SpatialWorkerType = GameInstance->GetSpatialWorkerType().ToString();
 
 	// Ensures that any connections attempting to using command line arguments have a valid locater host in the command line.
 	GameInstance->TryInjectSpatialLocatorIntoCommandLine();
@@ -278,6 +278,12 @@ void USpatialNetDriver::InitiateConnectionToSpatialOS(const FURL& URL)
 	else
 	{
 		ConnectionManager->SetupConnectionConfigFromURL(URL, SpatialWorkerType);
+	}
+
+	const FName SpatialLayerHint = GetGameInstance()->GetSpatialLayerHint();
+	if (IsServer() && SpatialLayerHint.IsValid())
+	{
+		ConnectionManager->ReceptionistConfig.WorkerId = FString::Printf(TEXT("%s-%s"), *SpatialLayerHint.ToString(), *FGuid::NewGuid().ToString());
 	}
 
 #if WITH_EDITOR

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -2675,5 +2675,5 @@ FUnrealObjectRef USpatialNetDriver::GetCurrentPlayerControllerRef()
 void USpatialNetDriver::InitializeVirtualWorkerTranslationManager()
 {
 	VirtualWorkerTranslationManager = MakeUnique<SpatialVirtualWorkerTranslationManager>(Receiver, Connection, VirtualWorkerTranslator.Get());
-	VirtualWorkerTranslationManager->SetNumberOfVirtualWorkers(LoadBalanceStrategy->GetMinimumRequiredWorkers());
+	VirtualWorkerTranslationManager->SetLayerVirtualWorkerMapping(Cast<ULayeredLBStrategy>(LoadBalanceStrategy)->GetLayerVirtualWorkerRequirements());
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslationManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslationManager.cpp
@@ -218,7 +218,7 @@ void SpatialVirtualWorkerTranslationManager::AssignServersWithLayerHints(const T
 		if (!PendingServer.LayerHint.IsNone())
 		{
 			uint32 AssignedLayerVirtualWorkerIndex = INDEX_NONE;
-			for (uint32 i = 0; i < UnassignedLayerVirtualWorkers.Num(); i++)
+			for (auto i = 0; i < UnassignedLayerVirtualWorkers.Num(); i++)
 			{
 				// If the server's preferred layer exists (and has unassigned virtual workers), assign that server.
 				TPair<FName, VirtualWorkerId> CurrentLayerVirtualWorker = UnassignedLayerVirtualWorkers[i];

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslationManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslationManager.cpp
@@ -231,8 +231,8 @@ void SpatialVirtualWorkerTranslationManager::AssignServersWithLayerHints(TArray<
 
 			if (AssignedLayerVirtualWorkerIndex == INDEX_NONE)
 			{
-				UE_LOG(LogSpatialVirtualWorkerTranslationManager, Warning, TEXT("Server worker %s had layer hint %s, "
-                    "but there were no workers for this layer in the load balancing strategy."),
+				UE_LOG(LogSpatialVirtualWorkerTranslationManager, Error, TEXT("Server worker %s had unused layer hint: %s. "
+                    "There were no unassigned virtual worker IDs remaining for this layer."),
                     *PendingServer.WorkerName, *PendingServer.LayerHint.ToString());
 				continue;
 			}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslationManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslationManager.cpp
@@ -70,72 +70,6 @@ void SpatialVirtualWorkerTranslationManager::WriteMappingToSchema(Schema_Object*
 	}
 }
 
-// This method is called on the worker who is authoritative over the translation mapping. Based on the results of the
-// system entity query, assign the VirtualWorkerIds to the workers represented by the system entities.
-void SpatialVirtualWorkerTranslationManager::ConstructVirtualWorkerMappingFromQueryResponse(const Worker_EntityQueryResponseOp& Op)
-{
-	struct ServerInfo
-	{
-		FString WorkerName;
-		Worker_EntityId ServerWorkerEntityId;
-		FName LayerHint;
-	};
-
-	TArray<ServerInfo> PendingServersToAssign;
-	PendingServersToAssign.Reserve(Op.result_count);
-
-	// The query response is an array of entities. Each of these represents a worker.
-	for (uint32_t i = 0; i < Op.result_count; ++i)
-	{
-		const Worker_Entity& Entity = Op.results[i];
-		for (uint32_t j = 0; j < Entity.component_count; j++)
-		{
-			const Worker_ComponentData& Data = Entity.components[j];
-			// System entities which represent workers have a component on them which specifies the SpatialOS worker ID,
-			// which is the string we use to refer to them as a physical worker ID.
-			if (Data.component_id == SpatialConstants::SERVER_WORKER_COMPONENT_ID)
-			{
-				const Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
-
-				// The translator should only acknowledge workers that are ready to begin play. This means we can make
-				// guarantees based on where non-GSM-authoritative servers canBeginPlay=true as an AddComponent
-				// or ComponentUpdate op. This affects how startup Actors are treated in a zoned environment.
-				const bool bWorkerIsReadyToBeginPlay = SpatialGDK::GetBoolFromSchema(ComponentObject, SpatialConstants::SERVER_WORKER_READY_TO_BEGIN_PLAY_ID);
-				if (!bWorkerIsReadyToBeginPlay)
-				{
-					continue;
-				}
-
-				PendingServersToAssign.Add(ServerInfo
-					{
-						SpatialGDK::GetStringFromSchema(ComponentObject, SpatialConstants::SERVER_WORKER_NAME_ID),
-						Entity.entity_id,
-						*SpatialGDK::GetStringFromSchema(ComponentObject, SpatialConstants::SERVER_WORKER_LAYER_HINT_ID)
-					});
-			}
-		}
-	}
-
-	TArray<uint32> AssignedIndices;
-	AssignedIndices.Reserve(UnassignedLayerVirtualWorkers.Num());
-	for (const ServerInfo& PendingServer : PendingServersToAssign)
-	{
-		if (!PendingServer.LayerHint.IsNone())
-		{
-			VirtualWorkerId HintVirtualWorker = SpatialConstants::INVALID_VIRTUAL_WORKER_ID;
-			for (uint32 i = 0; i < UnassignedLayerVirtualWorkers.Num(); i++)
-			{
-				TPair<FName, VirtualWorkerId> CurrentVirtualWorker = UnassignedLayerVirtualWorkers[i];
-				if (PendingServer.LayerHint.IsEqual(CurrentVirtualWorker.Key))
-				{
-					// We found a worker which wants to be part of a specific layer.
-					Assign()
-				}
-			}
-		}
-	}
-}
-
 // This will be called on the worker authoritative for the translation mapping to push the new version of the map
 // to the SpatialOS storage.
 void SpatialVirtualWorkerTranslationManager::SendVirtualWorkerMappingUpdate() const
@@ -201,39 +135,126 @@ void SpatialVirtualWorkerTranslationManager::ServerWorkerEntityQueryDelegate(con
 
 	if (Op.status_code != WORKER_STATUS_CODE_SUCCESS)
 	{
-		UE_LOG(LogSpatialVirtualWorkerTranslationManager, Warning, TEXT("Could not find ServerWorker Entities via entity query: %s, retrying."), UTF8_TO_TCHAR(Op.message));
-	}
-	else
-	{
-		UE_LOG(LogSpatialVirtualWorkerTranslationManager, Log, TEXT("Processing ServerWorker Entity query response"));
-		ConstructVirtualWorkerMappingFromQueryResponse(Op);
+		UE_LOG(LogSpatialVirtualWorkerTranslationManager, Warning, TEXT("Could not find ServerWorker Entities via "
+			"entity query: %s. Retrying."), UTF8_TO_TCHAR(Op.message));
+		QueryForServerWorkerEntities();
+		return;
 	}
 
-	// If the translation mapping is complete, publish it. Otherwise retry the server worker entity query.
-	if (UnassignedVirtualWorkers.IsEmpty())
+	const TArray<ServerInfo> PendingServersToAssign = GetPendingServersToAssignFromQuery(Op);
+	if (PendingServersToAssign.Num() != UnassignedLayerVirtualWorkers.Num())
 	{
-		SendVirtualWorkerMappingUpdate();
-	}
-	else
-	{
-		UE_LOG(LogSpatialVirtualWorkerTranslationManager, Log, TEXT("Waiting for all virtual workers to be assigned before publishing translation update."));
+		UE_LOG(LogSpatialVirtualWorkerTranslationManager, Log, TEXT("Waiting for all virtual workers to be assigned "
+			"before publishing translation update."));
 		QueryForServerWorkerEntities();
+		return;
+	}
+
+	UE_LOG(LogSpatialVirtualWorkerTranslationManager, Log, TEXT("ServerWorker Entity query successfully found %d"
+		"workers."), PendingServersToAssign.Num());
+
+	AssignServersWithLayerHints(PendingServersToAssign);
+	checkf(PendingServersToAssign.Num() == UnassignedLayerVirtualWorkers.Num(), TEXT("When assigning servers with "
+		"layer hints, we developed a mismatch in available server and pending virtaul worker counts, this is fatal."
+		"PendingServersToAssign: %d. UnassignedLayerVirtualWorkers: %d."), PendingServersToAssign.Num(),
+		UnassignedLayerVirtualWorkers.Num())
+
+	uint32 CurrentVirtualWorkerIndex = 0;
+	for (const ServerInfo& RemainingServersToAssign : PendingServersToAssign)
+	{
+		AssignWorker(RemainingServersToAssign, UnassignedLayerVirtualWorkers[CurrentVirtualWorkerIndex++].Value);
+	}
+
+	SendVirtualWorkerMappingUpdate();
+}
+
+TArray<SpatialVirtualWorkerTranslationManager::ServerInfo> SpatialVirtualWorkerTranslationManager::GetPendingServersToAssignFromQuery(const Worker_EntityQueryResponseOp& Op)
+{
+	TArray<ServerInfo> PendingServersToAssign;
+	PendingServersToAssign.Reserve(Op.result_count);
+
+	// The query response is an array of entities. Each of these represents a worker.
+	for (uint32_t i = 0; i < Op.result_count; ++i)
+	{
+		const Worker_Entity& Entity = Op.results[i];
+		for (uint32_t j = 0; j < Entity.component_count; j++)
+		{
+			const Worker_ComponentData& Data = Entity.components[j];
+			// System entities which represent workers have a component on them which specifies the SpatialOS worker ID,
+			// which is the string we use to refer to them as a physical worker ID.
+			if (Data.component_id == SpatialConstants::SERVER_WORKER_COMPONENT_ID)
+			{
+				const Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
+
+				// The translator should only acknowledge workers that are ready to begin play. This means we can make
+				// guarantees based on where non-GSM-authoritative servers canBeginPlay=true as an AddComponent
+				// or ComponentUpdate op. This affects how startup Actors are treated in a zoned environment.
+				const bool bWorkerIsReadyToBeginPlay = SpatialGDK::GetBoolFromSchema(ComponentObject, SpatialConstants::SERVER_WORKER_READY_TO_BEGIN_PLAY_ID);
+				if (!bWorkerIsReadyToBeginPlay)
+				{
+					continue;
+				}
+
+				PendingServersToAssign.Add(ServerInfo
+                    {
+                        SpatialGDK::GetStringFromSchema(ComponentObject, SpatialConstants::SERVER_WORKER_NAME_ID),
+                        Entity.entity_id,
+                        *SpatialGDK::GetStringFromSchema(ComponentObject, SpatialConstants::SERVER_WORKER_LAYER_HINT_ID)
+                    });
+			}
+		}
+	}
+
+	return PendingServersToAssign;
+}
+
+void SpatialVirtualWorkerTranslationManager::AssignServersWithLayerHints(const TArray<ServerInfo>& PendingServersToAssign)
+{
+	TArray<uint32> AssignedIndices;
+	AssignedIndices.Reserve(UnassignedLayerVirtualWorkers.Num());
+	for (const ServerInfo& PendingServer : PendingServersToAssign)
+	{
+		// Does one of our connected servers express a preference for which layer it is in?
+		if (!PendingServer.LayerHint.IsNone())
+		{
+			uint32 AssignedLayerVirtualWorkerIndex = INDEX_NONE;
+			for (uint32 i = 0; i < UnassignedLayerVirtualWorkers.Num(); i++)
+			{
+				// If the server's preferred layer exists (and has unassigned virtual workers), assign that server.
+				TPair<FName, VirtualWorkerId> CurrentLayerVirtualWorker = UnassignedLayerVirtualWorkers[i];
+				if (PendingServer.LayerHint.IsEqual(CurrentLayerVirtualWorker.Key))
+				{
+					AssignWorker(PendingServer, CurrentLayerVirtualWorker.Value);
+					AssignedLayerVirtualWorkerIndex = i;
+				}
+			}
+
+			if (AssignedLayerVirtualWorkerIndex == INDEX_NONE)
+			{
+				UE_LOG(LogSpatialVirtualWorkerTranslationManager, Warning, TEXT("Server worker %s had layer hint %s, "
+                    "but there were no workers for this layer in the load balancing strategy."),
+                    *PendingServer.WorkerName, *PendingServer.LayerHint.ToString());
+				continue;
+			}
+
+			UE_LOG(LogSpatialVirtualWorkerTranslationManager, Log, TEXT("Server worker %s was successfully assigned "
+				"to be part of hinted layer: %s"), *PendingServer.WorkerName, *PendingServer.LayerHint.ToString());
+
+			UnassignedLayerVirtualWorkers.RemoveAt(AssignedLayerVirtualWorkerIndex);
+		}
 	}
 }
 
-void SpatialVirtualWorkerTranslationManager::AssignWorker(const PhysicalWorkerName& Name, const Worker_EntityId& ServerWorkerEntityId, const VirtualWorkerId& VirtualWorkerId)
+void SpatialVirtualWorkerTranslationManager::AssignWorker(const ServerInfo& ServerInfo, const VirtualWorkerId& VirtualWorkerId)
 {
-	if (PhysicalToVirtualWorkerMapping.Contains(Name))
+	if (PhysicalToVirtualWorkerMapping.Contains(ServerInfo.WorkerName))
 	{
 		return;
 	}
 
-	// Get a VirtualWorkerId from the list of unassigned work.
-	VirtualWorkerId Id;
-	UnassignedVirtualWorkers.Dequeue(Id);
+	VirtualToPhysicalWorkerMapping.Add(VirtualWorkerId, MakeTuple(ServerInfo.WorkerName, ServerInfo.ServerWorkerEntityId));
+	PhysicalToVirtualWorkerMapping.Add(ServerInfo.WorkerName, VirtualWorkerId);
 
-	VirtualToPhysicalWorkerMapping.Add(Id, MakeTuple(Name, ServerWorkerEntityId));
-	PhysicalToVirtualWorkerMapping.Add(Name, Id);
-
-	UE_LOG(LogSpatialVirtualWorkerTranslationManager, Log, TEXT("Assigned VirtualWorker %d to simulate on Worker %s"), Id, *Name);
+	UE_LOG(LogSpatialVirtualWorkerTranslationManager, Log, TEXT("Assigned VirtualWorker %d to simulate on Worker %s"),
+		VirtualWorkerId, *ServerInfo.WorkerName);
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslationManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslationManager.cpp
@@ -226,6 +226,7 @@ void SpatialVirtualWorkerTranslationManager::AssignServersWithLayerHints(TArray<
 					AssignWorker(PendingServer, CurrentLayerVirtualWorker.Value);
 					AssignedServers.Add(PendingServer.WorkerName);
 					AssignedLayerVirtualWorkerIndex = i;
+					break;
 				}
 			}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -258,11 +258,14 @@ void USpatialSender::RetryServerWorkerEntityCreation(Worker_EntityId EntityId, i
 	ComponentWriteAcl.Add(SpatialConstants::SERVER_WORKER_COMPONENT_ID, WorkerIdPermission);
 	ComponentWriteAcl.Add(SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID, WorkerIdPermission);
 
+	FString LayerHint = TEXT("");
+	FParse::Value(FCommandLine::Get(), TEXT("LayerHint="), LayerHint);
+
 	TArray<FWorkerComponentData> Components;
 	Components.Add(Position().CreatePositionData());
 	Components.Add(Metadata(FString::Format(TEXT("WorkerEntity:{0}"), { Connection->GetWorkerId() })).CreateMetadataData());
 	Components.Add(EntityAcl(WorkerIdPermission, ComponentWriteAcl).CreateEntityAclData());
-	Components.Add(ServerWorker(Connection->GetWorkerId(), false).CreateServerWorkerData());
+	Components.Add(ServerWorker(Connection->GetWorkerId(), false, LayerHint).CreateServerWorkerData());
 	check(NetDriver != nullptr);
 	// It is unlikely the load balance strategy would be set up at this point, but we call this function again later when it is ready in order
 	// to set the interest of the server worker according to the strategy.

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -259,7 +259,7 @@ void USpatialSender::RetryServerWorkerEntityCreation(Worker_EntityId EntityId, i
 	ComponentWriteAcl.Add(SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID, WorkerIdPermission);
 
 	FString LayerHint = TEXT("");
-	FParse::Value(FCommandLine::Get(), TEXT("LayerHint="), LayerHint);
+	FParse::Value(FCommandLine::Get(), TEXT("-LayerHint"), LayerHint);
 
 	TArray<FWorkerComponentData> Components;
 	Components.Add(Position().CreatePositionData());

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -265,7 +265,7 @@ void USpatialSender::RetryServerWorkerEntityCreation(Worker_EntityId EntityId, i
 	Components.Add(Position().CreatePositionData());
 	Components.Add(Metadata(FString::Format(TEXT("WorkerEntity:{0}"), { Connection->GetWorkerId() })).CreateMetadataData());
 	Components.Add(EntityAcl(WorkerIdPermission, ComponentWriteAcl).CreateEntityAclData());
-	Components.Add(ServerWorker(Connection->GetWorkerId(), false, LayerHint).CreateServerWorkerData());
+	Components.Add(ServerWorker(Connection->GetWorkerId(), false, NetDriver->GetLayerHint()).CreateServerWorkerData());
 	check(NetDriver != nullptr);
 	// It is unlikely the load balance strategy would be set up at this point, but we call this function again later when it is ready in order
 	// to set the interest of the server worker according to the strategy.

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -258,9 +258,6 @@ void USpatialSender::RetryServerWorkerEntityCreation(Worker_EntityId EntityId, i
 	ComponentWriteAcl.Add(SpatialConstants::SERVER_WORKER_COMPONENT_ID, WorkerIdPermission);
 	ComponentWriteAcl.Add(SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID, WorkerIdPermission);
 
-	FString LayerHint = TEXT("");
-	FParse::Value(FCommandLine::Get(), TEXT("-LayerHint"), LayerHint);
-
 	TArray<FWorkerComponentData> Components;
 	Components.Add(Position().CreatePositionData());
 	Components.Add(Metadata(FString::Format(TEXT("WorkerEntity:{0}"), { Connection->GetWorkerId() })).CreateMetadataData());

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
@@ -2,8 +2,6 @@
 
 #include "LoadBalancing/LayeredLBStrategy.h"
 
-
-#include "ILauncherProfile.h"
 #include "EngineClasses/SpatialNetDriver.h"
 #include "EngineClasses/SpatialWorldSettings.h"
 #include "LoadBalancing/GridBasedLBStrategy.h"

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
@@ -51,7 +51,6 @@ void ULayeredLBStrategy::SetLocalVirtualWorkerId(VirtualWorkerId InLocalVirtualW
 	}
 
 	LocalVirtualWorkerId = InLocalVirtualWorkerId;
-c
 }
 
 TSet<VirtualWorkerId> ULayeredLBStrategy::GetVirtualWorkerIds() const

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
@@ -2,6 +2,8 @@
 
 #include "LoadBalancing/LayeredLBStrategy.h"
 
+
+#include "ILauncherProfile.h"
 #include "EngineClasses/SpatialNetDriver.h"
 #include "EngineClasses/SpatialWorldSettings.h"
 #include "LoadBalancing/GridBasedLBStrategy.h"
@@ -51,10 +53,7 @@ void ULayeredLBStrategy::SetLocalVirtualWorkerId(VirtualWorkerId InLocalVirtualW
 	}
 
 	LocalVirtualWorkerId = InLocalVirtualWorkerId;
-	for (const auto& Elem : LayerNameToLBStrategy)
-	{
-		Elem.Value->SetLocalVirtualWorkerId(InLocalVirtualWorkerId);
-	}
+c
 }
 
 TSet<VirtualWorkerId> ULayeredLBStrategy::GetVirtualWorkerIds() const
@@ -164,6 +163,16 @@ uint32 ULayeredLBStrategy::GetMinimumRequiredWorkers() const
 
 	UE_LOG(LogLayeredLBStrategy, Verbose, TEXT("LayeredLBStrategy needs %d workers to support all layer strategies."), MinimumRequiredWorkers);
 	return MinimumRequiredWorkers;
+}
+
+TMap<FName, uint32> ULayeredLBStrategy::GetLayerVirtualWorkerRequirements() const
+{
+	TMap<FName, uint32> LayerVirtualWorkerRequirements;
+	for (const auto& Layer : LayerNameToLBStrategy)
+	{
+		LayerVirtualWorkerRequirements.Add(Layer.Key, Layer.Value->GetMinimumRequiredWorkers());
+	}
+	return LayerVirtualWorkerRequirements;
 }
 
 void ULayeredLBStrategy::SetVirtualWorkerIds(const VirtualWorkerId& FirstVirtualWorkerId, const VirtualWorkerId& LastVirtualWorkerId)

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
@@ -51,6 +51,11 @@ void ULayeredLBStrategy::SetLocalVirtualWorkerId(VirtualWorkerId InLocalVirtualW
 	}
 
 	LocalVirtualWorkerId = InLocalVirtualWorkerId;
+
+	for (const auto& Elem : LayerNameToLBStrategy)
+	{
+		Elem.Value->SetLocalVirtualWorkerId(InLocalVirtualWorkerId);
+	}
 }
 
 TSet<VirtualWorkerId> ULayeredLBStrategy::GetVirtualWorkerIds() const

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/SpatialMultiWorkerSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/SpatialMultiWorkerSettings.cpp
@@ -48,6 +48,18 @@ uint32 UAbstractSpatialMultiWorkerSettings::GetMinimumRequiredWorkerCount() cons
 	return WorkerCount;
 }
 
+TMap<FName, uint32> UAbstractSpatialMultiWorkerSettings::GetLayerWorkerCounts() const
+{
+	TMap<FName, uint32> LayerVirtualWorkerRequirements;
+
+	for (const auto& Layer : WorkerLayers)
+	{
+		LayerVirtualWorkerRequirements.Add(Layer.Name, GetDefault<UAbstractLBStrategy>(Layer.LoadBalanceStrategy)->GetMinimumRequiredWorkers());
+	}
+
+	return LayerVirtualWorkerRequirements;
+}
+
 #if WITH_EDITOR
 void UAbstractSpatialMultiWorkerSettings::ValidateFirstLayerIsDefaultLayer()
 {

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "EngineClasses/SpatialGameInstance.h"
 #include "EngineClasses/SpatialLoadBalanceEnforcer.h"
 #include "EngineClasses/SpatialVirtualWorkerTranslationManager.h"
 #include "EngineClasses/SpatialVirtualWorkerTranslator.h"
@@ -193,6 +194,8 @@ public:
 #if ENGINE_MINOR_VERSION <= 24
 	float GetElapsedTime() { return Time; }
 #endif
+
+	FName GetLayerHint() const { return GetGameInstance()->GetSpatialLayerHint(); }
 
 private:
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialVirtualWorkerTranslationManager.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialVirtualWorkerTranslationManager.h
@@ -70,7 +70,7 @@ private:
 	void QueryForServerWorkerEntities();
 	void ServerWorkerEntityQueryDelegate(const Worker_EntityQueryResponseOp& Op);
 	static TArray<ServerInfo> GetPendingServersToAssignFromQuery(const Worker_EntityQueryResponseOp& Op);
-	void AssignServersWithLayerHints(const TArray<ServerInfo>& PendingServersToAssign);
+	void AssignServersWithLayerHints(TArray<ServerInfo>& PendingServersToAssign);
 	void SendVirtualWorkerMappingUpdate() const;
 
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialVirtualWorkerTranslationManager.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialVirtualWorkerTranslationManager.h
@@ -44,6 +44,13 @@ public:
 	void AuthorityChanged(const Worker_AuthorityChangeOp& AuthChangeOp);
 
 private:
+	struct ServerInfo
+	{
+		FString WorkerName;
+		Worker_EntityId ServerWorkerEntityId;
+		FName LayerHint;
+	};
+
 	SpatialOSDispatcherInterface* Receiver;
 	SpatialOSWorkerInterface* Connection;
 
@@ -62,9 +69,10 @@ private:
 	// based on the response.
 	void QueryForServerWorkerEntities();
 	void ServerWorkerEntityQueryDelegate(const Worker_EntityQueryResponseOp& Op);
-	void ConstructVirtualWorkerMappingFromQueryResponse(const Worker_EntityQueryResponseOp& Op);
+	static TArray<ServerInfo> GetPendingServersToAssignFromQuery(const Worker_EntityQueryResponseOp& Op);
+	void AssignServersWithLayerHints(const TArray<ServerInfo>& PendingServersToAssign);
 	void SendVirtualWorkerMappingUpdate() const;
 
-	void AssignWorker(const PhysicalWorkerName& WorkerId, const Worker_EntityId& ServerWorkerEntityId, const VirtualWorkerId& VirtualWorkerId);
-};
 
+	void AssignWorker(const ServerInfo& ServerInfo, const VirtualWorkerId& VirtualWorkerId);
+};

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialVirtualWorkerTranslationManager.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialVirtualWorkerTranslationManager.h
@@ -38,7 +38,7 @@ public:
 		SpatialOSWorkerInterface* InConnection,
 		SpatialVirtualWorkerTranslator* InTranslator);
 
-	void SetNumberOfVirtualWorkers(const uint32 NumVirtualWorkers);
+	void SetLayerVirtualWorkerMapping(const TMap<FName, uint32>& LayerToVirtualWorker);
 
 	// The translation manager only cares about changes to the authority of the translation mapping.
 	void AuthorityChanged(const Worker_AuthorityChangeOp& AuthChangeOp);
@@ -51,7 +51,7 @@ private:
 
 	TMap<VirtualWorkerId, TPair<PhysicalWorkerName, Worker_EntityId>> VirtualToPhysicalWorkerMapping;
 	TMap<PhysicalWorkerName, VirtualWorkerId> PhysicalToVirtualWorkerMapping;
-	TQueue<VirtualWorkerId> UnassignedVirtualWorkers;
+	TArray<TPair<FName, VirtualWorkerId>> UnassignedLayerVirtualWorkers;
 
 	bool bWorkerEntityQueryInFlight;
 
@@ -65,6 +65,6 @@ private:
 	void ConstructVirtualWorkerMappingFromQueryResponse(const Worker_EntityQueryResponseOp& Op);
 	void SendVirtualWorkerMappingUpdate() const;
 
-	void AssignWorker(const PhysicalWorkerName& WorkerId, const Worker_EntityId& ServerWorkerEntityId);
+	void AssignWorker(const PhysicalWorkerName& WorkerId, const Worker_EntityId& ServerWorkerEntityId, const VirtualWorkerId& VirtualWorkerId);
 };
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
@@ -28,6 +28,13 @@ struct FConnectionConfig
 		const TCHAR* CommandLine = FCommandLine::Get();
 
 		FParse::Value(CommandLine, TEXT("workerId"), WorkerId);
+
+		FString LayerHint = TEXT("");
+		if (FParse::Value(FCommandLine::Get(), TEXT("-LayerHint"), LayerHint))
+		{
+			WorkerId = FString::Printf(TEXT("%s-%s"), *LayerHint, *FGuid::NewGuid().ToString());
+		}
+
 		FParse::Bool(CommandLine, TEXT("enableWorkerSDKProtocolLogging"), EnableWorkerSDKProtocolLogging);
 		FParse::Bool(CommandLine, TEXT("enableWorkerSDKOpLogging"), EnableWorkerSDKOpLogging);
 		FParse::Value(CommandLine, TEXT("workerSDKLogPrefix"), WorkerSDKLogPrefix);

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
@@ -28,13 +28,6 @@ struct FConnectionConfig
 		const TCHAR* CommandLine = FCommandLine::Get();
 
 		FParse::Value(CommandLine, TEXT("workerId"), WorkerId);
-
-		FString LayerHint = TEXT("");
-		if (FParse::Value(FCommandLine::Get(), TEXT("-LayerHint"), LayerHint))
-		{
-			WorkerId = FString::Printf(TEXT("%s-%s"), *LayerHint, *FGuid::NewGuid().ToString());
-		}
-
 		FParse::Bool(CommandLine, TEXT("enableWorkerSDKProtocolLogging"), EnableWorkerSDKProtocolLogging);
 		FParse::Bool(CommandLine, TEXT("enableWorkerSDKOpLogging"), EnableWorkerSDKOpLogging);
 		FParse::Value(CommandLine, TEXT("workerSDKLogPrefix"), WorkerSDKLogPrefix);

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialConnectionManager.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialConnectionManager.h
@@ -4,8 +4,9 @@
 
 #include "Interop/Connection/SpatialOSWorkerInterface.h"
 #include "Interop/Connection/ConnectionConfig.h"
-#include "SpatialCommonTypes.h"
 #include "SpatialGDKSettings.h"
+
+#include "Engine/EngineBaseTypes.h"
 
 #include "SpatialConnectionManager.generated.h"
 
@@ -29,9 +30,9 @@ class SPATIALGDK_API USpatialConnectionManager : public UObject
 public:
 	virtual void FinishDestroy() override;
 	void DestroyConnection();
-	
+
 	using LoginTokenResponseCallback = TFunction<bool(const Worker_Alpha_LoginTokensResponse*)>;
-    
+
     /// Register a callback using this function.
     /// It will be triggered when receiving login tokens using the development authentication flow inside SpatialWorkerConnection.
     /// @param Callback - callback function.

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LayeredLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LayeredLBStrategy.h
@@ -64,6 +64,8 @@ public:
 
 	FName GetLocalLayerName() const;
 
+	TMap<FName, uint32> GetLayerVirtualWorkerRequirements() const;s
+
 private:
 	TArray<VirtualWorkerId> VirtualWorkerIds;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LayeredLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LayeredLBStrategy.h
@@ -64,7 +64,7 @@ public:
 
 	FName GetLocalLayerName() const;
 
-	TMap<FName, uint32> GetLayerVirtualWorkerRequirements() const;s
+	TMap<FName, uint32> GetLayerVirtualWorkerRequirements() const;
 
 private:
 	TArray<VirtualWorkerId> VirtualWorkerIds;

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/SpatialMultiWorkerSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/SpatialMultiWorkerSettings.h
@@ -33,12 +33,14 @@ public:
     virtual void PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent) override;
 #endif
 
-	uint32 GetMinimumRequiredWorkerCount() const;
-
 	static FLayerInfo GetDefaultLayerInfo()
 	{
 		return { SpatialConstants::DefaultLayer, { AActor::StaticClass() }, USingleWorkerStrategy::StaticClass() };
-	};
+	}
+
+	uint32 GetMinimumRequiredWorkerCount() const;
+
+	TMap<FName, uint32> GetLayerWorkerCounts() const;
 
 	UPROPERTY(EditAnywhere, Category = "Multi-Worker")
 	TArray<FLayerInfo> WorkerLayers;

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/ServerWorker.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/ServerWorker.h
@@ -26,12 +26,14 @@ struct ServerWorker : Component
 	ServerWorker()
 		: WorkerName(SpatialConstants::INVALID_WORKER_NAME)
 		, bReadyToBeginPlay(false)
+		, LayerHint(TEXT(""))
 	{}
 
-	ServerWorker(const PhysicalWorkerName& InWorkerName, const bool bInReadyToBeginPlay)
+	ServerWorker(const PhysicalWorkerName& InWorkerName, const bool bInReadyToBeginPlay, const FString& InLayerHint)
 	{
 		WorkerName = InWorkerName;
 		bReadyToBeginPlay = bInReadyToBeginPlay;
+		LayerHint = InLayerHint;
 	}
 
 	ServerWorker(const Worker_ComponentData& Data)
@@ -40,6 +42,7 @@ struct ServerWorker : Component
 
 		WorkerName = GetStringFromSchema(ComponentObject, SpatialConstants::SERVER_WORKER_NAME_ID);
 		bReadyToBeginPlay = GetBoolFromSchema(ComponentObject, SpatialConstants::SERVER_WORKER_READY_TO_BEGIN_PLAY_ID);
+		LayerHint = GetStringFromSchema(ComponentObject, SpatialConstants::SERVER_WORKER_LAYER_HINT_ID);
 	}
 
 	Worker_ComponentData CreateServerWorkerData()
@@ -51,6 +54,7 @@ struct ServerWorker : Component
 
 		AddStringToSchema(ComponentObject, SpatialConstants::SERVER_WORKER_NAME_ID, WorkerName);
 		Schema_AddBool(ComponentObject, SpatialConstants::SERVER_WORKER_READY_TO_BEGIN_PLAY_ID, bReadyToBeginPlay);
+		AddStringToSchema(ComponentObject, SpatialConstants::SERVER_WORKER_LAYER_HINT_ID, LayerHint);
 
 		return Data;
 	}
@@ -64,6 +68,7 @@ struct ServerWorker : Component
 
 		AddStringToSchema(ComponentObject, SpatialConstants::SERVER_WORKER_NAME_ID, WorkerName);
 		Schema_AddBool(ComponentObject, SpatialConstants::SERVER_WORKER_READY_TO_BEGIN_PLAY_ID, bReadyToBeginPlay);
+		AddStringToSchema(ComponentObject, SpatialConstants::SERVER_WORKER_LAYER_HINT_ID, LayerHint);
 
 		return Update;
 	}
@@ -74,6 +79,7 @@ struct ServerWorker : Component
 
 		WorkerName = GetStringFromSchema(ComponentObject, SpatialConstants::SERVER_WORKER_NAME_ID);
 		bReadyToBeginPlay = GetBoolFromSchema(ComponentObject, SpatialConstants::SERVER_WORKER_READY_TO_BEGIN_PLAY_ID);
+		LayerHint = GetStringFromSchema(ComponentObject, SpatialConstants::SERVER_WORKER_LAYER_HINT_ID);
 	}
 
 	static Worker_CommandRequest CreateForwardPlayerSpawnRequest(Schema_CommandRequest* SchemaCommandRequest)
@@ -112,6 +118,7 @@ struct ServerWorker : Component
 
 	PhysicalWorkerName WorkerName;
 	bool bReadyToBeginPlay;
+	FString LayerHint;
 };
 
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/ServerWorker.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/ServerWorker.h
@@ -29,7 +29,7 @@ struct ServerWorker : Component
 		, LayerHint(TEXT(""))
 	{}
 
-	ServerWorker(const PhysicalWorkerName& InWorkerName, const bool bInReadyToBeginPlay, const FString& InLayerHint)
+	ServerWorker(const PhysicalWorkerName& InWorkerName, const bool bInReadyToBeginPlay, const FName& InLayerHint)
 	{
 		WorkerName = InWorkerName;
 		bReadyToBeginPlay = bInReadyToBeginPlay;
@@ -42,7 +42,7 @@ struct ServerWorker : Component
 
 		WorkerName = GetStringFromSchema(ComponentObject, SpatialConstants::SERVER_WORKER_NAME_ID);
 		bReadyToBeginPlay = GetBoolFromSchema(ComponentObject, SpatialConstants::SERVER_WORKER_READY_TO_BEGIN_PLAY_ID);
-		LayerHint = GetStringFromSchema(ComponentObject, SpatialConstants::SERVER_WORKER_LAYER_HINT_ID);
+		LayerHint = *GetStringFromSchema(ComponentObject, SpatialConstants::SERVER_WORKER_LAYER_HINT_ID);
 	}
 
 	Worker_ComponentData CreateServerWorkerData()
@@ -54,7 +54,7 @@ struct ServerWorker : Component
 
 		AddStringToSchema(ComponentObject, SpatialConstants::SERVER_WORKER_NAME_ID, WorkerName);
 		Schema_AddBool(ComponentObject, SpatialConstants::SERVER_WORKER_READY_TO_BEGIN_PLAY_ID, bReadyToBeginPlay);
-		AddStringToSchema(ComponentObject, SpatialConstants::SERVER_WORKER_LAYER_HINT_ID, LayerHint);
+		AddStringToSchema(ComponentObject, SpatialConstants::SERVER_WORKER_LAYER_HINT_ID, LayerHint.ToString());
 
 		return Data;
 	}
@@ -68,7 +68,7 @@ struct ServerWorker : Component
 
 		AddStringToSchema(ComponentObject, SpatialConstants::SERVER_WORKER_NAME_ID, WorkerName);
 		Schema_AddBool(ComponentObject, SpatialConstants::SERVER_WORKER_READY_TO_BEGIN_PLAY_ID, bReadyToBeginPlay);
-		AddStringToSchema(ComponentObject, SpatialConstants::SERVER_WORKER_LAYER_HINT_ID, LayerHint);
+		AddStringToSchema(ComponentObject, SpatialConstants::SERVER_WORKER_LAYER_HINT_ID, LayerHint.ToString());
 
 		return Update;
 	}
@@ -79,7 +79,7 @@ struct ServerWorker : Component
 
 		WorkerName = GetStringFromSchema(ComponentObject, SpatialConstants::SERVER_WORKER_NAME_ID);
 		bReadyToBeginPlay = GetBoolFromSchema(ComponentObject, SpatialConstants::SERVER_WORKER_READY_TO_BEGIN_PLAY_ID);
-		LayerHint = GetStringFromSchema(ComponentObject, SpatialConstants::SERVER_WORKER_LAYER_HINT_ID);
+		LayerHint = *GetStringFromSchema(ComponentObject, SpatialConstants::SERVER_WORKER_LAYER_HINT_ID);
 	}
 
 	static Worker_CommandRequest CreateForwardPlayerSpawnRequest(Schema_CommandRequest* SchemaCommandRequest)
@@ -118,7 +118,7 @@ struct ServerWorker : Component
 
 	PhysicalWorkerName WorkerName;
 	bool bReadyToBeginPlay;
-	FString LayerHint;
+	FName LayerHint;
 };
 
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -196,6 +196,7 @@ const Schema_FieldId SPATIAL_DEBUGGING_IS_LOCKED                         = 5;
 // ServerWorker Field IDs.
 const Schema_FieldId SERVER_WORKER_NAME_ID								 = 1;
 const Schema_FieldId SERVER_WORKER_READY_TO_BEGIN_PLAY_ID				 = 2;
+const Schema_FieldId SERVER_WORKER_LAYER_HINT_ID		 				 = 3;
 const Schema_FieldId SERVER_WORKER_FORWARD_SPAWN_REQUEST_COMMAND_ID		 = 1;
 
 // SpawnPlayerRequest type IDs.

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -198,7 +198,7 @@ bool FSpatialGDKEditorModule::ShouldPackageMobileCommandLineArgs() const
 	return GetDefault<USpatialGDKEditorSettings>()->bPackageMobileCommandLineArgs;
 }
 
-TMap<FName, int32> GetPIELayerWorkerCounts()
+TMap<FName, uint32> GetPIELayerWorkerCounts()
 {
 	const USpatialGDKEditorSettings* EditorSettings = GetDefault<USpatialGDKEditorSettings>();
 	if (EditorSettings->bGenerateDefaultLaunchConfig && EditorSettings->LaunchConfigDesc.ServerWorkerConfig.bAutoNumEditorInstances)
@@ -207,23 +207,21 @@ TMap<FName, int32> GetPIELayerWorkerCounts()
 		check(EditorWorld);
 		return GetLayerWorkerCountMappingFromWorldSettings(*EditorWorld);
 	}
-	else
-	{
-		return {{SpatialConstants::DefaultLayer, EditorSettings->LaunchConfigDesc.ServerWorkerConfig.NumEditorInstances + 0}};
-	}
+
+	return {{SpatialConstants::DefaultLayer, (uint32) EditorSettings->LaunchConfigDesc.ServerWorkerConfig.NumEditorInstances}};
 }
 
-bool FSpatialGDKEditorModule::ForEveryServerWorker(TFunction<void(const FName&, int32)> Function) const
+bool FSpatialGDKEditorModule::ForEachLayerServerWorker(TFunction<void(const FName&, uint32)> Function) const
 {
 	if (ShouldStartLocalServer())
 	{
 		int32 AdditionalServerIndex = 0;
+
 		for (const auto& LayerWorkerCount : GetPIELayerWorkerCounts())
 		{
-			for (int32 i = 0; i < LayerWorkerCount.Value; i++)
+			for (uint32 i = 0; i < LayerWorkerCount.Value; i++)
 			{
-				Function(LayerWorkerCount.Key, AdditionalServerIndex);
-				AdditionalServerIndex++;
+				Function(LayerWorkerCount.Key, AdditionalServerIndex++);
 			}
 		}
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/Utils/LaunchConfigurationEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/Utils/LaunchConfigurationEditor.cpp
@@ -31,7 +31,7 @@ void ULaunchConfigurationEditor::PostInitProperties()
 	const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>();
 
 	LaunchConfiguration = SpatialGDKEditorSettings->LaunchConfigDesc;
-	LaunchConfiguration.ServerWorkerConfig.NumEditorInstances = GetWorkerCountFromWorldSettings(*EditorWorld);
+	LaunchConfiguration.ServerWorkerConfig.NumEditorInstances = GetTotalWorkerCountFromWorldSettings(*EditorWorld);
 }
 
 void ULaunchConfigurationEditor::SaveConfiguration()

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKDefaultLaunchConfigGenerator.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKDefaultLaunchConfigGenerator.h
@@ -12,7 +12,9 @@ DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKDefaultLaunchConfigGenerator, Log, All)
 class UAbstractRuntimeLoadBalancingStrategy;
 struct FSpatialLaunchConfigDescription;
 
-TMap<FName, int32>  SPATIALGDKEDITOR_API GetLayerWorkerCountMappingFromWorldSettings(const UWorld& World);
+TMap<FName, uint32> SPATIALGDKEDITOR_API GetLayerWorkerCountMappingFromWorldSettings(const UWorld& World);
+
+uint32 SPATIALGDKEDITOR_API GetTotalWorkerCountFromWorldSettings(const UWorld& World);
 
 bool SPATIALGDKEDITOR_API FillWorkerConfigurationFromCurrentMap(FWorkerTypeLaunchSection& OutWorker, FIntPoint& OutWorldDimensions);
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKDefaultLaunchConfigGenerator.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKDefaultLaunchConfigGenerator.h
@@ -12,7 +12,7 @@ DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKDefaultLaunchConfigGenerator, Log, All)
 class UAbstractRuntimeLoadBalancingStrategy;
 struct FSpatialLaunchConfigDescription;
 
-uint32 SPATIALGDKEDITOR_API GetWorkerCountFromWorldSettings(const UWorld& World);
+TMap<FName, int32>  SPATIALGDKEDITOR_API GetLayerWorkerCountMappingFromWorldSettings(const UWorld& World);
 
 bool SPATIALGDKEDITOR_API FillWorkerConfigurationFromCurrentMap(FWorkerTypeLaunchSection& OutWorker, FIntPoint& OutWorldDimensions);
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorModule.h
@@ -50,9 +50,8 @@ private:
 	virtual FString GetMobileClientCommandLineArgs() const override;
 	virtual bool ShouldPackageMobileCommandLineArgs() const override;
 
-	virtual bool ForEveryServerWorker(TFunction<void(const FName&, int32)> Function) const override;
+	virtual bool ForEachLayerServerWorker(TFunction<void(const FName&, uint32)> Function) const override;
 
-private:
 	void RegisterSettings();
 	void UnregisterSettings();
 	bool HandleEditorSettingsSaved();
@@ -60,7 +59,6 @@ private:
 	bool CanStartSession(FText& OutErrorMessage) const;
 	bool ShouldStartLocalServer() const;
 
-private:
 	TSharedPtr<FSpatialGDKEditor> SpatialGDKEditorInstance;
 	TUniquePtr<FSpatialGDKEditorCommandLineArgsManager> CommandLineArgsManager;
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -790,7 +790,11 @@ void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment()
 		Conf.bManualWorkerConnectionOnly = true;
 		if (Conf.bAutoNumEditorInstances)
 		{
-			Conf.NumEditorInstances = GetWorkerCountFromWorldSettings(*EditorWorld);
+			Conf.NumEditorInstances = 0;
+			for (const auto& LayerWorkerCount : GetLayerWorkerCountMappingFromWorldSettings(*EditorWorld))
+			{
+				Conf.NumEditorInstances += LayerWorkerCount.Value;
+			}
 		}
 
 		if (!ValidateGeneratedLaunchConfig(LaunchConfigDescription, Conf))

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -790,11 +790,7 @@ void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment()
 		Conf.bManualWorkerConnectionOnly = true;
 		if (Conf.bAutoNumEditorInstances)
 		{
-			Conf.NumEditorInstances = 0;
-			for (const auto& LayerWorkerCount : GetLayerWorkerCountMappingFromWorldSettings(*EditorWorld))
-			{
-				Conf.NumEditorInstances += LayerWorkerCount.Value;
-			}
+			Conf.NumEditorInstances = GetTotalWorkerCountFromWorldSettings(*EditorWorld);
 		}
 
 		if (!ValidateGeneratedLaunchConfig(LaunchConfigDescription, Conf))
@@ -1247,7 +1243,7 @@ void FSpatialGDKEditorToolbarModule::GenerateConfigFromCurrentMap()
 
 	FSpatialLaunchConfigDescription LaunchConfiguration = SpatialGDKEditorSettings->LaunchConfigDesc;
 	FWorkerTypeLaunchSection& ServerWorkerConfig = LaunchConfiguration.ServerWorkerConfig;
-	ServerWorkerConfig.NumEditorInstances = GetWorkerCountFromWorldSettings(*EditorWorld);
+	ServerWorkerConfig.NumEditorInstances = GetTotalWorkerCountFromWorldSettings(*EditorWorld);
 
 	GenerateLaunchConfig(LaunchConfig, &LaunchConfiguration, ServerWorkerConfig);
 

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/EngineClasses/SpatialVirtualWorkerTranslationManager/SpatialVirtualWorkerTranslationManagerTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/EngineClasses/SpatialVirtualWorkerTranslationManager/SpatialVirtualWorkerTranslationManagerTest.cpp
@@ -81,7 +81,7 @@ VIRTUALWORKERTRANSLATIONMANAGER_TEST(Given_a_failed_query_response_THEN_query_ag
 	ResponseOp.result_count = 0;
 	ResponseOp.message = "Failed call";
 
-	Manager->SetLayerVirtualWorkerMapping(1);
+	Manager->SetLayerVirtualWorkerMapping({{SpatialConstants::DefaultLayer, 1}});
 
 	Delegate->ExecuteIfBound(ResponseOp);
 	TestTrue("After a failed query response, the TranslationManager queried again for server worker entities.", Connection->GetLastEntityQuery() != nullptr);
@@ -104,7 +104,7 @@ VIRTUALWORKERTRANSLATIONMANAGER_TEST(Given_a_successful_query_without_enough_wor
 	ResponseOp.message = "Successfully returned 0 entities";
 
 	// Make sure the TranslationManager is expecting more workers than are returned.
-	Manager->SetLayerVirtualWorkerMapping(1);
+	Manager->SetLayerVirtualWorkerMapping({{SpatialConstants::DefaultLayer, 1}});
 
 	Delegate->ExecuteIfBound(ResponseOp);
 	TestTrue("When not enough workers available, the TranslationManager queried again for server worker entities.", Connection->GetLastEntityQuery() != nullptr);
@@ -133,7 +133,7 @@ VIRTUALWORKERTRANSLATIONMANAGER_TEST(Given_a_successful_query_with_invalid_worke
 	ResponseOp.results = &worker;
 
 	// Make sure the TranslationManager is only expecting a single worker.
-	Manager->SetLayerVirtualWorkerMapping(1);
+	Manager->SetLayerVirtualWorkerMapping({{SpatialConstants::DefaultLayer, 1}});
 
 	Delegate->ExecuteIfBound(ResponseOp);
 	TestTrue("When enough workers available but they are invalid, the TranslationManager queried again for server worker entities.", Connection->GetLastEntityQuery() != nullptr);

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/EngineClasses/SpatialVirtualWorkerTranslationManager/SpatialVirtualWorkerTranslationManagerTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/EngineClasses/SpatialVirtualWorkerTranslationManager/SpatialVirtualWorkerTranslationManagerTest.cpp
@@ -81,7 +81,7 @@ VIRTUALWORKERTRANSLATIONMANAGER_TEST(Given_a_failed_query_response_THEN_query_ag
 	ResponseOp.result_count = 0;
 	ResponseOp.message = "Failed call";
 
-	Manager->SetNumberOfVirtualWorkers(1);
+	Manager->SetLayerVirtualWorkerMapping(1);
 
 	Delegate->ExecuteIfBound(ResponseOp);
 	TestTrue("After a failed query response, the TranslationManager queried again for server worker entities.", Connection->GetLastEntityQuery() != nullptr);
@@ -104,7 +104,7 @@ VIRTUALWORKERTRANSLATIONMANAGER_TEST(Given_a_successful_query_without_enough_wor
 	ResponseOp.message = "Successfully returned 0 entities";
 
 	// Make sure the TranslationManager is expecting more workers than are returned.
-	Manager->SetNumberOfVirtualWorkers(1);
+	Manager->SetLayerVirtualWorkerMapping(1);
 
 	Delegate->ExecuteIfBound(ResponseOp);
 	TestTrue("When not enough workers available, the TranslationManager queried again for server worker entities.", Connection->GetLastEntityQuery() != nullptr);
@@ -133,7 +133,7 @@ VIRTUALWORKERTRANSLATIONMANAGER_TEST(Given_a_successful_query_with_invalid_worke
 	ResponseOp.results = &worker;
 
 	// Make sure the TranslationManager is only expecting a single worker.
-	Manager->SetNumberOfVirtualWorkers(1);
+	Manager->SetLayerVirtualWorkerMapping(1);
 
 	Delegate->ExecuteIfBound(ResponseOp);
 	TestTrue("When enough workers available but they are invalid, the TranslationManager queried again for server worker entities.", Connection->GetLastEntityQuery() != nullptr);


### PR DESCRIPTION
[UNR-3918 - Expose layers to help multiworker users](https://improbableio.atlassian.net/browse/UNR-3918)
[Engine PR](https://github.com/improbableio/UnrealEngine/pull/619)

![default-layers](https://user-images.githubusercontent.com/9222722/89436679-78a14300-d73e-11ea-8e18-b4857faf8263.gif)

### Description

Allows workers to express a preference for a worker to be part of.

In PIE, previously, the number of workers to launch is decided by the multiserver settings and now, this instead returns a worker count per layer, such that a hint can be passed to each worker. This works when not running in a single process. When running worker executables directly, users can pass a `-LayerHint Offloading` CLI arg which is used by the worker. If a worker expresses a layer preference however the translation manager finds that there are no remaining virtual workers for that layer to be assigned, an error will be printed, and the worker will instead be assigned to whatever layer needing assignment remains.

### Worker names

Server worker names are now set based on the layer hint. Users starting worker instances with layer hints that mismatch the load balancing strategy will mean the worker who's layer preference is not accepted will have an erroneous worker name. This is ultimately a comparable error to users passing an incorrect `-workerType` argument in previous versions of the GDK, except that in this case, the deployment itself will functionality still work.
