### PR TITLE
* adding missing include to LayerInfo.h

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/LayerInfo.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/LayerInfo.h
@@ -5,6 +5,7 @@
 #include "LoadBalancing/GridBasedLBStrategy.h"
 
 #include "CoreMinimal.h"
+#include "Templates/SubclassOf.h"
 
 #include "LayerInfo.generated.h"
 


### PR DESCRIPTION
#### Description
Added a missing include to LayerInfo.h, which was explosed due to Unity/non-unity build differences.

#### Release note
N/A

#### Tests
Compiled Windows Development Editor.

#### Documentation
N/A
