### PR TITLE
bug/unr4271-spatial-debugger-editor-toggle-not-saved

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -277,7 +277,7 @@ bool USpatialGDKSettings::GetPreventClientCloudDeploymentAutoConnect() const
 };
 
 #if WITH_EDITOR
-void USpatialGDKSettings::SetMultiWorkerEnabled(bool bIsEnabled)
+void USpatialGDKSettings::SetMultiWorkerEditorEnabled(bool bIsEnabled)
 {
 	bEnableMultiWorker = bIsEnabled;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -280,7 +280,6 @@ bool USpatialGDKSettings::GetPreventClientCloudDeploymentAutoConnect() const
 void USpatialGDKSettings::SetMultiWorkerEnabled(bool bIsEnabled)
 {
 	bEnableMultiWorker = bIsEnabled;
-	SaveConfig();
 }
 #endif // WITH_EDITOR
 

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -265,7 +265,7 @@ public:
 	bool UseRPCRingBuffer() const;
 
 #if WITH_EDITOR
-	void SetMultiWorkerEnabled(const bool bIsEnabled);
+	void SetMultiWorkerEditorEnabled(const bool bIsEnabled);
 	FORCEINLINE bool IsMultiWorkerEditorEnabled() const { return bEnableMultiWorker; }
 #endif // WITH_EDITOR
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -250,7 +250,6 @@ void USpatialGDKEditorSettings::SetSimulatedPlayersEnabledState(bool IsEnabled)
 void USpatialGDKEditorSettings::SetSpatialDebuggerEditorEnabled(bool IsEnabled)
 {
 	bSpatialDebuggerEditorEnabled = IsEnabled;
-	SaveConfig();
 }
 
 void USpatialGDKEditorSettings::SetAutoGenerateCloudLaunchConfigEnabledState(bool IsEnabled)

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -729,9 +729,13 @@ void FSpatialGDKEditorToolbarModule::ToggleSpatialDebuggerEditor()
 	if (SpatialDebugger.IsValid())
 	{
 		USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetMutableDefault<USpatialGDKEditorSettings>();
-		SpatialGDKEditorSettings->SetSpatialDebuggerEditorEnabled(!SpatialGDKEditorSettings->bSpatialDebuggerEditorEnabled);
+		SpatialGDKEditorSettings->SetSpatialDebuggerEditorEnabled(!SpatialGDKEditorSettings->IsSpatialDebuggerEditorEnabled());
+		GDK_PROPERTY(Property)* SpatialDebuggerEditorEnabledProperty =
+			USpatialGDKEditorSettings::StaticClass()->FindPropertyByName(FName("bSpatialDebuggerEditorEnabled"));
+		SpatialGDKEditorSettings->UpdateSinglePropertyInConfigFile(SpatialDebuggerEditorEnabledProperty,
+																   SpatialGDKEditorSettings->GetDefaultConfigFilename());
 
-		SpatialDebugger->EditorSpatialToggleDebugger(SpatialGDKEditorSettings->bSpatialDebuggerEditorEnabled);
+		SpatialDebugger->EditorSpatialToggleDebugger(SpatialGDKEditorSettings->IsSpatialDebuggerEditorEnabled());
 	}
 	else
 	{
@@ -742,7 +746,9 @@ void FSpatialGDKEditorToolbarModule::ToggleSpatialDebuggerEditor()
 void FSpatialGDKEditorToolbarModule::ToggleMultiworkerEditor()
 {
 	USpatialGDKSettings* SpatialGDKSettings = GetMutableDefault<USpatialGDKSettings>();
-	SpatialGDKSettings->SetMultiWorkerEnabled(!SpatialGDKSettings->bEnableMultiWorker);
+	SpatialGDKSettings->SetMultiWorkerEnabled(!SpatialGDKSettings->IsMultiWorkerEditorEnabled());
+	GDK_PROPERTY(Property)* EnableMultiWorkerProperty = USpatialGDKSettings::StaticClass()->FindPropertyByName(FName("bEnableMultiWorker"));
+	SpatialGDKSettings->UpdateSinglePropertyInConfigFile(EnableMultiWorkerProperty, SpatialGDKSettings->GetDefaultConfigFilename());
 
 	if (SpatialDebugger.IsValid())
 	{

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -746,7 +746,7 @@ void FSpatialGDKEditorToolbarModule::ToggleSpatialDebuggerEditor()
 void FSpatialGDKEditorToolbarModule::ToggleMultiworkerEditor()
 {
 	USpatialGDKSettings* SpatialGDKSettings = GetMutableDefault<USpatialGDKSettings>();
-	SpatialGDKSettings->SetMultiWorkerEnabled(!SpatialGDKSettings->IsMultiWorkerEditorEnabled());
+	SpatialGDKSettings->SetMultiWorkerEditorEnabled(!SpatialGDKSettings->IsMultiWorkerEditorEnabled());
 	GDK_PROPERTY(Property)* EnableMultiWorkerProperty = USpatialGDKSettings::StaticClass()->FindPropertyByName(FName("bEnableMultiWorker"));
 	SpatialGDKSettings->UpdateSinglePropertyInConfigFile(EnableMultiWorkerProperty, SpatialGDKSettings->GetDefaultConfigFilename());
 


### PR DESCRIPTION
#### Description
Use UpdateSinglePropertyInConfigFile() instead of SaveConfig() when toggling the "Spatial Editor Debugger" and "Enable Multi-worker" from the toolbar, following the same pattern as "SpatialOS Networking" toggle.

![image](https://user-images.githubusercontent.com/64085832/95749219-ee2c1100-0ca3-11eb-96fa-759d74fda371.png)

#### Tests
Manual tests by changing the toggles from the drop-down menu and checking the changes were made in the corresponding files.
"Spatial Editor Debugger" toggle -> Game\Config\DefaultSpatialGDKEditorSettings.ini
"Enable Multi-worker" toggle -> Game\Config\DefaultSpatialGDKSettings.ini

STRONGLY SUGGESTED: How can this be verified by QA?
Same as the tests above.

