### PR TITLE
Smarter positioning of Spatial Debugger tag elements

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
@@ -462,7 +462,7 @@ void ASpatialDebugger::DrawTag(UCanvas* Canvas, const FVector2D& ScreenLocation,
 		return;
 	}
 
-	static const float BaseHorizontalOffset(16.0f);
+	static const float BaseHorizontalOffset = 16.0f;
 	static const float NumberScale = 0.75f;
 	static const float TextScale = 0.5f;
 	const float AuthWidth = NumberScale * GetNumberOfDigitsIn(DebuggingInfo->AuthoritativeVirtualWorkerId);

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
@@ -675,7 +675,7 @@ void ASpatialDebugger::DrawDebugLocalPlayer(UCanvas* Canvas)
 	for (int32 i = 0; i < ActorsToDisplay.Num(); ++i)
 	{
 		const Worker_EntityId EntityId = NetDriver->PackageMap->GetEntityIdFromObject(ActorsToDisplay[i]);
-		DrawTag(Canvas, ScreenLocation, EntityId, ActorsToDisplay[i]->GetName(), false);
+		DrawTag(Canvas, ScreenLocation, EntityId, ActorsToDisplay[i]->GetName(), false /*bCentre*/ );
 		ScreenLocation.Y += PLAYER_TAG_VERTICAL_OFFSET;
 	}
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
@@ -444,7 +444,8 @@ void ASpatialDebugger::ActorAuthorityIntentChanged(Worker_EntityId EntityId, Vir
 	NetDriver->Connection->SendComponentUpdate(EntityId, &DebuggingUpdate);
 }
 
