### PR TITLE
[UNR-4249] Change onSubObjectDeleted to use a weak pointer

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -735,7 +735,7 @@ int64 USpatialActorChannel::ReplicateActor()
 
 				if (ObjectRef.IsValid())
 				{
-					OnSubobjectDeleted(ObjectRef, RepComp.Key());
+					OnSubobjectDeleted(ObjectRef, RepComp.Key(), RepComp.Value()->GetWeakObjectPtr());
 
 					Sender->SendRemoveComponentForClassInfo(EntityId,
 															NetDriver->ClassInfoManager->GetClassInfoByComponentId(ObjectRef.Offset));
@@ -1403,15 +1403,15 @@ void USpatialActorChannel::ClientProcessOwnershipChange(bool bNewNetOwned)
 	}
 }
 
-void USpatialActorChannel::OnSubobjectDeleted(const FUnrealObjectRef& ObjectRef, UObject* Object)
+void USpatialActorChannel::OnSubobjectDeleted(const FUnrealObjectRef& ObjectRef, UObject* Object, const TWeakObjectPtr<UObject>& ObjectWeakPtr)
 {
 	CreateSubObjects.Remove(Object);
-
+	
 	Receiver->MoveMappedObjectToUnmapped(ObjectRef);
-	if (FSpatialObjectRepState* SubObjectRefMap = ObjectReferenceMap.Find(Object))
+	if (FSpatialObjectRepState* SubObjectRefMap = ObjectReferenceMap.Find(ObjectWeakPtr))
 	{
 		Receiver->CleanupRepStateMap(*SubObjectRefMap);
-		ObjectReferenceMap.Remove(Object);
+		ObjectReferenceMap.Remove(ObjectWeakPtr);
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -2115,7 +2115,7 @@ TWeakObjectPtr<USpatialNetConnection> USpatialNetDriver::FindClientConnectionFro
 
 void USpatialNetDriver::ProcessPendingDormancy()
 {
-	TSet<TWeakObjectPtr<USpatialActorChannel>> RemainingChannels;
+	decltype(PendingDormantChannels) RemainingChannels;
 	for (auto& PendingDormantChannel : PendingDormantChannels)
 	{
 		if (PendingDormantChannel.IsValid())

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -499,7 +499,8 @@ void USpatialReceiver::ProcessRemoveComponent(const Worker_RemoveComponentOp& Op
 		{
 			if (USpatialActorChannel* Channel = NetDriver->GetActorChannelByEntityId(Op.entity_id))
 			{
-				Channel->OnSubobjectDeleted(ObjectRef, Object);
+				TWeakObjectPtr<UObject> WeakPtr(Object);
+				Channel->OnSubobjectDeleted(ObjectRef, Object, WeakPtr);
 
 				Actor->OnSubobjectDestroyFromReplication(Object);
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -220,10 +220,7 @@ void USpatialSender::SendRemoveComponentForClassInfo(Worker_EntityId EntityId, c
 	{
 		if (SubobjectComponentId != SpatialConstants::INVALID_COMPONENT_ID)
 		{
-			if (StaticComponentView->HasComponent(EntityId, SubobjectComponentId))
-			{
-				ComponentsToRemove.Add(SubobjectComponentId);
-			}
+			ComponentsToRemove.Add(SubobjectComponentId);
 		}
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -220,7 +220,10 @@ void USpatialSender::SendRemoveComponentForClassInfo(Worker_EntityId EntityId, c
 	{
 		if (SubobjectComponentId != SpatialConstants::INVALID_COMPONENT_ID)
 		{
-			ComponentsToRemove.Add(SubobjectComponentId);
+			if (StaticComponentView->HasComponent(EntityId, SubobjectComponentId))
+			{
+				ComponentsToRemove.Add(SubobjectComponentId);
+			}
 		}
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -310,9 +310,9 @@ public:
 	// If this actor channel is responsible for creating a new entity, this will be set to true during initial replication.
 	bool bCreatingNewEntity;
 
-	TSet<TWeakObjectPtr<UObject>> PendingDynamicSubobjects;
+	TSet<TWeakObjectPtr<UObject>, TWeakPointerKeyFuncs<TWeakObjectPtr<UObject>, false>> PendingDynamicSubobjects;
 
-	TMap<TWeakObjectPtr<UObject>, FSpatialObjectRepState> ObjectReferenceMap;
+	TMap<TWeakObjectPtr<UObject>, FSpatialObjectRepState, FDefaultSetAllocator, TWeakObjectPtrMapKeyFuncs<TWeakObjectPtr<UObject>, FSpatialObjectRepState, false>> ObjectReferenceMap;
 
 private:
 	Worker_EntityId EntityId;
@@ -356,7 +356,7 @@ private:
 	// the state of those properties at the last time we sent them, and is used to detect
 	// when those properties change.
 	TArray<uint8>* ActorHandoverShadowData;
-	TMap<TWeakObjectPtr<UObject>, TSharedRef<TArray<uint8>>> HandoverShadowDataMap;
+	TMap<TWeakObjectPtr<UObject>, TSharedRef<TArray<uint8>>, FDefaultSetAllocator, TWeakObjectPtrMapKeyFuncs<TWeakObjectPtr<UObject>, TSharedRef<TArray<uint8>>, false>> HandoverShadowDataMap;
 
 	// Band-aid until we get Actor Sets.
 	// Used on server-side workers only.

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -275,7 +275,8 @@ public:
 	bool IsListening() const;
 
 	// Call when a subobject is deleted to unmap its references and cleanup its cached informations.
-	void OnSubobjectDeleted(const FUnrealObjectRef& ObjectRef, UObject* Object);
+	// NB : ObjectPtr might be a dangling pointer.
+	void OnSubobjectDeleted(const FUnrealObjectRef& ObjectRef, UObject* ObjectPtr, const TWeakObjectPtr<UObject>& ObjectWeakPtr);
 
 	static void ResetShadowData(FRepLayout& RepLayout, FRepStateStaticBuffer& StaticBuffer, UObject* TargetObject);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -310,7 +310,7 @@ public:
 	// If this actor channel is responsible for creating a new entity, this will be set to true during initial replication.
 	bool bCreatingNewEntity;
 
-	TSet<TWeakObjectPtr<UObject>, TWeakPointerKeyFuncs<TWeakObjectPtr<UObject>, false>> PendingDynamicSubobjects;
+	TSet<TWeakObjectPtr<UObject>, TWeakObjectPtrKeyFuncs<TWeakObjectPtr<UObject>, false>> PendingDynamicSubobjects;
 
 	TMap<TWeakObjectPtr<UObject>, FSpatialObjectRepState, FDefaultSetAllocator,
 		 TWeakObjectPtrMapKeyFuncs<TWeakObjectPtr<UObject>, FSpatialObjectRepState, false>>

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -312,7 +312,9 @@ public:
 
 	TSet<TWeakObjectPtr<UObject>, TWeakPointerKeyFuncs<TWeakObjectPtr<UObject>, false>> PendingDynamicSubobjects;
 
-	TMap<TWeakObjectPtr<UObject>, FSpatialObjectRepState, FDefaultSetAllocator, TWeakObjectPtrMapKeyFuncs<TWeakObjectPtr<UObject>, FSpatialObjectRepState, false>> ObjectReferenceMap;
+	TMap<TWeakObjectPtr<UObject>, FSpatialObjectRepState, FDefaultSetAllocator,
+		 TWeakObjectPtrMapKeyFuncs<TWeakObjectPtr<UObject>, FSpatialObjectRepState, false>>
+		ObjectReferenceMap;
 
 private:
 	Worker_EntityId EntityId;
@@ -356,7 +358,9 @@ private:
 	// the state of those properties at the last time we sent them, and is used to detect
 	// when those properties change.
 	TArray<uint8>* ActorHandoverShadowData;
-	TMap<TWeakObjectPtr<UObject>, TSharedRef<TArray<uint8>>, FDefaultSetAllocator, TWeakObjectPtrMapKeyFuncs<TWeakObjectPtr<UObject>, TSharedRef<TArray<uint8>>, false>> HandoverShadowDataMap;
+	TMap<TWeakObjectPtr<UObject>, TSharedRef<TArray<uint8>>, FDefaultSetAllocator,
+		 TWeakObjectPtrMapKeyFuncs<TWeakObjectPtr<UObject>, TSharedRef<TArray<uint8>>, false>>
+		HandoverShadowDataMap;
 
 	// Band-aid until we get Actor Sets.
 	// Used on server-side workers only.

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -231,7 +231,7 @@ private:
 
 	TMap<Worker_EntityId_Key, USpatialActorChannel*> EntityToActorChannel;
 	TSet<Worker_EntityId_Key> DormantEntities;
-	TSet<TWeakObjectPtr<USpatialActorChannel>, TWeakPointerKeyFuncs<TWeakObjectPtr<USpatialActorChannel>, false>> PendingDormantChannels;
+	TSet<TWeakObjectPtr<USpatialActorChannel>, TWeakObjectPtrKeyFuncs<TWeakObjectPtr<USpatialActorChannel>, false>> PendingDormantChannels;
 
 	TMap<FString, TWeakObjectPtr<USpatialNetConnection>> WorkerConnections;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -231,7 +231,7 @@ private:
 
 	TMap<Worker_EntityId_Key, USpatialActorChannel*> EntityToActorChannel;
 	TSet<Worker_EntityId_Key> DormantEntities;
-	TSet<TWeakObjectPtr<USpatialActorChannel>> PendingDormantChannels;
+	TSet<TWeakObjectPtr<USpatialActorChannel>, TWeakPointerKeyFuncs<TWeakObjectPtr<USpatialActorChannel>, false>> PendingDormantChannels;
 
 	TMap<FString, TWeakObjectPtr<USpatialNetConnection>> WorkerConnections;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialClassInfoManager.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialClassInfoManager.h
@@ -148,7 +148,9 @@ private:
 	UPROPERTY()
 	USpatialNetDriver* NetDriver;
 
-	TMap<TWeakObjectPtr<UClass>, TSharedRef<FClassInfo>, FDefaultSetAllocator, TWeakObjectPtrMapKeyFuncs<TWeakObjectPtr<UClass>, TSharedRef<FClassInfo>, false>> ClassInfoMap;
+	TMap<TWeakObjectPtr<UClass>, TSharedRef<FClassInfo>, FDefaultSetAllocator,
+		 TWeakObjectPtrMapKeyFuncs<TWeakObjectPtr<UClass>, TSharedRef<FClassInfo>, false>>
+		ClassInfoMap;
 	TMap<Worker_ComponentId, TSharedRef<FClassInfo>> ComponentToClassInfoMap;
 	TMap<Worker_ComponentId, uint32> ComponentToOffsetMap;
 	TMap<Worker_ComponentId, ESchemaComponentType> ComponentToCategoryMap;

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialClassInfoManager.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialClassInfoManager.h
@@ -148,7 +148,7 @@ private:
 	UPROPERTY()
 	USpatialNetDriver* NetDriver;
 
-	TMap<TWeakObjectPtr<UClass>, TSharedRef<FClassInfo>> ClassInfoMap;
+	TMap<TWeakObjectPtr<UClass>, TSharedRef<FClassInfo>, FDefaultSetAllocator, TWeakObjectPtrMapKeyFuncs<TWeakObjectPtr<UClass>, TSharedRef<FClassInfo>, false>> ClassInfoMap;
 	TMap<Worker_ComponentId, TSharedRef<FClassInfo>> ComponentToClassInfoMap;
 	TMap<Worker_ComponentId, uint32> ComponentToOffsetMap;
 	TMap<Worker_ComponentId, ESchemaComponentType> ComponentToCategoryMap;

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -64,9 +64,9 @@ struct FPendingRPC
 // TODO: Clear TMap entries when USpatialActorChannel gets deleted - UNR:100
 // care for actor getting deleted before actor channel
 using FChannelObjectPair = TPair<TWeakObjectPtr<USpatialActorChannel>, TWeakObjectPtr<UObject>>;
-using FRPCsOnEntityCreationMap = TMap<TWeakObjectPtr<const UObject>, SpatialGDK::RPCsOnEntityCreation>;
+using FRPCsOnEntityCreationMap = TMap<TWeakObjectPtr<const UObject>, SpatialGDK::RPCsOnEntityCreation, FDefaultSetAllocator, TWeakObjectPtrMapKeyFuncs<TWeakObjectPtr<const UObject>, SpatialGDK::RPCsOnEntityCreation, false>>;
 using FUpdatesQueuedUntilAuthority = TMap<Worker_EntityId_Key, TArray<FWorkerComponentUpdate>>;
-using FChannelsToUpdatePosition = TSet<TWeakObjectPtr<USpatialActorChannel>>;
+using FChannelsToUpdatePosition = TSet<TWeakObjectPtr<USpatialActorChannel>, TWeakPointerKeyFuncs<TWeakObjectPtr<USpatialActorChannel>, false>>;
 
 UCLASS()
 class SPATIALGDK_API USpatialSender : public UObject

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -64,9 +64,11 @@ struct FPendingRPC
 // TODO: Clear TMap entries when USpatialActorChannel gets deleted - UNR:100
 // care for actor getting deleted before actor channel
 using FChannelObjectPair = TPair<TWeakObjectPtr<USpatialActorChannel>, TWeakObjectPtr<UObject>>;
-using FRPCsOnEntityCreationMap = TMap<TWeakObjectPtr<const UObject>, SpatialGDK::RPCsOnEntityCreation, FDefaultSetAllocator, TWeakObjectPtrMapKeyFuncs<TWeakObjectPtr<const UObject>, SpatialGDK::RPCsOnEntityCreation, false>>;
+using FRPCsOnEntityCreationMap = TMap<TWeakObjectPtr<const UObject>, SpatialGDK::RPCsOnEntityCreation, FDefaultSetAllocator,
+									  TWeakObjectPtrMapKeyFuncs<TWeakObjectPtr<const UObject>, SpatialGDK::RPCsOnEntityCreation, false>>;
 using FUpdatesQueuedUntilAuthority = TMap<Worker_EntityId_Key, TArray<FWorkerComponentUpdate>>;
-using FChannelsToUpdatePosition = TSet<TWeakObjectPtr<USpatialActorChannel>, TWeakPointerKeyFuncs<TWeakObjectPtr<USpatialActorChannel>, false>>;
+using FChannelsToUpdatePosition =
+	TSet<TWeakObjectPtr<USpatialActorChannel>, TWeakPointerKeyFuncs<TWeakObjectPtr<USpatialActorChannel>, false>>;
 
 UCLASS()
 class SPATIALGDK_API USpatialSender : public UObject

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -68,7 +68,7 @@ using FRPCsOnEntityCreationMap = TMap<TWeakObjectPtr<const UObject>, SpatialGDK:
 									  TWeakObjectPtrMapKeyFuncs<TWeakObjectPtr<const UObject>, SpatialGDK::RPCsOnEntityCreation, false>>;
 using FUpdatesQueuedUntilAuthority = TMap<Worker_EntityId_Key, TArray<FWorkerComponentUpdate>>;
 using FChannelsToUpdatePosition =
-	TSet<TWeakObjectPtr<USpatialActorChannel>, TWeakPointerKeyFuncs<TWeakObjectPtr<USpatialActorChannel>, false>>;
+	TSet<TWeakObjectPtr<USpatialActorChannel>, TWeakObjectPtrKeyFuncs<TWeakObjectPtr<USpatialActorChannel>, false>>;
 
 UCLASS()
 class SPATIALGDK_API USpatialSender : public UObject

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialCommonTypes.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialCommonTypes.h
@@ -49,7 +49,7 @@ struct FTrackableWorkerType : public T
 #endif
 };
 
-template<typename ElementType, bool bInAllowDuplicateKeys /*= false*/>
+template <typename ElementType, bool bInAllowDuplicateKeys /*= false*/>
 struct TWeakPointerKeyFuncs : DefaultKeyFuncs<ElementType, bInAllowDuplicateKeys>
 {
 	using typename DefaultKeyFuncs<ElementType, bInAllowDuplicateKeys>::KeyInitType;
@@ -57,10 +57,7 @@ struct TWeakPointerKeyFuncs : DefaultKeyFuncs<ElementType, bInAllowDuplicateKeys
 	/**
 	 * @return True if the keys match.
 	 */
-	static FORCEINLINE bool Matches(KeyInitType A, KeyInitType B)
-	{
-		return A.HasSameIndexAndSerialNumber(B);
-	}
+	static FORCEINLINE bool Matches(KeyInitType A, KeyInitType B) { return A.HasSameIndexAndSerialNumber(B); }
 };
 
 // TODO: These can be removed once event tracing is enabled UNR-3981

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialCommonTypes.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialCommonTypes.h
@@ -50,7 +50,7 @@ struct FTrackableWorkerType : public T
 };
 
 template <typename ElementType, bool bInAllowDuplicateKeys /*= false*/>
-struct TWeakPointerKeyFuncs : DefaultKeyFuncs<ElementType, bInAllowDuplicateKeys>
+struct TWeakObjectPtrKeyFuncs : DefaultKeyFuncs<ElementType, bInAllowDuplicateKeys>
 {
 	using typename DefaultKeyFuncs<ElementType, bInAllowDuplicateKeys>::KeyInitType;
 	using typename DefaultKeyFuncs<ElementType, bInAllowDuplicateKeys>::ElementInitType;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialCommonTypes.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialCommonTypes.h
@@ -49,6 +49,20 @@ struct FTrackableWorkerType : public T
 #endif
 };
 
+template<typename ElementType, bool bInAllowDuplicateKeys /*= false*/>
+struct TWeakPointerKeyFuncs : DefaultKeyFuncs<ElementType, bInAllowDuplicateKeys>
+{
+	using typename DefaultKeyFuncs<ElementType, bInAllowDuplicateKeys>::KeyInitType;
+	using typename DefaultKeyFuncs<ElementType, bInAllowDuplicateKeys>::ElementInitType;
+	/**
+	 * @return True if the keys match.
+	 */
+	static FORCEINLINE bool Matches(KeyInitType A, KeyInitType B)
+	{
+		return A.HasSameIndexAndSerialNumber(B);
+	}
+};
+
 // TODO: These can be removed once event tracing is enabled UNR-3981
 using FWorkerComponentUpdate = FTrackableWorkerType<Worker_ComponentUpdate>;
 using FWorkerComponentData = FTrackableWorkerType<Worker_ComponentData>;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/EntityFactory.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/EntityFactory.h
@@ -22,7 +22,8 @@ namespace SpatialGDK
 class SpatialRPCService;
 
 struct RPCsOnEntityCreation;
-using FRPCsOnEntityCreationMap = TMap<TWeakObjectPtr<const UObject>, RPCsOnEntityCreation, FDefaultSetAllocator, TWeakObjectPtrMapKeyFuncs<TWeakObjectPtr<const UObject>, SpatialGDK::RPCsOnEntityCreation, false>>;
+using FRPCsOnEntityCreationMap = TMap<TWeakObjectPtr<const UObject>, RPCsOnEntityCreation, FDefaultSetAllocator,
+									  TWeakObjectPtrMapKeyFuncs<TWeakObjectPtr<const UObject>, SpatialGDK::RPCsOnEntityCreation, false>>;
 
 class SPATIALGDK_API EntityFactory
 {

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/EntityFactory.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/EntityFactory.h
@@ -22,7 +22,7 @@ namespace SpatialGDK
 class SpatialRPCService;
 
 struct RPCsOnEntityCreation;
-using FRPCsOnEntityCreationMap = TMap<TWeakObjectPtr<const UObject>, RPCsOnEntityCreation>;
+using FRPCsOnEntityCreationMap = TMap<TWeakObjectPtr<const UObject>, RPCsOnEntityCreation, FDefaultSetAllocator, TWeakObjectPtrMapKeyFuncs<TWeakObjectPtr<const UObject>, SpatialGDK::RPCsOnEntityCreation, false>>;
 
 class SPATIALGDK_API EntityFactory
 {


### PR DESCRIPTION
#### Description
OnSubobjectDeleted was called with a dangling pointer, which was used to build a weak pointer, causing a crash.
This fix add a weak pointer to the method, in order to be able to properly cleanup the map.

#### Release note

#### Tests

#### Documentation