### PR TITLE
[UNR-4301] Spike routing worker

### DIFF
--- a/SpatialGDK/Extras/schema/query_tags.schema
+++ b/SpatialGDK/Extras/schema/query_tags.schema
@@ -34,3 +34,7 @@ component ServerNonAuthGDKKnownEntityTag {
 component ClientGDKKnownEntityTag {
     id = 2008;
 }
+
+component RoutingWorkerEntityTag {
+    id = 2009;
+}

--- a/SpatialGDK/Extras/schema/rpc_payload.schema
+++ b/SpatialGDK/Extras/schema/rpc_payload.schema
@@ -12,3 +12,13 @@ type UnrealRPCPayload {
     bytes rpc_payload = 3;
     option<TracePayload> rpc_trace = 4;
 }
+
+type ACKList {
+    list<uint64> acks = 1;
+}
+
+type ACKItem {
+    EntityId sender = 1;
+    uint64 rpc_id = 2;
+    uint64 sender_revision = 3;
+}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslationManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslationManager.cpp
@@ -131,7 +131,7 @@ void SpatialVirtualWorkerTranslationManager::SendVirtualWorkerMappingUpdate() co
 
 void SpatialVirtualWorkerTranslationManager::QueryForServerWorkerEntities()
 {
-	UE_LOG(LogSpatialVirtualWorkerTranslationManager, Log, TEXT("Sending query for WorkerEntities"));
+	UE_LOG(LogSpatialVirtualWorkerTranslationManager, Verbose, TEXT("Sending query for WorkerEntities"));
 
 	if (bWorkerEntityQueryInFlight)
 	{
@@ -179,7 +179,7 @@ void SpatialVirtualWorkerTranslationManager::ServerWorkerEntityQueryDelegate(con
 	}
 	else
 	{
-		UE_LOG(LogSpatialVirtualWorkerTranslationManager, Log, TEXT("Processing ServerWorker Entity query response"));
+		UE_LOG(LogSpatialVirtualWorkerTranslationManager, Verbose, TEXT("Processing ServerWorker Entity query response"));
 		ConstructVirtualWorkerMappingFromQueryResponse(Op);
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
@@ -192,6 +192,11 @@ const TArray<FString>& USpatialWorkerConnection::GetWorkerAttributes() const
 	return Coordinator->GetWorkerAttributes();
 }
 
+SpatialGDK::ViewCoordinator& USpatialWorkerConnection::GetCoordinator() const
+{
+	return *Coordinator;
+}
+
 SpatialGDK::CallbackId USpatialWorkerConnection::RegisterComponentAddedCallback(Worker_ComponentId ComponentId,
 																				SpatialGDK::FComponentValueCallback Callback)
 {

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
@@ -78,7 +78,6 @@ void UGlobalStateManager::ApplyDeploymentMapData(const Worker_ComponentData& Dat
 void UGlobalStateManager::ApplyStartupActorManagerData(const Worker_ComponentData& Data)
 {
 	Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
-
 	bCanBeginPlay = GetBoolFromSchema(ComponentObject, SpatialConstants::STARTUP_ACTOR_MANAGER_CAN_BEGIN_PLAY_ID);
 
 	TrySendWorkerReadyToBeginPlay();
@@ -288,7 +287,7 @@ void UGlobalStateManager::SetAcceptingPlayers(bool bInAcceptingPlayers)
 
 void UGlobalStateManager::AuthorityChanged(const Worker_AuthorityChangeOp& AuthOp)
 {
-	UE_LOG(LogGlobalStateManager, Verbose, TEXT("Authority over the GSM component %d has changed. This worker %s authority."),
+	UE_LOG(LogGlobalStateManager, Log, TEXT("Authority over the GSM component %d has changed. This worker %s authority."),
 		   AuthOp.component_id, AuthOp.authority == WORKER_AUTHORITY_AUTHORITATIVE ? TEXT("now has") : TEXT("does not have"));
 
 	if (AuthOp.authority != WORKER_AUTHORITY_AUTHORITATIVE)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
@@ -82,7 +82,7 @@ ERPCType GetRPCType(UFunction* RemoteFunction)
 	}
 	else if (RemoteFunction->HasAnyFunctionFlags(FUNC_NetCrossServer))
 	{
-		return ERPCType::CrossServer;
+		return ERPCType::CrossServerSender;
 	}
 	else if (RemoteFunction->HasAnyFunctionFlags(FUNC_NetReliable))
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialRoutingSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialRoutingSystem.cpp
@@ -1,0 +1,553 @@
+#include "Interop/SpatialRoutingSystem.h"
+#include "Interop/Connection/SpatialOSWorkerInterface.h"
+#include "Schema/ServerWorker.h"
+#include "Utils/InterestFactory.h"
+
+DEFINE_LOG_CATEGORY(LogSpatialRoutingSystem);
+
+namespace SpatialGDK
+{
+void SpatialRoutingSystem::ProcessUpdate(Worker_EntityId Entity, const ComponentChange& Change, RoutingComponents& Components)
+{
+	switch (Change.ComponentId)
+	{
+	case SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID:
+		switch (Change.Type)
+		{
+		case ComponentChange::COMPLETE_UPDATE:
+		{
+			Worker_ComponentData Data;
+			Data.component_id = SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID;
+			Data.schema_type = Change.CompleteUpdate.Data;
+			Components.Sender.Emplace(CrossServerEndpointSender(Data));
+
+			break;
+		}
+		case ComponentChange::UPDATE:
+		{
+			Worker_ComponentUpdate Update;
+			Update.component_id = SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID;
+			Update.schema_type = Change.Update;
+			Components.Sender->ApplyComponentUpdate(Update);
+			break;
+		}
+		}
+		OnSenderChanged(Entity, Components);
+		break;
+	case SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID:
+		switch (Change.Type)
+		{
+		case ComponentChange::COMPLETE_UPDATE:
+		{
+			Worker_ComponentData Data;
+			Data.component_id = SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID;
+			Data.schema_type = Change.CompleteUpdate.Data;
+			Components.ReceiverACK.Emplace(CrossServerEndpointReceiverACK(Data));
+			break;
+		}
+
+		case ComponentChange::UPDATE:
+		{
+			Worker_ComponentUpdate Update;
+			Update.component_id = SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID;
+			Update.schema_type = Change.Update;
+			Components.ReceiverACK->ApplyComponentUpdate(Update);
+			break;
+		}
+		}
+		OnReceiverACKChanged(Entity, Components);
+		break;
+	default:
+		checkNoEntry();
+		break;
+	}
+}
+
+void SpatialRoutingSystem::OnSenderChanged(Worker_EntityId SenderId, RoutingComponents& Components)
+{
+	TMap<CrossServer::RPCKey, Worker_EntityId> ReceiverDisappeared;
+	CrossServer::RPCAllocMap SlotsToClear = Components.AllocMap;
+
+	const RPCRingBuffer& Buffer = Components.Sender->ReliableRPCBuffer;
+
+	// First loop to free Receiver slots.
+	for (uint32 SlotIdx = 0; SlotIdx < RPCRingBufferUtils::GetRingBufferSize(ERPCType::CrossServerSender); ++SlotIdx)
+	{
+		const TOptional<RPCPayload>& Element = Buffer.RingBuffer[SlotIdx];
+		if (Element.IsSet())
+		{
+			const TOptional<FUnrealObjectRef>& Counterpart = Buffer.Counterpart[SlotIdx];
+
+			Worker_EntityId Receiver = Counterpart->Entity;
+			uint64 RPCId = Counterpart->Offset;
+			CrossServer::RPCKey RPCKey(SenderId, RPCId);
+			SlotsToClear.Remove(RPCKey);
+
+			if (RoutingComponents* ReceiverComps = RoutingWorkerView.Find(Receiver))
+			{
+				if (ReceiverComps->Receiver.Mailbox.Find(RPCKey) == nullptr)
+				{
+					CrossServer::SentRPCEntry Entry;
+					Entry.RPCId = RPCKey;
+					Entry.Target = Receiver;
+					Entry.Timestamp = FPlatformTime::Cycles64();
+					Entry.SourceSlot = SlotIdx;
+
+					ReceiverComps->Receiver.Mailbox.Add(RPCKey, Entry);
+					ReceiverComps->Receiver.Schedule.Add(RPCKey);
+					ReceiversToInspect.Add(Receiver);
+				}
+			}
+			else
+			{
+				ReceiverDisappeared.Add(RPCKey, Receiver);
+			}
+		}
+	}
+
+	for (auto const& SlotToClear : SlotsToClear)
+	{
+		const CrossServer::RPCSlots& Slots = SlotToClear.Value;
+
+		{
+			EntityComponentId SenderPair(SenderId, SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID);
+			Components.SenderACKAlloc.Occupied[Slots.SenderACKSlot] = false;
+			Components.SenderACKAlloc.ToClear[Slots.SenderACKSlot] = true;
+
+			GetOrCreateComponentUpdate(SenderPair);
+		}
+
+		if (RoutingComponents* ReceiverComps = RoutingWorkerView.Find(Slots.ReceiverSlot.Receiver))
+		{
+			ClearReceiverSlot(Slots.ReceiverSlot.Receiver, SlotToClear.Key, *ReceiverComps);
+		}
+
+		Components.AllocMap.Remove(SlotToClear.Key);
+	}
+
+	for (auto RPC : ReceiverDisappeared)
+	{
+		auto& Slots = Components.AllocMap.FindOrAdd(RPC.Key);
+		if (Slots.SenderACKSlot < 0)
+		{
+			Slots.ReceiverSlot.Receiver = RPC.Value;
+			WriteACKToSender(RPC.Key, Components);
+		}
+	}
+}
+
+void SpatialRoutingSystem::ClearReceiverSlot(Worker_EntityId Receiver, CrossServer::RPCKey RPCKey, RoutingComponents& ReceiverComponents)
+{
+	CrossServer::SentRPCEntry* SentRPC = ReceiverComponents.Receiver.Mailbox.Find(RPCKey);
+	check(SentRPC != nullptr);
+
+	EntityComponentId ReceiverPair(Receiver, SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID);
+
+	check(SentRPC->DestinationSlot.IsSet());
+	uint32 SlotIdx = SentRPC->DestinationSlot.GetValue();
+
+	ReceiverComponents.Receiver.Mailbox.Remove(RPCKey);
+	ReceiverComponents.Receiver.Alloc.Occupied[SlotIdx] = false;
+	ReceiverComponents.Receiver.Alloc.ToClear[SlotIdx] = true;
+
+	GetOrCreateComponentUpdate(ReceiverPair);
+	if (!ReceiverComponents.Receiver.Schedule.IsEmpty())
+	{
+		ReceiversToInspect.Add(ReceiverPair.Get<0>());
+	}
+}
+
+void SpatialRoutingSystem::TransferRPCsToReceiver(Worker_EntityId ReceiverId, RoutingComponents& Components)
+{
+	if (RoutingComponents* ReceiverComps = RoutingWorkerView.Find(ReceiverId))
+	{
+		while (!ReceiverComps->Receiver.Schedule.IsEmpty())
+		{
+			TOptional<uint32> FreeSlot = ReceiverComps->Receiver.FindFreeSlot();
+			if (!FreeSlot)
+			{
+				return;
+			}
+			CrossServer::RPCKey RPCToSend = ReceiverComps->Receiver.Schedule.Extract();
+			CrossServer::SentRPCEntry& SentRPC = ReceiverComps->Receiver.Mailbox.FindChecked(RPCToSend);
+
+			check(!SentRPC.DestinationSlot.IsSet());
+
+			Worker_EntityId SenderId = RPCToSend.Get<0>();
+			uint64 RPCId = RPCToSend.Get<1>();
+
+			RoutingComponents* SenderComps = RoutingWorkerView.Find(SenderId);
+
+			if (!SenderComps)
+			{
+				ReceiverComps->Receiver.Mailbox.Remove(RPCToSend);
+				// Sender disappeared before we could deliver the RPC :/ copy payload ? tombstone? drop?
+				continue;
+			}
+
+			const RPCRingBuffer& Buffer = SenderComps->Sender->ReliableRPCBuffer;
+			const TOptional<RPCPayload>& Element = Buffer.RingBuffer[SentRPC.SourceSlot];
+			const TOptional<FUnrealObjectRef>& Counterpart = Buffer.Counterpart[SentRPC.SourceSlot];
+			check(Element.IsSet());
+
+			Schema_ComponentUpdate* ReceiverUpdate =
+				GetOrCreateComponentUpdate(EntityComponentId(ReceiverId, SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID));
+			Schema_Object* EndpointObject = Schema_GetComponentUpdateFields(ReceiverUpdate);
+
+			uint32 SlotIdx = FreeSlot.GetValue();
+			RPCRingBufferDescriptor Descriptor = RPCRingBufferUtils::GetRingBufferDescriptor(ERPCType::CrossServerReceiver);
+			uint32 Field = Descriptor.GetRingBufferElementFieldId(ERPCType::CrossServerReceiver, SlotIdx + 1);
+
+			Schema_Object* RPCObject = Schema_AddObject(EndpointObject, Field);
+			Element->WriteToSchemaObject(RPCObject);
+
+			FUnrealObjectRef SenderBackRef(SenderId, RPCId);
+			AddObjectRefToSchema(EndpointObject, Field + 1, SenderBackRef);
+
+			SentRPC.DestinationSlot = SlotIdx;
+			ReceiverComps->Receiver.Alloc.Occupied[SlotIdx] = true;
+			ReceiverComps->Receiver.Alloc.ToClear[SlotIdx] = false;
+
+			CrossServer::ACKSlot ReceiverSlot;
+			ReceiverSlot.Receiver = ReceiverId;
+
+			// This one is superfluous.
+			ReceiverSlot.Slot = SlotIdx;
+
+			SenderComps->AllocMap.Add(RPCToSend).ReceiverSlot = ReceiverSlot;
+		}
+	}
+}
+
+void SpatialRoutingSystem::WriteACKToSender(CrossServer::RPCKey RPCKey, RoutingComponents& SenderComponents)
+{
+	// Both SentRPC and Slots entries should be cleared at the same time.
+	CrossServer::RPCSlots* Slots = SenderComponents.AllocMap.Find(RPCKey);
+	check(Slots != nullptr);
+
+	if (Slots->SenderACKSlot < 0)
+	{
+		Slots->SenderACKSlot = SenderComponents.SenderACKAlloc.Occupied.FindAndSetFirstZeroBit();
+		if (Slots->SenderACKSlot >= 0)
+		{
+			SenderComponents.SenderACKAlloc.ToClear[Slots->SenderACKSlot] = false;
+
+			EntityComponentId SenderPair(RPCKey.Get<0>(), SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID);
+			Schema_ComponentUpdate* Update = GetOrCreateComponentUpdate(SenderPair);
+			Schema_Object* UpdateObject = Schema_GetComponentUpdateFields(Update);
+
+			ACKItem SenderACK;
+			SenderACK.Sender = RPCKey.Get<0>();
+			SenderACK.RPCId = RPCKey.Get<1>();
+
+			Schema_Object* NewEntry = Schema_AddObject(UpdateObject, 2 + Slots->SenderACKSlot);
+			SenderACK.WriteToSchema(NewEntry);
+		}
+		else
+		{
+			checkNoEntry();
+			// Out of free slots, should not be possible.
+			UE_LOG(LogTemp, Log, TEXT("Out of sender ACK slot"));
+		}
+	}
+	else
+	{
+		// Already taken care of.
+	}
+}
+
+void SpatialRoutingSystem::OnReceiverACKChanged(Worker_EntityId EntityId, RoutingComponents& Components)
+{
+	CrossServerEndpointReceiverACK& ReceiverACK = Components.ReceiverACK.GetValue();
+	for (int32 SlotIdx = 0; SlotIdx < ReceiverACK.ACKArray.Num(); ++SlotIdx)
+	{
+		if (ReceiverACK.ACKArray[SlotIdx])
+		{
+			const ACKItem& ReceiverACKItem = ReceiverACK.ACKArray[SlotIdx].GetValue();
+
+			CrossServer::RPCKey RPCKey(ReceiverACKItem.Sender, ReceiverACKItem.RPCId);
+			CrossServer::SentRPCEntry* SentRPC = Components.Receiver.Mailbox.Find(RPCKey);
+			if (SentRPC == nullptr)
+			{
+				continue;
+			}
+
+			RoutingComponents* SenderComponents = RoutingWorkerView.Find(ReceiverACKItem.Sender);
+			if (SenderComponents != nullptr)
+			{
+				WriteACKToSender(RPCKey, *SenderComponents);
+			}
+			else
+			{
+				// Sender disappeared, clear Receiver slot.
+				ClearReceiverSlot(EntityId, RPCKey, Components);
+			}
+		}
+	}
+}
+
+Schema_ComponentUpdate* SpatialRoutingSystem::GetOrCreateComponentUpdate(
+	TPair<Worker_EntityId_Key, Worker_ComponentId> EntityComponentIdPair)
+{
+	Schema_ComponentUpdate** ComponentUpdatePtr = PendingComponentUpdatesToSend.Find(EntityComponentIdPair);
+	if (ComponentUpdatePtr == nullptr)
+	{
+		ComponentUpdatePtr = &PendingComponentUpdatesToSend.Add(EntityComponentIdPair, Schema_CreateComponentUpdate());
+	}
+	return *ComponentUpdatePtr;
+}
+
+void SpatialRoutingSystem::Advance(SpatialOSWorkerInterface* Connection)
+{
+	const TArray<Worker_Op>& Messages = Connection->GetWorkerMessages();
+	for (const auto& Message : Messages)
+	{
+		switch (Message.op_type)
+		{
+		case WORKER_OP_TYPE_RESERVE_ENTITY_IDS_RESPONSE:
+		{
+			const Worker_ReserveEntityIdsResponseOp& Op = Message.op.reserve_entity_ids_response;
+			if (Op.request_id == RoutingWorkerEntityRequest)
+			{
+				if (Op.first_entity_id == SpatialConstants::INVALID_ENTITY_ID)
+				{
+					UE_LOG(LogSpatialRoutingSystem, Error, TEXT("Reserve entity failed : %s"), UTF8_TO_TCHAR(Op.message));
+					RoutingWorkerEntityRequest = 0;
+				}
+				else
+				{
+					RoutingWorkerEntity = Message.op.reserve_entity_ids_response.first_entity_id;
+					CreateRoutingWorkerEntity(Connection);
+				}
+			}
+			break;
+		}
+		case WORKER_OP_TYPE_CREATE_ENTITY_RESPONSE:
+		{
+			const Worker_CreateEntityResponseOp& Op = Message.op.create_entity_response;
+			if (Op.request_id == RoutingWorkerEntityRequest)
+			{
+				if (Op.entity_id == SpatialConstants::INVALID_ENTITY_ID)
+				{
+					UE_LOG(LogSpatialRoutingSystem, Error, TEXT("Create entity failed : %s"), UTF8_TO_TCHAR(Op.message));
+					RoutingWorkerEntityRequest = 0;
+				}
+			}
+		}
+		break;
+		}
+	}
+
+	const FSubViewDelta& SubViewDelta = SubView.GetViewDelta();
+	for (const EntityDelta& Delta : SubViewDelta.EntityDeltas)
+	{
+		switch (Delta.Type)
+		{
+		case EntityDelta::UPDATE:
+		{
+			RoutingComponents& Components = RoutingWorkerView.FindChecked(Delta.EntityId);
+			for (const ComponentChange& Change : Delta.ComponentUpdates)
+			{
+				ProcessUpdate(Delta.EntityId, Change, Components);
+			}
+
+			for (const ComponentChange& Change : Delta.ComponentsRefreshed)
+			{
+				ProcessUpdate(Delta.EntityId, Change, Components);
+			}
+		}
+		break;
+		case EntityDelta::ADD:
+		{
+			const EntityViewElement& EntityView = SubView.GetView()->FindChecked(Delta.EntityId);
+			RoutingComponents& Components = RoutingWorkerView.Add(Delta.EntityId);
+
+			for (const auto& ComponentDesc : EntityView.Components)
+			{
+				switch (ComponentDesc.GetComponentId())
+				{
+				case SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID:
+					Components.Sender = CrossServerEndpointSender(ComponentDesc.GetWorkerComponentData());
+					// Should inspect the component if we were reloading a snapshot
+					break;
+				case SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID:
+				{
+					CrossServerEndpointSenderACK TempView(ComponentDesc.GetWorkerComponentData());
+					for (int32 SlotIdx = 0; SlotIdx < TempView.ACKArray.Num(); ++SlotIdx)
+					{
+						const auto& Slot = TempView.ACKArray[SlotIdx];
+						if (Slot.IsSet())
+						{
+							CrossServer::RPCSlots& Slots = Components.AllocMap.FindOrAdd(CrossServer::RPCKey(Slot->Sender, Slot->RPCId));
+							Slots.SenderACKSlot = SlotIdx;
+							Components.SenderACKAlloc.Occupied[SlotIdx] = true;
+						}
+					}
+				}
+				break;
+				case SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID:
+				{
+					CrossServerEndpointReceiver TempView(ComponentDesc.GetWorkerComponentData());
+					for (int32 SlotIdx = 0; SlotIdx < TempView.ReliableRPCBuffer.RingBuffer.Num(); ++SlotIdx)
+					{
+						const auto& Slot = TempView.ReliableRPCBuffer.RingBuffer[SlotIdx];
+						if (Slot.IsSet())
+						{
+							const TOptional<FUnrealObjectRef>& SenderBackRef = TempView.ReliableRPCBuffer.Counterpart[SlotIdx];
+							check(SenderBackRef.IsSet());
+
+							CrossServer::RPCKey RPCKey(SenderBackRef->Entity, (uint64)SenderBackRef->Offset);
+							CrossServer::SentRPCEntry NewEntry;
+							NewEntry.RPCId = RPCKey;
+							// NewEntry.SourceSlot = ??
+							NewEntry.DestinationSlot = SlotIdx;
+							NewEntry.Target = SenderBackRef->Entity;
+							NewEntry.Timestamp = 0;
+							NewEntry.EntityRequest = 0;
+
+							Components.Receiver.Mailbox.Add(RPCKey, NewEntry);
+							Components.Receiver.Alloc.Occupied[SlotIdx] = true;
+
+							RoutingComponents& SenderComponents = RoutingWorkerView.FindOrAdd(NewEntry.Target);
+							// If we were reloading a snapshot, have to check that the sender still exists.
+							CrossServer::RPCSlots& Slots = SenderComponents.AllocMap.FindOrAdd(RPCKey);
+							Slots.ReceiverSlot.Receiver = Delta.EntityId;
+							Slots.ReceiverSlot.Slot = SlotIdx;
+						}
+					}
+				}
+				break;
+				case SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID:
+					Components.ReceiverACK = CrossServerEndpointReceiverACK(ComponentDesc.GetWorkerComponentData());
+					// Should inspect the component if we were reloading a snapshot
+					break;
+				}
+			}
+		}
+		break;
+		case EntityDelta::REMOVE:
+		case EntityDelta::TEMPORARILY_REMOVED:
+		{
+			ReceiversToInspect.Remove(Delta.EntityId);
+			PendingComponentUpdatesToSend.Remove(
+				EntityComponentId(Delta.EntityId, SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID));
+			PendingComponentUpdatesToSend.Remove(
+				EntityComponentId(Delta.EntityId, SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID));
+
+			if (RoutingComponents* Components = RoutingWorkerView.Find(Delta.EntityId))
+			{
+				for (auto MailboxItem : Components->Receiver.Mailbox)
+				{
+					CrossServer::SentRPCEntry& Entry = MailboxItem.Value;
+					if (Entry.DestinationSlot)
+					{
+						RoutingComponents* SenderComponents = RoutingWorkerView.Find(Entry.RPCId.Get<0>());
+						if (SenderComponents != nullptr)
+						{
+							WriteACKToSender(Entry.RPCId, *SenderComponents);
+						}
+					}
+				}
+
+				for (auto Slots : Components->AllocMap)
+				{
+					Worker_EntityId Receiver = Slots.Value.ReceiverSlot.Receiver;
+					if (Receiver != SpatialConstants::INVALID_ENTITY_ID && Slots.Value.SenderACKSlot != -1)
+					{
+						// The receiver would be waiting for an update from the sender.
+						RoutingComponents* ReceiverComponents = RoutingWorkerView.Find(Receiver);
+						if (ReceiverComponents)
+						{
+							ClearReceiverSlot(Receiver, Slots.Key, *ReceiverComponents);
+						}
+					}
+				}
+
+				RoutingWorkerView.Remove(Delta.EntityId);
+			}
+		}
+		break;
+		default:
+			break;
+		}
+	}
+
+	for (auto Receiver : ReceiversToInspect)
+	{
+		TransferRPCsToReceiver(Receiver, RoutingWorkerView.FindChecked(Receiver));
+	}
+	ReceiversToInspect.Empty();
+}
+
+void SpatialRoutingSystem::Flush(SpatialOSWorkerInterface* Connection)
+{
+	for (auto& Entry : PendingComponentUpdatesToSend)
+	{
+		Worker_EntityId Entity = Entry.Key.Get<0>();
+		Worker_ComponentId CompId = Entry.Key.Get<1>();
+
+		if (RoutingComponents* Components = RoutingWorkerView.Find(Entity))
+		{
+			if (CompId == SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID)
+			{
+				RPCRingBufferDescriptor Descriptor = RPCRingBufferUtils::GetRingBufferDescriptor(ERPCType::CrossServerReceiver);
+
+				for (int32 ToClear = Components->Receiver.Alloc.ToClear.Find(true); ToClear >= 0;
+					 ToClear = Components->Receiver.Alloc.ToClear.Find(true))
+				{
+					uint32 Field = Descriptor.GetRingBufferElementFieldId(ERPCType::CrossServerReceiver, ToClear + 1);
+
+					Schema_AddComponentUpdateClearedField(Entry.Value, Field);
+					Schema_AddComponentUpdateClearedField(Entry.Value, Field + 1);
+
+					Components->Receiver.Alloc.ToClear[ToClear] = false;
+				}
+			}
+
+			if (CompId == SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID)
+			{
+				for (int32 ToClear = Components->SenderACKAlloc.ToClear.Find(true); ToClear >= 0;
+					 ToClear = Components->SenderACKAlloc.ToClear.Find(true))
+				{
+					Schema_AddComponentUpdateClearedField(Entry.Value, ToClear + 2);
+
+					Components->SenderACKAlloc.ToClear[ToClear] = false;
+				}
+			}
+		}
+		FWorkerComponentUpdate Update;
+		Update.component_id = CompId;
+		Update.schema_type = Entry.Value;
+		Connection->SendComponentUpdate(Entity, &Update);
+	}
+	PendingComponentUpdatesToSend.Empty();
+}
+
+void SpatialRoutingSystem::Init(SpatialOSWorkerInterface* Connection)
+{
+	RoutingWorkerEntityRequest = Connection->SendReserveEntityIdsRequest(1);
+}
+
+void SpatialRoutingSystem::CreateRoutingWorkerEntity(SpatialOSWorkerInterface* Connection)
+{
+	const WorkerRequirementSet WorkerIdPermission{ { FString::Printf(TEXT("workerId:%s"), *RoutingWorkerId) } };
+
+	WriteAclMap ComponentWriteAcl;
+	ComponentWriteAcl.Add(SpatialConstants::POSITION_COMPONENT_ID, WorkerIdPermission);
+	ComponentWriteAcl.Add(SpatialConstants::METADATA_COMPONENT_ID, WorkerIdPermission);
+	ComponentWriteAcl.Add(SpatialConstants::ENTITY_ACL_COMPONENT_ID, WorkerIdPermission);
+	ComponentWriteAcl.Add(SpatialConstants::INTEREST_COMPONENT_ID, WorkerIdPermission);
+	// ComponentWriteAcl.Add(SpatialConstants::SERVER_WORKER_COMPONENT_ID, WorkerIdPermission);
+
+	TArray<FWorkerComponentData> Components;
+	Components.Add(Position().CreatePositionData());
+	Components.Add(Metadata(FString::Printf(TEXT("WorkerEntity:%s"), *RoutingWorkerId)).CreateMetadataData());
+	Components.Add(EntityAcl(WorkerIdPermission, ComponentWriteAcl).CreateEntityAclData());
+	// Components.Add(ServerWorker(Connection->GetWorkerId(), false).CreateServerWorkerData());
+
+	Components.Add(InterestFactory::CreateRoutingWorkerInterest().CreateInterestData());
+
+	RoutingWorkerEntityRequest = Connection->SendCreateEntityRequest(Components, &RoutingWorkerEntity);
+}
+
+} // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStaticComponentView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStaticComponentView.cpp
@@ -7,6 +7,7 @@
 #include "Schema/ClientRPCEndpointLegacy.h"
 #include "Schema/Component.h"
 #include "Schema/ComponentPresence.h"
+#include "Schema/CrossServerEndpoint.h"
 #include "Schema/DebugComponent.h"
 #include "Schema/Heartbeat.h"
 #include "Schema/Interest.h"
@@ -112,6 +113,18 @@ void USpatialStaticComponentView::OnAddComponent(const Worker_AddComponentOp& Op
 	case SpatialConstants::GDK_DEBUG_COMPONENT_ID:
 		Data = MakeUnique<SpatialGDK::DebugComponent>(Op.data);
 		break;
+	case SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID:
+		Data = MakeUnique<SpatialGDK::CrossServerEndpointSender>(Op.data);
+		break;
+	case SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID:
+		Data = MakeUnique<SpatialGDK::CrossServerEndpointSenderACK>(Op.data);
+		break;
+	case SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID:
+		Data = MakeUnique<SpatialGDK::CrossServerEndpointReceiver>(Op.data);
+		break;
+	case SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID:
+		Data = MakeUnique<SpatialGDK::CrossServerEndpointReceiverACK>(Op.data);
+		break;
 	default:
 		// Component is not hand written, but we still want to know the existence of it on this entity.
 		Data = nullptr;
@@ -174,6 +187,18 @@ void USpatialStaticComponentView::OnComponentUpdate(const Worker_ComponentUpdate
 		break;
 	case SpatialConstants::GDK_DEBUG_COMPONENT_ID:
 		Component = GetComponentData<SpatialGDK::DebugComponent>(Op.entity_id);
+		break;
+	case SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID:
+		Component = GetComponentData<SpatialGDK::CrossServerEndpointSender>(Op.entity_id);
+		break;
+	case SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID:
+		Component = GetComponentData<SpatialGDK::CrossServerEndpointSenderACK>(Op.entity_id);
+		break;
+	case SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID:
+		Component = GetComponentData<SpatialGDK::CrossServerEndpointReceiver>(Op.entity_id);
+		break;
+	case SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID:
+		Component = GetComponentData<SpatialGDK::CrossServerEndpointReceiverACK>(Op.entity_id);
 		break;
 	default:
 		return;

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSubSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSubSystem.cpp
@@ -1,0 +1,3 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "Interop/SpatialSubSystem.h"

--- a/SpatialGDK/Source/SpatialGDK/Private/Schema/CrossServerEndpoint.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Schema/CrossServerEndpoint.cpp
@@ -1,0 +1,141 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "Schema/CrossServerEndpoint.h"
+
+namespace SpatialGDK
+{
+CrossServerEndpoint::CrossServerEndpoint(const Worker_ComponentData& Data, ERPCType Type)
+	: ReliableRPCBuffer(Type)
+{
+	ReadFromSchema(Schema_GetComponentDataFields(Data.schema_type));
+}
+
+void CrossServerEndpoint::ApplyComponentUpdate(const Worker_ComponentUpdate& Update)
+{
+	ReadFromSchema(Schema_GetComponentUpdateFields(Update.schema_type));
+	uint32 ClearCount = Schema_GetComponentUpdateClearedFieldCount(Update.schema_type);
+	TArray<Schema_FieldId> ClearedFields;
+	ClearedFields.SetNum(ClearCount);
+	Schema_GetComponentUpdateClearedFieldList(Update.schema_type, ClearedFields.GetData());
+
+	for (auto Field : ClearedFields)
+	{
+		uint32 SlotIdx = (Field - 1);
+		if (SlotIdx % 2 == 0)
+		{
+			ReliableRPCBuffer.RingBuffer[SlotIdx / 2].Reset();
+			ReliableRPCBuffer.Counterpart[SlotIdx / 2].Reset();
+		}
+	}
+}
+
+void CrossServerEndpoint::ReadFromSchema(Schema_Object* SchemaObject)
+{
+	RPCRingBufferUtils::ReadBufferFromSchema(SchemaObject, ReliableRPCBuffer);
+}
+
+CrossServerEndpointACK::CrossServerEndpointACK(const Worker_ComponentData& Data, ERPCType InType)
+	: Type(InType)
+{
+	ReadFromSchema(Schema_GetComponentDataFields(Data.schema_type));
+}
+
+void CrossServerEndpointACK::ApplyComponentUpdate(const Worker_ComponentUpdate& Update)
+{
+	ReadFromSchema(Schema_GetComponentUpdateFields(Update.schema_type));
+}
+
+void CrossServerEndpointACK::ReadFromSchema(Schema_Object* SchemaObject)
+{
+	RPCRingBufferUtils::ReadAckFromSchema(SchemaObject, Type, RPCAck);
+}
+
+void ACKItem::ReadFromSchema(Schema_Object* SchemaObject)
+{
+	Sender = Schema_GetEntityId(SchemaObject, 1);
+	RPCId = Schema_GetUint64(SchemaObject, 2);
+	SenderRevision = Schema_GetUint64(SchemaObject, 3);
+}
+
+void ACKItem::WriteToSchema(Schema_Object* SchemaObject)
+{
+	Schema_AddEntityId(SchemaObject, 1, Sender);
+	Schema_AddUint64(SchemaObject, 2, RPCId);
+	Schema_AddUint64(SchemaObject, 3, SenderRevision);
+}
+
+CrossServerEndpointSenderACK::CrossServerEndpointSenderACK(const Worker_ComponentData& Data)
+{
+	ReadFromSchema(Schema_GetComponentDataFields(Data.schema_type));
+}
+
+void CrossServerEndpointSenderACK::ApplyComponentUpdate(const Worker_ComponentUpdate& Update)
+{
+	ReadFromSchema(Schema_GetComponentUpdateFields(Update.schema_type));
+}
+
+void CrossServerEndpointSenderACK::ReadFromSchema(Schema_Object* SchemaObject)
+{
+	RPCRingBufferUtils::ReadAckFromSchema(SchemaObject, ERPCType::CrossServerSender, RPCAck);
+
+	uint32 Count = RPCRingBufferUtils::GetRingBufferSize(ERPCType::CrossServerSender);
+	ACKArray.Empty(Count);
+	ACKArray.SetNum(Count);
+	for (uint32 ACKIdx = 0; ACKIdx < Count; ++ACKIdx)
+	{
+		uint32 OptCount = Schema_GetObjectCount(SchemaObject, 2 + ACKIdx);
+		if (OptCount > 0)
+		{
+			Schema_Object* ACKItemObject = Schema_GetObject(SchemaObject, 2 + ACKIdx);
+			ACKArray[ACKIdx].Emplace(ACKItem());
+			ACKArray[ACKIdx].GetValue().ReadFromSchema(ACKItemObject);
+		}
+	}
+
+	// uint32 Count = Schema_GetObjectCount(SchemaObject, 2);
+	//
+	// DottedRPCACK.Empty();
+	// for (uint32 EntryIdx = 0; EntryIdx < Count; ++EntryIdx)
+	//{
+	//	Schema_Object* MapEntry = Schema_IndexObject(SchemaObject, 2, EntryIdx);
+	//
+	//	Worker_EntityId Entity = Schema_GetEntityId(MapEntry, SCHEMA_MAP_KEY_FIELD_ID);
+	//
+	//	Schema_Object* ACKListObject = Schema_GetObject(MapEntry, SCHEMA_MAP_VALUE_FIELD_ID);
+	//
+	//	uint32 ACKCount = Schema_GetUint64Count(ACKListObject, 1);
+	//	TArray<uint64> ACKList;
+	//	ACKList.SetNum(ACKCount);
+	//	Schema_GetUint64List(ACKListObject, 1, reinterpret_cast<uint64_t*>(ACKList.GetData()));
+	//
+	//	DottedRPCACK.Add(Entity, MoveTemp(ACKList));
+	//}
+}
+
+// void CrossServerEndpointSenderACK::CreateUpdate(Schema_ComponentUpdate* OutUpdate)
+//{
+//	Schema_Object* Object = Schema_GetComponentUpdateFields(OutUpdate);
+//
+//	Schema_AddUint64(Object, 1, RPCAck);
+//
+//	if (DottedRPCACK.Num() == 0)
+//	{
+//		Schema_AddComponentUpdateClearedField(OutUpdate, 2);
+//	}
+//
+//	for (auto const& ACKEntry : DottedRPCACK)
+//	{
+//		Schema_Object* MapEntry = Schema_AddObject(Object, 2);
+//
+//		Schema_AddEntityId(MapEntry, SCHEMA_MAP_KEY_FIELD_ID, ACKEntry.Key);
+//		Schema_Object* ACKListObject = Schema_AddObject(MapEntry, SCHEMA_MAP_VALUE_FIELD_ID);
+//
+//		// Schema_AddUint64List(ACKListObject, 1, reinterpret_cast<uint64_t const*>(ACKEntry.Value.GetData()), ACKEntry.Value.Num());
+//
+//		auto* buffer = Schema_AllocateBuffer(ACKListObject, ACKEntry.Value.Num() * sizeof(uint64));
+//		FMemory::Memcpy(buffer, ACKEntry.Value.GetData(), ACKEntry.Value.Num() * sizeof(uint64));
+//		Schema_AddUint64List(ACKListObject, 1, reinterpret_cast<uint64_t const*>(buffer), ACKEntry.Value.Num());
+//	}
+//}
+
+} // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Private/Schema/CrossServerEndpoint.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Schema/CrossServerEndpoint.cpp
@@ -43,11 +43,19 @@ CrossServerEndpointACK::CrossServerEndpointACK(const Worker_ComponentData& Data,
 void CrossServerEndpointACK::ApplyComponentUpdate(const Worker_ComponentUpdate& Update)
 {
 	ReadFromSchema(Schema_GetComponentUpdateFields(Update.schema_type));
-}
+	uint32 ClearCount = Schema_GetComponentUpdateClearedFieldCount(Update.schema_type);
+	TArray<Schema_FieldId> ClearedFields;
+	ClearedFields.SetNum(ClearCount);
+	Schema_GetComponentUpdateClearedFieldList(Update.schema_type, ClearedFields.GetData());
 
-void CrossServerEndpointACK::ReadFromSchema(Schema_Object* SchemaObject)
-{
-	RPCRingBufferUtils::ReadAckFromSchema(SchemaObject, Type, RPCAck);
+	for (auto Field : ClearedFields)
+	{
+		if (Field >= 2)
+		{
+			uint32 SlotIdx = (Field - 2);
+			ACKArray[SlotIdx].Reset();
+		}
+	}
 }
 
 void ACKItem::ReadFromSchema(Schema_Object* SchemaObject)
@@ -64,22 +72,11 @@ void ACKItem::WriteToSchema(Schema_Object* SchemaObject)
 	Schema_AddUint64(SchemaObject, 3, SenderRevision);
 }
 
-CrossServerEndpointSenderACK::CrossServerEndpointSenderACK(const Worker_ComponentData& Data)
+void CrossServerEndpointACK::ReadFromSchema(Schema_Object* SchemaObject)
 {
-	ReadFromSchema(Schema_GetComponentDataFields(Data.schema_type));
-}
+	RPCRingBufferUtils::ReadAckFromSchema(SchemaObject, Type, RPCAck);
 
-void CrossServerEndpointSenderACK::ApplyComponentUpdate(const Worker_ComponentUpdate& Update)
-{
-	ReadFromSchema(Schema_GetComponentUpdateFields(Update.schema_type));
-}
-
-void CrossServerEndpointSenderACK::ReadFromSchema(Schema_Object* SchemaObject)
-{
-	RPCRingBufferUtils::ReadAckFromSchema(SchemaObject, ERPCType::CrossServerSender, RPCAck);
-
-	uint32 Count = RPCRingBufferUtils::GetRingBufferSize(ERPCType::CrossServerSender);
-	ACKArray.Empty(Count);
+	uint32 Count = RPCRingBufferUtils::GetRingBufferSize(Type);
 	ACKArray.SetNum(Count);
 	for (uint32 ACKIdx = 0; ACKIdx < Count; ++ACKIdx)
 	{
@@ -91,51 +88,6 @@ void CrossServerEndpointSenderACK::ReadFromSchema(Schema_Object* SchemaObject)
 			ACKArray[ACKIdx].GetValue().ReadFromSchema(ACKItemObject);
 		}
 	}
-
-	// uint32 Count = Schema_GetObjectCount(SchemaObject, 2);
-	//
-	// DottedRPCACK.Empty();
-	// for (uint32 EntryIdx = 0; EntryIdx < Count; ++EntryIdx)
-	//{
-	//	Schema_Object* MapEntry = Schema_IndexObject(SchemaObject, 2, EntryIdx);
-	//
-	//	Worker_EntityId Entity = Schema_GetEntityId(MapEntry, SCHEMA_MAP_KEY_FIELD_ID);
-	//
-	//	Schema_Object* ACKListObject = Schema_GetObject(MapEntry, SCHEMA_MAP_VALUE_FIELD_ID);
-	//
-	//	uint32 ACKCount = Schema_GetUint64Count(ACKListObject, 1);
-	//	TArray<uint64> ACKList;
-	//	ACKList.SetNum(ACKCount);
-	//	Schema_GetUint64List(ACKListObject, 1, reinterpret_cast<uint64_t*>(ACKList.GetData()));
-	//
-	//	DottedRPCACK.Add(Entity, MoveTemp(ACKList));
-	//}
 }
-
-// void CrossServerEndpointSenderACK::CreateUpdate(Schema_ComponentUpdate* OutUpdate)
-//{
-//	Schema_Object* Object = Schema_GetComponentUpdateFields(OutUpdate);
-//
-//	Schema_AddUint64(Object, 1, RPCAck);
-//
-//	if (DottedRPCACK.Num() == 0)
-//	{
-//		Schema_AddComponentUpdateClearedField(OutUpdate, 2);
-//	}
-//
-//	for (auto const& ACKEntry : DottedRPCACK)
-//	{
-//		Schema_Object* MapEntry = Schema_AddObject(Object, 2);
-//
-//		Schema_AddEntityId(MapEntry, SCHEMA_MAP_KEY_FIELD_ID, ACKEntry.Key);
-//		Schema_Object* ACKListObject = Schema_AddObject(MapEntry, SCHEMA_MAP_VALUE_FIELD_ID);
-//
-//		// Schema_AddUint64List(ACKListObject, 1, reinterpret_cast<uint64_t const*>(ACKEntry.Value.GetData()), ACKEntry.Value.Num());
-//
-//		auto* buffer = Schema_AllocateBuffer(ACKListObject, ACKEntry.Value.Num() * sizeof(uint64));
-//		FMemory::Memcpy(buffer, ACKEntry.Value.GetData(), ACKEntry.Value.Num() * sizeof(uint64));
-//		Schema_AddUint64List(ACKListObject, 1, reinterpret_cast<uint64_t const*>(buffer), ACKEntry.Value.Num());
-//	}
-//}
 
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -111,6 +111,7 @@ USpatialGDKSettings::USpatialGDKSettings(const FObjectInitializer& ObjectInitial
 	, bUseRPCRingBuffers(true)
 	, DefaultRPCRingBufferSize(32)
 	, MaxRPCRingBufferSize(32)
+	, CrossServerRPCImplementation(ECrossServerRPCImplementation::SpatialCommand)
 	// TODO - UNR 2514 - These defaults are not necessarily optimal - readdress when we have better data
 	, bTcpNoDelay(false)
 	, UdpServerDownstreamUpdateIntervalMS(1)

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ComponentData.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ComponentData.cpp
@@ -39,7 +39,15 @@ bool ComponentData::ApplyUpdate(const ComponentUpdate& Update)
 	check(Update.GetComponentId() == GetComponentId());
 	check(Update.GetUnderlying() != nullptr);
 
-	return Schema_ApplyComponentUpdateToData(Update.GetUnderlying(), Data.Get()) != 0;
+	bool bSuccess = Schema_ApplyComponentUpdateToData(Update.GetUnderlying(), Data.Get()) != 0;
+
+	if (!bSuccess)
+	{
+		FUTF8ToTCHAR conv(Schema_GetError(Schema_GetComponentDataFields(Data.Get())));
+		UE_LOG(LogTemp, Error, TEXT("ApplyUpdate : %s"), conv.Get());
+	}
+
+	return bSuccess;
 }
 
 Schema_Object* ComponentData::GetFields() const

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/RPCServiceTest.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/RPCServiceTest.cpp
@@ -57,7 +57,8 @@ constexpr Worker_EntityId RPCTestEntityId_2 = 42;
 const SpatialGDK::RPCPayload SimplePayload = SpatialGDK::RPCPayload(1, 0, TArray<uint8>({ 1 }, 1));
 
 ExtractRPCDelegate DefaultRPCDelegate =
-	ExtractRPCDelegate::CreateLambda([](Worker_EntityId EntityId, ERPCType RPCType, const SpatialGDK::RPCPayload& Payload) {
+	ExtractRPCDelegate::CreateLambda([](Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType RPCType,
+										const SpatialGDK::RPCPayload& Payload, uint32 Slot) {
 		return true;
 	});
 
@@ -157,7 +158,7 @@ bool CompareRPCPayload(const SpatialGDK::RPCPayload& Payload1, const SpatialGDK:
 bool CompareSchemaObjectToSendAndPayload(Schema_Object* SchemaObject, const SpatialGDK::RPCPayload& Payload, ERPCType RPCType, uint64 RPCId)
 {
 	SpatialGDK::RPCRingBufferDescriptor Descriptor = SpatialGDK::RPCRingBufferUtils::GetRingBufferDescriptor(RPCType);
-	Schema_Object* RPCObject = Schema_GetObject(SchemaObject, Descriptor.GetRingBufferElementFieldId(RPCId));
+	Schema_Object* RPCObject = Schema_GetObject(SchemaObject, Descriptor.GetRingBufferElementFieldId(RPCType, RPCId));
 	return CompareRPCPayload(SpatialGDK::RPCPayload(RPCObject), Payload);
 }
 
@@ -199,7 +200,8 @@ FWorkerComponentData GetComponentDataOnEntityCreationFromRPCService(SpatialGDK::
 RPC_SERVICE_TEST(GIVEN_authority_over_server_endpoint_WHEN_push_client_reliable_rpcs_to_the_service_THEN_rpc_push_result_success)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, SERVER_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ClientReliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientReliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::Success));
 	return true;
 }
@@ -207,7 +209,8 @@ RPC_SERVICE_TEST(GIVEN_authority_over_server_endpoint_WHEN_push_client_reliable_
 RPC_SERVICE_TEST(GIVEN_authority_over_server_endpoint_WHEN_push_client_unreliable_rpcs_to_the_service_THEN_rpc_push_result_success)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, SERVER_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ClientUnreliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientUnreliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::Success));
 	return true;
 }
@@ -216,7 +219,8 @@ RPC_SERVICE_TEST(
 	GIVEN_authority_over_server_endpoint_WHEN_push_server_reliable_rpcs_to_the_service_THEN_rpc_push_result_no_buffer_authority)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, SERVER_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ServerReliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerReliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::NoRingBufferAuthority));
 	return true;
 }
@@ -225,7 +229,8 @@ RPC_SERVICE_TEST(
 	GIVEN_authority_over_server_endpoint_WHEN_push_server_unreliable_rpcs_to_the_service_THEN_rpc_push_result_no_buffer_authority)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, SERVER_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ServerUnreliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerUnreliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::NoRingBufferAuthority));
 	return true;
 }
@@ -234,7 +239,8 @@ RPC_SERVICE_TEST(
 	GIVEN_authority_over_client_endpoint_WHEN_push_client_reliable_rpcs_to_the_service_THEN_rpc_push_result_no_buffer_authority)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, CLIENT_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ClientReliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientReliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::NoRingBufferAuthority));
 	return true;
 }
