### PR TITLE
Feature/unr 4197 subview api

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/Dispatcher.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/Dispatcher.cpp
@@ -200,9 +200,9 @@ void FDispatcher::HandleComponentPresenceChanges(Worker_EntityId EntityId, const
 			const FEntityComponentChange EntityComponentChange = { EntityId, *ChangeIt };
 			(CallbackIt->*Callbacks).Invoke(EntityComponentChange);
 			CallbackIt->ComponentValueCallbacks.Invoke(EntityComponentChange);
+			++ChangeIt;
+			++CallbackIt;
 		}
-		++ChangeIt;
-		++CallbackIt;
 	}
 }
 
@@ -229,9 +229,9 @@ void FDispatcher::HandleComponentValueChanges(Worker_EntityId EntityId, const Co
 		{
 			const FEntityComponentChange EntityComponentChange = { EntityId, *ChangeIt };
 			CallbackIt->ComponentValueCallbacks.Invoke(EntityComponentChange);
+			++ChangeIt;
+			++CallbackIt;
 		}
-		++ChangeIt;
-		++CallbackIt;
 	}
 }
 
@@ -258,9 +258,9 @@ void FDispatcher::HandleAuthorityChange(Worker_EntityId EntityId, const Componen
 		else
 		{
 			(CallbackIt->*Callbacks).Invoke(EntityId);
+			++ChangeIt;
+			++CallbackIt;
 		}
-		++ChangeIt;
-		++CallbackIt;
 	}
 }
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/OpList/ViewDeltaLegacyOpList.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/OpList/ViewDeltaLegacyOpList.cpp
@@ -26,7 +26,7 @@ TArray<Worker_Op> GetOpsFromEntityDeltas(const TArray<EntityDelta>& Deltas)
 		StartCriticalSection.op.critical_section.in_critical_section = 1;
 		Ops.Add(StartCriticalSection);
 
-		if (Entity.bAdded)
+		if (Entity.Type == EntityDelta::ADD)
 		{
 			Worker_Op Op = {};
 			Op.op_type = WORKER_OP_TYPE_ADD_ENTITY;
@@ -111,7 +111,7 @@ TArray<Worker_Op> GetOpsFromEntityDeltas(const TArray<EntityDelta>& Deltas)
 			Ops.Push(Op);
 		}
 
