### PR TITLE
Spatial view stuff critical section cleanup

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialEventTracer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialEventTracer.cpp
@@ -187,32 +187,27 @@ void SpatialEventTracer::StreamDeleter::operator()(Io_Stream* StreamToDestroy) c
 	Io_Stream_Destroy(StreamToDestroy);
 }
 
-void SpatialEventTracer::AddComponent(const Worker_Op& Op)
+void SpatialEventTracer::AddComponent(Worker_EntityId EntityId, Worker_ComponentId ComponentId, const Trace_SpanId& SpanId)
 {
-	const Worker_AddComponentOp& AddComponentOp = Op.op.add_component;
-	EntityComponentId Id(AddComponentOp.entity_id, AddComponentOp.data.component_id);
-	EntityComponentSpanIds.FindOrAdd(Id, Op.span_id);
+	EntityComponentSpanIds.FindOrAdd({ EntityId, ComponentId }, SpanId);
 }
 
-void SpatialEventTracer::RemoveComponent(const Worker_Op& Op)
+void SpatialEventTracer::RemoveComponent(Worker_EntityId EntityId, Worker_ComponentId ComponentId)
 {
-	const Worker_RemoveComponentOp& RemoveComponentOp = Op.op.remove_component;
-	EntityComponentId Id(RemoveComponentOp.entity_id, RemoveComponentOp.component_id);
-	EntityComponentSpanIds.Remove(Id);
+	EntityComponentSpanIds.Remove({ EntityId, ComponentId });
 }
 