@@ -243,7 +249,8 @@ RPC_SERVICE_TEST(
 	GIVEN_authority_over_client_endpoint_WHEN_push_client_unreliable_rpcs_to_the_service_THEN_rpc_push_result_no_buffer_authority)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, CLIENT_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ClientUnreliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientUnreliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::NoRingBufferAuthority));
 	return true;
 }
@@ -251,7 +258,8 @@ RPC_SERVICE_TEST(
 RPC_SERVICE_TEST(GIVEN_authority_over_client_endpoint_WHEN_push_server_reliable_rpcs_to_the_service_THEN_rpc_push_result_success)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, CLIENT_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ServerReliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerReliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::Success));
 	return true;
 }
@@ -259,7 +267,8 @@ RPC_SERVICE_TEST(GIVEN_authority_over_client_endpoint_WHEN_push_server_reliable_
 RPC_SERVICE_TEST(GIVEN_authority_over_client_endpoint_WHEN_push_server_unreliable_rpcs_to_the_service_THEN_rpc_push_result_success)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, CLIENT_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ServerUnreliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerUnreliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::Success));
 	return true;
 }
@@ -267,7 +276,8 @@ RPC_SERVICE_TEST(GIVEN_authority_over_client_endpoint_WHEN_push_server_unreliabl
 RPC_SERVICE_TEST(GIVEN_authority_over_client_endpoint_WHEN_push_multicast_rpcs_to_the_service_THEN_rpc_push_result_no_buffer_authority)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, CLIENT_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::NetMulticast, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::NetMulticast, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::NoRingBufferAuthority));
 	return true;
 }
