### PR TITLE
[UNR-4138] Fix nightly tests

### DIFF
--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/GridBasedLBStrategyTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/GridBasedLBStrategyTest.cpp
@@ -54,6 +54,10 @@ DEFINE_LATENT_AUTOMATION_COMMAND(FCleanup);
 bool FCleanup::Update()
 {
 	TestWorld = nullptr;
+	for (auto Pair : TestActors)
+	{
+		Pair.Value->Destroy(true);
+	}
 	TestActors.Empty();
 	Strat = nullptr;
 

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/GridBasedLBStrategyTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/GridBasedLBStrategy/GridBasedLBStrategyTest.cpp
@@ -56,7 +56,7 @@ bool FCleanup::Update()
 	TestWorld = nullptr;
 	for (auto Pair : TestActors)
 	{
-		Pair.Value->Destroy(true);
+		Pair.Value->Destroy(/*bNetForce*/ true);
 	}
 	TestActors.Empty();
 	Strat = nullptr;

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/LayeredLBStrategy/LayeredLBStrategyTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/LayeredLBStrategy/LayeredLBStrategyTest.cpp
@@ -198,6 +198,17 @@ bool FCheckShouldHaveAuthMatchesWhoShouldHaveAuth::Update()
 	return true;
 }
 
+DEFINE_LATENT_AUTOMATION_COMMAND_ONE_PARAMETER(FCleanup, TSharedPtr<TestData>, TestData);
+bool FCleanup::Update()
+{
+	for (auto Pair : TestData->TestActors)
+	{
+		Pair.Value->Destroy(true);
+	}
+
+	return true;
+}
+
 LAYEREDLBSTRATEGY_TEST(GIVEN_strat_is_not_ready_WHEN_local_virtual_worker_id_is_set_THEN_is_ready)
 {
 	AutomationOpenMap("/Engine/Maps/Entry");
@@ -315,6 +326,7 @@ LAYEREDLBSTRATEGY_TEST(Given_layered_strat_of_default_strat_WHEN_who_should_have
 	ADD_LATENT_AUTOMATION_COMMAND(FSetLocalVirtualWorker(Data, 1));
 	ADD_LATENT_AUTOMATION_COMMAND(FSpawnLayer1PawnAtLocation(Data, TEXT("DefaultLayerActor"), FVector::ZeroVector));
 	ADD_LATENT_AUTOMATION_COMMAND(FCheckWhoShouldHaveAuthority(Data, this, "DefaultLayerActor", 1));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -358,6 +370,7 @@ LAYEREDLBSTRATEGY_TEST(Given_two_actors_of_same_type_at_same_position_WHEN_who_s
 
 	ADD_LATENT_AUTOMATION_COMMAND(FCheckActorsAuth(Data, this, TEXT("Layer1Actor1"), TEXT("Layer1Actor2"), true));
 	ADD_LATENT_AUTOMATION_COMMAND(FCheckActorsAuth(Data, this, TEXT("Layer2Actor1"), TEXT("Later2Actor2"), true));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -380,6 +393,7 @@ LAYEREDLBSTRATEGY_TEST(GIVEN_two_actors_of_different_types_and_same_positions_ma
 	ADD_LATENT_AUTOMATION_COMMAND(FSpawnLayer2PawnAtLocation(Data, TEXT("Layer2Actor"), FVector::ZeroVector));
 
 	ADD_LATENT_AUTOMATION_COMMAND(FCheckActorsAuth(Data, this, TEXT("Layer1Actor"), TEXT("Layer2Actor"), false));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/LayeredLBStrategy/LayeredLBStrategyTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/LayeredLBStrategy/LayeredLBStrategyTest.cpp
@@ -203,7 +203,7 @@ bool FCleanup::Update()
 {
 	for (auto Pair : TestData->TestActors)
 	{
-		Pair.Value->Destroy(true);
+		Pair.Value->Destroy(/*bNetForce*/ true);
 	}
 
 	return true;

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/OwnershipLockingPolicy/OwnershipLockingPolicyTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/OwnershipLockingPolicy/OwnershipLockingPolicyTest.cpp
@@ -289,12 +289,12 @@ bool FTestIsLocked::Update()
 	return true;
 }
 
-DEFINE_LATENT_AUTOMATION_COMMAND_ONE_PARAMETER(FCleanupWorld, TSharedPtr<TestData>, Data);
-bool FCleanupWorld::Update()
+DEFINE_LATENT_AUTOMATION_COMMAND_ONE_PARAMETER(FCleanup, TSharedPtr<TestData>, Data);
+bool FCleanup::Update()
 {
 	for (auto Pair : Data->TestActors)
 	{
-		Data->TestWorld->DestroyActor(Pair.Value, true);
+		Pair.Value->Destroy(/*bNetForce*/ true);
 	}
 	Data->TestActors.Empty();
 	return true;
@@ -349,7 +349,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_an_actor_has_not_been_locked_WHEN_IsLocked_is_
 	ADD_LATENT_AUTOMATION_COMMAND(FSpawnActor(Data, "Actor"));
 	ADD_LATENT_AUTOMATION_COMMAND(FWaitForActor(Data, "Actor"));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", false));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -367,7 +367,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_Actor_is_not_locked_WHEN_ReleaseLock_is_called
 	ADD_LATENT_AUTOMATION_COMMAND(FWaitForActor(Data, "Actor"));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FReleaseLock(this, Data, "Actor", "First lock", false));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -384,7 +384,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_WHEN_the_locked_Actor_is
 	ADD_LATENT_AUTOMATION_COMMAND(FSetActorRole(Data, "Actor", ROLE_SimulatedProxy));
 	ADD_LATENT_AUTOMATION_COMMAND(FAcquireLock(this, Data, "Actor", "First lock", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", false));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -404,7 +404,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_WHEN_the_locked_Actor_is
 	// We cannot call IsLocked with a deleted Actor so instead we try to release the lock we held
 	// for the Actor and check that it fails.
 	ADD_LATENT_AUTOMATION_COMMAND(FReleaseAllLocks(this, Data, 1));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -425,7 +425,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_twice_WHEN_the_locked_Ac
 	// We cannot call IsLocked with a deleted Actor so instead we try to release the lock we held
 	// for the Actor and check that it fails.
 	ADD_LATENT_AUTOMATION_COMMAND(FReleaseAllLocks(this, Data, 2));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -444,7 +444,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_and_ReleaseLock_are_called_WHEN_Is
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FReleaseLock(this, Data, "Actor", "First lock", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", false));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -467,7 +467,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_and_ReleaseLock_are_called_twice_W
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FReleaseLock(this, Data, "Actor", "Second lock", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", false));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -487,7 +487,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_and_ReleaseLock_are_called_WHEN_Re
 	ADD_LATENT_AUTOMATION_COMMAND(FReleaseLock(this, Data, "Actor", "First lock", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FReleaseLock(this, Data, "Actor", "First lock", false));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -508,7 +508,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_and_ReleaseLock_are_called_WHEN_Ac
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FAcquireLock(this, Data, "Actor", "Second lock", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", true));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -538,7 +538,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_and_ReleaseLock_are_called_on_hier
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "B", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", false));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -566,7 +566,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_and_ReleaseLock_are_called_on_hier
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "B", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", false));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -594,7 +594,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_and_ReleaseLock_are_called_on_hier
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "B", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", false));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -630,7 +630,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_and_ReleaseLock_are_called_on_mult
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "B", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", false));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -657,7 +657,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_on_hierarchy_leaf_Actor_
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "A", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "B", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", false));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -682,7 +682,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_on_hierarchy_leaf_Actor_
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "A", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", false));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -707,7 +707,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_on_hierarchy_leaf_Actor_
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "B", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", false));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -732,7 +732,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_on_hierarchy_path_Actor_
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "B", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", false));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -757,7 +757,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_on_hierarchy_root_Actor_
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "B", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", false));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -782,7 +782,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_on_hierarchy_root_Actor_
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "A", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", true));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -815,7 +815,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_on_leaf_hierarchy_Actor_
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "E", true));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -844,7 +844,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_on_leaf_hierarchy_Actor_
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "E", true));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -871,7 +871,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_on_leaf_hierarchy_Actor_
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "E", true));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -900,7 +900,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_on_hierarchy_path_Actor_
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "E", true));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -931,7 +931,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_on_hierarchy_path_Actor_
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "E", true));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -958,7 +958,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_on_hierarchy_path_Actor_
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "E", false));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -989,7 +989,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_on_hierarchy_root_WHEN_h
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "E", true));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -1018,7 +1018,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_on_hierarchy_root_WHEN_h
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "E", false));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -1036,7 +1036,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_Actor_is_not_locked_WHEN_ReleaseLock_delegate_
 	ADD_LATENT_AUTOMATION_COMMAND(FWaitForActor(Data, "Actor"));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FReleaseLockViaDelegate(this, Data, "Actor", "First lock", false));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -1055,7 +1055,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_and_ReleaseLock_delegates_are_exec
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FReleaseLockViaDelegate(this, Data, "Actor", "First lock", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", false));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -1078,7 +1078,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_and_ReleaseLock_delegates_are_exec
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FReleaseLockViaDelegate(this, Data, "Actor", "Second lock", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", false));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }
@@ -1098,7 +1098,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLockDelegate_and_ReleaseLockDelegate_ar
 	ADD_LATENT_AUTOMATION_COMMAND(FReleaseLockViaDelegate(this, Data, "Actor", "First lock", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FReleaseLockViaDelegate(this, Data, "Actor", "First lock", false));
-	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanup(Data));
 
 	return true;
 }

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/OwnershipLockingPolicy/OwnershipLockingPolicyTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/OwnershipLockingPolicy/OwnershipLockingPolicyTest.cpp
@@ -289,6 +289,17 @@ bool FTestIsLocked::Update()
 	return true;
 }
 
