### PR TITLE
Spatial debugger editor missing property change event

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/WorkerRegion.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/WorkerRegion.cpp
@@ -38,13 +38,15 @@ void AWorkerRegion::Init(UMaterial* BackgroundMaterial, UMaterial* InCombinedMat
 	// Setup the basic boundary material, this will always be shown in the editor
 	Mesh->SetMaterial(0, BackgroundMaterialInstance);
 
-	// For runtime, initialise the canvas for creating the combined boundary material which will be setup when the DrawToCanvasRenderTarget
+	// For runtime, initialise the canvas for creating the combined boundary material which will be rendered when the DrawToCanvasRenderTarget
 	// callback is triggered
 	CombinedMaterial = InCombinedMaterial;
 	WorkerInfoFont = InWorkerInfoFont;
 	WorkerInfo = InWorkerInfo;
 	CanvasRenderTarget = UCanvasRenderTarget2D::CreateCanvasRenderTarget2D(this, UCanvasRenderTarget2D::StaticClass(), 1024, 1024);
 	CanvasRenderTarget->OnCanvasRenderTargetUpdate.AddDynamic(this, &AWorkerRegion::DrawToCanvasRenderTarget);
+	// Setup the boundary material to combine background and text - needs to be created before SetOpacity
+	CombinedMaterialInstance = UMaterialInstanceDynamic::Create(CombinedMaterial, nullptr);
 
 	SetOpacity(Opacity);
 	SetColor(Color);
@@ -58,8 +60,7 @@ void AWorkerRegion::Init(UMaterial* BackgroundMaterial, UMaterial* InCombinedMat
 // at runtime and not in the editor
 void AWorkerRegion::DrawToCanvasRenderTarget(UCanvas* Canvas, int32 Width, int32 Height)
 {
-	// Setup the boundary material to combine background and text
-	CombinedMaterialInstance = UMaterialInstanceDynamic::Create(CombinedMaterial, nullptr);
+	// Set the boundary material that combines background and text
 	Mesh->SetMaterial(0, CombinedMaterialInstance);
 
 	// Draw the worker background to the canvas
@@ -82,10 +83,7 @@ void AWorkerRegion::SetHeight(const float Height)
 void AWorkerRegion::SetOpacity(const float Opacity)
 {
 	BackgroundMaterialInstance->SetScalarParameterValue(WORKER_REGION_MATERIAL_OPACITY_PARAM, Opacity);
-	if (CombinedMaterialInstance != nullptr)
-	{
-		CombinedMaterialInstance->SetScalarParameterValue(WORKER_REGION_MATERIAL_OPACITY_PARAM, Opacity);
-	}
+	CombinedMaterialInstance->SetScalarParameterValue(WORKER_REGION_MATERIAL_OPACITY_PARAM, Opacity);
 }
 
 void AWorkerRegion::SetPositionAndScale(const FBox2D& Extents, const float VerticalScale)

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/WorkerRegion.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/WorkerRegion.cpp
@@ -38,8 +38,8 @@ void AWorkerRegion::Init(UMaterial* BackgroundMaterial, UMaterial* InCombinedMat
 	// Setup the basic boundary material, this will always be shown in the editor
 	Mesh->SetMaterial(0, BackgroundMaterialInstance);
 
-	// For runtime, initialise the canvas for creating the combined boundary material which will be rendered when the DrawToCanvasRenderTarget
-	// callback is triggered
+	// For runtime, initialise the canvas for creating the combined boundary material which will be rendered when the
+	// DrawToCanvasRenderTarget callback is triggered
 	CombinedMaterial = InCombinedMaterial;
 	WorkerInfoFont = InWorkerInfoFont;
 	WorkerInfo = InWorkerInfo;

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
@@ -764,7 +764,7 @@ void ASpatialDebugger::PostEditChangeProperty(FPropertyChangedEvent& PropertyCha
 		if (PropertyName == GET_MEMBER_NAME_CHECKED(ASpatialDebugger, WorkerRegionHeight)
 			|| PropertyName == GET_MEMBER_NAME_CHECKED(ASpatialDebugger, WorkerRegionVerticalScale)
 			|| PropertyName == GET_MEMBER_NAME_CHECKED(ASpatialDebugger, WorkerRegionOpacity))
-			
+
 		{
 			EditorRefreshWorkerRegions();
 		}

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
@@ -760,7 +760,6 @@ void ASpatialDebugger::PostEditChangeProperty(FPropertyChangedEvent& PropertyCha
 	if (PropertyChangedEvent.Property != nullptr)
 	{
 		const FName PropertyName(PropertyChangedEvent.Property->GetFName());
-		// TODO: Add opacity and check for any other properties that affect look
 		if (PropertyName == GET_MEMBER_NAME_CHECKED(ASpatialDebugger, WorkerRegionHeight)
 			|| PropertyName == GET_MEMBER_NAME_CHECKED(ASpatialDebugger, WorkerRegionVerticalScale)
 			|| PropertyName == GET_MEMBER_NAME_CHECKED(ASpatialDebugger, WorkerRegionOpacity))

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialDebugger.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialDebugger.h
@@ -222,6 +222,7 @@ private:
 
 #if WITH_EDITOR
 	void EditorInitialiseWorkerRegions();
+	void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent);
 #endif
 
 	static const int ENTITY_ACTOR_MAP_RESERVATION_COUNT = 512;


### PR DESCRIPTION
#### Description
Added a property changed event for Spatial Debugger to refresh the worker regions in the editor when any visible property change is made to the Worker Regions e.g. Opacity, Height, and Vertical Scale. 
Also fixed an issue with Opacity not updating on the new combined worker boundary material.

#### Release note
These changes relate to new features that have not been released yet so I think a note about the bug is not needed.

#### Tests
Added tests to https://docs.google.com/spreadsheets/d/1Ld-2mkBAhA3i7Asf39tf_JeWScbw1Ya3mlYXGDrrWZw/edit#gid=0

STRONGLY SUGGESTED: How can this be verified by QA?
Run the new tests from the above test plan in the section: Change Spatial Debugger visual properties

#### Documentation
These changes relate to new features that have not been released yet so I think a note about the bug is not needed.
