### PR TITLE
make gameplay debugger only available for debug and development

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -6,7 +6,6 @@
 #include "EngineClasses/SpatialNetDriver.h"
 #include "EngineClasses/SpatialPackageMapClient.h"
 #include "EngineClasses/SpatialVirtualWorkerTranslator.h"
-#include "GameplayDebuggerCategoryReplicator.h"
 #include "Interop/SpatialRPCService.h"
 #include "LoadBalancing/AbstractLBStrategy.h"
 #include "Schema/AuthorityIntent.h"

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialActorUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialActorUtils.h
@@ -94,12 +94,11 @@ inline FVector GetActorSpatialPosition(const AActor* InActor)
 
 inline bool DoesActorClassIgnoreVisibilityCheck(AActor* InActor)
 {
+	if (InActor->IsA(APlayerController::StaticClass()) || InActor->IsA(AGameModeBase::StaticClass())
 #if WITH_UNREAL_DEVELOPER_TOOLS || (!UE_BUILD_SHIPPING && !UE_BUILD_TEST)
-	if (InActor->IsA(APlayerController::StaticClass()) || InActor->IsA(AGameplayDebuggerCategoryReplicator::StaticClass())
-		|| InActor->IsA(AGameModeBase::StaticClass()))
-#else
-	if (InActor->IsA(APlayerController::StaticClass()) || InActor->IsA(AGameModeBase::StaticClass()))
+		|| InActor->IsA(AGameplayDebuggerCategoryReplicator::StaticClass())
 #endif
+	)
 
 	{
 		return true;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialActorUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialActorUtils.h
@@ -5,15 +5,17 @@
 #include "EngineClasses/SpatialNetConnection.h"
 
 #include "Components/SceneComponent.h"
-#include "Containers/Array.h"
 #include "Containers/UnrealString.h"
 #include "Engine/EngineTypes.h"
 #include "GameFramework/Actor.h"
 #include "GameFramework/Controller.h"
 #include "GameFramework/GameMode.h"
 #include "GameFramework/PlayerController.h"
-#include "GameplayDebuggerCategoryReplicator.h"
 #include "Math/Vector.h"
+
+#if WITH_UNREAL_DEVELOPER_TOOLS || (!UE_BUILD_SHIPPING && !UE_BUILD_TEST)
+#include "GameplayDebuggerCategoryReplicator.h"
+#endif
 
 namespace SpatialGDK
 {
@@ -92,8 +94,13 @@ inline FVector GetActorSpatialPosition(const AActor* InActor)
 
 inline bool DoesActorClassIgnoreVisibilityCheck(AActor* InActor)
 {
+#if WITH_UNREAL_DEVELOPER_TOOLS || (!UE_BUILD_SHIPPING && !UE_BUILD_TEST)
 	if (InActor->IsA(APlayerController::StaticClass()) || InActor->IsA(AGameplayDebuggerCategoryReplicator::StaticClass())
 		|| InActor->IsA(AGameModeBase::StaticClass()))
+#else
+	if (InActor->IsA(APlayerController::StaticClass()) || InActor->IsA(AGameModeBase::StaticClass()))
+#endif
+
 	{
 		return true;
 	}

--- a/SpatialGDK/Source/SpatialGDK/SpatialGDK.Build.cs
+++ b/SpatialGDK/Source/SpatialGDK/SpatialGDK.Build.cs
@@ -37,13 +37,18 @@ public class SpatialGDK : ModuleRules
                 "CoreUObject",
                 "Engine",
                 "EngineSettings",
-                "GameplayDebugger",
                 "InputCore",
                 "OnlineSubsystemUtils",
                 "Projects",
                 "ReplicationGraph",
                 "Sockets"
             });
+
+        if (Target.bBuildDeveloperTools || (Target.Configuration != UnrealTargetConfiguration.Shipping &&
+                                            Target.Configuration != UnrealTargetConfiguration.Test))
+        {
+            PublicDependencyModuleNames.Add("GameplayDebugger");
+        }
 
         if (Target.bBuildEditor)
         {


### PR DESCRIPTION
#### Description
GamePlayDebugger is only available either when `bBuildDeveloperTools ` is explicitly set or when it's building for debug/development. This is currently breaking some of our builds, so adding the checks into the GDK as well.

#### Release note
none required

#### Tests
Tested it locally and also kicked off a new build to test it: https://buildkite.com/improbable/unrealgdk-nfr/builds/2718

#### Documentation
none required

