### PR TITLE
Feature/unr 1373 entity id reservation

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -187,6 +187,11 @@ void USpatialGDKSettings::PostEditChangeProperty(struct FPropertyChangedEvent& P
 	{
 		UpdateServicesRegionFile();
 	}
+	else if (Name == GET_MEMBER_NAME_CHECKED(USpatialGDKSettings, EntityPoolInitialReservationCount))
+	{
+		if (EntityPoolInitialReservationCount > 10000)
+			EntityPoolInitialReservationCount = 10000;
+	}
 }
 
 bool USpatialGDKSettings::CanEditChange(const GDK_PROPERTY(Property) * InProperty) const

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -190,7 +190,9 @@ void USpatialGDKSettings::PostEditChangeProperty(struct FPropertyChangedEvent& P
 	else if (Name == GET_MEMBER_NAME_CHECKED(USpatialGDKSettings, EntityPoolInitialReservationCount))
 	{
 		if (EntityPoolInitialReservationCount > 10000)
+		{
 			EntityPoolInitialReservationCount = 10000;
+		}
 	}
 }
 


### PR DESCRIPTION
#### Description
Set a cap of 10,000 reserved entity IDs in the GUI (Project Settings) to reflect this cap imposed by the runtime.

#### Release note
Small fix, no release note required?

#### Tests
Manually tested from the GUI.

How can this be verified by QA? - Manual test in the GUI (Project Settings -> Entity ID Reservation)

#### Documentation
Small fix, no documentation required?

#### Primary reviewers
@improbable-danny @joshuahuburn 
