### PR TITLE
UNR-4128 - Prevent crash on editor startup because of invalid SpatialDebugger pointer

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -720,7 +720,7 @@ void FSpatialGDKEditorToolbarModule::StopSpatialServiceButtonClicked()
 
 void FSpatialGDKEditorToolbarModule::ToggleSpatialDebuggerEditor()
 {
-	if (IsValid(SpatialDebugger))
+	if (SpatialDebugger.IsValid())
 	{
 		USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetMutableDefault<USpatialGDKEditorSettings>();
 		SpatialGDKEditorSettings->SetSpatialDebuggerEditorEnabled(!SpatialGDKEditorSettings->bSpatialDebuggerEditorEnabled);
@@ -1097,7 +1097,7 @@ void FSpatialGDKEditorToolbarModule::OnPropertyChanged(UObject* ObjectBeingModif
 		}
 		else if (PropertyName == GET_MEMBER_NAME_CHECKED(USpatialGDKEditorSettings, bSpatialDebuggerEditorEnabled))
 		{
-			if (IsValid(SpatialDebugger))
+			if (SpatialDebugger.IsValid())
 			{
 				SpatialDebugger->EditorSpatialToggleDebugger(Settings->bSpatialDebuggerEditorEnabled);
 			}
@@ -1415,7 +1415,7 @@ bool FSpatialGDKEditorToolbarModule::IsBuildClientWorkerEnabled() const
 
 void FSpatialGDKEditorToolbarModule::DestroySpatialDebuggerEditor()
 {
-	if (IsValid(SpatialDebugger))
+	if (SpatialDebugger.IsValid())
 	{
 		SpatialDebugger->Destroy();
 		SpatialDebugger = nullptr;
@@ -1446,7 +1446,7 @@ bool FSpatialGDKEditorToolbarModule::IsSpatialDebuggerEditorEnabled() const
 
 bool FSpatialGDKEditorToolbarModule::AllowWorkerBoundaries() const
 {
-	return IsValid(SpatialDebugger) && SpatialDebugger->EditorAllowWorkerBoundaries();
+	return SpatialDebugger.IsValid() && SpatialDebugger->EditorAllowWorkerBoundaries();
 }
 
 void FSpatialGDKEditorToolbarModule::OnCheckedBuildClientWorker()

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -60,6 +60,7 @@ FSpatialGDKEditorToolbarModule::FSpatialGDKEditorToolbarModule()
 	: AutoStopLocalDeployment(EAutoStopLocalDeploymentMode::Never)
 	, bSchemaBuildError(false)
 	, bStartingCloudDeployment(false)
+	, SpatialDebugger(nullptr)
 {
 }
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -196,6 +196,5 @@ private:
 	void GenerateConfigFromCurrentMap();
 
 	// Used to show worker boundaries in the editor
-	UPROPERTY()
-	ASpatialDebugger* SpatialDebugger;
+	TWeakObjectPtr<ASpatialDebugger> SpatialDebugger;
 };


### PR DESCRIPTION
#### Description
Initialize SpatialDebugger to nullptr in constructor of FSpatialGDKEditorToolbarModule

#### Tests
Ran the editor with the default map set as benchmarkgym and two zones configured.

STRONGLY SUGGESTED: First test that the benchmarkgym works on master, if it crashes in IsValid(SpatialDebugger) then this fix should resolve it.. if the default configuration does not crash, change the default map to benchmarkgym and relaunch the editor (I believe in this case it may crash).. this fix prevents the crash.

#### Primary reviewers
@MatthewSandfordImprobable @samiwh 
