### PR TITLE
Default runtime 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **注意**：自虚幻引擎开发套件 v0.8.0 版本起，其日志提供中英文两个版本。每个日志的中文版本都置于英文版本之后。
 
 ## [`x.y.z`] - Unreleased
+- The GDK now uses SpatialOS Runtime version 0.5.0 by default.
 
 ### Breaking changes:
 - The condition for sending Spatial position updates has been changed, the two variables `PositionUpdateFrequency` and `PositionDistanceThreshold` have now been removed from the GDK settings. To update your project:

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesConstants.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesConstants.h
@@ -33,7 +33,7 @@ const FString SpatialOSDirectory = FPaths::ConvertRelativePathToFull(FPaths::Com
 const FString SpatialOSConfigFileName = TEXT("spatialos.json");
 const FString ChinaEnvironmentArgument = TEXT(" --environment=cn-production");
 
-const FString SpatialOSRuntimePinnedStandardVersion = TEXT("0.4.3");
+const FString SpatialOSRuntimePinnedStandardVersion = TEXT("0.5.0");
 const FString SpatialOSRuntimePinnedCompatbilityModeVersion = TEXT("14.5.4");
 
 const FString InspectorURL = TEXT("http://localhost:31000/inspector");


### PR DESCRIPTION
#### Description
Update to runtime 0.5.0 since 0.4.3 does not work with latest zoning changes.
Note: if this gets merged in, the LaunchSpatial.bat scripts in the engine and example project should also update their runtime_version argument accordingly.
