### PR TITLE
Fix crash in tests when running mac ci

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/RPCServiceTest.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/RPCServiceTest.cpp
@@ -541,6 +541,11 @@ bool FDropRPCQueueTest::Update()
 			false);
 	}
 
+	if (!ensure(Data->TestWorld->NetDriver != nullptr))
+	{
+		Test->TestTrue("Did not create necessary net driver", false);
+	}
+
 	AActor* Actor = Data->Actor;
 	USpatialNetDriver* SpatialNetDriver = Cast<USpatialNetDriver>(Data->TestWorld->NetDriver);
 	Worker_EntityId EntityId = SpatialNetDriver->PackageMap->GetEntityIdFromObject(Actor);

--- a/ci/build-project.sh
+++ b/ci/build-project.sh
@@ -30,6 +30,9 @@ pushd "$(dirname "$0")"
     mkdir -p "${TEST_REPO_PATH}/Game/Plugins"
     cp -R "${GDK_HOME}" "${TEST_REPO_PATH}/Game/Plugins/UnrealGDK"
 
+    # Unreal likes to save some settings outside of the project folders. Let's clean this up to make sure it doesn't cause issues when running the tests.
+    rm -rf ~/Library/Preferences/Unreal\ Engine/
+
     # Disable tutorials, otherwise the closing of the window will crash the editor due to some graphic context reason
     echo "\r\n[/Script/IntroTutorials.TutorialStateSettings]\r\nTutorialsProgress=(Tutorial=/Engine/Tutorial/Basics/LevelEditorAttract.LevelEditorAttract_C,CurrentStage=0,bUserDismissed=True)\r\n" >> "${UNREAL_PATH}/Engine/Config/BaseEditorSettings.ini"
     pushd "${UNREAL_PATH}"


### PR DESCRIPTION
#### Description

When running Unreal on mac, it saves some settings outside of the actual project folder. This has caused a test to start using the wrong netmode -> no net driver got created. Additionally, the test crashed, because we did not check whether the net driver exists.

passing mac build: https://buildkite.com/improbable/unrealgdk-premerge/builds/17355#_