### PR TITLE
Fix PlayerState migration with rep graph

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialReplicationGraph.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialReplicationGraph.cpp
@@ -51,6 +51,8 @@ void USpatialReplicationGraph::OnOwnerUpdated(AActor* Actor, AActor* OldOwner)
 
 	if (NewOwner != nullptr)
 	{
+		GlobalActorReplicationInfoMap.Get(NewOwner);
+		GlobalActorReplicationInfoMap.Get(Actor);
 		GlobalActorReplicationInfoMap.AddDependentActor(NewOwner, Actor);
 	}
 }


### PR DESCRIPTION
Gnarly bug where PlayerState isn't added as a dependency to the PlayerController because the PlayerController isn't in the GlobalActorReplicationInfoMap at this stage in the startup lifecycle. This prevents the PlayerState being found as a dependent Actor during the migration process, and so gets stuck on an old worker