### PR TITLE
Move access to `this` before FinishTest, since the lambda is invalid after that

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestShutdownPreparation/SpatialTestShutdownPreparationTrigger.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestShutdownPreparation/SpatialTestShutdownPreparationTrigger.cpp
@@ -97,8 +97,8 @@ void ASpatialTestShutdownPreparationTrigger::BeginPlay()
 			StepTimer += DeltaTime;
 			if (StepTimer > TriggerEventWaitTime)
 			{
-				FinishStep();
 				StepTimer = 0.0f;
+				FinishStep();
 			}
 		});
 
@@ -136,8 +136,8 @@ void ASpatialTestShutdownPreparationTrigger::BeginPlay()
 			StepTimer += DeltaTime;
 			if (StepTimer > TriggerEventWaitTime)
 			{
-				FinishStep();
 				StepTimer = 0.0f;
+				FinishStep();
 			}
 		});
 
@@ -155,8 +155,8 @@ void ASpatialTestShutdownPreparationTrigger::BeginPlay()
 					StepTimer += DeltaTime;
 					if (StepTimer > TriggerEventWaitTime)
 					{
-						FinishStep();
 						StepTimer = 0.0f;
+						FinishStep();
 					}
 				});
 	}


### PR DESCRIPTION

#### Description
FinishTest resets its local step definition to default values. The lambda for the step's code is stored in the definition, which means that the reset clears out the captured values of the lambda, in this case the `this` pointer. That means that accessing it after FinishStep leads to crashes (though only in Debug builds, since only those scribble the overwritten memory).
This issue will be investigated properly in the future, but for now these changes should fix the immediate issue with this test.
