### PR TITLE
Increment RequireSetup for event tracing

### DIFF
--- a/RequireSetup
+++ b/RequireSetup
@@ -1,4 +1,4 @@
 Increment the below number whenever it is required to run Setup.bat as part of a new commit.
 Our git hooks will detect this file has been updated and automatically run Setup.bat on pull.
 
-67
+68


### PR DESCRIPTION
#### Description
Event tracing doesn't compile unless you run `Setup.bat` to update the worker libs. Incrementing `RequireSetup` will run `Setup.bat` automatically when someone pulls master.

#### Primary reviewers
@MatthewSandfordImprobable @improbable-danny 