@@ -275,7 +285,8 @@ RPC_SERVICE_TEST(GIVEN_authority_over_client_endpoint_WHEN_push_multicast_rpcs_t
 RPC_SERVICE_TEST(GIVEN_authority_over_server_endpoint_WHEN_push_multicast_rpcs_to_the_service_THEN_rpc_push_result_success)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, SERVER_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::NetMulticast, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::NetMulticast, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::Success));
 	return true;
 }
@@ -283,7 +294,8 @@ RPC_SERVICE_TEST(GIVEN_authority_over_server_endpoint_WHEN_push_multicast_rpcs_t
 RPC_SERVICE_TEST(GIVEN_authority_over_server_and_client_endpoint_WHEN_push_rpcs_to_the_service_THEN_rpc_push_result_has_ack_authority)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, SERVER_AND_CLIENT_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ClientReliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientReliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::HasAckAuthority));
 	return true;
 }
@@ -297,10 +309,11 @@ RPC_SERVICE_TEST(
 	uint32 RPCsToSend = GetDefault<USpatialGDKSettings>()->GetRPCRingBufferSize(ERPCType::ClientReliable);
 	for (uint32 i = 0; i < RPCsToSend; ++i)
 	{
-		RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ClientReliable, SimplePayload, false);
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientReliable, SimplePayload, false);
 	}
 
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ClientReliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientReliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::QueueOverflowed));
 	return true;
 }
@@ -314,10 +327,11 @@ RPC_SERVICE_TEST(
 	uint32 RPCsToSend = GetDefault<USpatialGDKSettings>()->GetRPCRingBufferSize(ERPCType::ClientUnreliable);
 	for (uint32 i = 0; i < RPCsToSend; ++i)
 	{
-		RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ClientUnreliable, SimplePayload, false);
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientUnreliable, SimplePayload, false);
 	}
 
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ClientUnreliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientUnreliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::DropOverflowed));
 	return true;
 }
@@ -331,10 +345,11 @@ RPC_SERVICE_TEST(
 	uint32 RPCsToSend = GetDefault<USpatialGDKSettings>()->GetRPCRingBufferSize(ERPCType::ServerReliable);
 	for (uint32 i = 0; i < RPCsToSend; ++i)
 	{
-		RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ServerReliable, SimplePayload, false);
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerReliable, SimplePayload, false);
 	}
 
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ServerReliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerReliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::QueueOverflowed));
 	return true;
 }
@@ -348,10 +363,11 @@ RPC_SERVICE_TEST(
 	uint32 RPCsToSend = GetDefault<USpatialGDKSettings>()->GetRPCRingBufferSize(ERPCType::ServerUnreliable);
 	for (uint32 i = 0; i < RPCsToSend; ++i)
 	{
-		RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ServerUnreliable, SimplePayload, false);
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerUnreliable, SimplePayload, false);
 	}
 
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ServerUnreliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerUnreliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::DropOverflowed));
 	return true;
 }
@@ -364,10 +380,11 @@ RPC_SERVICE_TEST(GIVEN_authority_over_server_endpoint_WHEN_push_overflow_multica
 	uint32 RPCsToSend = GetDefault<USpatialGDKSettings>()->GetRPCRingBufferSize(ERPCType::NetMulticast);
 	for (uint32 i = 0; i < RPCsToSend; ++i)
 	{
-		RPCService.PushRPC(RPCTestEntityId_1, ERPCType::NetMulticast, SimplePayload, false);
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::NetMulticast, SimplePayload, false);
 	}
 
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::NetMulticast, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::NetMulticast, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::Success));
 	return true;
 }
@@ -386,7 +403,7 @@ RPC_SERVICE_TEST(
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService(EntityIdArray, CLIENT_AUTH);
 	for (const EntityPayload& EntityPayloadItem : EntityPayloads)
 	{
-		RPCService.PushRPC(EntityPayloadItem.EntityId, ERPCType::ServerUnreliable, EntityPayloadItem.Payload, false);
+		RPCService.PushRPC(EntityPayloadItem.EntityId, FUnrealObjectRef(), ERPCType::ServerUnreliable, EntityPayloadItem.Payload, false);
 	}
 
 	TArray<SpatialGDK::SpatialRPCService::UpdateToSend> UpdateToSendArray = RPCService.GetRPCsAndAcksToSend();
@@ -417,7 +434,7 @@ RPC_SERVICE_TEST(GIVEN_no_authority_over_rpc_endpoint_WHEN_push_client_reliable_
 	// Create RPCService with empty component view
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({}, NO_AUTH);
 
-	RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ClientReliable, SimplePayload, false);
+	RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientReliable, SimplePayload, false);
 
 	FWorkerComponentData ComponentData =
 		GetComponentDataOnEntityCreationFromRPCService(RPCService, RPCTestEntityId_1, ERPCType::ClientReliable);
@@ -432,8 +449,8 @@ RPC_SERVICE_TEST(GIVEN_no_authority_over_rpc_endpoint_WHEN_push_multicast_rpcs_t
 	// Create RPCService with empty component view
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({}, NO_AUTH);
 
-	RPCService.PushRPC(RPCTestEntityId_1, ERPCType::NetMulticast, SimplePayload, false);
-	RPCService.PushRPC(RPCTestEntityId_1, ERPCType::NetMulticast, SimplePayload, false);
+	RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::NetMulticast, SimplePayload, false);
+	RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::NetMulticast, SimplePayload, false);
 
 	FWorkerComponentData ComponentData =
 		GetComponentDataOnEntityCreationFromRPCService(RPCService, RPCTestEntityId_1, ERPCType::NetMulticast);
