### PR TITLE
Bug/unr 4132 specifying launch config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made the DeploymentLauncher stop multiple deployments in parallel to improve performance when working with large numbers of deployments.
 - Fixed an issue where possessing a new pawn and immediately setting the owner of the old pawn to the controller could cause server RPCs from that pawn to be dropped.
 - Added support for the `bHidden` relevancy flag. Clients will not checkout Actors that have `bHidden` set to true (unless they are always relevant or the root component has collisions enabled).
+- Fixed an issue with deployments failing due to the incorrect number of workers when the launch config was specified, rather than automatically generated.
 
 ## [`0.11.0`] - 2020-09-03
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -253,7 +253,7 @@ uint32 GetPIEServerWorkers()
 	const USpatialGDKEditorSettings* EditorSettings = GetDefault<USpatialGDKEditorSettings>();
 	if (EditorSettings->bGenerateDefaultLaunchConfig && !EditorSettings->LaunchConfigDesc.ServerWorkerConfig.bAutoNumEditorInstances)
 	{
-		return EditorSettings->LaunchConfigDesc.ServerWorkerConfig.NumEditorInstances;	
+		return EditorSettings->LaunchConfigDesc.ServerWorkerConfig.NumEditorInstances;
 	}
 	else
 	{

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -251,15 +251,15 @@ bool FSpatialGDKEditorModule::ShouldPackageMobileCommandLineArgs() const
 uint32 GetPIEServerWorkers()
 {
 	const USpatialGDKEditorSettings* EditorSettings = GetDefault<USpatialGDKEditorSettings>();
-	if (EditorSettings->bGenerateDefaultLaunchConfig && EditorSettings->LaunchConfigDesc.ServerWorkerConfig.bAutoNumEditorInstances)
+	if (EditorSettings->bGenerateDefaultLaunchConfig && !EditorSettings->LaunchConfigDesc.ServerWorkerConfig.bAutoNumEditorInstances)
+	{
+		return EditorSettings->LaunchConfigDesc.ServerWorkerConfig.NumEditorInstances;	
+	}
+	else
 	{
 		UWorld* EditorWorld = GEditor->GetEditorWorldContext().World();
 		check(EditorWorld);
 		return GetWorkerCountFromWorldSettings(*EditorWorld);
-	}
-	else
-	{
-		return EditorSettings->LaunchConfigDesc.ServerWorkerConfig.NumEditorInstances;
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -833,7 +833,7 @@ void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment(FString ForceSnaps
 				FPaths::Combine(FPaths::ConvertRelativePathToFull(FPaths::ProjectIntermediateDir()),
 								FString::Printf(TEXT("Improbable/%s_CloudLaunchConfig.json"), *EditorWorld->GetMapName()));
 			Conf.NumEditorInstances = GetWorkerCountFromWorldSettings(*EditorWorld, true);
-			
+
 			GenerateLaunchConfig(CloudLaunchConfig, &LaunchConfigDescription, Conf);
 		}
 	}

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -832,11 +832,8 @@ void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment(FString ForceSnaps
 			FString CloudLaunchConfig =
 				FPaths::Combine(FPaths::ConvertRelativePathToFull(FPaths::ProjectIntermediateDir()),
 								FString::Printf(TEXT("Improbable/%s_CloudLaunchConfig.json"), *EditorWorld->GetMapName()));
-			if (Conf.bAutoNumEditorInstances)
-			{
-				Conf.NumEditorInstances = GetWorkerCountFromWorldSettings(*EditorWorld, true);
-			}
-
+			Conf.NumEditorInstances = GetWorkerCountFromWorldSettings(*EditorWorld, true);
+			
 			GenerateLaunchConfig(CloudLaunchConfig, &LaunchConfigDescription, Conf);
 		}
 	}


### PR DESCRIPTION
#### Description
When specifying a local or cloud launch config the deployments did not run. This was due to the incorrect number of workers returned by the function FSpatialGDKEditorModule::GetPIEServerWorkers(). 

When the "Auto-generate launch configuration file" in Editor settings was unchecked as in the case when specifying the launch configs, GetPIEServerWorkers() returned the number of workers specified in "Instance to launch in editor" which is not correct.

To fix this bug I reversed the test and check first if "Auto-generate launch configuration file" is checked and the "Automatically compute the number of instances to launch" is not set. Only in this case is the number of workers specified in "Instance to launch in editor" returned otherwise the number of workers is calculated. As shown in the image below.

![image](https://user-images.githubusercontent.com/64085832/93749019-deb82b80-fc01-11ea-9593-bcf1eb019614.png)

Also fixed the number of workers in the cloud launch config to be independent of the editor setting, which was found during additional testing for this PR.

#### Release note
- Fixed an issue with deployments failing due to the incorrect number of workers when the launch config was specified, rather than automatically generated.

#### Tests
I used the previous tests for extending the launch config, which highlighted this bug initially and I also added test cases for manually setting the number of workers: https://docs.google.com/spreadsheets/d/1e29E74dtz2XMwde1eJm5hlU4-Bt_y-HznzCwTsgyW1U/edit#gid=0

STRONGLY SUGGESTED: How can this be verified by QA?
Perform the tests in the section above.

#### Documentation
NA

#### Known Issues
Changing editor settings results in the SpatialDebugger in the editor being disabled on closing and reopening Unreal. [https://improbableio.atlassian.net/browse/UNR-4271]
