### PR TITLE
UNR-3925: Use valid ip address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   1. Navigate to the root of GDK repo and run `git fetch && git checkout 0.11.0`.
   1. In the same GDK directory, run `Setup.bat`.
 - `-nocompile` flag that was previously used with `BuildWorker.bat` to skip building the game binaries and automation scripts, is now split into `-nobuild` to skip building the game binaries and `-nocompile` to skip compiling the automation scripts.
+- The simulated player worker configuration has been updated. Instead of using `connect.to.spatialos` to indicate that you want to connect to a cloud deployment, we now use `127.0.0.1` to ensure that address resolution upon initializing the connection passes. The passed IP address won't be used when actually connecting to a cloud deployment.
 
 ### Features:
 - You can now change the GDK Editor Setting `Stop local deployment on stop play in editor` in order to automatically stop deployment when you stop playing in editor.

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/SpatialConfig/spatialos.SimulatedPlayerCoordinator.worker.json
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/SpatialConfig/spatialos.SimulatedPlayerCoordinator.worker.json
@@ -40,7 +40,7 @@
         "${IMPROBABLE_WORKER_ID}",
         "coordinator_start_delay_millis=10000",
 
-        "connect.to.spatialos",
+        "127.0.0.1",
         "+workerType",
         "UnrealClient",
         "+deployment",

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
@@ -221,6 +221,8 @@ bool FSpatialGDKEditorCommandLineArgsManager::TryConstructMobileCommandLineArgum
 	}
 	else if (ConnectionFlow == ESpatialOSNetFlow::CloudDeployment)
 	{
+		//  127.0.0.1 is only used to indicate that we want to connect to a deployment.
+		// This address won't be used when actually trying to connect, but Unreal will try to resolve the address and close the connection if it fails.
 		TravelUrl = TEXT("127.0.0.1");
 
 		if (SpatialGDKSettings->DevelopmentAuthenticationToken.IsEmpty())

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
@@ -221,7 +221,7 @@ bool FSpatialGDKEditorCommandLineArgsManager::TryConstructMobileCommandLineArgum
 	}
 	else if (ConnectionFlow == ESpatialOSNetFlow::CloudDeployment)
 	{
-		//  127.0.0.1 is only used to indicate that we want to connect to a deployment.
+		// 127.0.0.1 is only used to indicate that we want to connect to a deployment.
 		// This address won't be used when actually trying to connect, but Unreal will try to resolve the address and close the connection if it fails.
 		TravelUrl = TEXT("127.0.0.1");
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorCommandLineArgsManager.cpp
@@ -221,7 +221,7 @@ bool FSpatialGDKEditorCommandLineArgsManager::TryConstructMobileCommandLineArgum
 	}
 	else if (ConnectionFlow == ESpatialOSNetFlow::CloudDeployment)
 	{
-		TravelUrl = TEXT("connect.to.spatialos");
+		TravelUrl = TEXT("127.0.0.1");
 
 		if (SpatialGDKSettings->DevelopmentAuthenticationToken.IsEmpty())
 		{

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -179,7 +179,7 @@ FString FSpatialGDKEditorModule::GetMobileClientCommandLineArgs() const
 	}
 	else if (ShouldConnectToCloudDeployment())
 	{
-		CommandLine = TEXT("connect.to.spatialos -devAuthToken ") + GetDevAuthToken();
+		CommandLine = TEXT("127.0.0.1 -devAuthToken ") + GetDevAuthToken();
 		FString CloudDeploymentName = GetSpatialOSCloudDeploymentName();
 		if (!CloudDeploymentName.IsEmpty())
 		{

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -179,6 +179,8 @@ FString FSpatialGDKEditorModule::GetMobileClientCommandLineArgs() const
 	}
 	else if (ShouldConnectToCloudDeployment())
 	{
+		//  127.0.0.1 is only used to indicate that we want to connect to a deployment.
+		// This address won't be used when actually trying to connect, but Unreal will try to resolve the address and close the connection if it fails.
 		CommandLine = TEXT("127.0.0.1 -devAuthToken ") + GetDevAuthToken();
 		FString CloudDeploymentName = GetSpatialOSCloudDeploymentName();
 		if (!CloudDeploymentName.IsEmpty())

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -179,7 +179,7 @@ FString FSpatialGDKEditorModule::GetMobileClientCommandLineArgs() const
 	}
 	else if (ShouldConnectToCloudDeployment())
 	{
-		//  127.0.0.1 is only used to indicate that we want to connect to a deployment.
+		// 127.0.0.1 is only used to indicate that we want to connect to a deployment.
 		// This address won't be used when actually trying to connect, but Unreal will try to resolve the address and close the connection if it fails.
 		CommandLine = TEXT("127.0.0.1 -devAuthToken ") + GetDevAuthToken();
 		FString CloudDeploymentName = GetSpatialOSCloudDeploymentName();


### PR DESCRIPTION
#### Description
With UE 4.25 using an invalid address leads to the connection being closed. Let's use a valid IP address to fix this. we are not using this address anyway, so it can just be localhost.

#### Release note
todo

#### Tests
Tested it by running cloud deployments and connecting sim players. Still need to test it on mobile.

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

#### Reminders (IMPORTANT)
If your change relies on a breaking engine change:
* Increment `SPATIAL_ENGINE_VERSION` in `Engine\Source\Runtime\Launch\Resources\SpatialVersion.h` (in the engine fork) as well as `SPATIAL_GDK_VERSION` in `SpatialGDK\Source\SpatialGDK\Public\Utils\EngineVersionCheck.h`. This helps others by providing a more helpful message during compilation to make sure the GDK and the Engine are up to date.

If your change updates `Setup.bat`, `Setup.sh`, core SDK version, any C# tools in `SpatialGDK\Build\Programs\Improbable.Unreal.Scripts`, or hand-written schema in `SpatialGDK\Extras\schema`:
* Increment the number in `RequireSetup`. This will automatically run `Setup.bat` or `Setup.sh` when the GDK is next pulled.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