@@ -465,7 +482,8 @@ RPC_SERVICE_TEST(
 	int RPCsExtracted = 0;
 	bool bPayloadsMatch = true;
 	ExtractRPCDelegate RPCDelegate = ExtractRPCDelegate::CreateLambda(
-		[&RPCsExtracted, &bPayloadsMatch](Worker_EntityId EntityId, ERPCType RPCType, const SpatialGDK::RPCPayload& Payload) {
+		[&RPCsExtracted, &bPayloadsMatch](Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType RPCType,
+										  const SpatialGDK::RPCPayload& Payload, uint32 Slot) {
 			RPCsExtracted++;
 			bPayloadsMatch &= CompareRPCPayload(Payload, SimplePayload);
 			bPayloadsMatch &= EntityId == RPCTestEntityId_1;

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/TestRoutingWorker.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/TestRoutingWorker.cpp
@@ -1,0 +1,810 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "CoreMinimal.h"
+
+// Engine
+#include "Engine/Engine.h"
+#include "GameFramework/GameStateBase.h"
+#include "Misc/AutomationTest.h"
+#include "Tests/AutomationCommon.h"
+#include "Tests/TestActor.h"
+#include "Tests/TestDefinitions.h"
+#include "Tests/TestingComponentViewHelpers.h"
+
+// GDK
+#include "Interop/Connection/SpatialOSWorkerInterface.h"
+#include "Interop/SpatialRPCService.h"
+#include "Interop/SpatialRoutingSystem.h"
+#include "Interop/SpatialStaticComponentView.h"
+#include "Schema/CrossServerEndpoint.h"
+#include "SpatialView/OpList/EntityComponentOpList.h"
+#include "SpatialView/ViewCoordinator.h"
+
+#include "improbable/c_schema.h"
+
+class SpatialOSWorkerConnectionSpy : public SpatialOSWorkerInterface
+{
+public:
+	SpatialOSWorkerConnectionSpy();
+
+	virtual const TArray<SpatialGDK::EntityDelta>& GetEntityDeltas() override;
+	virtual const TArray<Worker_Op>& GetWorkerMessages() override;
+	virtual Worker_RequestId SendReserveEntityIdsRequest(uint32_t NumOfEntities) override;
+	virtual Worker_RequestId SendCreateEntityRequest(TArray<FWorkerComponentData> Components, const Worker_EntityId* EntityId) override;
+	virtual Worker_RequestId SendDeleteEntityRequest(Worker_EntityId EntityId) override;
+	virtual void SendAddComponent(Worker_EntityId EntityId, FWorkerComponentData* ComponentData) override;
+	virtual void SendRemoveComponent(Worker_EntityId EntityId, Worker_ComponentId ComponentId) override;
+	virtual void SendComponentUpdate(Worker_EntityId EntityId, FWorkerComponentUpdate* ComponentUpdate) override;
+	virtual Worker_RequestId SendCommandRequest(Worker_EntityId EntityId, Worker_CommandRequest* Request, uint32_t CommandId) override;
+	virtual void SendCommandResponse(Worker_RequestId RequestId, Worker_CommandResponse* Response) override;
+	virtual void SendCommandFailure(Worker_RequestId RequestId, const FString& Message) override;
+	virtual void SendLogMessage(uint8_t Level, const FName& LoggerName, const TCHAR* Message) override;
+	virtual void SendComponentInterest(Worker_EntityId EntityId, TArray<Worker_InterestOverride>&& ComponentInterest) override;
+	virtual Worker_RequestId SendEntityQueryRequest(const Worker_EntityQuery* EntityQuery) override;
+	virtual void SendMetrics(SpatialGDK::SpatialMetrics Metrics) override;
+
+	// The following methods are used to query for state in tests.
+	const Worker_EntityQuery* GetLastEntityQuery();
+	void ClearLastEntityQuery();
+
+	Worker_RequestId GetLastRequestId();
+
+	USpatialStaticComponentView* ComponentView;
+	TSet<TPair<Worker_EntityId_Key, Worker_ComponentId>> Updates;
+
+private:
+	Worker_RequestId NextRequestId;
+
+	const Worker_EntityQuery* LastEntityQuery;
+
+	TArray<SpatialGDK::EntityDelta> PlaceholderEntityDeltas;
+	TArray<Worker_Op> PlaceholderWorkerMessages;
+};
+
+SpatialOSWorkerConnectionSpy::SpatialOSWorkerConnectionSpy()
+	: NextRequestId(0)
+	, LastEntityQuery(nullptr)
+{
+	ComponentView = NewObject<USpatialStaticComponentView>();
+}
+
+const TArray<SpatialGDK::EntityDelta>& SpatialOSWorkerConnectionSpy::GetEntityDeltas()
+{
+	return PlaceholderEntityDeltas;
+}
+
+const TArray<Worker_Op>& SpatialOSWorkerConnectionSpy::GetWorkerMessages()
+{
+	return PlaceholderWorkerMessages;
+}
+
+Worker_RequestId SpatialOSWorkerConnectionSpy::SendReserveEntityIdsRequest(uint32_t NumOfEntities)
+{
+	return NextRequestId++;
+}
+
+Worker_RequestId SpatialOSWorkerConnectionSpy::SendCreateEntityRequest(TArray<FWorkerComponentData> Components,
+																	   const Worker_EntityId* EntityId)
+{
+	return NextRequestId++;
+}
+
+Worker_RequestId SpatialOSWorkerConnectionSpy::SendDeleteEntityRequest(Worker_EntityId EntityId)
+{
+	ComponentView->OnRemoveEntity(EntityId);
+	return NextRequestId++;
+}
+
+void SpatialOSWorkerConnectionSpy::SendAddComponent(Worker_EntityId EntityId, FWorkerComponentData* ComponentData) {}
+
+void SpatialOSWorkerConnectionSpy::SendRemoveComponent(Worker_EntityId EntityId, Worker_ComponentId ComponentId)
+{
+	Worker_RemoveComponentOp Op;
+	Op.entity_id = EntityId;
+	Op.component_id = ComponentId;
+	ComponentView->OnRemoveComponent(Op);
+}
+
+void SpatialOSWorkerConnectionSpy::SendComponentUpdate(Worker_EntityId EntityId, FWorkerComponentUpdate* ComponentUpdate)
+{
+	Worker_ComponentUpdateOp Update;
+	Update.entity_id = EntityId;
+	Update.update.component_id = ComponentUpdate->component_id;
+	Update.update.schema_type = ComponentUpdate->schema_type;
+	ComponentView->OnComponentUpdate(Update);
+
+	Updates.Add(MakeTuple(EntityId, ComponentUpdate->component_id));
+}
+
+Worker_RequestId SpatialOSWorkerConnectionSpy::SendCommandRequest(Worker_EntityId EntityId, Worker_CommandRequest* Request,
+																  uint32_t CommandId)
+{
+	return NextRequestId++;
+}
+
+void SpatialOSWorkerConnectionSpy::SendCommandResponse(Worker_RequestId RequestId, Worker_CommandResponse* Response) {}
+
+void SpatialOSWorkerConnectionSpy::SendCommandFailure(Worker_RequestId RequestId, const FString& Message) {}
+
+void SpatialOSWorkerConnectionSpy::SendLogMessage(uint8_t Level, const FName& LoggerName, const TCHAR* Message) {}
+
+void SpatialOSWorkerConnectionSpy::SendComponentInterest(Worker_EntityId EntityId, TArray<Worker_InterestOverride>&& ComponentInterest) {}
+
+Worker_RequestId SpatialOSWorkerConnectionSpy::SendEntityQueryRequest(const Worker_EntityQuery* EntityQuery)
+{
+	LastEntityQuery = EntityQuery;
+	return NextRequestId++;
+}
+
+void SpatialOSWorkerConnectionSpy::SendMetrics(SpatialGDK::SpatialMetrics Metrics) {}
+
+const Worker_EntityQuery* SpatialOSWorkerConnectionSpy::GetLastEntityQuery()
+{
+	return LastEntityQuery;
+}
+
+void SpatialOSWorkerConnectionSpy::ClearLastEntityQuery()
+{
+	LastEntityQuery = nullptr;
+}
+
+Worker_RequestId SpatialOSWorkerConnectionSpy::GetLastRequestId()
+{
+	return NextRequestId - 1;
+}
+
+#define ROUTING_SERVICE_TEST(TestName) GDK_TEST(Core, SpatialRPCService, TestName)
+namespace SpatialGDK
+{
+class ConnectionHandlerStub : public AbstractConnectionHandler
+{
+public:
+	void SetListsOfOpLists(TArray<TArray<OpList>> List) { ListsOfOpLists = MoveTemp(List); }
+
+	virtual void Advance() override
+	{
+		QueuedOpLists = MoveTemp(ListsOfOpLists[0]);
+		ListsOfOpLists.RemoveAt(0);
+	}
+
+	virtual uint32 GetOpListCount() override { return QueuedOpLists.Num(); }
+
+	virtual OpList GetNextOpList() override
+	{
+		OpList Temp = MoveTemp(QueuedOpLists[0]);
+		QueuedOpLists.RemoveAt(0);
+		return Temp;
+	}
+
+	virtual void SendMessages(TUniquePtr<MessagesToSend> Messages) override {}
+
+	virtual const FString& GetWorkerId() const override { return WorkerId; }
+
+	virtual const TArray<FString>& GetWorkerAttributes() const override { return Attributes; }
+
+private:
+	TArray<TArray<OpList>> ListsOfOpLists;
+	TArray<OpList> QueuedOpLists;
+	FString WorkerId = TEXT("test_worker");
+	TArray<FString> Attributes = { TEXT("test") };
+};
+
+void AddEntityAndCrossServerComponents(EntityComponentOpListBuilder& Builder, Worker_EntityId Id)
+{
+	Builder.AddEntity(Id);
+	Builder.AddComponent(Id, ComponentData{ SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID });
+	Builder.AddComponent(Id, ComponentData{ SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID });
+	Builder.AddComponent(Id, ComponentData{ SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID });
+	Builder.AddComponent(Id, ComponentData{ SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID });
+	Builder.AddComponent(Id, ComponentData{ SpatialConstants::ROUTINGWORKER_TAG_COMPONENT_ID });
+
+	Builder.SetAuthority(Id, SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID, WORKER_AUTHORITY_NOT_AUTHORITATIVE);
+	Builder.SetAuthority(Id, SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID, WORKER_AUTHORITY_AUTHORITATIVE);
+	Builder.SetAuthority(Id, SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID, WORKER_AUTHORITY_AUTHORITATIVE);
+	Builder.SetAuthority(Id, SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID, WORKER_AUTHORITY_NOT_AUTHORITATIVE);
+	Builder.SetAuthority(Id, SpatialConstants::ROUTINGWORKER_TAG_COMPONENT_ID, WORKER_AUTHORITY_NOT_AUTHORITATIVE);
+}
+
+void AddEntityAndCrossServerComponents(USpatialStaticComponentView& View, Worker_EntityId Id)
+{
+	Worker_AddComponentOp Op;
+	Op.entity_id = Id;
+	Op.data.schema_type = Schema_CreateComponentData();
+
+	Op.data.component_id = SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID;
+	View.OnAddComponent(Op);
+
+	Op.data.component_id = SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID;
+	View.OnAddComponent(Op);
+
+	Op.data.component_id = SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID;
+	View.OnAddComponent(Op);
+
+	Op.data.component_id = SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID;
+	View.OnAddComponent(Op);
+
+	Worker_AuthorityChangeOp AuthOp;
+	AuthOp.entity_id = Id;
+	AuthOp.authority = WORKER_AUTHORITY_AUTHORITATIVE;
+
+	AuthOp.component_id = SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID;
+	View.OnAuthorityChange(AuthOp);
+
+	AuthOp.component_id = SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID;
+	View.OnAuthorityChange(AuthOp);
+
+	AuthOp.authority = WORKER_AUTHORITY_NOT_AUTHORITATIVE;
+	AuthOp.component_id = SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID;
+	View.OnAuthorityChange(AuthOp);
+
+	AuthOp.component_id = SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID;
+	View.OnAuthorityChange(AuthOp);
+}
+
+void RemoveEntityAndCrossServerComponents(EntityComponentOpListBuilder& Builder, Worker_EntityId Id)
+{
+	// Builder.SetAuthority(Id, SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID, WORKER_AUTHORITY_NOT_AUTHORITATIVE);
+	// Builder.SetAuthority(Id, SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID, WORKER_AUTHORITY_NOT_AUTHORITATIVE);
+
+	Builder.RemoveComponent(Id, SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID);
+	Builder.RemoveComponent(Id, SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID);
+	Builder.RemoveComponent(Id, SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID);
+	Builder.RemoveComponent(Id, SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID);
+	Builder.RemoveComponent(Id, SpatialConstants::ROUTINGWORKER_TAG_COMPONENT_ID);
+	Builder.RemoveEntity(Id);
+}
+
+void RemoveEntityAndCrossServerComponents(SpatialOSWorkerConnectionSpy& Connection, Worker_EntityId Id)
+{
+	Connection.SendRemoveComponent(Id, SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID);
+	Connection.SendRemoveComponent(Id, SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID);
+	Connection.SendRemoveComponent(Id, SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID);
+	Connection.SendRemoveComponent(Id, SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID);
+	Connection.SendRemoveComponent(Id, SpatialConstants::ROUTINGWORKER_TAG_COMPONENT_ID);
+	Connection.SendDeleteEntityRequest(Id);
+
+	for (auto Iterator = Connection.Updates.CreateIterator(); Iterator; ++Iterator)
+	{
+		if (Iterator->Key == Id)
+		{
+			Iterator.RemoveCurrent();
+		}
+	}
+}
+
+bool ExtractUpdatesFromRPCService(ConnectionHandlerStub& Stub, SpatialGDK::SpatialRPCService& RPCService)
+{
+	bool bHadUpdates = false;
+	EntityComponentOpListBuilder Builder;
+	TArray<TArray<OpList>> ListsOfOpLists;
+	TArray<OpList> OpLists;
+
+	auto ListOfUpdates = RPCService.GetRPCsAndAcksToSend();
+
+	for (const auto& Update : ListOfUpdates)
+	{
+		Builder.UpdateComponent(Update.EntityId,
+								ComponentUpdate(OwningComponentUpdatePtr(Update.Update.schema_type), Update.Update.component_id));
+		bHadUpdates = true;
+	}
+
+	OpLists.Add(MoveTemp(Builder).CreateOpList());
+	ListsOfOpLists.Add(MoveTemp(OpLists));
+	Stub.SetListsOfOpLists(MoveTemp(ListsOfOpLists));
+
+	return bHadUpdates;
+}
+
+bool ProcessRPCUpdates(TSet<TPair<Worker_EntityId_Key, Worker_ComponentId>>& Updates, SpatialGDK::SpatialRPCService& RPCService,
+					   TSet<Worker_EntityId_Key> FilterUpdates = TSet<Worker_EntityId_Key>())
+{
+	bool bHadUpdates = false;
+	for (const auto& Update : Updates)
+	{
+		if (FilterUpdates.Num() != 0 && !FilterUpdates.Contains(Update.Get<0>()))
+		{
+			continue;
+		}
+
+		switch (Update.Get<1>())
+		{
+		case SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID:
+			RPCService.ExtractRPCsForEntity(Update.Get<0>(), Update.Get<1>());
+			bHadUpdates = true;
+			break;
+		case SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID:
+			RPCService.UpdateMergedACKs(Update.Get<0>());
+			bHadUpdates = true;
+			break;
+		default:
+			checkNoEntry();
+		}
+	}
+	Updates.Empty();
+
+	return bHadUpdates;
+}
+
+struct RPCToSend
+{
+	RPCToSend(Worker_EntityId InSender, Worker_EntityId InTarget, uint32 InPayloadId)
+		: Sender(InSender)
+		, Target(InTarget)
+		, PayloadId(InPayloadId)
+	{
+	}
+
+	Worker_EntityId Sender;
+	Worker_EntityId Target;
+	uint32 PayloadId;
+};
+
+struct Components
+{
+	Components(Worker_EntityId Entity, USpatialStaticComponentView* View)
+	{
+		Sender = View->GetComponentData<CrossServerEndpointSender>(Entity);
+		Receiver = View->GetComponentData<CrossServerEndpointReceiver>(Entity);
+		SenderACK = View->GetComponentData<CrossServerEndpointSenderACK>(Entity);
+		ReceiverACK = View->GetComponentData<CrossServerEndpointReceiverACK>(Entity);
+	}
+
+	bool CheckSettled()
+	{
+		for (auto& Slot : Sender->ReliableRPCBuffer.Counterpart)
+		{
+			if (Slot.IsSet())
+			{
+				return false;
+			}
+		}
+		for (auto& Slot : SenderACK->ACKArray)
+		{
+			if (Slot.IsSet())
+			{
+				return false;
+			}
+		}
+		for (auto& Slot : Receiver->ReliableRPCBuffer.Counterpart)
+		{
+			if (Slot.IsSet())
+			{
+				return false;
+			}
+		}
+		for (auto& Slot : ReceiverACK->ACKArray)
+		{
+			if (Slot.IsSet())
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	CrossServerEndpointSender* Sender;
+	CrossServerEndpointReceiver* Receiver;
+	CrossServerEndpointSenderACK* SenderACK;
+	CrossServerEndpointReceiverACK* ReceiverACK;
+};
+
+struct TestRoutingFixture
+{
+	TestRoutingFixture()
+		: Handler(MakeUnique<ConnectionHandlerStub>())
+		, Stub(Handler.Get())
+		, Coordinator(MoveTemp(Handler))
+		, RoutingSystem(Coordinator.CreateSubView(SpatialConstants::ROUTINGWORKER_TAG_COMPONENT_ID,
+												  [](const Worker_EntityId, const SpatialGDK::EntityViewElement&) {
+													  return true;
+												  },
+												  {}),
+						TEXT(""))
+	{
+	}
+
+	bool Step()
+	{
+		Coordinator.Advance();
+
+		RoutingSystem.Advance(&Spy);
+		RoutingSystem.Flush(&Spy);
+
+		return Spy.Updates.Num() > 0;
+	}
+
+private:
+	TUniquePtr<ConnectionHandlerStub> Handler;
+
+public:
+	ConnectionHandlerStub* Stub;
+	ViewCoordinator Coordinator;
+
+	SpatialGDK::SpatialRoutingSystem RoutingSystem;
+
+	SpatialOSWorkerConnectionSpy Spy;
+};
+
+ROUTING_SERVICE_TEST(TestRouting_BasicOp)
+{
+	TArray<Worker_EntityId> Entities;
+	for (uint32 i = 0; i < 4; ++i)
+	{
+		Entities.Add((i + 1) * 10);
+	}
+
+	TArray<TArray<OpList>> ListsOfOpLists;
+	{
+		TArray<OpList> OpLists;
+		EntityComponentOpListBuilder Builder;
+		for (auto Entity : Entities)
+		{
+			AddEntityAndCrossServerComponents(Builder, Entity);
+		}
+		OpLists.Add(MoveTemp(Builder).CreateOpList());
+		ListsOfOpLists.Add(MoveTemp(OpLists));
+	}
+
+	TestRoutingFixture TestFixture;
+
+	SpatialOSWorkerConnectionSpy& Spy = TestFixture.Spy;
+	ConnectionHandlerStub* Stub = TestFixture.Stub;
+	Stub->SetListsOfOpLists(MoveTemp(ListsOfOpLists));
+	TestFixture.Step();
+
+	for (auto Entity : Entities)
+	{
+		AddEntityAndCrossServerComponents(*Spy.ComponentView, Entity);
+	}
+
+	Worker_EntityId Entity1 = Entities[0];
+	Worker_EntityId Entity2 = Entities[1];
+
+	CrossServerEndpointReceiver& Receiver2 = *Spy.ComponentView->GetComponentData<CrossServerEndpointReceiver>(Entity2);
+	CrossServerEndpointSenderACK& SenderACK1 = *Spy.ComponentView->GetComponentData<CrossServerEndpointSenderACK>(Entity1);
+	CrossServerEndpointReceiverACK& ReceiverACK2 = *Spy.ComponentView->GetComponentData<CrossServerEndpointReceiverACK>(Entity2);
+
+	RPCPayload Payload(0, 1337, TArray<uint8>());
+
+	SpatialGDK::SpatialRPCService* RPCServiceBackptr = nullptr;
+
+	TSet<TPair<Worker_EntityId, uint32>> ExpectedRPCs = { MakeTuple(Entity2, 1337u) };
+
+	auto ExtractRPCCallback = [this, &ExpectedRPCs, &RPCServiceBackptr](Worker_EntityId Target, const FUnrealObjectRef& SenderRef,
+																		ERPCType Type, const SpatialGDK::RPCPayload& Payload,
+																		uint64 SenderRev) {
+		int32 NumRemoved = ExpectedRPCs.Remove(MakeTuple(Target, Payload.Index));
+		FString DebugText = FString::Printf(TEXT("RPC %i from %llu to %llu was unexpected"), Payload.Index, SenderRef.Entity, Target);
+		TestTrue(*DebugText, NumRemoved > 0);
+
+		RPCServiceBackptr->WriteCrossServerACKFor(Target, SenderRef.Entity, SenderRef.Offset, SenderRev, Type);
+		return true;
+	};
+
+	SpatialGDK::SpatialRPCService RPCService(ExtractRPCDelegate::CreateLambda(ExtractRPCCallback), Spy.ComponentView, nullptr);
+	RPCServiceBackptr = &RPCService;
+	for (auto Entity : Entities)
+	{
+		RPCService.OnEndpointAuthorityGained(Entity, SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID);
+		RPCService.OnEndpointAuthorityGained(Entity, SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID);
+	}
+
+	RPCService.PushRPC(Entity1, FUnrealObjectRef(Entity2, 0), ERPCType::CrossServerSender, Payload, false);
+	ExtractUpdatesFromRPCService(*Stub, RPCService);
+
+	TestFixture.Step();
+
+	TestTrue(TEXT("SentRPC"), Receiver2.ReliableRPCBuffer.Counterpart.Num() > 0);
+	TestTrue(TEXT("SentRPC"), Receiver2.ReliableRPCBuffer.Counterpart[0].IsSet());
+	const FUnrealObjectRef& SenderBackRef = Receiver2.ReliableRPCBuffer.Counterpart[0].GetValue();
+	TestTrue(TEXT("SentRPC"), SenderBackRef.Entity == Entity1);
+
+	ProcessRPCUpdates(Spy.Updates, RPCService);
+
+	TestTrue(TEXT("ReceivedRPC"), ExpectedRPCs.Num() == 0);
+
+	ExtractUpdatesFromRPCService(*Stub, RPCService);
+
+	TestFixture.Step();
+
+	TestTrue(TEXT("ACKWritten"), SenderACK1.ACKArray.Num() > 0);
+	TestTrue(TEXT("ACKWritten"), SenderACK1.ACKArray[0].IsSet());
+	const ACKItem& ACK = SenderACK1.ACKArray[0].GetValue();
+	TestTrue(TEXT("ACKWritten"), ACK.Sender == Entity1);
+
+	ProcessRPCUpdates(Spy.Updates, RPCService);
+	ExtractUpdatesFromRPCService(*Stub, RPCService);
+
+	TestFixture.Step();
+
+	for (auto& Slot : SenderACK1.ACKArray)
+	{
+		TestTrue(TEXT("SenderACK cleanued up"), !Slot.IsSet());
+	}
+
+	for (auto& Slot : Receiver2.ReliableRPCBuffer.Counterpart)
+	{
+		TestTrue(TEXT("Receiver cleaned up"), !Slot.IsSet());
+	}
+
+	ProcessRPCUpdates(Spy.Updates, RPCService);
+	ExtractUpdatesFromRPCService(*Stub, RPCService);
+
+	TestFixture.Step();
+
+	for (auto& Slot : ReceiverACK2.ACKArray)
+	{
+		TestTrue(TEXT("Receiver ACK cleaned up"), !Slot.IsSet());
+	}
+
+	TArray<RPCToSend> RPCs;
+	uint32 RPCId = 1;
+	for (uint32 i = 0; i < 8; ++i)
+	{
+		for (int32 j = 0; j < Entities.Num(); ++j)
+			for (int32 k = j + 1; k < Entities.Num(); ++k)
+			{
+				RPCs.Add(RPCToSend(Entities[j], Entities[k], RPCId++));
+				RPCs.Add(RPCToSend(Entities[k], Entities[j], RPCId++));
+			}
+	}
+
+	for (auto& RPC : RPCs)
+	{
+		ExpectedRPCs.Add(MakeTuple(RPC.Target, RPC.PayloadId));
+	}
+
+	bool bHasProcessedMessages = true;
+	while (RPCs.Num() != 0 || bHasProcessedMessages)
+	{
+		if (RPCs.Num() > 0)
+		{
+			RPCToSend RPC = RPCs.Last();
+			RPCPayload DummyPayload(0, RPC.PayloadId, TArray<uint8>());
+			if (RPCService.PushRPC(RPC.Sender, FUnrealObjectRef(RPC.Target, 0), ERPCType::CrossServerSender, DummyPayload, false)
+				== EPushRPCResult::Success)
+			{
+				RPCs.Pop();
+			}
+		}
+
+		bHasProcessedMessages = false;
+		bHasProcessedMessages |= ProcessRPCUpdates(Spy.Updates, RPCService);
+		bHasProcessedMessages |= ExtractUpdatesFromRPCService(*Stub, RPCService);
+		TestFixture.Step();
+	}
+
+	TestTrue(TEXT("All RPCs sent and accounted for"), ExpectedRPCs.Num() == 0);
+	for (auto Entity : Entities)
+	{
+		Components Comps(Entity, Spy.ComponentView);
+		TestTrue(TEXT("Settled"), Comps.CheckSettled());
+	}
+
+	return true;
+}
+
+ROUTING_SERVICE_TEST(TestRouting_Delete)
+{
+	const uint32 Delays = 8;
+
+	TArray<Worker_EntityId> Entities;
+	for (uint32 i = 0; i < 4 * Delays * 2; ++i)
+	{
+		Entities.Add((i + 1) * 10);
+	}
+
+	TArray<TArray<OpList>> ListsOfOpLists;
+	{
+		TArray<OpList> OpLists;
+		EntityComponentOpListBuilder Builder;
+		for (auto Entity : Entities)
+		{
+			AddEntityAndCrossServerComponents(Builder, Entity);
+		}
+		OpLists.Add(MoveTemp(Builder).CreateOpList());
+		ListsOfOpLists.Add(MoveTemp(OpLists));
+	}
+
+	TestRoutingFixture TestFixture;
+
+	SpatialOSWorkerConnectionSpy& Spy = TestFixture.Spy;
+	ConnectionHandlerStub* Stub = TestFixture.Stub;
+	Stub->SetListsOfOpLists(MoveTemp(ListsOfOpLists));
+	TestFixture.Step();
+
+	for (auto Entity : Entities)
+	{
+		AddEntityAndCrossServerComponents(*Spy.ComponentView, Entity);
+	}
+
+	SpatialGDK::SpatialRPCService* RPCServiceBackptr = nullptr;
+
+	TSet<TPair<Worker_EntityId, uint32>> ExpectedRPCs;
+
+	auto ExtractRPCCallback = [this, &ExpectedRPCs, &RPCServiceBackptr](Worker_EntityId Target, const FUnrealObjectRef& SenderRef,
+																		ERPCType Type, const SpatialGDK::RPCPayload& Payload,
+																		uint64 SenderRev) {
+		RPCServiceBackptr->WriteCrossServerACKFor(Target, SenderRef.Entity, SenderRef.Offset, SenderRev, Type);
+		return true;
+	};
+
+	SpatialGDK::SpatialRPCService RPCService(ExtractRPCDelegate::CreateLambda(ExtractRPCCallback), Spy.ComponentView, nullptr);
+	RPCServiceBackptr = &RPCService;
+	for (auto Entity : Entities)
+	{
+		RPCService.OnEndpointAuthorityGained(Entity, SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID);
+		RPCService.OnEndpointAuthorityGained(Entity, SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID);
+	}
+
+	for (uint32 Attempt = 0; Attempt < 4; ++Attempt)
+		for (uint32 CurDelay = 0; CurDelay < Delays; ++CurDelay)
+		{
+			Worker_EntityId Sender = Entities[2 * (Attempt * Delays + CurDelay) + 0];
+			Worker_EntityId Receiver = Entities[2 * (Attempt * Delays + CurDelay) + 1];
+
+			Worker_EntityId ToRemove = (Attempt / 2) == 0 ? Sender : Receiver;
+			Worker_EntityId ToCheck = (Attempt / 2) == 1 ? Sender : Receiver;
+
+			RPCPayload DummyPayload(0, 0, TArray<uint8>());
+			RPCService.PushRPC(Sender, FUnrealObjectRef(Receiver, 0), ERPCType::CrossServerSender, DummyPayload, false);
+
+			uint32 Delay = 0;
+			bool bHasProcessedMessages = true;
+			while (bHasProcessedMessages)
+			{
+				auto PerformDeletion = [&] {
+					RPCService.OnEndpointAuthorityLost(ToRemove, SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID);
+					RPCService.OnEndpointAuthorityLost(ToRemove, SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID);
+					RemoveEntityAndCrossServerComponents(Spy, ToRemove);
+
+					TArray<OpList> OpLists;
+					EntityComponentOpListBuilder Builder;
+					RemoveEntityAndCrossServerComponents(Builder, ToRemove);
+					OpLists.Add(MoveTemp(Builder).CreateOpList());
+					ListsOfOpLists.Add(MoveTemp(OpLists));
+					Stub->SetListsOfOpLists(MoveTemp(ListsOfOpLists));
+					TestFixture.Step();
+				};
+
+				if (Delay == CurDelay && Attempt % 2 == 0)
+				{
+					PerformDeletion();
+				}
+
+				bHasProcessedMessages = false;
+				bHasProcessedMessages |= ProcessRPCUpdates(Spy.Updates, RPCService);
+
+				if (Delay == CurDelay && Attempt % 2 == 1)
+				{
+					PerformDeletion();
+				}
+
+				bHasProcessedMessages |= ExtractUpdatesFromRPCService(*Stub, RPCService);
+				bHasProcessedMessages |= TestFixture.Step();
+
+				++Delay;
+			}
+
+			Components Comps(ToCheck, Spy.ComponentView);
+			bool Settled = Comps.CheckSettled();
+			if (!Settled)
+			{
+				FString Debug = FString::Printf(TEXT("Attempt %i for delay %i is not settled"), Attempt, Delay);
+				TestTrue(Debug, Settled);
+			}
+		}
+
+	return true;
+}
+
+ROUTING_SERVICE_TEST(TestRouting_Capacity)
+{
+	TArray<Worker_EntityId> Entities;
+	for (uint32 i = 0; i < 4; ++i)
+	{
+		Entities.Add((i + 1) * 10);
+	}
+
+	TArray<TArray<OpList>> ListsOfOpLists;
+	{
+		TArray<OpList> OpLists;
+		EntityComponentOpListBuilder Builder;
+		for (auto Entity : Entities)
+		{
+			AddEntityAndCrossServerComponents(Builder, Entity);
+		}
+		OpLists.Add(MoveTemp(Builder).CreateOpList());
+		ListsOfOpLists.Add(MoveTemp(OpLists));
+	}
+
+	TestRoutingFixture TestFixture;
+
+	SpatialOSWorkerConnectionSpy& Spy = TestFixture.Spy;
+	ConnectionHandlerStub* Stub = TestFixture.Stub;
+	Stub->SetListsOfOpLists(MoveTemp(ListsOfOpLists));
+	TestFixture.Step();
+
+	for (auto Entity : Entities)
+	{
+		AddEntityAndCrossServerComponents(*Spy.ComponentView, Entity);
+	}
+
+	SpatialGDK::SpatialRPCService* RPCServiceBackptr = nullptr;
+
+	TSet<TPair<Worker_EntityId, uint32>> ExpectedRPCs;
+
+	auto ExtractRPCCallback = [this, &ExpectedRPCs, &RPCServiceBackptr](Worker_EntityId Target, const FUnrealObjectRef& SenderRef,
+																		ERPCType Type, const SpatialGDK::RPCPayload& Payload,
+																		uint64 SenderRev) {
+		int32 NumRemoved = ExpectedRPCs.Remove(MakeTuple(Target, Payload.Index));
+		FString DebugText = FString::Printf(TEXT("RPC %i from %llu to %llu was unexpected"), Payload.Index, SenderRef.Entity, Target);
+		TestTrue(*DebugText, NumRemoved > 0);
+		RPCServiceBackptr->WriteCrossServerACKFor(Target, SenderRef.Entity, SenderRef.Offset, SenderRev, Type);
+		return true;
+	};
+
+	SpatialGDK::SpatialRPCService RPCService(ExtractRPCDelegate::CreateLambda(ExtractRPCCallback), Spy.ComponentView, nullptr);
+	RPCServiceBackptr = &RPCService;
+	for (auto Entity : Entities)
+	{
+		RPCService.OnEndpointAuthorityGained(Entity, SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID);
+		RPCService.OnEndpointAuthorityGained(Entity, SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID);
+	}
+
+	uint32 MaxCapacity = SpatialGDK::RPCRingBufferUtils::GetRingBufferSize(ERPCType::CrossServerSender);
+
+	TArray<uint32> TargetIdx;
+	for (int32 idx = 0; idx < 4; ++idx)
+	{
+		TargetIdx.Add((idx + 1) % 4);
+	}
+
+	// Should take 2 steps to fan out and receive updates.
+	uint32 RPCPerStep = MaxCapacity / 2;
+	uint32 RPCAlloc = 0;
+	for (uint32 BatchNum = 0; BatchNum < 16; ++BatchNum)
+	{
+		ProcessRPCUpdates(Spy.Updates, RPCService);
+
+		for (uint32 i = 0; i < 4; ++i)
+		{
+			Worker_EntityId Sender = Entities[i];
+			Worker_EntityId Receiver = Entities[TargetIdx[i]];
+			for (uint32 j = 0; j < RPCPerStep; ++j)
+			{
+				RPCPayload DummyPayload(0, RPCAlloc, TArray<uint8>());
+				ExpectedRPCs.Add(MakeTuple(Receiver, RPCAlloc));
+				++RPCAlloc;
+				SpatialGDK::EPushRPCResult Result =
+					RPCService.PushRPC(Sender, FUnrealObjectRef(Receiver, 0), ERPCType::CrossServerSender, DummyPayload, false);
+				TestTrue(TEXT("Did not run out of capacity"), Result == EPushRPCResult::Success);
+				do
+				{
+					TargetIdx[i] = (TargetIdx[i] + 1) % 4;
+					Receiver = Entities[TargetIdx[i]];
+				} while (Receiver == Sender);
+			}
+		}
+		ExtractUpdatesFromRPCService(*Stub, RPCService);
+		TestFixture.Step();
+	}
+	bool bHasProcessedMessages = true;
+	while (bHasProcessedMessages)
+	{
+		bHasProcessedMessages = false;
+		bHasProcessedMessages |= ProcessRPCUpdates(Spy.Updates, RPCService);
+		bHasProcessedMessages |= ExtractUpdatesFromRPCService(*Stub, RPCService);
+		bHasProcessedMessages |= TestFixture.Step();
+	}
+	TestTrue(TEXT("All RPC were received"), ExpectedRPCs.Num() == 0);
+
+	return true;
+}
+
+ROUTING_SERVICE_TEST(TestRouting_Migration)
+{
+	return true;
+}
+
+} // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -58,6 +58,13 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 	WorkerRequirementSet AnyServerOrClientRequirementSet = { SpatialConstants::UnrealServerAttributeSet,
 															 SpatialConstants::UnrealClientAttributeSet };
 
+	WorkerRequirementSet AllServersPermission = { SpatialConstants::UnrealServerAttributeSet,
+												  SpatialConstants::UnrealRoutingWorkerAttributeSet };
+
+	WorkerRequirementSet AllWorkersPermission = { SpatialConstants::UnrealServerAttributeSet,
+												  SpatialConstants::UnrealRoutingWorkerAttributeSet,
+												  SpatialConstants::UnrealClientAttributeSet };
+
 	WorkerAttributeSet OwningClientAttributeSet = { ClientWorkerAttribute };
 
 	WorkerRequirementSet AnyServerOrOwningClientRequirementSet = { SpatialConstants::UnrealServerAttributeSet, OwningClientAttributeSet };
@@ -93,7 +100,7 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 	WorkerRequirementSet ReadAcl;
 	if (Class->HasAnySpatialClassFlags(SPATIALCLASS_ServerOnly))
 	{
-		ReadAcl = AnyServerRequirementSet;
+		ReadAcl = AllServersPermission;
 	}
 	else if (Actor->IsA<APlayerController>())
 	{
@@ -101,7 +108,7 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 	}
 	else
 	{
-		ReadAcl = AnyServerOrClientRequirementSet;
+		ReadAcl = AllWorkersPermission;
 	}
 
 	WriteAclMap ComponentWriteAcl;
@@ -431,6 +438,7 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 	ComponentDatas.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::CLIENT_AUTH_TAG_COMPONENT_ID));
 	ComponentDatas.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::CLIENT_NON_AUTH_TAG_COMPONENT_ID));
 	ComponentDatas.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::LB_TAG_COMPONENT_ID));
