### PR TITLE
Feature/unr 4255 test expected log

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
@@ -369,9 +369,9 @@ void ASpatialFunctionalTest::FinishTest(EFunctionalTestResult TestResult, const 
 }
 
 void ASpatialFunctionalTest::AddExpectedLogError(const FString& ExpectedPatternString, int32 Occurrences /*= 1*/,
-												 bool ExactMatch /*= false*/)
+												 bool bExactMatch /*= false*/)
 {
-	UAutomationBlueprintFunctionLibrary::AddExpectedLogError(ExpectedPatternString, Occurrences, ExactMatch);
+	UAutomationBlueprintFunctionLibrary::AddExpectedLogError(ExpectedPatternString, Occurrences, bExactMatch);
 }
 
 void ASpatialFunctionalTest::CrossServerFinishTest_Implementation(EFunctionalTestResult TestResult, const FString& Message)

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
@@ -2,6 +2,7 @@
 
 #include "SpatialFunctionalTest.h"
 
+#include "AutomationBlueprintFunctionLibrary.h"
 #include "Engine/Engine.h"
 #include "Engine/World.h"
 #include "EngineClasses/SpatialNetDriver.h"
@@ -211,8 +212,6 @@ void ASpatialFunctionalTest::StartTest()
 {
 	Super::StartTest();
 
-	SetupExpectedErrors();
-
 	StartStep(0);
 }
 
@@ -369,29 +368,9 @@ void ASpatialFunctionalTest::FinishTest(EFunctionalTestResult TestResult, const 
 	}
 }
 
-void ASpatialFunctionalTest::AddExpectedError(const FString& ExpectedErrorPattern, int NumOccurences /*= 1*/,
-											  bool bAllowPartialMatch /*= true*/)
+void ASpatialFunctionalTest::AddExpectedLogError(const FString& ExpectedPatternString, int32 Occurrences /*= 1*/, bool ExactMatch /*= false*/)
 {
-	if (HasAuthority())
-	{
-		ExpectedErrors.Add({ ExpectedErrorPattern, NumOccurences, bAllowPartialMatch });
-	}
-}
-
-void ASpatialFunctionalTest::SetupExpectedErrors()
-{
-	if (HasAuthority())
-	{
-		FAutomationTestBase* CurrentTest = FAutomationTestFramework::Get().GetCurrentTest();
-		check(CurrentTest != nullptr);
-		for (const auto& ExpectedError : ExpectedErrors)
-		{
-			CurrentTest->AddExpectedError(
-				ExpectedError.ErrorPattern,
-				ExpectedError.bAllowPartialMatch ? EAutomationExpectedErrorFlags::Contains : EAutomationExpectedErrorFlags::Exact,
-				ExpectedError.NumOccurences);
-		}
-	}
+	UAutomationBlueprintFunctionLibrary::AddExpectedLogError(ExpectedPatternString, Occurrences, ExactMatch);
 }
 
 void ASpatialFunctionalTest::CrossServerFinishTest_Implementation(EFunctionalTestResult TestResult, const FString& Message)

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
@@ -368,7 +368,8 @@ void ASpatialFunctionalTest::FinishTest(EFunctionalTestResult TestResult, const 
 	}
 }
 
-void ASpatialFunctionalTest::AddExpectedLogError(const FString& ExpectedPatternString, int32 Occurrences /*= 1*/, bool ExactMatch /*= false*/)
+void ASpatialFunctionalTest::AddExpectedLogError(const FString& ExpectedPatternString, int32 Occurrences /*= 1*/,
+												 bool ExactMatch /*= false*/)
 {
 	UAutomationBlueprintFunctionLibrary::AddExpectedLogError(ExpectedPatternString, Occurrences, ExactMatch);
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
@@ -93,6 +93,9 @@ void ASpatialFunctionalTest::BeginPlay()
 	{
 		SetupClientPlayerRegistrationFlow();
 	}
+
+
+
 }
 
 void ASpatialFunctionalTest::Tick(float DeltaSeconds)
@@ -210,6 +213,8 @@ bool ASpatialFunctionalTest::IsReady_Implementation()
 void ASpatialFunctionalTest::StartTest()
 {
 	Super::StartTest();
+
+	SetupExpectedErrors();
 
 	StartStep(0);
 }
