### PR TITLE
Add missing RPCService guard

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1976,7 +1976,9 @@ FRPCErrorInfo USpatialReceiver::ApplyRPCInternal(UObject* TargetObject, UFunctio
 		{
 			TargetObject->ProcessEvent(Function, Parms);
 
-			if (RPCType != ERPCType::CrossServer &&
+			if (GetDefault<USpatialGDKSettings>()->UseRPCRingBuffer() &&
+				RPCService != nullptr &&
+				RPCType != ERPCType::CrossServer &&
 				RPCType != ERPCType::NetMulticast)
 			{
 				RPCService->IncrementAckedRPCID(PendingRPCParams.ObjectRef.Entity, RPCType);


### PR DESCRIPTION
Adds a missing guard (it's used in all other accesses of the RPCService in this file)

#### Release note
None added: this is a fix to code introduced after the last release.

#### Tests
My project was breaking before, now it doesn't \0/

#### Documentation
-

#### Primary reviewers
@MatthewSandfordImprobable @padhansell 