+	ComponentDatas.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::ROUTINGWORKER_TAG_COMPONENT_ID));
 
 	return ComponentDatas;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -81,7 +81,14 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 			   *Actor->GetName(), *NetDriver->LoadBalanceStrategy->GetName());
 	}
 
+	const USpatialGDKSettings* SpatialSettings = GetDefault<USpatialGDKSettings>();
+
+	FString RoutingWorkerName = NetDriver->GetRoutingWorkerId();
+
+	check(SpatialSettings->CrossServerRPCImplementation != ECrossServerRPCImplementation::RoutingWorker || !RoutingWorkerName.IsEmpty());
+
 	const WorkerRequirementSet AuthoritativeWorkerRequirementSet = { WorkerAttributeOrSpecificWorker };
+	const WorkerRequirementSet RoutingWorkerRequirementSet = { { FString::Format(TEXT("workerId:{0}"), { *RoutingWorkerName }) } };
 
 	WorkerRequirementSet ReadAcl;
 	if (Class->HasAnySpatialClassFlags(SPATIALCLASS_ServerOnly))
@@ -102,14 +109,29 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 	ComponentWriteAcl.Add(SpatialConstants::INTEREST_COMPONENT_ID, AuthoritativeWorkerRequirementSet);
 	ComponentWriteAcl.Add(SpatialConstants::SPAWN_DATA_COMPONENT_ID, AuthoritativeWorkerRequirementSet);
 	ComponentWriteAcl.Add(SpatialConstants::DORMANT_COMPONENT_ID, AuthoritativeWorkerRequirementSet);
-	ComponentWriteAcl.Add(SpatialConstants::SERVER_TO_SERVER_COMMAND_ENDPOINT_COMPONENT_ID, AuthoritativeWorkerRequirementSet);
+
+	if (SpatialSettings->CrossServerRPCImplementation == ECrossServerRPCImplementation::RoutingWorker)
+	{
+		ComponentWriteAcl.Add(SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID, AuthoritativeWorkerRequirementSet);
+		ComponentWriteAcl.Add(SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID, RoutingWorkerRequirementSet);
+		ComponentWriteAcl.Add(SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID, RoutingWorkerRequirementSet);
+		ComponentWriteAcl.Add(SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID, AuthoritativeWorkerRequirementSet);
+	}
+	else if (SpatialSettings->CrossServerRPCImplementation == ECrossServerRPCImplementation::WorkerEntityMailbox)
+	{
+		ComponentWriteAcl.Add(SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID, AuthoritativeWorkerRequirementSet);
+	}
+	else if (SpatialSettings->CrossServerRPCImplementation == ECrossServerRPCImplementation::SpatialCommand)
+	{
+		ComponentWriteAcl.Add(SpatialConstants::SERVER_TO_SERVER_COMMAND_ENDPOINT_COMPONENT_ID, AuthoritativeWorkerRequirementSet);
+	}
+
 	ComponentWriteAcl.Add(SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID, AuthoritativeWorkerRequirementSet);
 	ComponentWriteAcl.Add(SpatialConstants::UNREAL_METADATA_COMPONENT_ID, AuthoritativeWorkerRequirementSet);
 	ComponentWriteAcl.Add(SpatialConstants::NET_OWNING_CLIENT_WORKER_COMPONENT_ID, AuthoritativeWorkerRequirementSet);
 	ComponentWriteAcl.Add(SpatialConstants::ENTITY_ACL_COMPONENT_ID, AnyServerRequirementSet);
 	ComponentWriteAcl.Add(SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID, AuthoritativeWorkerRequirementSet);
 
-	const USpatialGDKSettings* SpatialSettings = GetDefault<USpatialGDKSettings>();
 	if (SpatialSettings->UseRPCRingBuffer() && RPCService != nullptr)
 	{
 		ComponentWriteAcl.Add(SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID, OwningClientOnlyRequirementSet);
@@ -285,7 +307,21 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 
 	Channel->SetNeedOwnerInterestUpdate(!NetDriver->InterestFactory->DoOwnersHaveEntityId(Actor));
 
-	ComponentDatas.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::SERVER_TO_SERVER_COMMAND_ENDPOINT_COMPONENT_ID));
+	if (SpatialSettings->CrossServerRPCImplementation == ECrossServerRPCImplementation::RoutingWorker)
+	{
+		ComponentDatas.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID));
+		ComponentDatas.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID));
+		ComponentDatas.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID));
+		ComponentDatas.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID));
+	}
+	else if (SpatialSettings->CrossServerRPCImplementation == ECrossServerRPCImplementation::WorkerEntityMailbox)
+	{
+		ComponentDatas.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID));
+	}
+	else if (SpatialSettings->CrossServerRPCImplementation == ECrossServerRPCImplementation::SpatialCommand)
+	{
+		ComponentDatas.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::SERVER_TO_SERVER_COMMAND_ENDPOINT_COMPONENT_ID));
+	}
 
 	if (SpatialSettings->UseRPCRingBuffer() && RPCService != nullptr)
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -101,7 +101,7 @@ Worker_ComponentUpdate InterestFactory::CreateInterestUpdate(AActor* InActor, co
 	return CreateInterest(InActor, InInfo, InEntityId).CreateInterestUpdate();
 }
 
-Interest InterestFactory::CreateServerWorkerInterest(const UAbstractLBStrategy* LBStrategy, bool bDebug)
+Interest InterestFactory::CreateServerWorkerInterest(const UAbstractLBStrategy* LBStrategy, bool bDebug, bool bIsRoutingWorker)
 {
 	const USpatialGDKSettings* SpatialGDKSettings = GetDefault<USpatialGDKSettings>();
 
@@ -158,6 +158,37 @@ Interest InterestFactory::CreateServerWorkerInterest(const UAbstractLBStrategy* 
 		ServerQuery = Query();
 		ServerQuery.ResultComponentIds = SchemaResultType{ SpatialConstants::GDK_DEBUG_COMPONENT_ID };
 		ServerQuery.Constraint.ComponentConstraint = SpatialConstants::GDK_DEBUG_COMPONENT_ID;
+		AddComponentQueryPairToInterestComponent(ServerInterest, SpatialConstants::POSITION_COMPONENT_ID, ServerQuery);
+	}
+
+	if (SpatialGDKSettings->CrossServerRPCImplementation == ECrossServerRPCImplementation::WorkerEntityMailbox)
+	{
+		ServerQuery = Query();
+		ServerQuery.ResultComponentIds = SchemaResultType{ SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID };
+
+		ServerQuery.Constraint.ComponentConstraint = SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID;
+		AddComponentQueryPairToInterestComponent(ServerInterest, SpatialConstants::POSITION_COMPONENT_ID, ServerQuery);
+
+		ServerQuery = Query();
+		ServerQuery.ResultComponentIds = SchemaResultType{ SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID };
+
+		ServerQuery.Constraint.ComponentConstraint = SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID;
+		AddComponentQueryPairToInterestComponent(ServerInterest, SpatialConstants::POSITION_COMPONENT_ID, ServerQuery);
+	}
+	else if (SpatialGDKSettings->CrossServerRPCImplementation == ECrossServerRPCImplementation::RoutingWorker && bIsRoutingWorker)
+	{
+		ServerQuery = Query();
+		ServerQuery.ResultComponentIds = SchemaResultType{ SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID,
+														   SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID };
+		ServerQuery.Constraint.ComponentConstraint = SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID;
+
+		AddComponentQueryPairToInterestComponent(ServerInterest, SpatialConstants::POSITION_COMPONENT_ID, ServerQuery);
+
+		ServerQuery = Query();
+		ServerQuery.ResultComponentIds = SchemaResultType{ SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID,
+														   SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID };
+		ServerQuery.Constraint.ComponentConstraint = SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID;
+
 		AddComponentQueryPairToInterestComponent(ServerInterest, SpatialConstants::POSITION_COMPONENT_ID, ServerQuery);
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCContainer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCContainer.cpp
@@ -94,18 +94,18 @@ void LogRPCError(const FRPCErrorInfo& ErrorInfo, ERPCQueueType QueueType, const 
 //}
 
 FPendingRPCParams::FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, ERPCType InType,
-									 RPCPayload&& InPayload, uint32 InSlot)
+									 RPCPayload&& InPayload, uint64 InSenderRev)
 	: ObjectRef(InTargetObjectRef)
 	, SenderObjectRef(InSenderObjectRef)
 	, Payload(MoveTemp(InPayload))
-	, Slot(InSlot)
+	, SenderRev(InSenderRev)
 	, Timestamp(FDateTime::Now())
 	, Type(InType)
 {
 }
 
 void FRPCContainer::ProcessOrQueueRPC(const FUnrealObjectRef& TargetObjectRef, const FUnrealObjectRef& SenderObjectRef, ERPCType Type,
-									  RPCPayload&& Payload, uint32 Slot)
+									  RPCPayload&& Payload, uint64 SenderRev)
 {
 	FArrayOfParams& ArrayOfParams = QueuedRPCs.FindOrAdd(Type).FindOrAdd(TargetObjectRef.Entity);
 
@@ -121,7 +121,7 @@ void FRPCContainer::ProcessOrQueueRPC(const FUnrealObjectRef& TargetObjectRef, c
 		}
 	}
 
-	FPendingRPCParams Params{ TargetObjectRef, SenderObjectRef, Type, MoveTemp(Payload), Slot };
+	FPendingRPCParams Params{ TargetObjectRef, SenderObjectRef, Type, MoveTemp(Payload), SenderRev };
 
 	if (!ObjectHasRPCsQueuedOfType(Params.ObjectRef.Entity, Params.Type))
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCContainer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCContainer.cpp
@@ -87,17 +87,41 @@ void LogRPCError(const FRPCErrorInfo& ErrorInfo, ERPCQueueType QueueType, const 
 }
 } // namespace
 
-FPendingRPCParams::FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, ERPCType InType, RPCPayload&& InPayload)
+// FPendingRPCParams::FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, ERPCType
+// InType, RPCPayload&& InPayload) 	: ObjectRef(InTargetObjectRef) 	, SenderObjectRef(InSenderObjectRef) 	, Payload(MoveTemp(InPayload)) ,
+// Timestamp(FDateTime::Now()) 	, Type(InType)
+//{
+//}
+
+FPendingRPCParams::FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, ERPCType InType,
+									 RPCPayload&& InPayload, uint32 InSlot)
 	: ObjectRef(InTargetObjectRef)
+	, SenderObjectRef(InSenderObjectRef)
 	, Payload(MoveTemp(InPayload))
+	, Slot(InSlot)
 	, Timestamp(FDateTime::Now())
 	, Type(InType)
 {
 }
 
-void FRPCContainer::ProcessOrQueueRPC(const FUnrealObjectRef& TargetObjectRef, ERPCType Type, RPCPayload&& Payload)
+void FRPCContainer::ProcessOrQueueRPC(const FUnrealObjectRef& TargetObjectRef, const FUnrealObjectRef& SenderObjectRef, ERPCType Type,
+									  RPCPayload&& Payload, uint32 Slot)
 {
-	FPendingRPCParams Params{ TargetObjectRef, Type, MoveTemp(Payload) };
+	FArrayOfParams& ArrayOfParams = QueuedRPCs.FindOrAdd(Type).FindOrAdd(TargetObjectRef.Entity);
+
+	if (Type == ERPCType::CrossServerSender)
+	{
+		for (auto const& Entry : ArrayOfParams)
+		{
+			if (Entry.SenderObjectRef == SenderObjectRef)
+			{
+				// Already queued RPC, can happen while reading RPC over several frames.
+				return;
+			}
+		}
+	}
+
+	FPendingRPCParams Params{ TargetObjectRef, SenderObjectRef, Type, MoveTemp(Payload), Slot };
 
 	if (!ObjectHasRPCsQueuedOfType(Params.ObjectRef.Entity, Params.Type))
 	{
@@ -110,7 +134,6 @@ void FRPCContainer::ProcessOrQueueRPC(const FUnrealObjectRef& TargetObjectRef, E
 		}
 	}
 
-	FArrayOfParams& ArrayOfParams = QueuedRPCs.FindOrAdd(Params.Type).FindOrAdd(Params.ObjectRef.Entity);
 	ArrayOfParams.Push(MoveTemp(Params));
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetricsDisplay.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetricsDisplay.cpp
@@ -64,12 +64,12 @@ void ASpatialMetricsDisplay::Destroyed()
 	}
 }
 
-bool ASpatialMetricsDisplay::ServerUpdateWorkerStats_Validate(const float Time, const FWorkerStats& OneWorkerStats)
+bool ASpatialMetricsDisplay::ServerUpdateWorkerStats_Validate(AActor* Sender, const float Time, const FWorkerStats& OneWorkerStats)
 {
 	return true;
 }
 
-void ASpatialMetricsDisplay::ServerUpdateWorkerStats_Implementation(const float Time, const FWorkerStats& OneWorkerStats)
+void ASpatialMetricsDisplay::ServerUpdateWorkerStats_Implementation(AActor* Sender, const float Time, const FWorkerStats& OneWorkerStats)
 {
 	int32 StatsIndex = WorkerStats.Find(OneWorkerStats);
 
@@ -254,7 +254,7 @@ void ASpatialMetricsDisplay::Tick(float DeltaSeconds)
 	}
 #endif // USE_SERVER_PERF_COUNTERS
 
