### PR TITLE
Increment RequireSetup after changes to hand-written schema

### DIFF
--- a/RequireSetup
+++ b/RequireSetup
@@ -1,4 +1,4 @@
 Increment the below number whenever it is required to run Setup.bat as part of a new commit.
 Our git hooks will detect this file has been updated and automatically run Setup.bat on pull.
 
-68
+69


### PR DESCRIPTION
#### Description
Increment RequireSetup so `Setup.bat` runs automatically to update the hand-written schema in the `spatial` folder after pulling the new changes.

#### Primary reviewers
@jacquese @mironec 
