### PR TITLE
UNR-4163 zoning latency nfr

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
@@ -178,6 +178,17 @@ USpatialLatencyTracer* USpatialLatencyTracer::GetTracer(UObject* WorldContextObj
 	return nullptr;
 }
 
+FString USpatialLatencyTracer::GetTraceMetadata(UObject* WorldContextObject)
+{
+#ifdef TRACE_LIB_ACTIVE
+	if (USpatialLatencyTracer* Tracer = GetTracer(WorldContextObject))
+	{
+		return Tracer->TraceMetadata;
+	}
+#endif
+	return "";
+}
+
 #if TRACE_LIB_ACTIVE
 bool USpatialLatencyTracer::IsValidKey(const TraceKey Key)
 {

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
@@ -180,7 +180,7 @@ USpatialLatencyTracer* USpatialLatencyTracer::GetTracer(UObject* WorldContextObj
 
 FString USpatialLatencyTracer::GetTraceMetadata(UObject* WorldContextObject)
 {
-#ifdef TRACE_LIB_ACTIVE
+#if TRACE_LIB_ACTIVE
 	if (USpatialLatencyTracer* Tracer = GetTracer(WorldContextObject))
 	{
 		return Tracer->TraceMetadata;

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLatencyTracer.cpp
@@ -186,7 +186,7 @@ FString USpatialLatencyTracer::GetTraceMetadata(UObject* WorldContextObject)
 		return Tracer->TraceMetadata;
 	}
 #endif
-	return "";
+	return TEXT("");
 }
 
 #if TRACE_LIB_ACTIVE

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracer.h
@@ -130,6 +130,9 @@ public:
 	// Internal GDK usage, shouldn't be used by game code
 	static USpatialLatencyTracer* GetTracer(UObject* WorldContextObject);
 
+	UFUNCTION(BlueprintPure, Category = "SpatialOS", meta = (WorldContext = "WorldContextObject"))
+	static FString GetTraceMetadata(UObject* WorldContextObject);
+
 #if TRACE_LIB_ACTIVE
 
 	bool IsValidKey(TraceKey Key);


### PR DESCRIPTION
#### Description
Add a blueprint callable SetTraceMetadata function. Because for zoning latency tracing of cross server RPCs and property updates it's necessary to have a consistent runid and we'd like to leverage the existing id which is the deployment Id of the simulated players deployment, so that we can continue to gather the metrics for client to server rpc and multicast rpc and simply add the additional cross server latency metrics.

#### Tests
I ran many cloud deployments with simulated players as well as running test cases in the nfr framework, for example:
https://buildkite.com/improbable/product-research-benchmarks-run/builds/15865#827c0602-7c02-4bd6-9288-bd720c7479be

STRONGLY SUGGESTED: Run the gdk_latency_zone2_1 test scenario via the nfr framework.

#### Reminders (IMPORTANT)
I believe this should generally not be impactful, it's only relevant for using tracing via the google stack driver.
This PR is prerequisite to subsequent PRs being merged.

#### Primary reviewers
@m-samiec @MatthewSandfordImprobable @yujunting 