-	ServerUpdateWorkerStats(SpatialNetDriver->GetElapsedTime(), Stats);
+	ServerUpdateWorkerStats(nullptr, SpatialNetDriver->GetElapsedTime(), Stats);
 
 #endif // !UE_BUILD_SHIPPING
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -51,6 +51,11 @@ DECLARE_DWORD_ACCUMULATOR_STAT_EXTERN(TEXT("Consider List Size"), STAT_SpatialCo
 DECLARE_DWORD_ACCUMULATOR_STAT_EXTERN(TEXT("Num Relevant Actors"), STAT_SpatialActorsRelevant, STATGROUP_SpatialNet, );
 DECLARE_DWORD_ACCUMULATOR_STAT_EXTERN(TEXT("Num Changed Relevant Actors"), STAT_SpatialActorsChanged, STATGROUP_SpatialNet, );
 
+namespace SpatialGDK
+{
+struct SpatialRoutingSystem;
+}
+
 UCLASS()
 class SPATIALGDK_API USpatialNetDriver : public UIpNetDriver
 {
@@ -134,6 +139,8 @@ public:
 	void CleanUpClientConnection(USpatialNetConnection* ClientConnection);
 	const FString& GetRoutingWorkerId();
 
+	void QueryRoutingWorkerId();
+
 	UPROPERTY()
 	USpatialWorkerConnection* Connection;
 	UPROPERTY()
@@ -166,6 +173,8 @@ public:
 	USpatialWorkerFlags* SpatialWorkerFlags;
 	UPROPERTY()
 	USpatialNetDriverDebugContext* DebugCtx;
+
+	SpatialGDK::SpatialRoutingSystem* RoutingSystem = nullptr;
 
 	TUniquePtr<SpatialGDK::InterestFactory> InterestFactory;
 	TUniquePtr<SpatialLoadBalanceEnforcer> LoadBalanceEnforcer;
@@ -228,6 +237,7 @@ private:
 
 	FString SnapshotToLoad;
 	FString RoutingWorkerId;
+	bool bRoutingWorkerQueryInFlight = false;
 
 	// Client variable which stores the SessionId given to us by the server in the URL options.
 	// Used to compare against the GSM SessionId to ensure the the server is ready to spawn players.

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -81,6 +81,9 @@ public:
 	virtual void Shutdown() override;
 	virtual void NotifyActorFullyDormantForConnection(AActor* Actor, UNetConnection* NetConnection) override;
 	virtual void OnOwnerUpdated(AActor* Actor, AActor* OldOwner) override;
+
+	virtual void PushCrossServerRPCSender(AActor* Sender) override;
+	virtual void PopCrossServerRPCSender(AActor* Sender) override;
 	// End UNetDriver interface.
 
 	void OnConnectionToSpatialOSSucceeded();
@@ -129,6 +132,7 @@ public:
 	void SetSpatialDebugger(ASpatialDebugger* InSpatialDebugger);
 	TWeakObjectPtr<USpatialNetConnection> FindClientConnectionFromWorkerId(const FString& WorkerId);
 	void CleanUpClientConnection(USpatialNetConnection* ClientConnection);
+	const FString& GetRoutingWorkerId();
 
 	UPROPERTY()
 	USpatialWorkerConnection* Connection;
@@ -223,6 +227,7 @@ private:
 	bool bMapLoaded;
 
 	FString SnapshotToLoad;
+	FString RoutingWorkerId;
 
 	// Client variable which stores the SessionId given to us by the server in the URL options.
 	// Used to compare against the GSM SessionId to ensure the the server is ready to spawn players.

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialWorkerConnection.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialWorkerConnection.h
@@ -53,6 +53,8 @@ public:
 	PhysicalWorkerName GetWorkerId() const;
 	const TArray<FString>& GetWorkerAttributes() const;
 
+	SpatialGDK::ViewCoordinator& GetCoordinator() const;
+
 	SpatialGDK::CallbackId RegisterComponentAddedCallback(Worker_ComponentId ComponentId, SpatialGDK::FComponentValueCallback Callback);
 	SpatialGDK::CallbackId RegisterComponentRemovedCallback(Worker_ComponentId ComponentId, SpatialGDK::FComponentValueCallback Callback);
 	SpatialGDK::CallbackId RegisterComponentValueCallback(Worker_ComponentId ComponentId, SpatialGDK::FComponentValueCallback Callback);

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialOSDispatcherInterface.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialOSDispatcherInterface.h
@@ -36,7 +36,8 @@ public:
 		PURE_VIRTUAL(SpatialOSDispatcherInterface::OnComponentUpdate, return;);
 	virtual void OnEntityQueryResponse(const Worker_EntityQueryResponseOp& Op)
 		PURE_VIRTUAL(SpatialOSDispatcherInterface::OnEntityQueryResponse, return;);
-	virtual bool OnExtractIncomingRPC(Worker_EntityId EntityId, ERPCType RPCType, const SpatialGDK::RPCPayload& Payload)
+	virtual bool OnExtractIncomingRPC(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType RPCType,
+									  const SpatialGDK::RPCPayload& Payload, uint32 Slot)
 		PURE_VIRTUAL(SpatialOSDispatcherInterface::OnExtractIncomingRPC, return false;);
 	virtual void OnCommandRequest(const Worker_CommandRequestOp& Op) PURE_VIRTUAL(SpatialOSDispatcherInterface::OnCommandRequest, return;);
 	virtual void OnCommandResponse(const Worker_CommandResponseOp& Op)

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialOSDispatcherInterface.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialOSDispatcherInterface.h
@@ -37,7 +37,7 @@ public:
 	virtual void OnEntityQueryResponse(const Worker_EntityQueryResponseOp& Op)
 		PURE_VIRTUAL(SpatialOSDispatcherInterface::OnEntityQueryResponse, return;);
 	virtual bool OnExtractIncomingRPC(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType RPCType,
-									  const SpatialGDK::RPCPayload& Payload, uint32 Slot)
+									  const SpatialGDK::RPCPayload& Payload, uint64 SenderRev)
 		PURE_VIRTUAL(SpatialOSDispatcherInterface::OnExtractIncomingRPC, return false;);
 	virtual void OnCommandRequest(const Worker_CommandRequestOp& Op) PURE_VIRTUAL(SpatialOSDispatcherInterface::OnCommandRequest, return;);
 	virtual void OnCommandResponse(const Worker_CommandResponseOp& Op)

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialRPCService.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialRPCService.h
@@ -11,13 +11,18 @@
 #include <WorkerSDK/improbable/c_schema.h>
 #include <WorkerSDK/improbable/c_worker.h>
 
+#include "Containers/BitArray.h"
+
 DECLARE_LOG_CATEGORY_EXTERN(LogSpatialRPCService, Log, All);
+
+class SpatialOSWorkerInterface;
 
 class USpatialLatencyTracer;
 class USpatialStaticComponentView;
 struct RPCRingBuffer;
 
-DECLARE_DELEGATE_RetVal_ThreeParams(bool, ExtractRPCDelegate, Worker_EntityId, ERPCType, const SpatialGDK::RPCPayload&);
+DECLARE_DELEGATE_RetVal_FiveParams(bool, ExtractRPCDelegate, Worker_EntityId, const FUnrealObjectRef&, ERPCType,
+								   const SpatialGDK::RPCPayload&, uint32);
 
 namespace SpatialGDK
 {
@@ -60,7 +65,8 @@ public:
 	SpatialRPCService(ExtractRPCDelegate ExtractRPCCallback, const USpatialStaticComponentView* View,
 					  USpatialLatencyTracer* SpatialLatencyTracer);
 
-	EPushRPCResult PushRPC(Worker_EntityId EntityId, ERPCType Type, RPCPayload Payload, bool bCreatedEntity);
+	EPushRPCResult PushRPC(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType Type, RPCPayload Payload,
+						   bool bCreatedEntity);
 	void PushOverflowedRPCs();
 
 	struct UpdateToSend
@@ -70,6 +76,10 @@ public:
 	};
 	TArray<UpdateToSend> GetRPCsAndAcksToSend();
 	TArray<FWorkerComponentData> GetRPCComponentsOnEntityCreation(Worker_EntityId EntityId);
+	void CheckLocalTargets(Worker_EntityId LocalWorkerEntityId);
+	void HandleTimeout(SpatialOSWorkerInterface* Sender);
+	bool OnEntityRequestResponse(Worker_EntityId LocalWorkerEntityId, Worker_RequestId Request, bool bEntityExists);
+	void OnEntityRemoved(Worker_EntityId LocalWorkerEntityId, Worker_EntityId Entity);
 
 	// Calls ExtractRPCCallback for each RPC it extracts from a given component. If the callback returns false,
 	// stops retrieving RPCs.
@@ -84,14 +94,19 @@ public:
 	void OnEndpointAuthorityGained(Worker_EntityId EntityId, Worker_ComponentId ComponentId);
 	void OnEndpointAuthorityLost(Worker_EntityId EntityId, Worker_ComponentId ComponentId);
 
+	void WriteCrossServerACKFor(Worker_EntityId Receiver, Worker_EntityId Sender, uint64 RPCId, uint32 Slot);
+	void UpdateMergedACKs(Worker_EntityId WorkerId, Worker_EntityId RemoteReceiver);
+
 private:
 	// For now, we should drop overflowed RPCs when entity crosses the boundary.
 	// When locking works as intended, we should re-evaluate how this will work (drop after some time?).
 	void ClearOverflowedRPCs(Worker_EntityId EntityId);
 
-	EPushRPCResult PushRPCInternal(Worker_EntityId EntityId, ERPCType Type, RPCPayload&& Payload, bool bCreatedEntity);
+	EPushRPCResult PushRPCInternal(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType Type, RPCPayload&& Payload,
+								   bool bCreatedEntity);
 
 	void ExtractRPCsForType(Worker_EntityId EntityId, ERPCType Type);
+	void ExtractCrossServerRPCsForType(Worker_EntityId EntityId, ERPCType Type);
 
 	void AddOverflowedRPC(EntityRPCType EntityType, RPCPayload&& Payload);
 
@@ -102,6 +117,12 @@ private:
 	Schema_ComponentData* GetOrCreateComponentData(EntityComponentId EntityComponentIdPair);
 
 private:
+	TOptional<uint32_t> FindFreeSlotForCrossServerSender();
+
+	// void CleanupACKsFor(Worker_EntityId Sender, uint64 MinRPCId, TSet<Worker_EntityId_Key> const& ReceiversToIgnore);
+
+	void CleanupACKsFor(Worker_EntityId Sender);
+
 	ExtractRPCDelegate ExtractRPCCallback;
 	const USpatialStaticComponentView* View;
 	USpatialLatencyTracer* SpatialLatencyTracer;
@@ -119,10 +140,42 @@ private:
 	TMap<EntityComponentId, Schema_ComponentUpdate*> PendingComponentUpdatesToSend;
 	TMap<EntityRPCType, TArray<RPCPayload>> OverflowedRPCs;
 
+	struct SentRPCEntry
+	{
+		bool operator==(SentRPCEntry const& iRHS) const { return FMemory::Memcmp(this, &iRHS, sizeof(SentRPCEntry)) == 0; }
+
+		uint64 RPCId;
+		uint64 Timestamp;
+		uint32 Slot;
+		Worker_EntityId Target;
+		TOptional<Worker_RequestId> EntityRequest;
+	};
+
+	// For sender
+	TMultiMap<Worker_EntityId_Key, SentRPCEntry> CrossServerMailbox;
+	TBitArray<FDefaultBitArrayAllocator> CrossServerOccupiedSlots;
+	TBitArray<FDefaultBitArrayAllocator> CrossServerSlotsToClear;
+
+	// For receiver
+	// Contains the number of available slots for acks for the given receiver.
+	TMap<Worker_EntityId_Key, uint32> ACKComponentsToTrack;
+
+	struct ACKSlot
+	{
+		bool operator==(ACKSlot const& iRHS) const { return Receiver == iRHS.Receiver && Slot == iRHS.Slot; }
+		Worker_EntityId Receiver;
+		int32 Slot;
+	};
+
+	// Map from sender to ack slots.
+	TMap<Worker_EntityId_Key, TArray<ACKSlot>> CrossServerACKMap;
+
 #if TRACE_LIB_ACTIVE
 	void ProcessResultToLatencyTrace(const EPushRPCResult Result, const TraceKey Trace);
 	TMap<EntityComponentId, TraceKey> PendingTraces;
 #endif
+
+	bool bShouldCheckSentRPCForLocalTarget = false;
 };
 
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -78,7 +78,8 @@ public:
 
 	// This gets bound to a delegate in SpatialRPCService and is called for each RPC extracted when calling
 	// SpatialRPCService::ExtractRPCsForEntity.
-	virtual bool OnExtractIncomingRPC(Worker_EntityId EntityId, ERPCType RPCType, const SpatialGDK::RPCPayload& Payload) override;
+	virtual bool OnExtractIncomingRPC(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType RPCType,
+									  const SpatialGDK::RPCPayload& Payload, uint32 Slot) override;
 
 	virtual void OnCommandRequest(const Worker_CommandRequestOp& Op) override;
 	virtual void OnCommandResponse(const Worker_CommandResponseOp& Op) override;
@@ -154,7 +155,8 @@ private:
 
 	bool IsReceivedEntityTornOff(Worker_EntityId EntityId);
 
-	void ProcessOrQueueIncomingRPC(const FUnrealObjectRef& InTargetObjectRef, SpatialGDK::RPCPayload InPayload);
+	void ProcessOrQueueIncomingRPC(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef,
+								   SpatialGDK::RPCPayload InPayload, uint32 Slot);
 
 	void ResolveIncomingOperations(UObject* Object, const FUnrealObjectRef& ObjectRef);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -79,7 +79,7 @@ public:
 	// This gets bound to a delegate in SpatialRPCService and is called for each RPC extracted when calling
 	// SpatialRPCService::ExtractRPCsForEntity.
 	virtual bool OnExtractIncomingRPC(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType RPCType,
-									  const SpatialGDK::RPCPayload& Payload, uint32 Slot) override;
+									  const SpatialGDK::RPCPayload& Payload, uint64 SenderRev) override;
 
 	virtual void OnCommandRequest(const Worker_CommandRequestOp& Op) override;
 	virtual void OnCommandResponse(const Worker_CommandResponseOp& Op) override;

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialRoutingSystem.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialRoutingSystem.h
@@ -1,0 +1,72 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+#include "Schema/CrossServerEndpoint.h"
+#include "SpatialView/SubView.h"
+#include "Utils/CrossServerUtils.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogSpatialRoutingSystem, Log, All)
+
+class SpatialOSWorkerInterface;
+
+namespace SpatialGDK
+{
+struct SpatialRoutingSystem
+{
+	SpatialRoutingSystem(const FSubView& InSubView, FString InRoutingWorkerId)
+		: SubView(InSubView)
+		, RoutingWorkerId(InRoutingWorkerId)
+	{
+	}
+
+	void Init(SpatialOSWorkerInterface* Connection);
+
+	void Advance(SpatialOSWorkerInterface* Connection);
+
+	void Flush(SpatialOSWorkerInterface* Connection);
+
+private:
+	const FSubView& SubView;
+
+	struct RoutingComponents
+	{
+		TOptional<CrossServerEndpointSender> Sender;
+
+		// Allocation slots for Sender ACKSlots
+		CrossServer::SlotAlloc SenderACKAlloc;
+
+		// Map of Receiver slots and Sender ACK slots to check when the sender buffer changes.
+		CrossServer::RPCAllocMap AllocMap;
+
+		CrossServer::SenderState Receiver;
+
+		TOptional<CrossServerEndpointReceiverACK> ReceiverACK;
+	};
+
+	void ProcessUpdate(Worker_EntityId, const ComponentChange& Change, RoutingComponents& Components);
+
+	void OnSenderChanged(Worker_EntityId, RoutingComponents& Components);
+	void TransferRPCsToReceiver(Worker_EntityId ReceiverId, RoutingComponents& Components);
+
+	void OnReceiverACKChanged(Worker_EntityId, RoutingComponents& Components);
+	void WriteACKToSender(CrossServer::RPCKey RPCKey, RoutingComponents& SenderComponents);
+	void ClearReceiverSlot(Worker_EntityId Receiver, CrossServer::RPCKey RPCKey, RoutingComponents& ReceiverComponents);
+
+	typedef TPair<Worker_EntityId_Key, Worker_ComponentId> EntityComponentId;
+
+	Schema_ComponentUpdate* GetOrCreateComponentUpdate(EntityComponentId EntityComponentIdPair);
+
+	TMap<Worker_EntityId_Key, RoutingComponents> RoutingWorkerView;
+
+	TMap<EntityComponentId, Schema_ComponentUpdate*> PendingComponentUpdatesToSend;
+
+	void CreateRoutingWorkerEntity(SpatialOSWorkerInterface* Connection);
+	Worker_RequestId RoutingWorkerEntityRequest;
+	Worker_EntityId RoutingWorkerEntity;
+	FString RoutingWorkerId;
+	TSet<Worker_EntityId_Key> ReceiversToInspect;
+};
+} // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -7,6 +7,7 @@
 #include "EngineClasses/SpatialLoadBalanceEnforcer.h"
 #include "EngineClasses/SpatialNetBitWriter.h"
 #include "Interop/SpatialClassInfoManager.h"
+#include "Interop/SpatialOSDispatcherInterface.h"
 #include "Interop/SpatialRPCService.h"
 #include "Schema/RPCPayload.h"
 #include "TimerManager.h"
@@ -79,8 +80,9 @@ public:
 	FRPCErrorInfo SendRPC(const FPendingRPCParams& Params);
 	void SendOnEntityCreationRPC(UObject* TargetObject, UFunction* Function, const SpatialGDK::RPCPayload& Payload,
 								 USpatialActorChannel* Channel, const FUnrealObjectRef& TargetObjectRef);
-	void SendCrossServerRPC(UObject* TargetObject, UFunction* Function, const SpatialGDK::RPCPayload& Payload,
-							USpatialActorChannel* Channel, const FUnrealObjectRef& TargetObjectRef);
+	bool SendCrossServerRPC(UObject* TargetObject, UFunction* Function, const SpatialGDK::RPCPayload& Payload,
+							USpatialActorChannel* Channel, const FUnrealObjectRef& TargetObjectRef,
+							const FUnrealObjectRef& SenderObjectRef);
 	FRPCErrorInfo SendLegacyRPC(UObject* TargetObject, UFunction* Function, const SpatialGDK::RPCPayload& Payload,
 								USpatialActorChannel* Channel, const FUnrealObjectRef& TargetObjectRef);
 	bool SendRingBufferedRPC(UObject* TargetObject, UFunction* Function, const SpatialGDK::RPCPayload& Payload,
@@ -118,7 +120,8 @@ public:
 	void UpdateClientAuthoritativeComponentAclEntries(Worker_EntityId EntityId, const FString& OwnerWorkerAttribute);
 	void UpdateInterestComponent(AActor* Actor);
 
-	void ProcessOrQueueOutgoingRPC(const FUnrealObjectRef& InTargetObjectRef, SpatialGDK::RPCPayload&& InPayload);
+	void ProcessOrQueueOutgoingRPC(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef,
+								   SpatialGDK::RPCPayload&& InPayload);
 	void ProcessUpdatesQueuedUntilAuthority(Worker_EntityId EntityId, Worker_ComponentId ComponentId);
 
 	void FlushRPCService();
@@ -132,6 +135,7 @@ public:
 	void CreateServerWorkerEntity();
 	void RetryServerWorkerEntityCreation(Worker_EntityId EntityId, int AttemptCounte);
 	void UpdateServerWorkerEntityInterestAndPosition();
+	void UpdateServerWorkerVisibility();
 
 	void ClearPendingRPCs(const Worker_EntityId EntityId);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSubSystem.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSubSystem.h
@@ -1,0 +1,3 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/CrossServerEndpoint.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/CrossServerEndpoint.h
@@ -23,6 +23,16 @@ private:
 	void ReadFromSchema(Schema_Object* SchemaObject);
 };
 
