### PR TITLE
Fix RPC Service crash after server travel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When the `SpatialStatics::GetActorEntityId` function is passed a `nullptr`, it now returns `SpatialConstants::INVALID_ENTITY_ID`.
 - Removed the `EditorWorkerController` class. It is no longer required for running consecutive PIE sessions.
 - Fixed a crash that occurred when overflowed RPCs remained overflowed after a flush attempt.
+- Fixed a crash that sometimes occurred after performing server travel with ring buffers enabled.
 
 ## [`0.10.0`] - 2020-07-08
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialRPCService.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialRPCService.cpp
@@ -428,10 +428,25 @@ void SpatialRPCService::ExtractRPCsForType(Worker_EntityId EntityId, ERPCType Ty
 
 	if (Type == ERPCType::NetMulticast)
 	{
+		if (!LastSeenMulticastRPCIds.Contains(EntityId))
+		{
+			UE_LOG(LogSpatialRPCService, Warning,
+				   TEXT("Tried to extract RPCs but no entry in Last Seen Map! This can happen after server travel. Entity: %lld, type: "
+						"Multicast"),
+				   EntityId);
+			return;
+		}
 		LastSeenRPCId = LastSeenMulticastRPCIds[EntityId];
 	}
 	else
 	{
+		if (!LastSeenRPCIds.Contains(EntityTypePair))
+		{
+			UE_LOG(LogSpatialRPCService, Warning,
+				   TEXT("Tried to extract RPCs but no entry in Last Seen Map! This can happen after server travel. Entity: %lld, type: %s"),
+				   EntityId, *SpatialConstants::RPCTypeToString(Type));
+			return;
+		}
 		LastSeenRPCId = LastSeenRPCIds[EntityTypePair];
 	}
 


### PR DESCRIPTION
#### Description
Print a warning and early out in `ExtractRPCsForType` if there's no entry for the entity + RPC type in the `LastSeenMulticastRPCIds` or `LastSeenRPCIds` map. This could happen when the RPC service is destroyed following a server travel, but the view still contains entities from the previous session, and an update comes through.

#### Primary reviewers
@MatthewSandfordImprobable @mironec 
