### PR TITLE
Temporarily make 4.24 the primary engine version

### DIFF
--- a/ci/unreal-engine.version
+++ b/ci/unreal-engine.version
@@ -1,2 +1,2 @@
-HEAD 4.25-SpatialOSUnrealGDK
 HEAD 4.24-SpatialOSUnrealGDK
+HEAD 4.25-SpatialOSUnrealGDK


### PR DESCRIPTION
#### Description
Due to a bug in example project CI (presumably).

#### Release note
N/A

#### Tests
N/A
