### PR TITLE
[UNR-4113] Cleanup worker startup logs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue with deployments failing due to the incorrect number of workers when the launch config was specified, rather than automatically generated.
 - Fixed the `too many dynamic subobjects` error on Clients appearing when a Startup Actor, with one dynamic subobject was leaving and re-entering interest multiple times. Added the `RemovedDynamicSubobjectObjectRefs` map in `USpatialPackageMapClient` that keeps the dynamic subobjects removed from Startup Actor's client's interest to avoid duplication of the dynamic subojects when the Startup Actor re-enters the Client's interest.
 - Fixed an issue that prevented the Interest component from being initialized properly when provided with `Worker_ComponentData`.
-  
+- Cleaned up startup logs of a few noisy messages.
+
 ## [`0.11.0`] - 2020-09-03
 
 ### Breaking changes:

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -634,7 +634,7 @@ void USpatialNetDriver::GSMQueryDelegateFunction(const Worker_EntityQueryRespons
 	else if (!bNewAcceptingPlayers)
 	{
 		StartupClientDebugString = FString(
-			TEXT("GlobalStateManager not accepting players. This is likely caused by waiting for all the required workers to connect"));
+			TEXT("GlobalStateManager not accepting players. This is likely caused by waiting for all the required servers to connect"));
 		RetryQueryGSM();
 		return;
 	}
