### PR TITLE
[UNR-3837] Rollback additional server interest

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -40,8 +40,6 @@ void InterestFactory::CreateAndCacheInterestState()
 	ClientAuthInterestResultType = CreateClientAuthInterestResultType();
 	ServerNonAuthInterestResultType = CreateServerNonAuthInterestResultType();
 	ServerAuthInterestResultType = CreateServerAuthInterestResultType();
-	ServerNonAuthOwnerInterestResultType = ServerNonAuthInterestResultType;
-	ServerNonAuthOwnerInterestResultType.Add(SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID);
 }
 
 SchemaResultType InterestFactory::CreateClientNonAuthInterestResultType()
@@ -260,7 +258,7 @@ void InterestFactory::AddOwnerInterestOnServer(Interest& OutInterest, const AAct
 
 	if (OwnerChainQuery.Constraint.OrConstraint.Num() != 0)
 	{
-		OwnerChainQuery.ResultComponentIds = ServerNonAuthOwnerInterestResultType;
+		OwnerChainQuery.ResultComponentIds = ServerNonAuthInterestResultType;
 		AddComponentQueryPairToInterestComponent(OutInterest, SpatialConstants::POSITION_COMPONENT_ID, OwnerChainQuery);
 	}
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -349,7 +349,10 @@ const TArray<Worker_ComponentId> REQUIRED_COMPONENTS_FOR_NON_AUTH_SERVER_INTERES
 	GSM_SHUTDOWN_COMPONENT_ID,
 
 	// Unreal load balancing components
-	VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID
+	VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID,
+
+	// Authority intent component to handle scattered hierarchies
+	AUTHORITY_INTENT_COMPONENT_ID
 };
 
 // A list of components servers require on entities they are authoritative over on top of the components already checked out by the interest query.

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/InterestFactory.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/InterestFactory.h
@@ -107,7 +107,6 @@ private:
 	SchemaResultType ClientNonAuthInterestResultType;
 	SchemaResultType ClientAuthInterestResultType;
 	SchemaResultType ServerNonAuthInterestResultType;
-	SchemaResultType ServerNonAuthOwnerInterestResultType;
 	SchemaResultType ServerAuthInterestResultType;
 };
 


### PR DESCRIPTION
#### Description
PR https://github.com/spatialos/UnrealGDK/pull/2411 introduced an additional non-auth server interest type. That addition would actually only have downsides in setting the system in a state when it is waiting to get additional component information while trying to load balance a child actor.
It is better if there is no change of component interest for non-auth servers.