### PR TITLE
View Delta Tests: add connection status checks

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
@@ -159,19 +159,19 @@ void USpatialWorkerConnection::Advance()
 bool USpatialWorkerConnection::HasDisconnected() const
 {
 	check(Coordinator.IsValid());
-	return Coordinator->GetViewDelta().HasDisconnected();
+	return Coordinator->GetViewDelta().HasConnectionStatusChanged();
 }
 
 Worker_ConnectionStatusCode USpatialWorkerConnection::GetConnectionStatus() const
 {
 	check(Coordinator.IsValid());
-	return Coordinator->GetViewDelta().GetConnectionStatus();
+	return Coordinator->GetViewDelta().GetConnectionStatusChange();
 }
 
 FString USpatialWorkerConnection::GetDisconnectReason() const
 {
 	check(Coordinator.IsValid());
-	return Coordinator->GetViewDelta().GetDisconnectReason();
+	return Coordinator->GetViewDelta().GetConnectionStatusChangeMessage();
 }
 
 const SpatialGDK::EntityView& USpatialWorkerConnection::GetView() const

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
@@ -56,20 +56,20 @@ const TArray<Worker_Op>& ViewDelta::GetWorkerMessages() const
 	return WorkerMessages;
 }
 
-bool ViewDelta::HasDisconnected() const
+bool ViewDelta::HasConnectionStatusChanged() const
 {
 	return ConnectionStatusCode != 0;
 }
 
-Worker_ConnectionStatusCode ViewDelta::GetConnectionStatus() const
+Worker_ConnectionStatusCode ViewDelta::GetConnectionStatusChange() const
 {
-	check(HasDisconnected());
+	check(HasConnectionStatusChanged());
 	return static_cast<Worker_ConnectionStatusCode>(ConnectionStatusCode);
 }
 
-FString ViewDelta::GetDisconnectReason() const
+FString ViewDelta::GetConnectionStatusChangeMessage() const
 {
-	check(HasDisconnected());
+	check(HasConnectionStatusChanged());
 	return ConnectionStatusMessage;
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ExpectedViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ExpectedViewDelta.cpp
@@ -96,6 +96,19 @@ bool ExpectedViewDelta::Compare(const ViewDelta& Other)
 		return false;
 	}
 
+	if (Other.HasDisconnected())
+	{
+		if (ConnectionStatusCode != Other.GetConnectionStatus())
+		{
+			return false;
+		}
+
+		if (ConnectionStatusMessage != Other.GetDisconnectReason())
+		{
+			return false;
+		}
+	}
+
 	SortEntityDeltas();
 	TArray<uint32> DeltaKeys;
 	EntityDeltas.GetKeys(DeltaKeys);

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ExpectedViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ExpectedViewDelta.cpp
@@ -96,13 +96,8 @@ bool ExpectedViewDelta::Compare(const ViewDelta& Other)
 		return false;
 	}
 
-	// Calling GetConnectionStatus() when we are still connected will result in failing an assertion.
-	// Let's first check if both Deltas believe they are disconnected before checking the actual status code and reason.
-	if (Other.HasConnectionStatusChanged() && ConnectionStatusCode == 0)
-	{
-		return false;
-	}
-
+	// We need to check if a disconnect op has been processed during the last tick.
+	// First call HasConnectionStatusChanged() before comparing the values stored.
 	if (Other.HasConnectionStatusChanged())
 	{
 		if (ConnectionStatusCode != Other.GetConnectionStatusChange())

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ExpectedViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ExpectedViewDelta.cpp
@@ -96,6 +96,13 @@ bool ExpectedViewDelta::Compare(const ViewDelta& Other)
 		return false;
 	}
 
+	// Calling GetConnectionStatus() when we are still connected will result in failing an assertion.
+	// Let's first check if both Deltas believe they are disconnected before checking the actual status code and reason.
+	if (Other.HasDisconnected() && ConnectionStatusCode == 0)
+	{
+		return false;
+	}
+
 	if (Other.HasDisconnected())
 	{
 		if (ConnectionStatusCode != Other.GetConnectionStatus())

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ExpectedViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/ExpectedViewDelta.cpp
@@ -98,19 +98,19 @@ bool ExpectedViewDelta::Compare(const ViewDelta& Other)
 
 	// Calling GetConnectionStatus() when we are still connected will result in failing an assertion.
 	// Let's first check if both Deltas believe they are disconnected before checking the actual status code and reason.
-	if (Other.HasDisconnected() && ConnectionStatusCode == 0)
+	if (Other.HasConnectionStatusChanged() && ConnectionStatusCode == 0)
 	{
 		return false;
 	}
 
-	if (Other.HasDisconnected())
+	if (Other.HasConnectionStatusChanged())
 	{
-		if (ConnectionStatusCode != Other.GetConnectionStatus())
+		if (ConnectionStatusCode != Other.GetConnectionStatusChange())
 		{
 			return false;
 		}
 
-		if (ConnectionStatusMessage != Other.GetDisconnectReason())
+		if (ConnectionStatusMessage != Other.GetConnectionStatusChangeMessage())
 		{
 			return false;
 		}

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
@@ -36,9 +36,9 @@ public:
 	const TArray<EntityDelta>& GetEntityDeltas() const;
 	const TArray<Worker_Op>& GetWorkerMessages() const;
 
-	bool HasDisconnected() const;
-	Worker_ConnectionStatusCode GetConnectionStatus() const;
-	FString GetDisconnectReason() const;
+	bool HasConnectionStatusChanged() const;
+	Worker_ConnectionStatusCode GetConnectionStatusChange() const;
+	FString GetConnectionStatusChangeMessage() const;
 
 private:
 	struct ReceivedComponentChange


### PR DESCRIPTION
#### Description
Those checks somehow got lost when I first merged in the expected view delta class. This adds some additional checks to make sure that the connection status code and disconnect reason are tested correctly.