@@ -2584,7 +2584,7 @@ void USpatialNetDriver::TryFinishStartup()
 		else if (!GlobalStateManager->IsReady())
 		{
 			UE_CLOG(bShouldLogStartup, LogSpatialOSNetDriver, Log,
-					TEXT("Waiting for the GSM to be ready (this includes waiting for the expected number of workers to be connected)"));
+					TEXT("Waiting for the GSM to be ready (this includes waiting for the expected number of servers to be connected)"));
 		}
 		else if (VirtualWorkerTranslator.IsValid() && !VirtualWorkerTranslator->IsReady())
 		{

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslationManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslationManager.cpp
@@ -132,7 +132,7 @@ void SpatialVirtualWorkerTranslationManager::SendVirtualWorkerMappingUpdate() co
 
 void SpatialVirtualWorkerTranslationManager::QueryForServerWorkerEntities()
 {
-	UE_LOG(LogSpatialVirtualWorkerTranslationManager, Log, TEXT("Sending query for WorkerEntities"));
+	UE_LOG(LogSpatialVirtualWorkerTranslationManager, Verbose, TEXT("Sending query for WorkerEntities"));
 
 	if (bWorkerEntityQueryInFlight)
 	{
@@ -180,7 +180,7 @@ void SpatialVirtualWorkerTranslationManager::ServerWorkerEntityQueryDelegate(con
 	}
 	else
 	{
-		UE_LOG(LogSpatialVirtualWorkerTranslationManager, Log, TEXT("Processing ServerWorker Entity query response"));
+		UE_LOG(LogSpatialVirtualWorkerTranslationManager, Verbose, TEXT("Processing ServerWorker Entity query response"));
 		ConstructVirtualWorkerMappingFromQueryResponse(Op);
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslationManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslationManager.cpp
@@ -19,11 +19,12 @@ SpatialVirtualWorkerTranslationManager::SpatialVirtualWorkerTranslationManager(S
 {
 }
 
-void SpatialVirtualWorkerTranslationManager::SetNumberOfVirtualWorkers(const uint32 NumVirtualWorkers)
+void SpatialVirtualWorkerTranslationManager::SetNumberOfVirtualWorkers(const uint32 InNumVirtualWorkers)
 {
 	UE_LOG(LogSpatialVirtualWorkerTranslationManager, Log, TEXT("TranslationManager is configured to look for %d workers"),
-		   NumVirtualWorkers);
+		   InNumVirtualWorkers);
 
+	NumVirtualWorkers = InNumVirtualWorkers;
 	// Currently, this should only be called once on startup. In the future we may allow for more
 	// flexibility.
 	for (uint32 i = 1; i <= NumVirtualWorkers; i++)
@@ -191,7 +192,9 @@ void SpatialVirtualWorkerTranslationManager::ServerWorkerEntityQueryDelegate(con
 	else
 	{
 		UE_LOG(LogSpatialVirtualWorkerTranslationManager, Log,
-			   TEXT("Waiting for all virtual workers to be assigned before publishing translation update."));
+			   TEXT("Waiting for all virtual workers to be assigned before publishing translation update. "
+					"We currently have %i workers connected out of the %i required"),
+			   VirtualToPhysicalWorkerMapping.Num(), NumVirtualWorkers);
 		QueryForServerWorkerEntities();
 	}
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
@@ -606,7 +606,7 @@ bool UGlobalStateManager::GetAcceptingPlayersAndSessionIdFromQueryResponse(const
 
 void UGlobalStateManager::SetDeploymentMapURL(const FString& MapURL)
 {
-	UE_LOG(LogGlobalStateManager, Log, TEXT("Setting DeploymentMapURL: %s"), *MapURL);
+	UE_LOG(LogGlobalStateManager, Verbose, TEXT("Setting DeploymentMapURL: %s"), *MapURL);
 	DeploymentMapURL = MapURL;
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -125,6 +125,7 @@ USpatialGDKSettings::USpatialGDKSettings(const FObjectInitializer& ObjectInitial
 	, bUseSecureClientConnection(false)
 	, bUseSecureServerConnection(false)
 	, bEnableClientQueriesOnServer(false)
+	, StartupLogRate(5.0f)
 {
 	DefaultReceptionistHost = SpatialConstants::LOCAL_HOST;
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -304,5 +304,5 @@ private:
 
 	TSet<Worker_EntityId_Key> OwnershipChangedEntities;
 	uint64 StartupTimestamp;
-	FString StartupDebugString;
+	FString StartupClientDebugString;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -303,4 +303,6 @@ private:
 	void ProcessOwnershipChanges();
 
 	TSet<Worker_EntityId_Key> OwnershipChangedEntities;
+	uint64 StartupTimestamp;
+	FString StartupDebugString;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialVirtualWorkerTranslationManager.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialVirtualWorkerTranslationManager.h
@@ -51,6 +51,7 @@ private:
 	TMap<VirtualWorkerId, TPair<PhysicalWorkerName, Worker_EntityId>> VirtualToPhysicalWorkerMapping;
 	TMap<PhysicalWorkerName, VirtualWorkerId> PhysicalToVirtualWorkerMapping;
 	TQueue<VirtualWorkerId> UnassignedVirtualWorkers;
+	uint32 NumVirtualWorkers;
 
 	bool bWorkerEntityQueryInFlight;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/GlobalStateManager.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/GlobalStateManager.h
@@ -37,8 +37,8 @@ public:
 
 	DECLARE_DELEGATE_OneParam(QueryDelegate, const Worker_EntityQueryResponseOp&);
 	void QueryGSM(const QueryDelegate& Callback);
-	bool GetAcceptingPlayersAndSessionIdFromQueryResponse(const Worker_EntityQueryResponseOp& Op, bool& OutAcceptingPlayers,
-														  int32& OutSessionId);
+	static bool GetAcceptingPlayersAndSessionIdFromQueryResponse(const Worker_EntityQueryResponseOp& Op, bool& OutAcceptingPlayers,
+																 int32& OutSessionId);
 	void ApplyVirtualWorkerMappingFromQueryResponse(const Worker_EntityQueryResponseOp& Op) const;
 	void ApplyDeploymentMapDataFromQueryResponse(const Worker_EntityQueryResponseOp& Op);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -371,4 +371,10 @@ public:
 		meta = (DisplayName = "Whether or not to suppress a warning if an RPC of Type is being called with unresolved references. Default is false.  QueuedIncomingWaitRPC time is still respected."))
 	// clang-format on
 	TMap<ERPCType, bool> RPCTypeAllowUnresolvedParamMap;
+
+	/**
+	 * Time in seconds, controls at which frequency logs related to startup are emitted.
+	 */
+	UPROPERTY(Config)
+	float StartupLogRate;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -375,6 +375,6 @@ public:
 	/**
 	 * Time in seconds, controls at which frequency logs related to startup are emitted.
 	 */
-	UPROPERTY(Config)
+	UPROPERTY(EditAnywhere, Config, Category = "Logging", AdvancedDisplay)
 	float StartupLogRate;
 };


### PR DESCRIPTION
#### Description
Made some noisy logs verbose, and kept relevant ones around. Spam still occurs in case of a problematic startup.
Logs relevant to startup are scattered around in various classes, and some phases are stateless. It would require an additional mechanism (status callback, global map) to gather them and emit them in a controlled fashion. Is it worth thinking about such a mechanism ?