@@ -363,6 +368,31 @@ void ASpatialFunctionalTest::FinishTest(EFunctionalTestResult TestResult, const 
 		if (AuxLocalFlowController != nullptr)
 		{
 			AuxLocalFlowController->NotifyFinishTest(TestResult, Message);
+		}
+	}
+}
+
+void ASpatialFunctionalTest::AddExpectedError(const FString& ExpectedErrorPattern, int NumOccurences /*= 1*/,
+											  bool bAllowPartialMatch /*= true*/)
+{
+	if(HasAuthority())
+	{
+		ExpectedErrors.Add({ ExpectedErrorPattern, NumOccurences, bAllowPartialMatch });
+	}
+}
+
+void ASpatialFunctionalTest::SetupExpectedErrors()
+{
+	if(HasAuthority())
+	{
+		FAutomationTestBase* CurrentTest = FAutomationTestFramework::Get().GetCurrentTest();
+		check(CurrentTest != nullptr);
+		for(const auto& ExpectedError : ExpectedErrors)
+		{
+			CurrentTest->AddExpectedError(ExpectedError.ErrorPattern,
+										  ExpectedError.bAllowPartialMatch ? EAutomationExpectedErrorFlags::Contains : EAutomationExpectedErrorFlags::Exact,
+										  ExpectedError.NumOccurences);
+			
 		}
 	}
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
@@ -93,9 +93,6 @@ void ASpatialFunctionalTest::BeginPlay()
 	{
 		SetupClientPlayerRegistrationFlow();
 	}
-
-
-
 }
 
 void ASpatialFunctionalTest::Tick(float DeltaSeconds)
