### PR TITLE
Bugfix/unr 3992 replicating actors with nonreplicating owners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes:
 - Added the `Handover` tag to `APlayerController::LastSpectatorSyncLocation` and `APlayerController::LastSpectatorSyncRotation` in order to fix a character spawning issue for players starting in the `Spectating` state when using zoning.
-
+- No longer AddOwnerInterestToServer unless the owner is replicating, otherwise this warning fires erroneously: "Interest for Actor <ActorName> is out of date because owner <OwnerName> does not have an entity id."
 ## [`0.11.0`] - 2020-07-29
 
 ### Breaking changes:

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -242,7 +242,7 @@ void InterestFactory::AddOwnerInterestOnServer(Interest& OutInterest, const AAct
 	AActor* Owner = InActor->GetOwner();
 	Query OwnerChainQuery;
 	
-	while (Owner != nullptr && !Owner->IsPendingKillPending())
+	while (Owner != nullptr && !Owner->IsPendingKillPending() && Owner->GetIsReplicated())
 	{
 		QueryConstraint OwnerQuery;
 		OwnerQuery.EntityIdConstraint = PackageMap->GetEntityIdFromObject(Owner);


### PR DESCRIPTION
#### Description
We only want to AddOwnerInterestOnServer if the owner is replicating, otherwise we get the warning "Interest for Actor <ActorName> is out of date because owner <OwnerName> does not have an entity id."

#### Release note
Release note added.

#### Tests
Verified the warning no longer fires on our project.

#### Documentation
Release note.

#### Primary reviewers
@m-samiec @ImprobableNic 