### PR TITLE
[unr-4279] Clear Step After Ticking

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestFlowController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestFlowController.cpp
@@ -59,6 +59,13 @@ void ASpatialFunctionalTestFlowController::Tick(float DeltaSeconds)
 	{
 		CurrentStep.Tick(DeltaSeconds);
 	}
+
+	// Did it stop now or before the Tick was called?
+	if (!CurrentStep.bIsRunning)
+	{
+		SetActorTickEnabled(false);
+		CurrentStep.Reset();
+	}
 }
 
 void ASpatialFunctionalTestFlowController::CrossServerSetWorkerId_Implementation(int NewWorkerId)
@@ -200,8 +207,7 @@ void ASpatialFunctionalTestFlowController::StartStepInternal(const int StepIndex
 
 void ASpatialFunctionalTestFlowController::StopStepInternal()
 {
-	SetActorTickEnabled(false);
-	CurrentStep.Reset();
+	CurrentStep.bIsRunning = false;
 }
 
 void ASpatialFunctionalTestFlowController::ServerNotifyFinishTest_Implementation(EFunctionalTestResult TestResult, const FString& Message)


### PR DESCRIPTION
Changed how CurrentStep.Reset() is called to prevent the lambdas being GCed (would happen when you do more things after calling FinishStep())