-		if (Entity.bRemoved)
+		if (Entity.Type == EntityDelta::REMOVE)
 		{
 			Worker_Op Op = {};
 			Op.op_type = WORKER_OP_TYPE_REMOVE_ENTITY;

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "SpatialView/SubView.h"
+
+#include "Utils/ComponentFactory.h"
+
+namespace SpatialGDK
+{
+SubView::SubView(const Worker_ComponentId TagComponentId,
+	const TFunction<bool(const Worker_EntityId, const EntityViewElement&)> Filter,
+	const EntityView& View,
+	FDispatcher& Dispatcher)
+	: TagComponentId(TagComponentId), Filter(Filter), View(View),
+	TaggedEntities(TSet<Worker_EntityId>{}),
+	CompleteEntities(TSet<Worker_EntityId>{}),
+    NewlyCompleteEntities(TSet<Worker_EntityId>{}),
+    NewlyIncompleteEntities(TSet<Worker_EntityId>{})
+{
+	Dispatcher.RegisterAndInvokeComponentAddedCallback(TagComponentId, [this](const FEntityComponentChange Change)
+	{
+		OnTaggedEntityAdded(Change.EntityId);
+	}, View);
+	Dispatcher.RegisterComponentRemovedCallback(TagComponentId, [this](const FEntityComponentChange Change)
+	{
+		OnTaggedEntityRemoved(Change.EntityId);
+	});
+}
+
+void SubView::TagQuery(Query& QueryToTag) const
+{
+	QueryConstraint TagConstraint;
+	TagConstraint.ComponentConstraint = TagComponentId;
+
+	QueryConstraint NewConstraint;
+	NewConstraint.AndConstraint.Add(QueryToTag.Constraint);
+	NewConstraint.AndConstraint.Add(TagConstraint);
+
+	QueryToTag.Constraint = NewConstraint;
+	QueryToTag.ResultComponentIds.Add(TagComponentId);
+}
+
+void SubView::TagEntity(TArray<FWorkerComponentData>& Components) const
+{
+	Components.Add(ComponentFactory::CreateEmptyComponentData(TagComponentId));
+}
+
+void SubView::AdvanceViewDelta(const ViewDelta& Delta)
+{
+	// TODO: Filtering given delta by complete entities and add/removes for newly complete and incomplete entities
+	// respectively. Probably requires new view delta functionality to build from worker messages and entity deltas.
+}
+
+const ViewDelta& SubView::GetViewDelta() const
+{
+	return SubDelta;
+}
+
+void SubView::RefreshEntity(const Worker_EntityId EntityId)
+{
+	if (TaggedEntities.Contains(EntityId))
+	{
+		CheckEntityAgainstFilter(EntityId);
+	}
+}
+
+void SubView::OnTaggedEntityAdded(const Worker_EntityId EntityId)
+{
+	TaggedEntities.Add(EntityId);
+	CheckEntityAgainstFilter(EntityId);
+}
+
+void SubView::OnTaggedEntityRemoved(const Worker_EntityId EntityId)
+{
+	TaggedEntities.Remove(EntityId);
+	CompleteEntities.Remove(EntityId);
+}
+
+void SubView::CheckEntityAgainstFilter(const Worker_EntityId EntityId)
+{
+	if (Filter(EntityId, View[EntityId]))
+	{
+		bool* AlreadyInSet = nullptr;
+		CompleteEntities.Add(EntityId, AlreadyInSet);
+		if (!AlreadyInSet)
+		{
+			NewlyCompleteEntities.Add(EntityId);
+		}
+		return;
+	}
+	if (CompleteEntities.Contains(EntityId))
+	{
+		NewlyIncompleteEntities.Add(EntityId);
+		CompleteEntities.Remove(EntityId);
+	}
+}
+} // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
@@ -6,22 +6,23 @@
 
 namespace SpatialGDK
 {
-SubView::SubView(const Worker_ComponentId TagComponentId,
-	const TFunction<bool(const Worker_EntityId, const EntityViewElement&)> Filter,
-	const EntityView& View,
-	FDispatcher& Dispatcher)
-	: TagComponentId(TagComponentId), Filter(Filter), View(View),
-	TaggedEntities(TSet<Worker_EntityId>{}),
-	CompleteEntities(TSet<Worker_EntityId>{}),
-    NewlyCompleteEntities(TSet<Worker_EntityId>{}),
-    NewlyIncompleteEntities(TSet<Worker_EntityId>{})
+SubView::SubView(const Worker_ComponentId TagComponentId, const TFunction<bool(const Worker_EntityId, const EntityViewElement&)> Filter,
+				 const EntityView& View, FDispatcher& Dispatcher)
+	: TagComponentId(TagComponentId)
+	, Filter(Filter)
+	, View(View)
+	, TaggedEntities(TSet<Worker_EntityId>{})
+	, CompleteEntities(TSet<Worker_EntityId>{})
+	, NewlyCompleteEntities(TSet<Worker_EntityId>{})
+	, NewlyIncompleteEntities(TSet<Worker_EntityId>{})
 {
-	Dispatcher.RegisterAndInvokeComponentAddedCallback(TagComponentId, [this](const FEntityComponentChange Change)
-	{
-		OnTaggedEntityAdded(Change.EntityId);
-	}, View);
-	Dispatcher.RegisterComponentRemovedCallback(TagComponentId, [this](const FEntityComponentChange Change)
-	{
+	Dispatcher.RegisterAndInvokeComponentAddedCallback(
+		TagComponentId,
+		[this](const FEntityComponentChange Change) {
+			OnTaggedEntityAdded(Change.EntityId);
+		},
+		View);
+	Dispatcher.RegisterComponentRemovedCallback(TagComponentId, [this](const FEntityComponentChange Change) {
 		OnTaggedEntityRemoved(Change.EntityId);
 	});
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
@@ -48,6 +48,11 @@ void SubView::TagEntity(TArray<FWorkerComponentData>& Components) const
 
 void SubView::AdvanceViewDelta(const ViewDelta& Delta)
 {
+	// Note: Complete entities will be a longer list than the others for the majority of iterations under
+	// probable normal usage. This sort could then become expensive, and a potential optimisation would be
+	// to maintain the ordering of complete entities when merging in the newly complete entities and enforcing
+	// that complete entities is always sorted. This would also need to be enforced in the temporarily incomplete case.
+	// If this sort shows up in a profile it would be worth trying.
 	Algo::Sort(CompleteEntities);
 	Algo::Sort(NewlyCompleteEntities);
 	Algo::Sort(NewlyIncompleteEntities);

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
@@ -16,7 +16,7 @@ SubView::SubView(const Worker_ComponentId TagComponentId, const FFilterPredicate
 	, NewlyCompleteEntities(TArray<Worker_EntityId>{})
 	, NewlyIncompleteEntities(TArray<Worker_EntityId>{})
 {
-	RegisterTagCallbacks(View, Dispatcher);
+	RegisterTagCallbacks(Dispatcher);
 	RegisterRefreshCallbacks(DispatcherRefreshCallbacks);
 }
 
@@ -71,7 +71,7 @@ void SubView::RefreshEntity(const Worker_EntityId EntityId)
 	}
 }
 
-void SubView::RegisterTagCallbacks(const EntityView& View, FDispatcher& Dispatcher)
+void SubView::RegisterTagCallbacks(FDispatcher& Dispatcher)
 {
 	Dispatcher.RegisterAndInvokeComponentAddedCallback(
 		TagComponentId,

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
@@ -6,8 +6,8 @@
 
 namespace SpatialGDK
 {
-SubView::SubView(const Worker_ComponentId TagComponentId, const FFilterPredicate Filter, const EntityView& View, FDispatcher& Dispatcher,
-				 const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks)
+SubView::SubView(const Worker_ComponentId& TagComponentId, const FFilterPredicate& Filter, const EntityView& View, FDispatcher& Dispatcher,
+				 const TArray<FDispatcherRefreshCallback>& DispatcherRefreshCallbacks)
 	: TagComponentId(TagComponentId)
 	, Filter(Filter)
 	, View(View)
@@ -71,7 +71,7 @@ const SubViewDelta& SubView::GetViewDelta() const
 	return SubDelta;
 }
 
-void SubView::RefreshEntity(const Worker_EntityId EntityId)
+void SubView::RefreshEntity(const Worker_EntityId& EntityId)
 {
 	if (TaggedEntities.Contains(EntityId))
 	{
@@ -80,19 +80,19 @@ void SubView::RefreshEntity(const Worker_EntityId EntityId)
 }
 
 FDispatcherRefreshCallback SubView::CreateComponentExistenceDispatcherRefreshCallback(
-	FDispatcher& Dispatcher, Worker_ComponentId ComponentId,
-	FComponentChangeRefreshPredicate RefreshPredicate = [](FEntityComponentChange) {
+	FDispatcher& Dispatcher, const Worker_ComponentId& ComponentId,
+	const FComponentChangeRefreshPredicate& RefreshPredicate = [](const FEntityComponentChange&) {
 		return true;
 	})
 {
-	return [ComponentId, &Dispatcher, RefreshPredicate](FRefreshCallback Callback) {
-		Dispatcher.RegisterComponentAddedCallback(ComponentId, [RefreshPredicate, Callback](FEntityComponentChange Change) {
+	return [ComponentId, &Dispatcher, RefreshPredicate](const FRefreshCallback& Callback) {
+		Dispatcher.RegisterComponentAddedCallback(ComponentId, [RefreshPredicate, Callback](const FEntityComponentChange& Change) {
 			if (RefreshPredicate(Change))
 			{
 				Callback(Change.EntityId);
 			}
 		});
-		Dispatcher.RegisterComponentRemovedCallback(ComponentId, [RefreshPredicate, Callback](FEntityComponentChange Change) {
+		Dispatcher.RegisterComponentRemovedCallback(ComponentId, [RefreshPredicate, Callback](const FEntityComponentChange& Change) {
 			if (RefreshPredicate(Change))
 			{
 				Callback(Change.EntityId);
@@ -102,12 +102,12 @@ FDispatcherRefreshCallback SubView::CreateComponentExistenceDispatcherRefreshCal
 }
 
 FDispatcherRefreshCallback SubView::CreateComponentChangedDispatcherRefreshCallback(
-	FDispatcher& Dispatcher, Worker_ComponentId ComponentId,
-	FComponentChangeRefreshPredicate RefreshPredicate = [](FEntityComponentChange) {
+	FDispatcher& Dispatcher, const Worker_ComponentId& ComponentId,
+	const FComponentChangeRefreshPredicate& RefreshPredicate = [](const FEntityComponentChange&) {
 		return true;
 	})
 {
-	return [ComponentId, &Dispatcher, RefreshPredicate](FRefreshCallback Callback) {
+	return [ComponentId, &Dispatcher, RefreshPredicate](const FRefreshCallback& Callback) {
 		Dispatcher.RegisterComponentValueCallback(ComponentId, [RefreshPredicate, Callback](const FEntityComponentChange Change) {
 			if (RefreshPredicate(Change))
 			{
@@ -118,18 +118,18 @@ FDispatcherRefreshCallback SubView::CreateComponentChangedDispatcherRefreshCallb
 }
 
 FDispatcherRefreshCallback SubView::CreateAuthorityChangeDispatcherRefreshCallback(
-	FDispatcher& Dispatcher, Worker_ComponentId ComponentId, FAuthorityChangeRefreshPredicate RefreshPredicate = [](Worker_EntityId) {
+	FDispatcher& Dispatcher, const Worker_ComponentId& ComponentId, const FAuthorityChangeRefreshPredicate& RefreshPredicate = [](const Worker_EntityId&) {
 		return true;
 	})
 {
-	return [ComponentId, &Dispatcher, RefreshPredicate](FRefreshCallback Callback) {
-		Dispatcher.RegisterAuthorityGainedCallback(ComponentId, [RefreshPredicate, Callback](const Worker_EntityId Id) {
+	return [ComponentId, &Dispatcher, RefreshPredicate](const FRefreshCallback& Callback) {
+		Dispatcher.RegisterAuthorityGainedCallback(ComponentId, [RefreshPredicate, Callback](const Worker_EntityId& Id) {
 			if (RefreshPredicate(Id))
 			{
 				Callback(Id);
 			}
 		});
-		Dispatcher.RegisterAuthorityLostCallback(ComponentId, [RefreshPredicate, Callback](const Worker_EntityId Id) {
+		Dispatcher.RegisterAuthorityLostCallback(ComponentId, [RefreshPredicate, Callback](const Worker_EntityId& Id) {
 			if (RefreshPredicate(Id))
 			{
 				Callback(Id);
@@ -142,18 +142,18 @@ void SubView::RegisterTagCallbacks(FDispatcher& Dispatcher)
 {
 	Dispatcher.RegisterAndInvokeComponentAddedCallback(
 		TagComponentId,
-		[this](const FEntityComponentChange Change) {
+		[this](const FEntityComponentChange& Change) {
 			OnTaggedEntityAdded(Change.EntityId);
 		},
 		View);
-	Dispatcher.RegisterComponentRemovedCallback(TagComponentId, [this](const FEntityComponentChange Change) {
+	Dispatcher.RegisterComponentRemovedCallback(TagComponentId, [this](const FEntityComponentChange& Change) {
 		OnTaggedEntityRemoved(Change.EntityId);
 	});
 }
 
-void SubView::RegisterRefreshCallbacks(const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks)
+void SubView::RegisterRefreshCallbacks(const TArray<FDispatcherRefreshCallback>& DispatcherRefreshCallbacks)
 {
-	const FRefreshCallback RefreshEntityCallback = [this](const Worker_EntityId EntityId) {
+	const FRefreshCallback RefreshEntityCallback = [this](const Worker_EntityId& EntityId) {
 		RefreshEntity(EntityId);
 	};
 	for (FDispatcherRefreshCallback Callback : DispatcherRefreshCallbacks)
@@ -162,19 +162,19 @@ void SubView::RegisterRefreshCallbacks(const TArray<FDispatcherRefreshCallback> 
 	}
 }
 
-void SubView::OnTaggedEntityAdded(const Worker_EntityId EntityId)
+void SubView::OnTaggedEntityAdded(const Worker_EntityId& EntityId)
 {
 	TaggedEntities.Add(EntityId);
 	CheckEntityAgainstFilter(EntityId);
 }
 
-void SubView::OnTaggedEntityRemoved(const Worker_EntityId EntityId)
+void SubView::OnTaggedEntityRemoved(const Worker_EntityId& EntityId)
 {
 	TaggedEntities.RemoveSingleSwap(EntityId);
 	EntityIncomplete(EntityId);
 }
 
-void SubView::CheckEntityAgainstFilter(const Worker_EntityId EntityId)
+void SubView::CheckEntityAgainstFilter(const Worker_EntityId& EntityId)
 {
 	if (Filter(EntityId, View[EntityId]))
 	{
@@ -184,7 +184,7 @@ void SubView::CheckEntityAgainstFilter(const Worker_EntityId EntityId)
 	EntityIncomplete(EntityId);
 }
 
-void SubView::EntityComplete(const Worker_EntityId EntityId)
+void SubView::EntityComplete(const Worker_EntityId& EntityId)
 {
 	// We were just about to remove this entity, but it has become complete again before the delta was read.
 	// Mark it as temporarily incomplete, but otherwise treat it as if it hadn't gone incomplete.
@@ -201,7 +201,7 @@ void SubView::EntityComplete(const Worker_EntityId EntityId)
 	}
 }
 
-void SubView::EntityIncomplete(const Worker_EntityId EntityId)
+void SubView::EntityIncomplete(const Worker_EntityId& EntityId)
 {
 	// If we were about to add this, don't. It's as if we never saw it.
 	if (NewlyCompleteEntities.RemoveSingleSwap(EntityId))

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
@@ -58,7 +58,7 @@ void SubView::Advance(const ViewDelta& Delta)
 	Algo::Sort(NewlyIncompleteEntities);
 	Algo::Sort(TemporarilyIncompleteEntities);
 
-	SubDelta.Project(Delta, CompleteEntities, NewlyCompleteEntities, NewlyIncompleteEntities, TemporarilyIncompleteEntities);
+	Delta.Project(SubDelta, CompleteEntities, NewlyCompleteEntities, NewlyIncompleteEntities, TemporarilyIncompleteEntities);
 
 	CompleteEntities.Append(NewlyCompleteEntities);
 	NewlyCompleteEntities.Empty();
@@ -66,7 +66,7 @@ void SubView::Advance(const ViewDelta& Delta)
 	TemporarilyIncompleteEntities.Empty();
 }
 
-const ViewDelta& SubView::GetViewDelta() const
+const SubViewDelta& SubView::GetViewDelta() const
 {
 	return SubDelta;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
@@ -79,11 +79,9 @@ void SubView::RefreshEntity(const Worker_EntityId& EntityId)
 	}
 }
 
-FDispatcherRefreshCallback SubView::CreateComponentExistenceDispatcherRefreshCallback(
+FDispatcherRefreshCallback SubView::CreateComponentExistenceRefreshCallback(
 	FDispatcher& Dispatcher, const Worker_ComponentId& ComponentId,
-	const FComponentChangeRefreshPredicate& RefreshPredicate = [](const FEntityComponentChange&) {
-		return true;
-	})
+	const FComponentChangeRefreshPredicate& RefreshPredicate)
 {
 	return [ComponentId, &Dispatcher, RefreshPredicate](const FRefreshCallback& Callback) {
 		Dispatcher.RegisterComponentAddedCallback(ComponentId, [RefreshPredicate, Callback](const FEntityComponentChange& Change) {
@@ -101,11 +99,9 @@ FDispatcherRefreshCallback SubView::CreateComponentExistenceDispatcherRefreshCal
 	};
 }
 
-FDispatcherRefreshCallback SubView::CreateComponentChangedDispatcherRefreshCallback(
+FDispatcherRefreshCallback SubView::CreateComponentChangedRefreshCallback(
 	FDispatcher& Dispatcher, const Worker_ComponentId& ComponentId,
-	const FComponentChangeRefreshPredicate& RefreshPredicate = [](const FEntityComponentChange&) {
-		return true;
-	})
+	const FComponentChangeRefreshPredicate& RefreshPredicate)
 {
 	return [ComponentId, &Dispatcher, RefreshPredicate](const FRefreshCallback& Callback) {
 		Dispatcher.RegisterComponentValueCallback(ComponentId, [RefreshPredicate, Callback](const FEntityComponentChange Change) {
@@ -117,11 +113,9 @@ FDispatcherRefreshCallback SubView::CreateComponentChangedDispatcherRefreshCallb
 	};
 }
 
-FDispatcherRefreshCallback SubView::CreateAuthorityChangeDispatcherRefreshCallback(
+FDispatcherRefreshCallback SubView::CreateAuthorityChangeRefreshCallback(
 	FDispatcher& Dispatcher, const Worker_ComponentId& ComponentId,
-	const FAuthorityChangeRefreshPredicate& RefreshPredicate = [](const Worker_EntityId&) {
-		return true;
-	})
+	const FAuthorityChangeRefreshPredicate& RefreshPredicate)
 {
 	return [ComponentId, &Dispatcher, RefreshPredicate](const FRefreshCallback& Callback) {
 		Dispatcher.RegisterAuthorityGainedCallback(ComponentId, [RefreshPredicate, Callback](const Worker_EntityId& Id) {
@@ -196,7 +190,7 @@ void SubView::EntityComplete(const Worker_EntityId& EntityId)
 		return;
 	}
 	// This is new to us. Mark it as newly complete.
-	if (!CompleteEntities.Contains(EntityId))
+	if (!NewlyCompleteEntities.Contains(EntityId) && !CompleteEntities.Contains(EntityId))
 	{
 		NewlyCompleteEntities.Add(EntityId);
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
@@ -7,7 +7,7 @@
 namespace SpatialGDK
 {
 FSubView::FSubView(const Worker_ComponentId& TagComponentId, FFilterPredicate Filter, const EntityView* View, FDispatcher& Dispatcher,
-				 const TArray<FDispatcherRefreshCallback>& DispatcherRefreshCallbacks)
+				   const TArray<FDispatcherRefreshCallback>& DispatcherRefreshCallbacks)
 	: TagComponentId(TagComponentId)
 	, Filter(MoveTemp(Filter))
 	, View(View)
@@ -80,7 +80,7 @@ void FSubView::RefreshEntity(const Worker_EntityId& EntityId)
 }
 
 FDispatcherRefreshCallback FSubView::CreateComponentExistenceRefreshCallback(FDispatcher& Dispatcher, const Worker_ComponentId& ComponentId,
-																			const FComponentChangeRefreshPredicate& RefreshPredicate)
+																			 const FComponentChangeRefreshPredicate& RefreshPredicate)
 {
 	return [ComponentId, &Dispatcher, RefreshPredicate](const FRefreshCallback& Callback) {
 		Dispatcher.RegisterComponentAddedCallback(ComponentId, [RefreshPredicate, Callback](const FEntityComponentChange& Change) {
@@ -99,7 +99,7 @@ FDispatcherRefreshCallback FSubView::CreateComponentExistenceRefreshCallback(FDi
 }
 
 FDispatcherRefreshCallback FSubView::CreateComponentChangedRefreshCallback(FDispatcher& Dispatcher, const Worker_ComponentId& ComponentId,
-																		  const FComponentChangeRefreshPredicate& RefreshPredicate)
+																		   const FComponentChangeRefreshPredicate& RefreshPredicate)
 {
 	return [ComponentId, &Dispatcher, RefreshPredicate](const FRefreshCallback& Callback) {
 		Dispatcher.RegisterComponentValueCallback(ComponentId, [RefreshPredicate, Callback](const FEntityComponentChange Change) {
@@ -112,7 +112,7 @@ FDispatcherRefreshCallback FSubView::CreateComponentChangedRefreshCallback(FDisp
 }
 
 FDispatcherRefreshCallback FSubView::CreateAuthorityChangeRefreshCallback(FDispatcher& Dispatcher, const Worker_ComponentId& ComponentId,
-																		 const FAuthorityChangeRefreshPredicate& RefreshPredicate)
+																		  const FAuthorityChangeRefreshPredicate& RefreshPredicate)
 {
 	return [ComponentId, &Dispatcher, RefreshPredicate](const FRefreshCallback& Callback) {
 		Dispatcher.RegisterAuthorityGainedCallback(ComponentId, [RefreshPredicate, Callback](const Worker_EntityId& Id) {

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
@@ -118,7 +118,8 @@ FDispatcherRefreshCallback SubView::CreateComponentChangedDispatcherRefreshCallb
 }
 
 FDispatcherRefreshCallback SubView::CreateAuthorityChangeDispatcherRefreshCallback(
-	FDispatcher& Dispatcher, const Worker_ComponentId& ComponentId, const FAuthorityChangeRefreshPredicate& RefreshPredicate = [](const Worker_EntityId&) {
+	FDispatcher& Dispatcher, const Worker_ComponentId& ComponentId,
+	const FAuthorityChangeRefreshPredicate& RefreshPredicate = [](const Worker_EntityId&) {
 		return true;
 	})
 {

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
@@ -79,65 +79,62 @@ void SubView::RefreshEntity(const Worker_EntityId EntityId)
 	}
 }
 
-FDispatcherRefreshCallback SubView::CreateComponentExistenceDispatcherRefreshCallback(FDispatcher& Dispatcher,
-	Worker_ComponentId ComponentId, FComponentChangeRefreshPredicate RefreshPredicate = [](FEntityComponentChange){return true;})
+FDispatcherRefreshCallback SubView::CreateComponentExistenceDispatcherRefreshCallback(
+	FDispatcher& Dispatcher, Worker_ComponentId ComponentId,
+	FComponentChangeRefreshPredicate RefreshPredicate = [](FEntityComponentChange) {
+		return true;
+	})
 {
-	return [ComponentId, &Dispatcher, RefreshPredicate](FRefreshCallback Callback)
-	{
-		Dispatcher.RegisterComponentAddedCallback(ComponentId, [RefreshPredicate, Callback](FEntityComponentChange Change)
-		{
+	return [ComponentId, &Dispatcher, RefreshPredicate](FRefreshCallback Callback) {
+		Dispatcher.RegisterComponentAddedCallback(ComponentId, [RefreshPredicate, Callback](FEntityComponentChange Change) {
 			if (RefreshPredicate(Change))
 			{
 				Callback(Change.EntityId);
 			}
 		});
-		Dispatcher.RegisterComponentRemovedCallback(ComponentId, [RefreshPredicate, Callback](FEntityComponentChange Change)
-        {
-            if (RefreshPredicate(Change))
-            {
-                Callback(Change.EntityId);
-            }
-        });
+		Dispatcher.RegisterComponentRemovedCallback(ComponentId, [RefreshPredicate, Callback](FEntityComponentChange Change) {
+			if (RefreshPredicate(Change))
+			{
+				Callback(Change.EntityId);
+			}
+		});
 	};
 }
 
-FDispatcherRefreshCallback SubView::CreateComponentChangedDispatcherRefreshCallback(FDispatcher& Dispatcher,
-	Worker_ComponentId ComponentId, FComponentChangeRefreshPredicate RefreshPredicate = [](FEntityComponentChange){return true;})
-{
-	return [ComponentId, &Dispatcher, RefreshPredicate](FRefreshCallback Callback)
-	{
-		Dispatcher.RegisterComponentValueCallback(ComponentId, [RefreshPredicate, Callback](const FEntityComponentChange Change)
-        {
-            if (RefreshPredicate(Change))
-            {
-                Callback(Change.EntityId);
-            }
-        });
-	};
-}
-
-FDispatcherRefreshCallback SubView::CreateAuthorityChangeDispatcherRefreshCallback(FDispatcher& Dispatcher,
-	Worker_ComponentId ComponentId, FAuthorityChangeRefreshPredicate RefreshPredicate = [](Worker_EntityId)
-	{
+FDispatcherRefreshCallback SubView::CreateComponentChangedDispatcherRefreshCallback(
+	FDispatcher& Dispatcher, Worker_ComponentId ComponentId,
+	FComponentChangeRefreshPredicate RefreshPredicate = [](FEntityComponentChange) {
 		return true;
 	})
 {
-	return [ComponentId, &Dispatcher, RefreshPredicate](FRefreshCallback Callback)
-	{
-		Dispatcher.RegisterAuthorityGainedCallback(ComponentId, [RefreshPredicate, Callback](const Worker_EntityId Id)
-        {
-            if (RefreshPredicate(Id))
-            {
-                Callback(Id);
-            }
-        });
-		Dispatcher.RegisterAuthorityLostCallback(ComponentId, [RefreshPredicate, Callback](const Worker_EntityId Id)
-        {
-            if (RefreshPredicate(Id))
-            {
-                Callback(Id);
-            }
-        });
+	return [ComponentId, &Dispatcher, RefreshPredicate](FRefreshCallback Callback) {
+		Dispatcher.RegisterComponentValueCallback(ComponentId, [RefreshPredicate, Callback](const FEntityComponentChange Change) {
+			if (RefreshPredicate(Change))
+			{
+				Callback(Change.EntityId);
+			}
+		});
+	};
+}
+
+FDispatcherRefreshCallback SubView::CreateAuthorityChangeDispatcherRefreshCallback(
+	FDispatcher& Dispatcher, Worker_ComponentId ComponentId, FAuthorityChangeRefreshPredicate RefreshPredicate = [](Worker_EntityId) {
+		return true;
+	})
+{
+	return [ComponentId, &Dispatcher, RefreshPredicate](FRefreshCallback Callback) {
+		Dispatcher.RegisterAuthorityGainedCallback(ComponentId, [RefreshPredicate, Callback](const Worker_EntityId Id) {
+			if (RefreshPredicate(Id))
+			{
+				Callback(Id);
+			}
+		});
+		Dispatcher.RegisterAuthorityLostCallback(ComponentId, [RefreshPredicate, Callback](const Worker_EntityId Id) {
+			if (RefreshPredicate(Id))
+			{
+				Callback(Id);
+			}
+		});
 	};
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
@@ -6,38 +6,38 @@
 
 namespace SpatialGDK
 {
-SubView::SubView(const Worker_ComponentId TagComponentId, const TFunction<bool(const Worker_EntityId, const EntityViewElement&)> Filter,
-				 const EntityView& View, FDispatcher& Dispatcher)
+SubView::SubView(const Worker_ComponentId TagComponentId, const FFilterPredicate Filter,
+	                 const EntityView& View, FDispatcher& Dispatcher, const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks)
 	: TagComponentId(TagComponentId)
 	, Filter(Filter)
 	, View(View)
-	, TaggedEntities(TSet<Worker_EntityId>{})
-	, CompleteEntities(TSet<Worker_EntityId>{})
-	, NewlyCompleteEntities(TSet<Worker_EntityId>{})
-	, NewlyIncompleteEntities(TSet<Worker_EntityId>{})
+	, TaggedEntities(TArray<Worker_EntityId>{})
+	, CompleteEntities(TArray<Worker_EntityId>{})
+	, NewlyCompleteEntities(TArray<Worker_EntityId>{})
+	, NewlyIncompleteEntities(TArray<Worker_EntityId>{})
 {
-	Dispatcher.RegisterAndInvokeComponentAddedCallback(
-		TagComponentId,
-		[this](const FEntityComponentChange Change) {
-			OnTaggedEntityAdded(Change.EntityId);
-		},
-		View);
-	Dispatcher.RegisterComponentRemovedCallback(TagComponentId, [this](const FEntityComponentChange Change) {
-		OnTaggedEntityRemoved(Change.EntityId);
-	});
+	RegisterTagCallbacks(View, Dispatcher);
+	RegisterRefreshCallbacks(DispatcherRefreshCallbacks);
 }
 
 void SubView::TagQuery(Query& QueryToTag) const
 {
+	QueryToTag.ResultComponentIds.Add(TagComponentId);
+
 	QueryConstraint TagConstraint;
 	TagConstraint.ComponentConstraint = TagComponentId;
+
+	if (QueryToTag.Constraint.AndConstraint.Num() != 0)
+	{
+		QueryToTag.Constraint.AndConstraint.Add(TagConstraint);
+		return;
+	}
 
 	QueryConstraint NewConstraint;
 	NewConstraint.AndConstraint.Add(QueryToTag.Constraint);
 	NewConstraint.AndConstraint.Add(TagConstraint);
 
 	QueryToTag.Constraint = NewConstraint;
-	QueryToTag.ResultComponentIds.Add(TagComponentId);
 }
 
 void SubView::TagEntity(TArray<FWorkerComponentData>& Components) const
@@ -47,8 +47,15 @@ void SubView::TagEntity(TArray<FWorkerComponentData>& Components) const
 
 void SubView::AdvanceViewDelta(const ViewDelta& Delta)
 {
-	// TODO: Filtering given delta by complete entities and add/removes for newly complete and incomplete entities
-	// respectively. Probably requires new view delta functionality to build from worker messages and entity deltas.
+	Algo::Sort(CompleteEntities);
+	Algo::Sort(NewlyCompleteEntities);
+	Algo::Sort(NewlyIncompleteEntities);
+
+	SubDelta.Project(Delta, CompleteEntities, NewlyCompleteEntities, NewlyIncompleteEntities);
+
+	CompleteEntities.Append(NewlyCompleteEntities);
+	NewlyCompleteEntities.Empty();
+	NewlyIncompleteEntities.Empty();
 }
 
 const ViewDelta& SubView::GetViewDelta() const
@@ -64,6 +71,32 @@ void SubView::RefreshEntity(const Worker_EntityId EntityId)
 	}
 }
 
+
+void SubView::RegisterTagCallbacks(const EntityView& View, FDispatcher& Dispatcher)
+{
+	Dispatcher.RegisterAndInvokeComponentAddedCallback(
+        TagComponentId,
+        [this](const FEntityComponentChange Change) {
+            OnTaggedEntityAdded(Change.EntityId);
+        },
+        View);
+	Dispatcher.RegisterComponentRemovedCallback(TagComponentId, [this](const FEntityComponentChange Change) {
+        OnTaggedEntityRemoved(Change.EntityId);
+    });
+}
+
+void SubView::RegisterRefreshCallbacks(const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks)
+{
+	const FRefreshCallback RefreshEntityCallback = [this](const Worker_EntityId EntityId)
+	{
+		RefreshEntity(EntityId);
+	};
+	for (FDispatcherRefreshCallback Callback : DispatcherRefreshCallbacks)
+	{
+		Callback(RefreshEntityCallback);
+	}
+}
+
 void SubView::OnTaggedEntityAdded(const Worker_EntityId EntityId)
 {
 	TaggedEntities.Add(EntityId);
@@ -72,26 +105,47 @@ void SubView::OnTaggedEntityAdded(const Worker_EntityId EntityId)
 
 void SubView::OnTaggedEntityRemoved(const Worker_EntityId EntityId)
 {
-	TaggedEntities.Remove(EntityId);
-	CompleteEntities.Remove(EntityId);
+	TaggedEntities.RemoveSingleSwap(EntityId);
+	EntityIncomplete(EntityId);
 }
 
 void SubView::CheckEntityAgainstFilter(const Worker_EntityId EntityId)
 {
 	if (Filter(EntityId, View[EntityId]))
 	{
-		bool* AlreadyInSet = nullptr;
-		CompleteEntities.Add(EntityId, AlreadyInSet);
-		if (!AlreadyInSet)
-		{
-			NewlyCompleteEntities.Add(EntityId);
-		}
+		EntityComplete(EntityId);
 		return;
 	}
-	if (CompleteEntities.Contains(EntityId))
+	EntityIncomplete(EntityId);
+}
+
+void SubView::EntityComplete(const Worker_EntityId EntityId)
+{
+	// We were just about to remove this entity, but it has become complete again before the delta was read.
+	// Act as if it was never incomplete.
+	if (NewlyIncompleteEntities.RemoveSingleSwap(EntityId))
+	{
+		CompleteEntities.Add(EntityId);
+		return;
+	}
+	// This is new to us. Mark it as newly complete.
+	if (!CompleteEntities.Contains(EntityId))
+	{
+		NewlyCompleteEntities.Add(EntityId);
+	}
+}
+
+void SubView::EntityIncomplete(const Worker_EntityId EntityId)
+{
+	// If we were about to add this, don't. It's as if we never saw it.
+	if (NewlyCompleteEntities.RemoveSingleSwap(EntityId))
+	{
+		return;
+	}
+	// Otherwise, if it is currently complete, we need to remove it, and mark it as about to remove.
+	if (CompleteEntities.RemoveSingleSwap(EntityId))
 	{
 		NewlyIncompleteEntities.Add(EntityId);
-		CompleteEntities.Remove(EntityId);
 	}
 }
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
@@ -6,8 +6,8 @@
 
 namespace SpatialGDK
 {
-SubView::SubView(const Worker_ComponentId TagComponentId, const FFilterPredicate Filter,
-	                 const EntityView& View, FDispatcher& Dispatcher, const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks)
+SubView::SubView(const Worker_ComponentId TagComponentId, const FFilterPredicate Filter, const EntityView& View, FDispatcher& Dispatcher,
+				 const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks)
 	: TagComponentId(TagComponentId)
 	, Filter(Filter)
 	, View(View)
@@ -71,24 +71,22 @@ void SubView::RefreshEntity(const Worker_EntityId EntityId)
 	}
 }
 
-
 void SubView::RegisterTagCallbacks(const EntityView& View, FDispatcher& Dispatcher)
 {
 	Dispatcher.RegisterAndInvokeComponentAddedCallback(
-        TagComponentId,
-        [this](const FEntityComponentChange Change) {
-            OnTaggedEntityAdded(Change.EntityId);
-        },
-        View);
+		TagComponentId,
+		[this](const FEntityComponentChange Change) {
+			OnTaggedEntityAdded(Change.EntityId);
+		},
+		View);
 	Dispatcher.RegisterComponentRemovedCallback(TagComponentId, [this](const FEntityComponentChange Change) {
-        OnTaggedEntityRemoved(Change.EntityId);
-    });
+		OnTaggedEntityRemoved(Change.EntityId);
+	});
 }
 
 void SubView::RegisterRefreshCallbacks(const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks)
 {
-	const FRefreshCallback RefreshEntityCallback = [this](const Worker_EntityId EntityId)
-	{
+	const FRefreshCallback RefreshEntityCallback = [this](const Worker_EntityId EntityId) {
 		RefreshEntity(EntityId);
 	};
 	for (FDispatcherRefreshCallback Callback : DispatcherRefreshCallbacks)

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
@@ -79,9 +79,8 @@ void SubView::RefreshEntity(const Worker_EntityId& EntityId)
 	}
 }
 
-FDispatcherRefreshCallback SubView::CreateComponentExistenceRefreshCallback(
-	FDispatcher& Dispatcher, const Worker_ComponentId& ComponentId,
-	const FComponentChangeRefreshPredicate& RefreshPredicate)
+FDispatcherRefreshCallback SubView::CreateComponentExistenceRefreshCallback(FDispatcher& Dispatcher, const Worker_ComponentId& ComponentId,
+																			const FComponentChangeRefreshPredicate& RefreshPredicate)
 {
 	return [ComponentId, &Dispatcher, RefreshPredicate](const FRefreshCallback& Callback) {
 		Dispatcher.RegisterComponentAddedCallback(ComponentId, [RefreshPredicate, Callback](const FEntityComponentChange& Change) {
@@ -99,9 +98,8 @@ FDispatcherRefreshCallback SubView::CreateComponentExistenceRefreshCallback(
 	};
 }
 
-FDispatcherRefreshCallback SubView::CreateComponentChangedRefreshCallback(
-	FDispatcher& Dispatcher, const Worker_ComponentId& ComponentId,
-	const FComponentChangeRefreshPredicate& RefreshPredicate)
+FDispatcherRefreshCallback SubView::CreateComponentChangedRefreshCallback(FDispatcher& Dispatcher, const Worker_ComponentId& ComponentId,
+																		  const FComponentChangeRefreshPredicate& RefreshPredicate)
 {
 	return [ComponentId, &Dispatcher, RefreshPredicate](const FRefreshCallback& Callback) {
 		Dispatcher.RegisterComponentValueCallback(ComponentId, [RefreshPredicate, Callback](const FEntityComponentChange Change) {
@@ -113,9 +111,8 @@ FDispatcherRefreshCallback SubView::CreateComponentChangedRefreshCallback(
 	};
 }
 
-FDispatcherRefreshCallback SubView::CreateAuthorityChangeRefreshCallback(
-	FDispatcher& Dispatcher, const Worker_ComponentId& ComponentId,
-	const FAuthorityChangeRefreshPredicate& RefreshPredicate)
+FDispatcherRefreshCallback SubView::CreateAuthorityChangeRefreshCallback(FDispatcher& Dispatcher, const Worker_ComponentId& ComponentId,
+																		 const FAuthorityChangeRefreshPredicate& RefreshPredicate)
 {
 	return [ComponentId, &Dispatcher, RefreshPredicate](const FRefreshCallback& Callback) {
 		Dispatcher.RegisterAuthorityGainedCallback(ComponentId, [RefreshPredicate, Callback](const Worker_EntityId& Id) {

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewCoordinator.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewCoordinator.cpp
@@ -178,6 +178,24 @@ void ViewCoordinator::RemoveCallback(CallbackId Id)
 	Dispatcher.RemoveCallback(Id);
 }
 
+FDispatcherRefreshCallback ViewCoordinator::CreateComponentExistenceRefreshCallback(
+const Worker_ComponentId& ComponentId, const FComponentChangeRefreshPredicate& RefreshPredicate)
+{
+	return SubView::CreateComponentExistenceRefreshCallback(Dispatcher, ComponentId, RefreshPredicate);
+}
+
+FDispatcherRefreshCallback ViewCoordinator::CreateComponentChangedRefreshCallback(const Worker_ComponentId& ComponentId,
+const FComponentChangeRefreshPredicate& RefreshPredicate)
+{
+	return SubView::CreateComponentChangedRefreshCallback(Dispatcher, ComponentId, RefreshPredicate);
+}
+
+FDispatcherRefreshCallback ViewCoordinator::CreateAuthorityChangeRefreshCallback(const Worker_ComponentId& ComponentId,
+const FAuthorityChangeRefreshPredicate& RefreshPredicate)
+{
+	return SubView::CreateAuthorityChangeRefreshCallback(Dispatcher, ComponentId, RefreshPredicate);
+}
+
 const FString& ViewCoordinator::GetWorkerId() const
 {
 	return ConnectionHandler->GetWorkerId();

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewCoordinator.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewCoordinator.cpp
@@ -9,6 +9,7 @@ namespace SpatialGDK
 ViewCoordinator::ViewCoordinator(TUniquePtr<AbstractConnectionHandler> ConnectionHandler)
 	: ConnectionHandler(MoveTemp(ConnectionHandler))
 	, NextRequestId(1)
+	, SubViews(TArray<SubView>{})
 {
 }
 
@@ -52,17 +53,17 @@ void ViewCoordinator::FlushMessagesToSend()
 SubView& ViewCoordinator::CreateSubView(const Worker_ComponentId& Tag, const FFilterPredicate& Filter,
 										const TArray<FDispatcherRefreshCallback>& DispatcherRefreshCallbacks)
 {
-	const int Index = SubViews.Emplace(SubView{ Tag, Filter, View.GetView(), Dispatcher, DispatcherRefreshCallbacks });
+	const int Index = SubViews.Emplace(Tag, Filter, View.GetView(), Dispatcher, DispatcherRefreshCallbacks);
 	return SubViews[Index];
 }
 
 SubView& ViewCoordinator::CreateUnfilteredSubView(const Worker_ComponentId& Tag)
 {
-	const int Index = SubViews.Emplace(SubView{ Tag,
-												[](const Worker_EntityId&, const EntityViewElement&) {
-													return true;
-												},
-												View.GetView(), Dispatcher, TArray<FDispatcherRefreshCallback>{} });
+	const int Index = SubViews.Emplace(Tag,
+                                                [](const Worker_EntityId&, const EntityViewElement&) {
+                                                    return true;
+    },
+    View.GetView(), Dispatcher, TArray<FDispatcherRefreshCallback>{});
 	return SubViews[Index];
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewCoordinator.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewCoordinator.cpp
@@ -50,25 +50,26 @@ void ViewCoordinator::FlushMessagesToSend()
 }
 
 SubView& ViewCoordinator::CreateSubView(const Worker_ComponentId Tag, const FFilterPredicate Filter,
-                                        const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks)
+										const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks)
 {
 	// System asks dispatcher for callback, has info: type of callback and transformation to entity ID
 
-	FDispatcherRefreshCallback Callback = [this](FRefreshCallback RefreshCallback)
-	{
-		Dispatcher.RegisterComponentAddedCallback(1, [RefreshCallback](const FEntityComponentChange Change)
-		{
+	FDispatcherRefreshCallback Callback = [this](FRefreshCallback RefreshCallback) {
+		Dispatcher.RegisterComponentAddedCallback(1, [RefreshCallback](const FEntityComponentChange Change) {
 			RefreshCallback(Change.EntityId);
 		});
 	};
-	const int Index = SubViews.Emplace(SubView{Tag, Filter, View.GetView(), Dispatcher, DispatcherRefreshCallbacks});
+	const int Index = SubViews.Emplace(SubView{ Tag, Filter, View.GetView(), Dispatcher, DispatcherRefreshCallbacks });
 	return SubViews[Index];
 }
 
-
 SubView& ViewCoordinator::CreateUnfilteredSubView(const Worker_ComponentId Tag)
 {
-	const int Index = SubViews.Emplace(SubView{Tag, [](const Worker_EntityId, const EntityViewElement&){return true;}, View.GetView(), Dispatcher, TArray<FDispatcherRefreshCallback>{}});
+	const int Index = SubViews.Emplace(SubView{ Tag,
+												[](const Worker_EntityId, const EntityViewElement&) {
+													return true;
+												},
+												View.GetView(), Dispatcher, TArray<FDispatcherRefreshCallback>{} });
 	return SubViews[Index];
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewCoordinator.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewCoordinator.cpp
@@ -51,7 +51,7 @@ void ViewCoordinator::FlushMessagesToSend()
 }
 
 FSubView& ViewCoordinator::CreateSubView(const Worker_ComponentId& Tag, const FFilterPredicate& Filter,
-										const TArray<FDispatcherRefreshCallback>& DispatcherRefreshCallbacks)
+										 const TArray<FDispatcherRefreshCallback>& DispatcherRefreshCallbacks)
 {
 	const int Index = SubViews.Emplace(MakeUnique<FSubView>(Tag, Filter, View.GetViewPtr(), Dispatcher, DispatcherRefreshCallbacks));
 	return *SubViews[Index];

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewCoordinator.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewCoordinator.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
 #include "SpatialView/ViewCoordinator.h"
+
 #include "SpatialView/OpList/ViewDeltaLegacyOpList.h"
 
 namespace SpatialGDK
@@ -26,14 +27,19 @@ void ViewCoordinator::Advance()
 	}
 	View.AdvanceViewDelta();
 	Dispatcher.InvokeCallbacks(View.GetViewDelta().GetEntityDeltas());
+
+	for (SubView& SubviewToAdvance : SubViews)
+	{
+		SubviewToAdvance.Advance(View.GetViewDelta());
+	}
 }
 
-const ViewDelta& ViewCoordinator::GetViewDelta()
+const ViewDelta& ViewCoordinator::GetViewDelta() const
 {
 	return View.GetViewDelta();
 }
 
-const EntityView& ViewCoordinator::GetView()
+const EntityView& ViewCoordinator::GetView() const
 {
 	return View.GetView();
 }
@@ -41,6 +47,37 @@ const EntityView& ViewCoordinator::GetView()
 void ViewCoordinator::FlushMessagesToSend()
 {
 	ConnectionHandler->SendMessages(View.FlushLocalChanges());
+}
+
+SubView& ViewCoordinator::CreateSubView(const Worker_ComponentId Tag, const FFilterPredicate Filter,
+                                        const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks)
+{
+	// System asks dispatcher for callback, has info: type of callback and transformation to entity ID
+
+	FDispatcherRefreshCallback Callback = [this](FRefreshCallback RefreshCallback)
+	{
+		Dispatcher.RegisterComponentAddedCallback(1, [RefreshCallback](const FEntityComponentChange Change)
+		{
+			RefreshCallback(Change.EntityId);
+		});
+	};
+	const int Index = SubViews.Emplace(SubView{Tag, Filter, View.GetView(), Dispatcher, DispatcherRefreshCallbacks});
+	return SubViews[Index];
+}
+
+
+SubView& ViewCoordinator::CreateUnfilteredSubView(const Worker_ComponentId Tag)
+{
+	const int Index = SubViews.Emplace(SubView{Tag, [](const Worker_EntityId, const EntityViewElement&){return true;}, View.GetView(), Dispatcher, TArray<FDispatcherRefreshCallback>{}});
+	return SubViews[Index];
+}
+
+void ViewCoordinator::RefreshEntityCompleteness(const Worker_EntityId EntityId)
+{
+	for (SubView& SubviewToRefresh : SubViews)
+	{
+		SubviewToRefresh.RefreshEntity(EntityId);
+	}
 }
 
 void ViewCoordinator::SendAddComponent(Worker_EntityId EntityId, ComponentData Data)

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewCoordinator.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewCoordinator.cpp
@@ -52,13 +52,6 @@ void ViewCoordinator::FlushMessagesToSend()
 SubView& ViewCoordinator::CreateSubView(const Worker_ComponentId Tag, const FFilterPredicate Filter,
 										const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks)
 {
-	// System asks dispatcher for callback, has info: type of callback and transformation to entity ID
-
-	FDispatcherRefreshCallback Callback = [this](FRefreshCallback RefreshCallback) {
-		Dispatcher.RegisterComponentAddedCallback(1, [RefreshCallback](const FEntityComponentChange Change) {
-			RefreshCallback(Change.EntityId);
-		});
-	};
 	const int Index = SubViews.Emplace(SubView{ Tag, Filter, View.GetView(), Dispatcher, DispatcherRefreshCallbacks });
 	return SubViews[Index];
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewCoordinator.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewCoordinator.cpp
@@ -179,19 +179,19 @@ void ViewCoordinator::RemoveCallback(CallbackId Id)
 }
 
 FDispatcherRefreshCallback ViewCoordinator::CreateComponentExistenceRefreshCallback(
-const Worker_ComponentId& ComponentId, const FComponentChangeRefreshPredicate& RefreshPredicate)
+	const Worker_ComponentId& ComponentId, const FComponentChangeRefreshPredicate& RefreshPredicate)
 {
 	return SubView::CreateComponentExistenceRefreshCallback(Dispatcher, ComponentId, RefreshPredicate);
 }
 
 FDispatcherRefreshCallback ViewCoordinator::CreateComponentChangedRefreshCallback(const Worker_ComponentId& ComponentId,
-const FComponentChangeRefreshPredicate& RefreshPredicate)
+																				  const FComponentChangeRefreshPredicate& RefreshPredicate)
 {
 	return SubView::CreateComponentChangedRefreshCallback(Dispatcher, ComponentId, RefreshPredicate);
 }
 
 FDispatcherRefreshCallback ViewCoordinator::CreateAuthorityChangeRefreshCallback(const Worker_ComponentId& ComponentId,
-const FAuthorityChangeRefreshPredicate& RefreshPredicate)
+																				 const FAuthorityChangeRefreshPredicate& RefreshPredicate)
 {
 	return SubView::CreateAuthorityChangeRefreshCallback(Dispatcher, ComponentId, RefreshPredicate);
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewCoordinator.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewCoordinator.cpp
@@ -59,11 +59,12 @@ SubView& ViewCoordinator::CreateSubView(const Worker_ComponentId& Tag, const FFi
 
 SubView& ViewCoordinator::CreateUnfilteredSubView(const Worker_ComponentId& Tag)
 {
-	const int Index = SubViews.Emplace(Tag,
-                                                [](const Worker_EntityId&, const EntityViewElement&) {
-                                                    return true;
-    },
-    View.GetView(), Dispatcher, TArray<FDispatcherRefreshCallback>{});
+	const int Index = SubViews.Emplace(
+		Tag,
+		[](const Worker_EntityId&, const EntityViewElement&) {
+			return true;
+		},
+		View.GetView(), Dispatcher, TArray<FDispatcherRefreshCallback>{});
 	return SubViews[Index];
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewCoordinator.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewCoordinator.cpp
@@ -49,24 +49,24 @@ void ViewCoordinator::FlushMessagesToSend()
 	ConnectionHandler->SendMessages(View.FlushLocalChanges());
 }
 
-SubView& ViewCoordinator::CreateSubView(const Worker_ComponentId Tag, const FFilterPredicate Filter,
-										const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks)
+SubView& ViewCoordinator::CreateSubView(const Worker_ComponentId& Tag, const FFilterPredicate& Filter,
+										const TArray<FDispatcherRefreshCallback>& DispatcherRefreshCallbacks)
 {
 	const int Index = SubViews.Emplace(SubView{ Tag, Filter, View.GetView(), Dispatcher, DispatcherRefreshCallbacks });
 	return SubViews[Index];
 }
 
-SubView& ViewCoordinator::CreateUnfilteredSubView(const Worker_ComponentId Tag)
+SubView& ViewCoordinator::CreateUnfilteredSubView(const Worker_ComponentId& Tag)
 {
 	const int Index = SubViews.Emplace(SubView{ Tag,
-												[](const Worker_EntityId, const EntityViewElement&) {
+												[](const Worker_EntityId&, const EntityViewElement&) {
 													return true;
 												},
 												View.GetView(), Dispatcher, TArray<FDispatcherRefreshCallback>{} });
 	return SubViews[Index];
 }
 
-void ViewCoordinator::RefreshEntityCompleteness(const Worker_EntityId EntityId)
+void ViewCoordinator::RefreshEntityCompleteness(const Worker_EntityId& EntityId)
 {
 	for (SubView& SubviewToRefresh : SubViews)
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
@@ -8,665 +8,630 @@
 
 namespace SpatialGDK
 {
-	void ViewDelta::SetFromOpList(TArray<OpList> OpLists, EntityView& View)
+void ViewDelta::SetFromOpList(TArray<OpList> OpLists, EntityView& View)
+{
+	Clear();
+
+	for (OpList& Ops : OpLists)
 	{
-		Clear();
-
-		for (OpList& Ops : OpLists)
+		const uint32 Count = Ops.Count;
+		Worker_Op* OpData = Ops.Ops;
+		for (uint32 i = 0; i < Count; ++i)
 		{
-			const uint32 Count = Ops.Count;
-			Worker_Op* OpData = Ops.Ops;
-			for (uint32 i = 0; i < Count; ++i)
-			{
-				ProcessOp(OpData[i]);
-			}
-		}
-		OpListStorage = MoveTemp(OpLists);
-
-		PopulateEntityDeltas(View);
-	}
-
-	void ViewDelta::Project(const ViewDelta& Delta, const TArray<Worker_EntityId>& CompleteEntities,
-	                        const TArray<Worker_EntityId>& NewlyCompleteEntities,
-	                        const TArray<Worker_EntityId>& NewlyIncompleteEntities)
-	{
-		Clear();
-
-		// No projection is applied to worker messages, as they are not entity specific.
-		WorkerMessages = Delta.GetWorkerMessages();
-
-		// All arrays here are sorted by entity ID.
-		auto DeltaIt = Delta.GetEntityDeltas().CreateConstIterator();
-		auto CompleteIt = CompleteEntities.CreateConstIterator();
-		auto NewlyCompleteIt = NewlyCompleteEntities.CreateConstIterator();
-		auto NewlyIncompleteIt = NewlyIncompleteEntities.CreateConstIterator();
-
-		for (;;)
-		{
-			const Worker_EntityId MinEntityId = FMath::Min(FMath::Min(DeltaIt->EntityId, *CompleteIt),
-                                                        FMath::Min(*NewlyCompleteIt, *NewlyIncompleteIt));
-
-			// Find the intersection between complete entities and the entity IDs in the view delta, add them to this
-			// delta.
-			if (CompleteIt && DeltaIt && *CompleteIt == MinEntityId && DeltaIt->EntityId == MinEntityId)
-			{
-				EntityDeltas.Emplace(*DeltaIt);
-			}
-			// Newly complete entities are represented as marker add entities with no state.
-			if (NewlyCompleteIt && *NewlyCompleteIt == MinEntityId)
-			{
-				EntityDeltas.Emplace(EntityDelta{MinEntityId, true, false});
-				++NewlyCompleteIt;
-			}
-			// Newly incomplete entities are represented as marker remove entities with no state.
-			if (NewlyIncompleteIt && *NewlyIncompleteIt == MinEntityId)
-			{
-				EntityDeltas.Emplace(EntityDelta{MinEntityId, false, true});
-				++NewlyIncompleteIt;
-			}
-
-			// Logic for incrementing complete and delta iterators. If either iterator is done, null the other,
-			// as there can no longer be any intersection.
-			if (CompleteIt && *CompleteIt == MinEntityId)
-			{
-				++CompleteIt;
-				if (!CompleteIt)
-				{
-					DeltaIt.SetToEnd();
-				}
-			}
-			if (DeltaIt && DeltaIt->EntityId == MinEntityId)
-			{
-				++DeltaIt;
-				if (!DeltaIt)
-				{
-					CompleteIt.SetToEnd();
-				}
-			}
-
-			// Break when all iterators are done.
-			if (!CompleteIt && !NewlyCompleteIt && !NewlyIncompleteIt && !DeltaIt)
-			{
-				return;
-			}
+			ProcessOp(OpData[i]);
 		}
 	}
+	OpListStorage = MoveTemp(OpLists);
 
-	void ViewDelta::Clear()
+	PopulateEntityDeltas(View);
+}
+
+void ViewDelta::Project(const ViewDelta& Delta, const TArray<Worker_EntityId>& CompleteEntities,
+						const TArray<Worker_EntityId>& NewlyCompleteEntities, const TArray<Worker_EntityId>& NewlyIncompleteEntities)
+{
+	Clear();
+
+	// No projection is applied to worker messages, as they are not entity specific.
+	WorkerMessages = Delta.GetWorkerMessages();
+
+	// All arrays here are sorted by entity ID.
+	auto DeltaIt = Delta.GetEntityDeltas().CreateConstIterator();
+	auto CompleteIt = CompleteEntities.CreateConstIterator();
+	auto NewlyCompleteIt = NewlyCompleteEntities.CreateConstIterator();
+	auto NewlyIncompleteIt = NewlyIncompleteEntities.CreateConstIterator();
+
+	for (;;)
 	{
-		EntityChanges.Empty();
-		ComponentChanges.Empty();
-		AuthorityChanges.Empty();
+		const Worker_EntityId MinEntityId =
+			FMath::Min(FMath::Min(DeltaIt->EntityId, *CompleteIt), FMath::Min(*NewlyCompleteIt, *NewlyIncompleteIt));
 
-		ConnectionStatusCode = 0;
-
-		EntityDeltas.Empty();
-		WorkerMessages.Empty();
-		AuthorityGainedForDelta.Empty();
-		AuthorityLostForDelta.Empty();
-		AuthorityLostTempForDelta.Empty();
-		ComponentsAddedForDelta.Empty();
-		ComponentsRemovedForDelta.Empty();
-		ComponentUpdatesForDelta.Empty();
-		ComponentsRefreshedForDelta.Empty();
-		OpListStorage.Empty();
-	}
-
-	const TArray<EntityDelta>& ViewDelta::GetEntityDeltas() const
-	{
-		return EntityDeltas;
-	}
-
-	const TArray<Worker_Op>& ViewDelta::GetWorkerMessages() const
-	{
-		return WorkerMessages;
-	}
-
-	bool ViewDelta::HasDisconnected() const
-	{
-		return ConnectionStatusCode != 0;
-	}
-
-	Worker_ConnectionStatusCode ViewDelta::GetConnectionStatus() const
-	{
-		check(HasDisconnected());
-		return static_cast<Worker_ConnectionStatusCode>(ConnectionStatusCode);
-	}
-
-	FString ViewDelta::GetDisconnectReason() const
-	{
-		check(HasDisconnected());
-		return ConnectionStatusMessage;
-	}
-
-	ViewDelta::ReceivedComponentChange::ReceivedComponentChange(const Worker_AddComponentOp& Op)
-		: EntityId(Op.entity_id)
-		  , ComponentId(Op.data.component_id)
-		  , Type(ADD)
-		  , ComponentAdded(Op.data.schema_type)
-	{
-	}
-
-	ViewDelta::ReceivedComponentChange::ReceivedComponentChange(const Worker_ComponentUpdateOp& Op)
-		: EntityId(Op.entity_id)
-		  , ComponentId(Op.update.component_id)
-		  , Type(UPDATE)
-		  , ComponentUpdate(Op.update.schema_type)
-	{
-	}
-
-	ViewDelta::ReceivedComponentChange::ReceivedComponentChange(const Worker_RemoveComponentOp& Op)
-		: EntityId(Op.entity_id)
-		  , ComponentId(Op.component_id)
-		  , Type(REMOVE)
-	{
-	}
-
-	bool ViewDelta::DifferentEntity::operator()(const ReceivedEntityChange& E) const
-	{
-		return E.EntityId != EntityId;
-	}
-
-	bool ViewDelta::DifferentEntity::operator()(const ReceivedComponentChange& Op) const
-	{
-		return Op.EntityId != EntityId;
-	}
-
-	bool ViewDelta::DifferentEntity::operator()(const Worker_AuthorityChangeOp& Op) const
-	{
-		return Op.entity_id != EntityId;
-	}
-
-	bool ViewDelta::DifferentEntityComponent::operator()(const ReceivedComponentChange& Op) const
-	{
-		return Op.ComponentId != ComponentId || Op.EntityId != EntityId;
-	}
-
-	bool ViewDelta::DifferentEntityComponent::operator()(const Worker_AuthorityChangeOp& Op) const
-	{
-		return Op.component_id != ComponentId || Op.entity_id != EntityId;
-	}
-
-	bool ViewDelta::EntityComponentComparison::operator()(const ReceivedComponentChange& Lhs,
-	                                                      const ReceivedComponentChange& Rhs) const
-	{
-		if (Lhs.EntityId != Rhs.EntityId)
+		// Find the intersection between complete entities and the entity IDs in the view delta, add them to this
+		// delta.
+		if (CompleteIt && DeltaIt && *CompleteIt == MinEntityId && DeltaIt->EntityId == MinEntityId)
 		{
-			return Lhs.EntityId < Rhs.EntityId;
+			EntityDeltas.Emplace(*DeltaIt);
 		}
-		return Lhs.ComponentId < Rhs.ComponentId;
-	}
-
-	bool ViewDelta::EntityComponentComparison::operator()(const Worker_AuthorityChangeOp& Lhs,
-	                                                      const Worker_AuthorityChangeOp& Rhs) const
-	{
-		if (Lhs.entity_id != Rhs.entity_id)
+		// Newly complete entities are represented as marker add entities with no state.
+		if (NewlyCompleteIt && *NewlyCompleteIt == MinEntityId)
 		{
-			return Lhs.entity_id < Rhs.entity_id;
+			EntityDeltas.Emplace(EntityDelta{ MinEntityId, true, false });
+			++NewlyCompleteIt;
 		}
-		return Lhs.component_id < Rhs.component_id;
-	}
+		// Newly incomplete entities are represented as marker remove entities with no state.
+		if (NewlyIncompleteIt && *NewlyIncompleteIt == MinEntityId)
+		{
+			EntityDeltas.Emplace(EntityDelta{ MinEntityId, false, true });
+			++NewlyIncompleteIt;
+		}
 
-	bool ViewDelta::EntityComparison::operator()(const ReceivedEntityChange& Lhs, const ReceivedEntityChange& Rhs) const
+		// Logic for incrementing complete and delta iterators. If either iterator is done, null the other,
+		// as there can no longer be any intersection.
+		if (CompleteIt && *CompleteIt == MinEntityId)
+		{
+			++CompleteIt;
+			if (!CompleteIt)
+			{
+				DeltaIt.SetToEnd();
+			}
+		}
+		if (DeltaIt && DeltaIt->EntityId == MinEntityId)
+		{
+			++DeltaIt;
+			if (!DeltaIt)
+			{
+				CompleteIt.SetToEnd();
+			}
+		}
+
+		// Break when all iterators are done.
+		if (!CompleteIt && !NewlyCompleteIt && !NewlyIncompleteIt && !DeltaIt)
+		{
+			return;
+		}
+	}
+}
+
+void ViewDelta::Clear()
+{
+	EntityChanges.Empty();
+	ComponentChanges.Empty();
+	AuthorityChanges.Empty();
+
+	ConnectionStatusCode = 0;
+
+	EntityDeltas.Empty();
+	WorkerMessages.Empty();
+	AuthorityGainedForDelta.Empty();
+	AuthorityLostForDelta.Empty();
+	AuthorityLostTempForDelta.Empty();
+	ComponentsAddedForDelta.Empty();
+	ComponentsRemovedForDelta.Empty();
+	ComponentUpdatesForDelta.Empty();
+	ComponentsRefreshedForDelta.Empty();
+	OpListStorage.Empty();
+}
+
+const TArray<EntityDelta>& ViewDelta::GetEntityDeltas() const
+{
+	return EntityDeltas;
+}
+
+const TArray<Worker_Op>& ViewDelta::GetWorkerMessages() const
+{
+	return WorkerMessages;
+}
+
+bool ViewDelta::HasDisconnected() const
+{
+	return ConnectionStatusCode != 0;
+}
+
+Worker_ConnectionStatusCode ViewDelta::GetConnectionStatus() const
+{
+	check(HasDisconnected());
+	return static_cast<Worker_ConnectionStatusCode>(ConnectionStatusCode);
+}
+
+FString ViewDelta::GetDisconnectReason() const
+{
+	check(HasDisconnected());
+	return ConnectionStatusMessage;
+}
+
+ViewDelta::ReceivedComponentChange::ReceivedComponentChange(const Worker_AddComponentOp& Op)
+	: EntityId(Op.entity_id)
+	, ComponentId(Op.data.component_id)
+	, Type(ADD)
+	, ComponentAdded(Op.data.schema_type)
+{
+}
+
+ViewDelta::ReceivedComponentChange::ReceivedComponentChange(const Worker_ComponentUpdateOp& Op)
+	: EntityId(Op.entity_id)
+	, ComponentId(Op.update.component_id)
+	, Type(UPDATE)
+	, ComponentUpdate(Op.update.schema_type)
+{
+}
+
+ViewDelta::ReceivedComponentChange::ReceivedComponentChange(const Worker_RemoveComponentOp& Op)
+	: EntityId(Op.entity_id)
+	, ComponentId(Op.component_id)
+	, Type(REMOVE)
+{
+}
+
+bool ViewDelta::DifferentEntity::operator()(const ReceivedEntityChange& E) const
+{
+	return E.EntityId != EntityId;
+}
+
+bool ViewDelta::DifferentEntity::operator()(const ReceivedComponentChange& Op) const
+{
+	return Op.EntityId != EntityId;
+}
+
+bool ViewDelta::DifferentEntity::operator()(const Worker_AuthorityChangeOp& Op) const
+{
+	return Op.entity_id != EntityId;
+}
+
+bool ViewDelta::DifferentEntityComponent::operator()(const ReceivedComponentChange& Op) const
+{
+	return Op.ComponentId != ComponentId || Op.EntityId != EntityId;
+}
+
+bool ViewDelta::DifferentEntityComponent::operator()(const Worker_AuthorityChangeOp& Op) const
+{
+	return Op.component_id != ComponentId || Op.entity_id != EntityId;
+}
+
+bool ViewDelta::EntityComponentComparison::operator()(const ReceivedComponentChange& Lhs, const ReceivedComponentChange& Rhs) const
+{
+	if (Lhs.EntityId != Rhs.EntityId)
 	{
 		return Lhs.EntityId < Rhs.EntityId;
 	}
+	return Lhs.ComponentId < Rhs.ComponentId;
+}
 
-	bool ViewDelta::EntityComparison::operator()(const EntityProjection& Lhs, const EntityProjection& Rhs) const
+bool ViewDelta::EntityComponentComparison::operator()(const Worker_AuthorityChangeOp& Lhs, const Worker_AuthorityChangeOp& Rhs) const
+{
+	if (Lhs.entity_id != Rhs.entity_id)
 	{
-		return Lhs.EntityId < Rhs.EntityId;
+		return Lhs.entity_id < Rhs.entity_id;
 	}
+	return Lhs.component_id < Rhs.component_id;
+}
 
-	ComponentChange ViewDelta::CalculateAdd(ReceivedComponentChange* Start, ReceivedComponentChange* End,
-	                                        TArray<ComponentData>& Components)
+bool ViewDelta::EntityComparison::operator()(const ReceivedEntityChange& Lhs, const ReceivedEntityChange& Rhs) const
+{
+	return Lhs.EntityId < Rhs.EntityId;
+}
+
+bool ViewDelta::EntityComparison::operator()(const EntityProjection& Lhs, const EntityProjection& Rhs) const
+{
+	return Lhs.EntityId < Rhs.EntityId;
+}
+
+ComponentChange ViewDelta::CalculateAdd(ReceivedComponentChange* Start, ReceivedComponentChange* End, TArray<ComponentData>& Components)
+{
+	// There must be at least one component add; anything before it can be ignored.
+	ReceivedComponentChange* It = std::find_if(Start, End, [](const ReceivedComponentChange& Op) {
+		return Op.Type == ReceivedComponentChange::ADD;
+	});
+
+	Schema_ComponentData* Data = It->ComponentAdded;
+	++It;
+
+	while (It != End)
 	{
-		// There must be at least one component add; anything before it can be ignored.
-		ReceivedComponentChange* It = std::find_if(Start, End, [](const ReceivedComponentChange& Op)
+		switch (It->Type)
 		{
-			return Op.Type == ReceivedComponentChange::ADD;
-		});
-
-		Schema_ComponentData* Data = It->ComponentAdded;
+		case ReceivedComponentChange::ADD:
+			Data = It->ComponentAdded;
+			break;
+		case ReceivedComponentChange::UPDATE:
+			Schema_ApplyComponentUpdateToData(It->ComponentUpdate, Data);
+			break;
+		case ReceivedComponentChange::REMOVE:
+			break;
+		}
 		++It;
+	}
+	Components.Emplace(ComponentData::CreateCopy(Data, Start->ComponentId));
+	// We don't want to reference the component in the view as is isn't stable.
+	return ComponentChange(Start->ComponentId, Data);
+}
 
-		while (It != End)
+ComponentChange ViewDelta::CalculateCompleteUpdate(ReceivedComponentChange* Start, ReceivedComponentChange* End, Schema_ComponentData* Data,
+												   Schema_ComponentUpdate* Events, ComponentData& Component)
+{
+	for (auto It = Start; It != End; ++It)
+	{
+		switch (It->Type)
 		{
-			switch (It->Type)
+		case ReceivedComponentChange::ADD:
+			Data = It->ComponentAdded;
+			break;
+		case ReceivedComponentChange::UPDATE:
+			if (Data)
 			{
-			case ReceivedComponentChange::ADD:
-				Data = It->ComponentAdded;
-				break;
-			case ReceivedComponentChange::UPDATE:
 				Schema_ApplyComponentUpdateToData(It->ComponentUpdate, Data);
-				break;
-			case ReceivedComponentChange::REMOVE:
-				break;
 			}
-			++It;
-		}
-		Components.Emplace(ComponentData::CreateCopy(Data, Start->ComponentId));
-		// We don't want to reference the component in the view as is isn't stable.
-		return ComponentChange(Start->ComponentId, Data);
-	}
-
-	ComponentChange ViewDelta::CalculateCompleteUpdate(ReceivedComponentChange* Start, ReceivedComponentChange* End,
-	                                                   Schema_ComponentData* Data,
-	                                                   Schema_ComponentUpdate* Events, ComponentData& Component)
-	{
-		for (auto It = Start; It != End; ++It)
-		{
-			switch (It->Type)
+			if (Events)
 			{
-			case ReceivedComponentChange::ADD:
-				Data = It->ComponentAdded;
-				break;
-			case ReceivedComponentChange::UPDATE:
-				if (Data)
-				{
-					Schema_ApplyComponentUpdateToData(It->ComponentUpdate, Data);
-				}
-				if (Events)
-				{
-					Schema_MergeComponentUpdateIntoUpdate(It->ComponentUpdate, Events);
-				}
-				else
-				{
-					Events = It->ComponentUpdate;
-				}
-				break;
-			case ReceivedComponentChange::REMOVE:
-				break;
+				Schema_MergeComponentUpdateIntoUpdate(It->ComponentUpdate, Events);
 			}
+			else
+			{
+				Events = It->ComponentUpdate;
+			}
+			break;
+		case ReceivedComponentChange::REMOVE:
+			break;
 		}
-
-		Component = ComponentData::CreateCopy(Data, Start->ComponentId);
-		Schema_Object* EventsObj = Events ? Schema_GetComponentUpdateEvents(Events) : nullptr;
-		// Use the data from the op list as pointers from the view aren't stable.
-		return ComponentChange(Start->ComponentId, Data, EventsObj);
 	}
 
-	ComponentChange ViewDelta::CalculateUpdate(ReceivedComponentChange* Start, ReceivedComponentChange* End,
-	                                           ComponentData& Component)
+	Component = ComponentData::CreateCopy(Data, Start->ComponentId);
+	Schema_Object* EventsObj = Events ? Schema_GetComponentUpdateEvents(Events) : nullptr;
+	// Use the data from the op list as pointers from the view aren't stable.
+	return ComponentChange(Start->ComponentId, Data, EventsObj);
+}
+
+ComponentChange ViewDelta::CalculateUpdate(ReceivedComponentChange* Start, ReceivedComponentChange* End, ComponentData& Component)
+{
+	// For an update we don't know if we are calculating a complete-update or a regular update.
+	// So the first message processed might be an add or an update.
+	auto It = std::find_if(Start, End, [](const ReceivedComponentChange& Op) {
+		return Op.Type != ReceivedComponentChange::REMOVE;
+	});
+
+	// If the first message is an add then calculate a complete-update.
+	if (It->Type == ReceivedComponentChange::ADD)
 	{
-		// For an update we don't know if we are calculating a complete-update or a regular update.
-		// So the first message processed might be an add or an update.
-		auto It = std::find_if(Start, End, [](const ReceivedComponentChange& Op)
-		{
-			return Op.Type != ReceivedComponentChange::REMOVE;
-		});
+		return CalculateCompleteUpdate(It + 1, End, It->ComponentAdded, nullptr, Component);
+	}
 
-		// If the first message is an add then calculate a complete-update.
-		if (It->Type == ReceivedComponentChange::ADD)
+	Schema_ComponentUpdate* Update = It->ComponentUpdate;
+	++It;
+	while (It != End)
+	{
+		switch (It->Type)
 		{
-			return CalculateCompleteUpdate(It + 1, End, It->ComponentAdded, nullptr, Component);
+		case ReceivedComponentChange::ADD:
+			return CalculateCompleteUpdate(It + 1, End, It->ComponentAdded, Update, Component);
+		case ReceivedComponentChange::UPDATE:
+			Schema_MergeComponentUpdateIntoUpdate(It->ComponentUpdate, Update);
+			break;
+		case ReceivedComponentChange::REMOVE:
+			return CalculateCompleteUpdate(It + 1, End, nullptr, nullptr, Component);
 		}
-
-		Schema_ComponentUpdate* Update = It->ComponentUpdate;
 		++It;
-		while (It != End)
-		{
-			switch (It->Type)
-			{
-			case ReceivedComponentChange::ADD:
-				return CalculateCompleteUpdate(It + 1, End, It->ComponentAdded, Update, Component);
-			case ReceivedComponentChange::UPDATE:
-				Schema_MergeComponentUpdateIntoUpdate(It->ComponentUpdate, Update);
-				break;
-			case ReceivedComponentChange::REMOVE:
-				return CalculateCompleteUpdate(It + 1, End, nullptr, nullptr, Component);
-			}
-			++It;
-		}
-
-		Schema_ApplyComponentUpdateToData(Update, Component.GetUnderlying());
-		Component = Component.DeepCopy();
-		return ComponentChange(Start->ComponentId, Update);
 	}
 
-	void ViewDelta::ProcessOp(Worker_Op& Op)
+	Schema_ApplyComponentUpdateToData(Update, Component.GetUnderlying());
+	Component = Component.DeepCopy();
+	return ComponentChange(Start->ComponentId, Update);
+}
+
+void ViewDelta::ProcessOp(Worker_Op& Op)
+{
+	switch (static_cast<Worker_OpType>(Op.op_type))
 	{
-		switch (static_cast<Worker_OpType>(Op.op_type))
+	case WORKER_OP_TYPE_DISCONNECT:
+		ConnectionStatusCode = Op.op.disconnect.connection_status_code;
+		ConnectionStatusMessage = Op.op.disconnect.reason;
+		break;
+	case WORKER_OP_TYPE_LOG_MESSAGE:
+		// Log messages deprecated.
+		break;
+	case WORKER_OP_TYPE_CRITICAL_SECTION:
+		// Ignore critical sections.
+		break;
+	case WORKER_OP_TYPE_ADD_ENTITY:
+		EntityChanges.Push(ReceivedEntityChange{ Op.op.add_entity.entity_id, true });
+		break;
+	case WORKER_OP_TYPE_REMOVE_ENTITY:
+		EntityChanges.Push(ReceivedEntityChange{ Op.op.remove_entity.entity_id, false });
+		break;
+	case WORKER_OP_TYPE_METRICS:
+	case WORKER_OP_TYPE_FLAG_UPDATE:
+	case WORKER_OP_TYPE_RESERVE_ENTITY_IDS_RESPONSE:
+	case WORKER_OP_TYPE_CREATE_ENTITY_RESPONSE:
+	case WORKER_OP_TYPE_DELETE_ENTITY_RESPONSE:
+	case WORKER_OP_TYPE_ENTITY_QUERY_RESPONSE:
+	case WORKER_OP_TYPE_COMMAND_REQUEST:
+	case WORKER_OP_TYPE_COMMAND_RESPONSE:
+		WorkerMessages.Push(Op);
+		break;
+	case WORKER_OP_TYPE_ADD_COMPONENT:
+		ComponentChanges.Emplace(Op.op.add_component);
+		break;
+	case WORKER_OP_TYPE_REMOVE_COMPONENT:
+		ComponentChanges.Emplace(Op.op.remove_component);
+		break;
+	case WORKER_OP_TYPE_AUTHORITY_CHANGE:
+		if (Op.op.authority_change.authority != WORKER_AUTHORITY_AUTHORITY_LOSS_IMMINENT)
 		{
-		case WORKER_OP_TYPE_DISCONNECT:
-			ConnectionStatusCode = Op.op.disconnect.connection_status_code;
-			ConnectionStatusMessage = Op.op.disconnect.reason;
-			break;
-		case WORKER_OP_TYPE_LOG_MESSAGE:
-			// Log messages deprecated.
-			break;
-		case WORKER_OP_TYPE_CRITICAL_SECTION:
-			// Ignore critical sections.
-			break;
-		case WORKER_OP_TYPE_ADD_ENTITY:
-			EntityChanges.Push(ReceivedEntityChange{Op.op.add_entity.entity_id, true});
-			break;
-		case WORKER_OP_TYPE_REMOVE_ENTITY:
-			EntityChanges.Push(ReceivedEntityChange{Op.op.remove_entity.entity_id, false});
-			break;
-		case WORKER_OP_TYPE_METRICS:
-		case WORKER_OP_TYPE_FLAG_UPDATE:
-		case WORKER_OP_TYPE_RESERVE_ENTITY_IDS_RESPONSE:
-		case WORKER_OP_TYPE_CREATE_ENTITY_RESPONSE:
-		case WORKER_OP_TYPE_DELETE_ENTITY_RESPONSE:
-		case WORKER_OP_TYPE_ENTITY_QUERY_RESPONSE:
-		case WORKER_OP_TYPE_COMMAND_REQUEST:
-		case WORKER_OP_TYPE_COMMAND_RESPONSE:
-			WorkerMessages.Push(Op);
-			break;
-		case WORKER_OP_TYPE_ADD_COMPONENT:
-			ComponentChanges.Emplace(Op.op.add_component);
-			break;
-		case WORKER_OP_TYPE_REMOVE_COMPONENT:
-			ComponentChanges.Emplace(Op.op.remove_component);
-			break;
-		case WORKER_OP_TYPE_AUTHORITY_CHANGE:
-			if (Op.op.authority_change.authority != WORKER_AUTHORITY_AUTHORITY_LOSS_IMMINENT)
-			{
-				AuthorityChanges.Emplace(Op.op.authority_change);
-			}
-			break;
-		case WORKER_OP_TYPE_COMPONENT_UPDATE:
-			ComponentChanges.Emplace(Op.op.component_update);
-			break;
-		default:
+			AuthorityChanges.Emplace(Op.op.authority_change);
+		}
+		break;
+	case WORKER_OP_TYPE_COMPONENT_UPDATE:
+		ComponentChanges.Emplace(Op.op.component_update);
+		break;
+	default:
+		break;
+	}
+}
+
+void ViewDelta::PopulateEntityDeltas(EntityView& View)
+{
+	// Make sure there is enough space in the view delta storage.
+	// This allows us to rely on stable pointers as we add new elements.
+	ComponentsAddedForDelta.Reserve(ComponentChanges.Num());
+	ComponentsRemovedForDelta.Reserve(ComponentChanges.Num());
+	ComponentUpdatesForDelta.Reserve(ComponentChanges.Num());
+	ComponentsRefreshedForDelta.Reserve(ComponentChanges.Num());
+	AuthorityGainedForDelta.Reserve(AuthorityChanges.Num());
+	AuthorityLostForDelta.Reserve(AuthorityChanges.Num());
+	AuthorityLostTempForDelta.Reserve(AuthorityChanges.Num());
+
+	Algo::StableSort(ComponentChanges, EntityComponentComparison{});
+	Algo::StableSort(AuthorityChanges, EntityComponentComparison{});
+	Algo::StableSort(EntityChanges, EntityComparison{});
+
+	// Add sentinel elements to the ends of the arrays.
+	// Prevents the need for bounds checks on the iterators.
+	ComponentChanges.Emplace(Worker_RemoveComponentOp{ SENTINEL_ENTITY_ID, 0 });
+	AuthorityChanges.Emplace(Worker_AuthorityChangeOp{ SENTINEL_ENTITY_ID, 0, 0 });
+	EntityChanges.Emplace(ReceivedEntityChange{ SENTINEL_ENTITY_ID, false });
+
+	auto ComponentIt = ComponentChanges.GetData();
+	auto AuthorityIt = AuthorityChanges.GetData();
+	auto EntityIt = EntityChanges.GetData();
+
+	ReceivedComponentChange* ComponentChangesEnd = ComponentIt + ComponentChanges.Num();
+	Worker_AuthorityChangeOp* AuthorityChangesEnd = AuthorityIt + AuthorityChanges.Num();
+	ReceivedEntityChange* EntityChangesEnd = EntityIt + EntityChanges.Num();
+
+	// At the beginning of each loop each iterator should point to the first element for an entity.
+	// Each loop we want to work with a single entity ID.
+	// We check the entities each iterator is pointing to and pick the smallest one.
+	// If that is the sentinel ID then stop.
+	for (;;)
+	{
+		// Get the next entity ID. We want to pick the smallest entity referenced by the iterators.
+		// Convert to uint64 to ensure the sentinel value is larger than all valid IDs.
+		const uint64 MinEntityId = FMath::Min3(static_cast<uint64>(ComponentIt->EntityId), static_cast<uint64>(AuthorityIt->entity_id),
+											   static_cast<uint64>(EntityIt->EntityId));
+
+		// If no list has elements left to read then stop.
+		if (static_cast<Worker_EntityId>(MinEntityId) == SENTINEL_ENTITY_ID)
+		{
 			break;
 		}
-	}
 
-	void ViewDelta::PopulateEntityDeltas(EntityView& View)
-	{
-		// Make sure there is enough space in the view delta storage.
-		// This allows us to rely on stable pointers as we add new elements.
-		ComponentsAddedForDelta.Reserve(ComponentChanges.Num());
-		ComponentsRemovedForDelta.Reserve(ComponentChanges.Num());
-		ComponentUpdatesForDelta.Reserve(ComponentChanges.Num());
-		ComponentsRefreshedForDelta.Reserve(ComponentChanges.Num());
-		AuthorityGainedForDelta.Reserve(AuthorityChanges.Num());
-		AuthorityLostForDelta.Reserve(AuthorityChanges.Num());
-		AuthorityLostTempForDelta.Reserve(AuthorityChanges.Num());
+		const Worker_EntityId CurrentEntityId = static_cast<Worker_EntityId>(MinEntityId);
 
-		Algo::StableSort(ComponentChanges, EntityComponentComparison{});
-		Algo::StableSort(AuthorityChanges, EntityComponentComparison{});
-		Algo::StableSort(EntityChanges, EntityComparison{});
+		EntityDelta Delta = {};
+		Delta.EntityId = CurrentEntityId;
 
-		// Add sentinel elements to the ends of the arrays.
-		// Prevents the need for bounds checks on the iterators.
-		ComponentChanges.Emplace(Worker_RemoveComponentOp{SENTINEL_ENTITY_ID, 0});
-		AuthorityChanges.Emplace(Worker_AuthorityChangeOp{SENTINEL_ENTITY_ID, 0, 0});
-		EntityChanges.Emplace(ReceivedEntityChange{SENTINEL_ENTITY_ID, false});
+		EntityViewElement* ViewElement = View.Find(CurrentEntityId);
 
-		auto ComponentIt = ComponentChanges.GetData();
-		auto AuthorityIt = AuthorityChanges.GetData();
-		auto EntityIt = EntityChanges.GetData();
-
-		ReceivedComponentChange* ComponentChangesEnd = ComponentIt + ComponentChanges.Num();
-		Worker_AuthorityChangeOp* AuthorityChangesEnd = AuthorityIt + AuthorityChanges.Num();
-		ReceivedEntityChange* EntityChangesEnd = EntityIt + EntityChanges.Num();
-
-		// At the beginning of each loop each iterator should point to the first element for an entity.
-		// Each loop we want to work with a single entity ID.
-		// We check the entities each iterator is pointing to and pick the smallest one.
-		// If that is the sentinel ID then stop.
-		for (;;)
+		if (EntityIt->EntityId == CurrentEntityId)
 		{
-			// Get the next entity ID. We want to pick the smallest entity referenced by the iterators.
-			// Convert to uint64 to ensure the sentinel value is larger than all valid IDs.
-			const uint64 MinEntityId = FMath::Min3(static_cast<uint64>(ComponentIt->EntityId),
-			                                       static_cast<uint64>(AuthorityIt->entity_id),
-			                                       static_cast<uint64>(EntityIt->EntityId));
-
-			// If no list has elements left to read then stop.
-			if (static_cast<Worker_EntityId>(MinEntityId) == SENTINEL_ENTITY_ID)
+			EntityIt = ProcessEntityExistenceChange(EntityIt, EntityChangesEnd, Delta, &ViewElement, View);
+			// If the entity isn't present we don't need to process component and authority changes.
+			if (ViewElement == nullptr)
 			{
-				break;
-			}
+				ComponentIt = std::find_if(ComponentIt, ComponentChangesEnd, DifferentEntity{ CurrentEntityId });
+				AuthorityIt = std::find_if(AuthorityIt, AuthorityChangesEnd, DifferentEntity{ CurrentEntityId });
 
-			const Worker_EntityId CurrentEntityId = static_cast<Worker_EntityId>(MinEntityId);
-
-			EntityDelta Delta = {};
-			Delta.EntityId = CurrentEntityId;
-
-			EntityViewElement* ViewElement = View.Find(CurrentEntityId);
-
-			if (EntityIt->EntityId == CurrentEntityId)
-			{
-				EntityIt = ProcessEntityExistenceChange(EntityIt, EntityChangesEnd, Delta, &ViewElement, View);
-				// If the entity isn't present we don't need to process component and authority changes.
-				if (ViewElement == nullptr)
+				// Only add the entity delta if the entity previously existed in the view.
+				if (Delta.bRemoved)
 				{
-					ComponentIt = std::find_if(ComponentIt, ComponentChangesEnd, DifferentEntity{CurrentEntityId});
-					AuthorityIt = std::find_if(AuthorityIt, AuthorityChangesEnd, DifferentEntity{CurrentEntityId});
-
-					// Only add the entity delta if the entity previously existed in the view.
-					if (Delta.bRemoved)
-					{
-						EntityDeltas.Push(Delta);
-					}
-					continue;
+					EntityDeltas.Push(Delta);
 				}
+				continue;
 			}
-
-			if (ComponentIt->EntityId == CurrentEntityId)
-			{
-				ComponentIt = ProcessEntityComponentChanges(ComponentIt, ComponentChangesEnd, ViewElement->Components,
-				                                            Delta);
-			}
-
-			if (AuthorityIt->entity_id == CurrentEntityId)
-			{
-				AuthorityIt = ProcessEntityAuthorityChanges(AuthorityIt, AuthorityChangesEnd, ViewElement->Authority,
-				                                            Delta);
-			}
-
-			EntityDeltas.Push(Delta);
 		}
-	}
 
-	ViewDelta::ReceivedComponentChange* ViewDelta::ProcessEntityComponentChanges(
-		ReceivedComponentChange* It, ReceivedComponentChange* End,
-		TArray<ComponentData>& Components, EntityDelta& Delta)
-	{
-		int32 AddCount = 0;
-		int32 UpdateCount = 0;
-		int32 RemoveCount = 0;
-		int32 RefreshCount = 0;
-
-		const Worker_EntityId EntityId = It->EntityId;
-		// At the end of each loop `It` should point to the first element for an entity-component.
-		// Stop and return when the component is for a different entity.
-		// There will always be at least one iteration of the loop.
-		for (;;)
+		if (ComponentIt->EntityId == CurrentEntityId)
 		{
-			ReceivedComponentChange* NextComponentIt = std::find_if(
-				It, End, DifferentEntityComponent{EntityId, It->ComponentId});
+			ComponentIt = ProcessEntityComponentChanges(ComponentIt, ComponentChangesEnd, ViewElement->Components, Delta);
+		}
 
-			ComponentData* Component = Components.FindByPredicate(ComponentIdEquality{It->ComponentId});
-			const bool bComponentExists = Component != nullptr;
+		if (AuthorityIt->entity_id == CurrentEntityId)
+		{
+			AuthorityIt = ProcessEntityAuthorityChanges(AuthorityIt, AuthorityChangesEnd, ViewElement->Authority, Delta);
+		}
 
-			// The element one before NextComponentIt must be the last element for this component.
-			switch ((NextComponentIt - 1)->Type)
+		EntityDeltas.Push(Delta);
+	}
+}
+
+ViewDelta::ReceivedComponentChange* ViewDelta::ProcessEntityComponentChanges(ReceivedComponentChange* It, ReceivedComponentChange* End,
+																			 TArray<ComponentData>& Components, EntityDelta& Delta)
+{
+	int32 AddCount = 0;
+	int32 UpdateCount = 0;
+	int32 RemoveCount = 0;
+	int32 RefreshCount = 0;
+
+	const Worker_EntityId EntityId = It->EntityId;
+	// At the end of each loop `It` should point to the first element for an entity-component.
+	// Stop and return when the component is for a different entity.
+	// There will always be at least one iteration of the loop.
+	for (;;)
+	{
+		ReceivedComponentChange* NextComponentIt = std::find_if(It, End, DifferentEntityComponent{ EntityId, It->ComponentId });
+
+		ComponentData* Component = Components.FindByPredicate(ComponentIdEquality{ It->ComponentId });
+		const bool bComponentExists = Component != nullptr;
+
+		// The element one before NextComponentIt must be the last element for this component.
+		switch ((NextComponentIt - 1)->Type)
+		{
+		case ReceivedComponentChange::ADD:
+			if (bComponentExists)
 			{
-			case ReceivedComponentChange::ADD:
-				if (bComponentExists)
+				ComponentsRefreshedForDelta.Emplace(CalculateCompleteUpdate(It, NextComponentIt, nullptr, nullptr, *Component));
+				++RefreshCount;
+			}
+			else
+			{
+				ComponentsAddedForDelta.Emplace(CalculateAdd(It, NextComponentIt, Components));
+				++AddCount;
+			}
+			break;
+		case ReceivedComponentChange::UPDATE:
+			if (bComponentExists)
+			{
+				ComponentChange Update = CalculateUpdate(It, NextComponentIt, *Component);
+				if (Update.Type == ComponentChange::COMPLETE_UPDATE)
 				{
-					ComponentsRefreshedForDelta.Emplace(
-						CalculateCompleteUpdate(It, NextComponentIt, nullptr, nullptr, *Component));
+					ComponentsRefreshedForDelta.Emplace(Update);
 					++RefreshCount;
 				}
 				else
 				{
-					ComponentsAddedForDelta.Emplace(CalculateAdd(It, NextComponentIt, Components));
-					++AddCount;
+					ComponentUpdatesForDelta.Emplace(Update);
+					++UpdateCount;
 				}
-				break;
-			case ReceivedComponentChange::UPDATE:
-				if (bComponentExists)
-				{
-					ComponentChange Update = CalculateUpdate(It, NextComponentIt, *Component);
-					if (Update.Type == ComponentChange::COMPLETE_UPDATE)
-					{
-						ComponentsRefreshedForDelta.Emplace(Update);
-						++RefreshCount;
-					}
-					else
-					{
-						ComponentUpdatesForDelta.Emplace(Update);
-						++UpdateCount;
-					}
-				}
-				else
-				{
-					ComponentsAddedForDelta.Emplace(CalculateAdd(It, NextComponentIt, Components));
-					++AddCount;
-				}
-				break;
-			case ReceivedComponentChange::REMOVE:
-				if (bComponentExists)
-				{
-					ComponentsRemovedForDelta.Emplace(It->ComponentId);
-					Components.RemoveAtSwap(Component - Components.GetData());
-					++RemoveCount;
-				}
-				break;
 			}
-
-			if (NextComponentIt->EntityId != EntityId)
+			else
 			{
-				Delta.ComponentsAdded = {
-					ComponentsAddedForDelta.GetData() + ComponentsAddedForDelta.Num() - AddCount, AddCount
-				};
-				Delta.ComponentsRemoved = {
-					ComponentsRemovedForDelta.GetData() + ComponentsRemovedForDelta.Num() - RemoveCount, RemoveCount
-				};
-				Delta.ComponentUpdates = {
-					ComponentUpdatesForDelta.GetData() + ComponentUpdatesForDelta.Num() - UpdateCount, UpdateCount
-				};
-				Delta.ComponentsRefreshed = {
-					ComponentsRefreshedForDelta.GetData() + ComponentsRefreshedForDelta.Num() - RefreshCount,
-					RefreshCount
-				};
-				return NextComponentIt;
+				ComponentsAddedForDelta.Emplace(CalculateAdd(It, NextComponentIt, Components));
+				++AddCount;
 			}
+			break;
+		case ReceivedComponentChange::REMOVE:
+			if (bComponentExists)
+			{
+				ComponentsRemovedForDelta.Emplace(It->ComponentId);
+				Components.RemoveAtSwap(Component - Components.GetData());
+				++RemoveCount;
+			}
+			break;
+		}
 
-			It = NextComponentIt;
+		if (NextComponentIt->EntityId != EntityId)
+		{
+			Delta.ComponentsAdded = { ComponentsAddedForDelta.GetData() + ComponentsAddedForDelta.Num() - AddCount, AddCount };
+			Delta.ComponentsRemoved = { ComponentsRemovedForDelta.GetData() + ComponentsRemovedForDelta.Num() - RemoveCount, RemoveCount };
+			Delta.ComponentUpdates = { ComponentUpdatesForDelta.GetData() + ComponentUpdatesForDelta.Num() - UpdateCount, UpdateCount };
+			Delta.ComponentsRefreshed = { ComponentsRefreshedForDelta.GetData() + ComponentsRefreshedForDelta.Num() - RefreshCount,
+										  RefreshCount };
+			return NextComponentIt;
+		}
+
+		It = NextComponentIt;
+	}
+}
+
+Worker_AuthorityChangeOp* ViewDelta::ProcessEntityAuthorityChanges(Worker_AuthorityChangeOp* It, Worker_AuthorityChangeOp* End,
+																   TArray<Worker_ComponentId>& EntityAuthority, EntityDelta& Delta)
+{
+	int32 GainCount = 0;
+	int32 LossCount = 0;
+	int32 LossTempCount = 0;
+
+	const Worker_EntityId EntityId = It->entity_id;
+	// After each loop the iterator points to the first op relating to the next entity-component.
+	// Stop and return when that component is for a different entity.
+	// There will always be at least one iteration of the loop.
+	for (;;)
+	{
+		// Find the last element for this entity-component.
+		const Worker_ComponentId ComponentId = It->component_id;
+		It = std::find_if(It, End, DifferentEntityComponent{ EntityId, ComponentId }) - 1;
+		const int32 AuthorityIndex = EntityAuthority.Find(ComponentId);
+		const bool bHasAuthority = AuthorityIndex != INDEX_NONE;
+
+		if (It->authority == WORKER_AUTHORITY_AUTHORITATIVE)
+		{
+			if (bHasAuthority)
+			{
+				AuthorityLostTempForDelta.Emplace(ComponentId, AuthorityChange::AUTHORITY_LOST_TEMPORARILY);
+				++LossTempCount;
+			}
+			else
+			{
+				EntityAuthority.Push(ComponentId);
+				AuthorityGainedForDelta.Emplace(ComponentId, AuthorityChange::AUTHORITY_GAINED);
+				++GainCount;
+			}
+		}
+		else if (bHasAuthority)
+		{
+			AuthorityLostForDelta.Emplace(ComponentId, AuthorityChange::AUTHORITY_LOST);
+			EntityAuthority.RemoveAtSwap(AuthorityIndex);
+			++LossCount;
+		}
+
+		// Move to the next entity-component.
+		++It;
+
+		if (It->entity_id != EntityId)
+		{
+			Delta.AuthorityGained = { AuthorityGainedForDelta.GetData() + AuthorityGainedForDelta.Num() - GainCount, GainCount };
+			Delta.AuthorityLost = { AuthorityLostForDelta.GetData() + AuthorityLostForDelta.Num() - LossCount, LossCount };
+			Delta.AuthorityLostTemporarily = { AuthorityLostTempForDelta.GetData() + AuthorityLostTempForDelta.Num() - LossTempCount,
+											   LossTempCount };
+			return It;
 		}
 	}
+}
 
-	Worker_AuthorityChangeOp* ViewDelta::ProcessEntityAuthorityChanges(Worker_AuthorityChangeOp* It,
-	                                                                   Worker_AuthorityChangeOp* End,
-	                                                                   TArray<Worker_ComponentId>& EntityAuthority,
-	                                                                   EntityDelta& Delta)
+ViewDelta::ReceivedEntityChange* ViewDelta::ProcessEntityExistenceChange(ReceivedEntityChange* It, ReceivedEntityChange* End,
+																		 EntityDelta& Delta, EntityViewElement** ViewElement,
+																		 EntityView& View)
+{
+	// Find the last element relating to the same entity.
+	const Worker_EntityId EntityId = It->EntityId;
+	It = std::find_if(It, End, DifferentEntity{ EntityId }) - 1;
+
+	const bool bAlreadyInView = *ViewElement != nullptr;
+	const bool bEntityAdded = It->bAdded;
+
+	// If the entity's presence has not changed then return.
+	if (bEntityAdded == bAlreadyInView)
 	{
-		int32 GainCount = 0;
-		int32 LossCount = 0;
-		int32 LossTempCount = 0;
-
-		const Worker_EntityId EntityId = It->entity_id;
-		// After each loop the iterator points to the first op relating to the next entity-component.
-		// Stop and return when that component is for a different entity.
-		// There will always be at least one iteration of the loop.
-		for (;;)
-		{
-			// Find the last element for this entity-component.
-			const Worker_ComponentId ComponentId = It->component_id;
-			It = std::find_if(It, End, DifferentEntityComponent{EntityId, ComponentId}) - 1;
-			const int32 AuthorityIndex = EntityAuthority.Find(ComponentId);
-			const bool bHasAuthority = AuthorityIndex != INDEX_NONE;
-
-			if (It->authority == WORKER_AUTHORITY_AUTHORITATIVE)
-			{
-				if (bHasAuthority)
-				{
-					AuthorityLostTempForDelta.Emplace(ComponentId, AuthorityChange::AUTHORITY_LOST_TEMPORARILY);
-					++LossTempCount;
-				}
-				else
-				{
-					EntityAuthority.Push(ComponentId);
-					AuthorityGainedForDelta.Emplace(ComponentId, AuthorityChange::AUTHORITY_GAINED);
-					++GainCount;
-				}
-			}
-			else if (bHasAuthority)
-			{
-				AuthorityLostForDelta.Emplace(ComponentId, AuthorityChange::AUTHORITY_LOST);
-				EntityAuthority.RemoveAtSwap(AuthorityIndex);
-				++LossCount;
-			}
-
-			// Move to the next entity-component.
-			++It;
-
-			if (It->entity_id != EntityId)
-			{
-				Delta.AuthorityGained = {
-					AuthorityGainedForDelta.GetData() + AuthorityGainedForDelta.Num() - GainCount, GainCount
-				};
-				Delta.AuthorityLost = {
-					AuthorityLostForDelta.GetData() + AuthorityLostForDelta.Num() - LossCount, LossCount
-				};
-				Delta.AuthorityLostTemporarily = {
-					AuthorityLostTempForDelta.GetData() + AuthorityLostTempForDelta.Num() - LossTempCount,
-					LossTempCount
-				};
-				return It;
-			}
-		}
-	}
-
-	ViewDelta::ReceivedEntityChange* ViewDelta::ProcessEntityExistenceChange(
-		ReceivedEntityChange* It, ReceivedEntityChange* End,
-		EntityDelta& Delta, EntityViewElement** ViewElement,
-		EntityView& View)
-	{
-		// Find the last element relating to the same entity.
-		const Worker_EntityId EntityId = It->EntityId;
-		It = std::find_if(It, End, DifferentEntity{EntityId}) - 1;
-
-		const bool bAlreadyInView = *ViewElement != nullptr;
-		const bool bEntityAdded = It->bAdded;
-
-		// If the entity's presence has not changed then return.
-		if (bEntityAdded == bAlreadyInView)
-		{
-			return It + 1;
-		}
-
-		if (bEntityAdded)
-		{
-			Delta.bAdded = true;
-			*ViewElement = &View.Emplace(EntityId, EntityViewElement{});
-		}
-		else
-		{
-			Delta.bRemoved = true;
-
-			// Remove components.
-			const auto& Components = (*ViewElement)->Components;
-			for (const auto& Component : Components)
-			{
-				ComponentsRemovedForDelta.Emplace(Component.GetComponentId());
-			}
-			Delta.ComponentsRemoved = {
-				ComponentsRemovedForDelta.GetData() + ComponentsRemovedForDelta.Num() - Components.Num(),
-				Components.Num()
-			};
-
-			// Remove authority.
-			const auto& Authority = (*ViewElement)->Authority;
-			for (const auto& Id : Authority)
-			{
-				AuthorityLostForDelta.Emplace(Id, AuthorityChange::AUTHORITY_LOST);
-			}
-			Delta.AuthorityLost = {
-				AuthorityLostForDelta.GetData() + AuthorityLostForDelta.Num() - Authority.Num(), Authority.Num()
-			};
-
-			// Remove from view.
-			View.Remove(EntityId);
-			*ViewElement = nullptr;
-		}
-
 		return It + 1;
 	}
+
+	if (bEntityAdded)
+	{
+		Delta.bAdded = true;
+		*ViewElement = &View.Emplace(EntityId, EntityViewElement{});
+	}
+	else
+	{
+		Delta.bRemoved = true;
+
+		// Remove components.
+		const auto& Components = (*ViewElement)->Components;
+		for (const auto& Component : Components)
+		{
+			ComponentsRemovedForDelta.Emplace(Component.GetComponentId());
+		}
+		Delta.ComponentsRemoved = { ComponentsRemovedForDelta.GetData() + ComponentsRemovedForDelta.Num() - Components.Num(),
+									Components.Num() };
+
+		// Remove authority.
+		const auto& Authority = (*ViewElement)->Authority;
+		for (const auto& Id : Authority)
+		{
+			AuthorityLostForDelta.Emplace(Id, AuthorityChange::AUTHORITY_LOST);
+		}
+		Delta.AuthorityLost = { AuthorityLostForDelta.GetData() + AuthorityLostForDelta.Num() - Authority.Num(), Authority.Num() };
+
+		// Remove from view.
+		View.Remove(EntityId);
+		*ViewElement = nullptr;
+	}
+
+	return It + 1;
+}
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
@@ -27,7 +27,8 @@ void ViewDelta::SetFromOpList(TArray<OpList> OpLists, EntityView& View)
 }
 
 void ViewDelta::Project(const ViewDelta& Delta, const TArray<Worker_EntityId>& CompleteEntities,
-						const TArray<Worker_EntityId>& NewlyCompleteEntities, const TArray<Worker_EntityId>& NewlyIncompleteEntities, const TArray<Worker_EntityId>& TemporarilyIncompleteEntities)
+						const TArray<Worker_EntityId>& NewlyCompleteEntities, const TArray<Worker_EntityId>& NewlyIncompleteEntities,
+						const TArray<Worker_EntityId>& TemporarilyIncompleteEntities)
 {
 	Clear();
 
@@ -43,8 +44,8 @@ void ViewDelta::Project(const ViewDelta& Delta, const TArray<Worker_EntityId>& C
 
 	for (;;)
 	{
-		const Worker_EntityId MinEntityId =
-			FMath::Min(FMath::Min(DeltaIt->EntityId, *CompleteIt), FMath::Min3(*NewlyCompleteIt, *NewlyIncompleteIt, *TemporarilyIncompleteIt));
+		const Worker_EntityId MinEntityId = FMath::Min(FMath::Min(DeltaIt->EntityId, *CompleteIt),
+													   FMath::Min3(*NewlyCompleteIt, *NewlyIncompleteIt, *TemporarilyIncompleteIt));
 
 		// Find the intersection between complete entities and the entity IDs in the view delta, add them to this
 		// delta.

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
@@ -45,8 +45,7 @@ void ViewDelta::Project(const ViewDelta& Delta, const TArray<Worker_EntityId>& C
 	for (;;)
 	{
 		const Worker_EntityId MinEntityId = FMath::Min3(FMath::Min(DeltaIt->EntityId, *CompleteIt),
-													   FMath::Min(*NewlyCompleteIt, *NewlyIncompleteIt),
-													   *TemporarilyIncompleteIt);
+														FMath::Min(*NewlyCompleteIt, *NewlyIncompleteIt), *TemporarilyIncompleteIt);
 
 		// Find the intersection between complete entities and the entity IDs in the view delta, add them to this
 		// delta.

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
@@ -26,7 +26,7 @@ void ViewDelta::SetFromOpList(TArray<OpList> OpLists, EntityView& View)
 	PopulateEntityDeltas(View);
 }
 
-void ViewDelta::Project(SubViewDelta& SubDelta, const TArray<Worker_EntityId>& CompleteEntities,
+void ViewDelta::Project(FSubViewDelta& SubDelta, const TArray<Worker_EntityId>& CompleteEntities,
 						const TArray<Worker_EntityId>& NewlyCompleteEntities, const TArray<Worker_EntityId>& NewlyIncompleteEntities,
 						const TArray<Worker_EntityId>& TemporarilyIncompleteEntities) const
 {

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
@@ -209,11 +209,6 @@ bool ViewDelta::EntityComparison::operator()(const ReceivedEntityChange& Lhs, co
 	return Lhs.EntityId < Rhs.EntityId;
 }
 
-bool ViewDelta::EntityComparison::operator()(const EntityProjection& Lhs, const EntityProjection& Rhs) const
-{
-	return Lhs.EntityId < Rhs.EntityId;
-}
-
 ComponentChange ViewDelta::CalculateAdd(ReceivedComponentChange* Start, ReceivedComponentChange* End, TArray<ComponentData>& Components)
 {
 	// There must be at least one component add; anything before it can be ignored.

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
@@ -381,6 +381,11 @@ void ViewDelta::PopulateEntityDeltas(EntityView& View)
 	Algo::StableSort(AuthorityChanges, EntityComponentComparison{});
 	Algo::StableSort(EntityChanges, EntityComparison{});
 
+	// The sentinel entity ID has the property that when converted to a uint64 it will be greater than INT64_MAX.
+	// If we convert all entity IDs to uint64s before comparing them we can then be assured that the sentinel values
+	// will be greater than all valid IDs.
+	static const Worker_EntityId SENTINEL_ENTITY_ID = -1;
+
 	// Add sentinel elements to the ends of the arrays.
 	// Prevents the need for bounds checks on the iterators.
 	ComponentChanges.Emplace(Worker_RemoveComponentOp{ SENTINEL_ENTITY_ID, 0 });

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
@@ -8,566 +8,665 @@
 
 namespace SpatialGDK
 {
-void ViewDelta::SetFromOpList(TArray<OpList> OpLists, EntityView& View)
-{
-	Clear();
-
-	for (OpList& Ops : OpLists)
+	void ViewDelta::SetFromOpList(TArray<OpList> OpLists, EntityView& View)
 	{
-		const uint32 Count = Ops.Count;
-		Worker_Op* OpData = Ops.Ops;
-		for (uint32 i = 0; i < Count; ++i)
+		Clear();
+
+		for (OpList& Ops : OpLists)
 		{
-			ProcessOp(OpData[i]);
+			const uint32 Count = Ops.Count;
+			Worker_Op* OpData = Ops.Ops;
+			for (uint32 i = 0; i < Count; ++i)
+			{
+				ProcessOp(OpData[i]);
+			}
+		}
+		OpListStorage = MoveTemp(OpLists);
+
+		PopulateEntityDeltas(View);
+	}
+
+	void ViewDelta::Project(const ViewDelta& Delta, const TArray<Worker_EntityId>& CompleteEntities,
+	                        const TArray<Worker_EntityId>& NewlyCompleteEntities,
+	                        const TArray<Worker_EntityId>& NewlyIncompleteEntities)
+	{
+		Clear();
+
+		// No projection is applied to worker messages, as they are not entity specific.
+		WorkerMessages = Delta.GetWorkerMessages();
+
+		// All arrays here are sorted by entity ID.
+		auto DeltaIt = Delta.GetEntityDeltas().CreateConstIterator();
+		auto CompleteIt = CompleteEntities.CreateConstIterator();
+		auto NewlyCompleteIt = NewlyCompleteEntities.CreateConstIterator();
+		auto NewlyIncompleteIt = NewlyIncompleteEntities.CreateConstIterator();
+
+		for (;;)
+		{
+			const Worker_EntityId MinEntityId = FMath::Min(FMath::Min(DeltaIt->EntityId, *CompleteIt),
+                                                        FMath::Min(*NewlyCompleteIt, *NewlyIncompleteIt));
+
+			// Find the intersection between complete entities and the entity IDs in the view delta, add them to this
+			// delta.
+			if (CompleteIt && DeltaIt && *CompleteIt == MinEntityId && DeltaIt->EntityId == MinEntityId)
+			{
+				EntityDeltas.Emplace(*DeltaIt);
+			}
+			// Newly complete entities are represented as marker add entities with no state.
+			if (NewlyCompleteIt && *NewlyCompleteIt == MinEntityId)
+			{
+				EntityDeltas.Emplace(EntityDelta{MinEntityId, true, false});
+				++NewlyCompleteIt;
+			}
+			// Newly incomplete entities are represented as marker remove entities with no state.
+			if (NewlyIncompleteIt && *NewlyIncompleteIt == MinEntityId)
+			{
+				EntityDeltas.Emplace(EntityDelta{MinEntityId, false, true});
+				++NewlyIncompleteIt;
+			}
+
+			// Logic for incrementing complete and delta iterators. If either iterator is done, null the other,
+			// as there can no longer be any intersection.
+			if (CompleteIt && *CompleteIt == MinEntityId)
+			{
+				++CompleteIt;
+				if (!CompleteIt)
+				{
+					DeltaIt.SetToEnd();
+				}
+			}
+			if (DeltaIt && DeltaIt->EntityId == MinEntityId)
+			{
+				++DeltaIt;
+				if (!DeltaIt)
+				{
+					CompleteIt.SetToEnd();
+				}
+			}
+
+			// Break when all iterators are done.
+			if (!CompleteIt && !NewlyCompleteIt && !NewlyIncompleteIt && !DeltaIt)
+			{
+				return;
+			}
 		}
 	}
-	OpListStorage = MoveTemp(OpLists);
 
-	PopulateEntityDeltas(View);
-}
+	void ViewDelta::Clear()
+	{
+		EntityChanges.Empty();
+		ComponentChanges.Empty();
+		AuthorityChanges.Empty();
 
-void ViewDelta::Clear()
-{
-	EntityChanges.Empty();
-	ComponentChanges.Empty();
-	AuthorityChanges.Empty();
+		ConnectionStatusCode = 0;
 
-	ConnectionStatusCode = 0;
+		EntityDeltas.Empty();
+		WorkerMessages.Empty();
+		AuthorityGainedForDelta.Empty();
+		AuthorityLostForDelta.Empty();
+		AuthorityLostTempForDelta.Empty();
+		ComponentsAddedForDelta.Empty();
+		ComponentsRemovedForDelta.Empty();
+		ComponentUpdatesForDelta.Empty();
+		ComponentsRefreshedForDelta.Empty();
+		OpListStorage.Empty();
+	}
 
-	EntityDeltas.Empty();
-	WorkerMessages.Empty();
-	AuthorityGainedForDelta.Empty();
-	AuthorityLostForDelta.Empty();
-	AuthorityLostTempForDelta.Empty();
-	ComponentsAddedForDelta.Empty();
-	ComponentsRemovedForDelta.Empty();
-	ComponentUpdatesForDelta.Empty();
-	ComponentsRefreshedForDelta.Empty();
-	OpListStorage.Empty();
-}
+	const TArray<EntityDelta>& ViewDelta::GetEntityDeltas() const
+	{
+		return EntityDeltas;
+	}
 
-const TArray<EntityDelta>& ViewDelta::GetEntityDeltas() const
-{
-	return EntityDeltas;
-}
+	const TArray<Worker_Op>& ViewDelta::GetWorkerMessages() const
+	{
+		return WorkerMessages;
+	}
 
-const TArray<Worker_Op>& ViewDelta::GetWorkerMessages() const
-{
-	return WorkerMessages;
-}
+	bool ViewDelta::HasDisconnected() const
+	{
+		return ConnectionStatusCode != 0;
+	}
 
-bool ViewDelta::HasDisconnected() const
-{
-	return ConnectionStatusCode != 0;
-}
+	Worker_ConnectionStatusCode ViewDelta::GetConnectionStatus() const
+	{
+		check(HasDisconnected());
+		return static_cast<Worker_ConnectionStatusCode>(ConnectionStatusCode);
+	}
 
-Worker_ConnectionStatusCode ViewDelta::GetConnectionStatus() const
-{
-	check(HasDisconnected());
-	return static_cast<Worker_ConnectionStatusCode>(ConnectionStatusCode);
-}
+	FString ViewDelta::GetDisconnectReason() const
+	{
+		check(HasDisconnected());
+		return ConnectionStatusMessage;
+	}
 
-FString ViewDelta::GetDisconnectReason() const
-{
-	check(HasDisconnected());
-	return ConnectionStatusMessage;
-}
+	ViewDelta::ReceivedComponentChange::ReceivedComponentChange(const Worker_AddComponentOp& Op)
+		: EntityId(Op.entity_id)
+		  , ComponentId(Op.data.component_id)
+		  , Type(ADD)
+		  , ComponentAdded(Op.data.schema_type)
+	{
+	}
 
-ViewDelta::ReceivedComponentChange::ReceivedComponentChange(const Worker_AddComponentOp& Op)
-	: EntityId(Op.entity_id)
-	, ComponentId(Op.data.component_id)
-	, Type(ADD)
-	, ComponentAdded(Op.data.schema_type)
-{
-}
+	ViewDelta::ReceivedComponentChange::ReceivedComponentChange(const Worker_ComponentUpdateOp& Op)
+		: EntityId(Op.entity_id)
+		  , ComponentId(Op.update.component_id)
+		  , Type(UPDATE)
+		  , ComponentUpdate(Op.update.schema_type)
+	{
+	}
 
-ViewDelta::ReceivedComponentChange::ReceivedComponentChange(const Worker_ComponentUpdateOp& Op)
-	: EntityId(Op.entity_id)
-	, ComponentId(Op.update.component_id)
-	, Type(UPDATE)
-	, ComponentUpdate(Op.update.schema_type)
-{
-}
+	ViewDelta::ReceivedComponentChange::ReceivedComponentChange(const Worker_RemoveComponentOp& Op)
+		: EntityId(Op.entity_id)
+		  , ComponentId(Op.component_id)
+		  , Type(REMOVE)
+	{
+	}
 
-ViewDelta::ReceivedComponentChange::ReceivedComponentChange(const Worker_RemoveComponentOp& Op)
-	: EntityId(Op.entity_id)
-	, ComponentId(Op.component_id)
-	, Type(REMOVE)
-{
-}
+	bool ViewDelta::DifferentEntity::operator()(const ReceivedEntityChange& E) const
+	{
+		return E.EntityId != EntityId;
+	}
 
-bool ViewDelta::DifferentEntity::operator()(const ReceivedEntityChange& E) const
-{
-	return E.EntityId != EntityId;
-}
+	bool ViewDelta::DifferentEntity::operator()(const ReceivedComponentChange& Op) const
+	{
+		return Op.EntityId != EntityId;
+	}
 
-bool ViewDelta::DifferentEntity::operator()(const ReceivedComponentChange& Op) const
-{
-	return Op.EntityId != EntityId;
-}
+	bool ViewDelta::DifferentEntity::operator()(const Worker_AuthorityChangeOp& Op) const
+	{
+		return Op.entity_id != EntityId;
+	}
 
-bool ViewDelta::DifferentEntity::operator()(const Worker_AuthorityChangeOp& Op) const
-{
-	return Op.entity_id != EntityId;
-}
+	bool ViewDelta::DifferentEntityComponent::operator()(const ReceivedComponentChange& Op) const
+	{
+		return Op.ComponentId != ComponentId || Op.EntityId != EntityId;
+	}
 
-bool ViewDelta::DifferentEntityComponent::operator()(const ReceivedComponentChange& Op) const
-{
-	return Op.ComponentId != ComponentId || Op.EntityId != EntityId;
-}
+	bool ViewDelta::DifferentEntityComponent::operator()(const Worker_AuthorityChangeOp& Op) const
+	{
+		return Op.component_id != ComponentId || Op.entity_id != EntityId;
+	}
 
-bool ViewDelta::DifferentEntityComponent::operator()(const Worker_AuthorityChangeOp& Op) const
-{
-	return Op.component_id != ComponentId || Op.entity_id != EntityId;
-}
+	bool ViewDelta::EntityComponentComparison::operator()(const ReceivedComponentChange& Lhs,
+	                                                      const ReceivedComponentChange& Rhs) const
+	{
+		if (Lhs.EntityId != Rhs.EntityId)
+		{
+			return Lhs.EntityId < Rhs.EntityId;
+		}
+		return Lhs.ComponentId < Rhs.ComponentId;
+	}
 
-bool ViewDelta::EntityComponentComparison::operator()(const ReceivedComponentChange& Lhs, const ReceivedComponentChange& Rhs) const
-{
-	if (Lhs.EntityId != Rhs.EntityId)
+	bool ViewDelta::EntityComponentComparison::operator()(const Worker_AuthorityChangeOp& Lhs,
+	                                                      const Worker_AuthorityChangeOp& Rhs) const
+	{
+		if (Lhs.entity_id != Rhs.entity_id)
+		{
+			return Lhs.entity_id < Rhs.entity_id;
+		}
+		return Lhs.component_id < Rhs.component_id;
+	}
+
+	bool ViewDelta::EntityComparison::operator()(const ReceivedEntityChange& Lhs, const ReceivedEntityChange& Rhs) const
 	{
 		return Lhs.EntityId < Rhs.EntityId;
 	}
-	return Lhs.ComponentId < Rhs.ComponentId;
-}
 
-bool ViewDelta::EntityComponentComparison::operator()(const Worker_AuthorityChangeOp& Lhs, const Worker_AuthorityChangeOp& Rhs) const
-{
-	if (Lhs.entity_id != Rhs.entity_id)
+	bool ViewDelta::EntityComparison::operator()(const EntityProjection& Lhs, const EntityProjection& Rhs) const
 	{
-		return Lhs.entity_id < Rhs.entity_id;
+		return Lhs.EntityId < Rhs.EntityId;
 	}
-	return Lhs.component_id < Rhs.component_id;
-}
 
-bool ViewDelta::EntityComparison::operator()(const ReceivedEntityChange& Lhs, const ReceivedEntityChange& Rhs) const
-{
-	return Lhs.EntityId < Rhs.EntityId;
-}
-
-ComponentChange ViewDelta::CalculateAdd(ReceivedComponentChange* Start, ReceivedComponentChange* End, TArray<ComponentData>& Components)
-{
-	// There must be at least one component add; anything before it can be ignored.
-	ReceivedComponentChange* It = std::find_if(Start, End, [](const ReceivedComponentChange& Op) {
-		return Op.Type == ReceivedComponentChange::ADD;
-	});
-
-	Schema_ComponentData* Data = It->ComponentAdded;
-	++It;
-
-	while (It != End)
+	ComponentChange ViewDelta::CalculateAdd(ReceivedComponentChange* Start, ReceivedComponentChange* End,
+	                                        TArray<ComponentData>& Components)
 	{
-		switch (It->Type)
+		// There must be at least one component add; anything before it can be ignored.
+		ReceivedComponentChange* It = std::find_if(Start, End, [](const ReceivedComponentChange& Op)
 		{
-		case ReceivedComponentChange::ADD:
-			Data = It->ComponentAdded;
-			break;
-		case ReceivedComponentChange::UPDATE:
-			Schema_ApplyComponentUpdateToData(It->ComponentUpdate, Data);
-			break;
-		case ReceivedComponentChange::REMOVE:
-			break;
-		}
+			return Op.Type == ReceivedComponentChange::ADD;
+		});
+
+		Schema_ComponentData* Data = It->ComponentAdded;
 		++It;
-	}
-	Components.Emplace(ComponentData::CreateCopy(Data, Start->ComponentId));
-	// We don't want to reference the component in the view as is isn't stable.
-	return ComponentChange(Start->ComponentId, Data);
-}
 
-ComponentChange ViewDelta::CalculateCompleteUpdate(ReceivedComponentChange* Start, ReceivedComponentChange* End, Schema_ComponentData* Data,
-												   Schema_ComponentUpdate* Events, ComponentData& Component)
-{
-	for (auto It = Start; It != End; ++It)
-	{
-		switch (It->Type)
+		while (It != End)
 		{
-		case ReceivedComponentChange::ADD:
-			Data = It->ComponentAdded;
-			break;
-		case ReceivedComponentChange::UPDATE:
-			if (Data)
+			switch (It->Type)
 			{
+			case ReceivedComponentChange::ADD:
+				Data = It->ComponentAdded;
+				break;
+			case ReceivedComponentChange::UPDATE:
 				Schema_ApplyComponentUpdateToData(It->ComponentUpdate, Data);
+				break;
+			case ReceivedComponentChange::REMOVE:
+				break;
 			}
-			if (Events)
+			++It;
+		}
+		Components.Emplace(ComponentData::CreateCopy(Data, Start->ComponentId));
+		// We don't want to reference the component in the view as is isn't stable.
+		return ComponentChange(Start->ComponentId, Data);
+	}
+
+	ComponentChange ViewDelta::CalculateCompleteUpdate(ReceivedComponentChange* Start, ReceivedComponentChange* End,
+	                                                   Schema_ComponentData* Data,
+	                                                   Schema_ComponentUpdate* Events, ComponentData& Component)
+	{
+		for (auto It = Start; It != End; ++It)
+		{
+			switch (It->Type)
 			{
-				Schema_MergeComponentUpdateIntoUpdate(It->ComponentUpdate, Events);
-			}
-			else
-			{
-				Events = It->ComponentUpdate;
-			}
-			break;
-		case ReceivedComponentChange::REMOVE:
-			break;
-		}
-	}
-
-	Component = ComponentData::CreateCopy(Data, Start->ComponentId);
-	Schema_Object* EventsObj = Events ? Schema_GetComponentUpdateEvents(Events) : nullptr;
-	// Use the data from the op list as pointers from the view aren't stable.
-	return ComponentChange(Start->ComponentId, Data, EventsObj);
-}
-
-ComponentChange ViewDelta::CalculateUpdate(ReceivedComponentChange* Start, ReceivedComponentChange* End, ComponentData& Component)
-{
-	// For an update we don't know if we are calculating a complete-update or a regular update.
-	// So the first message processed might be an add or an update.
-	auto It = std::find_if(Start, End, [](const ReceivedComponentChange& Op) {
-		return Op.Type != ReceivedComponentChange::REMOVE;
-	});
-
-	// If the first message is an add then calculate a complete-update.
-	if (It->Type == ReceivedComponentChange::ADD)
-	{
-		return CalculateCompleteUpdate(It + 1, End, It->ComponentAdded, nullptr, Component);
-	}
-
-	Schema_ComponentUpdate* Update = It->ComponentUpdate;
-	++It;
-	while (It != End)
-	{
-		switch (It->Type)
-		{
-		case ReceivedComponentChange::ADD:
-			return CalculateCompleteUpdate(It + 1, End, It->ComponentAdded, Update, Component);
-		case ReceivedComponentChange::UPDATE:
-			Schema_MergeComponentUpdateIntoUpdate(It->ComponentUpdate, Update);
-			break;
-		case ReceivedComponentChange::REMOVE:
-			return CalculateCompleteUpdate(It + 1, End, nullptr, nullptr, Component);
-		}
-		++It;
-	}
-
-	Schema_ApplyComponentUpdateToData(Update, Component.GetUnderlying());
-	Component = Component.DeepCopy();
-	return ComponentChange(Start->ComponentId, Update);
-}
-
-void ViewDelta::ProcessOp(Worker_Op& Op)
-{
-	switch (static_cast<Worker_OpType>(Op.op_type))
-	{
-	case WORKER_OP_TYPE_DISCONNECT:
-		ConnectionStatusCode = Op.op.disconnect.connection_status_code;
-		ConnectionStatusMessage = Op.op.disconnect.reason;
-		break;
-	case WORKER_OP_TYPE_LOG_MESSAGE:
-		// Log messages deprecated.
-		break;
-	case WORKER_OP_TYPE_CRITICAL_SECTION:
-		// Ignore critical sections.
-		break;
-	case WORKER_OP_TYPE_ADD_ENTITY:
-		EntityChanges.Push(ReceivedEntityChange{ Op.op.add_entity.entity_id, true });
-		break;
-	case WORKER_OP_TYPE_REMOVE_ENTITY:
-		EntityChanges.Push(ReceivedEntityChange{ Op.op.remove_entity.entity_id, false });
-		break;
-	case WORKER_OP_TYPE_METRICS:
-	case WORKER_OP_TYPE_FLAG_UPDATE:
-	case WORKER_OP_TYPE_RESERVE_ENTITY_IDS_RESPONSE:
-	case WORKER_OP_TYPE_CREATE_ENTITY_RESPONSE:
-	case WORKER_OP_TYPE_DELETE_ENTITY_RESPONSE:
-	case WORKER_OP_TYPE_ENTITY_QUERY_RESPONSE:
-	case WORKER_OP_TYPE_COMMAND_REQUEST:
-	case WORKER_OP_TYPE_COMMAND_RESPONSE:
-		WorkerMessages.Push(Op);
-		break;
-	case WORKER_OP_TYPE_ADD_COMPONENT:
-		ComponentChanges.Emplace(Op.op.add_component);
-		break;
-	case WORKER_OP_TYPE_REMOVE_COMPONENT:
-		ComponentChanges.Emplace(Op.op.remove_component);
-		break;
-	case WORKER_OP_TYPE_AUTHORITY_CHANGE:
-		if (Op.op.authority_change.authority != WORKER_AUTHORITY_AUTHORITY_LOSS_IMMINENT)
-		{
-			AuthorityChanges.Emplace(Op.op.authority_change);
-		}
-		break;
-	case WORKER_OP_TYPE_COMPONENT_UPDATE:
-		ComponentChanges.Emplace(Op.op.component_update);
-		break;
-	default:
-		break;
-	}
-}
-
-void ViewDelta::PopulateEntityDeltas(EntityView& View)
-{
-	// Make sure there is enough space in the view delta storage.
-	// This allows us to rely on stable pointers as we add new elements.
-	ComponentsAddedForDelta.Reserve(ComponentChanges.Num());
-	ComponentsRemovedForDelta.Reserve(ComponentChanges.Num());
-	ComponentUpdatesForDelta.Reserve(ComponentChanges.Num());
-	ComponentsRefreshedForDelta.Reserve(ComponentChanges.Num());
-	AuthorityGainedForDelta.Reserve(AuthorityChanges.Num());
-	AuthorityLostForDelta.Reserve(AuthorityChanges.Num());
-	AuthorityLostTempForDelta.Reserve(AuthorityChanges.Num());
-
-	Algo::StableSort(ComponentChanges, EntityComponentComparison{});
-	Algo::StableSort(AuthorityChanges, EntityComponentComparison{});
-	Algo::StableSort(EntityChanges, EntityComparison{});
-
-	// The sentinel entity ID has the property that when converted to a uint64 it will be greater than INT64_MAX.
-	// If we convert all entity IDs to uint64s before comparing them we can then be assured that the sentinel values
-	// will be greater than all valid IDs.
-	static const Worker_EntityId SENTINEL_ENTITY_ID = -1;
-
-	// Add sentinel elements to the ends of the arrays.
-	// Prevents the need for bounds checks on the iterators.
-	ComponentChanges.Emplace(Worker_RemoveComponentOp{ SENTINEL_ENTITY_ID, 0 });
-	AuthorityChanges.Emplace(Worker_AuthorityChangeOp{ SENTINEL_ENTITY_ID, 0, 0 });
-	EntityChanges.Emplace(ReceivedEntityChange{ SENTINEL_ENTITY_ID, false });
-
-	auto ComponentIt = ComponentChanges.GetData();
-	auto AuthorityIt = AuthorityChanges.GetData();
-	auto EntityIt = EntityChanges.GetData();
-
-	ReceivedComponentChange* ComponentChangesEnd = ComponentIt + ComponentChanges.Num();
-	Worker_AuthorityChangeOp* AuthorityChangesEnd = AuthorityIt + AuthorityChanges.Num();
-	ReceivedEntityChange* EntityChangesEnd = EntityIt + EntityChanges.Num();
-
-	// At the beginning of each loop each iterator should point to the first element for an entity.
-	// Each loop we want to work with a single entity ID.
-	// We check the entities each iterator is pointing to and pick the smallest one.
-	// If that is the sentinel ID then stop.
-	for (;;)
-	{
-		// Get the next entity ID. We want to pick the smallest entity referenced by the iterators.
-		// Convert to uint64 to ensure the sentinel value is larger than all valid IDs.
-		const uint64 MinEntityId = FMath::Min3(static_cast<uint64>(ComponentIt->EntityId), static_cast<uint64>(AuthorityIt->entity_id),
-											   static_cast<uint64>(EntityIt->EntityId));
-
-		// If no list has elements left to read then stop.
-		if (static_cast<Worker_EntityId>(MinEntityId) == SENTINEL_ENTITY_ID)
-		{
-			break;
-		}
-
-		const Worker_EntityId CurrentEntityId = static_cast<Worker_EntityId>(MinEntityId);
-
-		EntityDelta Delta = {};
-		Delta.EntityId = CurrentEntityId;
-
-		EntityViewElement* ViewElement = View.Find(CurrentEntityId);
-
-		if (EntityIt->EntityId == CurrentEntityId)
-		{
-			EntityIt = ProcessEntityExistenceChange(EntityIt, EntityChangesEnd, Delta, &ViewElement, View);
-			// If the entity isn't present we don't need to process component and authority changes.
-			if (ViewElement == nullptr)
-			{
-				ComponentIt = std::find_if(ComponentIt, ComponentChangesEnd, DifferentEntity{ CurrentEntityId });
-				AuthorityIt = std::find_if(AuthorityIt, AuthorityChangesEnd, DifferentEntity{ CurrentEntityId });
-
-				// Only add the entity delta if the entity previously existed in the view.
-				if (Delta.bRemoved)
+			case ReceivedComponentChange::ADD:
+				Data = It->ComponentAdded;
+				break;
+			case ReceivedComponentChange::UPDATE:
+				if (Data)
 				{
-					EntityDeltas.Push(Delta);
+					Schema_ApplyComponentUpdateToData(It->ComponentUpdate, Data);
 				}
-				continue;
+				if (Events)
+				{
+					Schema_MergeComponentUpdateIntoUpdate(It->ComponentUpdate, Events);
+				}
+				else
+				{
+					Events = It->ComponentUpdate;
+				}
+				break;
+			case ReceivedComponentChange::REMOVE:
+				break;
 			}
 		}
 
-		if (ComponentIt->EntityId == CurrentEntityId)
-		{
-			ComponentIt = ProcessEntityComponentChanges(ComponentIt, ComponentChangesEnd, ViewElement->Components, Delta);
-		}
-
-		if (AuthorityIt->entity_id == CurrentEntityId)
-		{
-			AuthorityIt = ProcessEntityAuthorityChanges(AuthorityIt, AuthorityChangesEnd, ViewElement->Authority, Delta);
-		}
-
-		EntityDeltas.Push(Delta);
+		Component = ComponentData::CreateCopy(Data, Start->ComponentId);
+		Schema_Object* EventsObj = Events ? Schema_GetComponentUpdateEvents(Events) : nullptr;
+		// Use the data from the op list as pointers from the view aren't stable.
+		return ComponentChange(Start->ComponentId, Data, EventsObj);
 	}
-}
 
-ViewDelta::ReceivedComponentChange* ViewDelta::ProcessEntityComponentChanges(ReceivedComponentChange* It, ReceivedComponentChange* End,
-																			 TArray<ComponentData>& Components, EntityDelta& Delta)
-{
-	int32 AddCount = 0;
-	int32 UpdateCount = 0;
-	int32 RemoveCount = 0;
-	int32 RefreshCount = 0;
-
-	const Worker_EntityId EntityId = It->EntityId;
-	// At the end of each loop `It` should point to the first element for an entity-component.
-	// Stop and return when the component is for a different entity.
-	// There will always be at least one iteration of the loop.
-	for (;;)
+	ComponentChange ViewDelta::CalculateUpdate(ReceivedComponentChange* Start, ReceivedComponentChange* End,
+	                                           ComponentData& Component)
 	{
-		ReceivedComponentChange* NextComponentIt = std::find_if(It, End, DifferentEntityComponent{ EntityId, It->ComponentId });
-
-		ComponentData* Component = Components.FindByPredicate(ComponentIdEquality{ It->ComponentId });
-		const bool bComponentExists = Component != nullptr;
-
-		// The element one before NextComponentIt must be the last element for this component.
-		switch ((NextComponentIt - 1)->Type)
+		// For an update we don't know if we are calculating a complete-update or a regular update.
+		// So the first message processed might be an add or an update.
+		auto It = std::find_if(Start, End, [](const ReceivedComponentChange& Op)
 		{
-		case ReceivedComponentChange::ADD:
-			if (bComponentExists)
+			return Op.Type != ReceivedComponentChange::REMOVE;
+		});
+
+		// If the first message is an add then calculate a complete-update.
+		if (It->Type == ReceivedComponentChange::ADD)
+		{
+			return CalculateCompleteUpdate(It + 1, End, It->ComponentAdded, nullptr, Component);
+		}
+
+		Schema_ComponentUpdate* Update = It->ComponentUpdate;
+		++It;
+		while (It != End)
+		{
+			switch (It->Type)
 			{
-				ComponentsRefreshedForDelta.Emplace(CalculateCompleteUpdate(It, NextComponentIt, nullptr, nullptr, *Component));
-				++RefreshCount;
+			case ReceivedComponentChange::ADD:
+				return CalculateCompleteUpdate(It + 1, End, It->ComponentAdded, Update, Component);
+			case ReceivedComponentChange::UPDATE:
+				Schema_MergeComponentUpdateIntoUpdate(It->ComponentUpdate, Update);
+				break;
+			case ReceivedComponentChange::REMOVE:
+				return CalculateCompleteUpdate(It + 1, End, nullptr, nullptr, Component);
 			}
-			else
+			++It;
+		}
+
+		Schema_ApplyComponentUpdateToData(Update, Component.GetUnderlying());
+		Component = Component.DeepCopy();
+		return ComponentChange(Start->ComponentId, Update);
+	}
+
+	void ViewDelta::ProcessOp(Worker_Op& Op)
+	{
+		switch (static_cast<Worker_OpType>(Op.op_type))
+		{
+		case WORKER_OP_TYPE_DISCONNECT:
+			ConnectionStatusCode = Op.op.disconnect.connection_status_code;
+			ConnectionStatusMessage = Op.op.disconnect.reason;
+			break;
+		case WORKER_OP_TYPE_LOG_MESSAGE:
+			// Log messages deprecated.
+			break;
+		case WORKER_OP_TYPE_CRITICAL_SECTION:
+			// Ignore critical sections.
+			break;
+		case WORKER_OP_TYPE_ADD_ENTITY:
+			EntityChanges.Push(ReceivedEntityChange{Op.op.add_entity.entity_id, true});
+			break;
+		case WORKER_OP_TYPE_REMOVE_ENTITY:
+			EntityChanges.Push(ReceivedEntityChange{Op.op.remove_entity.entity_id, false});
+			break;
+		case WORKER_OP_TYPE_METRICS:
+		case WORKER_OP_TYPE_FLAG_UPDATE:
+		case WORKER_OP_TYPE_RESERVE_ENTITY_IDS_RESPONSE:
+		case WORKER_OP_TYPE_CREATE_ENTITY_RESPONSE:
+		case WORKER_OP_TYPE_DELETE_ENTITY_RESPONSE:
+		case WORKER_OP_TYPE_ENTITY_QUERY_RESPONSE:
+		case WORKER_OP_TYPE_COMMAND_REQUEST:
+		case WORKER_OP_TYPE_COMMAND_RESPONSE:
+			WorkerMessages.Push(Op);
+			break;
+		case WORKER_OP_TYPE_ADD_COMPONENT:
+			ComponentChanges.Emplace(Op.op.add_component);
+			break;
+		case WORKER_OP_TYPE_REMOVE_COMPONENT:
+			ComponentChanges.Emplace(Op.op.remove_component);
+			break;
+		case WORKER_OP_TYPE_AUTHORITY_CHANGE:
+			if (Op.op.authority_change.authority != WORKER_AUTHORITY_AUTHORITY_LOSS_IMMINENT)
 			{
-				ComponentsAddedForDelta.Emplace(CalculateAdd(It, NextComponentIt, Components));
-				++AddCount;
+				AuthorityChanges.Emplace(Op.op.authority_change);
 			}
 			break;
-		case ReceivedComponentChange::UPDATE:
-			if (bComponentExists)
+		case WORKER_OP_TYPE_COMPONENT_UPDATE:
+			ComponentChanges.Emplace(Op.op.component_update);
+			break;
+		default:
+			break;
+		}
+	}
+
+	void ViewDelta::PopulateEntityDeltas(EntityView& View)
+	{
+		// Make sure there is enough space in the view delta storage.
+		// This allows us to rely on stable pointers as we add new elements.
+		ComponentsAddedForDelta.Reserve(ComponentChanges.Num());
+		ComponentsRemovedForDelta.Reserve(ComponentChanges.Num());
+		ComponentUpdatesForDelta.Reserve(ComponentChanges.Num());
+		ComponentsRefreshedForDelta.Reserve(ComponentChanges.Num());
+		AuthorityGainedForDelta.Reserve(AuthorityChanges.Num());
+		AuthorityLostForDelta.Reserve(AuthorityChanges.Num());
+		AuthorityLostTempForDelta.Reserve(AuthorityChanges.Num());
+
+		Algo::StableSort(ComponentChanges, EntityComponentComparison{});
+		Algo::StableSort(AuthorityChanges, EntityComponentComparison{});
+		Algo::StableSort(EntityChanges, EntityComparison{});
+
+		// Add sentinel elements to the ends of the arrays.
+		// Prevents the need for bounds checks on the iterators.
+		ComponentChanges.Emplace(Worker_RemoveComponentOp{SENTINEL_ENTITY_ID, 0});
+		AuthorityChanges.Emplace(Worker_AuthorityChangeOp{SENTINEL_ENTITY_ID, 0, 0});
+		EntityChanges.Emplace(ReceivedEntityChange{SENTINEL_ENTITY_ID, false});
+
+		auto ComponentIt = ComponentChanges.GetData();
+		auto AuthorityIt = AuthorityChanges.GetData();
+		auto EntityIt = EntityChanges.GetData();
+
+		ReceivedComponentChange* ComponentChangesEnd = ComponentIt + ComponentChanges.Num();
+		Worker_AuthorityChangeOp* AuthorityChangesEnd = AuthorityIt + AuthorityChanges.Num();
+		ReceivedEntityChange* EntityChangesEnd = EntityIt + EntityChanges.Num();
+
+		// At the beginning of each loop each iterator should point to the first element for an entity.
+		// Each loop we want to work with a single entity ID.
+		// We check the entities each iterator is pointing to and pick the smallest one.
+		// If that is the sentinel ID then stop.
+		for (;;)
+		{
+			// Get the next entity ID. We want to pick the smallest entity referenced by the iterators.
+			// Convert to uint64 to ensure the sentinel value is larger than all valid IDs.
+			const uint64 MinEntityId = FMath::Min3(static_cast<uint64>(ComponentIt->EntityId),
+			                                       static_cast<uint64>(AuthorityIt->entity_id),
+			                                       static_cast<uint64>(EntityIt->EntityId));
+
+			// If no list has elements left to read then stop.
+			if (static_cast<Worker_EntityId>(MinEntityId) == SENTINEL_ENTITY_ID)
 			{
-				ComponentChange Update = CalculateUpdate(It, NextComponentIt, *Component);
-				if (Update.Type == ComponentChange::COMPLETE_UPDATE)
+				break;
+			}
+
+			const Worker_EntityId CurrentEntityId = static_cast<Worker_EntityId>(MinEntityId);
+
+			EntityDelta Delta = {};
+			Delta.EntityId = CurrentEntityId;
+
+			EntityViewElement* ViewElement = View.Find(CurrentEntityId);
+
+			if (EntityIt->EntityId == CurrentEntityId)
+			{
+				EntityIt = ProcessEntityExistenceChange(EntityIt, EntityChangesEnd, Delta, &ViewElement, View);
+				// If the entity isn't present we don't need to process component and authority changes.
+				if (ViewElement == nullptr)
 				{
-					ComponentsRefreshedForDelta.Emplace(Update);
+					ComponentIt = std::find_if(ComponentIt, ComponentChangesEnd, DifferentEntity{CurrentEntityId});
+					AuthorityIt = std::find_if(AuthorityIt, AuthorityChangesEnd, DifferentEntity{CurrentEntityId});
+
+					// Only add the entity delta if the entity previously existed in the view.
+					if (Delta.bRemoved)
+					{
+						EntityDeltas.Push(Delta);
+					}
+					continue;
+				}
+			}
+
+			if (ComponentIt->EntityId == CurrentEntityId)
+			{
+				ComponentIt = ProcessEntityComponentChanges(ComponentIt, ComponentChangesEnd, ViewElement->Components,
+				                                            Delta);
+			}
+
+			if (AuthorityIt->entity_id == CurrentEntityId)
+			{
+				AuthorityIt = ProcessEntityAuthorityChanges(AuthorityIt, AuthorityChangesEnd, ViewElement->Authority,
+				                                            Delta);
+			}
+
+			EntityDeltas.Push(Delta);
+		}
+	}
+
+	ViewDelta::ReceivedComponentChange* ViewDelta::ProcessEntityComponentChanges(
+		ReceivedComponentChange* It, ReceivedComponentChange* End,
+		TArray<ComponentData>& Components, EntityDelta& Delta)
+	{
+		int32 AddCount = 0;
+		int32 UpdateCount = 0;
+		int32 RemoveCount = 0;
+		int32 RefreshCount = 0;
+
+		const Worker_EntityId EntityId = It->EntityId;
+		// At the end of each loop `It` should point to the first element for an entity-component.
+		// Stop and return when the component is for a different entity.
+		// There will always be at least one iteration of the loop.
+		for (;;)
+		{
+			ReceivedComponentChange* NextComponentIt = std::find_if(
+				It, End, DifferentEntityComponent{EntityId, It->ComponentId});
+
+			ComponentData* Component = Components.FindByPredicate(ComponentIdEquality{It->ComponentId});
+			const bool bComponentExists = Component != nullptr;
+
+			// The element one before NextComponentIt must be the last element for this component.
+			switch ((NextComponentIt - 1)->Type)
+			{
+			case ReceivedComponentChange::ADD:
+				if (bComponentExists)
+				{
+					ComponentsRefreshedForDelta.Emplace(
+						CalculateCompleteUpdate(It, NextComponentIt, nullptr, nullptr, *Component));
 					++RefreshCount;
 				}
 				else
 				{
-					ComponentUpdatesForDelta.Emplace(Update);
-					++UpdateCount;
+					ComponentsAddedForDelta.Emplace(CalculateAdd(It, NextComponentIt, Components));
+					++AddCount;
+				}
+				break;
+			case ReceivedComponentChange::UPDATE:
+				if (bComponentExists)
+				{
+					ComponentChange Update = CalculateUpdate(It, NextComponentIt, *Component);
+					if (Update.Type == ComponentChange::COMPLETE_UPDATE)
+					{
+						ComponentsRefreshedForDelta.Emplace(Update);
+						++RefreshCount;
+					}
+					else
+					{
+						ComponentUpdatesForDelta.Emplace(Update);
+						++UpdateCount;
+					}
+				}
+				else
+				{
+					ComponentsAddedForDelta.Emplace(CalculateAdd(It, NextComponentIt, Components));
+					++AddCount;
+				}
+				break;
+			case ReceivedComponentChange::REMOVE:
+				if (bComponentExists)
+				{
+					ComponentsRemovedForDelta.Emplace(It->ComponentId);
+					Components.RemoveAtSwap(Component - Components.GetData());
+					++RemoveCount;
+				}
+				break;
+			}
+
+			if (NextComponentIt->EntityId != EntityId)
+			{
+				Delta.ComponentsAdded = {
+					ComponentsAddedForDelta.GetData() + ComponentsAddedForDelta.Num() - AddCount, AddCount
+				};
+				Delta.ComponentsRemoved = {
+					ComponentsRemovedForDelta.GetData() + ComponentsRemovedForDelta.Num() - RemoveCount, RemoveCount
+				};
+				Delta.ComponentUpdates = {
+					ComponentUpdatesForDelta.GetData() + ComponentUpdatesForDelta.Num() - UpdateCount, UpdateCount
+				};
+				Delta.ComponentsRefreshed = {
+					ComponentsRefreshedForDelta.GetData() + ComponentsRefreshedForDelta.Num() - RefreshCount,
+					RefreshCount
+				};
+				return NextComponentIt;
+			}
+
+			It = NextComponentIt;
+		}
+	}
+
+	Worker_AuthorityChangeOp* ViewDelta::ProcessEntityAuthorityChanges(Worker_AuthorityChangeOp* It,
+	                                                                   Worker_AuthorityChangeOp* End,
+	                                                                   TArray<Worker_ComponentId>& EntityAuthority,
+	                                                                   EntityDelta& Delta)
+	{
+		int32 GainCount = 0;
+		int32 LossCount = 0;
+		int32 LossTempCount = 0;
+
+		const Worker_EntityId EntityId = It->entity_id;
+		// After each loop the iterator points to the first op relating to the next entity-component.
+		// Stop and return when that component is for a different entity.
+		// There will always be at least one iteration of the loop.
+		for (;;)
+		{
+			// Find the last element for this entity-component.
+			const Worker_ComponentId ComponentId = It->component_id;
+			It = std::find_if(It, End, DifferentEntityComponent{EntityId, ComponentId}) - 1;
+			const int32 AuthorityIndex = EntityAuthority.Find(ComponentId);
+			const bool bHasAuthority = AuthorityIndex != INDEX_NONE;
+
+			if (It->authority == WORKER_AUTHORITY_AUTHORITATIVE)
+			{
+				if (bHasAuthority)
+				{
+					AuthorityLostTempForDelta.Emplace(ComponentId, AuthorityChange::AUTHORITY_LOST_TEMPORARILY);
+					++LossTempCount;
+				}
+				else
+				{
+					EntityAuthority.Push(ComponentId);
+					AuthorityGainedForDelta.Emplace(ComponentId, AuthorityChange::AUTHORITY_GAINED);
+					++GainCount;
 				}
 			}
-			else
+			else if (bHasAuthority)
 			{
-				ComponentsAddedForDelta.Emplace(CalculateAdd(It, NextComponentIt, Components));
-				++AddCount;
+				AuthorityLostForDelta.Emplace(ComponentId, AuthorityChange::AUTHORITY_LOST);
+				EntityAuthority.RemoveAtSwap(AuthorityIndex);
+				++LossCount;
 			}
-			break;
-		case ReceivedComponentChange::REMOVE:
-			if (bComponentExists)
+
+			// Move to the next entity-component.
+			++It;
+
+			if (It->entity_id != EntityId)
 			{
-				ComponentsRemovedForDelta.Emplace(It->ComponentId);
-				Components.RemoveAtSwap(Component - Components.GetData());
-				++RemoveCount;
+				Delta.AuthorityGained = {
+					AuthorityGainedForDelta.GetData() + AuthorityGainedForDelta.Num() - GainCount, GainCount
+				};
+				Delta.AuthorityLost = {
+					AuthorityLostForDelta.GetData() + AuthorityLostForDelta.Num() - LossCount, LossCount
+				};
+				Delta.AuthorityLostTemporarily = {
+					AuthorityLostTempForDelta.GetData() + AuthorityLostTempForDelta.Num() - LossTempCount,
+					LossTempCount
+				};
+				return It;
 			}
-			break;
-		}
-
-		if (NextComponentIt->EntityId != EntityId)
-		{
-			Delta.ComponentsAdded = { ComponentsAddedForDelta.GetData() + ComponentsAddedForDelta.Num() - AddCount, AddCount };
-			Delta.ComponentsRemoved = { ComponentsRemovedForDelta.GetData() + ComponentsRemovedForDelta.Num() - RemoveCount, RemoveCount };
-			Delta.ComponentUpdates = { ComponentUpdatesForDelta.GetData() + ComponentUpdatesForDelta.Num() - UpdateCount, UpdateCount };
-			Delta.ComponentsRefreshed = { ComponentsRefreshedForDelta.GetData() + ComponentsRefreshedForDelta.Num() - RefreshCount,
-										  RefreshCount };
-			return NextComponentIt;
-		}
-
-		It = NextComponentIt;
-	}
-}
-
-Worker_AuthorityChangeOp* ViewDelta::ProcessEntityAuthorityChanges(Worker_AuthorityChangeOp* It, Worker_AuthorityChangeOp* End,
-																   TArray<Worker_ComponentId>& EntityAuthority, EntityDelta& Delta)
-{
-	int32 GainCount = 0;
-	int32 LossCount = 0;
-	int32 LossTempCount = 0;
-
-	const Worker_EntityId EntityId = It->entity_id;
-	// After each loop the iterator points to the first op relating to the next entity-component.
-	// Stop and return when that component is for a different entity.
-	// There will always be at least one iteration of the loop.
-	for (;;)
-	{
-		// Find the last element for this entity-component.
-		const Worker_ComponentId ComponentId = It->component_id;
-		It = std::find_if(It, End, DifferentEntityComponent{ EntityId, ComponentId }) - 1;
-		const int32 AuthorityIndex = EntityAuthority.Find(ComponentId);
-		const bool bHasAuthority = AuthorityIndex != INDEX_NONE;
-
-		if (It->authority == WORKER_AUTHORITY_AUTHORITATIVE)
-		{
-			if (bHasAuthority)
-			{
-				AuthorityLostTempForDelta.Emplace(ComponentId, AuthorityChange::AUTHORITY_LOST_TEMPORARILY);
-				++LossTempCount;
-			}
-			else
-			{
-				EntityAuthority.Push(ComponentId);
-				AuthorityGainedForDelta.Emplace(ComponentId, AuthorityChange::AUTHORITY_GAINED);
-				++GainCount;
-			}
-		}
-		else if (bHasAuthority)
-		{
-			AuthorityLostForDelta.Emplace(ComponentId, AuthorityChange::AUTHORITY_LOST);
-			EntityAuthority.RemoveAtSwap(AuthorityIndex);
-			++LossCount;
-		}
-
-		// Move to the next entity-component.
-		++It;
-
-		if (It->entity_id != EntityId)
-		{
-			Delta.AuthorityGained = { AuthorityGainedForDelta.GetData() + AuthorityGainedForDelta.Num() - GainCount, GainCount };
-			Delta.AuthorityLost = { AuthorityLostForDelta.GetData() + AuthorityLostForDelta.Num() - LossCount, LossCount };
-			Delta.AuthorityLostTemporarily = { AuthorityLostTempForDelta.GetData() + AuthorityLostTempForDelta.Num() - LossTempCount,
-											   LossTempCount };
-			return It;
 		}
 	}
-}
 
-ViewDelta::ReceivedEntityChange* ViewDelta::ProcessEntityExistenceChange(ReceivedEntityChange* It, ReceivedEntityChange* End,
-																		 EntityDelta& Delta, EntityViewElement** ViewElement,
-																		 EntityView& View)
-{
-	// Find the last element relating to the same entity.
-	const Worker_EntityId EntityId = It->EntityId;
-	It = std::find_if(It, End, DifferentEntity{ EntityId }) - 1;
-
-	const bool bAlreadyInView = *ViewElement != nullptr;
-	const bool bEntityAdded = It->bAdded;
-
-	// If the entity's presence has not changed then return.
-	if (bEntityAdded == bAlreadyInView)
+	ViewDelta::ReceivedEntityChange* ViewDelta::ProcessEntityExistenceChange(
+		ReceivedEntityChange* It, ReceivedEntityChange* End,
+		EntityDelta& Delta, EntityViewElement** ViewElement,
+		EntityView& View)
 	{
+		// Find the last element relating to the same entity.
+		const Worker_EntityId EntityId = It->EntityId;
+		It = std::find_if(It, End, DifferentEntity{EntityId}) - 1;
+
+		const bool bAlreadyInView = *ViewElement != nullptr;
+		const bool bEntityAdded = It->bAdded;
+
+		// If the entity's presence has not changed then return.
+		if (bEntityAdded == bAlreadyInView)
+		{
+			return It + 1;
+		}
+
+		if (bEntityAdded)
+		{
+			Delta.bAdded = true;
+			*ViewElement = &View.Emplace(EntityId, EntityViewElement{});
+		}
+		else
+		{
+			Delta.bRemoved = true;
+
+			// Remove components.
+			const auto& Components = (*ViewElement)->Components;
+			for (const auto& Component : Components)
+			{
+				ComponentsRemovedForDelta.Emplace(Component.GetComponentId());
+			}
+			Delta.ComponentsRemoved = {
+				ComponentsRemovedForDelta.GetData() + ComponentsRemovedForDelta.Num() - Components.Num(),
+				Components.Num()
+			};
+
+			// Remove authority.
+			const auto& Authority = (*ViewElement)->Authority;
+			for (const auto& Id : Authority)
+			{
+				AuthorityLostForDelta.Emplace(Id, AuthorityChange::AUTHORITY_LOST);
+			}
+			Delta.AuthorityLost = {
+				AuthorityLostForDelta.GetData() + AuthorityLostForDelta.Num() - Authority.Num(), Authority.Num()
+			};
+
+			// Remove from view.
+			View.Remove(EntityId);
+			*ViewElement = nullptr;
+		}
+
 		return It + 1;
 	}
-
-	if (bEntityAdded)
-	{
-		Delta.bAdded = true;
-		*ViewElement = &View.Emplace(EntityId, EntityViewElement{});
-	}
-	else
-	{
-		Delta.bRemoved = true;
-
-		// Remove components.
-		const auto& Components = (*ViewElement)->Components;
-		for (const auto& Component : Components)
-		{
-			ComponentsRemovedForDelta.Emplace(Component.GetComponentId());
-		}
-		Delta.ComponentsRemoved = { ComponentsRemovedForDelta.GetData() + ComponentsRemovedForDelta.Num() - Components.Num(),
-									Components.Num() };
-
-		// Remove authority.
-		const auto& Authority = (*ViewElement)->Authority;
-		for (const auto& Id : Authority)
-		{
-			AuthorityLostForDelta.Emplace(Id, AuthorityChange::AUTHORITY_LOST);
-		}
-		Delta.AuthorityLost = { AuthorityLostForDelta.GetData() + AuthorityLostForDelta.Num() - Authority.Num(), Authority.Num() };
-
-		// Remove from view.
-		View.Remove(EntityId);
-		*ViewElement = nullptr;
-	}
-
-	return It + 1;
-}
-
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
@@ -27,9 +27,8 @@ void ViewDelta::SetFromOpList(TArray<OpList> OpLists, EntityView& View)
 }
 
 void ViewDelta::Project(SubViewDelta& SubDelta, const TArray<Worker_EntityId>& CompleteEntities,
-                        const TArray<Worker_EntityId>& NewlyCompleteEntities,
-                        const TArray<Worker_EntityId>& NewlyIncompleteEntities,
-                        const TArray<Worker_EntityId>& TemporarilyIncompleteEntities) const
+						const TArray<Worker_EntityId>& NewlyCompleteEntities, const TArray<Worker_EntityId>& NewlyIncompleteEntities,
+						const TArray<Worker_EntityId>& TemporarilyIncompleteEntities) const
 {
 	SubDelta.EntityDeltas.Empty();
 

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
@@ -50,7 +50,8 @@ void ViewDelta::Project(SubViewDelta& SubDelta, const TArray<Worker_EntityId>& C
 		const Worker_EntityId NewlyIncompleteId = NewlyIncompleteIt ? *NewlyIncompleteIt : SENTINEL_ENTITY_ID;
 		const Worker_EntityId TemporarilyIncompleteId = TemporarilyIncompleteIt ? *TemporarilyIncompleteIt : SENTINEL_ENTITY_ID;
 		const uint64 MinEntityId = FMath::Min3(FMath::Min(static_cast<uint64>(DeltaId), static_cast<uint64>(CompleteId)),
-														FMath::Min(static_cast<uint64>(NewlyCompleteId), static_cast<uint64>(NewlyIncompleteId)), static_cast<uint64>(TemporarilyIncompleteId));
+											   FMath::Min(static_cast<uint64>(NewlyCompleteId), static_cast<uint64>(NewlyIncompleteId)),
+											   static_cast<uint64>(TemporarilyIncompleteId));
 		const Worker_EntityId CurrentEntityId = static_cast<Worker_EntityId>(MinEntityId);
 		// If no list has elements left to read then stop.
 		if (CurrentEntityId == SENTINEL_ENTITY_ID)

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/WorkerView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/WorkerView.cpp
@@ -30,6 +30,12 @@ const EntityView& WorkerView::GetView() const
 	return View;
 }
 
+
+const EntityView* WorkerView::GetViewPtr() const
+{
+	return &View;
+}
+
 void WorkerView::EnqueueOpList(OpList Ops)
 {
 	// Ensure that we only process closed critical sections.

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/WorkerView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/WorkerView.cpp
@@ -30,7 +30,6 @@ const EntityView& WorkerView::GetView() const
 	return View;
 }
 
-
 const EntityView* WorkerView::GetViewPtr() const
 {
 	return &View;

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ComponentTestUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ComponentTestUtils.h
@@ -24,6 +24,11 @@ inline ComponentData CreateTestComponentData(const Worker_ComponentId Id, const 
 	return Data;
 }
 
+inline double GetValueFromSchemaComponentData(Schema_ComponentData* Data)
+{
+	return Schema_GetDouble(Schema_GetComponentDataFields(Data), EntityComponentTestUtils::TEST_DOUBLE_FIELD_ID);
+}
+
 inline ComponentUpdate CreateTestComponentUpdate(const Worker_ComponentId Id, const double Value)
 {
 	ComponentUpdate Update{ Id };

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ComponentTestUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ComponentTestUtils.h
@@ -240,19 +240,24 @@ inline bool CompareEntityComponentCompleteUpdates(const EntityComponentCompleteU
 	return CompareComponentData(Lhs.CompleteUpdate, Rhs.CompleteUpdate) && CompareComponentUpdateEvents(Lhs.Events, Rhs.Events);
 }
 
-inline bool CompareEntityComponentId(const EntityComponentId& Lhs, const EntityComponentId& Rhs)
+inline bool EntityComponentIdEquality(const EntityComponentId& Lhs, const EntityComponentId& Rhs)
 {
 	return Lhs == Rhs;
 }
 
-inline bool CompareWorkerComponentId(const Worker_ComponentId Lhs, const Worker_ComponentId Rhs)
+inline bool WorkerComponentIdEquality(const Worker_ComponentId Lhs, const Worker_ComponentId Rhs)
 {
 	return Lhs == Rhs;
 }
 
-inline bool CompareWorkerEntityIdKey(const Worker_EntityId Lhs, const Worker_EntityId Rhs)
+inline bool WorkerEntityIdEquality(const Worker_EntityId Lhs, const Worker_EntityId Rhs)
 {
 	return Lhs == Rhs;
+}
+
+inline bool CompareWorkerEntityId(const Worker_EntityId Lhs, const Worker_EntityId Rhs)
+{
+	return Lhs < Rhs;
 }
 
 template <typename T, typename Predicate>
@@ -283,7 +288,7 @@ inline bool AreEquivalent(const TArray<EntityComponentData>& Lhs, const TArray<E
 
 inline bool AreEquivalent(const TArray<EntityComponentId>& Lhs, const TArray<EntityComponentId>& Rhs)
 {
-	return AreEquivalent(Lhs, Rhs, CompareEntityComponentId);
+	return AreEquivalent(Lhs, Rhs, EntityComponentIdEquality);
 }
 
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/DispatcherTest.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/DispatcherTest.cpp
@@ -6,7 +6,6 @@
 #include "SpatialView/Dispatcher.h"
 #include "SpatialView/EntityDelta.h"
 #include "SpatialView/EntityView.h"
-#include "SpatialView/OpList/EntityComponentOpList.h"
 #include "SpatialView/ViewDelta.h"
 #include "SpatialViewUtils.h"
 #include "Tests/TestDefinitions.h"
@@ -21,19 +20,6 @@ constexpr Worker_EntityId ENTITY_ID = 1;
 constexpr Worker_EntityId OTHER_ENTITY_ID = 2;
 constexpr double COMPONENT_VALUE = 3;
 constexpr double OTHER_COMPONENT_VALUE = 4;
-
-void PopulateViewDeltaWithComponentAdded(SpatialGDK::ViewDelta& Delta, SpatialGDK::EntityView& View, const Worker_EntityId EntityId,
-										 const Worker_ComponentId ComponentId, const double Value)
-{
-	SpatialGDK::EntityComponentOpListBuilder OpListBuilder;
-	OpListBuilder.AddComponent(EntityId, SpatialGDK::CreateTestComponentData(ComponentId, Value));
-	SetFromOpList(Delta, View, MoveTemp(OpListBuilder));
-}
-
-double GetValueFromSchemaComponentData(Schema_ComponentData* Data)
-{
-	return Schema_GetDouble(Schema_GetComponentDataFields(Data), SpatialGDK::EntityComponentTestUtils::TEST_DOUBLE_FIELD_ID);
-}
 } // anonymous namespace
 
 DISPATCHER_TEST(GIVEN_Dispatcher_WHEN_Callback_Added_Then_Invoked_THEN_Callback_Invoked_With_Correct_Values)
@@ -45,7 +31,7 @@ DISPATCHER_TEST(GIVEN_Dispatcher_WHEN_Callback_Added_Then_Invoked_THEN_Callback_
 
 	const SpatialGDK::FComponentValueCallback Callback = [&Invoked](const SpatialGDK::FEntityComponentChange& Change) {
 		if (Change.EntityId == ENTITY_ID && Change.Change.ComponentId == COMPONENT_ID
-			&& GetValueFromSchemaComponentData(Change.Change.Data) == COMPONENT_VALUE)
+			&& SpatialGDK::GetValueFromSchemaComponentData(Change.Change.Data) == COMPONENT_VALUE)
 		{
 			Invoked = true;
 		}
@@ -53,7 +39,7 @@ DISPATCHER_TEST(GIVEN_Dispatcher_WHEN_Callback_Added_Then_Invoked_THEN_Callback_
 	Dispatcher.RegisterComponentAddedCallback(COMPONENT_ID, Callback);
 
 	AddEntityToView(View, ENTITY_ID);
-	PopulateViewDeltaWithComponentAdded(Delta, View, ENTITY_ID, COMPONENT_ID, COMPONENT_VALUE);
+	PopulateViewDeltaWithComponentAddedWithValue(Delta, View, ENTITY_ID, COMPONENT_ID, COMPONENT_VALUE);
 	Dispatcher.InvokeCallbacks(Delta.GetEntityDeltas());
 
 	TestTrue("Callback was invoked", Invoked);
@@ -61,16 +47,16 @@ DISPATCHER_TEST(GIVEN_Dispatcher_WHEN_Callback_Added_Then_Invoked_THEN_Callback_
 	// Now a few more times, but with incorrect values, just in case
 	Invoked = false;
 
-	PopulateViewDeltaWithComponentAdded(Delta, View, ENTITY_ID, COMPONENT_ID, OTHER_COMPONENT_VALUE);
+	PopulateViewDeltaWithComponentAddedWithValue(Delta, View, ENTITY_ID, COMPONENT_ID, OTHER_COMPONENT_VALUE);
 	Dispatcher.InvokeCallbacks(Delta.GetEntityDeltas());
 	TestFalse("Callback was not invoked", Invoked);
 
-	PopulateViewDeltaWithComponentAdded(Delta, View, ENTITY_ID, OTHER_COMPONENT_ID, COMPONENT_VALUE);
+	PopulateViewDeltaWithComponentAddedWithValue(Delta, View, ENTITY_ID, OTHER_COMPONENT_ID, COMPONENT_VALUE);
 	Dispatcher.InvokeCallbacks(Delta.GetEntityDeltas());
 	TestFalse("Callback was not invoked", Invoked);
 
 	AddEntityToView(View, OTHER_ENTITY_ID);
-	PopulateViewDeltaWithComponentAdded(Delta, View, OTHER_ENTITY_ID, COMPONENT_ID, COMPONENT_VALUE);
+	PopulateViewDeltaWithComponentAddedWithValue(Delta, View, OTHER_ENTITY_ID, COMPONENT_ID, COMPONENT_VALUE);
 	Dispatcher.InvokeCallbacks(Delta.GetEntityDeltas());
 	TestFalse("Callback was not invoked", Invoked);
 
@@ -90,7 +76,7 @@ DISPATCHER_TEST(GIVEN_Dispatcher_With_Callback_WHEN_Callback_Removed_THEN_Callba
 
 	const SpatialGDK::CallbackId Id = Dispatcher.RegisterComponentAddedCallback(COMPONENT_ID, Callback);
 	AddEntityToView(View, ENTITY_ID);
-	PopulateViewDeltaWithComponentAdded(Delta, View, ENTITY_ID, COMPONENT_ID, COMPONENT_VALUE);
+	PopulateViewDeltaWithComponentAddedWithValue(Delta, View, ENTITY_ID, COMPONENT_ID, COMPONENT_VALUE);
 	Dispatcher.InvokeCallbacks(Delta.GetEntityDeltas());
 
 	TestTrue("Callback was invoked", Invoked);
@@ -113,7 +99,7 @@ DISPATCHER_TEST(GIVEN_Dispatcher_WHEN_Callback_Added_And_Invoked_THEN_Callback_I
 
 	const SpatialGDK::FComponentValueCallback Callback = [&Invoked](const SpatialGDK::FEntityComponentChange& Change) {
 		if (Change.EntityId == ENTITY_ID && Change.Change.ComponentId == COMPONENT_ID
-			&& GetValueFromSchemaComponentData(Change.Change.Data) == COMPONENT_VALUE)
+			&& SpatialGDK::GetValueFromSchemaComponentData(Change.Change.Data) == COMPONENT_VALUE)
 		{
 			Invoked = true;
 		}
@@ -129,10 +115,156 @@ DISPATCHER_TEST(GIVEN_Dispatcher_WHEN_Callback_Added_And_Invoked_THEN_Callback_I
 	// Double check the callback is actually called on invocation as well.
 	View[ENTITY_ID].Components.Empty();
 	Invoked = false;
-	PopulateViewDeltaWithComponentAdded(Delta, View, ENTITY_ID, COMPONENT_ID, COMPONENT_VALUE);
+	PopulateViewDeltaWithComponentAddedWithValue(Delta, View, ENTITY_ID, COMPONENT_ID, COMPONENT_VALUE);
 	Dispatcher.InvokeCallbacks(Delta.GetEntityDeltas());
 
 	TestTrue("Callback was invoked", Invoked);
+
+	return true;
+}
+
+DISPATCHER_TEST(GIVEN_Dispatcher_WHEN_Component_Changed_Callback_Added_Then_Invoked_THEN_Callback_Invoked)
+{
+	bool Invoked = false;
+	SpatialGDK::FDispatcher Dispatcher;
+	SpatialGDK::EntityView View;
+	SpatialGDK::ViewDelta Delta;
+
+	const SpatialGDK::FComponentValueCallback Callback = [&Invoked](const SpatialGDK::FEntityComponentChange&) {
+		Invoked = true;
+	};
+	Dispatcher.RegisterComponentValueCallback(COMPONENT_ID, Callback);
+
+	AddEntityToView(View, ENTITY_ID);
+	PopulateViewDeltaWithComponentAddedWithValue(Delta, View, ENTITY_ID, COMPONENT_ID, COMPONENT_VALUE);
+	Dispatcher.InvokeCallbacks(Delta.GetEntityDeltas());
+
+	TestTrue("Callback was invoked", Invoked);
+
+	PopulateViewDeltaWithComponentUpdated(Delta, View, ENTITY_ID, COMPONENT_ID, OTHER_COMPONENT_VALUE);
+	Invoked = false;
+	Dispatcher.InvokeCallbacks(Delta.GetEntityDeltas());
+
+	TestTrue("Callback was invoked again", Invoked);
+
+	return true;
+}
+
+DISPATCHER_TEST(GIVEN_Dispatcher_WHEN_Component_Removed_Callback_Added_Then_Invoked_THEN_Callback_Invoked)
+{
+	bool Invoked = false;
+	SpatialGDK::FDispatcher Dispatcher;
+	SpatialGDK::EntityView View;
+	SpatialGDK::ViewDelta Delta;
+
+	const SpatialGDK::FComponentValueCallback Callback = [&Invoked](const SpatialGDK::FEntityComponentChange&) {
+		Invoked = true;
+	};
+	Dispatcher.RegisterComponentRemovedCallback(COMPONENT_ID, Callback);
+
+	AddEntityToView(View, ENTITY_ID);
+	AddComponentToView(View, ENTITY_ID, SpatialGDK::ComponentData{COMPONENT_ID});
+
+	PopulateViewDeltaWithComponentRemoved(Delta, View, ENTITY_ID, COMPONENT_ID);
+	Dispatcher.InvokeCallbacks(Delta.GetEntityDeltas());
+
+	TestTrue("Callback was invoked", Invoked);
+
+	return true;
+}
+
+DISPATCHER_TEST(GIVEN_Dispatcher_WHEN_Authority_Gained_Callback_Added_Then_Invoked_THEN_Callback_Invoked)
+{
+	bool Invoked = false;
+	SpatialGDK::FDispatcher Dispatcher;
+	SpatialGDK::EntityView View;
+	SpatialGDK::ViewDelta Delta;
+
+	const SpatialGDK::FEntityCallback Callback = [&Invoked](const Worker_EntityId&) {
+		Invoked = true;
+	};
+	Dispatcher.RegisterAuthorityGainedCallback(COMPONENT_ID, Callback);
+
+	AddEntityToView(View, ENTITY_ID);
+	AddComponentToView(View, ENTITY_ID, SpatialGDK::ComponentData{COMPONENT_ID});
+
+	PopulateViewDeltaWithAuthorityChange(Delta, View, ENTITY_ID, COMPONENT_ID, WORKER_AUTHORITY_AUTHORITATIVE);
+	Dispatcher.InvokeCallbacks(Delta.GetEntityDeltas());
+
+	TestTrue("Callback was invoked", Invoked);
+
+	return true;
+}
+
+DISPATCHER_TEST(GIVEN_Dispatcher_WHEN_Authority_Lost_Callback_Added_Then_Invoked_THEN_Callback_Invoked)
+{
+	bool Invoked = false;
+	SpatialGDK::FDispatcher Dispatcher;
+	SpatialGDK::EntityView View;
+	SpatialGDK::ViewDelta Delta;
+
+	const SpatialGDK::FEntityCallback Callback = [&Invoked](const Worker_EntityId&) {
+		Invoked = true;
+	};
+	Dispatcher.RegisterAuthorityLostCallback(COMPONENT_ID, Callback);
+
+	AddEntityToView(View, ENTITY_ID);
+	AddComponentToView(View, ENTITY_ID, SpatialGDK::ComponentData{COMPONENT_ID});
+	AddAuthorityToView(View, ENTITY_ID, COMPONENT_ID);
+
+	PopulateViewDeltaWithAuthorityChange(Delta, View, ENTITY_ID, COMPONENT_ID, WORKER_AUTHORITY_NOT_AUTHORITATIVE);
+	Dispatcher.InvokeCallbacks(Delta.GetEntityDeltas());
+
+	TestTrue("Callback was invoked", Invoked);
+
+	return true;
+}
+
+DISPATCHER_TEST(GIVEN_Dispatcher_WHEN_Authority_Lost_Temp_Callback_Added_Then_Invoked_THEN_Callback_Invoked)
+{
+	bool Invoked = false;
+	SpatialGDK::FDispatcher Dispatcher;
+	SpatialGDK::EntityView View;
+	SpatialGDK::ViewDelta Delta;
+
+	const SpatialGDK::FEntityCallback Callback = [&Invoked](const Worker_EntityId&) {
+		Invoked = true;
+	};
+	Dispatcher.RegisterAuthorityLostTempCallback(COMPONENT_ID, Callback);
+
+	AddEntityToView(View, ENTITY_ID);
+	AddComponentToView(View, ENTITY_ID, SpatialGDK::ComponentData{COMPONENT_ID});
+	AddAuthorityToView(View, ENTITY_ID, COMPONENT_ID);
+
+	PopulateViewDeltaWithAuthorityLostTemp(Delta, View, ENTITY_ID, COMPONENT_ID);
+	Dispatcher.InvokeCallbacks(Delta.GetEntityDeltas());
+
+	TestTrue("Callback was invoked", Invoked);
+
+	return true;
+}
+
+DISPATCHER_TEST(GIVEN_Dispatcher_WHEN_Many_Callbacks_Added_Then_Invoked_THEN_All_Callbacks_Correctly_Invoked)
+{
+	int InvokeCount = 0;
+	int NumberOfCallbacks = 100;
+	SpatialGDK::FDispatcher Dispatcher;
+	SpatialGDK::EntityView View;
+	SpatialGDK::ViewDelta Delta;
+
+	const SpatialGDK::FComponentValueCallback Callback = [&InvokeCount](const SpatialGDK::FEntityComponentChange&) {
+		++InvokeCount;
+	};
+	for (int i = 0; i < NumberOfCallbacks; ++i)
+	{
+		Dispatcher.RegisterComponentAddedCallback(COMPONENT_ID, Callback);
+	}
+
+	AddEntityToView(View, ENTITY_ID);
+	PopulateViewDeltaWithComponentAddedWithValue(Delta, View, ENTITY_ID, COMPONENT_ID, COMPONENT_VALUE);
+	Dispatcher.InvokeCallbacks(Delta.GetEntityDeltas());
+
+	TestEqual("Callback was invoked the expected number of times", InvokeCount, NumberOfCallbacks);
 
 	return true;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/DispatcherTest.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/DispatcherTest.cpp
@@ -163,7 +163,7 @@ DISPATCHER_TEST(GIVEN_Dispatcher_WHEN_Component_Removed_Callback_Added_Then_Invo
 	Dispatcher.RegisterComponentRemovedCallback(COMPONENT_ID, Callback);
 
 	AddEntityToView(View, ENTITY_ID);
-	AddComponentToView(View, ENTITY_ID, SpatialGDK::ComponentData{COMPONENT_ID});
+	AddComponentToView(View, ENTITY_ID, SpatialGDK::ComponentData{ COMPONENT_ID });
 
 	PopulateViewDeltaWithComponentRemoved(Delta, View, ENTITY_ID, COMPONENT_ID);
 	Dispatcher.InvokeCallbacks(Delta.GetEntityDeltas());
@@ -186,7 +186,7 @@ DISPATCHER_TEST(GIVEN_Dispatcher_WHEN_Authority_Gained_Callback_Added_Then_Invok
 	Dispatcher.RegisterAuthorityGainedCallback(COMPONENT_ID, Callback);
 
 	AddEntityToView(View, ENTITY_ID);
-	AddComponentToView(View, ENTITY_ID, SpatialGDK::ComponentData{COMPONENT_ID});
+	AddComponentToView(View, ENTITY_ID, SpatialGDK::ComponentData{ COMPONENT_ID });
 
 	PopulateViewDeltaWithAuthorityChange(Delta, View, ENTITY_ID, COMPONENT_ID, WORKER_AUTHORITY_AUTHORITATIVE);
 	Dispatcher.InvokeCallbacks(Delta.GetEntityDeltas());
@@ -209,7 +209,7 @@ DISPATCHER_TEST(GIVEN_Dispatcher_WHEN_Authority_Lost_Callback_Added_Then_Invoked
 	Dispatcher.RegisterAuthorityLostCallback(COMPONENT_ID, Callback);
 
 	AddEntityToView(View, ENTITY_ID);
-	AddComponentToView(View, ENTITY_ID, SpatialGDK::ComponentData{COMPONENT_ID});
+	AddComponentToView(View, ENTITY_ID, SpatialGDK::ComponentData{ COMPONENT_ID });
 	AddAuthorityToView(View, ENTITY_ID, COMPONENT_ID);
 
 	PopulateViewDeltaWithAuthorityChange(Delta, View, ENTITY_ID, COMPONENT_ID, WORKER_AUTHORITY_NOT_AUTHORITATIVE);
@@ -233,7 +233,7 @@ DISPATCHER_TEST(GIVEN_Dispatcher_WHEN_Authority_Lost_Temp_Callback_Added_Then_In
 	Dispatcher.RegisterAuthorityLostTempCallback(COMPONENT_ID, Callback);
 
 	AddEntityToView(View, ENTITY_ID);
-	AddComponentToView(View, ENTITY_ID, SpatialGDK::ComponentData{COMPONENT_ID});
+	AddComponentToView(View, ENTITY_ID, SpatialGDK::ComponentData{ COMPONENT_ID });
 	AddAuthorityToView(View, ENTITY_ID, COMPONENT_ID);
 
 	PopulateViewDeltaWithAuthorityLostTemp(Delta, View, ENTITY_ID, COMPONENT_ID);

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ExpectedViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ExpectedViewDelta.cpp
@@ -11,7 +11,7 @@ using namespace SpatialGDK;
 
 ExpectedViewDelta& ExpectedViewDelta::AddEntityDelta(const Worker_EntityId EntityId, const EntityChangeType ChangeType)
 {
-	EntityDeltas.Add(EntityId, { EntityId, ChangeType == ADD, ChangeType == REMOVE });
+	EntityDeltas.Add(EntityId, { EntityId, ChangeType == ADD ? ExpectedEntityDelta::ADD : ChangeType == REMOVE ? ExpectedEntityDelta::REMOVE : ExpectedEntityDelta::UPDATE});
 	return *this;
 }
 
@@ -104,14 +104,34 @@ bool ExpectedViewDelta::Compare(const ViewDelta& Other)
 			return false;
 		}
 
-		if (LhsEntityDelta.bAdded != RhsEntityDelta.bAdded)
+		switch (LhsEntityDelta.Type)
 		{
-			return false;
-		}
-
-		if (LhsEntityDelta.bRemoved != RhsEntityDelta.bRemoved)
-		{
-			return false;
+			case ExpectedEntityDelta::UPDATE:
+				if (!(RhsEntityDelta.Type == EntityDelta::UPDATE))
+				{
+					return false;
+				}
+				break;
+			case ExpectedEntityDelta::ADD:
+				if (!(RhsEntityDelta.Type == EntityDelta::ADD))
+				{
+					return false;
+				}
+				break;
+			case ExpectedEntityDelta::REMOVE:
+				if (!(RhsEntityDelta.Type == EntityDelta::REMOVE))
+				{
+					return false;
+				}
+				break;
+			case ExpectedEntityDelta::TEMPORARILY_REMOVED:
+				if (!(RhsEntityDelta.Type == EntityDelta::TEMPORARILY_REMOVED))
+				{
+					return false;
+				}
+				break;
+			default:
+				checkNoEntry();
 		}
 
 		if (!CompareData(LhsEntityDelta.AuthorityGained, RhsEntityDelta.AuthorityGained, CompareAuthorityChanges))

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ExpectedViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ExpectedViewDelta.cpp
@@ -11,9 +11,11 @@ using namespace SpatialGDK;
 
 ExpectedViewDelta& ExpectedViewDelta::AddEntityDelta(const Worker_EntityId EntityId, const EntityChangeType ChangeType)
 {
-	EntityDeltas.Add(EntityId,
-					 { EntityId, ChangeType == UPDATE ? ExpectedEntityDelta::UPDATE
-												   : ChangeType == ADD ? ExpectedEntityDelta::ADD : ChangeType == REMOVE ? ExpectedEntityDelta::REMOVE : ExpectedEntityDelta::TEMPORARILY_REMOVED});
+	EntityDeltas.Add(
+		EntityId, { EntityId, ChangeType == UPDATE ? ExpectedEntityDelta::UPDATE
+												   : ChangeType == ADD ? ExpectedEntityDelta::ADD
+																	   : ChangeType == REMOVE ? ExpectedEntityDelta::REMOVE
+																							  : ExpectedEntityDelta::TEMPORARILY_REMOVED });
 	return *this;
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ExpectedViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ExpectedViewDelta.cpp
@@ -11,7 +11,9 @@ using namespace SpatialGDK;
 
 ExpectedViewDelta& ExpectedViewDelta::AddEntityDelta(const Worker_EntityId EntityId, const EntityChangeType ChangeType)
 {
-	EntityDeltas.Add(EntityId, { EntityId, ChangeType == ADD ? ExpectedEntityDelta::ADD : ChangeType == REMOVE ? ExpectedEntityDelta::REMOVE : ExpectedEntityDelta::UPDATE});
+	EntityDeltas.Add(EntityId,
+					 { EntityId, ChangeType == ADD ? ExpectedEntityDelta::ADD
+												   : ChangeType == REMOVE ? ExpectedEntityDelta::REMOVE : ExpectedEntityDelta::UPDATE });
 	return *this;
 }
 
@@ -106,32 +108,32 @@ bool ExpectedViewDelta::Compare(const ViewDelta& Other)
 
 		switch (LhsEntityDelta.Type)
 		{
-			case ExpectedEntityDelta::UPDATE:
-				if (!(RhsEntityDelta.Type == EntityDelta::UPDATE))
-				{
-					return false;
-				}
-				break;
-			case ExpectedEntityDelta::ADD:
-				if (!(RhsEntityDelta.Type == EntityDelta::ADD))
-				{
-					return false;
-				}
-				break;
-			case ExpectedEntityDelta::REMOVE:
-				if (!(RhsEntityDelta.Type == EntityDelta::REMOVE))
-				{
-					return false;
-				}
-				break;
-			case ExpectedEntityDelta::TEMPORARILY_REMOVED:
-				if (!(RhsEntityDelta.Type == EntityDelta::TEMPORARILY_REMOVED))
-				{
-					return false;
-				}
-				break;
-			default:
-				checkNoEntry();
+		case ExpectedEntityDelta::UPDATE:
+			if (!(RhsEntityDelta.Type == EntityDelta::UPDATE))
+			{
+				return false;
+			}
+			break;
+		case ExpectedEntityDelta::ADD:
+			if (!(RhsEntityDelta.Type == EntityDelta::ADD))
+			{
+				return false;
+			}
+			break;
+		case ExpectedEntityDelta::REMOVE:
+			if (!(RhsEntityDelta.Type == EntityDelta::REMOVE))
+			{
+				return false;
+			}
+			break;
+		case ExpectedEntityDelta::TEMPORARILY_REMOVED:
+			if (!(RhsEntityDelta.Type == EntityDelta::TEMPORARILY_REMOVED))
+			{
+				return false;
+			}
+			break;
+		default:
+			checkNoEntry();
 		}
 
 		if (!CompareData(LhsEntityDelta.AuthorityGained, RhsEntityDelta.AuthorityGained, CompareAuthorityChanges))

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/SpatialViewUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/SpatialViewUtils.h
@@ -33,7 +33,7 @@ inline void AddAuthorityToView(EntityView& View, const Worker_EntityId EntityId,
 }
 
 inline void PopulateViewDeltaWithComponentAdded(ViewDelta& Delta, EntityView& View, const Worker_EntityId EntityId,
-                                                    const Worker_ComponentId ComponentId)
+												const Worker_ComponentId ComponentId)
 {
 	EntityComponentOpListBuilder OpListBuilder;
 	OpListBuilder.AddComponent(EntityId, ComponentData{ ComponentId });
@@ -41,7 +41,7 @@ inline void PopulateViewDeltaWithComponentAdded(ViewDelta& Delta, EntityView& Vi
 }
 
 inline void PopulateViewDeltaWithComponentAddedWithValue(ViewDelta& Delta, EntityView& View, const Worker_EntityId EntityId,
-                                                const Worker_ComponentId ComponentId, const double Value)
+														 const Worker_ComponentId ComponentId, const double Value)
 {
 	EntityComponentOpListBuilder OpListBuilder;
 	OpListBuilder.AddComponent(EntityId, CreateTestComponentData(ComponentId, Value));
@@ -49,7 +49,7 @@ inline void PopulateViewDeltaWithComponentAddedWithValue(ViewDelta& Delta, Entit
 }
 
 inline void PopulateViewDeltaWithComponentUpdated(ViewDelta& Delta, EntityView& View, const Worker_EntityId EntityId,
-                                                  const Worker_ComponentId ComponentId, const double Value)
+												  const Worker_ComponentId ComponentId, const double Value)
 {
 	EntityComponentOpListBuilder OpListBuilder;
 	OpListBuilder.UpdateComponent(EntityId, CreateTestComponentUpdate(ComponentId, Value));
@@ -57,7 +57,7 @@ inline void PopulateViewDeltaWithComponentUpdated(ViewDelta& Delta, EntityView& 
 }
 
 inline void PopulateViewDeltaWithComponentRemoved(ViewDelta& Delta, EntityView& View, const Worker_EntityId EntityId,
-                                                  const Worker_ComponentId ComponentId)
+												  const Worker_ComponentId ComponentId)
 {
 	EntityComponentOpListBuilder OpListBuilder;
 	OpListBuilder.RemoveComponent(EntityId, ComponentId);
@@ -65,7 +65,7 @@ inline void PopulateViewDeltaWithComponentRemoved(ViewDelta& Delta, EntityView& 
 }
 
 inline void PopulateViewDeltaWithAuthorityChange(ViewDelta& Delta, EntityView& View, const Worker_EntityId EntityId,
-                                                      const Worker_ComponentId ComponentId, const Worker_Authority Authority)
+												 const Worker_ComponentId ComponentId, const Worker_Authority Authority)
 {
 	EntityComponentOpListBuilder OpListBuilder;
 	OpListBuilder.SetAuthority(EntityId, ComponentId, Authority);
@@ -73,7 +73,7 @@ inline void PopulateViewDeltaWithAuthorityChange(ViewDelta& Delta, EntityView& V
 }
 
 inline void PopulateViewDeltaWithAuthorityLostTemp(ViewDelta& Delta, EntityView& View, const Worker_EntityId EntityId,
-                                                      const Worker_ComponentId ComponentId)
+												   const Worker_ComponentId ComponentId)
 {
 	EntityComponentOpListBuilder OpListBuilder;
 	OpListBuilder.SetAuthority(EntityId, ComponentId, WORKER_AUTHORITY_NOT_AUTHORITATIVE);

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/SpatialViewUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/SpatialViewUtils.h
@@ -87,7 +87,7 @@ inline bool CompareViews(const EntityView& Lhs, const EntityView& Rhs)
 	TArray<Worker_EntityId_Key> RhsKeys;
 	Lhs.GetKeys(LhsKeys);
 	Rhs.GetKeys(RhsKeys);
-	if (!AreEquivalent(LhsKeys, RhsKeys, CompareWorkerEntityIdKey))
+	if (!AreEquivalent(LhsKeys, RhsKeys, WorkerEntityIdEquality))
 	{
 		return false;
 	}
@@ -102,7 +102,7 @@ inline bool CompareViews(const EntityView& Lhs, const EntityView& Rhs)
 			return false;
 		}
 
-		if (!AreEquivalent(LhsElement->Authority, RhsElement->Authority, CompareWorkerComponentId))
+		if (!AreEquivalent(LhsElement->Authority, RhsElement->Authority, WorkerComponentIdEquality))
 		{
 			return false;
 		}

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/SpatialViewUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/SpatialViewUtils.h
@@ -32,6 +32,55 @@ inline void AddAuthorityToView(EntityView& View, const Worker_EntityId EntityId,
 	View[EntityId].Authority.Push(ComponentId);
 }
 
+inline void PopulateViewDeltaWithComponentAdded(ViewDelta& Delta, EntityView& View, const Worker_EntityId EntityId,
+                                                    const Worker_ComponentId ComponentId)
+{
+	EntityComponentOpListBuilder OpListBuilder;
+	OpListBuilder.AddComponent(EntityId, ComponentData{ ComponentId });
+	SetFromOpList(Delta, View, MoveTemp(OpListBuilder));
+}
+
+inline void PopulateViewDeltaWithComponentAddedWithValue(ViewDelta& Delta, EntityView& View, const Worker_EntityId EntityId,
+                                                const Worker_ComponentId ComponentId, const double Value)
+{
+	EntityComponentOpListBuilder OpListBuilder;
+	OpListBuilder.AddComponent(EntityId, CreateTestComponentData(ComponentId, Value));
+	SetFromOpList(Delta, View, MoveTemp(OpListBuilder));
+}
+
+inline void PopulateViewDeltaWithComponentUpdated(ViewDelta& Delta, EntityView& View, const Worker_EntityId EntityId,
+                                                  const Worker_ComponentId ComponentId, const double Value)
+{
+	EntityComponentOpListBuilder OpListBuilder;
+	OpListBuilder.UpdateComponent(EntityId, CreateTestComponentUpdate(ComponentId, Value));
+	SetFromOpList(Delta, View, MoveTemp(OpListBuilder));
+}
+
+inline void PopulateViewDeltaWithComponentRemoved(ViewDelta& Delta, EntityView& View, const Worker_EntityId EntityId,
+                                                  const Worker_ComponentId ComponentId)
+{
+	EntityComponentOpListBuilder OpListBuilder;
+	OpListBuilder.RemoveComponent(EntityId, ComponentId);
+	SetFromOpList(Delta, View, MoveTemp(OpListBuilder));
+}
+
+inline void PopulateViewDeltaWithAuthorityChange(ViewDelta& Delta, EntityView& View, const Worker_EntityId EntityId,
+                                                      const Worker_ComponentId ComponentId, const Worker_Authority Authority)
+{
+	EntityComponentOpListBuilder OpListBuilder;
+	OpListBuilder.SetAuthority(EntityId, ComponentId, Authority);
+	SetFromOpList(Delta, View, MoveTemp(OpListBuilder));
+}
+
+inline void PopulateViewDeltaWithAuthorityLostTemp(ViewDelta& Delta, EntityView& View, const Worker_EntityId EntityId,
+                                                      const Worker_ComponentId ComponentId)
+{
+	EntityComponentOpListBuilder OpListBuilder;
+	OpListBuilder.SetAuthority(EntityId, ComponentId, WORKER_AUTHORITY_NOT_AUTHORITATIVE);
+	OpListBuilder.SetAuthority(EntityId, ComponentId, WORKER_AUTHORITY_AUTHORITATIVE);
+	SetFromOpList(Delta, View, MoveTemp(OpListBuilder));
+}
+
 inline bool CompareViews(const EntityView& Lhs, const EntityView& Rhs)
 {
 	TArray<Worker_EntityId_Key> LhsKeys;

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/SubViewTest.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/SubViewTest.cpp
@@ -103,18 +103,19 @@ SUBVIEW_TEST(
 	EntityView View;
 	ViewDelta Delta;
 
-	FSubView SubView( TAG_COMPONENT_ID,
-				 [](const Worker_EntityId&, const EntityViewElement& Element) {
-					 const ComponentData* It = Element.Components.FindByPredicate(ComponentIdEquality{ VALUE_COMPONENT_ID });
-					 if (GetValueFromSchemaComponentData(It->GetUnderlying()) == CORRECT_VALUE)
-					 {
-						 return true;
-					 }
-					 return false;
-				 },
-				 &View, Dispatcher,
-				 TArray<FDispatcherRefreshCallback>{
-					 FSubView::CreateComponentChangedRefreshCallback(Dispatcher, VALUE_COMPONENT_ID, NoComponentChangeRefreshPredicate) } );
+	FSubView SubView(
+		TAG_COMPONENT_ID,
+		[](const Worker_EntityId&, const EntityViewElement& Element) {
+			const ComponentData* It = Element.Components.FindByPredicate(ComponentIdEquality{ VALUE_COMPONENT_ID });
+			if (GetValueFromSchemaComponentData(It->GetUnderlying()) == CORRECT_VALUE)
+			{
+				return true;
+			}
+			return false;
+		},
+		&View, Dispatcher,
+		TArray<FDispatcherRefreshCallback>{
+			FSubView::CreateComponentChangedRefreshCallback(Dispatcher, VALUE_COMPONENT_ID, NoComponentChangeRefreshPredicate) });
 
 	AddEntityToView(View, TAGGED_ENTITY_ID);
 	AddComponentToView(View, TAGGED_ENTITY_ID, CreateTestComponentData(VALUE_COMPONENT_ID, CORRECT_VALUE));
@@ -164,11 +165,12 @@ SUBVIEW_TEST(GIVEN_Tagged_Incomplete_Entity_Which_Should_Be_Complete_WHEN_Refres
 
 	bool IsFilterComplete = false;
 
-	FSubView SubView( TAG_COMPONENT_ID,
-				 [&IsFilterComplete](const Worker_EntityId&, const EntityViewElement&) {
-					 return IsFilterComplete;
-				 },
-				 &View, Dispatcher, NoRefreshCallbacks );
+	FSubView SubView(
+		TAG_COMPONENT_ID,
+		[&IsFilterComplete](const Worker_EntityId&, const EntityViewElement&) {
+			return IsFilterComplete;
+		},
+		&View, Dispatcher, NoRefreshCallbacks);
 
 	AddEntityToView(View, TAGGED_ENTITY_ID);
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/SubViewTest.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/SubViewTest.cpp
@@ -96,7 +96,8 @@ SUBVIEW_TEST(GIVEN_SubView_Without_Filter_WHEN_Tagged_Entity_Added_THEN_Delta_Co
 	return true;
 }
 
-SUBVIEW_TEST(GIVEN_SubView_With_Filter_WHEN_Tagged_Entities_Added_THEN_Delta_Only_Contains_Filtered_Entities_ALSO_Dispatcher_Callback_Refreshes_Correctly)
+SUBVIEW_TEST(
+	GIVEN_SubView_With_Filter_WHEN_Tagged_Entities_Added_THEN_Delta_Only_Contains_Filtered_Entities_ALSO_Dispatcher_Callback_Refreshes_Correctly)
 {
 	FDispatcher Dispatcher;
 	EntityView View;
@@ -167,8 +168,7 @@ SUBVIEW_TEST(GIVEN_Tagged_Incomplete_Entity_Which_Should_Be_Complete_WHEN_Refres
 				 [&IsFilterComplete](const Worker_EntityId&, const EntityViewElement&) {
 					 return IsFilterComplete;
 				 },
-				 View, Dispatcher,
-				 NoRefreshCallbacks };
+				 View, Dispatcher, NoRefreshCallbacks };
 
 	AddEntityToView(View, TAGGED_ENTITY_ID);
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/SubViewTest.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/SubViewTest.cpp
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
-#include "SpatialViewUtils.h"
 #include "SpatialView/OpList/EntityComponentOpList.h"
 #include "SpatialView/ViewCoordinator.h"
+#include "SpatialViewUtils.h"
 #include "Tests/TestDefinitions.h"
 #include "Utils/ComponentFactory.h"
 
@@ -10,28 +10,34 @@
 
 namespace SpatialGDK
 {
-	const Worker_EntityId ENTITY_ID = 1;
-	const Worker_EntityId TAGGED_ENTITY_ID = 2;
-	const Worker_EntityId OTHER_TAGGED_ENTITY_ID = 3;
-	const Worker_ComponentId TAG_COMPONENT_ID = 1;
-	const Worker_ComponentId VALUE_COMPONENT_ID = 2;
-	const double CORRECT_VALUE = 1;
-	const double INCORRECT_VALUE = 2;
+const Worker_EntityId ENTITY_ID = 1;
+const Worker_EntityId TAGGED_ENTITY_ID = 2;
+const Worker_EntityId OTHER_TAGGED_ENTITY_ID = 3;
+const Worker_ComponentId TAG_COMPONENT_ID = 1;
+const Worker_ComponentId VALUE_COMPONENT_ID = 2;
+const double CORRECT_VALUE = 1;
+const double INCORRECT_VALUE = 2;
 
-FFilterPredicate NoFilter = [](const Worker_EntityId&, const EntityViewElement&){return true;};
-FComponentChangeRefreshPredicate NoComponentChangeRefreshPredicate = [](const FEntityComponentChange&){return true;};
+FFilterPredicate NoFilter = [](const Worker_EntityId&, const EntityViewElement&) {
+	return true;
+};
+FComponentChangeRefreshPredicate NoComponentChangeRefreshPredicate = [](const FEntityComponentChange&) {
+	return true;
+};
 TArray<FDispatcherRefreshCallback> NoRefreshCallbacks = TArray<FDispatcherRefreshCallback>{};
 
 SUBVIEW_TEST(GIVEN_Set_Of_Components_WHEN_Entity_Tagged_THEN_Components_Contains_Tag)
 {
 	FDispatcher Dispatcher;
 	const EntityView View;
-	const SubView Sub{TAG_COMPONENT_ID, NoFilter, View, Dispatcher, NoRefreshCallbacks};
-	TArray<FWorkerComponentData> Components{ComponentFactory::CreateEmptyComponentData(VALUE_COMPONENT_ID)};
+	const SubView Sub{ TAG_COMPONENT_ID, NoFilter, View, Dispatcher, NoRefreshCallbacks };
+	TArray<FWorkerComponentData> Components{ ComponentFactory::CreateEmptyComponentData(VALUE_COMPONENT_ID) };
 
 	Sub.TagEntity(Components);
 
-	TestTrue("Components contains tag component", Components.ContainsByPredicate([](const FWorkerComponentData& Data){return Data.component_id == TAG_COMPONENT_ID;}));
+	TestTrue("Components contains tag component", Components.ContainsByPredicate([](const FWorkerComponentData& Data) {
+		return Data.component_id == TAG_COMPONENT_ID;
+	}));
 
 	return true;
 }
@@ -40,12 +46,12 @@ SUBVIEW_TEST(GIVEN_Query_WHEN_Query_Tagged_THEN_Query_Is_Tagged)
 {
 	FDispatcher Dispatcher;
 	const EntityView View;
-	SubView Sub{TAG_COMPONENT_ID, NoFilter, View, Dispatcher, NoRefreshCallbacks};
+	SubView Sub{ TAG_COMPONENT_ID, NoFilter, View, Dispatcher, NoRefreshCallbacks };
 	Query QueryToTag;
 	QueryConstraint Constraint;
 	Constraint.EntityIdConstraint = ENTITY_ID;
 	QueryToTag.Constraint = Constraint;
-	QueryToTag.ResultComponentIds =  SchemaResultType{ VALUE_COMPONENT_ID };
+	QueryToTag.ResultComponentIds = SchemaResultType{ VALUE_COMPONENT_ID };
 
 	Sub.TagQuery(QueryToTag);
 
@@ -54,7 +60,8 @@ SUBVIEW_TEST(GIVEN_Query_WHEN_Query_Tagged_THEN_Query_Is_Tagged)
 		return true;
 	}
 	TArray<QueryConstraint>& AndConstraint = QueryToTag.Constraint.AndConstraint;
-	Worker_ComponentId TestConstraintId = AndConstraint[0].ComponentConstraint.IsSet() ? AndConstraint[0].ComponentConstraint.GetValue() : AndConstraint[1].ComponentConstraint.GetValue();
+	Worker_ComponentId TestConstraintId = AndConstraint[0].ComponentConstraint.IsSet() ? AndConstraint[0].ComponentConstraint.GetValue()
+																					   : AndConstraint[1].ComponentConstraint.GetValue();
 	TestEqual("Constraint contains tag component constraint", TestConstraintId, TAG_COMPONENT_ID);
 
 	TestTrue("Result type contains tag", QueryToTag.ResultComponentIds.Contains(TAG_COMPONENT_ID));
@@ -68,7 +75,7 @@ SUBVIEW_TEST(GIVEN_SubView_Without_Filter_WHEN_Tagged_Entity_Added_THEN_Delta_Co
 	EntityView View;
 	ViewDelta Delta;
 
-	SubView Sub{TAG_COMPONENT_ID, NoFilter, View, Dispatcher, NoRefreshCallbacks};
+	SubView Sub{ TAG_COMPONENT_ID, NoFilter, View, Dispatcher, NoRefreshCallbacks };
 
 	AddEntityToView(View, TAGGED_ENTITY_ID);
 	PopulateViewDeltaWithComponentAdded(Delta, View, TAGGED_ENTITY_ID, TAG_COMPONENT_ID);
@@ -95,15 +102,18 @@ SUBVIEW_TEST(GIVEN_SubView_With_Filter_WHEN_Tagged_Entities_Added_THEN_Delta_Onl
 	EntityView View;
 	ViewDelta Delta;
 
-	SubView Sub{TAG_COMPONENT_ID, [](const Worker_EntityId&, const EntityViewElement& Element)
-	{
-		const ComponentData* It = Element.Components.FindByPredicate(ComponentIdEquality{ VALUE_COMPONENT_ID });
-		if (GetValueFromSchemaComponentData(It->GetUnderlying()) == CORRECT_VALUE)
-		{
-			return true;
-		}
-		return false;
-	}, View, Dispatcher, TArray<FDispatcherRefreshCallback>{SubView::CreateComponentChangedRefreshCallback(Dispatcher, VALUE_COMPONENT_ID, NoComponentChangeRefreshPredicate)}};
+	SubView Sub{ TAG_COMPONENT_ID,
+				 [](const Worker_EntityId&, const EntityViewElement& Element) {
+					 const ComponentData* It = Element.Components.FindByPredicate(ComponentIdEquality{ VALUE_COMPONENT_ID });
+					 if (GetValueFromSchemaComponentData(It->GetUnderlying()) == CORRECT_VALUE)
+					 {
+						 return true;
+					 }
+					 return false;
+				 },
+				 View, Dispatcher,
+				 TArray<FDispatcherRefreshCallback>{
+					 SubView::CreateComponentChangedRefreshCallback(Dispatcher, VALUE_COMPONENT_ID, NoComponentChangeRefreshPredicate) } };
 
 	AddEntityToView(View, TAGGED_ENTITY_ID);
 	AddComponentToView(View, TAGGED_ENTITY_ID, CreateTestComponentData(VALUE_COMPONENT_ID, CORRECT_VALUE));

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/SubViewTest.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/SubViewTest.cpp
@@ -1,0 +1,147 @@
+﻿// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "SpatialViewUtils.h"
+#include "SpatialView/OpList/EntityComponentOpList.h"
+#include "SpatialView/ViewCoordinator.h"
+#include "Tests/TestDefinitions.h"
+#include "Utils/ComponentFactory.h"
+
+#define SUBVIEW_TEST(TestName) GDK_TEST(Core, SubView, TestName)
+
+namespace SpatialGDK
+{
+	const Worker_EntityId ENTITY_ID = 1;
+	const Worker_EntityId TAGGED_ENTITY_ID = 2;
+	const Worker_EntityId OTHER_TAGGED_ENTITY_ID = 3;
+	const Worker_ComponentId TAG_COMPONENT_ID = 1;
+	const Worker_ComponentId VALUE_COMPONENT_ID = 2;
+	const double CORRECT_VALUE = 1;
+	const double INCORRECT_VALUE = 2;
+
+FFilterPredicate NoFilter = [](const Worker_EntityId&, const EntityViewElement&){return true;};
+FComponentChangeRefreshPredicate NoComponentChangeRefreshPredicate = [](const FEntityComponentChange&){return true;};
+TArray<FDispatcherRefreshCallback> NoRefreshCallbacks = TArray<FDispatcherRefreshCallback>{};
+
+SUBVIEW_TEST(GIVEN_Set_Of_Components_WHEN_Entity_Tagged_THEN_Components_Contains_Tag)
+{
+	FDispatcher Dispatcher;
+	const EntityView View;
+	const SubView Sub{TAG_COMPONENT_ID, NoFilter, View, Dispatcher, NoRefreshCallbacks};
+	TArray<FWorkerComponentData> Components{ComponentFactory::CreateEmptyComponentData(VALUE_COMPONENT_ID)};
+
+	Sub.TagEntity(Components);
+
+	TestTrue("Components contains tag component", Components.ContainsByPredicate([](const FWorkerComponentData& Data){return Data.component_id == TAG_COMPONENT_ID;}));
+
+	return true;
+}
+
+SUBVIEW_TEST(GIVEN_Query_WHEN_Query_Tagged_THEN_Query_Is_Tagged)
+{
+	FDispatcher Dispatcher;
+	const EntityView View;
+	SubView Sub{TAG_COMPONENT_ID, NoFilter, View, Dispatcher, NoRefreshCallbacks};
+	Query QueryToTag;
+	QueryConstraint Constraint;
+	Constraint.EntityIdConstraint = ENTITY_ID;
+	QueryToTag.Constraint = Constraint;
+	QueryToTag.ResultComponentIds =  SchemaResultType{ VALUE_COMPONENT_ID };
+
+	Sub.TagQuery(QueryToTag);
+
+	if (!TestNotEqual("Constraint is now an AND", QueryToTag.Constraint.AndConstraint.Num(), 0))
+	{
+		return true;
+	}
+	TArray<QueryConstraint>& AndConstraint = QueryToTag.Constraint.AndConstraint;
+	Worker_ComponentId TestConstraintId = AndConstraint[0].ComponentConstraint.IsSet() ? AndConstraint[0].ComponentConstraint.GetValue() : AndConstraint[1].ComponentConstraint.GetValue();
+	TestEqual("Constraint contains tag component constraint", TestConstraintId, TAG_COMPONENT_ID);
+
+	TestTrue("Result type contains tag", QueryToTag.ResultComponentIds.Contains(TAG_COMPONENT_ID));
+
+	return true;
+}
+
+SUBVIEW_TEST(GIVEN_SubView_Without_Filter_WHEN_Tagged_Entity_Added_THEN_Delta_Contains_Entity)
+{
+	FDispatcher Dispatcher;
+	EntityView View;
+	ViewDelta Delta;
+
+	SubView Sub{TAG_COMPONENT_ID, NoFilter, View, Dispatcher, NoRefreshCallbacks};
+
+	AddEntityToView(View, TAGGED_ENTITY_ID);
+	PopulateViewDeltaWithComponentAdded(Delta, View, TAGGED_ENTITY_ID, TAG_COMPONENT_ID);
+
+	Dispatcher.InvokeCallbacks(Delta.GetEntityDeltas());
+
+	Sub.Advance(Delta);
+	SubViewDelta SubDelta = Sub.GetViewDelta();
+
+	// The tagged entity should pass through to the sub view delta.
+	if (!TestEqual("There is one entity delta", SubDelta.EntityDeltas.Num(), 1))
+	{
+		// early out so we don't crash - test has already failed
+		return true;
+	}
+	TestEqual("The entity delta is for the correct entity ID", SubDelta.EntityDeltas[0].EntityId, TAGGED_ENTITY_ID);
+
+	return true;
+}
+
+SUBVIEW_TEST(GIVEN_SubView_With_Filter_WHEN_Tagged_Entities_Added_THEN_Delta_Only_Contains_Filtered_Entities)
+{
+	FDispatcher Dispatcher;
+	EntityView View;
+	ViewDelta Delta;
+
+	SubView Sub{TAG_COMPONENT_ID, [](const Worker_EntityId&, const EntityViewElement& Element)
+	{
+		const ComponentData* It = Element.Components.FindByPredicate(ComponentIdEquality{ VALUE_COMPONENT_ID });
+		if (GetValueFromSchemaComponentData(It->GetUnderlying()) == CORRECT_VALUE)
+		{
+			return true;
+		}
+		return false;
+	}, View, Dispatcher, TArray<FDispatcherRefreshCallback>{SubView::CreateComponentChangedRefreshCallback(Dispatcher, VALUE_COMPONENT_ID, NoComponentChangeRefreshPredicate)}};
+
+	AddEntityToView(View, TAGGED_ENTITY_ID);
+	AddComponentToView(View, TAGGED_ENTITY_ID, CreateTestComponentData(VALUE_COMPONENT_ID, CORRECT_VALUE));
+	AddEntityToView(View, OTHER_TAGGED_ENTITY_ID);
+	AddComponentToView(View, OTHER_TAGGED_ENTITY_ID, CreateTestComponentData(VALUE_COMPONENT_ID, INCORRECT_VALUE));
+
+	PopulateViewDeltaWithComponentAdded(Delta, View, TAGGED_ENTITY_ID, TAG_COMPONENT_ID);
+	Dispatcher.InvokeCallbacks(Delta.GetEntityDeltas());
+	Sub.Advance(Delta);
+	SubViewDelta SubDelta = Sub.GetViewDelta();
+
+	// The tagged entity should pass through to the sub view delta.
+	if (!TestEqual("There is one entity delta", SubDelta.EntityDeltas.Num(), 1))
+	{
+		// early out so we don't crash - test has already failed
+		return true;
+	}
+	TestEqual("The entity delta is for the correct entity ID", SubDelta.EntityDeltas[0].EntityId, TAGGED_ENTITY_ID);
+
+	PopulateViewDeltaWithComponentAdded(Delta, View, OTHER_TAGGED_ENTITY_ID, TAG_COMPONENT_ID);
+	Dispatcher.InvokeCallbacks(Delta.GetEntityDeltas());
+	Sub.Advance(Delta);
+	SubDelta = Sub.GetViewDelta();
+
+	TestEqual("There are no entity deltas", SubDelta.EntityDeltas.Num(), 0);
+
+	PopulateViewDeltaWithComponentUpdated(Delta, View, OTHER_TAGGED_ENTITY_ID, VALUE_COMPONENT_ID, CORRECT_VALUE);
+	Dispatcher.InvokeCallbacks(Delta.GetEntityDeltas());
+	Sub.Advance(Delta);
+	SubDelta = Sub.GetViewDelta();
+
+	if (!TestEqual("There is one entity delta", SubDelta.EntityDeltas.Num(), 1))
+	{
+		// early out so we don't crash - test has already failed
+		return true;
+	}
+	TestEqual("The entity delta is for the correct entity ID", SubDelta.EntityDeltas[0].EntityId, OTHER_TAGGED_ENTITY_ID);
+
+	return true;
+}
+} // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ViewCoordinatorTest.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ViewCoordinatorTest.cpp
@@ -77,7 +77,7 @@ VIEWCOORDINATOR_TEST(GIVEN_view_coordinator_WHEN_create_unfiltered_sub_view_THEN
 	return true;
 }
 
-	VIEWCOORDINATOR_TEST(GIVEN_view_coordinator_WHEN_create_filtered_sub_view_THEN_returns_sub_view_which_filters_tagged_entities)
+VIEWCOORDINATOR_TEST(GIVEN_view_coordinator_WHEN_create_filtered_sub_view_THEN_returns_sub_view_which_filters_tagged_entities)
 {
 	const Worker_EntityId TaggedEntityId = 1;
 	const Worker_EntityId OtherTaggedEntityId = 2;
@@ -91,10 +91,10 @@ VIEWCOORDINATOR_TEST(GIVEN_view_coordinator_WHEN_create_unfiltered_sub_view_THEN
 	EntityComponentOpListBuilder Builder;
 	Builder.AddEntity(TaggedEntityId);
 	Builder.AddComponent(TaggedEntityId, ComponentData{ TagComponentId });
-	Builder.AddComponent(TaggedEntityId, CreateTestComponentData( ValueComponentId, CorrectValue));
+	Builder.AddComponent(TaggedEntityId, CreateTestComponentData(ValueComponentId, CorrectValue));
 	Builder.AddEntity(OtherTaggedEntityId);
 	Builder.AddComponent(OtherTaggedEntityId, ComponentData{ TagComponentId });
-	Builder.AddComponent(OtherTaggedEntityId, CreateTestComponentData( ValueComponentId, IncorrectValue));
+	Builder.AddComponent(OtherTaggedEntityId, CreateTestComponentData(ValueComponentId, IncorrectValue));
 	OpLists.Add(MoveTemp(Builder).CreateOpList());
 	ListsOfOpLists.Add(MoveTemp(OpLists));
 
@@ -108,15 +108,17 @@ VIEWCOORDINATOR_TEST(GIVEN_view_coordinator_WHEN_create_unfiltered_sub_view_THEN
 	Handler->SetListsOfOpLists(MoveTemp(ListsOfOpLists));
 	ViewCoordinator Coordinator{ MoveTemp(Handler) };
 
-	auto& SubView = Coordinator.CreateSubView(TagComponentId, [CorrectValue, ValueComponentId](const Worker_EntityId& EntityId, const EntityViewElement& Element)
-	{
-		const ComponentData* It = Element.Components.FindByPredicate(ComponentIdEquality{ ValueComponentId });
-        if (GetValueFromSchemaComponentData(It->GetUnderlying()) == CorrectValue)
-		{
-			return true;
-		}
-		return false;
-	}, TArray<FDispatcherRefreshCallback>{Coordinator.CreateComponentChangedRefreshCallback(ValueComponentId)});
+	auto& SubView = Coordinator.CreateSubView(
+		TagComponentId,
+		[CorrectValue, ValueComponentId](const Worker_EntityId& EntityId, const EntityViewElement& Element) {
+			const ComponentData* It = Element.Components.FindByPredicate(ComponentIdEquality{ ValueComponentId });
+			if (GetValueFromSchemaComponentData(It->GetUnderlying()) == CorrectValue)
+			{
+				return true;
+			}
+			return false;
+		},
+		TArray<FDispatcherRefreshCallback>{ Coordinator.CreateComponentChangedRefreshCallback(ValueComponentId) });
 
 	Coordinator.Advance();
 	SubViewDelta Delta = SubView.GetViewDelta();
@@ -130,7 +132,7 @@ VIEWCOORDINATOR_TEST(GIVEN_view_coordinator_WHEN_create_unfiltered_sub_view_THEN
 
 	// The value on the other entity should have updated, so we should see an add for the second entity.
 	TestEqual("There is one entity delta", Delta.EntityDeltas.Num(), 1);
-	//TestEqual("The entity delta is for the correct entity ID", Delta.EntityDeltas[0].EntityId, 2);
+	// TestEqual("The entity delta is for the correct entity ID", Delta.EntityDeltas[0].EntityId, 2);
 
 	return true;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ViewCoordinatorTest.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ViewCoordinatorTest.cpp
@@ -1,61 +1,49 @@
 ﻿// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
 #include "ComponentTestUtils.h"
-#include "SpatialView/ViewCoordinator.h"
 #include "SpatialView/OpList/EntityComponentOpList.h"
 #include "SpatialView/OpList/ExtractedOpList.h"
+#include "SpatialView/ViewCoordinator.h"
 #include "Tests/TestDefinitions.h"
 
 #define VIEWCOORDINATOR_TEST(TestName) GDK_TEST(Core, ViewCoordinator, TestName)
 
 namespace SpatialGDK
 {
-	// A stub for controlling the series of oplists fed into the view coordinator. The list of oplists give to
-	// SetListsOfOplists will be processed one list of oplists at a time on each call to Advance.
-	class ConnectionHandlerStub : public AbstractConnectionHandler
+// A stub for controlling the series of oplists fed into the view coordinator. The list of oplists give to
+// SetListsOfOplists will be processed one list of oplists at a time on each call to Advance.
+class ConnectionHandlerStub : public AbstractConnectionHandler
+{
+public:
+	void SetListsOfOpLists(TArray<TArray<OpList>> List) { ListsOfOpLists = MoveTemp(List); }
+
+	virtual void Advance() override
 	{
-	public:
-		void SetListsOfOpLists(TArray<TArray<OpList>> List)
-		{
-			ListsOfOpLists = MoveTemp(List);
-		}
+		QueuedOpLists = MoveTemp(ListsOfOpLists[0]);
+		ListsOfOpLists.RemoveAt(0);
+	}
 
-		virtual void Advance() override
-		{
-			QueuedOpLists = MoveTemp(ListsOfOpLists[0]);
-			ListsOfOpLists.RemoveAt(0);
-		}
+	virtual uint32 GetOpListCount() override { return QueuedOpLists.Num(); }
 
-		virtual uint32 GetOpListCount() override
-		{
-			return QueuedOpLists.Num();
-		}
+	virtual OpList GetNextOpList() override
+	{
+		OpList Temp = MoveTemp(QueuedOpLists[0]);
+		QueuedOpLists.RemoveAt(0);
+		return Temp;
+	}
 
-		virtual OpList GetNextOpList() override
-		{
-			OpList Temp = MoveTemp(QueuedOpLists[0]);
-			QueuedOpLists.RemoveAt(0);
-			return Temp;
-		}
+	virtual void SendMessages(TUniquePtr<MessagesToSend> Messages) override {}
 
-		virtual void SendMessages(TUniquePtr<MessagesToSend> Messages) override {}
+	virtual const FString& GetWorkerId() const override { return WorkerId; }
 
-		virtual const FString& GetWorkerId() const override
-		{
-			return WorkerId;
-		}
+	virtual const TArray<FString>& GetWorkerAttributes() const override { return Attributes; }
 
-		virtual const TArray<FString>& GetWorkerAttributes() const override
-		{
-			return Attributes;
-		}
-
-	private:
-		TArray<TArray<OpList>> ListsOfOpLists;
-		TArray<OpList> QueuedOpLists;
-		FString WorkerId = "test_worker";
-		TArray<FString> Attributes{"test"};
-	};
+private:
+	TArray<TArray<OpList>> ListsOfOpLists;
+	TArray<OpList> QueuedOpLists;
+	FString WorkerId = "test_worker";
+	TArray<FString> Attributes{ "test" };
+};
 
 VIEWCOORDINATOR_TEST(GIVEN_view_coordinator_WHEN_create_unfiltered_sub_view_THEN_returns_sub_view_which_passes_through_tagged_entity)
 {
@@ -66,13 +54,13 @@ VIEWCOORDINATOR_TEST(GIVEN_view_coordinator_WHEN_create_unfiltered_sub_view_THEN
 	TArray<OpList> FirstOpList;
 	EntityComponentOpListBuilder Builder;
 	Builder.AddEntity(EntityId);
-	Builder.AddComponent(EntityId, ComponentData{TagComponentId});
+	Builder.AddComponent(EntityId, ComponentData{ TagComponentId });
 	FirstOpList.Add(MoveTemp(Builder).CreateOpList());
 	ListsOfOpLists.Add(MoveTemp(FirstOpList));
 
 	auto Handler = MakeUnique<ConnectionHandlerStub>();
 	Handler->SetListsOfOpLists(MoveTemp(ListsOfOpLists));
-	ViewCoordinator Coordinator{MoveTemp(Handler)};
+	ViewCoordinator Coordinator{ MoveTemp(Handler) };
 	auto& SubView = Coordinator.CreateUnfilteredSubView(TagComponentId);
 
 	Coordinator.Advance();

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ViewCoordinatorTest.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ViewCoordinatorTest.cpp
@@ -171,11 +171,11 @@ VIEWCOORDINATOR_TEST(GIVEN_view_coordinator_with_multiple_tracked_subviews_WHEN_
 	for (int i = 0; i < NumberOfSubViews; ++i)
 	{
 		SubViews.Emplace(&Coordinator.CreateSubView(
-        TagComponentId,
-        [&EntityComplete](const Worker_EntityId&, const EntityViewElement&) {
-            return EntityComplete;
-        },
-        TArray<FDispatcherRefreshCallback>{}));
+			TagComponentId,
+			[&EntityComplete](const Worker_EntityId&, const EntityViewElement&) {
+				return EntityComplete;
+			},
+			TArray<FDispatcherRefreshCallback>{}));
 	}
 
 	Coordinator.Advance();

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ViewCoordinatorTest.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ViewCoordinatorTest.cpp
@@ -1,0 +1,86 @@
+﻿// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "ComponentTestUtils.h"
+#include "SpatialView/ViewCoordinator.h"
+#include "SpatialView/OpList/EntityComponentOpList.h"
+#include "SpatialView/OpList/ExtractedOpList.h"
+#include "Tests/TestDefinitions.h"
+
+#define VIEWCOORDINATOR_TEST(TestName) GDK_TEST(Core, ViewCoordinator, TestName)
+
+namespace SpatialGDK
+{
+	// A stub for controlling the series of oplists fed into the view coordinator. The list of oplists give to
+	// SetListsOfOplists will be processed one list of oplists at a time on each call to Advance.
+	class ConnectionHandlerStub : public AbstractConnectionHandler
+	{
+	public:
+		void SetListsOfOpLists(TArray<TArray<OpList>> List)
+		{
+			ListsOfOpLists = MoveTemp(List);
+		}
+
+		virtual void Advance() override
+		{
+			QueuedOpLists = MoveTemp(ListsOfOpLists[0]);
+			ListsOfOpLists.RemoveAt(0);
+		}
+
+		virtual uint32 GetOpListCount() override
+		{
+			return QueuedOpLists.Num();
+		}
+
+		virtual OpList GetNextOpList() override
+		{
+			OpList Temp = MoveTemp(QueuedOpLists[0]);
+			QueuedOpLists.RemoveAt(0);
+			return Temp;
+		}
+
+		virtual void SendMessages(TUniquePtr<MessagesToSend> Messages) override {}
+
+		virtual const FString& GetWorkerId() const override
+		{
+			return WorkerId;
+		}
+
+		virtual const TArray<FString>& GetWorkerAttributes() const override
+		{
+			return Attributes;
+		}
+
+	private:
+		TArray<TArray<OpList>> ListsOfOpLists;
+		TArray<OpList> QueuedOpLists;
+		FString WorkerId = "test_worker";
+		TArray<FString> Attributes{"test"};
+	};
+
+VIEWCOORDINATOR_TEST(GIVEN_view_coordinator_WHEN_create_unfiltered_sub_view_THEN_returns_sub_view_which_passes_through_tagged_entity)
+{
+	const Worker_EntityId EntityId = 1;
+	const Worker_ComponentId TagComponentId = 1;
+
+	TArray<TArray<OpList>> ListsOfOpLists;
+	TArray<OpList> FirstOpList;
+	EntityComponentOpListBuilder Builder;
+	Builder.AddEntity(EntityId);
+	Builder.AddComponent(EntityId, ComponentData{TagComponentId});
+	FirstOpList.Add(MoveTemp(Builder).CreateOpList());
+	ListsOfOpLists.Add(MoveTemp(FirstOpList));
+
+	auto Handler = MakeUnique<ConnectionHandlerStub>();
+	Handler->SetListsOfOpLists(MoveTemp(ListsOfOpLists));
+	ViewCoordinator Coordinator{MoveTemp(Handler)};
+	auto& SubView = Coordinator.CreateUnfilteredSubView(TagComponentId);
+
+	Coordinator.Advance();
+	SubViewDelta Delta = SubView.GetViewDelta();
+
+	TestEqual("There is one entity delta", Delta.EntityDeltas.Num(), 1);
+	TestEqual("The entity delta is for the correct entity ID", Delta.EntityDeltas[0].EntityId, 1);
+
+	return true;
+}
+} // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ViewDeltaTest.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ViewDeltaTest.cpp
@@ -414,7 +414,8 @@ VIEWDELTA_TEST(GIVEN_view_delta_with_update_for_entity_complete_WHEN_project_THE
 	OpListBuilder.UpdateComponent(TestEntityId, CreateTestComponentUpdate(TestComponentId, OtherTestComponentValue));
 	SetFromOpList(Delta, View, MoveTemp(OpListBuilder));
 
-	Delta.Project(SubViewDelta, TArray<Worker_EntityId>{TestEntityId}, TArray<Worker_EntityId>{}, TArray<Worker_EntityId>{}, TArray<Worker_EntityId>{});
+	Delta.Project(SubViewDelta, TArray<Worker_EntityId>{ TestEntityId }, TArray<Worker_EntityId>{}, TArray<Worker_EntityId>{},
+				  TArray<Worker_EntityId>{});
 
 	ExpectedViewDelta ExpectedSubViewDelta;
 	ExpectedSubViewDelta.AddEntityDelta(TestEntityId, ExpectedViewDelta::UPDATE);
@@ -433,7 +434,8 @@ VIEWDELTA_TEST(GIVEN_empty_view_delta_with_newly_complete_entity_WHEN_project_TH
 	AddEntityToView(View, TestEntityId);
 	AddComponentToView(View, TestEntityId, CreateTestComponentData(TestComponentId, TestComponentValue));
 
-	Delta.Project(SubViewDelta, TArray<Worker_EntityId>{}, TArray<Worker_EntityId>{TestEntityId}, TArray<Worker_EntityId>{}, TArray<Worker_EntityId>{});
+	Delta.Project(SubViewDelta, TArray<Worker_EntityId>{}, TArray<Worker_EntityId>{ TestEntityId }, TArray<Worker_EntityId>{},
+				  TArray<Worker_EntityId>{});
 
 	ExpectedViewDelta ExpectedSubViewDelta;
 	ExpectedSubViewDelta.AddEntityDelta(TestEntityId, ExpectedViewDelta::ADD);
@@ -451,7 +453,8 @@ VIEWDELTA_TEST(GIVEN_empty_view_delta_with_newly_incomplete_entity_WHEN_project_
 	AddEntityToView(View, TestEntityId);
 	AddComponentToView(View, TestEntityId, CreateTestComponentData(TestComponentId, TestComponentValue));
 
-	Delta.Project(SubViewDelta, TArray<Worker_EntityId>{}, TArray<Worker_EntityId>{}, TArray<Worker_EntityId>{TestEntityId}, TArray<Worker_EntityId>{});
+	Delta.Project(SubViewDelta, TArray<Worker_EntityId>{}, TArray<Worker_EntityId>{}, TArray<Worker_EntityId>{ TestEntityId },
+				  TArray<Worker_EntityId>{});
 
 	ExpectedViewDelta ExpectedSubViewDelta;
 	ExpectedSubViewDelta.AddEntityDelta(TestEntityId, ExpectedViewDelta::REMOVE);
@@ -469,7 +472,8 @@ VIEWDELTA_TEST(GIVEN_empty_view_delta_with_temporarily_incomplete_entity_WHEN_pr
 	AddEntityToView(View, TestEntityId);
 	AddComponentToView(View, TestEntityId, CreateTestComponentData(TestComponentId, TestComponentValue));
 
-	Delta.Project(SubViewDelta, TArray<Worker_EntityId>{}, TArray<Worker_EntityId>{}, TArray<Worker_EntityId>{}, TArray<Worker_EntityId>{TestEntityId});
+	Delta.Project(SubViewDelta, TArray<Worker_EntityId>{}, TArray<Worker_EntityId>{}, TArray<Worker_EntityId>{},
+				  TArray<Worker_EntityId>{ TestEntityId });
 
 	ExpectedViewDelta ExpectedSubViewDelta;
 	ExpectedSubViewDelta.AddEntityDelta(TestEntityId, ExpectedViewDelta::TEMPORARILY_REMOVED);
@@ -500,7 +504,8 @@ VIEWDELTA_TEST(GIVEN_arbitrary_delta_and_completeness_WHEN_project_THEN_subview_
 	OpLists.Push(MoveTemp(OpListBuilder).CreateOpList());
 	Delta.SetFromOpList(MoveTemp(OpLists), View);
 
-	Delta.Project(SubViewDelta, TArray<Worker_EntityId>{TestEntityId, YetAnotherTestEntityId}, TArray<Worker_EntityId>{OtherTestEntityId}, TArray<Worker_EntityId>{AnotherTestEntityId}, TArray<Worker_EntityId>{});
+	Delta.Project(SubViewDelta, TArray<Worker_EntityId>{ TestEntityId, YetAnotherTestEntityId },
+				  TArray<Worker_EntityId>{ OtherTestEntityId }, TArray<Worker_EntityId>{ AnotherTestEntityId }, TArray<Worker_EntityId>{});
 
 	ExpectedViewDelta ExpectedSubViewDelta;
 	ExpectedSubViewDelta.AddEntityDelta(TestEntityId, ExpectedViewDelta::UPDATE);

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ViewDeltaTest.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ViewDeltaTest.cpp
@@ -12,6 +12,9 @@
 namespace SpatialGDK
 {
 const static Worker_EntityId TestEntityId = 1;
+const static Worker_EntityId OtherTestEntityId = 2;
+const static Worker_EntityId AnotherTestEntityId = 3;
+const static Worker_EntityId YetAnotherTestEntityId = 4;
 const static Worker_ComponentId TestComponentId = 1;
 const static double TestComponentValue = 20;
 const static double OtherTestComponentValue = 30;
@@ -394,6 +397,120 @@ VIEWDELTA_TEST(GIVEN_entity_and_component_in_view_WHEN_remove_entity_THEN_empty_
 
 	TestTrue("View Deltas are equal", ExpectedDelta.Compare(InputDelta));
 	TestTrue("Views are equal", CompareViews(InputView, ExpectedView));
+
+	return true;
+}
+
+// Projection Tests
+VIEWDELTA_TEST(GIVEN_view_delta_with_update_for_entity_complete_WHEN_project_THEN_contains_update)
+{
+	ViewDelta Delta;
+	FSubViewDelta SubViewDelta;
+	EntityView View;
+	AddEntityToView(View, TestEntityId);
+	AddComponentToView(View, TestEntityId, CreateTestComponentData(TestComponentId, TestComponentValue));
+
+	EntityComponentOpListBuilder OpListBuilder;
+	OpListBuilder.UpdateComponent(TestEntityId, CreateTestComponentUpdate(TestComponentId, OtherTestComponentValue));
+	SetFromOpList(Delta, View, MoveTemp(OpListBuilder));
+
+	Delta.Project(SubViewDelta, TArray<Worker_EntityId>{TestEntityId}, TArray<Worker_EntityId>{}, TArray<Worker_EntityId>{}, TArray<Worker_EntityId>{});
+
+	ExpectedViewDelta ExpectedSubViewDelta;
+	ExpectedSubViewDelta.AddEntityDelta(TestEntityId, ExpectedViewDelta::UPDATE);
+	ExpectedSubViewDelta.AddComponentUpdate(TestEntityId, CreateTestComponentUpdate(TestComponentId, OtherTestComponentValue));
+
+	TestTrue("View Deltas are equal", ExpectedSubViewDelta.Compare(SubViewDelta));
+
+	return true;
+}
+
+VIEWDELTA_TEST(GIVEN_empty_view_delta_with_newly_complete_entity_WHEN_project_THEN_contains_marker_add)
+{
+	ViewDelta Delta;
+	FSubViewDelta SubViewDelta;
+	EntityView View;
+	AddEntityToView(View, TestEntityId);
+	AddComponentToView(View, TestEntityId, CreateTestComponentData(TestComponentId, TestComponentValue));
+
+	Delta.Project(SubViewDelta, TArray<Worker_EntityId>{}, TArray<Worker_EntityId>{TestEntityId}, TArray<Worker_EntityId>{}, TArray<Worker_EntityId>{});
+
+	ExpectedViewDelta ExpectedSubViewDelta;
+	ExpectedSubViewDelta.AddEntityDelta(TestEntityId, ExpectedViewDelta::ADD);
+
+	TestTrue("View Deltas are equal", ExpectedSubViewDelta.Compare(SubViewDelta));
+
+	return true;
+}
+
+VIEWDELTA_TEST(GIVEN_empty_view_delta_with_newly_incomplete_entity_WHEN_project_THEN_contains_marker_remove)
+{
+	ViewDelta Delta;
+	FSubViewDelta SubViewDelta;
+	EntityView View;
+	AddEntityToView(View, TestEntityId);
+	AddComponentToView(View, TestEntityId, CreateTestComponentData(TestComponentId, TestComponentValue));
+
+	Delta.Project(SubViewDelta, TArray<Worker_EntityId>{}, TArray<Worker_EntityId>{}, TArray<Worker_EntityId>{TestEntityId}, TArray<Worker_EntityId>{});
+
+	ExpectedViewDelta ExpectedSubViewDelta;
+	ExpectedSubViewDelta.AddEntityDelta(TestEntityId, ExpectedViewDelta::REMOVE);
+
+	TestTrue("View Deltas are equal", ExpectedSubViewDelta.Compare(SubViewDelta));
+
+	return true;
+}
+
+VIEWDELTA_TEST(GIVEN_empty_view_delta_with_temporarily_incomplete_entity_WHEN_project_THEN_contains_marker_temporary_remove)
+{
+	ViewDelta Delta;
+	FSubViewDelta SubViewDelta;
+	EntityView View;
+	AddEntityToView(View, TestEntityId);
+	AddComponentToView(View, TestEntityId, CreateTestComponentData(TestComponentId, TestComponentValue));
+
+	Delta.Project(SubViewDelta, TArray<Worker_EntityId>{}, TArray<Worker_EntityId>{}, TArray<Worker_EntityId>{}, TArray<Worker_EntityId>{TestEntityId});
+
+	ExpectedViewDelta ExpectedSubViewDelta;
+	ExpectedSubViewDelta.AddEntityDelta(TestEntityId, ExpectedViewDelta::TEMPORARILY_REMOVED);
+
+	TestTrue("View Deltas are equal", ExpectedSubViewDelta.Compare(SubViewDelta));
+
+	return true;
+}
+
+VIEWDELTA_TEST(GIVEN_arbitrary_delta_and_completeness_WHEN_project_THEN_subview_delta_correct)
+{
+	ViewDelta Delta;
+	FSubViewDelta SubViewDelta;
+	EntityView View;
+	AddEntityToView(View, TestEntityId);
+	AddComponentToView(View, TestEntityId, CreateTestComponentData(TestComponentId, TestComponentValue));
+	AddEntityToView(View, OtherTestEntityId);
+	AddEntityToView(View, AnotherTestEntityId);
+	AddEntityToView(View, YetAnotherTestEntityId);
+	AddComponentToView(View, YetAnotherTestEntityId, CreateTestComponentData(TestComponentId, OtherTestComponentValue));
+
+	TArray<OpList> OpLists;
+	EntityComponentOpListBuilder OpListBuilder;
+	OpListBuilder.UpdateComponent(TestEntityId, CreateTestComponentUpdate(TestComponentId, OtherTestComponentValue));
+	OpLists.Push(MoveTemp(OpListBuilder).CreateOpList());
+	OpListBuilder = EntityComponentOpListBuilder{};
+	OpListBuilder.UpdateComponent(YetAnotherTestEntityId, CreateTestComponentUpdate(TestComponentId, TestComponentValue));
+	OpLists.Push(MoveTemp(OpListBuilder).CreateOpList());
+	Delta.SetFromOpList(MoveTemp(OpLists), View);
+
+	Delta.Project(SubViewDelta, TArray<Worker_EntityId>{TestEntityId, YetAnotherTestEntityId}, TArray<Worker_EntityId>{OtherTestEntityId}, TArray<Worker_EntityId>{AnotherTestEntityId}, TArray<Worker_EntityId>{});
+
+	ExpectedViewDelta ExpectedSubViewDelta;
+	ExpectedSubViewDelta.AddEntityDelta(TestEntityId, ExpectedViewDelta::UPDATE);
+	ExpectedSubViewDelta.AddComponentUpdate(TestEntityId, CreateTestComponentUpdate(TestComponentId, OtherTestComponentValue));
+	ExpectedSubViewDelta.AddEntityDelta(OtherTestEntityId, ExpectedViewDelta::ADD);
+	ExpectedSubViewDelta.AddEntityDelta(AnotherTestEntityId, ExpectedViewDelta::REMOVE);
+	ExpectedSubViewDelta.AddEntityDelta(YetAnotherTestEntityId, ExpectedViewDelta::UPDATE);
+	ExpectedSubViewDelta.AddComponentUpdate(YetAnotherTestEntityId, CreateTestComponentUpdate(TestComponentId, TestComponentValue));
+
+	TestTrue("View Deltas are equal", ExpectedSubViewDelta.Compare(SubViewDelta));
 
 	return true;
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/EntityDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/EntityDelta.h
@@ -110,8 +110,13 @@ private:
 struct EntityDelta
 {
 	Worker_EntityId EntityId;
-	bool bAdded;
-	bool bRemoved;
+	enum
+	{
+		UPDATE,
+		ADD,
+		REMOVE,
+		TEMPORARILY_REMOVED
+	} Type;
 	ComponentSpan<ComponentChange> ComponentsAdded;
 	ComponentSpan<ComponentChange> ComponentsRemoved;
 	ComponentSpan<ComponentChange> ComponentUpdates;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -26,7 +26,7 @@ public:
 	void RefreshEntity(const Worker_EntityId EntityId);
 
 private:
-	void RegisterTagCallbacks(const EntityView& View, FDispatcher& Dispatcher);
+	void RegisterTagCallbacks(FDispatcher& Dispatcher);
 	void RegisterRefreshCallbacks(const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks);
 	void OnTaggedEntityAdded(const Worker_EntityId EntityId);
 	void OnTaggedEntityRemoved(const Worker_EntityId EntityId);

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -25,6 +25,10 @@ public:
 	SubView(const Worker_ComponentId& TagComponentId, const FFilterPredicate& Filter, const EntityView& View, FDispatcher& Dispatcher,
 			const TArray<FDispatcherRefreshCallback>& DispatcherRefreshCallbacks);
 
+	// Non-copyable
+	SubView(const SubView&) = delete;
+	SubView& operator=(const SubView&) = delete;
+
 	void TagQuery(Query& QueryToTag) const;
 	void TagEntity(TArray<FWorkerComponentData>& Components) const;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -44,7 +44,7 @@ private:
 	TArray<Worker_EntityId> CompleteEntities;
 	TArray<Worker_EntityId> NewlyCompleteEntities;
 	TArray<Worker_EntityId> NewlyIncompleteEntities;
-	// TODO: TempIncompleteEntities
+	TArray<Worker_EntityId> TemporarilyIncompleteEntities;
 };
 
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -15,8 +15,8 @@ namespace SpatialGDK
 class SubView
 {
 public:
-	SubView(const Worker_ComponentId TagComponentId, const FFilterPredicate Filter,
-			const EntityView& View, FDispatcher& Dispatcher, const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks);
+	SubView(const Worker_ComponentId TagComponentId, const FFilterPredicate Filter, const EntityView& View, FDispatcher& Dispatcher,
+			const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks);
 
 	void TagQuery(Query& QueryToTag) const;
 	void TagEntity(TArray<FWorkerComponentData>& Components) const;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -8,36 +8,34 @@
 
 namespace SpatialGDK
 {
-	class SubView
-	{
-	public:
-		SubView(const Worker_ComponentId TagComponentId,
-			const TFunction<bool(const Worker_EntityId, const EntityViewElement&)> Filter,
-			const EntityView& View,
-			FDispatcher& Dispatcher);
+class SubView
+{
+public:
+	SubView(const Worker_ComponentId TagComponentId, const TFunction<bool(const Worker_EntityId, const EntityViewElement&)> Filter,
+			const EntityView& View, FDispatcher& Dispatcher);
 
-		void TagQuery(Query& QueryToTag) const;
-		void TagEntity(TArray<FWorkerComponentData>& Components) const;
+	void TagQuery(Query& QueryToTag) const;
+	void TagEntity(TArray<FWorkerComponentData>& Components) const;
 
-		void AdvanceViewDelta(const ViewDelta& Delta);
-		const ViewDelta& GetViewDelta() const;
-		void RefreshEntity(const Worker_EntityId EntityId);
+	void AdvanceViewDelta(const ViewDelta& Delta);
+	const ViewDelta& GetViewDelta() const;
+	void RefreshEntity(const Worker_EntityId EntityId);
 
-	private:
-		void OnTaggedEntityAdded(const Worker_EntityId EntityId);
-		void OnTaggedEntityRemoved(const Worker_EntityId EntityId);
-		void CheckEntityAgainstFilter(const Worker_EntityId EntityId);
+private:
+	void OnTaggedEntityAdded(const Worker_EntityId EntityId);
+	void OnTaggedEntityRemoved(const Worker_EntityId EntityId);
+	void CheckEntityAgainstFilter(const Worker_EntityId EntityId);
 
-		const Worker_ComponentId TagComponentId;
-		const TFunction<bool(const Worker_EntityId, const EntityViewElement&)> Filter;
-		const EntityView& View;
+	const Worker_ComponentId TagComponentId;
+	const TFunction<bool(const Worker_EntityId, const EntityViewElement&)> Filter;
+	const EntityView& View;
 
-		ViewDelta SubDelta;
+	ViewDelta SubDelta;
 
-		TSet<Worker_EntityId> TaggedEntities;
-		TSet<Worker_EntityId> CompleteEntities;
-		TSet<Worker_EntityId> NewlyCompleteEntities;
-		TSet<Worker_EntityId> NewlyIncompleteEntities;
-	};
+	TSet<Worker_EntityId> TaggedEntities;
+	TSet<Worker_EntityId> CompleteEntities;
+	TSet<Worker_EntityId> NewlyCompleteEntities;
+	TSet<Worker_EntityId> NewlyIncompleteEntities;
+};
 
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -17,6 +17,11 @@ namespace SpatialGDK
 class SubView
 {
 public:
+	// The subview constructor takes the filter and the dispatcher refresh callbacks for the subview, rather than
+	// adding them to the subview later. This is to maintain the invariant that a subview always has the correct
+	// full set of complete entities. During construction, it calculates the initial set of complete entities,
+	// and registers the passed dispatcher callbacks in order to ensure all possible changes which could change
+	// the state of completeness for any entity are picked up by the subview to maintain this invariant.
 	SubView(const Worker_ComponentId TagComponentId, const FFilterPredicate Filter, const EntityView& View, FDispatcher& Dispatcher,
 			const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks);
 
@@ -27,6 +32,9 @@ public:
 	const ViewDelta& GetViewDelta() const;
 	void RefreshEntity(const Worker_EntityId EntityId);
 
+	// Helper functions for creating dispatcher refresh callbacks for use when constructing a subview.
+	// Takes an optional predicate argument to further filter what causes a refresh. Example: Only trigger
+	// a refresh if the received component change has a change for a certain field.
 	static FDispatcherRefreshCallback CreateComponentExistenceDispatcherRefreshCallback(FDispatcher& Dispatcher,
 																						Worker_ComponentId ComponentId,
 																						FComponentChangeRefreshPredicate RefreshPredicate);

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -39,12 +39,13 @@ public:
 	// Helper functions for creating dispatcher refresh callbacks for use when constructing a subview.
 	// Takes an optional predicate argument to further filter what causes a refresh. Example: Only trigger
 	// a refresh if the received component change has a change for a certain field.
-	static FDispatcherRefreshCallback CreateComponentExistenceRefreshCallback(
-		FDispatcher& Dispatcher, const Worker_ComponentId& ComponentId, const FComponentChangeRefreshPredicate& RefreshPredicate);
-	static FDispatcherRefreshCallback CreateComponentChangedRefreshCallback(
-		FDispatcher& Dispatcher, const Worker_ComponentId& ComponentId, const FComponentChangeRefreshPredicate& RefreshPredicate);
-	static FDispatcherRefreshCallback CreateAuthorityChangeRefreshCallback(
-		FDispatcher& Dispatcher, const Worker_ComponentId& ComponentId, const FAuthorityChangeRefreshPredicate& RefreshPredicate);
+	static FDispatcherRefreshCallback CreateComponentExistenceRefreshCallback(FDispatcher& Dispatcher,
+																			  const Worker_ComponentId& ComponentId,
+																			  const FComponentChangeRefreshPredicate& RefreshPredicate);
+	static FDispatcherRefreshCallback CreateComponentChangedRefreshCallback(FDispatcher& Dispatcher, const Worker_ComponentId& ComponentId,
+																			const FComponentChangeRefreshPredicate& RefreshPredicate);
+	static FDispatcherRefreshCallback CreateAuthorityChangeRefreshCallback(FDispatcher& Dispatcher, const Worker_ComponentId& ComponentId,
+																		   const FAuthorityChangeRefreshPredicate& RefreshPredicate);
 
 private:
 	void RegisterTagCallbacks(FDispatcher& Dispatcher);

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -24,7 +24,7 @@ public:
 	// and registers the passed dispatcher callbacks in order to ensure all possible changes which could change
 	// the state of completeness for any entity are picked up by the subview to maintain this invariant.
 	FSubView(const Worker_ComponentId& TagComponentId, FFilterPredicate Filter, const EntityView* View, FDispatcher& Dispatcher,
-			const TArray<FDispatcherRefreshCallback>& DispatcherRefreshCallbacks);
+			 const TArray<FDispatcherRefreshCallback>& DispatcherRefreshCallbacks);
 
 	~FSubView() = default;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -35,15 +35,12 @@ public:
 	// Helper functions for creating dispatcher refresh callbacks for use when constructing a subview.
 	// Takes an optional predicate argument to further filter what causes a refresh. Example: Only trigger
 	// a refresh if the received component change has a change for a certain field.
-	static FDispatcherRefreshCallback CreateComponentExistenceDispatcherRefreshCallback(FDispatcher& Dispatcher,
-																						const Worker_ComponentId& ComponentId,
-																						const FComponentChangeRefreshPredicate& RefreshPredicate);
-	static FDispatcherRefreshCallback CreateComponentChangedDispatcherRefreshCallback(FDispatcher& Dispatcher,
-	const Worker_ComponentId& ComponentId,
-      const FComponentChangeRefreshPredicate& RefreshPredicate);
-	static FDispatcherRefreshCallback CreateAuthorityChangeDispatcherRefreshCallback(FDispatcher& Dispatcher,
-																					 const Worker_ComponentId& ComponentId,
-																					 const FAuthorityChangeRefreshPredicate& RefreshPredicate);
+	static FDispatcherRefreshCallback CreateComponentExistenceDispatcherRefreshCallback(
+		FDispatcher& Dispatcher, const Worker_ComponentId& ComponentId, const FComponentChangeRefreshPredicate& RefreshPredicate);
+	static FDispatcherRefreshCallback CreateComponentChangedDispatcherRefreshCallback(
+		FDispatcher& Dispatcher, const Worker_ComponentId& ComponentId, const FComponentChangeRefreshPredicate& RefreshPredicate);
+	static FDispatcherRefreshCallback CreateAuthorityChangeDispatcherRefreshCallback(
+		FDispatcher& Dispatcher, const Worker_ComponentId& ComponentId, const FAuthorityChangeRefreshPredicate& RefreshPredicate);
 
 private:
 	void RegisterTagCallbacks(FDispatcher& Dispatcher);

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
 #pragma once
+
 #include "Dispatcher.h"
 #include "EntityView.h"
 #include "Schema/Interest.h"
@@ -14,7 +15,7 @@ using FAuthorityChangeRefreshPredicate = TFunction<bool(Worker_EntityId)>;
 
 namespace SpatialGDK
 {
-class SubView
+class FSubView
 {
 public:
 	// The subview constructor takes the filter and the dispatcher refresh callbacks for the subview, rather than
@@ -22,18 +23,22 @@ public:
 	// full set of complete entities. During construction, it calculates the initial set of complete entities,
 	// and registers the passed dispatcher callbacks in order to ensure all possible changes which could change
 	// the state of completeness for any entity are picked up by the subview to maintain this invariant.
-	SubView(const Worker_ComponentId& TagComponentId, const FFilterPredicate& Filter, const EntityView& View, FDispatcher& Dispatcher,
+	FSubView(const Worker_ComponentId& TagComponentId, FFilterPredicate Filter, const EntityView* View, FDispatcher& Dispatcher,
 			const TArray<FDispatcherRefreshCallback>& DispatcherRefreshCallbacks);
 
-	// Non-copyable
-	SubView(const SubView&) = delete;
-	SubView& operator=(const SubView&) = delete;
+	~FSubView() = default;
+
+	// Non-copyable, non-movable
+	FSubView(const FSubView&) = delete;
+	FSubView(FSubView&&) = default;
+	FSubView& operator=(const FSubView&) = delete;
+	FSubView& operator=(FSubView&&) = default;
 
 	void TagQuery(Query& QueryToTag) const;
 	void TagEntity(TArray<FWorkerComponentData>& Components) const;
 
 	void Advance(const ViewDelta& Delta);
-	const SubViewDelta& GetViewDelta() const;
+	const FSubViewDelta& GetViewDelta() const;
 	void RefreshEntity(const Worker_EntityId& EntityId);
 
 	// Helper functions for creating dispatcher refresh callbacks for use when constructing a subview.
@@ -56,11 +61,11 @@ private:
 	void EntityComplete(const Worker_EntityId& EntityId);
 	void EntityIncomplete(const Worker_EntityId& EntityId);
 
-	const Worker_ComponentId TagComponentId;
-	const FFilterPredicate Filter;
-	const EntityView& View;
+	Worker_ComponentId TagComponentId;
+	FFilterPredicate Filter;
+	const EntityView* View;
 
-	SubViewDelta SubDelta;
+	FSubViewDelta SubViewDelta;
 
 	TArray<Worker_EntityId> TaggedEntities;
 	TArray<Worker_EntityId> CompleteEntities;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -6,9 +6,11 @@
 #include "Schema/Interest.h"
 #include "Templates/Function.h"
 
-typedef TFunction<bool(const Worker_EntityId, const SpatialGDK::EntityViewElement&)> FFilterPredicate;
-typedef TFunction<void(const Worker_EntityId)> FRefreshCallback;
-typedef TFunction<void(const FRefreshCallback)> FDispatcherRefreshCallback;
+using FFilterPredicate = TFunction<bool(const Worker_EntityId, const SpatialGDK::EntityViewElement&)>;
+using FRefreshCallback = TFunction<void(const Worker_EntityId)>;
+using FDispatcherRefreshCallback = TFunction<void(const FRefreshCallback)>;
+using FComponentChangeRefreshPredicate = TFunction<bool(SpatialGDK::FEntityComponentChange)>;
+using FAuthorityChangeRefreshPredicate = TFunction<bool(Worker_EntityId)>;
 
 namespace SpatialGDK
 {
@@ -21,9 +23,13 @@ public:
 	void TagQuery(Query& QueryToTag) const;
 	void TagEntity(TArray<FWorkerComponentData>& Components) const;
 
-	void AdvanceViewDelta(const ViewDelta& Delta);
+	void Advance(const ViewDelta& Delta);
 	const ViewDelta& GetViewDelta() const;
 	void RefreshEntity(const Worker_EntityId EntityId);
+
+	static FDispatcherRefreshCallback CreateComponentExistenceDispatcherRefreshCallback(FDispatcher& Dispatcher, Worker_ComponentId ComponentId, FComponentChangeRefreshPredicate RefreshPredicate);
+	static FDispatcherRefreshCallback CreateComponentChangedDispatcherRefreshCallback(FDispatcher& Dispatcher, Worker_ComponentId ComponentId, FComponentChangeRefreshPredicate RefreshPredicate);
+	static FDispatcherRefreshCallback CreateAuthorityChangeDispatcherRefreshCallback(FDispatcher& Dispatcher, Worker_ComponentId ComponentId, FAuthorityChangeRefreshPredicate RefreshPredicate);
 
 private:
 	void RegisterTagCallbacks(FDispatcher& Dispatcher);

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -6,13 +6,17 @@
 #include "Schema/Interest.h"
 #include "Templates/Function.h"
 
+typedef TFunction<bool(const Worker_EntityId, const SpatialGDK::EntityViewElement&)> FFilterPredicate;
+typedef TFunction<void(const Worker_EntityId)> FRefreshCallback;
+typedef TFunction<void(const FRefreshCallback)> FDispatcherRefreshCallback;
+
 namespace SpatialGDK
 {
 class SubView
 {
 public:
-	SubView(const Worker_ComponentId TagComponentId, const TFunction<bool(const Worker_EntityId, const EntityViewElement&)> Filter,
-			const EntityView& View, FDispatcher& Dispatcher);
+	SubView(const Worker_ComponentId TagComponentId, const FFilterPredicate Filter,
+			const EntityView& View, FDispatcher& Dispatcher, const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks);
 
 	void TagQuery(Query& QueryToTag) const;
 	void TagEntity(TArray<FWorkerComponentData>& Components) const;
@@ -22,20 +26,25 @@ public:
 	void RefreshEntity(const Worker_EntityId EntityId);
 
 private:
+	void RegisterTagCallbacks(const EntityView& View, FDispatcher& Dispatcher);
+	void RegisterRefreshCallbacks(const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks);
 	void OnTaggedEntityAdded(const Worker_EntityId EntityId);
 	void OnTaggedEntityRemoved(const Worker_EntityId EntityId);
 	void CheckEntityAgainstFilter(const Worker_EntityId EntityId);
+	void EntityComplete(const Worker_EntityId EntityId);
+	void EntityIncomplete(const Worker_EntityId EntityId);
 
 	const Worker_ComponentId TagComponentId;
-	const TFunction<bool(const Worker_EntityId, const EntityViewElement&)> Filter;
+	const FFilterPredicate Filter;
 	const EntityView& View;
 
 	ViewDelta SubDelta;
 
-	TSet<Worker_EntityId> TaggedEntities;
-	TSet<Worker_EntityId> CompleteEntities;
-	TSet<Worker_EntityId> NewlyCompleteEntities;
-	TSet<Worker_EntityId> NewlyIncompleteEntities;
+	TArray<Worker_EntityId> TaggedEntities;
+	TArray<Worker_EntityId> CompleteEntities;
+	TArray<Worker_EntityId> NewlyCompleteEntities;
+	TArray<Worker_EntityId> NewlyIncompleteEntities;
+	// TODO: TempIncompleteEntities
 };
 
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -39,11 +39,11 @@ public:
 	// Helper functions for creating dispatcher refresh callbacks for use when constructing a subview.
 	// Takes an optional predicate argument to further filter what causes a refresh. Example: Only trigger
 	// a refresh if the received component change has a change for a certain field.
-	static FDispatcherRefreshCallback CreateComponentExistenceDispatcherRefreshCallback(
+	static FDispatcherRefreshCallback CreateComponentExistenceRefreshCallback(
 		FDispatcher& Dispatcher, const Worker_ComponentId& ComponentId, const FComponentChangeRefreshPredicate& RefreshPredicate);
-	static FDispatcherRefreshCallback CreateComponentChangedDispatcherRefreshCallback(
+	static FDispatcherRefreshCallback CreateComponentChangedRefreshCallback(
 		FDispatcher& Dispatcher, const Worker_ComponentId& ComponentId, const FComponentChangeRefreshPredicate& RefreshPredicate);
-	static FDispatcherRefreshCallback CreateAuthorityChangeDispatcherRefreshCallback(
+	static FDispatcherRefreshCallback CreateAuthorityChangeRefreshCallback(
 		FDispatcher& Dispatcher, const Worker_ComponentId& ComponentId, const FAuthorityChangeRefreshPredicate& RefreshPredicate);
 
 private:

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -22,37 +22,37 @@ public:
 	// full set of complete entities. During construction, it calculates the initial set of complete entities,
 	// and registers the passed dispatcher callbacks in order to ensure all possible changes which could change
 	// the state of completeness for any entity are picked up by the subview to maintain this invariant.
-	SubView(const Worker_ComponentId TagComponentId, const FFilterPredicate Filter, const EntityView& View, FDispatcher& Dispatcher,
-			const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks);
+	SubView(const Worker_ComponentId& TagComponentId, const FFilterPredicate& Filter, const EntityView& View, FDispatcher& Dispatcher,
+			const TArray<FDispatcherRefreshCallback>& DispatcherRefreshCallbacks);
 
 	void TagQuery(Query& QueryToTag) const;
 	void TagEntity(TArray<FWorkerComponentData>& Components) const;
 
 	void Advance(const ViewDelta& Delta);
 	const SubViewDelta& GetViewDelta() const;
-	void RefreshEntity(const Worker_EntityId EntityId);
+	void RefreshEntity(const Worker_EntityId& EntityId);
 
 	// Helper functions for creating dispatcher refresh callbacks for use when constructing a subview.
 	// Takes an optional predicate argument to further filter what causes a refresh. Example: Only trigger
 	// a refresh if the received component change has a change for a certain field.
 	static FDispatcherRefreshCallback CreateComponentExistenceDispatcherRefreshCallback(FDispatcher& Dispatcher,
-																						Worker_ComponentId ComponentId,
-																						FComponentChangeRefreshPredicate RefreshPredicate);
+																						const Worker_ComponentId& ComponentId,
+																						const FComponentChangeRefreshPredicate& RefreshPredicate);
 	static FDispatcherRefreshCallback CreateComponentChangedDispatcherRefreshCallback(FDispatcher& Dispatcher,
-																					  Worker_ComponentId ComponentId,
-																					  FComponentChangeRefreshPredicate RefreshPredicate);
+	const Worker_ComponentId& ComponentId,
+      const FComponentChangeRefreshPredicate& RefreshPredicate);
 	static FDispatcherRefreshCallback CreateAuthorityChangeDispatcherRefreshCallback(FDispatcher& Dispatcher,
-																					 Worker_ComponentId ComponentId,
-																					 FAuthorityChangeRefreshPredicate RefreshPredicate);
+																					 const Worker_ComponentId& ComponentId,
+																					 const FAuthorityChangeRefreshPredicate& RefreshPredicate);
 
 private:
 	void RegisterTagCallbacks(FDispatcher& Dispatcher);
-	void RegisterRefreshCallbacks(const TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks);
-	void OnTaggedEntityAdded(const Worker_EntityId EntityId);
-	void OnTaggedEntityRemoved(const Worker_EntityId EntityId);
-	void CheckEntityAgainstFilter(const Worker_EntityId EntityId);
-	void EntityComplete(const Worker_EntityId EntityId);
-	void EntityIncomplete(const Worker_EntityId EntityId);
+	void RegisterRefreshCallbacks(const TArray<FDispatcherRefreshCallback>& DispatcherRefreshCallbacks);
+	void OnTaggedEntityAdded(const Worker_EntityId& EntityId);
+	void OnTaggedEntityRemoved(const Worker_EntityId& EntityId);
+	void CheckEntityAgainstFilter(const Worker_EntityId& EntityId);
+	void EntityComplete(const Worker_EntityId& EntityId);
+	void EntityIncomplete(const Worker_EntityId& EntityId);
 
 	const Worker_ComponentId TagComponentId;
 	const FFilterPredicate Filter;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -29,7 +29,7 @@ public:
 	void TagEntity(TArray<FWorkerComponentData>& Components) const;
 
 	void Advance(const ViewDelta& Delta);
-	const ViewDelta& GetViewDelta() const;
+	const SubViewDelta& GetViewDelta() const;
 	void RefreshEntity(const Worker_EntityId EntityId);
 
 	// Helper functions for creating dispatcher refresh callbacks for use when constructing a subview.
@@ -58,7 +58,7 @@ private:
 	const FFilterPredicate Filter;
 	const EntityView& View;
 
-	ViewDelta SubDelta;
+	SubViewDelta SubDelta;
 
 	TArray<Worker_EntityId> TaggedEntities;
 	TArray<Worker_EntityId> CompleteEntities;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -27,9 +27,15 @@ public:
 	const ViewDelta& GetViewDelta() const;
 	void RefreshEntity(const Worker_EntityId EntityId);
 
-	static FDispatcherRefreshCallback CreateComponentExistenceDispatcherRefreshCallback(FDispatcher& Dispatcher, Worker_ComponentId ComponentId, FComponentChangeRefreshPredicate RefreshPredicate);
-	static FDispatcherRefreshCallback CreateComponentChangedDispatcherRefreshCallback(FDispatcher& Dispatcher, Worker_ComponentId ComponentId, FComponentChangeRefreshPredicate RefreshPredicate);
-	static FDispatcherRefreshCallback CreateAuthorityChangeDispatcherRefreshCallback(FDispatcher& Dispatcher, Worker_ComponentId ComponentId, FAuthorityChangeRefreshPredicate RefreshPredicate);
+	static FDispatcherRefreshCallback CreateComponentExistenceDispatcherRefreshCallback(FDispatcher& Dispatcher,
+																						Worker_ComponentId ComponentId,
+																						FComponentChangeRefreshPredicate RefreshPredicate);
+	static FDispatcherRefreshCallback CreateComponentChangedDispatcherRefreshCallback(FDispatcher& Dispatcher,
+																					  Worker_ComponentId ComponentId,
+																					  FComponentChangeRefreshPredicate RefreshPredicate);
+	static FDispatcherRefreshCallback CreateAuthorityChangeDispatcherRefreshCallback(FDispatcher& Dispatcher,
+																					 Worker_ComponentId ComponentId,
+																					 FAuthorityChangeRefreshPredicate RefreshPredicate);
 
 private:
 	void RegisterTagCallbacks(FDispatcher& Dispatcher);

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+#include "Dispatcher.h"
+#include "EntityView.h"
+#include "Schema/Interest.h"
+#include "Templates/Function.h"
+
+namespace SpatialGDK
+{
+	class SubView
+	{
+	public:
+		SubView(const Worker_ComponentId TagComponentId,
+			const TFunction<bool(const Worker_EntityId, const EntityViewElement&)> Filter,
+			const EntityView& View,
+			FDispatcher& Dispatcher);
+
+		void TagQuery(Query& QueryToTag) const;
+		void TagEntity(TArray<FWorkerComponentData>& Components) const;
+
+		void AdvanceViewDelta(const ViewDelta& Delta);
+		const ViewDelta& GetViewDelta() const;
+		void RefreshEntity(const Worker_EntityId EntityId);
+
+	private:
+		void OnTaggedEntityAdded(const Worker_EntityId EntityId);
+		void OnTaggedEntityRemoved(const Worker_EntityId EntityId);
+		void CheckEntityAgainstFilter(const Worker_EntityId EntityId);
+
+		const Worker_ComponentId TagComponentId;
+		const TFunction<bool(const Worker_EntityId, const EntityViewElement&)> Filter;
+		const EntityView& View;
+
+		ViewDelta SubDelta;
+
+		TSet<Worker_EntityId> TaggedEntities;
+		TSet<Worker_EntityId> CompleteEntities;
+		TSet<Worker_EntityId> NewlyCompleteEntities;
+		TSet<Worker_EntityId> NewlyIncompleteEntities;
+	};
+
+} // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewCoordinator.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewCoordinator.h
@@ -29,15 +29,15 @@ public:
 	void FlushMessagesToSend();
 
 	// Create a subview with the specified tag, filter, and refresh callbacks.
-	SubView& CreateSubView(const Worker_ComponentId Tag, FFilterPredicate Filter,
-						   TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks);
+	SubView& CreateSubView(const Worker_ComponentId& Tag, const FFilterPredicate& Filter,
+						   const TArray<FDispatcherRefreshCallback>& DispatcherRefreshCallbacks);
 	// Create a subview with no filter. This also means no refresh callbacks, as no change from spatial could cause
 	// the subview's filter to change its truth value.
-	SubView& CreateUnfilteredSubView(const Worker_ComponentId Tag);
+	SubView& CreateUnfilteredSubView(const Worker_ComponentId& Tag);
 	// Force a refresh of the given entity ID across all subviews. Used when local state changes which could
 	// change any subview's filter's truth value for the given entity. Conceptually this can be thought of
 	// as marking the entity dirty for all subviews, although the refresh is immediate.
-	void RefreshEntityCompleteness(const Worker_EntityId EntityId);
+	void RefreshEntityCompleteness(const Worker_EntityId& EntityId);
 
 	const FString& GetWorkerId() const;
 	const TArray<FString>& GetWorkerAttributes() const;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewCoordinator.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewCoordinator.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "SubView.h"
 #include "SpatialView/ConnectionHandler/AbstractConnectionHandler.h"
 #include "SpatialView/Dispatcher.h"
 #include "SpatialView/WorkerView.h"
@@ -23,9 +24,13 @@ public:
 	ViewCoordinator& operator=(ViewCoordinator&&) = delete;
 
 	void Advance();
-	const ViewDelta& GetViewDelta();
-	const EntityView& GetView();
+	const ViewDelta& GetViewDelta() const;
+	const EntityView& GetView() const;
 	void FlushMessagesToSend();
+
+	SubView& CreateSubView(const Worker_ComponentId Tag, FFilterPredicate Filter, TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks);
+	SubView& CreateUnfilteredSubView(const Worker_ComponentId Tag);
+	void RefreshEntityCompleteness(const Worker_EntityId EntityId);
 
 	const FString& GetWorkerId() const;
 	const TArray<FString>& GetWorkerAttributes() const;
@@ -57,6 +62,7 @@ private:
 	TUniquePtr<AbstractConnectionHandler> ConnectionHandler;
 	Worker_RequestId NextRequestId;
 	FDispatcher Dispatcher;
+	TArray<SubView> SubViews;
 };
 
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewCoordinator.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewCoordinator.h
@@ -28,9 +28,15 @@ public:
 	const EntityView& GetView() const;
 	void FlushMessagesToSend();
 
+	// Create a subview with the specified tag, filter, and refresh callbacks.
 	SubView& CreateSubView(const Worker_ComponentId Tag, FFilterPredicate Filter,
 						   TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks);
+	// Create a subview with no filter. This also means no refresh callbacks, as no change from spatial could cause
+	// the subview's filter to change its truth value.
 	SubView& CreateUnfilteredSubView(const Worker_ComponentId Tag);
+	// Force a refresh of the given entity ID across all subviews. Used when local state changes which could
+	// change any subview's filter's truth value for the given entity. Conceptually this can be thought of
+	// as marking the entity dirty for all subviews, although the refresh is immediate.
 	void RefreshEntityCompleteness(const Worker_EntityId EntityId);
 
 	const FString& GetWorkerId() const;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewCoordinator.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewCoordinator.h
@@ -64,6 +64,16 @@ public:
 	CallbackId RegisterAuthorityLostTempCallback(Worker_ComponentId ComponentId, FEntityCallback Callback);
 	void RemoveCallback(CallbackId Id);
 
+	FDispatcherRefreshCallback CreateComponentExistenceRefreshCallback(const Worker_ComponentId& ComponentId, const FComponentChangeRefreshPredicate& RefreshPredicate = [](const FEntityComponentChange&) {
+    return true;
+});
+	FDispatcherRefreshCallback CreateComponentChangedRefreshCallback(const Worker_ComponentId& ComponentId, const FComponentChangeRefreshPredicate& RefreshPredicate = [](const FEntityComponentChange&) {
+    return true;
+});
+	FDispatcherRefreshCallback CreateAuthorityChangeRefreshCallback(const Worker_ComponentId& ComponentId, const FAuthorityChangeRefreshPredicate& RefreshPredicate = [](const Worker_EntityId&) {
+    return true;
+});
+
 private:
 	WorkerView View;
 	TUniquePtr<AbstractConnectionHandler> ConnectionHandler;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewCoordinator.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewCoordinator.h
@@ -64,15 +64,20 @@ public:
 	CallbackId RegisterAuthorityLostTempCallback(Worker_ComponentId ComponentId, FEntityCallback Callback);
 	void RemoveCallback(CallbackId Id);
 
-	FDispatcherRefreshCallback CreateComponentExistenceRefreshCallback(const Worker_ComponentId& ComponentId, const FComponentChangeRefreshPredicate& RefreshPredicate = [](const FEntityComponentChange&) {
-    return true;
-});
-	FDispatcherRefreshCallback CreateComponentChangedRefreshCallback(const Worker_ComponentId& ComponentId, const FComponentChangeRefreshPredicate& RefreshPredicate = [](const FEntityComponentChange&) {
-    return true;
-});
-	FDispatcherRefreshCallback CreateAuthorityChangeRefreshCallback(const Worker_ComponentId& ComponentId, const FAuthorityChangeRefreshPredicate& RefreshPredicate = [](const Worker_EntityId&) {
-    return true;
-});
+	FDispatcherRefreshCallback CreateComponentExistenceRefreshCallback(
+		const Worker_ComponentId& ComponentId,
+		const FComponentChangeRefreshPredicate& RefreshPredicate = [](const FEntityComponentChange&) {
+			return true;
+		});
+	FDispatcherRefreshCallback CreateComponentChangedRefreshCallback(
+		const Worker_ComponentId& ComponentId,
+		const FComponentChangeRefreshPredicate& RefreshPredicate = [](const FEntityComponentChange&) {
+			return true;
+		});
+	FDispatcherRefreshCallback CreateAuthorityChangeRefreshCallback(
+		const Worker_ComponentId& ComponentId, const FAuthorityChangeRefreshPredicate& RefreshPredicate = [](const Worker_EntityId&) {
+			return true;
+		});
 
 private:
 	WorkerView View;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewCoordinator.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewCoordinator.h
@@ -2,10 +2,10 @@
 
 #pragma once
 
-#include "SubView.h"
 #include "SpatialView/ConnectionHandler/AbstractConnectionHandler.h"
 #include "SpatialView/Dispatcher.h"
 #include "SpatialView/WorkerView.h"
+#include "SubView.h"
 #include "Templates/UniquePtr.h"
 
 namespace SpatialGDK
@@ -28,7 +28,8 @@ public:
 	const EntityView& GetView() const;
 	void FlushMessagesToSend();
 
-	SubView& CreateSubView(const Worker_ComponentId Tag, FFilterPredicate Filter, TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks);
+	SubView& CreateSubView(const Worker_ComponentId Tag, FFilterPredicate Filter,
+						   TArray<FDispatcherRefreshCallback> DispatcherRefreshCallbacks);
 	SubView& CreateUnfilteredSubView(const Worker_ComponentId Tag);
 	void RefreshEntityCompleteness(const Worker_EntityId EntityId);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewCoordinator.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewCoordinator.h
@@ -30,7 +30,7 @@ public:
 
 	// Create a subview with the specified tag, filter, and refresh callbacks.
 	FSubView& CreateSubView(const Worker_ComponentId& Tag, const FFilterPredicate& Filter,
-						   const TArray<FDispatcherRefreshCallback>& DispatcherRefreshCallbacks);
+							const TArray<FDispatcherRefreshCallback>& DispatcherRefreshCallbacks);
 	// Create a subview with no filter. This also means no refresh callbacks, as no change from spatial could cause
 	// the subview's filter to change its truth value.
 	FSubView& CreateUnfilteredSubView(const Worker_ComponentId& Tag);

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
@@ -33,7 +33,8 @@ public:
 	void SetFromOpList(TArray<OpList> OpLists, EntityView& View);
 	// Entity ID arrays are assumed to be sorted for view delta projection.
 	void Project(const ViewDelta& Delta, const TArray<Worker_EntityId>& CompleteEntities,
-				 const TArray<Worker_EntityId>& NewlyCompleteEntities, const TArray<Worker_EntityId>& NewlyIncompleteEntities, const TArray<Worker_EntityId>& TemporarilyIncompleteEntities);
+				 const TArray<Worker_EntityId>& NewlyCompleteEntities, const TArray<Worker_EntityId>& NewlyIncompleteEntities,
+				 const TArray<Worker_EntityId>& TemporarilyIncompleteEntities);
 	void Clear();
 
 	const TArray<EntityDelta>& GetEntityDeltas() const;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
@@ -33,7 +33,7 @@ public:
 	void SetFromOpList(TArray<OpList> OpLists, EntityView& View);
 	// Entity ID arrays are assumed to be sorted for view delta projection.
 	void Project(const ViewDelta& Delta, const TArray<Worker_EntityId>& CompleteEntities,
-				 const TArray<Worker_EntityId>& NewlyCompleteEntities, const TArray<Worker_EntityId>& NewlyIncompleteEntities);
+				 const TArray<Worker_EntityId>& NewlyCompleteEntities, const TArray<Worker_EntityId>& NewlyIncompleteEntities, const TArray<Worker_EntityId>& TemporarilyIncompleteEntities);
 	void Clear();
 
 	const TArray<EntityDelta>& GetEntityDeltas() const;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
@@ -155,11 +155,6 @@ private:
 	ReceivedEntityChange* ProcessEntityExistenceChange(ReceivedEntityChange* It, ReceivedEntityChange* End, EntityDelta& Delta,
 													   EntityViewElement** ViewElement, EntityView& View);
 
-	// The sentinel entity ID has the property that when converted to a uint64 it will be greater than INT64_MAX.
-	// If we convert all entity IDs to uint64s before comparing them we can then be assured that the sentinel values
-	// will be greater than all valid IDs.
-	static const Worker_EntityId SENTINEL_ENTITY_ID = -1;
-
 	TArray<ReceivedEntityChange> EntityChanges;
 	TArray<ReceivedComponentChange> ComponentChanges;
 	TArray<Worker_AuthorityChangeOp> AuthorityChanges;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
@@ -10,7 +10,7 @@
 
 namespace SpatialGDK
 {
-struct SubViewDelta
+struct FSubViewDelta
 {
 	TArray<EntityDelta> EntityDeltas;
 	const TArray<Worker_Op>* WorkerMessages;
@@ -40,7 +40,7 @@ public:
 	// Produces a projection of a given main view delta to a sub view delta. The passed SubViewDelta is populated with
 	// the projection. The given arrays represent the state of the sub view and dictates the projection.
 	// Entity ID arrays are assumed to be sorted for view delta projection.
-	void Project(SubViewDelta& SubDelta, const TArray<Worker_EntityId>& CompleteEntities,
+	void Project(FSubViewDelta& SubDelta, const TArray<Worker_EntityId>& CompleteEntities,
 				 const TArray<Worker_EntityId>& NewlyCompleteEntities, const TArray<Worker_EntityId>& NewlyIncompleteEntities,
 				 const TArray<Worker_EntityId>& TemporarilyIncompleteEntities) const;
 	void Clear();

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
@@ -33,7 +33,7 @@ public:
 	void SetFromOpList(TArray<OpList> OpLists, EntityView& View);
 	// Entity ID arrays are assumed to be sorted for view delta projection.
 	void Project(const ViewDelta& Delta, const TArray<Worker_EntityId>& CompleteEntities,
-		const TArray<Worker_EntityId>& NewlyCompleteEntities, const TArray<Worker_EntityId>& NewlyIncompleteEntities);
+				 const TArray<Worker_EntityId>& NewlyCompleteEntities, const TArray<Worker_EntityId>& NewlyIncompleteEntities);
 	void Clear();
 
 	const TArray<EntityDelta>& GetEntityDeltas() const;
@@ -77,9 +77,9 @@ private:
 		enum
 		{
 			COMPLETE,
-            NEWLY_COMPLETE,
-            NEWLY_INCOMPLETE
-        } Type;
+			NEWLY_COMPLETE,
+			NEWLY_INCOMPLETE
+		} Type;
 	};
 
 	// Comparator that will return true when the entity change in question is not for the same entity ID as stored.

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
@@ -41,9 +41,8 @@ public:
 	// the projection. The given arrays represent the state of the sub view and dictates the projection.
 	// Entity ID arrays are assumed to be sorted for view delta projection.
 	void Project(SubViewDelta& SubDelta, const TArray<Worker_EntityId>& CompleteEntities,
-	             const TArray<Worker_EntityId>& NewlyCompleteEntities,
-	             const TArray<Worker_EntityId>& NewlyIncompleteEntities,
-	             const TArray<Worker_EntityId>& TemporarilyIncompleteEntities) const;
+				 const TArray<Worker_EntityId>& NewlyCompleteEntities, const TArray<Worker_EntityId>& NewlyIncompleteEntities,
+				 const TArray<Worker_EntityId>& TemporarilyIncompleteEntities) const;
 	void Clear();
 
 	const TArray<EntityDelta>& GetEntityDeltas() const;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
@@ -10,6 +10,12 @@
 
 namespace SpatialGDK
 {
+struct SubViewDelta
+{
+	TArray<EntityDelta> EntityDeltas;
+	const TArray<Worker_Op>* WorkerMessages;
+};
+
 /**
  * Lists of changes made to a view as a list of EntityDeltas and miscellaneous other messages.
  * EntityDeltas are sorted by entity ID.
@@ -31,14 +37,13 @@ class ViewDelta
 {
 public:
 	void SetFromOpList(TArray<OpList> OpLists, EntityView& View);
-	// Produces a projection of a given main view delta to a view delta for another view. The given arrays represent the
-	// state of the new view and dictates the projection.
-	// Note: This method is designed for projecting the main worker view delta to a subview delta. It may work for other
-	// cases, but there are no guarantees.
+	// Produces a projection of a given main view delta to a sub view delta. The passed SubViewDelta is populated with
+	// the projection. The given arrays represent the state of the sub view and dictates the projection.
 	// Entity ID arrays are assumed to be sorted for view delta projection.
-	void Project(const ViewDelta& Delta, const TArray<Worker_EntityId>& CompleteEntities,
-				 const TArray<Worker_EntityId>& NewlyCompleteEntities, const TArray<Worker_EntityId>& NewlyIncompleteEntities,
-				 const TArray<Worker_EntityId>& TemporarilyIncompleteEntities);
+	void Project(SubViewDelta& SubDelta, const TArray<Worker_EntityId>& CompleteEntities,
+	             const TArray<Worker_EntityId>& NewlyCompleteEntities,
+	             const TArray<Worker_EntityId>& NewlyIncompleteEntities,
+	             const TArray<Worker_EntityId>& TemporarilyIncompleteEntities) const;
 	void Clear();
 
 	const TArray<EntityDelta>& GetEntityDeltas() const;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
@@ -152,6 +152,11 @@ private:
 	ReceivedEntityChange* ProcessEntityExistenceChange(ReceivedEntityChange* It, ReceivedEntityChange* End, EntityDelta& Delta,
 													   EntityViewElement** ViewElement, EntityView& View);
 
+	// The sentinel entity ID has the property that when converted to a uint64 it will be greater than INT64_MAX.
+	// If we convert all entity IDs to uint64s before comparing them we can then be assured that the sentinel values
+	// will be greater than all valid IDs.
+	static const Worker_EntityId SENTINEL_ENTITY_ID = -1;
+
 	TArray<ReceivedEntityChange> EntityChanges;
 	TArray<ReceivedComponentChange> ComponentChanges;
 	TArray<Worker_AuthorityChangeOp> AuthorityChanges;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
@@ -31,6 +31,10 @@ class ViewDelta
 {
 public:
 	void SetFromOpList(TArray<OpList> OpLists, EntityView& View);
+	// Produces a projection of a given main view delta to a view delta for another view. The given arrays represent the
+	// state of the new view and dictates the projection.
+	// Note: This method is designed for projecting the main worker view delta to a subview delta. It may work for other
+	// cases, but there are no guarantees.
 	// Entity ID arrays are assumed to be sorted for view delta projection.
 	void Project(const ViewDelta& Delta, const TArray<Worker_EntityId>& CompleteEntities,
 				 const TArray<Worker_EntityId>& NewlyCompleteEntities, const TArray<Worker_EntityId>& NewlyIncompleteEntities,

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
@@ -101,7 +101,6 @@ private:
 	struct EntityComparison
 	{
 		bool operator()(const ReceivedEntityChange& Lhs, const ReceivedEntityChange& Rhs) const;
-		bool operator()(const EntityProjection& Lhs, const EntityProjection& Rhs) const;
 	};
 
 	// Calculate and return the net component added in [`Start`, `End`).

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
@@ -71,17 +71,6 @@ private:
 		bool bAdded;
 	};
 
-	struct EntityProjection
-	{
-		Worker_EntityId EntityId;
-		enum
-		{
-			COMPLETE,
-			NEWLY_COMPLETE,
-			NEWLY_INCOMPLETE
-		} Type;
-	};
-
 	// Comparator that will return true when the entity change in question is not for the same entity ID as stored.
 	struct DifferentEntity
 	{

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/WorkerView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/WorkerView.h
@@ -20,6 +20,7 @@ public:
 
 	const ViewDelta& GetViewDelta() const;
 	const EntityView& GetView() const;
+	const EntityView* GetViewPtr() const;
 
 	// Add an OpList to generate the next ViewDelta.
 	void EnqueueOpList(OpList Ops);

--- a/SpatialGDK/Source/SpatialGDK/Public/Tests/SpatialView/ExpectedEntityDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Tests/SpatialView/ExpectedEntityDelta.h
@@ -9,8 +9,13 @@ namespace SpatialGDK
 struct ExpectedEntityDelta
 {
 	Worker_EntityId EntityId;
-	bool bAdded;
-	bool bRemoved;
+	enum
+	{
+		UPDATE,
+        ADD,
+        REMOVE,
+        TEMPORARILY_REMOVED
+    } Type;
 	TArray<ComponentData> DataStorage;
 	TArray<ComponentUpdate> UpdateStorage;
 	TArray<ComponentChange> ComponentsAdded;

--- a/SpatialGDK/Source/SpatialGDK/Public/Tests/SpatialView/ExpectedEntityDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Tests/SpatialView/ExpectedEntityDelta.h
@@ -12,10 +12,10 @@ struct ExpectedEntityDelta
 	enum
 	{
 		UPDATE,
-        ADD,
-        REMOVE,
-        TEMPORARILY_REMOVED
-    } Type;
+		ADD,
+		REMOVE,
+		TEMPORARILY_REMOVED
+	} Type;
 	TArray<ComponentData> DataStorage;
 	TArray<ComponentUpdate> UpdateStorage;
 	TArray<ComponentChange> ComponentsAdded;

--- a/SpatialGDK/Source/SpatialGDK/Public/Tests/SpatialView/ExpectedViewDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Tests/SpatialView/ExpectedViewDelta.h
@@ -13,9 +13,10 @@ class ExpectedViewDelta
 public:
 	enum EntityChangeType
 	{
+		UPDATE,
 		ADD,
 		REMOVE,
-		UPDATE
+		TEMPORARILY_REMOVED
 	};
 
 	ExpectedViewDelta& AddEntityDelta(const Worker_EntityId EntityId, const EntityChangeType ChangeType);
@@ -28,14 +29,17 @@ public:
 	ExpectedViewDelta& AddAuthorityLostTemporarily(const Worker_EntityId EntityId, const Worker_ComponentId ComponentId);
 	ExpectedViewDelta& AddDisconnect(const uint8 StatusCode, FString StatusMessage);
 
-	// Compares the Connection Status and the stored Entity Deltas
+	// Compares the stored Entity Deltas
 	bool Compare(const ViewDelta& Other);
+	bool Compare(const FSubViewDelta& Other);
 
 private:
 	void SortEntityDeltas();
 	TMap<uint32, ExpectedEntityDelta> EntityDeltas;
 	uint8 ConnectionStatusCode = 0;
 	FString ConnectionStatusMessage;
+
+	bool CompareDeltas(const TArray<EntityDelta>& Other);
 
 	template <typename T, typename Predicate>
 	bool CompareData(const TArray<T>& Lhs, const ComponentSpan<T>& Rhs, Predicate&& Comparator)


### PR DESCRIPTION
## Description
Implementation of subview API. Includes:

- tagging entities and queries
- usage of query tags for discerning which entities belong to which systems
- the filter API for the stage after tagged entities have been passed to a subview
- an API for indicating when filter refreshes have to occur:
- on certain dispatcher callbacks - a static API for creating dispatcher refresh callbacks is introduced in the subview
- due to local state changes - a method to force a refresh all subview filters is introduced in the view coordinator
- creating subviews in the view coordinator - also owns and maintains the subviews
- view delta projection from the main view delta to subview deltas, according to the state of the subview, called whenever the view coordinator advances

The way to register dispatcher callbacks for refreshing filter completeness on each subview is a little strange. The reasoning was that the subview must have enough information to become complete at the point of construction. So the user is expected to ask for a dispatcher refresh callback in advance, which they pass a predicate to indicating whether the change should trigger a refresh callback. The dispatcher refresh callback is then passed for subview construction.
Overall this means: As part of subview construction the subview passes its own refresh entity method to the given dispatcher refresh callback which registers a callback to the dispatcher for the given change type, and if it passes the user defined predicate, would trigger a refresh for that entity within that subview.

lots of tests

### For reviewers
The majority of this PR is tests. The primary logic is all in the view coordinator, sub view, and view delta classes.
