### PR TITLE
prevent-users-accidentally-using-layeredlbstrategy

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LayeredLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LayeredLBStrategy.h
@@ -40,7 +40,7 @@ struct FLBLayerInfo
  * to each Layer/Strategy and keep track of which Actors belong in which layer and should be load balanced
  * by the corresponding Strategy.
  */
-UCLASS()
+UCLASS(HideDropdown, NotBlueprintable)
 class SPATIALGDK_API ULayeredLBStrategy : public UAbstractLBStrategy
 {
 	GENERATED_BODY()


### PR DESCRIPTION
Users can currently select their dropdown to be a `LayeredLBStrategy`.

The `LayeredLBStrategy` should only be used by the GDK internally. If users select this in their configuration then can end up in infinite loops/stack overflows.