### PR TITLE
UNR-4239 Fix crash on WorkerView::SendComponentUpdate

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/WorkerView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/WorkerView.cpp
@@ -92,14 +92,16 @@ void WorkerView::SendAddComponent(Worker_EntityId EntityId, ComponentData Data)
 
 void WorkerView::SendComponentUpdate(Worker_EntityId EntityId, ComponentUpdate Update)
 {
-	EntityViewElement& Element = View.FindChecked(EntityId);
-	ComponentData* Component = Element.Components.FindByPredicate(ComponentIdEquality{ Update.GetComponentId() });
-	// check(Component != nullptr);
-	if (Component != nullptr)
+	if (View.Contains(EntityId))
 	{
-		Component->ApplyUpdate(Update);
+		EntityViewElement& Element = View.FindChecked(EntityId);
+		ComponentData* Component = Element.Components.FindByPredicate(ComponentIdEquality{ Update.GetComponentId() });
+		if (Component != nullptr)
+		{
+			Component->ApplyUpdate(Update);
+		}
+		LocalChanges->ComponentMessages.Emplace(EntityId, MoveTemp(Update));
 	}
-	LocalChanges->ComponentMessages.Emplace(EntityId, MoveTemp(Update));
 }
 
 void WorkerView::SendRemoveComponent(Worker_EntityId EntityId, Worker_ComponentId ComponentId)


### PR DESCRIPTION
After analyzing the nfr logs form buildkite, lots of simulate players crash on WorkerView::SendComponentUpdate() 
-------------------------------------------------

`
EntityViewElement& Element = View.FindChecked(EntityId);
ComponentData* Component = Element.Components.FindByPredicate(ComponentIdEquality{ Update.GetComponentId() });
`
Only fix this crash issue, but why the View didn't find a corresponding EntityId, may be caused by some reason.

-------------------------------------------------
For more information from:https://improbableio.atlassian.net/browse/UNR-4239
-------------------------------------------------
BuildKite:https://buildkite.com/improbable/unrealgdk-nfr/builds/2844
https://buildkite.com/improbable/product-research-benchmarks-run/builds/15932
-------------------------------------------------
