### PR TITLE
[UNR-3617] Fix incorrect condition check on ownership change

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -1235,7 +1235,8 @@ void USpatialActorChannel::ServerProcessOwnershipChange()
 {
 	SCOPE_CYCLE_COUNTER(STAT_ServerProcessOwnershipChange);
 	{
-		if (!IsReadyForReplication())
+		if (!IsReadyForReplication()
+		|| !IsAuthoritativeServer())
 		{
 			return;
 		}


### PR DESCRIPTION
#### Description
Re-add check that was removed in favor of IsReadyToReplicate, since it does not check that the given actor has an entity id.
