### PR TITLE
Subview API Implementation

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/OpList/ViewDeltaLegacyOpList.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/OpList/ViewDeltaLegacyOpList.cpp
@@ -26,7 +26,7 @@ TArray<Worker_Op> GetOpsFromEntityDeltas(const TArray<EntityDelta>& Deltas)
 		StartCriticalSection.op.critical_section.in_critical_section = 1;
 		Ops.Add(StartCriticalSection);
 
-		if (Entity.bAdded)
+		if (Entity.Type == EntityDelta::ADD)
 		{
 			Worker_Op Op = {};
 			Op.op_type = WORKER_OP_TYPE_ADD_ENTITY;
@@ -111,7 +111,7 @@ TArray<Worker_Op> GetOpsFromEntityDeltas(const TArray<EntityDelta>& Deltas)
 			Ops.Push(Op);
 		}
 
-		if (Entity.bRemoved)
+		if (Entity.Type == EntityDelta::REMOVE)
 		{
 			Worker_Op Op = {};
 			Op.op_type = WORKER_OP_TYPE_REMOVE_ENTITY;

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "SpatialView/SubView.h"
+
+#include "Utils/ComponentFactory.h"
+
+namespace SpatialGDK
+{
+SubView::SubView(const Worker_ComponentId TagComponentId,
+	const TFunction<bool(const Worker_EntityId, const EntityViewElement&)> Filter,
+	const EntityView& View,
+	FDispatcher& Dispatcher)
+	: TagComponentId(TagComponentId), Filter(Filter), View(View),
+	TaggedEntities(TSet<Worker_EntityId>{}),
+	CompleteEntities(TSet<Worker_EntityId>{}),
+    NewlyCompleteEntities(TSet<Worker_EntityId>{}),
+    NewlyIncompleteEntities(TSet<Worker_EntityId>{})
+{
+	Dispatcher.RegisterAndInvokeComponentAddedCallback(TagComponentId, [this](const FEntityComponentChange Change)
+	{
+		OnTaggedEntityAdded(Change.EntityId);
+	}, View);
+	Dispatcher.RegisterComponentRemovedCallback(TagComponentId, [this](const FEntityComponentChange Change)
+	{
+		OnTaggedEntityRemoved(Change.EntityId);
+	});
+}
+
+void SubView::TagQuery(Query& QueryToTag) const
+{
+	QueryConstraint TagConstraint;
+	TagConstraint.ComponentConstraint = TagComponentId;
+
+	QueryConstraint NewConstraint;
+	NewConstraint.AndConstraint.Add(QueryToTag.Constraint);
+	NewConstraint.AndConstraint.Add(TagConstraint);
+
+	QueryToTag.Constraint = NewConstraint;
+	QueryToTag.ResultComponentIds.Add(TagComponentId);
+}
+
+void SubView::TagEntity(TArray<FWorkerComponentData>& Components) const
+{
+	Components.Add(ComponentFactory::CreateEmptyComponentData(TagComponentId));
+}
+
+void SubView::AdvanceViewDelta(const ViewDelta& Delta)
+{
+	// TODO: Filtering given delta by complete entities and add/removes for newly complete and incomplete entities
+	// respectively. Probably requires new view delta functionality to build from worker messages and entity deltas.
+}
+
+const ViewDelta& SubView::GetViewDelta() const
+{
+	return SubDelta;
+}
+
+void SubView::RefreshEntity(const Worker_EntityId EntityId)
+{
+	if (TaggedEntities.Contains(EntityId))
+	{
+		CheckEntityAgainstFilter(EntityId);
+	}
+}
+
+void SubView::OnTaggedEntityAdded(const Worker_EntityId EntityId)
+{
+	TaggedEntities.Add(EntityId);
+	CheckEntityAgainstFilter(EntityId);
+}
+
+void SubView::OnTaggedEntityRemoved(const Worker_EntityId EntityId)
+{
+	TaggedEntities.Remove(EntityId);
+	CompleteEntities.Remove(EntityId);
+}
+
+void SubView::CheckEntityAgainstFilter(const Worker_EntityId EntityId)
+{
+	if (Filter(EntityId, View[EntityId]))
+	{
+		bool* AlreadyInSet = nullptr;
+		CompleteEntities.Add(EntityId, AlreadyInSet);
+		if (!AlreadyInSet)
+		{
+			NewlyCompleteEntities.Add(EntityId);
+		}
+		return;
+	}
+	if (CompleteEntities.Contains(EntityId))
+	{
+		NewlyIncompleteEntities.Add(EntityId);
+		CompleteEntities.Remove(EntityId);
+	}
+}
+} // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
@@ -6,22 +6,23 @@
 
 namespace SpatialGDK
 {
-SubView::SubView(const Worker_ComponentId TagComponentId,
-	const TFunction<bool(const Worker_EntityId, const EntityViewElement&)> Filter,
-	const EntityView& View,
-	FDispatcher& Dispatcher)
-	: TagComponentId(TagComponentId), Filter(Filter), View(View),
-	TaggedEntities(TSet<Worker_EntityId>{}),
-	CompleteEntities(TSet<Worker_EntityId>{}),
-    NewlyCompleteEntities(TSet<Worker_EntityId>{}),
-    NewlyIncompleteEntities(TSet<Worker_EntityId>{})
+SubView::SubView(const Worker_ComponentId TagComponentId, const TFunction<bool(const Worker_EntityId, const EntityViewElement&)> Filter,
+				 const EntityView& View, FDispatcher& Dispatcher)
+	: TagComponentId(TagComponentId)
+	, Filter(Filter)
+	, View(View)
+	, TaggedEntities(TSet<Worker_EntityId>{})
+	, CompleteEntities(TSet<Worker_EntityId>{})
+	, NewlyCompleteEntities(TSet<Worker_EntityId>{})
+	, NewlyIncompleteEntities(TSet<Worker_EntityId>{})
 {
-	Dispatcher.RegisterAndInvokeComponentAddedCallback(TagComponentId, [this](const FEntityComponentChange Change)
-	{
-		OnTaggedEntityAdded(Change.EntityId);
-	}, View);
-	Dispatcher.RegisterComponentRemovedCallback(TagComponentId, [this](const FEntityComponentChange Change)
-	{
+	Dispatcher.RegisterAndInvokeComponentAddedCallback(
+		TagComponentId,
+		[this](const FEntityComponentChange Change) {
+			OnTaggedEntityAdded(Change.EntityId);
+		},
+		View);
+	Dispatcher.RegisterComponentRemovedCallback(TagComponentId, [this](const FEntityComponentChange Change) {
 		OnTaggedEntityRemoved(Change.EntityId);
 	});
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
@@ -48,6 +48,11 @@ void SubView::TagEntity(TArray<FWorkerComponentData>& Components) const
 
 void SubView::AdvanceViewDelta(const ViewDelta& Delta)
 {
+	// Note: Complete entities will be a longer list than the others for the majority of iterations under
+	// probable normal usage. This sort could then become expensive, and a potential optimisation would be
+	// to maintain the ordering of complete entities when merging in the newly complete entities and enforcing
+	// that complete entities is always sorted. This would also need to be enforced in the temporarily incomplete case.
+	// If this sort shows up in a profile it would be worth trying.
 	Algo::Sort(CompleteEntities);
 	Algo::Sort(NewlyCompleteEntities);
 	Algo::Sort(NewlyIncompleteEntities);

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
@@ -16,7 +16,7 @@ SubView::SubView(const Worker_ComponentId TagComponentId, const FFilterPredicate
 	, NewlyCompleteEntities(TArray<Worker_EntityId>{})
 	, NewlyIncompleteEntities(TArray<Worker_EntityId>{})
 {
-	RegisterTagCallbacks(View, Dispatcher);
+	RegisterTagCallbacks(Dispatcher);
 	RegisterRefreshCallbacks(DispatcherRefreshCallbacks);
 }
 
@@ -71,7 +71,7 @@ void SubView::RefreshEntity(const Worker_EntityId EntityId)
 	}
 }
 
-void SubView::RegisterTagCallbacks(const EntityView& View, FDispatcher& Dispatcher)
+void SubView::RegisterTagCallbacks(FDispatcher& Dispatcher)
 {
 	Dispatcher.RegisterAndInvokeComponentAddedCallback(
 		TagComponentId,

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
@@ -58,7 +58,7 @@ void SubView::Advance(const ViewDelta& Delta)
 	Algo::Sort(NewlyIncompleteEntities);
 	Algo::Sort(TemporarilyIncompleteEntities);
 
-	SubDelta.Project(Delta, CompleteEntities, NewlyCompleteEntities, NewlyIncompleteEntities, TemporarilyIncompleteEntities);
+	Delta.Project(SubDelta, CompleteEntities, NewlyCompleteEntities, NewlyIncompleteEntities, TemporarilyIncompleteEntities);
 
 	CompleteEntities.Append(NewlyCompleteEntities);
 	NewlyCompleteEntities.Empty();
@@ -66,7 +66,7 @@ void SubView::Advance(const ViewDelta& Delta)
 	TemporarilyIncompleteEntities.Empty();
 }
 
-const ViewDelta& SubView::GetViewDelta() const
+const SubViewDelta& SubView::GetViewDelta() const
 {
 	return SubDelta;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
@@ -79,65 +79,62 @@ void SubView::RefreshEntity(const Worker_EntityId EntityId)
 	}
 }
 
-FDispatcherRefreshCallback SubView::CreateComponentExistenceDispatcherRefreshCallback(FDispatcher& Dispatcher,
-	Worker_ComponentId ComponentId, FComponentChangeRefreshPredicate RefreshPredicate = [](FEntityComponentChange){return true;})
+FDispatcherRefreshCallback SubView::CreateComponentExistenceDispatcherRefreshCallback(
+	FDispatcher& Dispatcher, Worker_ComponentId ComponentId,
+	FComponentChangeRefreshPredicate RefreshPredicate = [](FEntityComponentChange) {
+		return true;
+	})
 {
-	return [ComponentId, &Dispatcher, RefreshPredicate](FRefreshCallback Callback)
-	{
-		Dispatcher.RegisterComponentAddedCallback(ComponentId, [RefreshPredicate, Callback](FEntityComponentChange Change)
-		{
+	return [ComponentId, &Dispatcher, RefreshPredicate](FRefreshCallback Callback) {
+		Dispatcher.RegisterComponentAddedCallback(ComponentId, [RefreshPredicate, Callback](FEntityComponentChange Change) {
 			if (RefreshPredicate(Change))
 			{
 				Callback(Change.EntityId);
 			}
 		});
-		Dispatcher.RegisterComponentRemovedCallback(ComponentId, [RefreshPredicate, Callback](FEntityComponentChange Change)
-        {
-            if (RefreshPredicate(Change))
-            {
-                Callback(Change.EntityId);
-            }
-        });
+		Dispatcher.RegisterComponentRemovedCallback(ComponentId, [RefreshPredicate, Callback](FEntityComponentChange Change) {
+			if (RefreshPredicate(Change))
+			{
+				Callback(Change.EntityId);
+			}
+		});
 	};
 }
 
-FDispatcherRefreshCallback SubView::CreateComponentChangedDispatcherRefreshCallback(FDispatcher& Dispatcher,
-	Worker_ComponentId ComponentId, FComponentChangeRefreshPredicate RefreshPredicate = [](FEntityComponentChange){return true;})
-{
-	return [ComponentId, &Dispatcher, RefreshPredicate](FRefreshCallback Callback)
-	{
-		Dispatcher.RegisterComponentValueCallback(ComponentId, [RefreshPredicate, Callback](const FEntityComponentChange Change)
-        {
-            if (RefreshPredicate(Change))
-            {
-                Callback(Change.EntityId);
-            }
-        });
-	};
-}
-
-FDispatcherRefreshCallback SubView::CreateAuthorityChangeDispatcherRefreshCallback(FDispatcher& Dispatcher,
-	Worker_ComponentId ComponentId, FAuthorityChangeRefreshPredicate RefreshPredicate = [](Worker_EntityId)
-	{
+FDispatcherRefreshCallback SubView::CreateComponentChangedDispatcherRefreshCallback(
+	FDispatcher& Dispatcher, Worker_ComponentId ComponentId,
+	FComponentChangeRefreshPredicate RefreshPredicate = [](FEntityComponentChange) {
 		return true;
 	})
 {
-	return [ComponentId, &Dispatcher, RefreshPredicate](FRefreshCallback Callback)
-	{
-		Dispatcher.RegisterAuthorityGainedCallback(ComponentId, [RefreshPredicate, Callback](const Worker_EntityId Id)
-        {
-            if (RefreshPredicate(Id))
-            {
-                Callback(Id);
-            }
-        });
-		Dispatcher.RegisterAuthorityLostCallback(ComponentId, [RefreshPredicate, Callback](const Worker_EntityId Id)
-        {
-            if (RefreshPredicate(Id))
-            {
-                Callback(Id);
-            }
-        });
+	return [ComponentId, &Dispatcher, RefreshPredicate](FRefreshCallback Callback) {
+		Dispatcher.RegisterComponentValueCallback(ComponentId, [RefreshPredicate, Callback](const FEntityComponentChange Change) {
+			if (RefreshPredicate(Change))
+			{
+				Callback(Change.EntityId);
+			}
+		});
+	};
+}
+
+FDispatcherRefreshCallback SubView::CreateAuthorityChangeDispatcherRefreshCallback(
+	FDispatcher& Dispatcher, Worker_ComponentId ComponentId, FAuthorityChangeRefreshPredicate RefreshPredicate = [](Worker_EntityId) {
+		return true;
+	})
+{
+	return [ComponentId, &Dispatcher, RefreshPredicate](FRefreshCallback Callback) {
+		Dispatcher.RegisterAuthorityGainedCallback(ComponentId, [RefreshPredicate, Callback](const Worker_EntityId Id) {
+			if (RefreshPredicate(Id))
+			{
+				Callback(Id);
+			}
+		});
+		Dispatcher.RegisterAuthorityLostCallback(ComponentId, [RefreshPredicate, Callback](const Worker_EntityId Id) {
+			if (RefreshPredicate(Id))
+			{
+				Callback(Id);
+			}
+		});
 	};
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
@@ -6,38 +6,38 @@
 
 namespace SpatialGDK
 {
-SubView::SubView(const Worker_ComponentId TagComponentId, const TFunction<bool(const Worker_EntityId, const EntityViewElement&)> Filter,
-				 const EntityView& View, FDispatcher& Dispatcher)
+SubView::SubView(const Worker_ComponentId TagComponentId, const FFilterPredicate Filter,
+	                 const EntityView& View, FDispatcher& Dispatcher, const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks)
 	: TagComponentId(TagComponentId)
 	, Filter(Filter)
 	, View(View)
-	, TaggedEntities(TSet<Worker_EntityId>{})
-	, CompleteEntities(TSet<Worker_EntityId>{})
-	, NewlyCompleteEntities(TSet<Worker_EntityId>{})
-	, NewlyIncompleteEntities(TSet<Worker_EntityId>{})
+	, TaggedEntities(TArray<Worker_EntityId>{})
+	, CompleteEntities(TArray<Worker_EntityId>{})
+	, NewlyCompleteEntities(TArray<Worker_EntityId>{})
+	, NewlyIncompleteEntities(TArray<Worker_EntityId>{})
 {
-	Dispatcher.RegisterAndInvokeComponentAddedCallback(
-		TagComponentId,
-		[this](const FEntityComponentChange Change) {
-			OnTaggedEntityAdded(Change.EntityId);
-		},
-		View);
-	Dispatcher.RegisterComponentRemovedCallback(TagComponentId, [this](const FEntityComponentChange Change) {
-		OnTaggedEntityRemoved(Change.EntityId);
-	});
+	RegisterTagCallbacks(View, Dispatcher);
+	RegisterRefreshCallbacks(DispatcherRefreshCallbacks);
 }
 
 void SubView::TagQuery(Query& QueryToTag) const
 {
+	QueryToTag.ResultComponentIds.Add(TagComponentId);
+
 	QueryConstraint TagConstraint;
 	TagConstraint.ComponentConstraint = TagComponentId;
+
+	if (QueryToTag.Constraint.AndConstraint.Num() != 0)
+	{
+		QueryToTag.Constraint.AndConstraint.Add(TagConstraint);
+		return;
+	}
 
 	QueryConstraint NewConstraint;
 	NewConstraint.AndConstraint.Add(QueryToTag.Constraint);
 	NewConstraint.AndConstraint.Add(TagConstraint);
 
 	QueryToTag.Constraint = NewConstraint;
-	QueryToTag.ResultComponentIds.Add(TagComponentId);
 }
 
 void SubView::TagEntity(TArray<FWorkerComponentData>& Components) const
@@ -47,8 +47,15 @@ void SubView::TagEntity(TArray<FWorkerComponentData>& Components) const
 
 void SubView::AdvanceViewDelta(const ViewDelta& Delta)
 {
-	// TODO: Filtering given delta by complete entities and add/removes for newly complete and incomplete entities
-	// respectively. Probably requires new view delta functionality to build from worker messages and entity deltas.
+	Algo::Sort(CompleteEntities);
+	Algo::Sort(NewlyCompleteEntities);
+	Algo::Sort(NewlyIncompleteEntities);
+
+	SubDelta.Project(Delta, CompleteEntities, NewlyCompleteEntities, NewlyIncompleteEntities);
+
+	CompleteEntities.Append(NewlyCompleteEntities);
+	NewlyCompleteEntities.Empty();
+	NewlyIncompleteEntities.Empty();
 }
 
 const ViewDelta& SubView::GetViewDelta() const
@@ -64,6 +71,32 @@ void SubView::RefreshEntity(const Worker_EntityId EntityId)
 	}
 }
 
+
+void SubView::RegisterTagCallbacks(const EntityView& View, FDispatcher& Dispatcher)
+{
+	Dispatcher.RegisterAndInvokeComponentAddedCallback(
+        TagComponentId,
+        [this](const FEntityComponentChange Change) {
+            OnTaggedEntityAdded(Change.EntityId);
+        },
+        View);
+	Dispatcher.RegisterComponentRemovedCallback(TagComponentId, [this](const FEntityComponentChange Change) {
+        OnTaggedEntityRemoved(Change.EntityId);
+    });
+}
+
+void SubView::RegisterRefreshCallbacks(const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks)
+{
+	const FRefreshCallback RefreshEntityCallback = [this](const Worker_EntityId EntityId)
+	{
+		RefreshEntity(EntityId);
+	};
+	for (FDispatcherRefreshCallback Callback : DispatcherRefreshCallbacks)
+	{
+		Callback(RefreshEntityCallback);
+	}
+}
+
 void SubView::OnTaggedEntityAdded(const Worker_EntityId EntityId)
 {
 	TaggedEntities.Add(EntityId);
@@ -72,26 +105,47 @@ void SubView::OnTaggedEntityAdded(const Worker_EntityId EntityId)
 
 void SubView::OnTaggedEntityRemoved(const Worker_EntityId EntityId)
 {
-	TaggedEntities.Remove(EntityId);
-	CompleteEntities.Remove(EntityId);
+	TaggedEntities.RemoveSingleSwap(EntityId);
+	EntityIncomplete(EntityId);
 }
 
 void SubView::CheckEntityAgainstFilter(const Worker_EntityId EntityId)
 {
 	if (Filter(EntityId, View[EntityId]))
 	{
-		bool* AlreadyInSet = nullptr;
-		CompleteEntities.Add(EntityId, AlreadyInSet);
-		if (!AlreadyInSet)
-		{
-			NewlyCompleteEntities.Add(EntityId);
-		}
+		EntityComplete(EntityId);
 		return;
 	}
-	if (CompleteEntities.Contains(EntityId))
+	EntityIncomplete(EntityId);
+}
+
+void SubView::EntityComplete(const Worker_EntityId EntityId)
+{
+	// We were just about to remove this entity, but it has become complete again before the delta was read.
+	// Act as if it was never incomplete.
+	if (NewlyIncompleteEntities.RemoveSingleSwap(EntityId))
+	{
+		CompleteEntities.Add(EntityId);
+		return;
+	}
+	// This is new to us. Mark it as newly complete.
+	if (!CompleteEntities.Contains(EntityId))
+	{
+		NewlyCompleteEntities.Add(EntityId);
+	}
+}
+
+void SubView::EntityIncomplete(const Worker_EntityId EntityId)
+{
+	// If we were about to add this, don't. It's as if we never saw it.
+	if (NewlyCompleteEntities.RemoveSingleSwap(EntityId))
+	{
+		return;
+	}
+	// Otherwise, if it is currently complete, we need to remove it, and mark it as about to remove.
+	if (CompleteEntities.RemoveSingleSwap(EntityId))
 	{
 		NewlyIncompleteEntities.Add(EntityId);
-		CompleteEntities.Remove(EntityId);
 	}
 }
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
@@ -6,8 +6,8 @@
 
 namespace SpatialGDK
 {
-SubView::SubView(const Worker_ComponentId TagComponentId, const FFilterPredicate Filter,
-	                 const EntityView& View, FDispatcher& Dispatcher, const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks)
+SubView::SubView(const Worker_ComponentId TagComponentId, const FFilterPredicate Filter, const EntityView& View, FDispatcher& Dispatcher,
+				 const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks)
 	: TagComponentId(TagComponentId)
 	, Filter(Filter)
 	, View(View)
@@ -71,24 +71,22 @@ void SubView::RefreshEntity(const Worker_EntityId EntityId)
 	}
 }
 
-
 void SubView::RegisterTagCallbacks(const EntityView& View, FDispatcher& Dispatcher)
 {
 	Dispatcher.RegisterAndInvokeComponentAddedCallback(
-        TagComponentId,
-        [this](const FEntityComponentChange Change) {
-            OnTaggedEntityAdded(Change.EntityId);
-        },
-        View);
+		TagComponentId,
+		[this](const FEntityComponentChange Change) {
+			OnTaggedEntityAdded(Change.EntityId);
+		},
+		View);
 	Dispatcher.RegisterComponentRemovedCallback(TagComponentId, [this](const FEntityComponentChange Change) {
-        OnTaggedEntityRemoved(Change.EntityId);
-    });
+		OnTaggedEntityRemoved(Change.EntityId);
+	});
 }
 
 void SubView::RegisterRefreshCallbacks(const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks)
 {
-	const FRefreshCallback RefreshEntityCallback = [this](const Worker_EntityId EntityId)
-	{
+	const FRefreshCallback RefreshEntityCallback = [this](const Worker_EntityId EntityId) {
 		RefreshEntity(EntityId);
 	};
 	for (FDispatcherRefreshCallback Callback : DispatcherRefreshCallbacks)

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewCoordinator.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewCoordinator.cpp
@@ -50,25 +50,26 @@ void ViewCoordinator::FlushMessagesToSend()
 }
 
 SubView& ViewCoordinator::CreateSubView(const Worker_ComponentId Tag, const FFilterPredicate Filter,
-                                        const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks)
+										const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks)
 {
 	// System asks dispatcher for callback, has info: type of callback and transformation to entity ID
 
-	FDispatcherRefreshCallback Callback = [this](FRefreshCallback RefreshCallback)
-	{
-		Dispatcher.RegisterComponentAddedCallback(1, [RefreshCallback](const FEntityComponentChange Change)
-		{
+	FDispatcherRefreshCallback Callback = [this](FRefreshCallback RefreshCallback) {
+		Dispatcher.RegisterComponentAddedCallback(1, [RefreshCallback](const FEntityComponentChange Change) {
 			RefreshCallback(Change.EntityId);
 		});
 	};
-	const int Index = SubViews.Emplace(SubView{Tag, Filter, View.GetView(), Dispatcher, DispatcherRefreshCallbacks});
+	const int Index = SubViews.Emplace(SubView{ Tag, Filter, View.GetView(), Dispatcher, DispatcherRefreshCallbacks });
 	return SubViews[Index];
 }
 
-
 SubView& ViewCoordinator::CreateUnfilteredSubView(const Worker_ComponentId Tag)
 {
-	const int Index = SubViews.Emplace(SubView{Tag, [](const Worker_EntityId, const EntityViewElement&){return true;}, View.GetView(), Dispatcher, TArray<FDispatcherRefreshCallback>{}});
+	const int Index = SubViews.Emplace(SubView{ Tag,
+												[](const Worker_EntityId, const EntityViewElement&) {
+													return true;
+												},
+												View.GetView(), Dispatcher, TArray<FDispatcherRefreshCallback>{} });
 	return SubViews[Index];
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewCoordinator.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewCoordinator.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
 #include "SpatialView/ViewCoordinator.h"
+
 #include "SpatialView/OpList/ViewDeltaLegacyOpList.h"
 
 namespace SpatialGDK
@@ -26,14 +27,19 @@ void ViewCoordinator::Advance()
 	}
 	View.AdvanceViewDelta();
 	Dispatcher.InvokeCallbacks(View.GetViewDelta().GetEntityDeltas());
+
+	for (SubView& SubviewToAdvance : SubViews)
+	{
+		SubviewToAdvance.Advance(View.GetViewDelta());
+	}
 }
 
-const ViewDelta& ViewCoordinator::GetViewDelta()
+const ViewDelta& ViewCoordinator::GetViewDelta() const
 {
 	return View.GetViewDelta();
 }
 
-const EntityView& ViewCoordinator::GetView()
+const EntityView& ViewCoordinator::GetView() const
 {
 	return View.GetView();
 }
@@ -41,6 +47,37 @@ const EntityView& ViewCoordinator::GetView()
 void ViewCoordinator::FlushMessagesToSend()
 {
 	ConnectionHandler->SendMessages(View.FlushLocalChanges());
+}
+
+SubView& ViewCoordinator::CreateSubView(const Worker_ComponentId Tag, const FFilterPredicate Filter,
+                                        const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks)
+{
+	// System asks dispatcher for callback, has info: type of callback and transformation to entity ID
+
+	FDispatcherRefreshCallback Callback = [this](FRefreshCallback RefreshCallback)
+	{
+		Dispatcher.RegisterComponentAddedCallback(1, [RefreshCallback](const FEntityComponentChange Change)
+		{
+			RefreshCallback(Change.EntityId);
+		});
+	};
+	const int Index = SubViews.Emplace(SubView{Tag, Filter, View.GetView(), Dispatcher, DispatcherRefreshCallbacks});
+	return SubViews[Index];
+}
+
+
+SubView& ViewCoordinator::CreateUnfilteredSubView(const Worker_ComponentId Tag)
+{
+	const int Index = SubViews.Emplace(SubView{Tag, [](const Worker_EntityId, const EntityViewElement&){return true;}, View.GetView(), Dispatcher, TArray<FDispatcherRefreshCallback>{}});
+	return SubViews[Index];
+}
+
+void ViewCoordinator::RefreshEntityCompleteness(const Worker_EntityId EntityId)
+{
+	for (SubView& SubviewToRefresh : SubViews)
+	{
+		SubviewToRefresh.RefreshEntity(EntityId);
+	}
 }
 
 void ViewCoordinator::SendAddComponent(Worker_EntityId EntityId, ComponentData Data)

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewCoordinator.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewCoordinator.cpp
@@ -52,13 +52,6 @@ void ViewCoordinator::FlushMessagesToSend()
 SubView& ViewCoordinator::CreateSubView(const Worker_ComponentId Tag, const FFilterPredicate Filter,
 										const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks)
 {
-	// System asks dispatcher for callback, has info: type of callback and transformation to entity ID
-
-	FDispatcherRefreshCallback Callback = [this](FRefreshCallback RefreshCallback) {
-		Dispatcher.RegisterComponentAddedCallback(1, [RefreshCallback](const FEntityComponentChange Change) {
-			RefreshCallback(Change.EntityId);
-		});
-	};
 	const int Index = SubViews.Emplace(SubView{ Tag, Filter, View.GetView(), Dispatcher, DispatcherRefreshCallbacks });
 	return SubViews[Index];
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
@@ -8,665 +8,630 @@
 
 namespace SpatialGDK
 {
-	void ViewDelta::SetFromOpList(TArray<OpList> OpLists, EntityView& View)
+void ViewDelta::SetFromOpList(TArray<OpList> OpLists, EntityView& View)
+{
+	Clear();
+
+	for (OpList& Ops : OpLists)
 	{
-		Clear();
-
-		for (OpList& Ops : OpLists)
+		const uint32 Count = Ops.Count;
+		Worker_Op* OpData = Ops.Ops;
+		for (uint32 i = 0; i < Count; ++i)
 		{
-			const uint32 Count = Ops.Count;
-			Worker_Op* OpData = Ops.Ops;
-			for (uint32 i = 0; i < Count; ++i)
-			{
-				ProcessOp(OpData[i]);
-			}
-		}
-		OpListStorage = MoveTemp(OpLists);
-
-		PopulateEntityDeltas(View);
-	}
-
-	void ViewDelta::Project(const ViewDelta& Delta, const TArray<Worker_EntityId>& CompleteEntities,
-	                        const TArray<Worker_EntityId>& NewlyCompleteEntities,
-	                        const TArray<Worker_EntityId>& NewlyIncompleteEntities)
-	{
-		Clear();
-
-		// No projection is applied to worker messages, as they are not entity specific.
-		WorkerMessages = Delta.GetWorkerMessages();
-
-		// All arrays here are sorted by entity ID.
-		auto DeltaIt = Delta.GetEntityDeltas().CreateConstIterator();
-		auto CompleteIt = CompleteEntities.CreateConstIterator();
-		auto NewlyCompleteIt = NewlyCompleteEntities.CreateConstIterator();
-		auto NewlyIncompleteIt = NewlyIncompleteEntities.CreateConstIterator();
-
-		for (;;)
-		{
-			const Worker_EntityId MinEntityId = FMath::Min(FMath::Min(DeltaIt->EntityId, *CompleteIt),
-                                                        FMath::Min(*NewlyCompleteIt, *NewlyIncompleteIt));
-
-			// Find the intersection between complete entities and the entity IDs in the view delta, add them to this
-			// delta.
-			if (CompleteIt && DeltaIt && *CompleteIt == MinEntityId && DeltaIt->EntityId == MinEntityId)
-			{
-				EntityDeltas.Emplace(*DeltaIt);
-			}
-			// Newly complete entities are represented as marker add entities with no state.
-			if (NewlyCompleteIt && *NewlyCompleteIt == MinEntityId)
-			{
-				EntityDeltas.Emplace(EntityDelta{MinEntityId, true, false});
-				++NewlyCompleteIt;
-			}
-			// Newly incomplete entities are represented as marker remove entities with no state.
-			if (NewlyIncompleteIt && *NewlyIncompleteIt == MinEntityId)
-			{
-				EntityDeltas.Emplace(EntityDelta{MinEntityId, false, true});
-				++NewlyIncompleteIt;
-			}
-
-			// Logic for incrementing complete and delta iterators. If either iterator is done, null the other,
-			// as there can no longer be any intersection.
-			if (CompleteIt && *CompleteIt == MinEntityId)
-			{
-				++CompleteIt;
-				if (!CompleteIt)
-				{
-					DeltaIt.SetToEnd();
-				}
-			}
-			if (DeltaIt && DeltaIt->EntityId == MinEntityId)
-			{
-				++DeltaIt;
-				if (!DeltaIt)
-				{
-					CompleteIt.SetToEnd();
-				}
-			}
-
-			// Break when all iterators are done.
-			if (!CompleteIt && !NewlyCompleteIt && !NewlyIncompleteIt && !DeltaIt)
-			{
-				return;
-			}
+			ProcessOp(OpData[i]);
 		}
 	}
+	OpListStorage = MoveTemp(OpLists);
 
-	void ViewDelta::Clear()
+	PopulateEntityDeltas(View);
+}
+
+void ViewDelta::Project(const ViewDelta& Delta, const TArray<Worker_EntityId>& CompleteEntities,
+						const TArray<Worker_EntityId>& NewlyCompleteEntities, const TArray<Worker_EntityId>& NewlyIncompleteEntities)
+{
+	Clear();
+
+	// No projection is applied to worker messages, as they are not entity specific.
+	WorkerMessages = Delta.GetWorkerMessages();
+
+	// All arrays here are sorted by entity ID.
+	auto DeltaIt = Delta.GetEntityDeltas().CreateConstIterator();
+	auto CompleteIt = CompleteEntities.CreateConstIterator();
+	auto NewlyCompleteIt = NewlyCompleteEntities.CreateConstIterator();
+	auto NewlyIncompleteIt = NewlyIncompleteEntities.CreateConstIterator();
+
+	for (;;)
 	{
-		EntityChanges.Empty();
-		ComponentChanges.Empty();
-		AuthorityChanges.Empty();
+		const Worker_EntityId MinEntityId =
+			FMath::Min(FMath::Min(DeltaIt->EntityId, *CompleteIt), FMath::Min(*NewlyCompleteIt, *NewlyIncompleteIt));
 
-		ConnectionStatusCode = 0;
-
-		EntityDeltas.Empty();
-		WorkerMessages.Empty();
-		AuthorityGainedForDelta.Empty();
-		AuthorityLostForDelta.Empty();
-		AuthorityLostTempForDelta.Empty();
-		ComponentsAddedForDelta.Empty();
-		ComponentsRemovedForDelta.Empty();
-		ComponentUpdatesForDelta.Empty();
-		ComponentsRefreshedForDelta.Empty();
-		OpListStorage.Empty();
-	}
-
-	const TArray<EntityDelta>& ViewDelta::GetEntityDeltas() const
-	{
-		return EntityDeltas;
-	}
-
-	const TArray<Worker_Op>& ViewDelta::GetWorkerMessages() const
-	{
-		return WorkerMessages;
-	}
-
-	bool ViewDelta::HasDisconnected() const
-	{
-		return ConnectionStatusCode != 0;
-	}
-
-	Worker_ConnectionStatusCode ViewDelta::GetConnectionStatus() const
-	{
-		check(HasDisconnected());
-		return static_cast<Worker_ConnectionStatusCode>(ConnectionStatusCode);
-	}
-
-	FString ViewDelta::GetDisconnectReason() const
-	{
-		check(HasDisconnected());
-		return ConnectionStatusMessage;
-	}
-
-	ViewDelta::ReceivedComponentChange::ReceivedComponentChange(const Worker_AddComponentOp& Op)
-		: EntityId(Op.entity_id)
-		  , ComponentId(Op.data.component_id)
-		  , Type(ADD)
-		  , ComponentAdded(Op.data.schema_type)
-	{
-	}
-
-	ViewDelta::ReceivedComponentChange::ReceivedComponentChange(const Worker_ComponentUpdateOp& Op)
-		: EntityId(Op.entity_id)
-		  , ComponentId(Op.update.component_id)
-		  , Type(UPDATE)
-		  , ComponentUpdate(Op.update.schema_type)
-	{
-	}
-
-	ViewDelta::ReceivedComponentChange::ReceivedComponentChange(const Worker_RemoveComponentOp& Op)
-		: EntityId(Op.entity_id)
-		  , ComponentId(Op.component_id)
-		  , Type(REMOVE)
-	{
-	}
-
-	bool ViewDelta::DifferentEntity::operator()(const ReceivedEntityChange& E) const
-	{
-		return E.EntityId != EntityId;
-	}
-
-	bool ViewDelta::DifferentEntity::operator()(const ReceivedComponentChange& Op) const
-	{
-		return Op.EntityId != EntityId;
-	}
-
-	bool ViewDelta::DifferentEntity::operator()(const Worker_AuthorityChangeOp& Op) const
-	{
-		return Op.entity_id != EntityId;
-	}
-
-	bool ViewDelta::DifferentEntityComponent::operator()(const ReceivedComponentChange& Op) const
-	{
-		return Op.ComponentId != ComponentId || Op.EntityId != EntityId;
-	}
-
-	bool ViewDelta::DifferentEntityComponent::operator()(const Worker_AuthorityChangeOp& Op) const
-	{
-		return Op.component_id != ComponentId || Op.entity_id != EntityId;
-	}
-
-	bool ViewDelta::EntityComponentComparison::operator()(const ReceivedComponentChange& Lhs,
-	                                                      const ReceivedComponentChange& Rhs) const
-	{
-		if (Lhs.EntityId != Rhs.EntityId)
+		// Find the intersection between complete entities and the entity IDs in the view delta, add them to this
+		// delta.
+		if (CompleteIt && DeltaIt && *CompleteIt == MinEntityId && DeltaIt->EntityId == MinEntityId)
 		{
-			return Lhs.EntityId < Rhs.EntityId;
+			EntityDeltas.Emplace(*DeltaIt);
 		}
-		return Lhs.ComponentId < Rhs.ComponentId;
-	}
-
-	bool ViewDelta::EntityComponentComparison::operator()(const Worker_AuthorityChangeOp& Lhs,
-	                                                      const Worker_AuthorityChangeOp& Rhs) const
-	{
-		if (Lhs.entity_id != Rhs.entity_id)
+		// Newly complete entities are represented as marker add entities with no state.
+		if (NewlyCompleteIt && *NewlyCompleteIt == MinEntityId)
 		{
-			return Lhs.entity_id < Rhs.entity_id;
+			EntityDeltas.Emplace(EntityDelta{ MinEntityId, true, false });
+			++NewlyCompleteIt;
 		}
-		return Lhs.component_id < Rhs.component_id;
-	}
+		// Newly incomplete entities are represented as marker remove entities with no state.
+		if (NewlyIncompleteIt && *NewlyIncompleteIt == MinEntityId)
+		{
+			EntityDeltas.Emplace(EntityDelta{ MinEntityId, false, true });
+			++NewlyIncompleteIt;
+		}
 
-	bool ViewDelta::EntityComparison::operator()(const ReceivedEntityChange& Lhs, const ReceivedEntityChange& Rhs) const
+		// Logic for incrementing complete and delta iterators. If either iterator is done, null the other,
+		// as there can no longer be any intersection.
+		if (CompleteIt && *CompleteIt == MinEntityId)
+		{
+			++CompleteIt;
+			if (!CompleteIt)
+			{
+				DeltaIt.SetToEnd();
+			}
+		}
+		if (DeltaIt && DeltaIt->EntityId == MinEntityId)
+		{
+			++DeltaIt;
+			if (!DeltaIt)
+			{
+				CompleteIt.SetToEnd();
+			}
+		}
+
+		// Break when all iterators are done.
+		if (!CompleteIt && !NewlyCompleteIt && !NewlyIncompleteIt && !DeltaIt)
+		{
+			return;
+		}
+	}
+}
+
+void ViewDelta::Clear()
+{
+	EntityChanges.Empty();
+	ComponentChanges.Empty();
+	AuthorityChanges.Empty();
+
+	ConnectionStatusCode = 0;
+
+	EntityDeltas.Empty();
+	WorkerMessages.Empty();
+	AuthorityGainedForDelta.Empty();
+	AuthorityLostForDelta.Empty();
+	AuthorityLostTempForDelta.Empty();
+	ComponentsAddedForDelta.Empty();
+	ComponentsRemovedForDelta.Empty();
+	ComponentUpdatesForDelta.Empty();
+	ComponentsRefreshedForDelta.Empty();
+	OpListStorage.Empty();
+}
+
+const TArray<EntityDelta>& ViewDelta::GetEntityDeltas() const
+{
+	return EntityDeltas;
+}
+
+const TArray<Worker_Op>& ViewDelta::GetWorkerMessages() const
+{
+	return WorkerMessages;
+}
+
+bool ViewDelta::HasDisconnected() const
+{
+	return ConnectionStatusCode != 0;
+}
+
+Worker_ConnectionStatusCode ViewDelta::GetConnectionStatus() const
+{
+	check(HasDisconnected());
+	return static_cast<Worker_ConnectionStatusCode>(ConnectionStatusCode);
+}
+
+FString ViewDelta::GetDisconnectReason() const
+{
+	check(HasDisconnected());
+	return ConnectionStatusMessage;
+}
+
+ViewDelta::ReceivedComponentChange::ReceivedComponentChange(const Worker_AddComponentOp& Op)
+	: EntityId(Op.entity_id)
+	, ComponentId(Op.data.component_id)
+	, Type(ADD)
+	, ComponentAdded(Op.data.schema_type)
+{
+}
+
+ViewDelta::ReceivedComponentChange::ReceivedComponentChange(const Worker_ComponentUpdateOp& Op)
+	: EntityId(Op.entity_id)
+	, ComponentId(Op.update.component_id)
+	, Type(UPDATE)
+	, ComponentUpdate(Op.update.schema_type)
+{
+}
+
+ViewDelta::ReceivedComponentChange::ReceivedComponentChange(const Worker_RemoveComponentOp& Op)
+	: EntityId(Op.entity_id)
+	, ComponentId(Op.component_id)
+	, Type(REMOVE)
+{
+}
+
+bool ViewDelta::DifferentEntity::operator()(const ReceivedEntityChange& E) const
+{
+	return E.EntityId != EntityId;
+}
+
+bool ViewDelta::DifferentEntity::operator()(const ReceivedComponentChange& Op) const
+{
+	return Op.EntityId != EntityId;
+}
+
+bool ViewDelta::DifferentEntity::operator()(const Worker_AuthorityChangeOp& Op) const
+{
+	return Op.entity_id != EntityId;
+}
+
+bool ViewDelta::DifferentEntityComponent::operator()(const ReceivedComponentChange& Op) const
+{
+	return Op.ComponentId != ComponentId || Op.EntityId != EntityId;
+}
+
+bool ViewDelta::DifferentEntityComponent::operator()(const Worker_AuthorityChangeOp& Op) const
+{
+	return Op.component_id != ComponentId || Op.entity_id != EntityId;
+}
+
+bool ViewDelta::EntityComponentComparison::operator()(const ReceivedComponentChange& Lhs, const ReceivedComponentChange& Rhs) const
+{
+	if (Lhs.EntityId != Rhs.EntityId)
 	{
 		return Lhs.EntityId < Rhs.EntityId;
 	}
+	return Lhs.ComponentId < Rhs.ComponentId;
+}
 
-	bool ViewDelta::EntityComparison::operator()(const EntityProjection& Lhs, const EntityProjection& Rhs) const
+bool ViewDelta::EntityComponentComparison::operator()(const Worker_AuthorityChangeOp& Lhs, const Worker_AuthorityChangeOp& Rhs) const
+{
+	if (Lhs.entity_id != Rhs.entity_id)
 	{
-		return Lhs.EntityId < Rhs.EntityId;
+		return Lhs.entity_id < Rhs.entity_id;
 	}
+	return Lhs.component_id < Rhs.component_id;
+}
 
-	ComponentChange ViewDelta::CalculateAdd(ReceivedComponentChange* Start, ReceivedComponentChange* End,
-	                                        TArray<ComponentData>& Components)
+bool ViewDelta::EntityComparison::operator()(const ReceivedEntityChange& Lhs, const ReceivedEntityChange& Rhs) const
+{
+	return Lhs.EntityId < Rhs.EntityId;
+}
+
+bool ViewDelta::EntityComparison::operator()(const EntityProjection& Lhs, const EntityProjection& Rhs) const
+{
+	return Lhs.EntityId < Rhs.EntityId;
+}
+
+ComponentChange ViewDelta::CalculateAdd(ReceivedComponentChange* Start, ReceivedComponentChange* End, TArray<ComponentData>& Components)
+{
+	// There must be at least one component add; anything before it can be ignored.
+	ReceivedComponentChange* It = std::find_if(Start, End, [](const ReceivedComponentChange& Op) {
+		return Op.Type == ReceivedComponentChange::ADD;
+	});
+
+	Schema_ComponentData* Data = It->ComponentAdded;
+	++It;
+
+	while (It != End)
 	{
-		// There must be at least one component add; anything before it can be ignored.
-		ReceivedComponentChange* It = std::find_if(Start, End, [](const ReceivedComponentChange& Op)
+		switch (It->Type)
 		{
-			return Op.Type == ReceivedComponentChange::ADD;
-		});
-
-		Schema_ComponentData* Data = It->ComponentAdded;
+		case ReceivedComponentChange::ADD:
+			Data = It->ComponentAdded;
+			break;
+		case ReceivedComponentChange::UPDATE:
+			Schema_ApplyComponentUpdateToData(It->ComponentUpdate, Data);
+			break;
+		case ReceivedComponentChange::REMOVE:
+			break;
+		}
 		++It;
+	}
+	Components.Emplace(ComponentData::CreateCopy(Data, Start->ComponentId));
+	// We don't want to reference the component in the view as is isn't stable.
+	return ComponentChange(Start->ComponentId, Data);
+}
 
-		while (It != End)
+ComponentChange ViewDelta::CalculateCompleteUpdate(ReceivedComponentChange* Start, ReceivedComponentChange* End, Schema_ComponentData* Data,
+												   Schema_ComponentUpdate* Events, ComponentData& Component)
+{
+	for (auto It = Start; It != End; ++It)
+	{
+		switch (It->Type)
 		{
-			switch (It->Type)
+		case ReceivedComponentChange::ADD:
+			Data = It->ComponentAdded;
+			break;
+		case ReceivedComponentChange::UPDATE:
+			if (Data)
 			{
-			case ReceivedComponentChange::ADD:
-				Data = It->ComponentAdded;
-				break;
-			case ReceivedComponentChange::UPDATE:
 				Schema_ApplyComponentUpdateToData(It->ComponentUpdate, Data);
-				break;
-			case ReceivedComponentChange::REMOVE:
-				break;
 			}
-			++It;
-		}
-		Components.Emplace(ComponentData::CreateCopy(Data, Start->ComponentId));
-		// We don't want to reference the component in the view as is isn't stable.
-		return ComponentChange(Start->ComponentId, Data);
-	}
-
-	ComponentChange ViewDelta::CalculateCompleteUpdate(ReceivedComponentChange* Start, ReceivedComponentChange* End,
-	                                                   Schema_ComponentData* Data,
-	                                                   Schema_ComponentUpdate* Events, ComponentData& Component)
-	{
-		for (auto It = Start; It != End; ++It)
-		{
-			switch (It->Type)
+			if (Events)
 			{
-			case ReceivedComponentChange::ADD:
-				Data = It->ComponentAdded;
-				break;
-			case ReceivedComponentChange::UPDATE:
-				if (Data)
-				{
-					Schema_ApplyComponentUpdateToData(It->ComponentUpdate, Data);
-				}
-				if (Events)
-				{
-					Schema_MergeComponentUpdateIntoUpdate(It->ComponentUpdate, Events);
-				}
-				else
-				{
-					Events = It->ComponentUpdate;
-				}
-				break;
-			case ReceivedComponentChange::REMOVE:
-				break;
+				Schema_MergeComponentUpdateIntoUpdate(It->ComponentUpdate, Events);
 			}
+			else
+			{
+				Events = It->ComponentUpdate;
+			}
+			break;
+		case ReceivedComponentChange::REMOVE:
+			break;
 		}
-
-		Component = ComponentData::CreateCopy(Data, Start->ComponentId);
-		Schema_Object* EventsObj = Events ? Schema_GetComponentUpdateEvents(Events) : nullptr;
-		// Use the data from the op list as pointers from the view aren't stable.
-		return ComponentChange(Start->ComponentId, Data, EventsObj);
 	}
 
-	ComponentChange ViewDelta::CalculateUpdate(ReceivedComponentChange* Start, ReceivedComponentChange* End,
-	                                           ComponentData& Component)
+	Component = ComponentData::CreateCopy(Data, Start->ComponentId);
+	Schema_Object* EventsObj = Events ? Schema_GetComponentUpdateEvents(Events) : nullptr;
+	// Use the data from the op list as pointers from the view aren't stable.
+	return ComponentChange(Start->ComponentId, Data, EventsObj);
+}
+
+ComponentChange ViewDelta::CalculateUpdate(ReceivedComponentChange* Start, ReceivedComponentChange* End, ComponentData& Component)
+{
+	// For an update we don't know if we are calculating a complete-update or a regular update.
+	// So the first message processed might be an add or an update.
+	auto It = std::find_if(Start, End, [](const ReceivedComponentChange& Op) {
+		return Op.Type != ReceivedComponentChange::REMOVE;
+	});
+
+	// If the first message is an add then calculate a complete-update.
+	if (It->Type == ReceivedComponentChange::ADD)
 	{
-		// For an update we don't know if we are calculating a complete-update or a regular update.
-		// So the first message processed might be an add or an update.
-		auto It = std::find_if(Start, End, [](const ReceivedComponentChange& Op)
-		{
-			return Op.Type != ReceivedComponentChange::REMOVE;
-		});
+		return CalculateCompleteUpdate(It + 1, End, It->ComponentAdded, nullptr, Component);
+	}
 
-		// If the first message is an add then calculate a complete-update.
-		if (It->Type == ReceivedComponentChange::ADD)
+	Schema_ComponentUpdate* Update = It->ComponentUpdate;
+	++It;
+	while (It != End)
+	{
+		switch (It->Type)
 		{
-			return CalculateCompleteUpdate(It + 1, End, It->ComponentAdded, nullptr, Component);
+		case ReceivedComponentChange::ADD:
+			return CalculateCompleteUpdate(It + 1, End, It->ComponentAdded, Update, Component);
+		case ReceivedComponentChange::UPDATE:
+			Schema_MergeComponentUpdateIntoUpdate(It->ComponentUpdate, Update);
+			break;
+		case ReceivedComponentChange::REMOVE:
+			return CalculateCompleteUpdate(It + 1, End, nullptr, nullptr, Component);
 		}
-
-		Schema_ComponentUpdate* Update = It->ComponentUpdate;
 		++It;
-		while (It != End)
-		{
-			switch (It->Type)
-			{
-			case ReceivedComponentChange::ADD:
-				return CalculateCompleteUpdate(It + 1, End, It->ComponentAdded, Update, Component);
-			case ReceivedComponentChange::UPDATE:
-				Schema_MergeComponentUpdateIntoUpdate(It->ComponentUpdate, Update);
-				break;
-			case ReceivedComponentChange::REMOVE:
-				return CalculateCompleteUpdate(It + 1, End, nullptr, nullptr, Component);
-			}
-			++It;
-		}
-
-		Schema_ApplyComponentUpdateToData(Update, Component.GetUnderlying());
-		Component = Component.DeepCopy();
-		return ComponentChange(Start->ComponentId, Update);
 	}
 
-	void ViewDelta::ProcessOp(Worker_Op& Op)
+	Schema_ApplyComponentUpdateToData(Update, Component.GetUnderlying());
+	Component = Component.DeepCopy();
+	return ComponentChange(Start->ComponentId, Update);
+}
+
+void ViewDelta::ProcessOp(Worker_Op& Op)
+{
+	switch (static_cast<Worker_OpType>(Op.op_type))
 	{
-		switch (static_cast<Worker_OpType>(Op.op_type))
+	case WORKER_OP_TYPE_DISCONNECT:
+		ConnectionStatusCode = Op.op.disconnect.connection_status_code;
+		ConnectionStatusMessage = Op.op.disconnect.reason;
+		break;
+	case WORKER_OP_TYPE_LOG_MESSAGE:
+		// Log messages deprecated.
+		break;
+	case WORKER_OP_TYPE_CRITICAL_SECTION:
+		// Ignore critical sections.
+		break;
+	case WORKER_OP_TYPE_ADD_ENTITY:
+		EntityChanges.Push(ReceivedEntityChange{ Op.op.add_entity.entity_id, true });
+		break;
+	case WORKER_OP_TYPE_REMOVE_ENTITY:
+		EntityChanges.Push(ReceivedEntityChange{ Op.op.remove_entity.entity_id, false });
+		break;
+	case WORKER_OP_TYPE_METRICS:
+	case WORKER_OP_TYPE_FLAG_UPDATE:
+	case WORKER_OP_TYPE_RESERVE_ENTITY_IDS_RESPONSE:
+	case WORKER_OP_TYPE_CREATE_ENTITY_RESPONSE:
+	case WORKER_OP_TYPE_DELETE_ENTITY_RESPONSE:
+	case WORKER_OP_TYPE_ENTITY_QUERY_RESPONSE:
+	case WORKER_OP_TYPE_COMMAND_REQUEST:
+	case WORKER_OP_TYPE_COMMAND_RESPONSE:
+		WorkerMessages.Push(Op);
+		break;
+	case WORKER_OP_TYPE_ADD_COMPONENT:
+		ComponentChanges.Emplace(Op.op.add_component);
+		break;
+	case WORKER_OP_TYPE_REMOVE_COMPONENT:
+		ComponentChanges.Emplace(Op.op.remove_component);
+		break;
+	case WORKER_OP_TYPE_AUTHORITY_CHANGE:
+		if (Op.op.authority_change.authority != WORKER_AUTHORITY_AUTHORITY_LOSS_IMMINENT)
 		{
-		case WORKER_OP_TYPE_DISCONNECT:
-			ConnectionStatusCode = Op.op.disconnect.connection_status_code;
-			ConnectionStatusMessage = Op.op.disconnect.reason;
-			break;
-		case WORKER_OP_TYPE_LOG_MESSAGE:
-			// Log messages deprecated.
-			break;
-		case WORKER_OP_TYPE_CRITICAL_SECTION:
-			// Ignore critical sections.
-			break;
-		case WORKER_OP_TYPE_ADD_ENTITY:
-			EntityChanges.Push(ReceivedEntityChange{Op.op.add_entity.entity_id, true});
-			break;
-		case WORKER_OP_TYPE_REMOVE_ENTITY:
-			EntityChanges.Push(ReceivedEntityChange{Op.op.remove_entity.entity_id, false});
-			break;
-		case WORKER_OP_TYPE_METRICS:
-		case WORKER_OP_TYPE_FLAG_UPDATE:
-		case WORKER_OP_TYPE_RESERVE_ENTITY_IDS_RESPONSE:
-		case WORKER_OP_TYPE_CREATE_ENTITY_RESPONSE:
-		case WORKER_OP_TYPE_DELETE_ENTITY_RESPONSE:
-		case WORKER_OP_TYPE_ENTITY_QUERY_RESPONSE:
-		case WORKER_OP_TYPE_COMMAND_REQUEST:
-		case WORKER_OP_TYPE_COMMAND_RESPONSE:
-			WorkerMessages.Push(Op);
-			break;
-		case WORKER_OP_TYPE_ADD_COMPONENT:
-			ComponentChanges.Emplace(Op.op.add_component);
-			break;
-		case WORKER_OP_TYPE_REMOVE_COMPONENT:
-			ComponentChanges.Emplace(Op.op.remove_component);
-			break;
-		case WORKER_OP_TYPE_AUTHORITY_CHANGE:
-			if (Op.op.authority_change.authority != WORKER_AUTHORITY_AUTHORITY_LOSS_IMMINENT)
-			{
-				AuthorityChanges.Emplace(Op.op.authority_change);
-			}
-			break;
-		case WORKER_OP_TYPE_COMPONENT_UPDATE:
-			ComponentChanges.Emplace(Op.op.component_update);
-			break;
-		default:
+			AuthorityChanges.Emplace(Op.op.authority_change);
+		}
+		break;
+	case WORKER_OP_TYPE_COMPONENT_UPDATE:
+		ComponentChanges.Emplace(Op.op.component_update);
+		break;
+	default:
+		break;
+	}
+}
+
+void ViewDelta::PopulateEntityDeltas(EntityView& View)
+{
+	// Make sure there is enough space in the view delta storage.
+	// This allows us to rely on stable pointers as we add new elements.
+	ComponentsAddedForDelta.Reserve(ComponentChanges.Num());
+	ComponentsRemovedForDelta.Reserve(ComponentChanges.Num());
+	ComponentUpdatesForDelta.Reserve(ComponentChanges.Num());
+	ComponentsRefreshedForDelta.Reserve(ComponentChanges.Num());
+	AuthorityGainedForDelta.Reserve(AuthorityChanges.Num());
+	AuthorityLostForDelta.Reserve(AuthorityChanges.Num());
+	AuthorityLostTempForDelta.Reserve(AuthorityChanges.Num());
+
+	Algo::StableSort(ComponentChanges, EntityComponentComparison{});
+	Algo::StableSort(AuthorityChanges, EntityComponentComparison{});
+	Algo::StableSort(EntityChanges, EntityComparison{});
+
+	// Add sentinel elements to the ends of the arrays.
+	// Prevents the need for bounds checks on the iterators.
+	ComponentChanges.Emplace(Worker_RemoveComponentOp{ SENTINEL_ENTITY_ID, 0 });
+	AuthorityChanges.Emplace(Worker_AuthorityChangeOp{ SENTINEL_ENTITY_ID, 0, 0 });
+	EntityChanges.Emplace(ReceivedEntityChange{ SENTINEL_ENTITY_ID, false });
+
+	auto ComponentIt = ComponentChanges.GetData();
+	auto AuthorityIt = AuthorityChanges.GetData();
+	auto EntityIt = EntityChanges.GetData();
+
+	ReceivedComponentChange* ComponentChangesEnd = ComponentIt + ComponentChanges.Num();
+	Worker_AuthorityChangeOp* AuthorityChangesEnd = AuthorityIt + AuthorityChanges.Num();
+	ReceivedEntityChange* EntityChangesEnd = EntityIt + EntityChanges.Num();
+
+	// At the beginning of each loop each iterator should point to the first element for an entity.
+	// Each loop we want to work with a single entity ID.
+	// We check the entities each iterator is pointing to and pick the smallest one.
+	// If that is the sentinel ID then stop.
+	for (;;)
+	{
+		// Get the next entity ID. We want to pick the smallest entity referenced by the iterators.
+		// Convert to uint64 to ensure the sentinel value is larger than all valid IDs.
+		const uint64 MinEntityId = FMath::Min3(static_cast<uint64>(ComponentIt->EntityId), static_cast<uint64>(AuthorityIt->entity_id),
+											   static_cast<uint64>(EntityIt->EntityId));
+
+		// If no list has elements left to read then stop.
+		if (static_cast<Worker_EntityId>(MinEntityId) == SENTINEL_ENTITY_ID)
+		{
 			break;
 		}
-	}
 
-	void ViewDelta::PopulateEntityDeltas(EntityView& View)
-	{
-		// Make sure there is enough space in the view delta storage.
-		// This allows us to rely on stable pointers as we add new elements.
-		ComponentsAddedForDelta.Reserve(ComponentChanges.Num());
-		ComponentsRemovedForDelta.Reserve(ComponentChanges.Num());
-		ComponentUpdatesForDelta.Reserve(ComponentChanges.Num());
-		ComponentsRefreshedForDelta.Reserve(ComponentChanges.Num());
-		AuthorityGainedForDelta.Reserve(AuthorityChanges.Num());
-		AuthorityLostForDelta.Reserve(AuthorityChanges.Num());
-		AuthorityLostTempForDelta.Reserve(AuthorityChanges.Num());
+		const Worker_EntityId CurrentEntityId = static_cast<Worker_EntityId>(MinEntityId);
 
-		Algo::StableSort(ComponentChanges, EntityComponentComparison{});
-		Algo::StableSort(AuthorityChanges, EntityComponentComparison{});
-		Algo::StableSort(EntityChanges, EntityComparison{});
+		EntityDelta Delta = {};
+		Delta.EntityId = CurrentEntityId;
 
-		// Add sentinel elements to the ends of the arrays.
-		// Prevents the need for bounds checks on the iterators.
-		ComponentChanges.Emplace(Worker_RemoveComponentOp{SENTINEL_ENTITY_ID, 0});
-		AuthorityChanges.Emplace(Worker_AuthorityChangeOp{SENTINEL_ENTITY_ID, 0, 0});
-		EntityChanges.Emplace(ReceivedEntityChange{SENTINEL_ENTITY_ID, false});
+		EntityViewElement* ViewElement = View.Find(CurrentEntityId);
 
-		auto ComponentIt = ComponentChanges.GetData();
-		auto AuthorityIt = AuthorityChanges.GetData();
-		auto EntityIt = EntityChanges.GetData();
-
-		ReceivedComponentChange* ComponentChangesEnd = ComponentIt + ComponentChanges.Num();
-		Worker_AuthorityChangeOp* AuthorityChangesEnd = AuthorityIt + AuthorityChanges.Num();
-		ReceivedEntityChange* EntityChangesEnd = EntityIt + EntityChanges.Num();
-
-		// At the beginning of each loop each iterator should point to the first element for an entity.
-		// Each loop we want to work with a single entity ID.
-		// We check the entities each iterator is pointing to and pick the smallest one.
-		// If that is the sentinel ID then stop.
-		for (;;)
+		if (EntityIt->EntityId == CurrentEntityId)
 		{
-			// Get the next entity ID. We want to pick the smallest entity referenced by the iterators.
-			// Convert to uint64 to ensure the sentinel value is larger than all valid IDs.
-			const uint64 MinEntityId = FMath::Min3(static_cast<uint64>(ComponentIt->EntityId),
-			                                       static_cast<uint64>(AuthorityIt->entity_id),
-			                                       static_cast<uint64>(EntityIt->EntityId));
-
-			// If no list has elements left to read then stop.
-			if (static_cast<Worker_EntityId>(MinEntityId) == SENTINEL_ENTITY_ID)
+			EntityIt = ProcessEntityExistenceChange(EntityIt, EntityChangesEnd, Delta, &ViewElement, View);
+			// If the entity isn't present we don't need to process component and authority changes.
+			if (ViewElement == nullptr)
 			{
-				break;
-			}
+				ComponentIt = std::find_if(ComponentIt, ComponentChangesEnd, DifferentEntity{ CurrentEntityId });
+				AuthorityIt = std::find_if(AuthorityIt, AuthorityChangesEnd, DifferentEntity{ CurrentEntityId });
 
-			const Worker_EntityId CurrentEntityId = static_cast<Worker_EntityId>(MinEntityId);
-
-			EntityDelta Delta = {};
-			Delta.EntityId = CurrentEntityId;
-
-			EntityViewElement* ViewElement = View.Find(CurrentEntityId);
-
-			if (EntityIt->EntityId == CurrentEntityId)
-			{
-				EntityIt = ProcessEntityExistenceChange(EntityIt, EntityChangesEnd, Delta, &ViewElement, View);
-				// If the entity isn't present we don't need to process component and authority changes.
-				if (ViewElement == nullptr)
+				// Only add the entity delta if the entity previously existed in the view.
+				if (Delta.bRemoved)
 				{
-					ComponentIt = std::find_if(ComponentIt, ComponentChangesEnd, DifferentEntity{CurrentEntityId});
-					AuthorityIt = std::find_if(AuthorityIt, AuthorityChangesEnd, DifferentEntity{CurrentEntityId});
-
-					// Only add the entity delta if the entity previously existed in the view.
-					if (Delta.bRemoved)
-					{
-						EntityDeltas.Push(Delta);
-					}
-					continue;
+					EntityDeltas.Push(Delta);
 				}
+				continue;
 			}
-
-			if (ComponentIt->EntityId == CurrentEntityId)
-			{
-				ComponentIt = ProcessEntityComponentChanges(ComponentIt, ComponentChangesEnd, ViewElement->Components,
-				                                            Delta);
-			}
-
-			if (AuthorityIt->entity_id == CurrentEntityId)
-			{
-				AuthorityIt = ProcessEntityAuthorityChanges(AuthorityIt, AuthorityChangesEnd, ViewElement->Authority,
-				                                            Delta);
-			}
-
-			EntityDeltas.Push(Delta);
 		}
-	}
 
-	ViewDelta::ReceivedComponentChange* ViewDelta::ProcessEntityComponentChanges(
-		ReceivedComponentChange* It, ReceivedComponentChange* End,
-		TArray<ComponentData>& Components, EntityDelta& Delta)
-	{
-		int32 AddCount = 0;
-		int32 UpdateCount = 0;
-		int32 RemoveCount = 0;
-		int32 RefreshCount = 0;
-
-		const Worker_EntityId EntityId = It->EntityId;
-		// At the end of each loop `It` should point to the first element for an entity-component.
-		// Stop and return when the component is for a different entity.
-		// There will always be at least one iteration of the loop.
-		for (;;)
+		if (ComponentIt->EntityId == CurrentEntityId)
 		{
-			ReceivedComponentChange* NextComponentIt = std::find_if(
-				It, End, DifferentEntityComponent{EntityId, It->ComponentId});
+			ComponentIt = ProcessEntityComponentChanges(ComponentIt, ComponentChangesEnd, ViewElement->Components, Delta);
+		}
 
-			ComponentData* Component = Components.FindByPredicate(ComponentIdEquality{It->ComponentId});
-			const bool bComponentExists = Component != nullptr;
+		if (AuthorityIt->entity_id == CurrentEntityId)
+		{
+			AuthorityIt = ProcessEntityAuthorityChanges(AuthorityIt, AuthorityChangesEnd, ViewElement->Authority, Delta);
+		}
 
-			// The element one before NextComponentIt must be the last element for this component.
-			switch ((NextComponentIt - 1)->Type)
+		EntityDeltas.Push(Delta);
+	}
+}
+
+ViewDelta::ReceivedComponentChange* ViewDelta::ProcessEntityComponentChanges(ReceivedComponentChange* It, ReceivedComponentChange* End,
+																			 TArray<ComponentData>& Components, EntityDelta& Delta)
+{
+	int32 AddCount = 0;
+	int32 UpdateCount = 0;
+	int32 RemoveCount = 0;
+	int32 RefreshCount = 0;
+
+	const Worker_EntityId EntityId = It->EntityId;
+	// At the end of each loop `It` should point to the first element for an entity-component.
+	// Stop and return when the component is for a different entity.
+	// There will always be at least one iteration of the loop.
+	for (;;)
+	{
+		ReceivedComponentChange* NextComponentIt = std::find_if(It, End, DifferentEntityComponent{ EntityId, It->ComponentId });
+
+		ComponentData* Component = Components.FindByPredicate(ComponentIdEquality{ It->ComponentId });
+		const bool bComponentExists = Component != nullptr;
+
+		// The element one before NextComponentIt must be the last element for this component.
+		switch ((NextComponentIt - 1)->Type)
+		{
+		case ReceivedComponentChange::ADD:
+			if (bComponentExists)
 			{
-			case ReceivedComponentChange::ADD:
-				if (bComponentExists)
+				ComponentsRefreshedForDelta.Emplace(CalculateCompleteUpdate(It, NextComponentIt, nullptr, nullptr, *Component));
+				++RefreshCount;
+			}
+			else
+			{
+				ComponentsAddedForDelta.Emplace(CalculateAdd(It, NextComponentIt, Components));
+				++AddCount;
+			}
+			break;
+		case ReceivedComponentChange::UPDATE:
+			if (bComponentExists)
+			{
+				ComponentChange Update = CalculateUpdate(It, NextComponentIt, *Component);
+				if (Update.Type == ComponentChange::COMPLETE_UPDATE)
 				{
-					ComponentsRefreshedForDelta.Emplace(
-						CalculateCompleteUpdate(It, NextComponentIt, nullptr, nullptr, *Component));
+					ComponentsRefreshedForDelta.Emplace(Update);
 					++RefreshCount;
 				}
 				else
 				{
-					ComponentsAddedForDelta.Emplace(CalculateAdd(It, NextComponentIt, Components));
-					++AddCount;
+					ComponentUpdatesForDelta.Emplace(Update);
+					++UpdateCount;
 				}
-				break;
-			case ReceivedComponentChange::UPDATE:
-				if (bComponentExists)
-				{
-					ComponentChange Update = CalculateUpdate(It, NextComponentIt, *Component);
-					if (Update.Type == ComponentChange::COMPLETE_UPDATE)
-					{
-						ComponentsRefreshedForDelta.Emplace(Update);
-						++RefreshCount;
-					}
-					else
-					{
-						ComponentUpdatesForDelta.Emplace(Update);
-						++UpdateCount;
-					}
-				}
-				else
-				{
-					ComponentsAddedForDelta.Emplace(CalculateAdd(It, NextComponentIt, Components));
-					++AddCount;
-				}
-				break;
-			case ReceivedComponentChange::REMOVE:
-				if (bComponentExists)
-				{
-					ComponentsRemovedForDelta.Emplace(It->ComponentId);
-					Components.RemoveAtSwap(Component - Components.GetData());
-					++RemoveCount;
-				}
-				break;
 			}
-
-			if (NextComponentIt->EntityId != EntityId)
+			else
 			{
-				Delta.ComponentsAdded = {
-					ComponentsAddedForDelta.GetData() + ComponentsAddedForDelta.Num() - AddCount, AddCount
-				};
-				Delta.ComponentsRemoved = {
-					ComponentsRemovedForDelta.GetData() + ComponentsRemovedForDelta.Num() - RemoveCount, RemoveCount
-				};
-				Delta.ComponentUpdates = {
-					ComponentUpdatesForDelta.GetData() + ComponentUpdatesForDelta.Num() - UpdateCount, UpdateCount
-				};
-				Delta.ComponentsRefreshed = {
-					ComponentsRefreshedForDelta.GetData() + ComponentsRefreshedForDelta.Num() - RefreshCount,
-					RefreshCount
-				};
-				return NextComponentIt;
+				ComponentsAddedForDelta.Emplace(CalculateAdd(It, NextComponentIt, Components));
+				++AddCount;
 			}
+			break;
+		case ReceivedComponentChange::REMOVE:
+			if (bComponentExists)
+			{
+				ComponentsRemovedForDelta.Emplace(It->ComponentId);
+				Components.RemoveAtSwap(Component - Components.GetData());
+				++RemoveCount;
+			}
+			break;
+		}
 
-			It = NextComponentIt;
+		if (NextComponentIt->EntityId != EntityId)
+		{
+			Delta.ComponentsAdded = { ComponentsAddedForDelta.GetData() + ComponentsAddedForDelta.Num() - AddCount, AddCount };
+			Delta.ComponentsRemoved = { ComponentsRemovedForDelta.GetData() + ComponentsRemovedForDelta.Num() - RemoveCount, RemoveCount };
+			Delta.ComponentUpdates = { ComponentUpdatesForDelta.GetData() + ComponentUpdatesForDelta.Num() - UpdateCount, UpdateCount };
+			Delta.ComponentsRefreshed = { ComponentsRefreshedForDelta.GetData() + ComponentsRefreshedForDelta.Num() - RefreshCount,
+										  RefreshCount };
+			return NextComponentIt;
+		}
+
+		It = NextComponentIt;
+	}
+}
+
+Worker_AuthorityChangeOp* ViewDelta::ProcessEntityAuthorityChanges(Worker_AuthorityChangeOp* It, Worker_AuthorityChangeOp* End,
+																   TArray<Worker_ComponentId>& EntityAuthority, EntityDelta& Delta)
+{
+	int32 GainCount = 0;
+	int32 LossCount = 0;
+	int32 LossTempCount = 0;
+
+	const Worker_EntityId EntityId = It->entity_id;
+	// After each loop the iterator points to the first op relating to the next entity-component.
+	// Stop and return when that component is for a different entity.
+	// There will always be at least one iteration of the loop.
+	for (;;)
+	{
+		// Find the last element for this entity-component.
+		const Worker_ComponentId ComponentId = It->component_id;
+		It = std::find_if(It, End, DifferentEntityComponent{ EntityId, ComponentId }) - 1;
+		const int32 AuthorityIndex = EntityAuthority.Find(ComponentId);
+		const bool bHasAuthority = AuthorityIndex != INDEX_NONE;
+
+		if (It->authority == WORKER_AUTHORITY_AUTHORITATIVE)
+		{
+			if (bHasAuthority)
+			{
+				AuthorityLostTempForDelta.Emplace(ComponentId, AuthorityChange::AUTHORITY_LOST_TEMPORARILY);
+				++LossTempCount;
+			}
+			else
+			{
+				EntityAuthority.Push(ComponentId);
+				AuthorityGainedForDelta.Emplace(ComponentId, AuthorityChange::AUTHORITY_GAINED);
+				++GainCount;
+			}
+		}
+		else if (bHasAuthority)
+		{
+			AuthorityLostForDelta.Emplace(ComponentId, AuthorityChange::AUTHORITY_LOST);
+			EntityAuthority.RemoveAtSwap(AuthorityIndex);
+			++LossCount;
+		}
+
+		// Move to the next entity-component.
+		++It;
+
+		if (It->entity_id != EntityId)
+		{
+			Delta.AuthorityGained = { AuthorityGainedForDelta.GetData() + AuthorityGainedForDelta.Num() - GainCount, GainCount };
+			Delta.AuthorityLost = { AuthorityLostForDelta.GetData() + AuthorityLostForDelta.Num() - LossCount, LossCount };
+			Delta.AuthorityLostTemporarily = { AuthorityLostTempForDelta.GetData() + AuthorityLostTempForDelta.Num() - LossTempCount,
+											   LossTempCount };
+			return It;
 		}
 	}
+}
 
-	Worker_AuthorityChangeOp* ViewDelta::ProcessEntityAuthorityChanges(Worker_AuthorityChangeOp* It,
-	                                                                   Worker_AuthorityChangeOp* End,
-	                                                                   TArray<Worker_ComponentId>& EntityAuthority,
-	                                                                   EntityDelta& Delta)
+ViewDelta::ReceivedEntityChange* ViewDelta::ProcessEntityExistenceChange(ReceivedEntityChange* It, ReceivedEntityChange* End,
+																		 EntityDelta& Delta, EntityViewElement** ViewElement,
+																		 EntityView& View)
+{
+	// Find the last element relating to the same entity.
+	const Worker_EntityId EntityId = It->EntityId;
+	It = std::find_if(It, End, DifferentEntity{ EntityId }) - 1;
+
+	const bool bAlreadyInView = *ViewElement != nullptr;
+	const bool bEntityAdded = It->bAdded;
+
+	// If the entity's presence has not changed then return.
+	if (bEntityAdded == bAlreadyInView)
 	{
-		int32 GainCount = 0;
-		int32 LossCount = 0;
-		int32 LossTempCount = 0;
-
-		const Worker_EntityId EntityId = It->entity_id;
-		// After each loop the iterator points to the first op relating to the next entity-component.
-		// Stop and return when that component is for a different entity.
-		// There will always be at least one iteration of the loop.
-		for (;;)
-		{
-			// Find the last element for this entity-component.
-			const Worker_ComponentId ComponentId = It->component_id;
-			It = std::find_if(It, End, DifferentEntityComponent{EntityId, ComponentId}) - 1;
-			const int32 AuthorityIndex = EntityAuthority.Find(ComponentId);
-			const bool bHasAuthority = AuthorityIndex != INDEX_NONE;
-
-			if (It->authority == WORKER_AUTHORITY_AUTHORITATIVE)
-			{
-				if (bHasAuthority)
-				{
-					AuthorityLostTempForDelta.Emplace(ComponentId, AuthorityChange::AUTHORITY_LOST_TEMPORARILY);
-					++LossTempCount;
-				}
-				else
-				{
-					EntityAuthority.Push(ComponentId);
-					AuthorityGainedForDelta.Emplace(ComponentId, AuthorityChange::AUTHORITY_GAINED);
-					++GainCount;
-				}
-			}
-			else if (bHasAuthority)
-			{
-				AuthorityLostForDelta.Emplace(ComponentId, AuthorityChange::AUTHORITY_LOST);
-				EntityAuthority.RemoveAtSwap(AuthorityIndex);
-				++LossCount;
-			}
-
-			// Move to the next entity-component.
-			++It;
-
-			if (It->entity_id != EntityId)
-			{
-				Delta.AuthorityGained = {
-					AuthorityGainedForDelta.GetData() + AuthorityGainedForDelta.Num() - GainCount, GainCount
-				};
-				Delta.AuthorityLost = {
-					AuthorityLostForDelta.GetData() + AuthorityLostForDelta.Num() - LossCount, LossCount
-				};
-				Delta.AuthorityLostTemporarily = {
-					AuthorityLostTempForDelta.GetData() + AuthorityLostTempForDelta.Num() - LossTempCount,
-					LossTempCount
-				};
-				return It;
-			}
-		}
-	}
-
-	ViewDelta::ReceivedEntityChange* ViewDelta::ProcessEntityExistenceChange(
-		ReceivedEntityChange* It, ReceivedEntityChange* End,
-		EntityDelta& Delta, EntityViewElement** ViewElement,
-		EntityView& View)
-	{
-		// Find the last element relating to the same entity.
-		const Worker_EntityId EntityId = It->EntityId;
-		It = std::find_if(It, End, DifferentEntity{EntityId}) - 1;
-
-		const bool bAlreadyInView = *ViewElement != nullptr;
-		const bool bEntityAdded = It->bAdded;
-
-		// If the entity's presence has not changed then return.
-		if (bEntityAdded == bAlreadyInView)
-		{
-			return It + 1;
-		}
-
-		if (bEntityAdded)
-		{
-			Delta.bAdded = true;
-			*ViewElement = &View.Emplace(EntityId, EntityViewElement{});
-		}
-		else
-		{
-			Delta.bRemoved = true;
-
-			// Remove components.
-			const auto& Components = (*ViewElement)->Components;
-			for (const auto& Component : Components)
-			{
-				ComponentsRemovedForDelta.Emplace(Component.GetComponentId());
-			}
-			Delta.ComponentsRemoved = {
-				ComponentsRemovedForDelta.GetData() + ComponentsRemovedForDelta.Num() - Components.Num(),
-				Components.Num()
-			};
-
-			// Remove authority.
-			const auto& Authority = (*ViewElement)->Authority;
-			for (const auto& Id : Authority)
-			{
-				AuthorityLostForDelta.Emplace(Id, AuthorityChange::AUTHORITY_LOST);
-			}
-			Delta.AuthorityLost = {
-				AuthorityLostForDelta.GetData() + AuthorityLostForDelta.Num() - Authority.Num(), Authority.Num()
-			};
-
-			// Remove from view.
-			View.Remove(EntityId);
-			*ViewElement = nullptr;
-		}
-
 		return It + 1;
 	}
+
+	if (bEntityAdded)
+	{
+		Delta.bAdded = true;
+		*ViewElement = &View.Emplace(EntityId, EntityViewElement{});
+	}
+	else
+	{
+		Delta.bRemoved = true;
+
+		// Remove components.
+		const auto& Components = (*ViewElement)->Components;
+		for (const auto& Component : Components)
+		{
+			ComponentsRemovedForDelta.Emplace(Component.GetComponentId());
+		}
+		Delta.ComponentsRemoved = { ComponentsRemovedForDelta.GetData() + ComponentsRemovedForDelta.Num() - Components.Num(),
+									Components.Num() };
+
+		// Remove authority.
+		const auto& Authority = (*ViewElement)->Authority;
+		for (const auto& Id : Authority)
+		{
+			AuthorityLostForDelta.Emplace(Id, AuthorityChange::AUTHORITY_LOST);
+		}
+		Delta.AuthorityLost = { AuthorityLostForDelta.GetData() + AuthorityLostForDelta.Num() - Authority.Num(), Authority.Num() };
+
+		// Remove from view.
+		View.Remove(EntityId);
+		*ViewElement = nullptr;
+	}
+
+	return It + 1;
+}
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
@@ -27,7 +27,8 @@ void ViewDelta::SetFromOpList(TArray<OpList> OpLists, EntityView& View)
 }
 
 void ViewDelta::Project(const ViewDelta& Delta, const TArray<Worker_EntityId>& CompleteEntities,
-						const TArray<Worker_EntityId>& NewlyCompleteEntities, const TArray<Worker_EntityId>& NewlyIncompleteEntities, const TArray<Worker_EntityId>& TemporarilyIncompleteEntities)
+						const TArray<Worker_EntityId>& NewlyCompleteEntities, const TArray<Worker_EntityId>& NewlyIncompleteEntities,
+						const TArray<Worker_EntityId>& TemporarilyIncompleteEntities)
 {
 	Clear();
 
@@ -43,8 +44,8 @@ void ViewDelta::Project(const ViewDelta& Delta, const TArray<Worker_EntityId>& C
 
 	for (;;)
 	{
-		const Worker_EntityId MinEntityId =
-			FMath::Min(FMath::Min(DeltaIt->EntityId, *CompleteIt), FMath::Min3(*NewlyCompleteIt, *NewlyIncompleteIt, *TemporarilyIncompleteIt));
+		const Worker_EntityId MinEntityId = FMath::Min(FMath::Min(DeltaIt->EntityId, *CompleteIt),
+													   FMath::Min3(*NewlyCompleteIt, *NewlyIncompleteIt, *TemporarilyIncompleteIt));
 
 		// Find the intersection between complete entities and the entity IDs in the view delta, add them to this
 		// delta.

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
@@ -45,8 +45,7 @@ void ViewDelta::Project(const ViewDelta& Delta, const TArray<Worker_EntityId>& C
 	for (;;)
 	{
 		const Worker_EntityId MinEntityId = FMath::Min3(FMath::Min(DeltaIt->EntityId, *CompleteIt),
-													   FMath::Min(*NewlyCompleteIt, *NewlyIncompleteIt),
-													   *TemporarilyIncompleteIt);
+														FMath::Min(*NewlyCompleteIt, *NewlyIncompleteIt), *TemporarilyIncompleteIt);
 
 		// Find the intersection between complete entities and the entity IDs in the view delta, add them to this
 		// delta.

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
@@ -209,11 +209,6 @@ bool ViewDelta::EntityComparison::operator()(const ReceivedEntityChange& Lhs, co
 	return Lhs.EntityId < Rhs.EntityId;
 }
 
-bool ViewDelta::EntityComparison::operator()(const EntityProjection& Lhs, const EntityProjection& Rhs) const
-{
-	return Lhs.EntityId < Rhs.EntityId;
-}
-
 ComponentChange ViewDelta::CalculateAdd(ReceivedComponentChange* Start, ReceivedComponentChange* End, TArray<ComponentData>& Components)
 {
 	// There must be at least one component add; anything before it can be ignored.

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
@@ -381,6 +381,11 @@ void ViewDelta::PopulateEntityDeltas(EntityView& View)
 	Algo::StableSort(AuthorityChanges, EntityComponentComparison{});
 	Algo::StableSort(EntityChanges, EntityComparison{});
 
+	// The sentinel entity ID has the property that when converted to a uint64 it will be greater than INT64_MAX.
+	// If we convert all entity IDs to uint64s before comparing them we can then be assured that the sentinel values
+	// will be greater than all valid IDs.
+	static const Worker_EntityId SENTINEL_ENTITY_ID = -1;
+
 	// Add sentinel elements to the ends of the arrays.
 	// Prevents the need for bounds checks on the iterators.
 	ComponentChanges.Emplace(Worker_RemoveComponentOp{ SENTINEL_ENTITY_ID, 0 });

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
@@ -8,566 +8,665 @@
 
 namespace SpatialGDK
 {
-void ViewDelta::SetFromOpList(TArray<OpList> OpLists, EntityView& View)
-{
-	Clear();
-
-	for (OpList& Ops : OpLists)
+	void ViewDelta::SetFromOpList(TArray<OpList> OpLists, EntityView& View)
 	{
-		const uint32 Count = Ops.Count;
-		Worker_Op* OpData = Ops.Ops;
-		for (uint32 i = 0; i < Count; ++i)
+		Clear();
+
+		for (OpList& Ops : OpLists)
 		{
-			ProcessOp(OpData[i]);
+			const uint32 Count = Ops.Count;
+			Worker_Op* OpData = Ops.Ops;
+			for (uint32 i = 0; i < Count; ++i)
+			{
+				ProcessOp(OpData[i]);
+			}
+		}
+		OpListStorage = MoveTemp(OpLists);
+
+		PopulateEntityDeltas(View);
+	}
+
+	void ViewDelta::Project(const ViewDelta& Delta, const TArray<Worker_EntityId>& CompleteEntities,
+	                        const TArray<Worker_EntityId>& NewlyCompleteEntities,
+	                        const TArray<Worker_EntityId>& NewlyIncompleteEntities)
+	{
+		Clear();
+
+		// No projection is applied to worker messages, as they are not entity specific.
+		WorkerMessages = Delta.GetWorkerMessages();
+
+		// All arrays here are sorted by entity ID.
+		auto DeltaIt = Delta.GetEntityDeltas().CreateConstIterator();
+		auto CompleteIt = CompleteEntities.CreateConstIterator();
+		auto NewlyCompleteIt = NewlyCompleteEntities.CreateConstIterator();
+		auto NewlyIncompleteIt = NewlyIncompleteEntities.CreateConstIterator();
+
+		for (;;)
+		{
+			const Worker_EntityId MinEntityId = FMath::Min(FMath::Min(DeltaIt->EntityId, *CompleteIt),
+                                                        FMath::Min(*NewlyCompleteIt, *NewlyIncompleteIt));
+
+			// Find the intersection between complete entities and the entity IDs in the view delta, add them to this
+			// delta.
+			if (CompleteIt && DeltaIt && *CompleteIt == MinEntityId && DeltaIt->EntityId == MinEntityId)
+			{
+				EntityDeltas.Emplace(*DeltaIt);
+			}
+			// Newly complete entities are represented as marker add entities with no state.
+			if (NewlyCompleteIt && *NewlyCompleteIt == MinEntityId)
+			{
+				EntityDeltas.Emplace(EntityDelta{MinEntityId, true, false});
+				++NewlyCompleteIt;
+			}
+			// Newly incomplete entities are represented as marker remove entities with no state.
+			if (NewlyIncompleteIt && *NewlyIncompleteIt == MinEntityId)
+			{
+				EntityDeltas.Emplace(EntityDelta{MinEntityId, false, true});
+				++NewlyIncompleteIt;
+			}
+
+			// Logic for incrementing complete and delta iterators. If either iterator is done, null the other,
+			// as there can no longer be any intersection.
+			if (CompleteIt && *CompleteIt == MinEntityId)
+			{
+				++CompleteIt;
+				if (!CompleteIt)
+				{
+					DeltaIt.SetToEnd();
+				}
+			}
+			if (DeltaIt && DeltaIt->EntityId == MinEntityId)
+			{
+				++DeltaIt;
+				if (!DeltaIt)
+				{
+					CompleteIt.SetToEnd();
+				}
+			}
+
+			// Break when all iterators are done.
+			if (!CompleteIt && !NewlyCompleteIt && !NewlyIncompleteIt && !DeltaIt)
+			{
+				return;
+			}
 		}
 	}
-	OpListStorage = MoveTemp(OpLists);
 
-	PopulateEntityDeltas(View);
-}
+	void ViewDelta::Clear()
+	{
+		EntityChanges.Empty();
+		ComponentChanges.Empty();
+		AuthorityChanges.Empty();
 
-void ViewDelta::Clear()
-{
-	EntityChanges.Empty();
-	ComponentChanges.Empty();
-	AuthorityChanges.Empty();
+		ConnectionStatusCode = 0;
 
-	ConnectionStatusCode = 0;
+		EntityDeltas.Empty();
+		WorkerMessages.Empty();
+		AuthorityGainedForDelta.Empty();
+		AuthorityLostForDelta.Empty();
+		AuthorityLostTempForDelta.Empty();
+		ComponentsAddedForDelta.Empty();
+		ComponentsRemovedForDelta.Empty();
+		ComponentUpdatesForDelta.Empty();
+		ComponentsRefreshedForDelta.Empty();
+		OpListStorage.Empty();
+	}
 
-	EntityDeltas.Empty();
-	WorkerMessages.Empty();
-	AuthorityGainedForDelta.Empty();
-	AuthorityLostForDelta.Empty();
-	AuthorityLostTempForDelta.Empty();
-	ComponentsAddedForDelta.Empty();
-	ComponentsRemovedForDelta.Empty();
-	ComponentUpdatesForDelta.Empty();
-	ComponentsRefreshedForDelta.Empty();
-	OpListStorage.Empty();
-}
+	const TArray<EntityDelta>& ViewDelta::GetEntityDeltas() const
+	{
+		return EntityDeltas;
+	}
 
-const TArray<EntityDelta>& ViewDelta::GetEntityDeltas() const
-{
-	return EntityDeltas;
-}
+	const TArray<Worker_Op>& ViewDelta::GetWorkerMessages() const
+	{
+		return WorkerMessages;
+	}
 
-const TArray<Worker_Op>& ViewDelta::GetWorkerMessages() const
-{
-	return WorkerMessages;
-}
+	bool ViewDelta::HasDisconnected() const
+	{
+		return ConnectionStatusCode != 0;
+	}
 
-bool ViewDelta::HasDisconnected() const
-{
-	return ConnectionStatusCode != 0;
-}
+	Worker_ConnectionStatusCode ViewDelta::GetConnectionStatus() const
+	{
+		check(HasDisconnected());
+		return static_cast<Worker_ConnectionStatusCode>(ConnectionStatusCode);
+	}
 
-Worker_ConnectionStatusCode ViewDelta::GetConnectionStatus() const
-{
-	check(HasDisconnected());
-	return static_cast<Worker_ConnectionStatusCode>(ConnectionStatusCode);
-}
+	FString ViewDelta::GetDisconnectReason() const
+	{
+		check(HasDisconnected());
+		return ConnectionStatusMessage;
+	}
 
-FString ViewDelta::GetDisconnectReason() const
-{
-	check(HasDisconnected());
-	return ConnectionStatusMessage;
-}
+	ViewDelta::ReceivedComponentChange::ReceivedComponentChange(const Worker_AddComponentOp& Op)
+		: EntityId(Op.entity_id)
+		  , ComponentId(Op.data.component_id)
+		  , Type(ADD)
+		  , ComponentAdded(Op.data.schema_type)
+	{
+	}
 
-ViewDelta::ReceivedComponentChange::ReceivedComponentChange(const Worker_AddComponentOp& Op)
-	: EntityId(Op.entity_id)
-	, ComponentId(Op.data.component_id)
-	, Type(ADD)
-	, ComponentAdded(Op.data.schema_type)
-{
-}
+	ViewDelta::ReceivedComponentChange::ReceivedComponentChange(const Worker_ComponentUpdateOp& Op)
+		: EntityId(Op.entity_id)
+		  , ComponentId(Op.update.component_id)
+		  , Type(UPDATE)
+		  , ComponentUpdate(Op.update.schema_type)
+	{
+	}
 
-ViewDelta::ReceivedComponentChange::ReceivedComponentChange(const Worker_ComponentUpdateOp& Op)
-	: EntityId(Op.entity_id)
-	, ComponentId(Op.update.component_id)
-	, Type(UPDATE)
-	, ComponentUpdate(Op.update.schema_type)
-{
-}
+	ViewDelta::ReceivedComponentChange::ReceivedComponentChange(const Worker_RemoveComponentOp& Op)
+		: EntityId(Op.entity_id)
+		  , ComponentId(Op.component_id)
+		  , Type(REMOVE)
+	{
+	}
 
-ViewDelta::ReceivedComponentChange::ReceivedComponentChange(const Worker_RemoveComponentOp& Op)
-	: EntityId(Op.entity_id)
-	, ComponentId(Op.component_id)
-	, Type(REMOVE)
-{
-}
+	bool ViewDelta::DifferentEntity::operator()(const ReceivedEntityChange& E) const
+	{
+		return E.EntityId != EntityId;
+	}
 
-bool ViewDelta::DifferentEntity::operator()(const ReceivedEntityChange& E) const
-{
-	return E.EntityId != EntityId;
-}
+	bool ViewDelta::DifferentEntity::operator()(const ReceivedComponentChange& Op) const
+	{
+		return Op.EntityId != EntityId;
+	}
 
-bool ViewDelta::DifferentEntity::operator()(const ReceivedComponentChange& Op) const
-{
-	return Op.EntityId != EntityId;
-}
+	bool ViewDelta::DifferentEntity::operator()(const Worker_AuthorityChangeOp& Op) const
+	{
+		return Op.entity_id != EntityId;
+	}
 
-bool ViewDelta::DifferentEntity::operator()(const Worker_AuthorityChangeOp& Op) const
-{
-	return Op.entity_id != EntityId;
-}
+	bool ViewDelta::DifferentEntityComponent::operator()(const ReceivedComponentChange& Op) const
+	{
+		return Op.ComponentId != ComponentId || Op.EntityId != EntityId;
+	}
 
-bool ViewDelta::DifferentEntityComponent::operator()(const ReceivedComponentChange& Op) const
-{
-	return Op.ComponentId != ComponentId || Op.EntityId != EntityId;
-}
+	bool ViewDelta::DifferentEntityComponent::operator()(const Worker_AuthorityChangeOp& Op) const
+	{
+		return Op.component_id != ComponentId || Op.entity_id != EntityId;
+	}
 
-bool ViewDelta::DifferentEntityComponent::operator()(const Worker_AuthorityChangeOp& Op) const
-{
-	return Op.component_id != ComponentId || Op.entity_id != EntityId;
-}
+	bool ViewDelta::EntityComponentComparison::operator()(const ReceivedComponentChange& Lhs,
+	                                                      const ReceivedComponentChange& Rhs) const
+	{
+		if (Lhs.EntityId != Rhs.EntityId)
+		{
+			return Lhs.EntityId < Rhs.EntityId;
+		}
+		return Lhs.ComponentId < Rhs.ComponentId;
+	}
 
-bool ViewDelta::EntityComponentComparison::operator()(const ReceivedComponentChange& Lhs, const ReceivedComponentChange& Rhs) const
-{
-	if (Lhs.EntityId != Rhs.EntityId)
+	bool ViewDelta::EntityComponentComparison::operator()(const Worker_AuthorityChangeOp& Lhs,
+	                                                      const Worker_AuthorityChangeOp& Rhs) const
+	{
+		if (Lhs.entity_id != Rhs.entity_id)
+		{
+			return Lhs.entity_id < Rhs.entity_id;
+		}
+		return Lhs.component_id < Rhs.component_id;
+	}
+
+	bool ViewDelta::EntityComparison::operator()(const ReceivedEntityChange& Lhs, const ReceivedEntityChange& Rhs) const
 	{
 		return Lhs.EntityId < Rhs.EntityId;
 	}
-	return Lhs.ComponentId < Rhs.ComponentId;
-}
 
-bool ViewDelta::EntityComponentComparison::operator()(const Worker_AuthorityChangeOp& Lhs, const Worker_AuthorityChangeOp& Rhs) const
-{
-	if (Lhs.entity_id != Rhs.entity_id)
+	bool ViewDelta::EntityComparison::operator()(const EntityProjection& Lhs, const EntityProjection& Rhs) const
 	{
-		return Lhs.entity_id < Rhs.entity_id;
+		return Lhs.EntityId < Rhs.EntityId;
 	}
-	return Lhs.component_id < Rhs.component_id;
-}
 
-bool ViewDelta::EntityComparison::operator()(const ReceivedEntityChange& Lhs, const ReceivedEntityChange& Rhs) const
-{
-	return Lhs.EntityId < Rhs.EntityId;
-}
-
-ComponentChange ViewDelta::CalculateAdd(ReceivedComponentChange* Start, ReceivedComponentChange* End, TArray<ComponentData>& Components)
-{
-	// There must be at least one component add; anything before it can be ignored.
-	ReceivedComponentChange* It = std::find_if(Start, End, [](const ReceivedComponentChange& Op) {
-		return Op.Type == ReceivedComponentChange::ADD;
-	});
-
-	Schema_ComponentData* Data = It->ComponentAdded;
-	++It;
-
-	while (It != End)
+	ComponentChange ViewDelta::CalculateAdd(ReceivedComponentChange* Start, ReceivedComponentChange* End,
+	                                        TArray<ComponentData>& Components)
 	{
-		switch (It->Type)
+		// There must be at least one component add; anything before it can be ignored.
+		ReceivedComponentChange* It = std::find_if(Start, End, [](const ReceivedComponentChange& Op)
 		{
-		case ReceivedComponentChange::ADD:
-			Data = It->ComponentAdded;
-			break;
-		case ReceivedComponentChange::UPDATE:
-			Schema_ApplyComponentUpdateToData(It->ComponentUpdate, Data);
-			break;
-		case ReceivedComponentChange::REMOVE:
-			break;
-		}
+			return Op.Type == ReceivedComponentChange::ADD;
+		});
+
+		Schema_ComponentData* Data = It->ComponentAdded;
 		++It;
-	}
-	Components.Emplace(ComponentData::CreateCopy(Data, Start->ComponentId));
-	// We don't want to reference the component in the view as is isn't stable.
-	return ComponentChange(Start->ComponentId, Data);
-}
 
-ComponentChange ViewDelta::CalculateCompleteUpdate(ReceivedComponentChange* Start, ReceivedComponentChange* End, Schema_ComponentData* Data,
-												   Schema_ComponentUpdate* Events, ComponentData& Component)
-{
-	for (auto It = Start; It != End; ++It)
-	{
-		switch (It->Type)
+		while (It != End)
 		{
-		case ReceivedComponentChange::ADD:
-			Data = It->ComponentAdded;
-			break;
-		case ReceivedComponentChange::UPDATE:
-			if (Data)
+			switch (It->Type)
 			{
+			case ReceivedComponentChange::ADD:
+				Data = It->ComponentAdded;
+				break;
+			case ReceivedComponentChange::UPDATE:
 				Schema_ApplyComponentUpdateToData(It->ComponentUpdate, Data);
+				break;
+			case ReceivedComponentChange::REMOVE:
+				break;
 			}
-			if (Events)
+			++It;
+		}
+		Components.Emplace(ComponentData::CreateCopy(Data, Start->ComponentId));
+		// We don't want to reference the component in the view as is isn't stable.
+		return ComponentChange(Start->ComponentId, Data);
+	}
+
+	ComponentChange ViewDelta::CalculateCompleteUpdate(ReceivedComponentChange* Start, ReceivedComponentChange* End,
+	                                                   Schema_ComponentData* Data,
+	                                                   Schema_ComponentUpdate* Events, ComponentData& Component)
+	{
+		for (auto It = Start; It != End; ++It)
+		{
+			switch (It->Type)
 			{
-				Schema_MergeComponentUpdateIntoUpdate(It->ComponentUpdate, Events);
-			}
-			else
-			{
-				Events = It->ComponentUpdate;
-			}
-			break;
-		case ReceivedComponentChange::REMOVE:
-			break;
-		}
-	}
-
-	Component = ComponentData::CreateCopy(Data, Start->ComponentId);
-	Schema_Object* EventsObj = Events ? Schema_GetComponentUpdateEvents(Events) : nullptr;
-	// Use the data from the op list as pointers from the view aren't stable.
-	return ComponentChange(Start->ComponentId, Data, EventsObj);
-}
-
-ComponentChange ViewDelta::CalculateUpdate(ReceivedComponentChange* Start, ReceivedComponentChange* End, ComponentData& Component)
-{
-	// For an update we don't know if we are calculating a complete-update or a regular update.
-	// So the first message processed might be an add or an update.
-	auto It = std::find_if(Start, End, [](const ReceivedComponentChange& Op) {
-		return Op.Type != ReceivedComponentChange::REMOVE;
-	});
-
-	// If the first message is an add then calculate a complete-update.
-	if (It->Type == ReceivedComponentChange::ADD)
-	{
-		return CalculateCompleteUpdate(It + 1, End, It->ComponentAdded, nullptr, Component);
-	}
-
-	Schema_ComponentUpdate* Update = It->ComponentUpdate;
-	++It;
-	while (It != End)
-	{
-		switch (It->Type)
-		{
-		case ReceivedComponentChange::ADD:
-			return CalculateCompleteUpdate(It + 1, End, It->ComponentAdded, Update, Component);
-		case ReceivedComponentChange::UPDATE:
-			Schema_MergeComponentUpdateIntoUpdate(It->ComponentUpdate, Update);
-			break;
-		case ReceivedComponentChange::REMOVE:
-			return CalculateCompleteUpdate(It + 1, End, nullptr, nullptr, Component);
-		}
-		++It;
-	}
-
-	Schema_ApplyComponentUpdateToData(Update, Component.GetUnderlying());
-	Component = Component.DeepCopy();
-	return ComponentChange(Start->ComponentId, Update);
-}
-
-void ViewDelta::ProcessOp(Worker_Op& Op)
-{
-	switch (static_cast<Worker_OpType>(Op.op_type))
-	{
-	case WORKER_OP_TYPE_DISCONNECT:
-		ConnectionStatusCode = Op.op.disconnect.connection_status_code;
-		ConnectionStatusMessage = Op.op.disconnect.reason;
-		break;
-	case WORKER_OP_TYPE_LOG_MESSAGE:
-		// Log messages deprecated.
-		break;
-	case WORKER_OP_TYPE_CRITICAL_SECTION:
-		// Ignore critical sections.
-		break;
-	case WORKER_OP_TYPE_ADD_ENTITY:
-		EntityChanges.Push(ReceivedEntityChange{ Op.op.add_entity.entity_id, true });
-		break;
-	case WORKER_OP_TYPE_REMOVE_ENTITY:
-		EntityChanges.Push(ReceivedEntityChange{ Op.op.remove_entity.entity_id, false });
-		break;
-	case WORKER_OP_TYPE_METRICS:
-	case WORKER_OP_TYPE_FLAG_UPDATE:
-	case WORKER_OP_TYPE_RESERVE_ENTITY_IDS_RESPONSE:
-	case WORKER_OP_TYPE_CREATE_ENTITY_RESPONSE:
-	case WORKER_OP_TYPE_DELETE_ENTITY_RESPONSE:
-	case WORKER_OP_TYPE_ENTITY_QUERY_RESPONSE:
-	case WORKER_OP_TYPE_COMMAND_REQUEST:
-	case WORKER_OP_TYPE_COMMAND_RESPONSE:
-		WorkerMessages.Push(Op);
-		break;
-	case WORKER_OP_TYPE_ADD_COMPONENT:
-		ComponentChanges.Emplace(Op.op.add_component);
-		break;
-	case WORKER_OP_TYPE_REMOVE_COMPONENT:
-		ComponentChanges.Emplace(Op.op.remove_component);
-		break;
-	case WORKER_OP_TYPE_AUTHORITY_CHANGE:
-		if (Op.op.authority_change.authority != WORKER_AUTHORITY_AUTHORITY_LOSS_IMMINENT)
-		{
-			AuthorityChanges.Emplace(Op.op.authority_change);
-		}
-		break;
-	case WORKER_OP_TYPE_COMPONENT_UPDATE:
-		ComponentChanges.Emplace(Op.op.component_update);
-		break;
-	default:
-		break;
-	}
-}
-
-void ViewDelta::PopulateEntityDeltas(EntityView& View)
-{
-	// Make sure there is enough space in the view delta storage.
-	// This allows us to rely on stable pointers as we add new elements.
-	ComponentsAddedForDelta.Reserve(ComponentChanges.Num());
-	ComponentsRemovedForDelta.Reserve(ComponentChanges.Num());
-	ComponentUpdatesForDelta.Reserve(ComponentChanges.Num());
-	ComponentsRefreshedForDelta.Reserve(ComponentChanges.Num());
-	AuthorityGainedForDelta.Reserve(AuthorityChanges.Num());
-	AuthorityLostForDelta.Reserve(AuthorityChanges.Num());
-	AuthorityLostTempForDelta.Reserve(AuthorityChanges.Num());
-
-	Algo::StableSort(ComponentChanges, EntityComponentComparison{});
-	Algo::StableSort(AuthorityChanges, EntityComponentComparison{});
-	Algo::StableSort(EntityChanges, EntityComparison{});
-
-	// The sentinel entity ID has the property that when converted to a uint64 it will be greater than INT64_MAX.
-	// If we convert all entity IDs to uint64s before comparing them we can then be assured that the sentinel values
-	// will be greater than all valid IDs.
-	static const Worker_EntityId SENTINEL_ENTITY_ID = -1;
-
-	// Add sentinel elements to the ends of the arrays.
-	// Prevents the need for bounds checks on the iterators.
-	ComponentChanges.Emplace(Worker_RemoveComponentOp{ SENTINEL_ENTITY_ID, 0 });
-	AuthorityChanges.Emplace(Worker_AuthorityChangeOp{ SENTINEL_ENTITY_ID, 0, 0 });
-	EntityChanges.Emplace(ReceivedEntityChange{ SENTINEL_ENTITY_ID, false });
-
-	auto ComponentIt = ComponentChanges.GetData();
-	auto AuthorityIt = AuthorityChanges.GetData();
-	auto EntityIt = EntityChanges.GetData();
-
-	ReceivedComponentChange* ComponentChangesEnd = ComponentIt + ComponentChanges.Num();
-	Worker_AuthorityChangeOp* AuthorityChangesEnd = AuthorityIt + AuthorityChanges.Num();
-	ReceivedEntityChange* EntityChangesEnd = EntityIt + EntityChanges.Num();
-
-	// At the beginning of each loop each iterator should point to the first element for an entity.
-	// Each loop we want to work with a single entity ID.
-	// We check the entities each iterator is pointing to and pick the smallest one.
-	// If that is the sentinel ID then stop.
-	for (;;)
-	{
-		// Get the next entity ID. We want to pick the smallest entity referenced by the iterators.
-		// Convert to uint64 to ensure the sentinel value is larger than all valid IDs.
-		const uint64 MinEntityId = FMath::Min3(static_cast<uint64>(ComponentIt->EntityId), static_cast<uint64>(AuthorityIt->entity_id),
-											   static_cast<uint64>(EntityIt->EntityId));
-
-		// If no list has elements left to read then stop.
-		if (static_cast<Worker_EntityId>(MinEntityId) == SENTINEL_ENTITY_ID)
-		{
-			break;
-		}
-
-		const Worker_EntityId CurrentEntityId = static_cast<Worker_EntityId>(MinEntityId);
-
-		EntityDelta Delta = {};
-		Delta.EntityId = CurrentEntityId;
-
-		EntityViewElement* ViewElement = View.Find(CurrentEntityId);
-
-		if (EntityIt->EntityId == CurrentEntityId)
-		{
-			EntityIt = ProcessEntityExistenceChange(EntityIt, EntityChangesEnd, Delta, &ViewElement, View);
-			// If the entity isn't present we don't need to process component and authority changes.
-			if (ViewElement == nullptr)
-			{
-				ComponentIt = std::find_if(ComponentIt, ComponentChangesEnd, DifferentEntity{ CurrentEntityId });
-				AuthorityIt = std::find_if(AuthorityIt, AuthorityChangesEnd, DifferentEntity{ CurrentEntityId });
-
-				// Only add the entity delta if the entity previously existed in the view.
-				if (Delta.bRemoved)
+			case ReceivedComponentChange::ADD:
+				Data = It->ComponentAdded;
+				break;
+			case ReceivedComponentChange::UPDATE:
+				if (Data)
 				{
-					EntityDeltas.Push(Delta);
+					Schema_ApplyComponentUpdateToData(It->ComponentUpdate, Data);
 				}
-				continue;
+				if (Events)
+				{
+					Schema_MergeComponentUpdateIntoUpdate(It->ComponentUpdate, Events);
+				}
+				else
+				{
+					Events = It->ComponentUpdate;
+				}
+				break;
+			case ReceivedComponentChange::REMOVE:
+				break;
 			}
 		}
 
-		if (ComponentIt->EntityId == CurrentEntityId)
-		{
-			ComponentIt = ProcessEntityComponentChanges(ComponentIt, ComponentChangesEnd, ViewElement->Components, Delta);
-		}
-
-		if (AuthorityIt->entity_id == CurrentEntityId)
-		{
-			AuthorityIt = ProcessEntityAuthorityChanges(AuthorityIt, AuthorityChangesEnd, ViewElement->Authority, Delta);
-		}
-
-		EntityDeltas.Push(Delta);
+		Component = ComponentData::CreateCopy(Data, Start->ComponentId);
+		Schema_Object* EventsObj = Events ? Schema_GetComponentUpdateEvents(Events) : nullptr;
+		// Use the data from the op list as pointers from the view aren't stable.
+		return ComponentChange(Start->ComponentId, Data, EventsObj);
 	}
-}
 
-ViewDelta::ReceivedComponentChange* ViewDelta::ProcessEntityComponentChanges(ReceivedComponentChange* It, ReceivedComponentChange* End,
-																			 TArray<ComponentData>& Components, EntityDelta& Delta)
-{
-	int32 AddCount = 0;
-	int32 UpdateCount = 0;
-	int32 RemoveCount = 0;
-	int32 RefreshCount = 0;
-
-	const Worker_EntityId EntityId = It->EntityId;
-	// At the end of each loop `It` should point to the first element for an entity-component.
-	// Stop and return when the component is for a different entity.
-	// There will always be at least one iteration of the loop.
-	for (;;)
+	ComponentChange ViewDelta::CalculateUpdate(ReceivedComponentChange* Start, ReceivedComponentChange* End,
+	                                           ComponentData& Component)
 	{
-		ReceivedComponentChange* NextComponentIt = std::find_if(It, End, DifferentEntityComponent{ EntityId, It->ComponentId });
-
-		ComponentData* Component = Components.FindByPredicate(ComponentIdEquality{ It->ComponentId });
-		const bool bComponentExists = Component != nullptr;
-
-		// The element one before NextComponentIt must be the last element for this component.
-		switch ((NextComponentIt - 1)->Type)
+		// For an update we don't know if we are calculating a complete-update or a regular update.
+		// So the first message processed might be an add or an update.
+		auto It = std::find_if(Start, End, [](const ReceivedComponentChange& Op)
 		{
-		case ReceivedComponentChange::ADD:
-			if (bComponentExists)
+			return Op.Type != ReceivedComponentChange::REMOVE;
+		});
+
+		// If the first message is an add then calculate a complete-update.
+		if (It->Type == ReceivedComponentChange::ADD)
+		{
+			return CalculateCompleteUpdate(It + 1, End, It->ComponentAdded, nullptr, Component);
+		}
+
+		Schema_ComponentUpdate* Update = It->ComponentUpdate;
+		++It;
+		while (It != End)
+		{
+			switch (It->Type)
 			{
-				ComponentsRefreshedForDelta.Emplace(CalculateCompleteUpdate(It, NextComponentIt, nullptr, nullptr, *Component));
-				++RefreshCount;
+			case ReceivedComponentChange::ADD:
+				return CalculateCompleteUpdate(It + 1, End, It->ComponentAdded, Update, Component);
+			case ReceivedComponentChange::UPDATE:
+				Schema_MergeComponentUpdateIntoUpdate(It->ComponentUpdate, Update);
+				break;
+			case ReceivedComponentChange::REMOVE:
+				return CalculateCompleteUpdate(It + 1, End, nullptr, nullptr, Component);
 			}
-			else
+			++It;
+		}
+
+		Schema_ApplyComponentUpdateToData(Update, Component.GetUnderlying());
+		Component = Component.DeepCopy();
+		return ComponentChange(Start->ComponentId, Update);
+	}
+
+	void ViewDelta::ProcessOp(Worker_Op& Op)
+	{
+		switch (static_cast<Worker_OpType>(Op.op_type))
+		{
+		case WORKER_OP_TYPE_DISCONNECT:
+			ConnectionStatusCode = Op.op.disconnect.connection_status_code;
+			ConnectionStatusMessage = Op.op.disconnect.reason;
+			break;
+		case WORKER_OP_TYPE_LOG_MESSAGE:
+			// Log messages deprecated.
+			break;
+		case WORKER_OP_TYPE_CRITICAL_SECTION:
+			// Ignore critical sections.
+			break;
+		case WORKER_OP_TYPE_ADD_ENTITY:
+			EntityChanges.Push(ReceivedEntityChange{Op.op.add_entity.entity_id, true});
+			break;
+		case WORKER_OP_TYPE_REMOVE_ENTITY:
+			EntityChanges.Push(ReceivedEntityChange{Op.op.remove_entity.entity_id, false});
+			break;
+		case WORKER_OP_TYPE_METRICS:
+		case WORKER_OP_TYPE_FLAG_UPDATE:
+		case WORKER_OP_TYPE_RESERVE_ENTITY_IDS_RESPONSE:
+		case WORKER_OP_TYPE_CREATE_ENTITY_RESPONSE:
+		case WORKER_OP_TYPE_DELETE_ENTITY_RESPONSE:
+		case WORKER_OP_TYPE_ENTITY_QUERY_RESPONSE:
+		case WORKER_OP_TYPE_COMMAND_REQUEST:
+		case WORKER_OP_TYPE_COMMAND_RESPONSE:
+			WorkerMessages.Push(Op);
+			break;
+		case WORKER_OP_TYPE_ADD_COMPONENT:
+			ComponentChanges.Emplace(Op.op.add_component);
+			break;
+		case WORKER_OP_TYPE_REMOVE_COMPONENT:
+			ComponentChanges.Emplace(Op.op.remove_component);
+			break;
+		case WORKER_OP_TYPE_AUTHORITY_CHANGE:
+			if (Op.op.authority_change.authority != WORKER_AUTHORITY_AUTHORITY_LOSS_IMMINENT)
 			{
-				ComponentsAddedForDelta.Emplace(CalculateAdd(It, NextComponentIt, Components));
-				++AddCount;
+				AuthorityChanges.Emplace(Op.op.authority_change);
 			}
 			break;
-		case ReceivedComponentChange::UPDATE:
-			if (bComponentExists)
+		case WORKER_OP_TYPE_COMPONENT_UPDATE:
+			ComponentChanges.Emplace(Op.op.component_update);
+			break;
+		default:
+			break;
+		}
+	}
+
+	void ViewDelta::PopulateEntityDeltas(EntityView& View)
+	{
+		// Make sure there is enough space in the view delta storage.
+		// This allows us to rely on stable pointers as we add new elements.
+		ComponentsAddedForDelta.Reserve(ComponentChanges.Num());
+		ComponentsRemovedForDelta.Reserve(ComponentChanges.Num());
+		ComponentUpdatesForDelta.Reserve(ComponentChanges.Num());
+		ComponentsRefreshedForDelta.Reserve(ComponentChanges.Num());
+		AuthorityGainedForDelta.Reserve(AuthorityChanges.Num());
+		AuthorityLostForDelta.Reserve(AuthorityChanges.Num());
+		AuthorityLostTempForDelta.Reserve(AuthorityChanges.Num());
+
+		Algo::StableSort(ComponentChanges, EntityComponentComparison{});
+		Algo::StableSort(AuthorityChanges, EntityComponentComparison{});
+		Algo::StableSort(EntityChanges, EntityComparison{});
+
+		// Add sentinel elements to the ends of the arrays.
+		// Prevents the need for bounds checks on the iterators.
+		ComponentChanges.Emplace(Worker_RemoveComponentOp{SENTINEL_ENTITY_ID, 0});
+		AuthorityChanges.Emplace(Worker_AuthorityChangeOp{SENTINEL_ENTITY_ID, 0, 0});
+		EntityChanges.Emplace(ReceivedEntityChange{SENTINEL_ENTITY_ID, false});
+
+		auto ComponentIt = ComponentChanges.GetData();
+		auto AuthorityIt = AuthorityChanges.GetData();
+		auto EntityIt = EntityChanges.GetData();
+
+		ReceivedComponentChange* ComponentChangesEnd = ComponentIt + ComponentChanges.Num();
+		Worker_AuthorityChangeOp* AuthorityChangesEnd = AuthorityIt + AuthorityChanges.Num();
+		ReceivedEntityChange* EntityChangesEnd = EntityIt + EntityChanges.Num();
+
+		// At the beginning of each loop each iterator should point to the first element for an entity.
+		// Each loop we want to work with a single entity ID.
+		// We check the entities each iterator is pointing to and pick the smallest one.
+		// If that is the sentinel ID then stop.
+		for (;;)
+		{
+			// Get the next entity ID. We want to pick the smallest entity referenced by the iterators.
+			// Convert to uint64 to ensure the sentinel value is larger than all valid IDs.
+			const uint64 MinEntityId = FMath::Min3(static_cast<uint64>(ComponentIt->EntityId),
+			                                       static_cast<uint64>(AuthorityIt->entity_id),
+			                                       static_cast<uint64>(EntityIt->EntityId));
+
+			// If no list has elements left to read then stop.
+			if (static_cast<Worker_EntityId>(MinEntityId) == SENTINEL_ENTITY_ID)
 			{
-				ComponentChange Update = CalculateUpdate(It, NextComponentIt, *Component);
-				if (Update.Type == ComponentChange::COMPLETE_UPDATE)
+				break;
+			}
+
+			const Worker_EntityId CurrentEntityId = static_cast<Worker_EntityId>(MinEntityId);
+
+			EntityDelta Delta = {};
+			Delta.EntityId = CurrentEntityId;
+
+			EntityViewElement* ViewElement = View.Find(CurrentEntityId);
+
+			if (EntityIt->EntityId == CurrentEntityId)
+			{
+				EntityIt = ProcessEntityExistenceChange(EntityIt, EntityChangesEnd, Delta, &ViewElement, View);
+				// If the entity isn't present we don't need to process component and authority changes.
+				if (ViewElement == nullptr)
 				{
-					ComponentsRefreshedForDelta.Emplace(Update);
+					ComponentIt = std::find_if(ComponentIt, ComponentChangesEnd, DifferentEntity{CurrentEntityId});
+					AuthorityIt = std::find_if(AuthorityIt, AuthorityChangesEnd, DifferentEntity{CurrentEntityId});
+
+					// Only add the entity delta if the entity previously existed in the view.
+					if (Delta.bRemoved)
+					{
+						EntityDeltas.Push(Delta);
+					}
+					continue;
+				}
+			}
+
+			if (ComponentIt->EntityId == CurrentEntityId)
+			{
+				ComponentIt = ProcessEntityComponentChanges(ComponentIt, ComponentChangesEnd, ViewElement->Components,
+				                                            Delta);
+			}
+
+			if (AuthorityIt->entity_id == CurrentEntityId)
+			{
+				AuthorityIt = ProcessEntityAuthorityChanges(AuthorityIt, AuthorityChangesEnd, ViewElement->Authority,
+				                                            Delta);
+			}
+
+			EntityDeltas.Push(Delta);
+		}
+	}
+
+	ViewDelta::ReceivedComponentChange* ViewDelta::ProcessEntityComponentChanges(
+		ReceivedComponentChange* It, ReceivedComponentChange* End,
+		TArray<ComponentData>& Components, EntityDelta& Delta)
+	{
+		int32 AddCount = 0;
+		int32 UpdateCount = 0;
+		int32 RemoveCount = 0;
+		int32 RefreshCount = 0;
+
+		const Worker_EntityId EntityId = It->EntityId;
+		// At the end of each loop `It` should point to the first element for an entity-component.
+		// Stop and return when the component is for a different entity.
+		// There will always be at least one iteration of the loop.
+		for (;;)
+		{
+			ReceivedComponentChange* NextComponentIt = std::find_if(
+				It, End, DifferentEntityComponent{EntityId, It->ComponentId});
+
+			ComponentData* Component = Components.FindByPredicate(ComponentIdEquality{It->ComponentId});
+			const bool bComponentExists = Component != nullptr;
+
+			// The element one before NextComponentIt must be the last element for this component.
+			switch ((NextComponentIt - 1)->Type)
+			{
+			case ReceivedComponentChange::ADD:
+				if (bComponentExists)
+				{
+					ComponentsRefreshedForDelta.Emplace(
+						CalculateCompleteUpdate(It, NextComponentIt, nullptr, nullptr, *Component));
 					++RefreshCount;
 				}
 				else
 				{
-					ComponentUpdatesForDelta.Emplace(Update);
-					++UpdateCount;
+					ComponentsAddedForDelta.Emplace(CalculateAdd(It, NextComponentIt, Components));
+					++AddCount;
+				}
+				break;
+			case ReceivedComponentChange::UPDATE:
+				if (bComponentExists)
+				{
+					ComponentChange Update = CalculateUpdate(It, NextComponentIt, *Component);
+					if (Update.Type == ComponentChange::COMPLETE_UPDATE)
+					{
+						ComponentsRefreshedForDelta.Emplace(Update);
+						++RefreshCount;
+					}
+					else
+					{
+						ComponentUpdatesForDelta.Emplace(Update);
+						++UpdateCount;
+					}
+				}
+				else
+				{
+					ComponentsAddedForDelta.Emplace(CalculateAdd(It, NextComponentIt, Components));
+					++AddCount;
+				}
+				break;
+			case ReceivedComponentChange::REMOVE:
+				if (bComponentExists)
+				{
+					ComponentsRemovedForDelta.Emplace(It->ComponentId);
+					Components.RemoveAtSwap(Component - Components.GetData());
+					++RemoveCount;
+				}
+				break;
+			}
+
+			if (NextComponentIt->EntityId != EntityId)
+			{
+				Delta.ComponentsAdded = {
+					ComponentsAddedForDelta.GetData() + ComponentsAddedForDelta.Num() - AddCount, AddCount
+				};
+				Delta.ComponentsRemoved = {
+					ComponentsRemovedForDelta.GetData() + ComponentsRemovedForDelta.Num() - RemoveCount, RemoveCount
+				};
+				Delta.ComponentUpdates = {
+					ComponentUpdatesForDelta.GetData() + ComponentUpdatesForDelta.Num() - UpdateCount, UpdateCount
+				};
+				Delta.ComponentsRefreshed = {
+					ComponentsRefreshedForDelta.GetData() + ComponentsRefreshedForDelta.Num() - RefreshCount,
+					RefreshCount
+				};
+				return NextComponentIt;
+			}
+
+			It = NextComponentIt;
+		}
+	}
+
+	Worker_AuthorityChangeOp* ViewDelta::ProcessEntityAuthorityChanges(Worker_AuthorityChangeOp* It,
+	                                                                   Worker_AuthorityChangeOp* End,
+	                                                                   TArray<Worker_ComponentId>& EntityAuthority,
+	                                                                   EntityDelta& Delta)
+	{
+		int32 GainCount = 0;
+		int32 LossCount = 0;
+		int32 LossTempCount = 0;
+
+		const Worker_EntityId EntityId = It->entity_id;
+		// After each loop the iterator points to the first op relating to the next entity-component.
+		// Stop and return when that component is for a different entity.
+		// There will always be at least one iteration of the loop.
+		for (;;)
+		{
+			// Find the last element for this entity-component.
+			const Worker_ComponentId ComponentId = It->component_id;
+			It = std::find_if(It, End, DifferentEntityComponent{EntityId, ComponentId}) - 1;
+			const int32 AuthorityIndex = EntityAuthority.Find(ComponentId);
+			const bool bHasAuthority = AuthorityIndex != INDEX_NONE;
+
+			if (It->authority == WORKER_AUTHORITY_AUTHORITATIVE)
+			{
+				if (bHasAuthority)
+				{
+					AuthorityLostTempForDelta.Emplace(ComponentId, AuthorityChange::AUTHORITY_LOST_TEMPORARILY);
+					++LossTempCount;
+				}
+				else
+				{
+					EntityAuthority.Push(ComponentId);
+					AuthorityGainedForDelta.Emplace(ComponentId, AuthorityChange::AUTHORITY_GAINED);
+					++GainCount;
 				}
 			}
-			else
+			else if (bHasAuthority)
 			{
-				ComponentsAddedForDelta.Emplace(CalculateAdd(It, NextComponentIt, Components));
-				++AddCount;
+				AuthorityLostForDelta.Emplace(ComponentId, AuthorityChange::AUTHORITY_LOST);
+				EntityAuthority.RemoveAtSwap(AuthorityIndex);
+				++LossCount;
 			}
-			break;
-		case ReceivedComponentChange::REMOVE:
-			if (bComponentExists)
+
+			// Move to the next entity-component.
+			++It;
+
+			if (It->entity_id != EntityId)
 			{
-				ComponentsRemovedForDelta.Emplace(It->ComponentId);
-				Components.RemoveAtSwap(Component - Components.GetData());
-				++RemoveCount;
+				Delta.AuthorityGained = {
+					AuthorityGainedForDelta.GetData() + AuthorityGainedForDelta.Num() - GainCount, GainCount
+				};
+				Delta.AuthorityLost = {
+					AuthorityLostForDelta.GetData() + AuthorityLostForDelta.Num() - LossCount, LossCount
+				};
+				Delta.AuthorityLostTemporarily = {
+					AuthorityLostTempForDelta.GetData() + AuthorityLostTempForDelta.Num() - LossTempCount,
+					LossTempCount
+				};
+				return It;
 			}
-			break;
-		}
-
-		if (NextComponentIt->EntityId != EntityId)
-		{
-			Delta.ComponentsAdded = { ComponentsAddedForDelta.GetData() + ComponentsAddedForDelta.Num() - AddCount, AddCount };
-			Delta.ComponentsRemoved = { ComponentsRemovedForDelta.GetData() + ComponentsRemovedForDelta.Num() - RemoveCount, RemoveCount };
-			Delta.ComponentUpdates = { ComponentUpdatesForDelta.GetData() + ComponentUpdatesForDelta.Num() - UpdateCount, UpdateCount };
-			Delta.ComponentsRefreshed = { ComponentsRefreshedForDelta.GetData() + ComponentsRefreshedForDelta.Num() - RefreshCount,
-										  RefreshCount };
-			return NextComponentIt;
-		}
-
-		It = NextComponentIt;
-	}
-}
-
-Worker_AuthorityChangeOp* ViewDelta::ProcessEntityAuthorityChanges(Worker_AuthorityChangeOp* It, Worker_AuthorityChangeOp* End,
-																   TArray<Worker_ComponentId>& EntityAuthority, EntityDelta& Delta)
-{
-	int32 GainCount = 0;
-	int32 LossCount = 0;
-	int32 LossTempCount = 0;
-
-	const Worker_EntityId EntityId = It->entity_id;
-	// After each loop the iterator points to the first op relating to the next entity-component.
-	// Stop and return when that component is for a different entity.
-	// There will always be at least one iteration of the loop.
-	for (;;)
-	{
-		// Find the last element for this entity-component.
-		const Worker_ComponentId ComponentId = It->component_id;
-		It = std::find_if(It, End, DifferentEntityComponent{ EntityId, ComponentId }) - 1;
-		const int32 AuthorityIndex = EntityAuthority.Find(ComponentId);
-		const bool bHasAuthority = AuthorityIndex != INDEX_NONE;
-
-		if (It->authority == WORKER_AUTHORITY_AUTHORITATIVE)
-		{
-			if (bHasAuthority)
-			{
-				AuthorityLostTempForDelta.Emplace(ComponentId, AuthorityChange::AUTHORITY_LOST_TEMPORARILY);
-				++LossTempCount;
-			}
-			else
-			{
-				EntityAuthority.Push(ComponentId);
-				AuthorityGainedForDelta.Emplace(ComponentId, AuthorityChange::AUTHORITY_GAINED);
-				++GainCount;
-			}
-		}
-		else if (bHasAuthority)
-		{
-			AuthorityLostForDelta.Emplace(ComponentId, AuthorityChange::AUTHORITY_LOST);
-			EntityAuthority.RemoveAtSwap(AuthorityIndex);
-			++LossCount;
-		}
-
-		// Move to the next entity-component.
-		++It;
-
-		if (It->entity_id != EntityId)
-		{
-			Delta.AuthorityGained = { AuthorityGainedForDelta.GetData() + AuthorityGainedForDelta.Num() - GainCount, GainCount };
-			Delta.AuthorityLost = { AuthorityLostForDelta.GetData() + AuthorityLostForDelta.Num() - LossCount, LossCount };
-			Delta.AuthorityLostTemporarily = { AuthorityLostTempForDelta.GetData() + AuthorityLostTempForDelta.Num() - LossTempCount,
-											   LossTempCount };
-			return It;
 		}
 	}
-}
 
-ViewDelta::ReceivedEntityChange* ViewDelta::ProcessEntityExistenceChange(ReceivedEntityChange* It, ReceivedEntityChange* End,
-																		 EntityDelta& Delta, EntityViewElement** ViewElement,
-																		 EntityView& View)
-{
-	// Find the last element relating to the same entity.
-	const Worker_EntityId EntityId = It->EntityId;
-	It = std::find_if(It, End, DifferentEntity{ EntityId }) - 1;
-
-	const bool bAlreadyInView = *ViewElement != nullptr;
-	const bool bEntityAdded = It->bAdded;
-
-	// If the entity's presence has not changed then return.
-	if (bEntityAdded == bAlreadyInView)
+	ViewDelta::ReceivedEntityChange* ViewDelta::ProcessEntityExistenceChange(
+		ReceivedEntityChange* It, ReceivedEntityChange* End,
+		EntityDelta& Delta, EntityViewElement** ViewElement,
+		EntityView& View)
 	{
+		// Find the last element relating to the same entity.
+		const Worker_EntityId EntityId = It->EntityId;
+		It = std::find_if(It, End, DifferentEntity{EntityId}) - 1;
+
+		const bool bAlreadyInView = *ViewElement != nullptr;
+		const bool bEntityAdded = It->bAdded;
+
+		// If the entity's presence has not changed then return.
+		if (bEntityAdded == bAlreadyInView)
+		{
+			return It + 1;
+		}
+
+		if (bEntityAdded)
+		{
+			Delta.bAdded = true;
+			*ViewElement = &View.Emplace(EntityId, EntityViewElement{});
+		}
+		else
+		{
+			Delta.bRemoved = true;
+
+			// Remove components.
+			const auto& Components = (*ViewElement)->Components;
+			for (const auto& Component : Components)
+			{
+				ComponentsRemovedForDelta.Emplace(Component.GetComponentId());
+			}
+			Delta.ComponentsRemoved = {
+				ComponentsRemovedForDelta.GetData() + ComponentsRemovedForDelta.Num() - Components.Num(),
+				Components.Num()
+			};
+
+			// Remove authority.
+			const auto& Authority = (*ViewElement)->Authority;
+			for (const auto& Id : Authority)
+			{
+				AuthorityLostForDelta.Emplace(Id, AuthorityChange::AUTHORITY_LOST);
+			}
+			Delta.AuthorityLost = {
+				AuthorityLostForDelta.GetData() + AuthorityLostForDelta.Num() - Authority.Num(), Authority.Num()
+			};
+
+			// Remove from view.
+			View.Remove(EntityId);
+			*ViewElement = nullptr;
+		}
+
 		return It + 1;
 	}
-
-	if (bEntityAdded)
-	{
-		Delta.bAdded = true;
-		*ViewElement = &View.Emplace(EntityId, EntityViewElement{});
-	}
-	else
-	{
-		Delta.bRemoved = true;
-
-		// Remove components.
-		const auto& Components = (*ViewElement)->Components;
-		for (const auto& Component : Components)
-		{
-			ComponentsRemovedForDelta.Emplace(Component.GetComponentId());
-		}
-		Delta.ComponentsRemoved = { ComponentsRemovedForDelta.GetData() + ComponentsRemovedForDelta.Num() - Components.Num(),
-									Components.Num() };
-
-		// Remove authority.
-		const auto& Authority = (*ViewElement)->Authority;
-		for (const auto& Id : Authority)
-		{
-			AuthorityLostForDelta.Emplace(Id, AuthorityChange::AUTHORITY_LOST);
-		}
-		Delta.AuthorityLost = { AuthorityLostForDelta.GetData() + AuthorityLostForDelta.Num() - Authority.Num(), Authority.Num() };
-
-		// Remove from view.
-		View.Remove(EntityId);
-		*ViewElement = nullptr;
-	}
-
-	return It + 1;
-}
-
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
@@ -27,9 +27,8 @@ void ViewDelta::SetFromOpList(TArray<OpList> OpLists, EntityView& View)
 }
 
 void ViewDelta::Project(SubViewDelta& SubDelta, const TArray<Worker_EntityId>& CompleteEntities,
-                        const TArray<Worker_EntityId>& NewlyCompleteEntities,
-                        const TArray<Worker_EntityId>& NewlyIncompleteEntities,
-                        const TArray<Worker_EntityId>& TemporarilyIncompleteEntities) const
+						const TArray<Worker_EntityId>& NewlyCompleteEntities, const TArray<Worker_EntityId>& NewlyIncompleteEntities,
+						const TArray<Worker_EntityId>& TemporarilyIncompleteEntities) const
 {
 	SubDelta.EntityDeltas.Empty();
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ExpectedViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ExpectedViewDelta.cpp
@@ -11,7 +11,7 @@ using namespace SpatialGDK;
 
 ExpectedViewDelta& ExpectedViewDelta::AddEntityDelta(const Worker_EntityId EntityId, const EntityChangeType ChangeType)
 {
-	EntityDeltas.Add(EntityId, { EntityId, ChangeType == ADD, ChangeType == REMOVE });
+	EntityDeltas.Add(EntityId, { EntityId, ChangeType == ADD ? ExpectedEntityDelta::ADD : ChangeType == REMOVE ? ExpectedEntityDelta::REMOVE : ExpectedEntityDelta::UPDATE});
 	return *this;
 }
 
@@ -104,14 +104,34 @@ bool ExpectedViewDelta::Compare(const ViewDelta& Other)
 			return false;
 		}
 
-		if (LhsEntityDelta.bAdded != RhsEntityDelta.bAdded)
+		switch (LhsEntityDelta.Type)
 		{
-			return false;
-		}
-
-		if (LhsEntityDelta.bRemoved != RhsEntityDelta.bRemoved)
-		{
-			return false;
+			case ExpectedEntityDelta::UPDATE:
+				if (!(RhsEntityDelta.Type == EntityDelta::UPDATE))
+				{
+					return false;
+				}
+				break;
+			case ExpectedEntityDelta::ADD:
+				if (!(RhsEntityDelta.Type == EntityDelta::ADD))
+				{
+					return false;
+				}
+				break;
+			case ExpectedEntityDelta::REMOVE:
+				if (!(RhsEntityDelta.Type == EntityDelta::REMOVE))
+				{
+					return false;
+				}
+				break;
+			case ExpectedEntityDelta::TEMPORARILY_REMOVED:
+				if (!(RhsEntityDelta.Type == EntityDelta::TEMPORARILY_REMOVED))
+				{
+					return false;
+				}
+				break;
+			default:
+				checkNoEntry();
 		}
 
 		if (!CompareData(LhsEntityDelta.AuthorityGained, RhsEntityDelta.AuthorityGained, CompareAuthorityChanges))

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ExpectedViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ExpectedViewDelta.cpp
@@ -11,7 +11,9 @@ using namespace SpatialGDK;
 
 ExpectedViewDelta& ExpectedViewDelta::AddEntityDelta(const Worker_EntityId EntityId, const EntityChangeType ChangeType)
 {
-	EntityDeltas.Add(EntityId, { EntityId, ChangeType == ADD ? ExpectedEntityDelta::ADD : ChangeType == REMOVE ? ExpectedEntityDelta::REMOVE : ExpectedEntityDelta::UPDATE});
+	EntityDeltas.Add(EntityId,
+					 { EntityId, ChangeType == ADD ? ExpectedEntityDelta::ADD
+												   : ChangeType == REMOVE ? ExpectedEntityDelta::REMOVE : ExpectedEntityDelta::UPDATE });
 	return *this;
 }
 
@@ -106,32 +108,32 @@ bool ExpectedViewDelta::Compare(const ViewDelta& Other)
 
 		switch (LhsEntityDelta.Type)
 		{
-			case ExpectedEntityDelta::UPDATE:
-				if (!(RhsEntityDelta.Type == EntityDelta::UPDATE))
-				{
-					return false;
-				}
-				break;
-			case ExpectedEntityDelta::ADD:
-				if (!(RhsEntityDelta.Type == EntityDelta::ADD))
-				{
-					return false;
-				}
-				break;
-			case ExpectedEntityDelta::REMOVE:
-				if (!(RhsEntityDelta.Type == EntityDelta::REMOVE))
-				{
-					return false;
-				}
-				break;
-			case ExpectedEntityDelta::TEMPORARILY_REMOVED:
-				if (!(RhsEntityDelta.Type == EntityDelta::TEMPORARILY_REMOVED))
-				{
-					return false;
-				}
-				break;
-			default:
-				checkNoEntry();
+		case ExpectedEntityDelta::UPDATE:
+			if (!(RhsEntityDelta.Type == EntityDelta::UPDATE))
+			{
+				return false;
+			}
+			break;
+		case ExpectedEntityDelta::ADD:
+			if (!(RhsEntityDelta.Type == EntityDelta::ADD))
+			{
+				return false;
+			}
+			break;
+		case ExpectedEntityDelta::REMOVE:
+			if (!(RhsEntityDelta.Type == EntityDelta::REMOVE))
+			{
+				return false;
+			}
+			break;
+		case ExpectedEntityDelta::TEMPORARILY_REMOVED:
+			if (!(RhsEntityDelta.Type == EntityDelta::TEMPORARILY_REMOVED))
+			{
+				return false;
+			}
+			break;
+		default:
+			checkNoEntry();
 		}
 
 		if (!CompareData(LhsEntityDelta.AuthorityGained, RhsEntityDelta.AuthorityGained, CompareAuthorityChanges))

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/EntityDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/EntityDelta.h
@@ -110,8 +110,13 @@ private:
 struct EntityDelta
 {
 	Worker_EntityId EntityId;
-	bool bAdded;
-	bool bRemoved;
+	enum
+	{
+		UPDATE,
+		ADD,
+		REMOVE,
+		TEMPORARILY_REMOVED
+	} Type;
 	ComponentSpan<ComponentChange> ComponentsAdded;
 	ComponentSpan<ComponentChange> ComponentsRemoved;
 	ComponentSpan<ComponentChange> ComponentUpdates;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -26,7 +26,7 @@ public:
 	void RefreshEntity(const Worker_EntityId EntityId);
 
 private:
-	void RegisterTagCallbacks(const EntityView& View, FDispatcher& Dispatcher);
+	void RegisterTagCallbacks(FDispatcher& Dispatcher);
 	void RegisterRefreshCallbacks(const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks);
 	void OnTaggedEntityAdded(const Worker_EntityId EntityId);
 	void OnTaggedEntityRemoved(const Worker_EntityId EntityId);

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -44,7 +44,7 @@ private:
 	TArray<Worker_EntityId> CompleteEntities;
 	TArray<Worker_EntityId> NewlyCompleteEntities;
 	TArray<Worker_EntityId> NewlyIncompleteEntities;
-	// TODO: TempIncompleteEntities
+	TArray<Worker_EntityId> TemporarilyIncompleteEntities;
 };
 
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -15,8 +15,8 @@ namespace SpatialGDK
 class SubView
 {
 public:
-	SubView(const Worker_ComponentId TagComponentId, const FFilterPredicate Filter,
-			const EntityView& View, FDispatcher& Dispatcher, const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks);
+	SubView(const Worker_ComponentId TagComponentId, const FFilterPredicate Filter, const EntityView& View, FDispatcher& Dispatcher,
+			const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks);
 
 	void TagQuery(Query& QueryToTag) const;
 	void TagEntity(TArray<FWorkerComponentData>& Components) const;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -8,36 +8,34 @@
 
 namespace SpatialGDK
 {
-	class SubView
-	{
-	public:
-		SubView(const Worker_ComponentId TagComponentId,
-			const TFunction<bool(const Worker_EntityId, const EntityViewElement&)> Filter,
-			const EntityView& View,
-			FDispatcher& Dispatcher);
+class SubView
+{
+public:
+	SubView(const Worker_ComponentId TagComponentId, const TFunction<bool(const Worker_EntityId, const EntityViewElement&)> Filter,
+			const EntityView& View, FDispatcher& Dispatcher);
 
-		void TagQuery(Query& QueryToTag) const;
-		void TagEntity(TArray<FWorkerComponentData>& Components) const;
+	void TagQuery(Query& QueryToTag) const;
+	void TagEntity(TArray<FWorkerComponentData>& Components) const;
 
-		void AdvanceViewDelta(const ViewDelta& Delta);
-		const ViewDelta& GetViewDelta() const;
-		void RefreshEntity(const Worker_EntityId EntityId);
+	void AdvanceViewDelta(const ViewDelta& Delta);
+	const ViewDelta& GetViewDelta() const;
+	void RefreshEntity(const Worker_EntityId EntityId);
 
-	private:
-		void OnTaggedEntityAdded(const Worker_EntityId EntityId);
-		void OnTaggedEntityRemoved(const Worker_EntityId EntityId);
-		void CheckEntityAgainstFilter(const Worker_EntityId EntityId);
+private:
+	void OnTaggedEntityAdded(const Worker_EntityId EntityId);
+	void OnTaggedEntityRemoved(const Worker_EntityId EntityId);
+	void CheckEntityAgainstFilter(const Worker_EntityId EntityId);
 
-		const Worker_ComponentId TagComponentId;
-		const TFunction<bool(const Worker_EntityId, const EntityViewElement&)> Filter;
-		const EntityView& View;
+	const Worker_ComponentId TagComponentId;
+	const TFunction<bool(const Worker_EntityId, const EntityViewElement&)> Filter;
+	const EntityView& View;
 
-		ViewDelta SubDelta;
+	ViewDelta SubDelta;
 
-		TSet<Worker_EntityId> TaggedEntities;
-		TSet<Worker_EntityId> CompleteEntities;
-		TSet<Worker_EntityId> NewlyCompleteEntities;
-		TSet<Worker_EntityId> NewlyIncompleteEntities;
-	};
+	TSet<Worker_EntityId> TaggedEntities;
+	TSet<Worker_EntityId> CompleteEntities;
+	TSet<Worker_EntityId> NewlyCompleteEntities;
+	TSet<Worker_EntityId> NewlyIncompleteEntities;
+};
 
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -17,6 +17,11 @@ namespace SpatialGDK
 class SubView
 {
 public:
+	// The subview constructor takes the filter and the dispatcher refresh callbacks for the subview, rather than
+	// adding them to the subview later. This is to maintain the invariant that a subview always has the correct
+	// full set of complete entities. During construction, it calculates the initial set of complete entities,
+	// and registers the passed dispatcher callbacks in order to ensure all possible changes which could change
+	// the state of completeness for any entity are picked up by the subview to maintain this invariant.
 	SubView(const Worker_ComponentId TagComponentId, const FFilterPredicate Filter, const EntityView& View, FDispatcher& Dispatcher,
 			const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks);
 
@@ -27,6 +32,9 @@ public:
 	const ViewDelta& GetViewDelta() const;
 	void RefreshEntity(const Worker_EntityId EntityId);
 
+	// Helper functions for creating dispatcher refresh callbacks for use when constructing a subview.
+	// Takes an optional predicate argument to further filter what causes a refresh. Example: Only trigger
+	// a refresh if the received component change has a change for a certain field.
 	static FDispatcherRefreshCallback CreateComponentExistenceDispatcherRefreshCallback(FDispatcher& Dispatcher,
 																						Worker_ComponentId ComponentId,
 																						FComponentChangeRefreshPredicate RefreshPredicate);

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -6,9 +6,11 @@
 #include "Schema/Interest.h"
 #include "Templates/Function.h"
 
-typedef TFunction<bool(const Worker_EntityId, const SpatialGDK::EntityViewElement&)> FFilterPredicate;
-typedef TFunction<void(const Worker_EntityId)> FRefreshCallback;
-typedef TFunction<void(const FRefreshCallback)> FDispatcherRefreshCallback;
+using FFilterPredicate = TFunction<bool(const Worker_EntityId, const SpatialGDK::EntityViewElement&)>;
+using FRefreshCallback = TFunction<void(const Worker_EntityId)>;
+using FDispatcherRefreshCallback = TFunction<void(const FRefreshCallback)>;
+using FComponentChangeRefreshPredicate = TFunction<bool(SpatialGDK::FEntityComponentChange)>;
+using FAuthorityChangeRefreshPredicate = TFunction<bool(Worker_EntityId)>;
 
 namespace SpatialGDK
 {
@@ -21,9 +23,13 @@ public:
 	void TagQuery(Query& QueryToTag) const;
 	void TagEntity(TArray<FWorkerComponentData>& Components) const;
 
-	void AdvanceViewDelta(const ViewDelta& Delta);
+	void Advance(const ViewDelta& Delta);
 	const ViewDelta& GetViewDelta() const;
 	void RefreshEntity(const Worker_EntityId EntityId);
+
+	static FDispatcherRefreshCallback CreateComponentExistenceDispatcherRefreshCallback(FDispatcher& Dispatcher, Worker_ComponentId ComponentId, FComponentChangeRefreshPredicate RefreshPredicate);
+	static FDispatcherRefreshCallback CreateComponentChangedDispatcherRefreshCallback(FDispatcher& Dispatcher, Worker_ComponentId ComponentId, FComponentChangeRefreshPredicate RefreshPredicate);
+	static FDispatcherRefreshCallback CreateAuthorityChangeDispatcherRefreshCallback(FDispatcher& Dispatcher, Worker_ComponentId ComponentId, FAuthorityChangeRefreshPredicate RefreshPredicate);
 
 private:
 	void RegisterTagCallbacks(FDispatcher& Dispatcher);

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -6,13 +6,17 @@
 #include "Schema/Interest.h"
 #include "Templates/Function.h"
 
+typedef TFunction<bool(const Worker_EntityId, const SpatialGDK::EntityViewElement&)> FFilterPredicate;
+typedef TFunction<void(const Worker_EntityId)> FRefreshCallback;
+typedef TFunction<void(const FRefreshCallback)> FDispatcherRefreshCallback;
+
 namespace SpatialGDK
 {
 class SubView
 {
 public:
-	SubView(const Worker_ComponentId TagComponentId, const TFunction<bool(const Worker_EntityId, const EntityViewElement&)> Filter,
-			const EntityView& View, FDispatcher& Dispatcher);
+	SubView(const Worker_ComponentId TagComponentId, const FFilterPredicate Filter,
+			const EntityView& View, FDispatcher& Dispatcher, const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks);
 
 	void TagQuery(Query& QueryToTag) const;
 	void TagEntity(TArray<FWorkerComponentData>& Components) const;
@@ -22,20 +26,25 @@ public:
 	void RefreshEntity(const Worker_EntityId EntityId);
 
 private:
+	void RegisterTagCallbacks(const EntityView& View, FDispatcher& Dispatcher);
+	void RegisterRefreshCallbacks(const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks);
 	void OnTaggedEntityAdded(const Worker_EntityId EntityId);
 	void OnTaggedEntityRemoved(const Worker_EntityId EntityId);
 	void CheckEntityAgainstFilter(const Worker_EntityId EntityId);
+	void EntityComplete(const Worker_EntityId EntityId);
+	void EntityIncomplete(const Worker_EntityId EntityId);
 
 	const Worker_ComponentId TagComponentId;
-	const TFunction<bool(const Worker_EntityId, const EntityViewElement&)> Filter;
+	const FFilterPredicate Filter;
 	const EntityView& View;
 
 	ViewDelta SubDelta;
 
-	TSet<Worker_EntityId> TaggedEntities;
-	TSet<Worker_EntityId> CompleteEntities;
-	TSet<Worker_EntityId> NewlyCompleteEntities;
-	TSet<Worker_EntityId> NewlyIncompleteEntities;
+	TArray<Worker_EntityId> TaggedEntities;
+	TArray<Worker_EntityId> CompleteEntities;
+	TArray<Worker_EntityId> NewlyCompleteEntities;
+	TArray<Worker_EntityId> NewlyIncompleteEntities;
+	// TODO: TempIncompleteEntities
 };
 
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -29,7 +29,7 @@ public:
 	void TagEntity(TArray<FWorkerComponentData>& Components) const;
 
 	void Advance(const ViewDelta& Delta);
-	const ViewDelta& GetViewDelta() const;
+	const SubViewDelta& GetViewDelta() const;
 	void RefreshEntity(const Worker_EntityId EntityId);
 
 	// Helper functions for creating dispatcher refresh callbacks for use when constructing a subview.
@@ -58,7 +58,7 @@ private:
 	const FFilterPredicate Filter;
 	const EntityView& View;
 
-	ViewDelta SubDelta;
+	SubViewDelta SubDelta;
 
 	TArray<Worker_EntityId> TaggedEntities;
 	TArray<Worker_EntityId> CompleteEntities;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -27,9 +27,15 @@ public:
 	const ViewDelta& GetViewDelta() const;
 	void RefreshEntity(const Worker_EntityId EntityId);
 
-	static FDispatcherRefreshCallback CreateComponentExistenceDispatcherRefreshCallback(FDispatcher& Dispatcher, Worker_ComponentId ComponentId, FComponentChangeRefreshPredicate RefreshPredicate);
-	static FDispatcherRefreshCallback CreateComponentChangedDispatcherRefreshCallback(FDispatcher& Dispatcher, Worker_ComponentId ComponentId, FComponentChangeRefreshPredicate RefreshPredicate);
-	static FDispatcherRefreshCallback CreateAuthorityChangeDispatcherRefreshCallback(FDispatcher& Dispatcher, Worker_ComponentId ComponentId, FAuthorityChangeRefreshPredicate RefreshPredicate);
+	static FDispatcherRefreshCallback CreateComponentExistenceDispatcherRefreshCallback(FDispatcher& Dispatcher,
+																						Worker_ComponentId ComponentId,
+																						FComponentChangeRefreshPredicate RefreshPredicate);
+	static FDispatcherRefreshCallback CreateComponentChangedDispatcherRefreshCallback(FDispatcher& Dispatcher,
+																					  Worker_ComponentId ComponentId,
+																					  FComponentChangeRefreshPredicate RefreshPredicate);
+	static FDispatcherRefreshCallback CreateAuthorityChangeDispatcherRefreshCallback(FDispatcher& Dispatcher,
+																					 Worker_ComponentId ComponentId,
+																					 FAuthorityChangeRefreshPredicate RefreshPredicate);
 
 private:
 	void RegisterTagCallbacks(FDispatcher& Dispatcher);

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+#include "Dispatcher.h"
+#include "EntityView.h"
+#include "Schema/Interest.h"
+#include "Templates/Function.h"
+
+namespace SpatialGDK
+{
+	class SubView
+	{
+	public:
+		SubView(const Worker_ComponentId TagComponentId,
+			const TFunction<bool(const Worker_EntityId, const EntityViewElement&)> Filter,
+			const EntityView& View,
+			FDispatcher& Dispatcher);
+
+		void TagQuery(Query& QueryToTag) const;
+		void TagEntity(TArray<FWorkerComponentData>& Components) const;
+
+		void AdvanceViewDelta(const ViewDelta& Delta);
+		const ViewDelta& GetViewDelta() const;
+		void RefreshEntity(const Worker_EntityId EntityId);
+
+	private:
+		void OnTaggedEntityAdded(const Worker_EntityId EntityId);
+		void OnTaggedEntityRemoved(const Worker_EntityId EntityId);
+		void CheckEntityAgainstFilter(const Worker_EntityId EntityId);
+
+		const Worker_ComponentId TagComponentId;
+		const TFunction<bool(const Worker_EntityId, const EntityViewElement&)> Filter;
+		const EntityView& View;
+
+		ViewDelta SubDelta;
+
+		TSet<Worker_EntityId> TaggedEntities;
+		TSet<Worker_EntityId> CompleteEntities;
+		TSet<Worker_EntityId> NewlyCompleteEntities;
+		TSet<Worker_EntityId> NewlyIncompleteEntities;
+	};
+
+} // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewCoordinator.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewCoordinator.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "SubView.h"
 #include "SpatialView/ConnectionHandler/AbstractConnectionHandler.h"
 #include "SpatialView/Dispatcher.h"
 #include "SpatialView/WorkerView.h"
@@ -23,9 +24,13 @@ public:
 	ViewCoordinator& operator=(ViewCoordinator&&) = delete;
 
 	void Advance();
-	const ViewDelta& GetViewDelta();
-	const EntityView& GetView();
+	const ViewDelta& GetViewDelta() const;
+	const EntityView& GetView() const;
 	void FlushMessagesToSend();
+
+	SubView& CreateSubView(const Worker_ComponentId Tag, FFilterPredicate Filter, TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks);
+	SubView& CreateUnfilteredSubView(const Worker_ComponentId Tag);
+	void RefreshEntityCompleteness(const Worker_EntityId EntityId);
 
 	const FString& GetWorkerId() const;
 	const TArray<FString>& GetWorkerAttributes() const;
@@ -57,6 +62,7 @@ private:
 	TUniquePtr<AbstractConnectionHandler> ConnectionHandler;
 	Worker_RequestId NextRequestId;
 	FDispatcher Dispatcher;
+	TArray<SubView> SubViews;
 };
 
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewCoordinator.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewCoordinator.h
@@ -28,9 +28,15 @@ public:
 	const EntityView& GetView() const;
 	void FlushMessagesToSend();
 
+	// Create a subview with the specified tag, filter, and refresh callbacks.
 	SubView& CreateSubView(const Worker_ComponentId Tag, FFilterPredicate Filter,
 						   TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks);
+	// Create a subview with no filter. This also means no refresh callbacks, as no change from spatial could cause
+	// the subview's filter to change its truth value.
 	SubView& CreateUnfilteredSubView(const Worker_ComponentId Tag);
+	// Force a refresh of the given entity ID across all subviews. Used when local state changes which could
+	// change any subview's filter's truth value for the given entity. Conceptually this can be thought of
+	// as marking the entity dirty for all subviews, although the refresh is immediate.
 	void RefreshEntityCompleteness(const Worker_EntityId EntityId);
 
 	const FString& GetWorkerId() const;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewCoordinator.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewCoordinator.h
@@ -2,10 +2,10 @@
 
 #pragma once
 
-#include "SubView.h"
 #include "SpatialView/ConnectionHandler/AbstractConnectionHandler.h"
 #include "SpatialView/Dispatcher.h"
 #include "SpatialView/WorkerView.h"
+#include "SubView.h"
 #include "Templates/UniquePtr.h"
 
 namespace SpatialGDK
@@ -28,7 +28,8 @@ public:
 	const EntityView& GetView() const;
 	void FlushMessagesToSend();
 
-	SubView& CreateSubView(const Worker_ComponentId Tag, FFilterPredicate Filter, TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks);
+	SubView& CreateSubView(const Worker_ComponentId Tag, FFilterPredicate Filter,
+						   TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks);
 	SubView& CreateUnfilteredSubView(const Worker_ComponentId Tag);
 	void RefreshEntityCompleteness(const Worker_EntityId EntityId);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
@@ -33,7 +33,8 @@ public:
 	void SetFromOpList(TArray<OpList> OpLists, EntityView& View);
 	// Entity ID arrays are assumed to be sorted for view delta projection.
 	void Project(const ViewDelta& Delta, const TArray<Worker_EntityId>& CompleteEntities,
-				 const TArray<Worker_EntityId>& NewlyCompleteEntities, const TArray<Worker_EntityId>& NewlyIncompleteEntities, const TArray<Worker_EntityId>& TemporarilyIncompleteEntities);
+				 const TArray<Worker_EntityId>& NewlyCompleteEntities, const TArray<Worker_EntityId>& NewlyIncompleteEntities,
+				 const TArray<Worker_EntityId>& TemporarilyIncompleteEntities);
 	void Clear();
 
 	const TArray<EntityDelta>& GetEntityDeltas() const;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
@@ -33,7 +33,7 @@ public:
 	void SetFromOpList(TArray<OpList> OpLists, EntityView& View);
 	// Entity ID arrays are assumed to be sorted for view delta projection.
 	void Project(const ViewDelta& Delta, const TArray<Worker_EntityId>& CompleteEntities,
-				 const TArray<Worker_EntityId>& NewlyCompleteEntities, const TArray<Worker_EntityId>& NewlyIncompleteEntities);
+				 const TArray<Worker_EntityId>& NewlyCompleteEntities, const TArray<Worker_EntityId>& NewlyIncompleteEntities, const TArray<Worker_EntityId>& TemporarilyIncompleteEntities);
 	void Clear();
 
 	const TArray<EntityDelta>& GetEntityDeltas() const;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
@@ -155,11 +155,6 @@ private:
 	ReceivedEntityChange* ProcessEntityExistenceChange(ReceivedEntityChange* It, ReceivedEntityChange* End, EntityDelta& Delta,
 													   EntityViewElement** ViewElement, EntityView& View);
 
-	// The sentinel entity ID has the property that when converted to a uint64 it will be greater than INT64_MAX.
-	// If we convert all entity IDs to uint64s before comparing them we can then be assured that the sentinel values
-	// will be greater than all valid IDs.
-	static const Worker_EntityId SENTINEL_ENTITY_ID = -1;
-
 	TArray<ReceivedEntityChange> EntityChanges;
 	TArray<ReceivedComponentChange> ComponentChanges;
 	TArray<Worker_AuthorityChangeOp> AuthorityChanges;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
@@ -33,7 +33,7 @@ public:
 	void SetFromOpList(TArray<OpList> OpLists, EntityView& View);
 	// Entity ID arrays are assumed to be sorted for view delta projection.
 	void Project(const ViewDelta& Delta, const TArray<Worker_EntityId>& CompleteEntities,
-		const TArray<Worker_EntityId>& NewlyCompleteEntities, const TArray<Worker_EntityId>& NewlyIncompleteEntities);
+				 const TArray<Worker_EntityId>& NewlyCompleteEntities, const TArray<Worker_EntityId>& NewlyIncompleteEntities);
 	void Clear();
 
 	const TArray<EntityDelta>& GetEntityDeltas() const;
@@ -77,9 +77,9 @@ private:
 		enum
 		{
 			COMPLETE,
-            NEWLY_COMPLETE,
-            NEWLY_INCOMPLETE
-        } Type;
+			NEWLY_COMPLETE,
+			NEWLY_INCOMPLETE
+		} Type;
 	};
 
 	// Comparator that will return true when the entity change in question is not for the same entity ID as stored.

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
@@ -41,9 +41,8 @@ public:
 	// the projection. The given arrays represent the state of the sub view and dictates the projection.
 	// Entity ID arrays are assumed to be sorted for view delta projection.
 	void Project(SubViewDelta& SubDelta, const TArray<Worker_EntityId>& CompleteEntities,
-	             const TArray<Worker_EntityId>& NewlyCompleteEntities,
-	             const TArray<Worker_EntityId>& NewlyIncompleteEntities,
-	             const TArray<Worker_EntityId>& TemporarilyIncompleteEntities) const;
+				 const TArray<Worker_EntityId>& NewlyCompleteEntities, const TArray<Worker_EntityId>& NewlyIncompleteEntities,
+				 const TArray<Worker_EntityId>& TemporarilyIncompleteEntities) const;
 	void Clear();
 
 	const TArray<EntityDelta>& GetEntityDeltas() const;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
@@ -10,6 +10,12 @@
 
 namespace SpatialGDK
 {
+struct SubViewDelta
+{
+	TArray<EntityDelta> EntityDeltas;
+	const TArray<Worker_Op>* WorkerMessages;
+};
+
 /**
  * Lists of changes made to a view as a list of EntityDeltas and miscellaneous other messages.
  * EntityDeltas are sorted by entity ID.
@@ -31,14 +37,13 @@ class ViewDelta
 {
 public:
 	void SetFromOpList(TArray<OpList> OpLists, EntityView& View);
-	// Produces a projection of a given main view delta to a view delta for another view. The given arrays represent the
-	// state of the new view and dictates the projection.
-	// Note: This method is designed for projecting the main worker view delta to a subview delta. It may work for other
-	// cases, but there are no guarantees.
+	// Produces a projection of a given main view delta to a sub view delta. The passed SubViewDelta is populated with
+	// the projection. The given arrays represent the state of the sub view and dictates the projection.
 	// Entity ID arrays are assumed to be sorted for view delta projection.
-	void Project(const ViewDelta& Delta, const TArray<Worker_EntityId>& CompleteEntities,
-				 const TArray<Worker_EntityId>& NewlyCompleteEntities, const TArray<Worker_EntityId>& NewlyIncompleteEntities,
-				 const TArray<Worker_EntityId>& TemporarilyIncompleteEntities);
+	void Project(SubViewDelta& SubDelta, const TArray<Worker_EntityId>& CompleteEntities,
+	             const TArray<Worker_EntityId>& NewlyCompleteEntities,
+	             const TArray<Worker_EntityId>& NewlyIncompleteEntities,
+	             const TArray<Worker_EntityId>& TemporarilyIncompleteEntities) const;
 	void Clear();
 
 	const TArray<EntityDelta>& GetEntityDeltas() const;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
@@ -31,6 +31,10 @@ class ViewDelta
 {
 public:
 	void SetFromOpList(TArray<OpList> OpLists, EntityView& View);
+	// Produces a projection of a given main view delta to a view delta for another view. The given arrays represent the
+	// state of the new view and dictates the projection.
+	// Note: This method is designed for projecting the main worker view delta to a subview delta. It may work for other
+	// cases, but there are no guarantees.
 	// Entity ID arrays are assumed to be sorted for view delta projection.
 	void Project(const ViewDelta& Delta, const TArray<Worker_EntityId>& CompleteEntities,
 				 const TArray<Worker_EntityId>& NewlyCompleteEntities, const TArray<Worker_EntityId>& NewlyIncompleteEntities,

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
@@ -101,7 +101,6 @@ private:
 	struct EntityComparison
 	{
 		bool operator()(const ReceivedEntityChange& Lhs, const ReceivedEntityChange& Rhs) const;
-		bool operator()(const EntityProjection& Lhs, const EntityProjection& Rhs) const;
 	};
 
 	// Calculate and return the net component added in [`Start`, `End`).

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
@@ -71,17 +71,6 @@ private:
 		bool bAdded;
 	};
 
-	struct EntityProjection
-	{
-		Worker_EntityId EntityId;
-		enum
-		{
-			COMPLETE,
-			NEWLY_COMPLETE,
-			NEWLY_INCOMPLETE
-		} Type;
-	};
-
 	// Comparator that will return true when the entity change in question is not for the same entity ID as stored.
 	struct DifferentEntity
 	{

--- a/SpatialGDK/Source/SpatialGDK/Public/Tests/SpatialView/ExpectedEntityDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Tests/SpatialView/ExpectedEntityDelta.h
@@ -9,8 +9,13 @@ namespace SpatialGDK
 struct ExpectedEntityDelta
 {
 	Worker_EntityId EntityId;
-	bool bAdded;
-	bool bRemoved;
+	enum
+	{
+		UPDATE,
+        ADD,
+        REMOVE,
+        TEMPORARILY_REMOVED
+    } Type;
 	TArray<ComponentData> DataStorage;
 	TArray<ComponentUpdate> UpdateStorage;
 	TArray<ComponentChange> ComponentsAdded;

--- a/SpatialGDK/Source/SpatialGDK/Public/Tests/SpatialView/ExpectedEntityDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Tests/SpatialView/ExpectedEntityDelta.h
@@ -12,10 +12,10 @@ struct ExpectedEntityDelta
 	enum
 	{
 		UPDATE,
-        ADD,
-        REMOVE,
-        TEMPORARILY_REMOVED
-    } Type;
+		ADD,
+		REMOVE,
+		TEMPORARILY_REMOVED
+	} Type;
 	TArray<ComponentData> DataStorage;
 	TArray<ComponentUpdate> UpdateStorage;
 	TArray<ComponentChange> ComponentsAdded;


### PR DESCRIPTION
#### Description
Implementation of subview API. Includes:

- tagging entities and queries 
- usage of query tags for discerning which entities belong to which systems
- the filter API for the stage after tagged entities have been passed to a subview
- an API for indicating when filter refreshes have to occur:
    - on certain dispatcher callbacks - a static API for creating dispatcher refresh callbacks is introduced in the subview
    - due to local state changes - a method to force a refresh all subview filters is introduced in the view coordinator
- creating subviews in the view coordinator - also owns and maintains the subviews
- view delta projection from the main view delta to subview deltas, according to the state of the subview, called whenever the view coordinator advances

The way to register dispatcher callbacks for refreshing filter completeness on each subview is a little strange. The reasoning was that the subview must have enough information to become complete at the point of construction. So the user is expected to ask for a dispatcher refresh callback in advance, which they pass a predicate to indicating whether the change should trigger a refresh callback. The dispatcher refresh callback is then passed for subview construction. 
Overall this means: As part of subview construction the subview passes its own refresh entity method to the given dispatcher refresh callback which registers a callback to the dispatcher for the given change type, and if it passes the user defined predicate, would trigger a refresh for that entity within that subview.

tests are todo