-void SpatialEventTracer::UpdateComponent(const Worker_Op& Op)
+void SpatialEventTracer::UpdateComponent(Worker_EntityId EntityId, Worker_ComponentId ComponentId, const Trace_SpanId& SpanId)
 {
-	const Worker_ComponentUpdateOp& ComponentUpdateOp = Op.op.component_update;
-	EntityComponentId Id = { ComponentUpdateOp.entity_id, ComponentUpdateOp.update.component_id };
+	const EntityComponentId Id = { EntityId, ComponentId };
 
-	Trace_SpanId& OldSpanId = EntityComponentSpanIds.FindChecked(Id);
+	Trace_SpanId& StoredSpanId = EntityComponentSpanIds.FindChecked(Id);
 
-	Trace_SpanId MergeCauses[2] = { Op.span_id, OldSpanId };
-	TOptional<Trace_SpanId> SpanId = CreateSpan(MergeCauses, 2);
-	TraceEvent(FSpatialTraceEventBuilder::CreateMergeComponentUpdate(Id.EntityId, Id.ComponentId), SpanId);
+	Trace_SpanId MergeCauses[2] = { SpanId, StoredSpanId };
+	TOptional<Trace_SpanId> NewSpanId = CreateSpan(MergeCauses, 2);
+	TraceEvent(FSpatialTraceEventBuilder::CreateMergeComponentUpdate(Id.EntityId, Id.ComponentId), NewSpanId);
 
-	OldSpanId = SpanId.GetValue();
+	StoredSpanId = NewSpanId.GetValue();
 }
 
 Trace_SpanId SpatialEventTracer::GetSpanId(const EntityComponentId& Id) const

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/CriticalSectionFilter.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/CriticalSectionFilter.cpp
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "SpatialView/CriticalSectionFilter.h"
+
+#include "SpatialView/OpList/SplitOpList.h"
+
+namespace SpatialGDK
+{
+void FCriticalSectionFilter::AddOpList(OpList Ops)
+{ // Ensure that we only process closed critical sections.
+	// Scan backwards looking for critical sections ops.
+	for (uint32 i = Ops.Count; i > 0; --i)
+	{
+		Worker_Op& Op = Ops.Ops[i - 1];
+		if (Op.op_type != WORKER_OP_TYPE_CRITICAL_SECTION)
+		{
+			continue;
+		}
+
+		// There can only be one critical section open at a time.
+		// So any previous open critical section must now be closed.
+		for (OpList& OpenCriticalSection : OpenCriticalSectionOps)
+		{
+			ReadyOps.Add(MoveTemp(OpenCriticalSection));
+		}
+		OpenCriticalSectionOps.Empty();
+
+		// If critical section op is opening the section then enqueue any ops before this point and store the open critical section.
+		if (Op.op.critical_section.in_critical_section)
+		{
+			SplitOpListPair SplitOpLists(MoveTemp(Ops), i);
+			ReadyOps.Add(MoveTemp(SplitOpLists.Head));
+			OpenCriticalSectionOps.Add(MoveTemp(SplitOpLists.Tail));
+		}
+		// If critical section op is closing the section then enqueue all ops.
+		else
+		{
+			ReadyOps.Add(MoveTemp(Ops));
+		}
+		return;
+	}
+
+	// If no critical section is present then either add this to existing open section ops if there are any or enqueue if not.
+	if (OpenCriticalSectionOps.Num())
+	{
+		OpenCriticalSectionOps.Push(MoveTemp(Ops));
+	}
+	else
+	{
+		ReadyOps.Push(MoveTemp(Ops));
+	}
+}
+
+TArray<OpList> FCriticalSectionFilter::GetReadyOpLists()
+{
+	TArray<OpList> Temp = MoveTemp(ReadyOps);
+	ReadyOps.Empty();
+	return Temp;
+}
+} // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/CriticalSectionFilter.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/CriticalSectionFilter.cpp
@@ -7,8 +7,15 @@
 namespace SpatialGDK
 {
 void FCriticalSectionFilter::AddOpList(OpList Ops)
-{ // Ensure that we only process closed critical sections.
-	// Scan backwards looking for critical sections ops.
+{
+	// Work out which ops are in an open critical section by scanning backwards to the first critical sections op.
+	// Critical sections can't overlap so if the first op we find (the last one in the list) tells us the status of all received ops,
+	//
+	// If the first critical section op found is closed, we know that there are no open critical sections.
+	// In this case we expose all received ops as ready.
+	//
+	// If the first critical section op we find is open, we know that all subsequent ops are in an open critical section.
+	// In this case we split the op list around the open critical section start, set the first part to ready and queue the second.
 	for (uint32 i = Ops.Count; i > 0; --i)
 	{
 		Worker_Op& Op = Ops.Ops[i - 1];

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ReceivedOpEventHandler.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ReceivedOpEventHandler.cpp
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "SpatialView/ReceivedOpEventHandler.h"
+
+#include "Interop/Connection/SpatialTraceEventBuilder.h"
+
+namespace SpatialGDK
+{
+FReceivedOpEventHandler::FReceivedOpEventHandler(TSharedPtr<SpatialEventTracer> EventTracer)
+	: EventTracer(MoveTemp(EventTracer))
+{
+}
+
+void FReceivedOpEventHandler::ProcessOpLists(const OpList& Ops)
+{
+	if (EventTracer == nullptr || !EventTracer->IsEnabled())
+	{
+		return;
+	}
+
+	for (uint32 i = 0; i < Ops.Count; ++i)
+	{
+		Worker_Op& Op = Ops.Ops[i];
+
+		switch (static_cast<Worker_OpType>(Op.op_type))
+		{
+		case WORKER_OP_TYPE_ADD_ENTITY:
+			EventTracer->TraceEvent(FSpatialTraceEventBuilder::CreateReceiveCreateEntity(Op.op.add_entity.entity_id),
+									EventTracer->CreateSpan(&Op.span_id, 1));
+			break;
+		case WORKER_OP_TYPE_REMOVE_ENTITY:
+			EventTracer->TraceEvent(FSpatialTraceEventBuilder::CreateReceiveRemoveEntity(Op.op.remove_entity.entity_id),
+									EventTracer->CreateSpan(&Op.span_id, 1));
+			break;
+		case WORKER_OP_TYPE_ADD_COMPONENT:
+			EventTracer->AddComponent(Op.op.add_component.entity_id, Op.op.add_component.data.component_id, Op.span_id);
+			break;
+		case WORKER_OP_TYPE_REMOVE_COMPONENT:
+			EventTracer->RemoveComponent(Op.op.remove_component.entity_id, Op.op.remove_component.component_id);
+			break;
+		case WORKER_OP_TYPE_AUTHORITY_CHANGE:
+			EventTracer->TraceEvent(
+				FSpatialTraceEventBuilder::CreateAuthorityChange(Op.op.authority_change.entity_id, Op.op.authority_change.component_id,
+																 static_cast<Worker_Authority>(Op.op.authority_change.authority)),
+				EventTracer->CreateSpan(&Op.span_id, 1));
+			break;
+		case WORKER_OP_TYPE_COMPONENT_UPDATE:
+			EventTracer->UpdateComponent(Op.op.component_update.entity_id, Op.op.component_update.update.component_id, Op.span_id);
+			break;
+		default:
+			break;
+		}
+	}
+}
+
+} // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewCoordinator.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewCoordinator.cpp
@@ -24,9 +24,9 @@ void ViewCoordinator::Advance()
 	const uint32 OpListCount = ConnectionHandler->GetOpListCount();
 	for (uint32 i = 0; i < OpListCount; ++i)
 	{
-		View.EnqueueOpList(ConnectionHandler->GetNextOpList());
+		CriticalSectionFilter.AddOpList(ConnectionHandler->GetNextOpList());
 	}
-	View.AdvanceViewDelta();
+	View.AdvanceViewDelta(CriticalSectionFilter.GetReadyOpLists());
 	Dispatcher.InvokeCallbacks(View.GetViewDelta().GetEntityDeltas());
 
 	for (const TUniquePtr<FSubView>& SubviewToAdvance : SubViews)

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewCoordinator.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewCoordinator.cpp
@@ -53,7 +53,7 @@ void ViewCoordinator::FlushMessagesToSend()
 FSubView& ViewCoordinator::CreateSubView(Worker_ComponentId Tag, const FFilterPredicate& Filter,
 										 const TArray<FDispatcherRefreshCallback>& DispatcherRefreshCallbacks)
 {
-	const int Index = SubViews.Emplace(MakeUnique<FSubView>(Tag, Filter, View.GetViewPtr(), Dispatcher, DispatcherRefreshCallbacks));
+	const int Index = SubViews.Emplace(MakeUnique<FSubView>(Tag, Filter, &View.GetView(), Dispatcher, DispatcherRefreshCallbacks));
 	return *SubViews[Index];
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
@@ -2,7 +2,6 @@
 
 #include "SpatialView/ViewDelta.h"
 
-#include "Interop/Connection/SpatialEventTracer.h"
 #include "Interop/Connection/SpatialTraceEventBuilder.h"
 #include "SpatialView/EntityComponentTypes.h"
 
@@ -11,27 +10,12 @@
 
 namespace SpatialGDK
 {
-ViewDelta::ViewDelta()
-	: EventTracer(nullptr)
-{
-}
-
-ViewDelta::ViewDelta(SpatialEventTracer* InEventTracer)
-	: EventTracer(InEventTracer)
-{
-}
-
 void ViewDelta::SetFromOpList(TArray<OpList> OpLists, EntityView& View)
 {
 	Clear();
 	for (OpList& Ops : OpLists)
 	{
-		const uint32 Count = Ops.Count;
-		Worker_Op* OpData = Ops.Ops;
-		for (uint32 i = 0; i < Count; ++i)
-		{
-			ProcessOp(OpData[i]);
-		}
+		ProcessOpList(Ops);
 	}
 	OpListStorage = MoveTemp(OpLists);
 
@@ -345,85 +329,57 @@ ComponentChange ViewDelta::CalculateUpdate(ReceivedComponentChange* Start, Recei
 	return ComponentChange(Start->ComponentId, Update);
 }
 
-void ViewDelta::ProcessOp(Worker_Op& Op)
+void ViewDelta::ProcessOpList(const OpList& Ops)
 {
-	bool bEventTracerEnabled = EventTracer != nullptr && EventTracer->IsEnabled();
-
-	switch (static_cast<Worker_OpType>(Op.op_type))
+	for (uint32 i = 0; i < Ops.Count; ++i)
 	{
-	case WORKER_OP_TYPE_DISCONNECT:
-		ConnectionStatusCode = Op.op.disconnect.connection_status_code;
-		ConnectionStatusMessage = Op.op.disconnect.reason;
-		break;
-	case WORKER_OP_TYPE_LOG_MESSAGE:
-		// Log messages deprecated.
-		break;
-	case WORKER_OP_TYPE_CRITICAL_SECTION:
-		// Ignore critical sections.
-		break;
-	case WORKER_OP_TYPE_ADD_ENTITY:
-		EntityChanges.Push(ReceivedEntityChange{ Op.op.add_entity.entity_id, true });
-		if (bEventTracerEnabled)
+		const Worker_Op& Op = Ops.Ops[i];
+		switch (static_cast<Worker_OpType>(Op.op_type))
 		{
-			TOptional<Trace_SpanId> SpanId = EventTracer->CreateSpan(&Op.span_id, 1);
-			EventTracer->TraceEvent(FSpatialTraceEventBuilder::CreateReceiveCreateEntity(Op.op.add_entity.entity_id), SpanId);
+		case WORKER_OP_TYPE_DISCONNECT:
+			ConnectionStatusCode = Op.op.disconnect.connection_status_code;
+			ConnectionStatusMessage = Op.op.disconnect.reason;
+			break;
+		case WORKER_OP_TYPE_LOG_MESSAGE:
+			// Log messages deprecated.
+			break;
+		case WORKER_OP_TYPE_CRITICAL_SECTION:
+			// Ignore critical sections.
+			break;
+		case WORKER_OP_TYPE_ADD_ENTITY:
+			EntityChanges.Push(ReceivedEntityChange{ Op.op.add_entity.entity_id, true });
+			break;
+		case WORKER_OP_TYPE_REMOVE_ENTITY:
+			EntityChanges.Push(ReceivedEntityChange{ Op.op.remove_entity.entity_id, false });
+			break;
+		case WORKER_OP_TYPE_METRICS:
+		case WORKER_OP_TYPE_FLAG_UPDATE:
+		case WORKER_OP_TYPE_RESERVE_ENTITY_IDS_RESPONSE:
+		case WORKER_OP_TYPE_CREATE_ENTITY_RESPONSE:
+		case WORKER_OP_TYPE_DELETE_ENTITY_RESPONSE:
+		case WORKER_OP_TYPE_ENTITY_QUERY_RESPONSE:
+		case WORKER_OP_TYPE_COMMAND_REQUEST:
+		case WORKER_OP_TYPE_COMMAND_RESPONSE:
+			WorkerMessages.Push(Op);
+			break;
+		case WORKER_OP_TYPE_ADD_COMPONENT:
+			ComponentChanges.Emplace(Op.op.add_component);
+			break;
+		case WORKER_OP_TYPE_REMOVE_COMPONENT:
+			ComponentChanges.Emplace(Op.op.remove_component);
+			break;
+		case WORKER_OP_TYPE_AUTHORITY_CHANGE:
+			if (Op.op.authority_change.authority != WORKER_AUTHORITY_AUTHORITY_LOSS_IMMINENT)
+			{
+				AuthorityChanges.Emplace(Op.op.authority_change);
+			}
+			break;
+		case WORKER_OP_TYPE_COMPONENT_UPDATE:
+			ComponentChanges.Emplace(Op.op.component_update);
+			break;
+		default:
+			break;
 		}
-		break;
-	case WORKER_OP_TYPE_REMOVE_ENTITY:
-		EntityChanges.Push(ReceivedEntityChange{ Op.op.remove_entity.entity_id, false });
-		if (bEventTracerEnabled)
-		{
-			TOptional<Trace_SpanId> SpanId = EventTracer->CreateSpan(&Op.span_id, 1);
-			EventTracer->TraceEvent(FSpatialTraceEventBuilder::CreateReceiveRemoveEntity(Op.op.remove_entity.entity_id), SpanId);
-		}
-		break;
-	case WORKER_OP_TYPE_METRICS:
-	case WORKER_OP_TYPE_FLAG_UPDATE:
-	case WORKER_OP_TYPE_RESERVE_ENTITY_IDS_RESPONSE:
-	case WORKER_OP_TYPE_CREATE_ENTITY_RESPONSE:
-	case WORKER_OP_TYPE_DELETE_ENTITY_RESPONSE:
-	case WORKER_OP_TYPE_ENTITY_QUERY_RESPONSE:
-	case WORKER_OP_TYPE_COMMAND_REQUEST:
-	case WORKER_OP_TYPE_COMMAND_RESPONSE:
-		WorkerMessages.Push(Op);
-		break;
-	case WORKER_OP_TYPE_ADD_COMPONENT:
-		ComponentChanges.Emplace(Op.op.add_component);
-		if (bEventTracerEnabled)
-		{
-			EventTracer->AddComponent(Op);
-		}
-		break;
-	case WORKER_OP_TYPE_REMOVE_COMPONENT:
-		ComponentChanges.Emplace(Op.op.remove_component);
-		if (bEventTracerEnabled)
-		{
-			EventTracer->RemoveComponent(Op);
-		}
-		break;
-	case WORKER_OP_TYPE_AUTHORITY_CHANGE:
-		if (Op.op.authority_change.authority != WORKER_AUTHORITY_AUTHORITY_LOSS_IMMINENT)
-		{
-			AuthorityChanges.Emplace(Op.op.authority_change);
-		}
-		if (bEventTracerEnabled)
-		{
-			TOptional<Trace_SpanId> SpanId = EventTracer->CreateSpan(&Op.span_id, 1);
-			EventTracer->TraceEvent(
-				FSpatialTraceEventBuilder::CreateAuthorityChange(Op.op.authority_change.entity_id, Op.op.authority_change.component_id,
-																 static_cast<Worker_Authority>(Op.op.authority_change.authority)),
-				SpanId);
-		}
-		break;
-	case WORKER_OP_TYPE_COMPONENT_UPDATE:
-		ComponentChanges.Emplace(Op.op.component_update);
-		if (bEventTracerEnabled)
-		{
-			EventTracer->UpdateComponent(Op);
-		}
-		break;
-	default:
-		break;
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/WorkerView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/WorkerView.cpp
@@ -8,10 +8,8 @@
 
 namespace SpatialGDK
 {
-WorkerView::WorkerView(SpatialEventTracer* InEventTracer)
-	: Delta(InEventTracer)
-	, LocalChanges(MakeUnique<MessagesToSend>())
-	, EventTracer(InEventTracer)
+WorkerView::WorkerView()
+	: LocalChanges(MakeUnique<MessagesToSend>())
 {
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/WorkerView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/WorkerView.cpp
@@ -32,11 +32,6 @@ const EntityView& WorkerView::GetView() const
 	return View;
 }
 
-const EntityView* WorkerView::GetViewPtr() const
-{
-	return &View;
-}
-
 void WorkerView::EnqueueOpList(OpList Ops)
 {
 	// Ensure that we only process closed critical sections.

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/WorkerView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/WorkerView.cpp
@@ -15,11 +15,9 @@ WorkerView::WorkerView(SpatialEventTracer* InEventTracer)
 {
 }
 
-void WorkerView::AdvanceViewDelta()
+void WorkerView::AdvanceViewDelta(TArray<OpList> OpLists)
 {
-	Delta.Clear();
-	Delta.SetFromOpList(MoveTemp(QueuedOps), View);
-	QueuedOps.Empty();
+	Delta.SetFromOpList(MoveTemp(OpLists), View);
 }
 
 const ViewDelta& WorkerView::GetViewDelta() const
@@ -30,52 +28,6 @@ const ViewDelta& WorkerView::GetViewDelta() const
 const EntityView& WorkerView::GetView() const
 {
 	return View;
-}
-
-void WorkerView::EnqueueOpList(OpList Ops)
-{
-	// Ensure that we only process closed critical sections.
-	// Scan backwards looking for critical sections ops.
-	for (uint32 i = Ops.Count; i > 0; --i)
-	{
-		Worker_Op& Op = Ops.Ops[i - 1];
-		if (Op.op_type != WORKER_OP_TYPE_CRITICAL_SECTION)
-		{
-			continue;
-		}
-
-		// There can only be one critical section open at a time.
-		// So any previous open critical section must now be closed.
-		for (OpList& OpenCriticalSection : OpenCriticalSectionOps)
-		{
-			QueuedOps.Add(MoveTemp(OpenCriticalSection));
-		}
-		OpenCriticalSectionOps.Empty();
-
-		// If critical section op is opening the section then enqueue any ops before this point and store the open critical section.
-		if (Op.op.critical_section.in_critical_section)
-		{
-			SplitOpListPair SplitOpLists(MoveTemp(Ops), i);
-			QueuedOps.Add(MoveTemp(SplitOpLists.Head));
-			OpenCriticalSectionOps.Add(MoveTemp(SplitOpLists.Tail));
-		}
-		// If critical section op is closing the section then enqueue all ops.
-		else
-		{
-			QueuedOps.Add(MoveTemp(Ops));
-		}
-		return;
-	}
-
-	// If no critical section is present then either add this to existing open section ops if there are any or enqueue if not.
-	if (OpenCriticalSectionOps.Num())
-	{
-		OpenCriticalSectionOps.Push(MoveTemp(Ops));
-	}
-	else
-	{
-		QueuedOps.Push(MoveTemp(Ops));
-	}
 }
 
 TUniquePtr<MessagesToSend> WorkerView::FlushLocalChanges()

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/WorkerViewTest.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/WorkerViewTest.cpp
@@ -12,7 +12,7 @@ using namespace SpatialGDK;
 WORKERVIEW_TEST(GIVEN_WorkerView_with_one_CreateEntityRequest_WHEN_FlushLocalChanges_called_THEN_one_CreateEntityRequest_returned)
 {
 	// GIVEN
-	WorkerView View(nullptr);
+	WorkerView View;
 	CreateEntityRequest Request = {};
 	View.SendCreateEntityRequest(MoveTemp(Request));
 
@@ -29,7 +29,7 @@ WORKERVIEW_TEST(
 	GIVEN_WorkerView_with_multiple_CreateEntityRequest_WHEN_FlushLocalChanges_called_THEN_mutliple_CreateEntityRequests_returned)
 {
 	// GIVEN
-	WorkerView View(nullptr);
+	WorkerView View;
 	CreateEntityRequest Request = {};
 	View.SendCreateEntityRequest(MoveTemp(Request));
 	View.SendCreateEntityRequest(MoveTemp(Request));

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialEventTracer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialEventTracer.h
@@ -30,9 +30,9 @@ public:
 
 	bool IsEnabled() const;
 
-	void AddComponent(const Worker_Op& Op);
-	void RemoveComponent(const Worker_Op& Op);
-	void UpdateComponent(const Worker_Op& Op);
+	void AddComponent(Worker_EntityId EntityId, Worker_ComponentId ComponentId, const Trace_SpanId& SpanId);
+	void RemoveComponent(Worker_EntityId EntityId, Worker_ComponentId ComponentId);
+	void UpdateComponent(Worker_EntityId EntityId, Worker_ComponentId ComponentId, const Trace_SpanId& SpanId);
 
 	Trace_SpanId GetSpanId(const EntityComponentId& Id) const;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/CriticalSectionFilter.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/CriticalSectionFilter.h
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "Containers/Array.h"
+#include "OpList/OpList.h"
+
+namespace SpatialGDK
+{
+class FCriticalSectionFilter
+{
+public:
+	void AddOpList(OpList Ops);
+	TArray<OpList> GetReadyOpLists();
+
+private:
+	TArray<OpList> ReadyOps;
+	TArray<OpList> OpenCriticalSectionOps;
+};
+} // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/CriticalSectionFilter.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/CriticalSectionFilter.h
@@ -7,6 +7,7 @@
 
 namespace SpatialGDK
 {
+// Splits and queues op lists to ensure that we don't partially process open critical sections.
 class FCriticalSectionFilter
 {
 public:

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ReceivedOpEventHandler.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ReceivedOpEventHandler.h
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "Interop/Connection/SpatialEventTracer.h"
+#include "OpList/OpList.h"
+
+namespace SpatialGDK
+{
+class FReceivedOpEventHandler
+{
+public:
+	explicit FReceivedOpEventHandler(TSharedPtr<SpatialEventTracer> EventTracer = nullptr);
+	void ProcessOpLists(const OpList& Ops);
+
+private:
+	TSharedPtr<SpatialEventTracer> EventTracer;
+};
+} // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewCoordinator.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewCoordinator.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "SpatialView/ConnectionHandler/AbstractConnectionHandler.h"
+#include "SpatialView/CriticalSectionFilter.h"
 #include "SpatialView/Dispatcher.h"
 #include "SpatialView/WorkerView.h"
 #include "SubView.h"
@@ -83,11 +84,14 @@ public:
 private:
 	WorkerView View;
 	TUniquePtr<AbstractConnectionHandler> ConnectionHandler;
+
+	FCriticalSectionFilter CriticalSectionFilter;
+
 	Worker_RequestId NextRequestId;
 	FDispatcher Dispatcher;
+
 	TArray<TUniquePtr<FSubView>> SubViews;
 
-	// Stored on ViewCoordinator to handle lifetime
 	TSharedPtr<SpatialEventTracer> EventTracer;
 };
 

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewCoordinator.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewCoordinator.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "ReceivedOpEventHandler.h"
 #include "SpatialView/ConnectionHandler/AbstractConnectionHandler.h"
 #include "SpatialView/CriticalSectionFilter.h"
 #include "SpatialView/Dispatcher.h"
@@ -92,7 +93,7 @@ private:
 
 	TArray<TUniquePtr<FSubView>> SubViews;
 
-	TSharedPtr<SpatialEventTracer> EventTracer;
+	FReceivedOpEventHandler ReceivedOpEventHandler;
 };
 
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/ViewDelta.h
@@ -16,8 +16,6 @@ struct FSubViewDelta
 	const TArray<Worker_Op>* WorkerMessages;
 };
 
-class SpatialEventTracer;
-
 /**
  * Lists of changes made to a view as a list of EntityDeltas and miscellaneous other messages.
  * EntityDeltas are sorted by entity ID.
@@ -38,9 +36,6 @@ class SpatialEventTracer;
 class ViewDelta
 {
 public:
-	ViewDelta();
-	explicit ViewDelta(SpatialEventTracer* InEventTracer);
-
 	void SetFromOpList(TArray<OpList> OpLists, EntityView& View);
 	// Produces a projection of a given main view delta to a sub view delta. The passed SubViewDelta is populated with
 	// the projection. The given arrays represent the state of the sub view and dictates the projection.
@@ -56,8 +51,6 @@ public:
 	bool HasConnectionStatusChanged() const;
 	Worker_ConnectionStatusCode GetConnectionStatusChange() const;
 	FString GetConnectionStatusChangeMessage() const;
-
-	SpatialEventTracer* EventTracer;
 
 private:
 	struct ReceivedComponentChange
@@ -136,7 +129,7 @@ private:
 	// The accumulated component change in this range must be an update or a complete-update.
 	static ComponentChange CalculateUpdate(ReceivedComponentChange* Start, ReceivedComponentChange* End, ComponentData& Component);
 
-	void ProcessOp(Worker_Op& Op);
+	void ProcessOpList(const OpList& Ops);
 	void PopulateEntityDeltas(EntityView& View);
 
 	// Adds component changes to `Delta` and updates `Components` accordingly.
@@ -183,5 +176,4 @@ private:
 	TArray<ComponentChange> ComponentsRefreshedForDelta;
 	TArray<OpList> OpListStorage;
 };
-
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/WorkerView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/WorkerView.h
@@ -22,7 +22,6 @@ public:
 
 	const ViewDelta& GetViewDelta() const;
 	const EntityView& GetView() const;
-	const EntityView* GetViewPtr() const;
 
 	// Add an OpList to generate the next ViewDelta.
 	void EnqueueOpList(OpList Ops);

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/WorkerView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/WorkerView.h
@@ -2,19 +2,16 @@
 
 #pragma once
 
-#include "Containers/Set.h"
 #include "SpatialView/MessagesToSend.h"
 #include "SpatialView/OpList/OpList.h"
 #include "SpatialView/ViewDelta.h"
 
 namespace SpatialGDK
 {
-class SpatialEventTracer;
-
 class WorkerView
 {
 public:
-	explicit WorkerView(SpatialEventTracer* InEventTracer);
+	WorkerView();
 
 	// Process op lists to create a new view delta.
 	// The view delta will exist until the next call to AdvanceViewDelta.
@@ -44,7 +41,5 @@ private:
 	ViewDelta Delta;
 
 	TUniquePtr<MessagesToSend> LocalChanges;
-
-	SpatialEventTracer* EventTracer;
 };
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/WorkerView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/WorkerView.h
@@ -16,15 +16,12 @@ class WorkerView
 public:
 	explicit WorkerView(SpatialEventTracer* InEventTracer);
 
-	// Process queued op lists to create a new view delta.
-	// The view delta will exist until the next call to advance.
-	void AdvanceViewDelta();
+	// Process op lists to create a new view delta.
+	// The view delta will exist until the next call to AdvanceViewDelta.
+	void AdvanceViewDelta(TArray<OpList> OpLists);
 
 	const ViewDelta& GetViewDelta() const;
 	const EntityView& GetView() const;
-
-	// Add an OpList to generate the next ViewDelta.
-	void EnqueueOpList(OpList Ops);
 
 	// Ensure all local changes have been applied and return the resulting MessagesToSend.
 	TUniquePtr<MessagesToSend> FlushLocalChanges();
@@ -46,12 +43,8 @@ private:
 	EntityView View;
 	ViewDelta Delta;
 
-	TArray<OpList> QueuedOps;
-	TArray<OpList> OpenCriticalSectionOps;
-
 	TUniquePtr<MessagesToSend> LocalChanges;
 
 	SpatialEventTracer* EventTracer;
 };
-
 } // namespace SpatialGDK


### PR DESCRIPTION
Read in commit order to prevent long term health problems.

#### Description
Follow up work to the event tracing stuff.
Moves the critical section filtering from the worker view. Making it possible to remove event tracing code from the view delta.