### PR TITLE
UNR-3999 - Fix gcloud engine URL generation when using commit hash

### DIFF
--- a/ci/get-engine.ps1
+++ b/ci/get-engine.ps1
@@ -38,7 +38,7 @@ Push-Location "$($gdk_home)"
             $unreal_version = $(gsutil cp $head_pointer_gcs_path -) # the '-' at the end instructs gsutil to download the file and output the contents to stdout
         }
         else {
-            $unreal_version = $version_description
+            $unreal_version = "UnrealEngine-$version_description"
         }
     Pop-Location
 


### PR DESCRIPTION
#### Description
The get-engine.ps1 script does not format the gcloud url properly if you use a commit hash.

Format should be: UnrealEngine-commit hash.zip

This was found because the nightly mobile tests use the commit hash instead of a HEAD branch/name ...
I made an effort to review the other pipelines and I didn't find any other case where we explicitly used the commit hash, so I think this code path was just not exercised.

#### Testing
https://buildkite.com/improbable/unrealgdkexampleproject-nightly/builds/2729

#### Primary reviewers
@joshuahuburn @jessicafalk @yujunting 
