### PR TITLE
[UNR-3935] Remove cast to FSpatialNetBitReader in favor of a static methods.

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitReader.cpp
@@ -16,6 +16,8 @@ FSpatialNetBitReader::FSpatialNetBitReader(USpatialPackageMapClient* InPackageMa
 	, DynamicRefs(InDynamicRefs)
 	, UnresolvedRefs(InUnresolvedRefs)
 {
+	// Limitation of using a global TLS pointer, you can have at most a single instance of this object per thread.
+	// There should be no need to have more than one at a given time, but should that be the case we could move to a set per thread instead of a pointer.
 	check(GCurrentReader == nullptr);
 	GCurrentReader = this;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitReader.cpp
@@ -9,20 +9,20 @@
 
 DEFINE_LOG_CATEGORY(LogSpatialNetBitReader);
 
-static thread_local FSpatialNetBitReader* s_CurrentReader = nullptr;
+static thread_local FSpatialNetBitReader* GCurrentReader = nullptr;
 
 FSpatialNetBitReader::FSpatialNetBitReader(USpatialPackageMapClient* InPackageMap, uint8* Source, int64 CountBits, TSet<FUnrealObjectRef>& InDynamicRefs, TSet<FUnrealObjectRef>& InUnresolvedRefs)
 	: FNetBitReader(InPackageMap, Source, CountBits)
 	, DynamicRefs(InDynamicRefs)
 	, UnresolvedRefs(InUnresolvedRefs)
 {
-	check(s_CurrentReader == nullptr);
-	s_CurrentReader = this;
+	check(GCurrentReader == nullptr);
+	GCurrentReader = this;
 }
 
 FSpatialNetBitReader::~FSpatialNetBitReader()
 {
-	s_CurrentReader = nullptr;
+	GCurrentReader = nullptr;
 }
 
 void FSpatialNetBitReader::DeserializeObjectRef(FArchive& Archive, FUnrealObjectRef& ObjectRef)
@@ -63,15 +63,15 @@ UObject* FSpatialNetBitReader::ReadObject(FArchive& Archive, USpatialPackageMapC
 
 	UObject* Value = FUnrealObjectRef::ToObjectPtr(ObjectRef, PackageMap, bUnresolved);
 
-	if (s_CurrentReader != nullptr)
+	if (GCurrentReader != nullptr)
 	{
 		if (bUnresolved)
 		{
-			s_CurrentReader->UnresolvedRefs.Add(ObjectRef);
+			GCurrentReader->UnresolvedRefs.Add(ObjectRef);
 		}
 		else if (Value && !Value->IsFullNameStableForNetworking())
 		{
-			s_CurrentReader->DynamicRefs.Add(ObjectRef);
+			GCurrentReader->DynamicRefs.Add(ObjectRef);
 		}
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitReader.cpp
@@ -63,7 +63,7 @@ UObject* FSpatialNetBitReader::ReadObject(FArchive& Archive, USpatialPackageMapC
 
 	UObject* Value = FUnrealObjectRef::ToObjectPtr(ObjectRef, PackageMap, bUnresolved);
 
-	if(s_CurrentReader != nullptr)
+	if (s_CurrentReader != nullptr)
 	{
 		if (bUnresolved)
 		{
@@ -76,4 +76,14 @@ UObject* FSpatialNetBitReader::ReadObject(FArchive& Archive, USpatialPackageMapC
 	}
 
 	return Value;
+}
+
+FArchive& FSpatialNetBitReader::operator<<(FWeakObjectPtr& Value)
+{
+	UObject* Object;
+	*this << Object;
+
+	Value = Object;
+
+	return *this;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitReader.cpp
@@ -80,6 +80,14 @@ UObject* FSpatialNetBitReader::ReadObject(FArchive& Archive, USpatialPackageMapC
 	return Value;
 }
 
+FArchive& FSpatialNetBitReader::operator<<(UObject*& Value)
+{
+	bool bUnresolved = false;
+	Value = ReadObject(*this, Cast<USpatialPackageMapClient>(PackageMap), bUnresolved);
+
+	return *this;
+}
+
 FArchive& FSpatialNetBitReader::operator<<(FWeakObjectPtr& Value)
 {
 	UObject* Object;

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitWriter.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitWriter.cpp
@@ -40,11 +40,15 @@ void FSpatialNetBitWriter::SerializeObjectRef(FArchive& Archive, FUnrealObjectRe
 	Archive.SerializeBits(&ObjectRef.bUseClassPathToLoadObject, 1);
 }
 
+void FSpatialNetBitWriter::WriteObject(FArchive& Archive, USpatialPackageMapClient* PackageMap, UObject* Object)
+{
+	FUnrealObjectRef ObjectRef = FUnrealObjectRef::FromObjectPtr(Object, PackageMap);
+	SerializeObjectRef(Archive, ObjectRef);
+}
+
 FArchive& FSpatialNetBitWriter::operator<<(UObject*& Value)
 {
-	FUnrealObjectRef ObjectRef = FUnrealObjectRef::FromObjectPtr(Value, Cast<USpatialPackageMapClient>(PackageMap));
-	SerializeObjectRef(*this, ObjectRef);
-
+	WriteObject(*this, Cast<USpatialPackageMapClient>(PackageMap), Value);
 	return *this;
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitWriter.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetBitWriter.cpp
@@ -16,34 +16,34 @@ FSpatialNetBitWriter::FSpatialNetBitWriter(USpatialPackageMapClient* InPackageMa
 	: FNetBitWriter(InPackageMap, 0)
 {}
 
-void FSpatialNetBitWriter::SerializeObjectRef(FUnrealObjectRef& ObjectRef)
+void FSpatialNetBitWriter::SerializeObjectRef(FArchive& Archive, FUnrealObjectRef& ObjectRef)
 {
 	int64 EntityId = ObjectRef.Entity;
-	*this << EntityId;
-	*this << ObjectRef.Offset;
+	Archive << EntityId;
+	Archive << ObjectRef.Offset;
 
 	uint8 HasPath = ObjectRef.Path.IsSet();
-	SerializeBits(&HasPath, 1);
+	Archive.SerializeBits(&HasPath, 1);
 	if (HasPath)
 	{
-		*this << ObjectRef.Path.GetValue();
+		Archive << ObjectRef.Path.GetValue();
 	}
 
 	uint8 HasOuter = ObjectRef.Outer.IsSet();
-	SerializeBits(&HasOuter, 1);
+	Archive.SerializeBits(&HasOuter, 1);
 	if (HasOuter)
 	{
-		SerializeObjectRef(*ObjectRef.Outer);
+		SerializeObjectRef(Archive, *ObjectRef.Outer);
 	}
 
-	SerializeBits(&ObjectRef.bNoLoadOnClient, 1);
-	SerializeBits(&ObjectRef.bUseClassPathToLoadObject, 1);
+	Archive.SerializeBits(&ObjectRef.bNoLoadOnClient, 1);
+	Archive.SerializeBits(&ObjectRef.bUseClassPathToLoadObject, 1);
 }
 
 FArchive& FSpatialNetBitWriter::operator<<(UObject*& Value)
 {
 	FUnrealObjectRef ObjectRef = FUnrealObjectRef::FromObjectPtr(Value, Cast<USpatialPackageMapClient>(PackageMap));
-	SerializeObjectRef(ObjectRef);
+	SerializeObjectRef(*this, ObjectRef);
 
 	return *this;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -319,14 +319,18 @@ bool USpatialPackageMapClient::SerializeObject(FArchive& Ar, UClass* InClass, UO
 	// Super::SerializeObject is not called here on purpose
 	if (Ar.IsSaving())
 	{
-		Ar << Obj;
+		FUnrealObjectRef ObjectRef = FUnrealObjectRef::FromObjectPtr(Obj, this);
+		FSpatialNetBitWriter::SerializeObjectRef(Ar, ObjectRef);
+
 		return true;
 	}
+	else
+	{
+		bool bUnresolved = false;
+		Obj = FSpatialNetBitReader::ReadObject(Ar, this, bUnresolved);
 
-	bool bUnresolved = false;
-	Obj = FSpatialNetBitReader::ReadObject(Ar, this, bUnresolved);
-
-	return !bUnresolved;
+		return !bUnresolved;
+	}
 }
 
 const FClassInfo* USpatialPackageMapClient::TryResolveNewDynamicSubobjectAndGetClassInfo(UObject* Object)

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -323,9 +323,8 @@ bool USpatialPackageMapClient::SerializeObject(FArchive& Ar, UClass* InClass, UO
 		return true;
 	}
 
-	FSpatialNetBitReader& Reader = static_cast<FSpatialNetBitReader&>(Ar);
 	bool bUnresolved = false;
-	Obj = Reader.ReadObject(bUnresolved);
+	Obj = FSpatialNetBitReader::ReadObject(Ar, this, bUnresolved);
 
 	return !bUnresolved;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -319,9 +319,7 @@ bool USpatialPackageMapClient::SerializeObject(FArchive& Ar, UClass* InClass, UO
 	// Super::SerializeObject is not called here on purpose
 	if (Ar.IsSaving())
 	{
-		FUnrealObjectRef ObjectRef = FUnrealObjectRef::FromObjectPtr(Obj, this);
-		FSpatialNetBitWriter::SerializeObjectRef(Ar, ObjectRef);
-
+		FSpatialNetBitWriter::WriteObject(Ar, this, Obj);
 		return true;
 	}
 	else

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetBitReader.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetBitReader.h
@@ -20,9 +20,11 @@ public:
 
 	using FArchive::operator<<; // For visibility of the overloads we don't override
 
-	static UObject* ReadObject(FArchive& Archive, USpatialPackageMapClient* PackageMap, bool& bUnresolved);
+	virtual FArchive& operator<<(UObject*& Value) override;
 
-	FArchive& operator<<(FWeakObjectPtr& Value);
+	virtual FArchive& operator<<(FWeakObjectPtr& Value) override;
+
+	static UObject* ReadObject(FArchive& Archive, USpatialPackageMapClient* PackageMap, bool& bUnresolved);
 
 protected:
 	static void DeserializeObjectRef(FArchive& Archive, FUnrealObjectRef& ObjectRef);

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetBitReader.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetBitReader.h
@@ -22,6 +22,8 @@ public:
 
 	static UObject* ReadObject(FArchive& Archive, USpatialPackageMapClient* PackageMap, bool& bUnresolved);
 
+	FArchive& operator<<(FWeakObjectPtr& Value);
+
 protected:
 	static void DeserializeObjectRef(FArchive& Archive, FUnrealObjectRef& ObjectRef);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetBitReader.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetBitReader.h
@@ -16,16 +16,14 @@ class SPATIALGDK_API FSpatialNetBitReader : public FNetBitReader
 public:
 	FSpatialNetBitReader(USpatialPackageMapClient* InPackageMap, uint8* Source, int64 CountBits, TSet<FUnrealObjectRef>& InDynamicRefs, TSet<FUnrealObjectRef>& InUnresolvedRefs);
 
+	~FSpatialNetBitReader();
+
 	using FArchive::operator<<; // For visibility of the overloads we don't override
 
-	virtual FArchive& operator<<(UObject*& Value) override;
-
-	virtual FArchive& operator<<(struct FWeakObjectPtr& Value) override;
-
-	UObject* ReadObject(bool& bUnresolved);
+	static UObject* ReadObject(FArchive& Archive, USpatialPackageMapClient* PackageMap, bool& bUnresolved);
 
 protected:
-	void DeserializeObjectRef(FUnrealObjectRef& ObjectRef);
+	static void DeserializeObjectRef(FArchive& Archive, FUnrealObjectRef& ObjectRef);
 
 	TSet<FUnrealObjectRef>& DynamicRefs;
 	TSet<FUnrealObjectRef>& UnresolvedRefs;

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetBitWriter.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetBitWriter.h
@@ -21,5 +21,9 @@ public:
 
 	virtual FArchive& operator<<(struct FWeakObjectPtr& Value) override;
 
+	static void WriteObject(FArchive& Archive, USpatialPackageMapClient* PackageMap, UObject* Object);
+
+protected:
+
 	static void SerializeObjectRef(FArchive& Archive, FUnrealObjectRef& ObjectRef);
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetBitWriter.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetBitWriter.h
@@ -24,6 +24,5 @@ public:
 	static void WriteObject(FArchive& Archive, USpatialPackageMapClient* PackageMap, UObject* Object);
 
 protected:
-
 	static void SerializeObjectRef(FArchive& Archive, FUnrealObjectRef& ObjectRef);
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetBitWriter.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetBitWriter.h
@@ -21,6 +21,5 @@ public:
 
 	virtual FArchive& operator<<(struct FWeakObjectPtr& Value) override;
 
-protected:
-	void SerializeObjectRef(FUnrealObjectRef& ObjectRef);
+	static void SerializeObjectRef(FArchive& Archive, FUnrealObjectRef& ObjectRef);
 };


### PR DESCRIPTION
#### Description
The SpatialPackageMapClient incorrectly assumed that it would always be used from inside the net stack, and cast an archive to a FSpatialNetBitReader.
This was done in order to be able to distinguish null references from unresolved ones and return the expected value. We do not need the archive to be an actual FSpatialNetBitReader to do this work.
But we do need to perform the additional task of collecting the mapped/unresolved references. This is done by setting a tls pointer to an instance of FSpatialNetBitReader in its constructor. This allows the code to perform its expected tasks while being compatible with another type of archive. And we also keep a scoped workflow compared to the native driver which uses arrays on the package map client which are reset in between properties reads.

#### Tests
Ran the NetReferencesTest gym.

