### PR TITLE
Separate -nocompile from -nobuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   1. Run `GenerateProjectFiles.bat`, which is in the same root directory.
   1. Navigate to the root of GDK repo and run `git fetch && git checkout 0.11`.
   1. In the same GDK directory, run `Setup.bat`.
+- `-nocompile` flag that was previously used with `BuildWorker.bat` to skip building the game binaries and automation scripts, is now split into `-nobuild` to skip building the game binaries and `-nocompile` to skip compiling the automation scripts.
 
 ### Features:
 - You can now change the GDK Editor Setting `Stop local deployment on stop play in editor` in order to automatically stop deployment when you stop playing in editor.

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Build/Build.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Build/Build.cs
@@ -27,7 +27,7 @@ namespace Improbable
 
             if (help)
             {
-                Console.WriteLine("Usage: <GameName> <Platform> <Configuration> <game.uproject> [-nocompile] <Additional UAT args>");
+                Console.WriteLine("Usage: <GameName> <Platform> <Configuration> <game.uproject> [-nobuild] [-nocompile] <Additional UAT args>");
 
                 Environment.Exit(exitCode);
             }
@@ -36,8 +36,9 @@ namespace Improbable
             var platform = args[1];
             var configuration = args[2];
             var projectFile = Path.GetFullPath(args[3]);
+            var noBuild = args.Count(arg => arg.ToLowerInvariant() == "-nobuild") > 0;
             var noCompile = args.Count(arg => arg.ToLowerInvariant() == "-nocompile") > 0;
-            var additionalUATArgs = string.Join(" ", args.Skip(4).Where(arg => arg.ToLowerInvariant() != "-nocompile"));
+            var additionalUATArgs = string.Join(" ", args.Skip(4).Where(arg => (arg.ToLowerInvariant() != "-nobuild") && (arg.ToLowerInvariant() != "-nocompile")));
 
             var stagingDir = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(projectFile), "../spatial", "build", "unreal"));
             var outputDir = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(projectFile), "../spatial", "build", "assembly", "worker"));
@@ -152,7 +153,7 @@ exit /b !ERRORLEVEL!";
                 Common.RunRedirected(runUATBat, new[]
                 {
                     "BuildCookRun",
-                    noCompile ? "-nobuild" : "-build",
+                    noBuild ? "-nobuild" : "-build",
                     noCompile ? "-nocompile" : "-compile",
                     "-project=" + Quote(projectFile),
                     "-noP4",
@@ -260,7 +261,7 @@ exit /b !ERRORLEVEL!";
                 Common.RunRedirected(runUATBat, new[]
                 {
                     "BuildCookRun",
-                    noCompile ? "-nobuild" : "-build",
+                    noBuild ? "-nobuild" : "-build",
                     noCompile ? "-nocompile" : "-compile",
                     "-project=" + Quote(projectFile),
                     "-noP4",
@@ -311,7 +312,7 @@ exit /b !ERRORLEVEL!";
                 Common.RunRedirected(runUATBat, new[]
                 {
                     "BuildCookRun",
-                    noCompile ? "-nobuild" : "-build",
+                    noBuild ? "-nobuild" : "-build",
                     noCompile ? "-nocompile" : "-compile",
                     "-project=" + Quote(projectFile),
                     "-noP4",


### PR DESCRIPTION
#### Description
In the GDK build script, `-nocompile` has been conflated to affect both compiling the game binaries and the automation scripts. This will split it out so `-nobuild` can be passed to skip compiling the game binaries and `-nocompile` can be passed to skip the automation scripts (e.g. for pre-built engine, where from in 4.25 running UAT with `-compile` will cause an error).
