### PR TITLE
Ensure world is valid before dereferencing

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -204,9 +204,9 @@ USpatialGameInstance* USpatialNetDriver::GetGameInstance() const
 		const FWorldContext& WorldContext = GEngine->GetWorldContextFromPendingNetGameNetDriverChecked(this);
 		GameInstance = Cast<USpatialGameInstance>(WorldContext.OwningGameInstance);
 	}
-	else
+	else if (UWorld* World = GetWorld())
 	{
-		GameInstance = Cast<USpatialGameInstance>(GetWorld()->GetGameInstance());
+		GameInstance = Cast<USpatialGameInstance>(World->GetGameInstance());
 	}
 
 	return GameInstance;


### PR DESCRIPTION
#### Description
Fix for a crash seen in servers when shutting down. Logs indicate the world is shutting down, and at that point the `OnConnectionToSpatialOSFailed` delegate is called, which attempts to access an invalid world.

#### Primary reviewers
@mironec 