+struct ACKItem
+{
+	void ReadFromSchema(Schema_Object* SchemaObject);
+	void WriteToSchema(Schema_Object* SchemaObject);
+
+	Worker_EntityId Sender = SpatialConstants::INVALID_ENTITY_ID;
+	uint64 RPCId = 0;
+	uint64 SenderRevision = 0;
+};
+
 struct CrossServerEndpointACK : Component
 {
 	CrossServerEndpointACK(const Worker_ComponentData& Data, ERPCType Type);
@@ -31,6 +41,7 @@ struct CrossServerEndpointACK : Component
 
 	ERPCType Type;
 	uint64 RPCAck = 0;
+	TArray<TOptional<ACKItem>> ACKArray;
 
 private:
 	void ReadFromSchema(Schema_Object* SchemaObject);
@@ -39,7 +50,6 @@ private:
 struct CrossServerEndpointSender : CrossServerEndpoint
 {
 	static const Worker_ComponentId ComponentId = SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID;
-
 	CrossServerEndpointSender(const Worker_ComponentData& Data)
 		: CrossServerEndpoint(Data, ERPCType::CrossServerSender)
 	{
@@ -56,37 +66,18 @@ struct CrossServerEndpointReceiver : CrossServerEndpoint
 	}
 };
 
-struct ACKItem
-{
-	void ReadFromSchema(Schema_Object* SchemaObject);
-	void WriteToSchema(Schema_Object* SchemaObject);
-
-	Worker_EntityId Sender = SpatialConstants::INVALID_ENTITY_ID;
-	uint64 RPCId = 0;
-	uint64 SenderRevision = 0;
-};
-
-struct CrossServerEndpointSenderACK : Component
+struct CrossServerEndpointSenderACK : CrossServerEndpointACK
 {
 	static const Worker_ComponentId ComponentId = SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID;
-	CrossServerEndpointSenderACK(const Worker_ComponentData& Data);
-
-	// void CreateUpdate(Schema_ComponentUpdate* OutUpdate);
-
-	void ApplyComponentUpdate(const Worker_ComponentUpdate& Update) override;
-
-	uint64 RPCAck = 0;
-	// TMap<Worker_EntityId_Key, TArray<uint64>> DottedRPCACK;
-	TArray<TOptional<ACKItem>> ACKArray;
-
-private:
-	void ReadFromSchema(Schema_Object* SchemaObject);
+	CrossServerEndpointSenderACK(const Worker_ComponentData& Data)
+		: CrossServerEndpointACK(Data, ERPCType::CrossServerSender)
+	{
+	}
 };
 
 struct CrossServerEndpointReceiverACK : CrossServerEndpointACK
 {
 	static const Worker_ComponentId ComponentId = SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID;
-
 	CrossServerEndpointReceiverACK(const Worker_ComponentData& Data)
 		: CrossServerEndpointACK(Data, ERPCType::CrossServerReceiver)
 	{

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/CrossServerEndpoint.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/CrossServerEndpoint.h
@@ -1,0 +1,96 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "Schema/Component.h"
+#include "SpatialConstants.h"
+#include "Utils/RPCRingBuffer.h"
+
+#include <WorkerSDK/improbable/c_schema.h>
+#include <WorkerSDK/improbable/c_worker.h>
+
+namespace SpatialGDK
+{
+struct CrossServerEndpoint : Component
+{
+	CrossServerEndpoint(const Worker_ComponentData& Data, ERPCType Type);
+
+	void ApplyComponentUpdate(const Worker_ComponentUpdate& Update) override;
+
+	RPCRingBuffer ReliableRPCBuffer;
+
+private:
+	void ReadFromSchema(Schema_Object* SchemaObject);
+};
+
+struct CrossServerEndpointACK : Component
+{
+	CrossServerEndpointACK(const Worker_ComponentData& Data, ERPCType Type);
+
+	void ApplyComponentUpdate(const Worker_ComponentUpdate& Update) override;
+
+	ERPCType Type;
+	uint64 RPCAck = 0;
+
+private:
+	void ReadFromSchema(Schema_Object* SchemaObject);
+};
+
+struct CrossServerEndpointSender : CrossServerEndpoint
+{
+	static const Worker_ComponentId ComponentId = SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID;
+
+	CrossServerEndpointSender(const Worker_ComponentData& Data)
+		: CrossServerEndpoint(Data, ERPCType::CrossServerSender)
+	{
+	}
+};
+
+struct CrossServerEndpointReceiver : CrossServerEndpoint
+{
+	static const Worker_ComponentId ComponentId = SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID;
+
+	CrossServerEndpointReceiver(const Worker_ComponentData& Data)
+		: CrossServerEndpoint(Data, ERPCType::CrossServerReceiver)
+	{
+	}
+};
+
+struct ACKItem
+{
+	void ReadFromSchema(Schema_Object* SchemaObject);
+	void WriteToSchema(Schema_Object* SchemaObject);
+
+	Worker_EntityId Sender = SpatialConstants::INVALID_ENTITY_ID;
+	uint64 RPCId = 0;
+	uint64 SenderRevision = 0;
+};
+
+struct CrossServerEndpointSenderACK : Component
+{
+	static const Worker_ComponentId ComponentId = SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID;
+	CrossServerEndpointSenderACK(const Worker_ComponentData& Data);
+
+	// void CreateUpdate(Schema_ComponentUpdate* OutUpdate);
+
+	void ApplyComponentUpdate(const Worker_ComponentUpdate& Update) override;
+
+	uint64 RPCAck = 0;
+	// TMap<Worker_EntityId_Key, TArray<uint64>> DottedRPCACK;
+	TArray<TOptional<ACKItem>> ACKArray;
+
+private:
+	void ReadFromSchema(Schema_Object* SchemaObject);
+};
+
+struct CrossServerEndpointReceiverACK : CrossServerEndpointACK
+{
+	static const Worker_ComponentId ComponentId = SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID;
+
+	CrossServerEndpointReceiverACK(const Worker_ComponentData& Data)
+		: CrossServerEndpointACK(Data, ERPCType::CrossServerReceiver)
+	{
+	}
+};
+
+} // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -141,7 +141,8 @@ const Worker_ComponentId LB_TAG_COMPONENT_ID = 2005;
 const Worker_ComponentId SERVER_AUTH_GDK_KNOWN_ENTITY_TAG_COMPONENT_ID = 2006;
 const Worker_ComponentId SERVER_NON_AUTH_GDK_KNOWN_ENTITY_TAG_COMPONENT_ID = 2007;
 const Worker_ComponentId CLIENT_GDK_KNOWN_ENTITY_TAG_COMPONENT_ID = 2008;
-const Worker_ComponentId LAST_EC_COMPONENT_ID = 2008;
+const Worker_ComponentId ROUTINGWORKER_TAG_COMPONENT_ID = 2009;
+const Worker_ComponentId LAST_EC_COMPONENT_ID = 2009;
 
 const Schema_FieldId DEPLOYMENT_MAP_MAP_URL_ID = 1;
 const Schema_FieldId DEPLOYMENT_MAP_ACCEPTING_PLAYERS_ID = 2;
@@ -256,12 +257,15 @@ const FString INVALID_WORKER_NAME = TEXT("");
 
 static const FName DefaultLayer = FName(TEXT("DefaultLayer"));
 
+const FName RoutingWorkerType(TEXT("RoutingWorker"));
+
 const WorkerAttributeSet UnrealServerAttributeSet = TArray<FString>{ DefaultServerWorkerType.ToString() };
+const WorkerAttributeSet UnrealRoutingWorkerAttributeSet = TArray<FString>{ RoutingWorkerType.ToString() };
 const WorkerAttributeSet UnrealClientAttributeSet = TArray<FString>{ DefaultClientWorkerType.ToString() };
 
-const WorkerRequirementSet UnrealServerPermission{ { UnrealServerAttributeSet } };
 const WorkerRequirementSet UnrealClientPermission{ { UnrealClientAttributeSet } };
-const WorkerRequirementSet ClientOrServerPermission{ { UnrealClientAttributeSet, UnrealServerAttributeSet } };
+const WorkerRequirementSet ClientOrServerPermission{ { UnrealClientAttributeSet, UnrealServerAttributeSet,
+													   UnrealRoutingWorkerAttributeSet } };
 
 const FString ClientsStayConnectedURLOption = TEXT("clientsStayConnected");
 const FString SpatialSessionIdURLOption = TEXT("spatialSessionId=");

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -23,7 +23,8 @@ enum class ERPCType : uint8
 	ServerReliable,
 	ServerUnreliable,
 	NetMulticast,
-	CrossServer
+	CrossServerSender,
+	CrossServerReceiver,
 };
 
 enum ESchemaComponentType : int32
@@ -57,8 +58,10 @@ inline FString RPCTypeToString(ERPCType RPCType)
 		return TEXT("Server, Unreliable");
 	case ERPCType::NetMulticast:
 		return TEXT("Multicast");
-	case ERPCType::CrossServer:
-		return TEXT("CrossServer");
+	case ERPCType::CrossServerSender:
+		return TEXT("CrossServerSender");
+	case ERPCType::CrossServerReceiver:
+		return TEXT("CrossServerReceiver");
 	}
 
 	checkNoEntry();
@@ -95,6 +98,7 @@ const Worker_ComponentId DEPLOYMENT_MAP_COMPONENT_ID = 9994;
 const Worker_ComponentId STARTUP_ACTOR_MANAGER_COMPONENT_ID = 9993;
 const Worker_ComponentId GSM_SHUTDOWN_COMPONENT_ID = 9992;
 const Worker_ComponentId HEARTBEAT_COMPONENT_ID = 9991;
+
 // Marking the event-based RPC components as legacy while the ring buffer
 // implementation is under a feature flag.
 const Worker_ComponentId CLIENT_RPC_ENDPOINT_COMPONENT_ID_LEGACY = 9990;
@@ -110,6 +114,11 @@ const Worker_ComponentId DORMANT_COMPONENT_ID = 9981;
 const Worker_ComponentId AUTHORITY_INTENT_COMPONENT_ID = 9980;
 const Worker_ComponentId VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID = 9979;
 const Worker_ComponentId VISIBLE_COMPONENT_ID = 9970;
+
+const Worker_ComponentId CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID = 9960;
+const Worker_ComponentId CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID = 9961;
+const Worker_ComponentId CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID = 9962;
+const Worker_ComponentId CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID = 9963;
 
 const Worker_ComponentId CLIENT_ENDPOINT_COMPONENT_ID = 9978;
 const Worker_ComponentId SERVER_ENDPOINT_COMPONENT_ID = 9977;
@@ -365,6 +374,9 @@ const TArray<Worker_ComponentId> REQUIRED_COMPONENTS_FOR_AUTH_SERVER_INTEREST =
 	TArray<Worker_ComponentId>{ // RPCs from clients
 								CLIENT_ENDPOINT_COMPONENT_ID, CLIENT_RPC_ENDPOINT_COMPONENT_ID_LEGACY,
 
+								// Cross server endpoint
+								CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID, CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID,
+
 								// Heartbeat
 								HEARTBEAT_COMPONENT_ID
 	};
@@ -373,7 +385,7 @@ inline Worker_ComponentId RPCTypeToWorkerComponentIdLegacy(ERPCType RPCType)
 {
 	switch (RPCType)
 	{
-	case ERPCType::CrossServer:
+	case ERPCType::CrossServerSender:
 	{
 		return SpatialConstants::SERVER_TO_SERVER_COMMAND_ENDPOINT_COMPONENT_ID;
 	}

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -42,6 +42,17 @@ enum Type
 };
 }
 
+UENUM()
+namespace ECrossServerRPCImplementation
+{
+enum Type
+{
+	SpatialCommand,
+	WorkerEntityMailbox,
+	RoutingWorker,
+};
+}
+
 USTRUCT(BlueprintType)
 struct FDistanceFrequencyPair
 {
@@ -289,6 +300,9 @@ public:
 	 */
 	UPROPERTY(EditAnywhere, Config, Category = "Replication", meta = (DisplayName = "Max RPC Ring Buffer Size"))
 	uint32 MaxRPCRingBufferSize;
+
+	UPROPERTY(EditAnywhere, Config, Category = "Replication", meta = (DisplayName = "Cross Server RPC Implementation"))
+	TEnumAsByte<ECrossServerRPCImplementation::Type> CrossServerRPCImplementation;
 
 	/** Only valid on Tcp connections - indicates if we should enable TCP_NODELAY - see c_worker.h */
 	UPROPERTY(Config)

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
 #pragma once
 
@@ -55,6 +55,8 @@ public:
 																			const FComponentChangeRefreshPredicate& RefreshPredicate);
 	static FDispatcherRefreshCallback CreateAuthorityChangeRefreshCallback(FDispatcher& Dispatcher, const Worker_ComponentId ComponentId,
 																		   const FAuthorityChangeRefreshPredicate& RefreshPredicate);
+
+	const EntityView* GetView() const { return View; };
 
 private:
 	void RegisterTagCallbacks(FDispatcher& Dispatcher);

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/CrossServerUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/CrossServerUtils.h
@@ -1,0 +1,123 @@
+
+
+#pragma once
+
+#include "SpatialCommonTypes.h"
+#include "Utils/RPCRingBuffer.h"
+
+#include "Containers/BitArray.h"
+
+namespace SpatialGDK
+{
+namespace CrossServer
+{
+typedef TPair<Worker_EntityId_Key, uint64> RPCKey;
+
+struct SentRPCEntry
+{
+	bool operator==(SentRPCEntry const& iRHS) const { return FMemory::Memcmp(this, &iRHS, sizeof(SentRPCEntry)) == 0; }
+
+	RPCKey RPCId;
+	Worker_EntityId Target;
+	uint64 Timestamp;
+	uint32 SourceSlot;
+	TOptional<uint32> DestinationSlot;
+	TOptional<Worker_RequestId> EntityRequest;
+};
+
+struct SlotAlloc
+{
+	SlotAlloc()
+	{
+		Occupied.Init(false, RPCRingBufferUtils::GetRingBufferSize(ERPCType::CrossServerSender));
+		ToClear.Init(false, RPCRingBufferUtils::GetRingBufferSize(ERPCType::CrossServerSender));
+	}
+
+	TBitArray<FDefaultBitArrayAllocator> Occupied;
+	TBitArray<FDefaultBitArrayAllocator> ToClear;
+};
+
+struct RPCSchedule
+{
+	void Add(RPCKey RPC)
+	{
+		int32 ScheduleSize = SendingSchedule.Num();
+		SendingSchedule.Add(RPC);
+		RPCKey& LastAddition = SendingSchedule[ScheduleSize];
+		for (int32 i = 0; i < ScheduleSize; ++i)
+		{
+			RPCKey& Item = SendingSchedule[i];
+			if (Item.Get<0>() == LastAddition.Get<0>())
+			{
+				// Enforce ordering on same senders while keeping different senders order of arrival to avoid starvation.
+				if (Item.Get<1>() > LastAddition.Get<1>())
+				{
+					Swap(Item, LastAddition);
+				}
+			}
+		}
+	}
+
+	RPCKey Peek() { return SendingSchedule[0]; }
+
+	RPCKey Extract()
+	{
+		RPCKey NextRPC = SendingSchedule[0];
+		SendingSchedule.RemoveAt(0);
+		return NextRPC;
+	}
+
+	bool IsEmpty() const { return SendingSchedule.Num() == 0; }
+
+	TArray<RPCKey> SendingSchedule;
+};
+
+struct SenderState
+{
+	TOptional<uint32_t> FindFreeSlot()
+	{
+		int32 freeSlot = Alloc.Occupied.Find(false);
+		if (freeSlot >= 0)
+		{
+			return freeSlot;
+		}
+
+		return {};
+	}
+
+	TMap<RPCKey, SentRPCEntry> Mailbox;
+	RPCSchedule Schedule;
+
+	bool CompareRPC(RPCKey const& iKey1, RPCKey const& iKey2)
+	{
+		if (iKey1.Get<0>() == iKey2.Get<0>())
+		{
+			return iKey1.Get<1>() < iKey2.Get<1>();
+		}
+
+		SentRPCEntry& RPC1 = Mailbox.FindChecked(iKey1);
+		SentRPCEntry& RPC2 = Mailbox.FindChecked(iKey2);
+
+		return RPC1.Timestamp < RPC2.Timestamp;
+	}
+
+	SlotAlloc Alloc;
+};
+
+struct ACKSlot
+{
+	bool operator==(const ACKSlot& Other) const { return Receiver == Other.Receiver && Slot == Other.Slot; }
+
+	Worker_EntityId Receiver = 0;
+	uint32 Slot = -1;
+};
+
+struct RPCSlots
+{
+	ACKSlot ReceiverSlot;
+	int32 SenderACKSlot = -1;
+};
+
+typedef TMap<RPCKey, RPCSlots> RPCAllocMap;
+} // namespace CrossServer
+} // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/InterestFactory.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/InterestFactory.h
@@ -46,7 +46,7 @@ public:
 	Worker_ComponentData CreateInterestData(AActor* InActor, const FClassInfo& InInfo, const Worker_EntityId InEntityId) const;
 	Worker_ComponentUpdate CreateInterestUpdate(AActor* InActor, const FClassInfo& InInfo, const Worker_EntityId InEntityId) const;
 
-	Interest CreateServerWorkerInterest(const UAbstractLBStrategy* LBStrategy, bool bDebug);
+	Interest CreateServerWorkerInterest(const UAbstractLBStrategy* LBStrategy, bool bDebug, bool bIsRoutingWorker);
 
 	// Returns false if we could not get an owner's entityId in the Actor's owner chain.
 	bool DoOwnersHaveEntityId(const AActor* Actor) const;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/InterestFactory.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/InterestFactory.h
@@ -46,7 +46,8 @@ public:
 	Worker_ComponentData CreateInterestData(AActor* InActor, const FClassInfo& InInfo, const Worker_EntityId InEntityId) const;
 	Worker_ComponentUpdate CreateInterestUpdate(AActor* InActor, const FClassInfo& InInfo, const Worker_EntityId InEntityId) const;
 
-	Interest CreateServerWorkerInterest(const UAbstractLBStrategy* LBStrategy, bool bDebug, bool bIsRoutingWorker);
+	Interest CreateServerWorkerInterest(const UAbstractLBStrategy* LBStrategy, bool bDebug);
+	static Interest CreateRoutingWorkerInterest();
 
 	// Returns false if we could not get an owner's entityId in the Actor's owner chain.
 	bool DoOwnersHaveEntityId(const AActor* Actor) const;
@@ -88,8 +89,8 @@ private:
 
 	void AddNetCullDistanceQueries(Interest& OutInterest, const QueryConstraint& LevelConstraint) const;
 
-	void AddComponentQueryPairToInterestComponent(Interest& OutInterest, const Worker_ComponentId ComponentId,
-												  const Query& QueryToAdd) const;
+	static void AddComponentQueryPairToInterestComponent(Interest& OutInterest, const Worker_ComponentId ComponentId,
+														 const Query& QueryToAdd);
 
 	// System Defined Constraints
 	bool ShouldAddNetCullDistanceInterest(const AActor* InActor) const;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/RPCContainer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/RPCContainer.h
@@ -69,7 +69,10 @@ struct FRPCErrorInfo
 
 struct SPATIALGDK_API FPendingRPCParams
 {
-	FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, ERPCType InType, SpatialGDK::RPCPayload&& InPayload);
+	// FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, ERPCType InType,
+	// SpatialGDK::RPCPayload&& InPayload);
+	FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, ERPCType InType,
+					  SpatialGDK::RPCPayload&& InPayload, uint32 Slot);
 
 	// Moveable, not copyable.
 	FPendingRPCParams() = delete;
@@ -80,7 +83,9 @@ struct SPATIALGDK_API FPendingRPCParams
 	~FPendingRPCParams() = default;
 
 	FUnrealObjectRef ObjectRef;
+	FUnrealObjectRef SenderObjectRef;
 	SpatialGDK::RPCPayload Payload;
+	uint32 Slot;
 
 	FDateTime Timestamp;
 	ERPCType Type;
@@ -99,7 +104,8 @@ public:
 	~FRPCContainer() = default;
 
 	void BindProcessingFunction(const FProcessRPCDelegate& Function);
-	void ProcessOrQueueRPC(const FUnrealObjectRef& InTargetObjectRef, ERPCType InType, SpatialGDK::RPCPayload&& InPayload);
+	void ProcessOrQueueRPC(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, ERPCType InType,
+						   SpatialGDK::RPCPayload&& InPayload, uint32 Slot);
 	void ProcessRPCs();
 	void DropForEntity(const Worker_EntityId& EntityId);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/RPCContainer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/RPCContainer.h
@@ -72,7 +72,7 @@ struct SPATIALGDK_API FPendingRPCParams
 	// FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, ERPCType InType,
 	// SpatialGDK::RPCPayload&& InPayload);
 	FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, ERPCType InType,
-					  SpatialGDK::RPCPayload&& InPayload, uint32 Slot);
+					  SpatialGDK::RPCPayload&& InPayload, uint64 SenderRev);
 
 	// Moveable, not copyable.
 	FPendingRPCParams() = delete;
@@ -85,7 +85,7 @@ struct SPATIALGDK_API FPendingRPCParams
 	FUnrealObjectRef ObjectRef;
 	FUnrealObjectRef SenderObjectRef;
 	SpatialGDK::RPCPayload Payload;
-	uint32 Slot;
+	uint64 SenderRev;
 
 	FDateTime Timestamp;
 	ERPCType Type;
@@ -105,7 +105,7 @@ public:
 
 	void BindProcessingFunction(const FProcessRPCDelegate& Function);
 	void ProcessOrQueueRPC(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, ERPCType InType,
-						   SpatialGDK::RPCPayload&& InPayload, uint32 Slot);
+						   SpatialGDK::RPCPayload&& InPayload, uint64 SenderRev);
 	void ProcessRPCs();
 	void DropForEntity(const Worker_EntityId& EntityId);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/RPCRingBuffer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/RPCRingBuffer.h
@@ -52,6 +52,7 @@ RPCRingBufferDescriptor GetRingBufferDescriptor(ERPCType Type);
 uint32 GetRingBufferSize(ERPCType Type);
 
 Worker_ComponentId GetAckComponentId(ERPCType Type);
+
 Schema_FieldId GetAckFieldId(ERPCType Type);
 
 Schema_FieldId GetInitiallyPresentMulticastRPCsCountFieldId();

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetricsDisplay.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetricsDisplay.h
@@ -55,7 +55,7 @@ private:
 	const uint32 DropStatsIfNoUpdateForTime = 10; // seconds
 
 	UFUNCTION(CrossServer, Unreliable, WithValidation)