+DEFINE_LATENT_AUTOMATION_COMMAND_ONE_PARAMETER(FCleanupWorld, TSharedPtr<TestData>, Data);
+bool FCleanupWorld::Update()
+{
+	for (auto Pair : Data->TestActors)
+	{
+		Data->TestWorld->DestroyActor(Pair.Value, true);
+	}
+	Data->TestActors.Empty();
+	return true;
+}
+
 void SpawnABCDHierarchy(FAutomationTestBase* Test, TSharedPtr<TestData> Data)
 {
 	//        A
@@ -338,6 +349,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_an_actor_has_not_been_locked_WHEN_IsLocked_is_
 	ADD_LATENT_AUTOMATION_COMMAND(FSpawnActor(Data, "Actor"));
 	ADD_LATENT_AUTOMATION_COMMAND(FWaitForActor(Data, "Actor"));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", false));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -355,6 +367,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_Actor_is_not_locked_WHEN_ReleaseLock_is_called
 	ADD_LATENT_AUTOMATION_COMMAND(FWaitForActor(Data, "Actor"));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FReleaseLock(this, Data, "Actor", "First lock", false));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -371,6 +384,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_WHEN_the_locked_Actor_is
 	ADD_LATENT_AUTOMATION_COMMAND(FSetActorRole(Data, "Actor", ROLE_SimulatedProxy));
 	ADD_LATENT_AUTOMATION_COMMAND(FAcquireLock(this, Data, "Actor", "First lock", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", false));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -390,6 +404,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_WHEN_the_locked_Actor_is
 	// We cannot call IsLocked with a deleted Actor so instead we try to release the lock we held
 	// for the Actor and check that it fails.
 	ADD_LATENT_AUTOMATION_COMMAND(FReleaseAllLocks(this, Data, 1));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -410,6 +425,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_twice_WHEN_the_locked_Ac
 	// We cannot call IsLocked with a deleted Actor so instead we try to release the lock we held
 	// for the Actor and check that it fails.
 	ADD_LATENT_AUTOMATION_COMMAND(FReleaseAllLocks(this, Data, 2));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -428,6 +444,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_and_ReleaseLock_are_called_WHEN_Is
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FReleaseLock(this, Data, "Actor", "First lock", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", false));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -450,6 +467,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_and_ReleaseLock_are_called_twice_W
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FReleaseLock(this, Data, "Actor", "Second lock", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", false));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -469,6 +487,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_and_ReleaseLock_are_called_WHEN_Re
 	ADD_LATENT_AUTOMATION_COMMAND(FReleaseLock(this, Data, "Actor", "First lock", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FReleaseLock(this, Data, "Actor", "First lock", false));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -489,6 +508,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_and_ReleaseLock_are_called_WHEN_Ac
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FAcquireLock(this, Data, "Actor", "Second lock", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", true));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -518,6 +538,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_and_ReleaseLock_are_called_on_hier
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "B", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", false));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -545,6 +566,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_and_ReleaseLock_are_called_on_hier
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "B", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", false));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -572,6 +594,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_and_ReleaseLock_are_called_on_hier
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "B", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", false));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -607,6 +630,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_and_ReleaseLock_are_called_on_mult
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "B", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", false));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -633,6 +657,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_on_hierarchy_leaf_Actor_
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "A", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "B", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", false));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -657,6 +682,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_on_hierarchy_leaf_Actor_
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "A", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", false));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -681,6 +707,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_on_hierarchy_leaf_Actor_
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "B", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", false));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -705,6 +732,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_on_hierarchy_path_Actor_
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "B", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", false));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -729,6 +757,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_on_hierarchy_root_Actor_
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "B", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", false));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -753,6 +782,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_on_hierarchy_root_Actor_
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "A", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", true));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -785,6 +815,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_on_leaf_hierarchy_Actor_
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "E", true));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -813,6 +844,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_on_leaf_hierarchy_Actor_
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "E", true));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -839,6 +871,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_on_leaf_hierarchy_Actor_
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "E", true));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -867,6 +900,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_on_hierarchy_path_Actor_
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "E", true));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -897,6 +931,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_on_hierarchy_path_Actor_
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "E", true));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -923,6 +958,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_on_hierarchy_path_Actor_
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "E", false));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -953,6 +989,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_on_hierarchy_root_WHEN_h
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "E", true));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -981,6 +1018,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_is_called_on_hierarchy_root_WHEN_h
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "C", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "D", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "E", false));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -998,6 +1036,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_Actor_is_not_locked_WHEN_ReleaseLock_delegate_
 	ADD_LATENT_AUTOMATION_COMMAND(FWaitForActor(Data, "Actor"));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FReleaseLockViaDelegate(this, Data, "Actor", "First lock", false));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -1016,6 +1055,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_and_ReleaseLock_delegates_are_exec
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FReleaseLockViaDelegate(this, Data, "Actor", "First lock", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", false));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -1038,6 +1078,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLock_and_ReleaseLock_delegates_are_exec
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FReleaseLockViaDelegate(this, Data, "Actor", "Second lock", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", false));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }
@@ -1057,6 +1098,7 @@ OWNERSHIPLOCKINGPOLICY_TEST(GIVEN_AcquireLockDelegate_and_ReleaseLockDelegate_ar
 	ADD_LATENT_AUTOMATION_COMMAND(FReleaseLockViaDelegate(this, Data, "Actor", "First lock", true));
 	ADD_LATENT_AUTOMATION_COMMAND(FTestIsLocked(this, Data, "Actor", false));
 	ADD_LATENT_AUTOMATION_COMMAND(FReleaseLockViaDelegate(this, Data, "Actor", "First lock", false));
+	ADD_LATENT_AUTOMATION_COMMAND(FCleanupWorld(Data));
 
 	return true;
 }


### PR DESCRIPTION
#### Description
Fixing the nightly tests by cleaning up the world after running load balancing tests.
The leftover actors cause log spam and invalid replication state.

#### Release note
N/A

#### Tests
Ran a slow (~= nightly) test run: https://buildkite.com/improbable/unrealgdk-premerge/builds/16960

#### Documentation
N/A

#### Primary reviewers
Yes
