### PR TITLE
Remove FSpatialNetBitReader

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialFastArrayNetSerialize.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialFastArrayNetSerialize.cpp
@@ -9,7 +9,7 @@
 namespace SpatialGDK
 {
 
-bool FSpatialNetDeltaSerializeInfo::DeltaSerializeRead(USpatialNetDriver* NetDriver, FSpatialNetBitReader& Reader, UObject* Object, int32 ArrayIndex, GDK_PROPERTY(Property)* ParentProperty, UScriptStruct* NetDeltaStruct)
+bool FSpatialNetDeltaSerializeInfo::DeltaSerializeRead(USpatialNetDriver* NetDriver, FNetBitReader& Reader, UObject* Object, int32 ArrayIndex, GDK_PROPERTY(Property)* ParentProperty, UScriptStruct* NetDeltaStruct)
 {
 	FSpatialNetDeltaSerializeInfo NetDeltaInfo;
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -323,9 +323,8 @@ bool USpatialPackageMapClient::SerializeObject(FArchive& Ar, UClass* InClass, UO
 		return true;
 	}
 
-	FSpatialNetBitReader& Reader = static_cast<FSpatialNetBitReader&>(Ar);
 	bool bUnresolved = false;
-	Obj = Reader.ReadObject(bUnresolved);
+	Obj = FSpatialNetBitReader::ReadObject(bUnresolved, this, Ar);
 
 	return !bUnresolved;
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialFastArrayNetSerialize.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialFastArrayNetSerialize.h
@@ -7,7 +7,7 @@
 #include "Utils/GDKPropertyMacros.h"
 #include "Utils/RepLayoutUtils.h"
 
-class FSpatialNetBitReader;
+class FNetBitReader;
 class FSpatialNetBitWriter;
 class USpatialNetDriver;
 
@@ -41,7 +41,7 @@ struct FSpatialNetDeltaSerializeInfo : FNetDeltaSerializeInfo
 		bIsSpatialType = true;
 	}
 
-	static bool DeltaSerializeRead(USpatialNetDriver* NetDriver, FSpatialNetBitReader& Reader, UObject* Object, int32 ArrayIndex, GDK_PROPERTY(Property)* ParentProperty, UScriptStruct* NetDeltaStruct);
+	static bool DeltaSerializeRead(USpatialNetDriver* NetDriver, FNetBitReader& Reader, UObject* Object, int32 ArrayIndex, GDK_PROPERTY(Property)* ParentProperty, UScriptStruct* NetDeltaStruct);
 	static bool DeltaSerializeWrite(USpatialNetDriver* NetDriver, FSpatialNetBitWriter& Writer, UObject* Object, int32 ArrayIndex, GDK_PROPERTY(Property)* ParentProperty, UScriptStruct* NetDeltaStruct);
 };
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/RepLayoutUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/RepLayoutUtils.h
@@ -130,7 +130,7 @@ inline void RepLayout_ReceivePropertiesForRPC(FRepLayout& RepLayout, FNetBitRead
 	}
 }
 
-inline void ReadStructProperty(FSpatialNetBitReader& Reader, GDK_PROPERTY(StructProperty)* Property, USpatialNetDriver* NetDriver, uint8* Data, bool& bOutHasUnmapped)
+inline void ReadStructProperty(FNetBitReader& Reader, GDK_PROPERTY(StructProperty)* Property, USpatialNetDriver* NetDriver, uint8* Data, bool& bOutHasUnmapped)
 {
 	UScriptStruct* Struct = Property->Struct;
 


### PR DESCRIPTION
#### Description
Mapped and unresolved net references were collected in the FSpatialNetBitReader.
To be able to detect unresolved references from the USpatialPackageMapClient, the Archive we were reading from was cast to a FSpatialNetBitReader. We needed the extra information to distinguish a null reference from an unresolved one. 
This caused an issue for a customer since they were using the PackageMapClient with their own archive.
This PR remove the cast, as well as the FSpatialNetBitReader in favor of an object set on a thread local pointer which will collect the mapped/unresolved references.

#### Release note

#### Tests
Ran the NetReferences test gym.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
