### PR TITLE
Wait for deployment_ready before readiing flags

### DIFF
--- a/RequireSetup
+++ b/RequireSetup
@@ -1,4 +1,4 @@
 Increment the below number whenever it is required to run Setup.bat as part of a new commit.
 Our git hooks will detect this file has been updated and automatically run Setup.bat on pull.
 
-66
+67

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/ManagedWorkerCoordinator.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/ManagedWorkerCoordinator.cs
@@ -118,17 +118,18 @@ namespace Improbable.WorkerCoordinator
         {
             var connection = CoordinatorConnection.ConnectAndKeepAlive(Logger, ReceptionistHost, ReceptionistPort, CoordinatorWorkerId, CoordinatorWorkerType);
 
-            // Read worker flags.
-            Option<string> devAuthTokenOpt = connection.GetWorkerFlag(DevAuthTokenWorkerFlag);
-            Option<string> targetDeploymentOpt = connection.GetWorkerFlag(TargetDeploymentWorkerFlag);
-            int deploymentTotalNumSimulatedPlayers = int.Parse(GetWorkerFlagOrDefault(connection, DeploymentTotalNumSimulatedPlayersWorkerFlag, "100"));
 
             Logger.WriteLog("Waiting for target deployment to become ready.");
             var deploymentReadyTask = Task.Run(() => WaitForTargetDeploymentReady(connection));
             if (!deploymentReadyTask.Wait(TimeSpan.FromMinutes(15)))
             {
                 throw new TimeoutException("Timed out waiting for the deployment to be ready. Waited 15 minutes.");
-            } 
+            }
+
+            // Read worker flags.
+            Option<string> devAuthTokenOpt = connection.GetWorkerFlag(DevAuthTokenWorkerFlag);
+            Option<string> targetDeploymentOpt = connection.GetWorkerFlag(TargetDeploymentWorkerFlag);
+            int deploymentTotalNumSimulatedPlayers = int.Parse(GetWorkerFlagOrDefault(connection, DeploymentTotalNumSimulatedPlayersWorkerFlag, "100"));
 
             Logger.WriteLog($"Target deployment is ready. Starting {NumSimulatedPlayersToStart} simulated players.");
             Thread.Sleep(InitialStartDelayMillis);


### PR DESCRIPTION
When launching simplayer deployments, it is useful to change the target deployment. This change makes that possible by waiting for the deployment_ready flag to be set before reading additional flags.