-	virtual void ServerUpdateWorkerStats(const float Time, const FWorkerStats& OneWorkerStats);
+	virtual void ServerUpdateWorkerStats(AActor* Sender, const float Time, const FWorkerStats& OneWorkerStats);
 
 	bool ShouldRemoveStats(const float CurrentTime, const FWorkerStats& OneWorkerStats) const;
 	void DrawDebug(class UCanvas* Canvas, APlayerController* Controller);

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SchemaGenerator.cpp
@@ -345,7 +345,7 @@ void GenerateRPCEndpoint(FCodeWriter& Writer, FString EndpointName, Worker_Compo
 	{
 		uint32 RingBufferSize = GetDefault<USpatialGDKSettings>()->MaxRPCRingBufferSize;
 		Writer.Printf("uint64 last_acked_{0}_rpc_id = {1};", GetRPCFieldPrefix(AckedRPCType), FieldId++);
-		if (AckedRPCType == ERPCType::CrossServerSender)
+		if (AckedRPCType == ERPCType::CrossServerSender || AckedRPCType == ERPCType::CrossServerReceiver)
 		{
 			// Writer.Printf("map<EntityId, ACKList> {0}_dotted_rpc_ack = {1};", GetRPCFieldPrefix(AckedRPCType), FieldId++);
 			for (uint32 RingBufferIndex = 0; RingBufferIndex < RingBufferSize; RingBufferIndex++)

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SnapshotGenerator/SpatialGDKEditorSnapshotGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SnapshotGenerator/SpatialGDKEditorSnapshotGenerator.cpp
@@ -52,6 +52,8 @@ void SetEntityData(Worker_Entity& Entity, const TArray<FWorkerComponentData>& Co
 
 bool CreateSpawnerEntity(Worker_SnapshotOutputStream* OutputStream)
 {
+	const WorkerRequirementSet UnrealServerPermission{ { SpatialConstants::UnrealServerAttributeSet } };
+
 	Worker_Entity SpawnerEntity;
 	SpawnerEntity.entity_id = SpatialConstants::INITIAL_SPAWNER_ENTITY_ID;
 
@@ -62,12 +64,12 @@ bool CreateSpawnerEntity(Worker_SnapshotOutputStream* OutputStream)
 	TArray<FWorkerComponentData> Components;
 
 	WriteAclMap ComponentWriteAcl;
-	ComponentWriteAcl.Add(SpatialConstants::POSITION_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
-	ComponentWriteAcl.Add(SpatialConstants::METADATA_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
-	ComponentWriteAcl.Add(SpatialConstants::PERSISTENCE_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
-	ComponentWriteAcl.Add(SpatialConstants::ENTITY_ACL_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
-	ComponentWriteAcl.Add(SpatialConstants::PLAYER_SPAWNER_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
-	ComponentWriteAcl.Add(SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
+	ComponentWriteAcl.Add(SpatialConstants::POSITION_COMPONENT_ID, UnrealServerPermission);
+	ComponentWriteAcl.Add(SpatialConstants::METADATA_COMPONENT_ID, UnrealServerPermission);
+	ComponentWriteAcl.Add(SpatialConstants::PERSISTENCE_COMPONENT_ID, UnrealServerPermission);
+	ComponentWriteAcl.Add(SpatialConstants::ENTITY_ACL_COMPONENT_ID, UnrealServerPermission);
+	ComponentWriteAcl.Add(SpatialConstants::PLAYER_SPAWNER_COMPONENT_ID, UnrealServerPermission);
+	ComponentWriteAcl.Add(SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID, UnrealServerPermission);
 
 	Components.Add(Position(DeploymentOrigin).CreatePositionData());
 	Components.Add(Metadata(TEXT("SpatialSpawner")).CreateMetadataData());
@@ -126,20 +128,22 @@ Worker_ComponentData CreateStartupActorManagerData()
 
 bool CreateGlobalStateManager(Worker_SnapshotOutputStream* OutputStream)
 {
+	const WorkerRequirementSet UnrealServerPermission{ { SpatialConstants::UnrealServerAttributeSet } };
+
 	Worker_Entity GSM;
 	GSM.entity_id = SpatialConstants::INITIAL_GLOBAL_STATE_MANAGER_ENTITY_ID;
 
 	TArray<FWorkerComponentData> Components;
 
 	WriteAclMap ComponentWriteAcl;
-	ComponentWriteAcl.Add(SpatialConstants::POSITION_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
-	ComponentWriteAcl.Add(SpatialConstants::METADATA_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
-	ComponentWriteAcl.Add(SpatialConstants::PERSISTENCE_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
-	ComponentWriteAcl.Add(SpatialConstants::ENTITY_ACL_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
-	ComponentWriteAcl.Add(SpatialConstants::DEPLOYMENT_MAP_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
-	ComponentWriteAcl.Add(SpatialConstants::GSM_SHUTDOWN_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
-	ComponentWriteAcl.Add(SpatialConstants::STARTUP_ACTOR_MANAGER_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
-	ComponentWriteAcl.Add(SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
+	ComponentWriteAcl.Add(SpatialConstants::POSITION_COMPONENT_ID, UnrealServerPermission);
+	ComponentWriteAcl.Add(SpatialConstants::METADATA_COMPONENT_ID, UnrealServerPermission);
+	ComponentWriteAcl.Add(SpatialConstants::PERSISTENCE_COMPONENT_ID, UnrealServerPermission);
+	ComponentWriteAcl.Add(SpatialConstants::ENTITY_ACL_COMPONENT_ID, UnrealServerPermission);
+	ComponentWriteAcl.Add(SpatialConstants::DEPLOYMENT_MAP_COMPONENT_ID, UnrealServerPermission);
+	ComponentWriteAcl.Add(SpatialConstants::GSM_SHUTDOWN_COMPONENT_ID, UnrealServerPermission);
+	ComponentWriteAcl.Add(SpatialConstants::STARTUP_ACTOR_MANAGER_COMPONENT_ID, UnrealServerPermission);
+	ComponentWriteAcl.Add(SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID, UnrealServerPermission);
 
 	WorkerRequirementSet ReadACL = { SpatialConstants::UnrealServerAttributeSet };
 
@@ -175,18 +179,20 @@ Worker_ComponentData CreateVirtualWorkerTranslatorData()
 
 bool CreateVirtualWorkerTranslator(Worker_SnapshotOutputStream* OutputStream)
 {
+	const WorkerRequirementSet UnrealServerPermission{ { SpatialConstants::UnrealServerAttributeSet } };
+
 	Worker_Entity VirtualWorkerTranslator;
 	VirtualWorkerTranslator.entity_id = SpatialConstants::INITIAL_VIRTUAL_WORKER_TRANSLATOR_ENTITY_ID;
 
 	TArray<FWorkerComponentData> Components;
 
 	WriteAclMap ComponentWriteAcl;
-	ComponentWriteAcl.Add(SpatialConstants::POSITION_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
-	ComponentWriteAcl.Add(SpatialConstants::METADATA_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
-	ComponentWriteAcl.Add(SpatialConstants::PERSISTENCE_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
-	ComponentWriteAcl.Add(SpatialConstants::ENTITY_ACL_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
-	ComponentWriteAcl.Add(SpatialConstants::VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
-	ComponentWriteAcl.Add(SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID, SpatialConstants::UnrealServerPermission);
+	ComponentWriteAcl.Add(SpatialConstants::POSITION_COMPONENT_ID, UnrealServerPermission);
+	ComponentWriteAcl.Add(SpatialConstants::METADATA_COMPONENT_ID, UnrealServerPermission);
+	ComponentWriteAcl.Add(SpatialConstants::PERSISTENCE_COMPONENT_ID, UnrealServerPermission);
+	ComponentWriteAcl.Add(SpatialConstants::ENTITY_ACL_COMPONENT_ID, UnrealServerPermission);
+	ComponentWriteAcl.Add(SpatialConstants::VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID, UnrealServerPermission);
+	ComponentWriteAcl.Add(SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID, UnrealServerPermission);
 
 	WorkerRequirementSet ReadACL = { SpatialConstants::UnrealServerAttributeSet };
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
@@ -131,6 +131,7 @@ bool FillWorkerConfigurationFromCurrentMap(FWorkerTypeLaunchSection& OutWorker, 
 bool GenerateLaunchConfig(const FString& LaunchConfigPath, const FSpatialLaunchConfigDescription* InLaunchConfigDescription,
 						  const FWorkerTypeLaunchSection& InWorker)
 {
+	const USpatialGDKSettings* SpatialGDKSettings = GetDefault<USpatialGDKSettings>();
 	if (InLaunchConfigDescription != nullptr)
 	{
 		const FSpatialLaunchConfigDescription& LaunchConfigDescription = *InLaunchConfigDescription;
@@ -170,12 +171,20 @@ bool GenerateLaunchConfig(const FString& LaunchConfigPath, const FSpatialLaunchC
 			WriteLoadbalancingSection(Writer, SpatialConstants::DefaultServerWorkerType, InWorker.NumEditorInstances,
 									  InWorker.bManualWorkerConnectionOnly);
 		}
+		if (SpatialGDKSettings->CrossServerRPCImplementation == ECrossServerRPCImplementation::RoutingWorker)
+		{
+			WriteLoadbalancingSection(Writer, SpatialConstants::RoutingWorkerType, 1, InWorker.bManualWorkerConnectionOnly);
+		}
 		Writer->WriteArrayEnd();
 		Writer->WriteObjectEnd();				  // Load balancing section end
 		Writer->WriteArrayStart(TEXT("workers")); // Workers section begin
 		if (InWorker.NumEditorInstances > 0)
 		{
 			WriteWorkerSection(Writer, SpatialConstants::DefaultServerWorkerType, InWorker);
+		}
+		if (SpatialGDKSettings->CrossServerRPCImplementation == ECrossServerRPCImplementation::RoutingWorker)
+		{
+			WriteWorkerSection(Writer, SpatialConstants::RoutingWorkerType, InWorker);
 		}
 		// Write the client worker section
 		FWorkerTypeLaunchSection ClientWorker;

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultWorkerJsonGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultWorkerJsonGenerator.cpp
@@ -47,15 +47,18 @@ bool GenerateAllDefaultWorkerJsons(bool& bOutRedeployRequired)
 
 	if (const USpatialGDKSettings* SpatialGDKSettings = GetDefault<USpatialGDKSettings>())
 	{
-		const FName& Worker = SpatialConstants::DefaultServerWorkerType;
-		FString JsonPath = FPaths::Combine(WorkerJsonDir, FString::Printf(TEXT("spatialos.%s.worker.json"), *Worker.ToString()));
-		if (!FPaths::FileExists(JsonPath))
+		const FName WorkerTypes[] = { SpatialConstants::DefaultServerWorkerType, SpatialConstants::RoutingWorkerType };
+		for (auto Worker : WorkerTypes)
 		{
-			UE_LOG(LogSpatialGDKDefaultWorkerJsonGenerator, Verbose, TEXT("Could not find worker json at %s"), *JsonPath);
-
-			if (!GenerateDefaultWorkerJson(JsonPath, Worker.ToString(), bOutRedeployRequired))
+			FString JsonPath = FPaths::Combine(WorkerJsonDir, FString::Printf(TEXT("spatialos.%s.worker.json"), *Worker.ToString()));
+			if (!FPaths::FileExists(JsonPath))
 			{
-				bAllJsonsGeneratedSuccessfully = false;
+				UE_LOG(LogSpatialGDKDefaultWorkerJsonGenerator, Verbose, TEXT("Could not find worker json at %s"), *JsonPath);
+
+				if (!GenerateDefaultWorkerJson(JsonPath, Worker.ToString(), bOutRedeployRequired))
+				{
+					bAllJsonsGeneratedSuccessfully = false;
+				}
 			}
 		}
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -274,6 +274,13 @@ bool FSpatialGDKEditorModule::ForEveryServerWorker(TFunction<void(const FName&, 
 			AdditionalServerIndex++;
 		}
 
+		const USpatialGDKSettings* Settings = GetDefault<USpatialGDKSettings>();
+		if (Settings->CrossServerRPCImplementation == ECrossServerRPCImplementation::RoutingWorker)
+		{
+			Function(SpatialConstants::RoutingWorkerType, AdditionalServerIndex);
+			++AdditionalServerIndex;
+		}
+
 		return true;
 	}
 

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/SpatialOSDispatcherInterface/SpatialOSDispatcherSpy.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/SpatialOSDispatcherInterface/SpatialOSDispatcherSpy.cpp
@@ -26,7 +26,7 @@ void SpatialOSDispatcherSpy::OnComponentUpdate(const Worker_ComponentUpdateOp& O
 // This gets bound to a delegate in SpatialRPCService and is called for each RPC extracted when calling
 // SpatialRPCService::ExtractRPCsForEntity.
 bool SpatialOSDispatcherSpy::OnExtractIncomingRPC(Worker_EntityId EntityId, const FUnrealObjectRef&, ERPCType RPCType,
-												  const SpatialGDK::RPCPayload& Payload, uint32 Slot)
+												  const SpatialGDK::RPCPayload& Payload, uint64 SenderRev)
 {
 	return false;
 }

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/SpatialOSDispatcherInterface/SpatialOSDispatcherSpy.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/SpatialOSDispatcherInterface/SpatialOSDispatcherSpy.cpp
@@ -25,7 +25,8 @@ void SpatialOSDispatcherSpy::OnComponentUpdate(const Worker_ComponentUpdateOp& O
 
 // This gets bound to a delegate in SpatialRPCService and is called for each RPC extracted when calling
 // SpatialRPCService::ExtractRPCsForEntity.
-bool SpatialOSDispatcherSpy::OnExtractIncomingRPC(Worker_EntityId EntityId, ERPCType RPCType, const SpatialGDK::RPCPayload& Payload)
+bool SpatialOSDispatcherSpy::OnExtractIncomingRPC(Worker_EntityId EntityId, const FUnrealObjectRef&, ERPCType RPCType,
+												  const SpatialGDK::RPCPayload& Payload, uint32 Slot)
 {
 	return false;
 }

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/SpatialOSDispatcherInterface/SpatialOSDispatcherSpy.h
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/SpatialOSDispatcherInterface/SpatialOSDispatcherSpy.h
@@ -31,7 +31,8 @@ public:
 
 	// This gets bound to a delegate in SpatialRPCService and is called for each RPC extracted when calling
 	// SpatialRPCService::ExtractRPCsForEntity.
-	virtual bool OnExtractIncomingRPC(Worker_EntityId EntityId, ERPCType RPCType, const SpatialGDK::RPCPayload& Payload) override;
+	virtual bool OnExtractIncomingRPC(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType RPCType,
+									  const SpatialGDK::RPCPayload& Payload, uint32 Slot) override;
 
 	virtual void OnCommandRequest(const Worker_CommandRequestOp& Op) override;
 	virtual void OnCommandResponse(const Worker_CommandResponseOp& Op) override;

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/SpatialOSDispatcherInterface/SpatialOSDispatcherSpy.h
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/SpatialOSDispatcherInterface/SpatialOSDispatcherSpy.h
@@ -32,7 +32,7 @@ public:
 	// This gets bound to a delegate in SpatialRPCService and is called for each RPC extracted when calling
 	// SpatialRPCService::ExtractRPCsForEntity.
 	virtual bool OnExtractIncomingRPC(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType RPCType,
-									  const SpatialGDK::RPCPayload& Payload, uint32 Slot) override;
+									  const SpatialGDK::RPCPayload& Payload, uint64 SenderRev) override;
 
 	virtual void OnCommandRequest(const Worker_CommandRequestOp& Op) override;
 	virtual void OnCommandResponse(const Worker_CommandResponseOp& Op) override;

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Utils/RPCContainer/RPCContainerTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Utils/RPCContainer/RPCContainerTest.cpp
@@ -40,7 +40,7 @@ FPendingRPCParams CreateMockParameters(UObject* TargetObject, ERPCType Type)
 
 	FUnrealObjectRef ObjectRef = GenerateObjectRef(TargetObject);
 
-	return FPendingRPCParams{ ObjectRef, Type, MoveTemp(Payload) };
+	return FPendingRPCParams{ ObjectRef, FUnrealObjectRef(), Type, MoveTemp(Payload), 0 };
 }
 } // anonymous namespace
 
@@ -62,7 +62,7 @@ RPCCONTAINER_TEST(GIVEN_a_container_WHEN_one_value_has_been_added_THEN_it_is_que
 	FRPCContainer RPCs(ERPCQueueType::Send);
 	RPCs.BindProcessingFunction(FProcessRPCDelegate::CreateUObject(TargetObject, &UObjectStub::ProcessRPC));
 
-	RPCs.ProcessOrQueueRPC(Params.ObjectRef, Params.Type, MoveTemp(Params.Payload));
+	RPCs.ProcessOrQueueRPC(Params.ObjectRef, Params.SenderObjectRef, Params.Type, MoveTemp(Params.Payload), 0);
 
 	TestTrue("Has queued RPCs", RPCs.ObjectHasRPCsQueuedOfType(Params.ObjectRef.Entity, AnySchemaComponentType));
 
@@ -77,8 +77,8 @@ RPCCONTAINER_TEST(GIVEN_a_container_WHEN_multiple_values_of_same_type_have_been_
 	FRPCContainer RPCs(ERPCQueueType::Send);
 	RPCs.BindProcessingFunction(FProcessRPCDelegate::CreateUObject(TargetObject, &UObjectStub::ProcessRPC));
 
-	RPCs.ProcessOrQueueRPC(Params1.ObjectRef, Params1.Type, MoveTemp(Params1.Payload));
-	RPCs.ProcessOrQueueRPC(Params2.ObjectRef, Params2.Type, MoveTemp(Params2.Payload));
+	RPCs.ProcessOrQueueRPC(Params1.ObjectRef, Params1.SenderObjectRef, Params1.Type, MoveTemp(Params1.Payload), 0);
+	RPCs.ProcessOrQueueRPC(Params2.ObjectRef, Params2.SenderObjectRef, Params2.Type, MoveTemp(Params2.Payload), 0);
 
 	TestTrue("Has queued RPCs", RPCs.ObjectHasRPCsQueuedOfType(Params1.ObjectRef.Entity, AnyOtherSchemaComponentType));
 
@@ -92,7 +92,7 @@ RPCCONTAINER_TEST(GIVEN_a_container_storing_one_value_WHEN_processed_once_THEN_n
 	FRPCContainer RPCs(ERPCQueueType::Send);
 	RPCs.BindProcessingFunction(FProcessRPCDelegate::CreateUObject(TargetObject, &UObjectDummy::ProcessRPC));
 
-	RPCs.ProcessOrQueueRPC(Params.ObjectRef, Params.Type, MoveTemp(Params.Payload));
+	RPCs.ProcessOrQueueRPC(Params.ObjectRef, Params.SenderObjectRef, Params.Type, MoveTemp(Params.Payload), 0);
 
 	TestFalse("Has queued RPCs", RPCs.ObjectHasRPCsQueuedOfType(Params.ObjectRef.Entity, AnySchemaComponentType));
 
@@ -107,8 +107,8 @@ RPCCONTAINER_TEST(GIVEN_a_container_storing_multiple_values_of_same_type_WHEN_pr
 	FRPCContainer RPCs(ERPCQueueType::Send);
 	RPCs.BindProcessingFunction(FProcessRPCDelegate::CreateUObject(TargetObject, &UObjectDummy::ProcessRPC));
 
-	RPCs.ProcessOrQueueRPC(Params1.ObjectRef, Params1.Type, MoveTemp(Params1.Payload));
-	RPCs.ProcessOrQueueRPC(Params2.ObjectRef, Params2.Type, MoveTemp(Params2.Payload));
+	RPCs.ProcessOrQueueRPC(Params1.ObjectRef, Params1.SenderObjectRef, Params1.Type, MoveTemp(Params1.Payload), 0);
+	RPCs.ProcessOrQueueRPC(Params2.ObjectRef, Params2.SenderObjectRef, Params2.Type, MoveTemp(Params2.Payload), 0);
 
 	TestFalse("Has queued RPCs", RPCs.ObjectHasRPCsQueuedOfType(Params1.ObjectRef.Entity, AnyOtherSchemaComponentType));
 
@@ -125,8 +125,10 @@ RPCCONTAINER_TEST(GIVEN_a_container_WHEN_multiple_values_of_different_type_have_
 	FRPCContainer RPCs(ERPCQueueType::Send);
 	RPCs.BindProcessingFunction(FProcessRPCDelegate::CreateUObject(TargetObject, &UObjectStub::ProcessRPC));
 
-	RPCs.ProcessOrQueueRPC(ParamsUnreliable.ObjectRef, ParamsUnreliable.Type, MoveTemp(ParamsUnreliable.Payload));
-	RPCs.ProcessOrQueueRPC(ParamsReliable.ObjectRef, ParamsReliable.Type, MoveTemp(ParamsReliable.Payload));
+	RPCs.ProcessOrQueueRPC(ParamsUnreliable.ObjectRef, ParamsUnreliable.SenderObjectRef, ParamsUnreliable.Type,
+						   MoveTemp(ParamsUnreliable.Payload), 0);
+	RPCs.ProcessOrQueueRPC(ParamsReliable.ObjectRef, ParamsReliable.SenderObjectRef, ParamsReliable.Type, MoveTemp(ParamsReliable.Payload),
+						   0);
 
 	TestTrue("Has queued RPCs", RPCs.ObjectHasRPCsQueuedOfType(ParamsUnreliable.ObjectRef.Entity, AnyOtherSchemaComponentType));
 	TestTrue("Has queued RPCs", RPCs.ObjectHasRPCsQueuedOfType(ParamsReliable.ObjectRef.Entity, AnySchemaComponentType));
@@ -143,8 +145,10 @@ RPCCONTAINER_TEST(GIVEN_a_container_storing_multiple_values_of_different_type_WH
 	FRPCContainer RPCs(ERPCQueueType::Send);
 	RPCs.BindProcessingFunction(FProcessRPCDelegate::CreateUObject(TargetObject, &UObjectDummy::ProcessRPC));
 
-	RPCs.ProcessOrQueueRPC(ParamsUnreliable.ObjectRef, ParamsUnreliable.Type, MoveTemp(ParamsUnreliable.Payload));
-	RPCs.ProcessOrQueueRPC(ParamsReliable.ObjectRef, ParamsReliable.Type, MoveTemp(ParamsReliable.Payload));
+	RPCs.ProcessOrQueueRPC(ParamsUnreliable.ObjectRef, ParamsUnreliable.SenderObjectRef, ParamsUnreliable.Type,
+						   MoveTemp(ParamsUnreliable.Payload), 0);
+	RPCs.ProcessOrQueueRPC(ParamsReliable.ObjectRef, ParamsReliable.SenderObjectRef, ParamsReliable.Type, MoveTemp(ParamsReliable.Payload),
+						   0);
 
 	TestFalse("Has queued RPCs", RPCs.ObjectHasRPCsQueuedOfType(ParamsUnreliable.ObjectRef.Entity, AnyOtherSchemaComponentType));
 	TestFalse("Has queued RPCs", RPCs.ObjectHasRPCsQueuedOfType(ParamsReliable.ObjectRef.Entity, AnySchemaComponentType));
@@ -169,8 +173,8 @@ RPCCONTAINER_TEST(GIVEN_a_container_storing_multiple_values_of_different_type_WH
 		RPCIndices.FindOrAdd(AnyOtherSchemaComponentType).Push(ParamsUnreliable.Payload.Index);
 		RPCIndices.FindOrAdd(AnySchemaComponentType).Push(ParamsReliable.Payload.Index);
 
-		RPCs.ProcessOrQueueRPC(ObjectRef, ParamsUnreliable.Type, MoveTemp(ParamsUnreliable.Payload));
-		RPCs.ProcessOrQueueRPC(ObjectRef, ParamsReliable.Type, MoveTemp(ParamsReliable.Payload));
+		RPCs.ProcessOrQueueRPC(ObjectRef, ParamsUnreliable.SenderObjectRef, ParamsUnreliable.Type, MoveTemp(ParamsUnreliable.Payload), 0);
+		RPCs.ProcessOrQueueRPC(ObjectRef, ParamsReliable.SenderObjectRef, ParamsReliable.Type, MoveTemp(ParamsReliable.Payload), 0);
 	}
 
 	bool bProcessedInOrder = true;
@@ -202,7 +206,7 @@ RPCCONTAINER_TEST(GIVEN_a_container_with_one_value_WHEN_processing_after_RPCQueu
 	FPendingRPCParams Params = CreateMockParameters(TargetObject, AnySchemaComponentType);
 	FRPCContainer RPCs(ERPCQueueType::Send);
 	RPCs.BindProcessingFunction(FProcessRPCDelegate::CreateUObject(TargetObject, &UObjectStub::ProcessRPC));
-	RPCs.ProcessOrQueueRPC(Params.ObjectRef, Params.Type, MoveTemp(Params.Payload));
+	RPCs.ProcessOrQueueRPC(Params.ObjectRef, Params.SenderObjectRef, Params.Type, MoveTemp(Params.Payload), 0);
 
 	AddExpectedError(TEXT("Unresolved Parameters"), EAutomationExpectedErrorFlags::Contains, 1);
 


### PR DESCRIPTION
#### Description

Relies on https://github.com/improbableio/UnrealEngine/pull/666
This is built on top of the spike to support worker mailbox (publishing RPC on the worker entity).
[Document](https://docs.google.com/document/d/11ixXkqQ84dMGch0h8gCH_g2mF0RuXYffMcqkZr3kboA/edit?usp=sharing) for reference.
The main changes are : 

1. Add new CrossServerRPC components (CrossServerEndpoint.h/cpp). They contain a reliable RPC Buffer with the addition of a "counterpart", an entity reference used to track the sender/target.
2. Start an additional worker which will route RPCs from sender to receiver. Most of the plumbing to start different worker types is still around. The SpatialNetDriver then has forking points depending on the worker type. Long term, we could think about providing a first class generic concept for different types of worker (ones which would not check out Actors).
3. Additional arguments to the RPC service and callback in order to move the Sender/Target around (change from the current RPC system, the entity a RPC is written to might not be the one executing it).
4. CrossServerRPC handled by the RPCService. This is mostly separated though, and would become its own system.
5. RoutingWorker system built upon SpatialSubView. The routing worker does not go through SpatialReceiver at all. It only has interest on the CrossServerRPC endpoints for all entities. It is only hijacking the SpatialNetDriver for the connection stack.

#### Performance considerations :
A throughput analysis has been done regarding the worker-mailbox solution. Conclusions were presented in this document : 
https://docs.google.com/document/d/1gmZNuBNeHmOPqdtT9AGQZ8EV_Iex5OfahAP2ZsH0JrA/edit?usp=sharing
Throughput for the routing worker happened to be in the same order or magnitude, with similar scaling as the RingBuffer gets bigger (given 30 Hz server ticks).
In practice this would not be apple to apple comparison since the Routing worker implementation is able to take advantage of multiple senders. We stuck to the scenario where we have one sender per worker to be able to do some sort of comparison.
Another area where differences arise is latency. Measures were done using the CrossServer latency measures from the NFR map, using 4 local players on a 4 workers deployment.
Server workers tick at 30 Hz. In PIE, workers are executed sequentially.
- PIE with routing worker (worst case), 660-1330 ms, average at 1000 ms
- PIE with worker mailbox (worst case), average 600 ms.
- Worker mailbox. Avg 66 ms, some outliers at 100 ms
- Routing worker, evenly distributed in the range 66-133ms
- Routing worker ticking at 120 hz, evenly distributed in the range 66-100ms
- Commands, 66ms average, some outliers at 100 ms

So Latency increases compared to other solutions, but it is worth noting that no solutions is immune to the 100 ms latency anyway. Using a routing worker increases the chance of hitting and additional frame of latency though.

#### Future work : 
If we were to integrate this, a lot should be rewritten.
The RPC service has changed to be based on SubView as well.
Is the routing worker integration in the Spatial Net Driver a bespoke or a generic one (utility worker, relevant for USLB)?
There would be more to share in terms of code between the RoutingSystem and RPCService. They perform similar tasks, but the main difference comes from the fact that in the current implementation, we can switch between the Routing worker and Worker Entity mailbox RPC implementations.