### PR TITLE
Fix simplayer autoconnection

### DIFF
--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/DeploymentLauncher/DeploymentLauncher.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/DeploymentLauncher/DeploymentLauncher.cs
@@ -349,7 +349,7 @@ namespace Improbable
             deployment.WorkerFlags.Add(new WorkerFlag
             {
                 Key = TARGET_DEPLOYMENT_READY_TAG,
-                Value = autoConnect.ToString(),
+                Value = autoConnect.ToString().ToLower(),
                 WorkerType = CoordinatorWorkerName
             });
             deploymentServiceClient.UpdateDeployment(new UpdateDeploymentRequest { Deployment = deployment });
@@ -668,7 +668,7 @@ namespace Improbable
                         Console.WriteLine($"Unable to launch the deployment(s). Detail: '{e.Status.Detail}'");
                     }
 
-                    Console.WriteLine($"No further deployments will be started. Initiated startup for {simPlayerDeploymentId} out of the target {numSimDeployments} deployments.");
+                    Console.WriteLine($"No further deployments will be started. Initiated startup for {simPlayerDeploymentId - 1} out of the target {numSimDeployments} deployments.");
 
                     return operations;
                 }

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/ManagedWorkerCoordinator.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/ManagedWorkerCoordinator.cs
@@ -212,7 +212,7 @@ namespace Improbable.WorkerCoordinator
             while (true)
             {
                 var readyFlagOpt = connection.GetWorkerFlag(TargetDeploymentReadyWorkerFlag);
-                if (readyFlagOpt == "true")
+                if (readyFlagOpt.HasValue && readyFlagOpt.Value.ToLower() == "true")
                 {
                     // Ready.
                     break;


### PR DESCRIPTION
SimultedPlayerCoordinators wait for the `target_deployment_ready` tag to become `true`, but the DeploymentLauncher sets it to a capitalized `True`because of `bool::ToString`. This PR fixes this, and also includes a driveby fix for an off-by-one logging mistake of mine.

#### Release note
The code this fixes hasn't been released yet, but we probably do want to pull it into the 0.11 RC.

#### Tests
Tested by starting simulated player deployments for the Siege demo.

STRONGLY SUGGESTED: How can this be verified by QA?
Starts deployments using the DeploymentLauncher and see if the simplayers connect.

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@joshuahuburn @mironec 