-void ASpatialDebugger::DrawTag(UCanvas* Canvas, const FVector2D& ScreenLocation, const Worker_EntityId EntityId, const FString& ActorName, const bool bCentre)
+void ASpatialDebugger::DrawTag(UCanvas* Canvas, const FVector2D& ScreenLocation, const Worker_EntityId EntityId, const FString& ActorName,
+							   const bool bCentre)
 {
 	SCOPE_CYCLE_COUNTER(STAT_DrawTag);
 
@@ -468,7 +469,7 @@ void ASpatialDebugger::DrawTag(UCanvas* Canvas, const FVector2D& ScreenLocation,
 	const float AuthIntentWidth = NumberScale * GetNumberOfDigitsIn(DebuggingInfo->IntentVirtualWorkerId);
 	const float EntityIdWidth = NumberScale * GetNumberOfDigitsIn(EntityId);
 
-	int32 HorizontalOffset = 0; 
+	int32 HorizontalOffset = 0;
 	if (bCentre)
 	{
 		// If tag should be centered, calculate the total width of the icons and text to be rendered

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
@@ -638,7 +638,7 @@ void ASpatialDebugger::DrawDebug(UCanvas* Canvas, APlayerController* /* Controll
 					continue;
 				}
 
-				DrawTag(Canvas, ScreenLocation, EntityId, Actor->GetName(), true);
+				DrawTag(Canvas, ScreenLocation, EntityId, Actor->GetName(), true /*bCentre*/ );
 			}
 		}
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
@@ -444,13 +444,9 @@ void ASpatialDebugger::ActorAuthorityIntentChanged(Worker_EntityId EntityId, Vir
 	NetDriver->Connection->SendComponentUpdate(EntityId, &DebuggingUpdate);
 }
 
-void ASpatialDebugger::DrawTag(UCanvas* Canvas, const FVector2D& ScreenLocation, const Worker_EntityId EntityId, const FString& ActorName)
+void ASpatialDebugger::DrawTag(UCanvas* Canvas, const FVector2D& ScreenLocation, const Worker_EntityId EntityId, const FString& ActorName, const bool bCentre)
 {
 	SCOPE_CYCLE_COUNTER(STAT_DrawTag);
-
-	// TODO: Smarter positioning of elements so they're centered no matter how many are enabled
-	// https://improbableio.atlassian.net/browse/UNR-2360.
-	int32 HorizontalOffset = -32.0f;
 
 	check(NetDriver != nullptr && !NetDriver->IsServer());
 	if (!NetDriver->StaticComponentView->HasComponent(EntityId, SpatialConstants::SPATIAL_DEBUGGING_COMPONENT_ID))
@@ -460,13 +456,52 @@ void ASpatialDebugger::DrawTag(UCanvas* Canvas, const FVector2D& ScreenLocation,
 
 	const SpatialDebugging* DebuggingInfo = NetDriver->StaticComponentView->GetComponentData<SpatialDebugging>(EntityId);
 
-	static const float BaseHorizontalOffset(16.0f);
-
 	if (!FApp::CanEverRender()) // DrawIcon can attempt to use the underlying texture resource even when using nullrhi
 	{
 		return;
 	}
 
+	static const float BaseHorizontalOffset(16.0f);
+	static const float NumberScale = 0.75f;
+	static const float TextScale = 0.5f;
+	const float AuthWidth = NumberScale * GetNumberOfDigitsIn(DebuggingInfo->AuthoritativeVirtualWorkerId);
+	const float AuthIntentWidth = NumberScale * GetNumberOfDigitsIn(DebuggingInfo->IntentVirtualWorkerId);
+	const float EntityIdWidth = NumberScale * GetNumberOfDigitsIn(EntityId);
+
+	int32 HorizontalOffset = 0; 
+	if (bCentre)
+	{
+		// If tag should be centered, calculate the total width of the icons and text to be rendered
+		float TagWidth = 0;
+		if (bShowLock)
+		{
+			TagWidth += BaseHorizontalOffset;
+		}
+		if (bShowAuth)
+		{
+			TagWidth += BaseHorizontalOffset;
+			TagWidth += (BaseHorizontalOffset * AuthWidth);
+		}
+		if (bShowAuthIntent)
+		{
+			TagWidth += BaseHorizontalOffset;
+			TagWidth += (BaseHorizontalOffset * AuthIntentWidth);
+		}
+		if (bShowEntityId)
+		{
+			TagWidth += (BaseHorizontalOffset * EntityIdWidth);
+		}
+		if (bShowActorName)
+		{
+			const float ActorNameWidth = TextScale * ActorName.Len();
+			TagWidth += (BaseHorizontalOffset * ActorNameWidth);
+		}
+
+		// Calculate the offset based on the total width of the tag
+		HorizontalOffset = TagWidth / -2;
+	}
+
+	// Draw icons and text based on the offset
 	if (bShowLock)
 	{
 		SCOPE_CYCLE_COUNTER(STAT_DrawIcons);
@@ -486,13 +521,11 @@ void ASpatialDebugger::DrawTag(UCanvas* Canvas, const FVector2D& ScreenLocation,
 		Canvas->DrawIcon(Icons[ICON_AUTH], ScreenLocation.X + HorizontalOffset, ScreenLocation.Y, 1.0f);
 		HorizontalOffset += BaseHorizontalOffset;
 		Canvas->SetDrawColor(ServerWorkerColor);
-		const float BoxScaleBasedOnNumberSize = 0.75f * GetNumberOfDigitsIn(DebuggingInfo->AuthoritativeVirtualWorkerId);
-		Canvas->DrawScaledIcon(Icons[ICON_BOX], ScreenLocation.X + HorizontalOffset, ScreenLocation.Y,
-							   FVector(BoxScaleBasedOnNumberSize, 1.f, 1.f));
+		Canvas->DrawScaledIcon(Icons[ICON_BOX], ScreenLocation.X + HorizontalOffset, ScreenLocation.Y, FVector(AuthWidth, 1.f, 1.f));
 		Canvas->SetDrawColor(GetTextColorForBackgroundColor(ServerWorkerColor));
 		Canvas->DrawText(RenderFont, FString::FromInt(DebuggingInfo->AuthoritativeVirtualWorkerId), ScreenLocation.X + HorizontalOffset + 1,
 						 ScreenLocation.Y, 1.1f, 1.1f, FontRenderInfo);
-		HorizontalOffset += (BaseHorizontalOffset * BoxScaleBasedOnNumberSize);
+		HorizontalOffset += (BaseHorizontalOffset * AuthWidth);
 	}
 
 	if (bShowAuthIntent)
@@ -501,15 +534,13 @@ void ASpatialDebugger::DrawTag(UCanvas* Canvas, const FVector2D& ScreenLocation,
 		const FColor& VirtualWorkerColor = DebuggingInfo->IntentColor;
 		Canvas->SetDrawColor(FColor::White);
 		Canvas->DrawIcon(Icons[ICON_AUTH_INTENT], ScreenLocation.X + HorizontalOffset, ScreenLocation.Y, 1.0f);
-		HorizontalOffset += 16.0f;
+		HorizontalOffset += BaseHorizontalOffset;
 		Canvas->SetDrawColor(VirtualWorkerColor);
-		const float BoxScaleBasedOnNumberSize = 0.75f * GetNumberOfDigitsIn(DebuggingInfo->IntentVirtualWorkerId);
-		Canvas->DrawScaledIcon(Icons[ICON_BOX], ScreenLocation.X + HorizontalOffset, ScreenLocation.Y,
-							   FVector(BoxScaleBasedOnNumberSize, 1.f, 1.f));
+		Canvas->DrawScaledIcon(Icons[ICON_BOX], ScreenLocation.X + HorizontalOffset, ScreenLocation.Y, FVector(AuthIntentWidth, 1.f, 1.f));
 		Canvas->SetDrawColor(GetTextColorForBackgroundColor(VirtualWorkerColor));
 		Canvas->DrawText(RenderFont, FString::FromInt(DebuggingInfo->IntentVirtualWorkerId), ScreenLocation.X + HorizontalOffset + 1,
 						 ScreenLocation.Y, 1.1f, 1.1f, FontRenderInfo);
-		HorizontalOffset += (BaseHorizontalOffset * BoxScaleBasedOnNumberSize);
+		HorizontalOffset += (BaseHorizontalOffset * AuthIntentWidth);
 	}
 
 	FString Label;
@@ -606,7 +637,7 @@ void ASpatialDebugger::DrawDebug(UCanvas* Canvas, APlayerController* /* Controll
 					continue;
 				}
 
-				DrawTag(Canvas, ScreenLocation, EntityId, Actor->GetName());
+				DrawTag(Canvas, ScreenLocation, EntityId, Actor->GetName(), true);
 			}
 		}
 	}
@@ -643,7 +674,7 @@ void ASpatialDebugger::DrawDebugLocalPlayer(UCanvas* Canvas)
 	for (int32 i = 0; i < ActorsToDisplay.Num(); ++i)
 	{
 		const Worker_EntityId EntityId = NetDriver->PackageMap->GetEntityIdFromObject(ActorsToDisplay[i]);
-		DrawTag(Canvas, ScreenLocation, EntityId, ActorsToDisplay[i]->GetName());
+		DrawTag(Canvas, ScreenLocation, EntityId, ActorsToDisplay[i]->GetName(), false);
 		ScreenLocation.Y += PLAYER_TAG_VERTICAL_OFFSET;
 	}
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
@@ -465,8 +465,8 @@ void ASpatialDebugger::DrawTag(UCanvas* Canvas, const FVector2D& ScreenLocation,
 	static const float BaseHorizontalOffset = 16.0f;
 	static const float NumberScale = 0.75f;
 	static const float TextScale = 0.5f;
-	const float AuthWidth = NumberScale * GetNumberOfDigitsIn(DebuggingInfo->AuthoritativeVirtualWorkerId);
-	const float AuthIntentWidth = NumberScale * GetNumberOfDigitsIn(DebuggingInfo->IntentVirtualWorkerId);
+	const float AuthIdWidth = NumberScale * GetNumberOfDigitsIn(DebuggingInfo->AuthoritativeVirtualWorkerId);
+	const float AuthIntentIdWidth = NumberScale * GetNumberOfDigitsIn(DebuggingInfo->IntentVirtualWorkerId);
 	const float EntityIdWidth = NumberScale * GetNumberOfDigitsIn(EntityId);
 
 	int32 HorizontalOffset = 0;
@@ -476,24 +476,29 @@ void ASpatialDebugger::DrawTag(UCanvas* Canvas, const FVector2D& ScreenLocation,
 		float TagWidth = 0;
 		if (bShowLock)
 		{
+			// If showing the lock, add the lock icon width
 			TagWidth += BaseHorizontalOffset;
 		}
 		if (bShowAuth)
 		{
+			// If showing the authority, add the authority icon width and the width of the authoritative virtual worker ID 
 			TagWidth += BaseHorizontalOffset;
-			TagWidth += (BaseHorizontalOffset * AuthWidth);
+			TagWidth += (BaseHorizontalOffset * AuthIdWidth);
 		}
 		if (bShowAuthIntent)
 		{
+			// If showing the authority intent, add the authority intent icon width and the width of the authoritative intent virtual worker ID 
 			TagWidth += BaseHorizontalOffset;
-			TagWidth += (BaseHorizontalOffset * AuthIntentWidth);
+			TagWidth += (BaseHorizontalOffset * AuthIntentIdWidth);
 		}
 		if (bShowEntityId)
 		{
+			// If showing the entity ID, add the width of the entity ID 
 			TagWidth += (BaseHorizontalOffset * EntityIdWidth);
 		}
 		if (bShowActorName)
 		{
+			// If showing the actor name, add the width of the actor name 
 			const float ActorNameWidth = TextScale * ActorName.Len();
 			TagWidth += (BaseHorizontalOffset * ActorNameWidth);
 		}
@@ -522,11 +527,11 @@ void ASpatialDebugger::DrawTag(UCanvas* Canvas, const FVector2D& ScreenLocation,
 		Canvas->DrawIcon(Icons[ICON_AUTH], ScreenLocation.X + HorizontalOffset, ScreenLocation.Y, 1.0f);
 		HorizontalOffset += BaseHorizontalOffset;
 		Canvas->SetDrawColor(ServerWorkerColor);
-		Canvas->DrawScaledIcon(Icons[ICON_BOX], ScreenLocation.X + HorizontalOffset, ScreenLocation.Y, FVector(AuthWidth, 1.f, 1.f));
+		Canvas->DrawScaledIcon(Icons[ICON_BOX], ScreenLocation.X + HorizontalOffset, ScreenLocation.Y, FVector(AuthIdWidth, 1.f, 1.f));
 		Canvas->SetDrawColor(GetTextColorForBackgroundColor(ServerWorkerColor));
 		Canvas->DrawText(RenderFont, FString::FromInt(DebuggingInfo->AuthoritativeVirtualWorkerId), ScreenLocation.X + HorizontalOffset + 1,
 						 ScreenLocation.Y, 1.1f, 1.1f, FontRenderInfo);
-		HorizontalOffset += (BaseHorizontalOffset * AuthWidth);
+		HorizontalOffset += (BaseHorizontalOffset * AuthIdWidth);
 	}
 
 	if (bShowAuthIntent)
@@ -537,11 +542,11 @@ void ASpatialDebugger::DrawTag(UCanvas* Canvas, const FVector2D& ScreenLocation,
 		Canvas->DrawIcon(Icons[ICON_AUTH_INTENT], ScreenLocation.X + HorizontalOffset, ScreenLocation.Y, 1.0f);
 		HorizontalOffset += BaseHorizontalOffset;
 		Canvas->SetDrawColor(VirtualWorkerColor);
-		Canvas->DrawScaledIcon(Icons[ICON_BOX], ScreenLocation.X + HorizontalOffset, ScreenLocation.Y, FVector(AuthIntentWidth, 1.f, 1.f));
+		Canvas->DrawScaledIcon(Icons[ICON_BOX], ScreenLocation.X + HorizontalOffset, ScreenLocation.Y, FVector(AuthIntentIdWidth, 1.f, 1.f));
 		Canvas->SetDrawColor(GetTextColorForBackgroundColor(VirtualWorkerColor));
 		Canvas->DrawText(RenderFont, FString::FromInt(DebuggingInfo->IntentVirtualWorkerId), ScreenLocation.X + HorizontalOffset + 1,
 						 ScreenLocation.Y, 1.1f, 1.1f, FontRenderInfo);
-		HorizontalOffset += (BaseHorizontalOffset * AuthIntentWidth);
+		HorizontalOffset += (BaseHorizontalOffset * AuthIntentIdWidth);
 	}
 
 	FString Label;

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
@@ -481,24 +481,25 @@ void ASpatialDebugger::DrawTag(UCanvas* Canvas, const FVector2D& ScreenLocation,
 		}
 		if (bShowAuth)
 		{
-			// If showing the authority, add the authority icon width and the width of the authoritative virtual worker ID 
+			// If showing the authority, add the authority icon width and the width of the authoritative virtual worker ID
 			TagWidth += BaseHorizontalOffset;
 			TagWidth += (BaseHorizontalOffset * AuthIdWidth);
 		}
 		if (bShowAuthIntent)
 		{
-			// If showing the authority intent, add the authority intent icon width and the width of the authoritative intent virtual worker ID 
+			// If showing the authority intent, add the authority intent icon width and the width of the authoritative intent virtual worker
+			// ID
 			TagWidth += BaseHorizontalOffset;
 			TagWidth += (BaseHorizontalOffset * AuthIntentIdWidth);
 		}
 		if (bShowEntityId)
 		{
-			// If showing the entity ID, add the width of the entity ID 
+			// If showing the entity ID, add the width of the entity ID
 			TagWidth += (BaseHorizontalOffset * EntityIdWidth);
 		}
 		if (bShowActorName)
 		{
-			// If showing the actor name, add the width of the actor name 
+			// If showing the actor name, add the width of the actor name
 			const float ActorNameWidth = TextScale * ActorName.Len();
 			TagWidth += (BaseHorizontalOffset * ActorNameWidth);
 		}
@@ -542,7 +543,8 @@ void ASpatialDebugger::DrawTag(UCanvas* Canvas, const FVector2D& ScreenLocation,
 		Canvas->DrawIcon(Icons[ICON_AUTH_INTENT], ScreenLocation.X + HorizontalOffset, ScreenLocation.Y, 1.0f);
 		HorizontalOffset += BaseHorizontalOffset;
 		Canvas->SetDrawColor(VirtualWorkerColor);
-		Canvas->DrawScaledIcon(Icons[ICON_BOX], ScreenLocation.X + HorizontalOffset, ScreenLocation.Y, FVector(AuthIntentIdWidth, 1.f, 1.f));
+		Canvas->DrawScaledIcon(Icons[ICON_BOX], ScreenLocation.X + HorizontalOffset, ScreenLocation.Y,
+							   FVector(AuthIntentIdWidth, 1.f, 1.f));
 		Canvas->SetDrawColor(GetTextColorForBackgroundColor(VirtualWorkerColor));
 		Canvas->DrawText(RenderFont, FString::FromInt(DebuggingInfo->IntentVirtualWorkerId), ScreenLocation.X + HorizontalOffset + 1,
 						 ScreenLocation.Y, 1.1f, 1.1f, FontRenderInfo);
@@ -643,7 +645,7 @@ void ASpatialDebugger::DrawDebug(UCanvas* Canvas, APlayerController* /* Controll
 					continue;
 				}
 
-				DrawTag(Canvas, ScreenLocation, EntityId, Actor->GetName(), true /*bCentre*/ );
+				DrawTag(Canvas, ScreenLocation, EntityId, Actor->GetName(), true /*bCentre*/);
 			}
 		}
 	}
@@ -680,7 +682,7 @@ void ASpatialDebugger::DrawDebugLocalPlayer(UCanvas* Canvas)
 	for (int32 i = 0; i < ActorsToDisplay.Num(); ++i)
 	{
 		const Worker_EntityId EntityId = NetDriver->PackageMap->GetEntityIdFromObject(ActorsToDisplay[i]);
-		DrawTag(Canvas, ScreenLocation, EntityId, ActorsToDisplay[i]->GetName(), false /*bCentre*/ );
+		DrawTag(Canvas, ScreenLocation, EntityId, ActorsToDisplay[i]->GetName(), false /*bCentre*/);
 		ScreenLocation.Y += PLAYER_TAG_VERTICAL_OFFSET;
 	}
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialDebugger.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialDebugger.h
@@ -211,7 +211,8 @@ private:
 	// FDebugDrawDelegate
 	void DrawDebug(UCanvas* Canvas, APlayerController* Controller);
 
-	void DrawTag(UCanvas* Canvas, const FVector2D& ScreenLocation, const Worker_EntityId EntityId, const FString& ActorName);
+	void DrawTag(UCanvas* Canvas, const FVector2D& ScreenLocation, const Worker_EntityId EntityId, const FString& ActorName,
+				 const bool bCentre);
 	void DrawDebugLocalPlayer(UCanvas* Canvas);
 
 	void CreateWorkerRegions();


### PR DESCRIPTION
#### Description
Centre the Spatial Debugger tags over the actor's world location no matter how many parts of the tag (ex. Authority, Lock, etc) are enabled.

For the actors in the world:
1. Calculate the total width of the icons and text to be rendered
2. Calculate the horizontal offset based on the total width
3. Draw icons and text based on the calculated offset

#### Release note
I think this is too minor for a release note.

#### Tests
Tested manually with a local deployment of the Handover Gym by viewing different combinations of tags (ex. Authority, Lock, etc). 
See screenshots below:

![solution_final](https://user-images.githubusercontent.com/64085832/95839100-436f2d80-0d4b-11eb-9184-e3f045c0ef51.png)
![solution_final_a](https://user-images.githubusercontent.com/64085832/95839117-4833e180-0d4b-11eb-9850-29ab54ff4b62.png)
![solution_final_b](https://user-images.githubusercontent.com/64085832/95839126-4a963b80-0d4b-11eb-9d6c-35892005084f.png)
![solution_final_c](https://user-images.githubusercontent.com/64085832/95839131-4cf89580-0d4b-11eb-98ba-cf0ed2c4afe8.png)
![solution_final_d](https://user-images.githubusercontent.com/64085832/95839135-4ec25900-0d4b-11eb-89c8-758d5f09e3c2.png)

QA Testing
As above (Press F9 to activate the Spatial Debugger runtime menu)

#### Documentation
Updated the Spatial Debugger animation in https://docs.google.com/document/d/1G9cRz891Ycaiax-M7Psx3rlfX8qTIi0CTk8_71PL4Zg/edit#heading=h.j4ppr52lw6ck