@@ -375,7 +372,7 @@ void ASpatialFunctionalTest::FinishTest(EFunctionalTestResult TestResult, const 
 void ASpatialFunctionalTest::AddExpectedError(const FString& ExpectedErrorPattern, int NumOccurences /*= 1*/,
 											  bool bAllowPartialMatch /*= true*/)
 {
-	if(HasAuthority())
+	if (HasAuthority())
 	{
 		ExpectedErrors.Add({ ExpectedErrorPattern, NumOccurences, bAllowPartialMatch });
 	}
@@ -383,16 +380,16 @@ void ASpatialFunctionalTest::AddExpectedError(const FString& ExpectedErrorPatter
 
 void ASpatialFunctionalTest::SetupExpectedErrors()
 {
-	if(HasAuthority())
+	if (HasAuthority())
 	{
 		FAutomationTestBase* CurrentTest = FAutomationTestFramework::Get().GetCurrentTest();
 		check(CurrentTest != nullptr);
-		for(const auto& ExpectedError : ExpectedErrors)
+		for (const auto& ExpectedError : ExpectedErrors)
 		{
-			CurrentTest->AddExpectedError(ExpectedError.ErrorPattern,
-										  ExpectedError.bAllowPartialMatch ? EAutomationExpectedErrorFlags::Contains : EAutomationExpectedErrorFlags::Exact,
-										  ExpectedError.NumOccurences);
-			
+			CurrentTest->AddExpectedError(
+				ExpectedError.ErrorPattern,
+				ExpectedError.bAllowPartialMatch ? EAutomationExpectedErrorFlags::Contains : EAutomationExpectedErrorFlags::Exact,
+				ExpectedError.NumOccurences);
 		}
 	}
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
@@ -84,7 +84,7 @@ public:
 	// the steps themselves. Keep in mind that if the expected number of occurrences aren't met, the test fails.
 	// The same pattern can only be added once, so make sure to execute only in the test Authority or in a step that
 	// is running only on one worker.
-	void AddExpectedLogError(const FString& ExpectedPatternString, int32 Occurrences = 1, bool ExactMatch = false);
+	void AddExpectedLogError(const FString& ExpectedPatternString, int32 Occurrences = 1, bool bExactMatch = false);
 
 	UFUNCTION(CrossServer, Reliable)
 	void CrossServerFinishTest(EFunctionalTestResult TestResult, const FString& Message);

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
@@ -87,10 +87,11 @@ public:
 	// Ends the Test, can be called from any place.
 	virtual void FinishTest(EFunctionalTestResult TestResult, const FString& Message) override;
 
-	// clang-format off
-	UFUNCTION(BlueprintCallable, Category = "Spatial Functional Test", meta=(ToolTip = "Allows you to add expected error / warning log patterns so that the test doesn't fail in these situations. However, keep in mind that you need to set the exact number of occurences it should have, and the test will fail if they don't match!\n\nNote that if Allow Partial Match is 'False', the message needs to match exactly and if 'True' it will use a 'contains' comparison."))
-	// clang-format on
-	void AddExpectedError(const FString& ExpectedErrorPattern, int NumOccurences = 1, bool bAllowPartialMatch = true);
+	// Add expected log errors in C++. This can only be called when setting up the steps in PrepareTest() or in
+	// the steps themselves. Keep in mind that if the expected number of occurrences aren't met, the test fails.
+	// The same pattern can only be added once, so make sure to execute only in the test Authority or in a step that
+	// is running only on one worker.
+	void AddExpectedLogError(const FString& ExpectedPatternString, int32 Occurrences = 1, bool ExactMatch = false);
 
 	UFUNCTION(CrossServer, Reliable)
 	void CrossServerFinishTest(EFunctionalTestResult TestResult, const FString& Message);
@@ -384,12 +385,6 @@ private:
 	// Current Step Index, < 0 if not executing any, check consts at the top.
 	UPROPERTY(ReplicatedUsing = OnReplicated_CurrentStepIndex, Transient)
 	int CurrentStepIndex = SPATIAL_FUNCTIONAL_TEST_NOT_STARTED;
-
-	// Holds all expected errors for this test. The test will fail if the expected number of occurences don't match.
-	TArray<FSpatialFunctionalTestExpectedError> ExpectedErrors;
-
-	// At the start of the test will pass the messages to the FAutomationTestBase controlling this test.
-	void SetupExpectedErrors();
 
 	UFUNCTION()
 	void OnReplicated_CurrentStepIndex();

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
@@ -32,13 +32,6 @@ constexpr int SPATIAL_FUNCTIONAL_TEST_FINISHED = -2;	// Represents test already 
 
 class ULayeredLBStrategy;
 
-struct FSpatialFunctionalTestExpectedError
-{
-	FString ErrorPattern;	 // Log to try to match
-	int NumOccurences;		 // Number of times it has to occur, needs to be exact!
-	bool bAllowPartialMatch; // If True it will compare with 'contains', if False it will compare with 'equal'.
-};
-
 /*
  * A Spatial Functional NetTest allows you to define a series of steps, and control which server/client context they execute on
  * Servers and Clients are registered as Test Players by the framework, and request individual steps to be executed in the correct Player

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
@@ -32,9 +32,10 @@ constexpr int SPATIAL_FUNCTIONAL_TEST_FINISHED = -2;	// Represents test already 
 
 class ULayeredLBStrategy;
 
-struct FSpatialFunctionalTestExpectedError {
-	FString ErrorPattern; // Log to try to match
-	int NumOccurences; // Number of times it has to occur, needs to be exact!
+struct FSpatialFunctionalTestExpectedError
+{
+	FString ErrorPattern;	 // Log to try to match
+	int NumOccurences;		 // Number of times it has to occur, needs to be exact!
 	bool bAllowPartialMatch; // If True it will compare with 'contains', if False it will compare with 'equal'.
 };
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestClientNetOwnership/SpatialTestNetOwnership.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestClientNetOwnership/SpatialTestNetOwnership.cpp
@@ -45,7 +45,8 @@ void ASpatialTestNetOwnership::BeginPlay()
 {
 	Super::BeginPlay();
 
-	AddExpectedLogError(TEXT("No owning connection for actor NetOwnershipCube_0. Function ServerIncreaseRPCCount will not be processed."), 1, true);
+	AddExpectedLogError(TEXT("No owning connection for actor NetOwnershipCube_0. Function ServerIncreaseRPCCount will not be processed."),
+						1, true);
 
 	// Step definition for Client 1 to send a Server RPC
 	FSpatialFunctionalTestStepDefinition ClientSendRPCStepDefinition;

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestClientNetOwnership/SpatialTestNetOwnership.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestClientNetOwnership/SpatialTestNetOwnership.cpp
@@ -45,7 +45,8 @@ void ASpatialTestNetOwnership::BeginPlay()
 {
 	Super::BeginPlay();
 
-	AddExpectedError(TEXT("No owning connection for actor NetOwnershipCube_0. Function ServerIncreaseRPCCount will not be processed."), 1, false);
+	AddExpectedError(TEXT("No owning connection for actor NetOwnershipCube_0. Function ServerIncreaseRPCCount will not be processed."), 1,
+					 false);
 
 	// Step definition for Client 1 to send a Server RPC
 	FSpatialFunctionalTestStepDefinition ClientSendRPCStepDefinition;

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestClientNetOwnership/SpatialTestNetOwnership.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestClientNetOwnership/SpatialTestNetOwnership.cpp
@@ -45,6 +45,8 @@ void ASpatialTestNetOwnership::BeginPlay()
 {
 	Super::BeginPlay();
 
+	AddExpectedError(TEXT("No owning connection for actor NetOwnershipCube_0. Function ServerIncreaseRPCCount will not be processed."), 1, false);
+
 	// Step definition for Client 1 to send a Server RPC
 	FSpatialFunctionalTestStepDefinition ClientSendRPCStepDefinition;
 	ClientSendRPCStepDefinition.bIsNativeDefinition = true;

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestClientNetOwnership/SpatialTestNetOwnership.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestClientNetOwnership/SpatialTestNetOwnership.cpp
@@ -45,8 +45,7 @@ void ASpatialTestNetOwnership::BeginPlay()
 {
 	Super::BeginPlay();
 
-	AddExpectedError(TEXT("No owning connection for actor NetOwnershipCube_0. Function ServerIncreaseRPCCount will not be processed."), 1,
-					 false);
+	AddExpectedLogError(TEXT("No owning connection for actor NetOwnershipCube_0. Function ServerIncreaseRPCCount will not be processed."), 1, true);
 
 	// Step definition for Client 1 to send a Server RPC
 	FSpatialFunctionalTestStepDefinition ClientSendRPCStepDefinition;


### PR DESCRIPTION
#### Description
Added AddExpectedError API that allows you to flag warnings / errors as expected to appear, hence not making tests fail when they do.

#### Tests
Include SpatialTestNetOwnership fix to be able to always pass with green instead of "passing with warnings"
