### PR TITLE
[UNR-4390] Fix loadbalancing

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialLoadBalanceEnforcer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialLoadBalanceEnforcer.cpp
@@ -111,6 +111,12 @@ EntityComponentUpdate SpatialLoadBalanceEnforcer::ConstructAclUpdate(const Worke
 	// Ensure that every component ID in ComponentPresence is set in the write ACL.
 	for (const Worker_ComponentId RequiredComponentId : ComponentPresenceComponent.ComponentList)
 	{
+		// Skip entity completeness tags, as we do not want them to be delegated.
+		// This would create false completeness for workers which happened to be delegated the tag components.
+		if (SpatialConstants::IsEntityCompletenessComponent(RequiredComponentId))
+		{
+			continue;
+		}
 		ComponentIds.AddUnique(RequiredComponentId);
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
@@ -559,14 +559,10 @@ bool USpatialClassInfoManager::IsNetCullDistanceComponent(Worker_ComponentId Com
 	return SchemaDatabase->NetCullDistanceComponentIds.Contains(ComponentId);
 }
 
-bool USpatialClassInfoManager::IsEntityCompletenessComponent(Worker_ComponentId ComponentId) const
-{
-	return ComponentId >= SpatialConstants::FIRST_EC_COMPONENT_ID && ComponentId <= SpatialConstants::LAST_EC_COMPONENT_ID;
-}
-
 bool USpatialClassInfoManager::IsGeneratedQBIMarkerComponent(Worker_ComponentId ComponentId) const
 {
-	return IsSublevelComponent(ComponentId) || IsNetCullDistanceComponent(ComponentId) || IsEntityCompletenessComponent(ComponentId);
+	return IsSublevelComponent(ComponentId) || IsNetCullDistanceComponent(ComponentId)
+		   || SpatialConstants::IsEntityCompletenessComponent(ComponentId);
 }
 
 void USpatialClassInfoManager::QuitGame()

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -96,6 +96,10 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel, uin
 
 	ComponentDatas.Add(ComponentPresence(EntityFactory::GetComponentPresenceList(ComponentDatas)).CreateComponentPresenceData());
 
+	// Add Actor completeness tags.
+	// This has to come after the component presence list, so that Actor completeness tags don't get delegated.
+	ComponentDatas.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::LB_TAG_COMPONENT_ID));
+
 	Worker_EntityId EntityId = Channel->GetEntityId();
 
 	TOptional<Trace_SpanId> SpanId = EventTracer->CreateSpan();
@@ -274,11 +278,11 @@ void USpatialSender::RetryServerWorkerEntityCreation(Worker_EntityId EntityId, i
 					   ->CreateServerWorkerInterest(EntityId, NetDriver->LoadBalanceStrategy, NetDriver->DebugCtx != nullptr /*bDebug*/)
 					   .CreateInterestData());
 
-	// GDK known entities completeness tags
-	Components.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::GDK_KNOWN_ENTITY_TAG_COMPONENT_ID));
-
 	// Presence component. Must be calculated after all other components have been added.
 	Components.Add(ComponentPresence(EntityFactory::GetComponentPresenceList(Components)).CreateComponentPresenceData());
+
+	// GDK known entities completeness tags.
+	Components.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::GDK_KNOWN_ENTITY_TAG_COMPONENT_ID));
 
 	const Worker_RequestId RequestId = Connection->SendCreateEntityRequest(MoveTemp(Components), &EntityId);
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -96,10 +96,6 @@ Worker_RequestId USpatialSender::CreateEntity(USpatialActorChannel* Channel, uin
 
 	ComponentDatas.Add(ComponentPresence(EntityFactory::GetComponentPresenceList(ComponentDatas)).CreateComponentPresenceData());
 
-	// Add Actor completeness tags.
-	// This has to come after the component presence list, so that Actor completeness tags don't get delegated.
-	ComponentDatas.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::LB_TAG_COMPONENT_ID));
-
 	Worker_EntityId EntityId = Channel->GetEntityId();
 
 	TOptional<Trace_SpanId> SpanId = EventTracer->CreateSpan();
@@ -278,11 +274,11 @@ void USpatialSender::RetryServerWorkerEntityCreation(Worker_EntityId EntityId, i
 					   ->CreateServerWorkerInterest(EntityId, NetDriver->LoadBalanceStrategy, NetDriver->DebugCtx != nullptr /*bDebug*/)
 					   .CreateInterestData());
 
-	// Presence component. Must be calculated after all other components have been added.
-	Components.Add(ComponentPresence(EntityFactory::GetComponentPresenceList(Components)).CreateComponentPresenceData());
-
 	// GDK known entities completeness tags.
 	Components.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::GDK_KNOWN_ENTITY_TAG_COMPONENT_ID));
+
+	// Presence component. Must be calculated after all other components have been added.
+	Components.Add(ComponentPresence(EntityFactory::GetComponentPresenceList(Components)).CreateComponentPresenceData());
 
 	const Worker_RequestId RequestId = Connection->SendCreateEntityRequest(MoveTemp(Components), &EntityId);
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -400,12 +400,12 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 TArray<Worker_ComponentId> EntityFactory::GetComponentPresenceList(const TArray<FWorkerComponentData>& ComponentDatas)
 {
 	TArray<Worker_ComponentId> ComponentPresenceList;
-	ComponentPresenceList.Reserve(ComponentDatas.Num() + 1);
+	ComponentPresenceList.SetNum(ComponentDatas.Num() + 1);
 	for (int i = 0; i < ComponentDatas.Num(); i++)
 	{
-		ComponentPresenceList.Add(ComponentDatas[i].component_id);
+		ComponentPresenceList[i] = ComponentDatas[i].component_id;
 	}
-	ComponentPresenceList.Add(SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID);
+	ComponentPresenceList[ComponentDatas.Num()] = SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID;
 	return ComponentPresenceList;
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -412,7 +412,7 @@ TArray<Worker_ComponentId> EntityFactory::GetComponentPresenceList(const TArray<
 		}
 		ComponentPresenceList.Add(ComponentDatas[i].component_id);
 	}
-	ComponentPresenceList[ComponentDatas.Num()] = SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID;
+	ComponentPresenceList.Add(SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID);
 	return ComponentPresenceList;
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -389,9 +389,6 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 
 	ComponentDatas.Add(EntityAcl(ReadAcl, ComponentWriteAcl).CreateEntityAclData());
 
-	// Add Actor completeness tags.
-	ComponentDatas.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::LB_TAG_COMPONENT_ID));
-
 	return ComponentDatas;
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -403,13 +403,6 @@ TArray<Worker_ComponentId> EntityFactory::GetComponentPresenceList(const TArray<
 	ComponentPresenceList.Reserve(ComponentDatas.Num() + 1);
 	for (int i = 0; i < ComponentDatas.Num(); i++)
 	{
-		// Skip entity completeness tags, as we do not want them to be a part of ComponentPresence, and thus be delegated.
-		// This would create false completeness for workers which happened to be delegated the tag components.
-		if (ComponentDatas[i].component_id >= SpatialConstants::FIRST_EC_COMPONENT_ID
-			&& ComponentDatas[i].component_id <= SpatialConstants::LAST_EC_COMPONENT_ID)
-		{
-			continue;
-		}
 		ComponentPresenceList.Add(ComponentDatas[i].component_id);
 	}
 	ComponentPresenceList.Add(SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID);

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialClassInfoManager.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialClassInfoManager.h
@@ -120,7 +120,6 @@ public:
 	Worker_ComponentId ComputeActorInterestComponentId(const AActor* Actor) const;
 
 	bool IsNetCullDistanceComponent(Worker_ComponentId ComponentId) const;
-	bool IsEntityCompletenessComponent(Worker_ComponentId ComponentId) const;
 
 	const TArray<Worker_ComponentId>& GetComponentIdsForComponentType(const ESchemaComponentType ComponentType) const;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -373,6 +373,11 @@ const TArray<Worker_ComponentId> REQUIRED_COMPONENTS_FOR_AUTH_SERVER_INTEREST =
 								HEARTBEAT_COMPONENT_ID
 	};
 
+inline bool IsEntityCompletenessComponent(Worker_ComponentId ComponentId)
+{
+	return ComponentId >= SpatialConstants::FIRST_EC_COMPONENT_ID && ComponentId <= SpatialConstants::LAST_EC_COMPONENT_ID;
+}
+
 inline Worker_ComponentId RPCTypeToWorkerComponentIdLegacy(ERPCType RPCType)
 {
 	switch (RPCType)

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SnapshotGenerator/SpatialGDKEditorSnapshotGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SnapshotGenerator/SpatialGDKEditorSnapshotGenerator.cpp
@@ -75,11 +75,11 @@ bool CreateSpawnerEntity(Worker_SnapshotOutputStream* OutputStream)
 	Components.Add(EntityAcl(SpatialConstants::ClientOrServerPermission, ComponentWriteAcl).CreateEntityAclData());
 	Components.Add(PlayerSpawnerData);
 
-	// Presence component. Must be calculated after all other components have been added.
-	Components.Add(ComponentPresence(EntityFactory::GetComponentPresenceList(Components)).CreateComponentPresenceData());
-
 	// GDK known entities completeness tags.
 	Components.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::GDK_KNOWN_ENTITY_TAG_COMPONENT_ID));
+
+	// Presence component. Must be calculated after all other components have been added.
+	Components.Add(ComponentPresence(EntityFactory::GetComponentPresenceList(Components)).CreateComponentPresenceData());
 
 	SetEntityData(SpawnerEntity, Components);
 
@@ -149,11 +149,11 @@ bool CreateGlobalStateManager(Worker_SnapshotOutputStream* OutputStream)
 	Components.Add(CreateStartupActorManagerData());
 	Components.Add(EntityAcl(ReadACL, ComponentWriteAcl).CreateEntityAclData());
 
-	// Presence component. Must be calculated after all other components have been added.
-	Components.Add(ComponentPresence(EntityFactory::GetComponentPresenceList(Components)).CreateComponentPresenceData());
-
 	// GDK known entities completeness tags.
 	Components.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::GDK_KNOWN_ENTITY_TAG_COMPONENT_ID));
+
+	// Presence component. Must be calculated after all other components have been added.
+	Components.Add(ComponentPresence(EntityFactory::GetComponentPresenceList(Components)).CreateComponentPresenceData());
 
 	SetEntityData(GSM, Components);
 
@@ -192,11 +192,11 @@ bool CreateVirtualWorkerTranslator(Worker_SnapshotOutputStream* OutputStream)
 	Components.Add(CreateVirtualWorkerTranslatorData());
 	Components.Add(EntityAcl(ReadACL, ComponentWriteAcl).CreateEntityAclData());
 
-	// Presence component. Must be calculated after all other components have been added.
-	Components.Add(ComponentPresence(EntityFactory::GetComponentPresenceList(Components)).CreateComponentPresenceData());
-
 	// GDK known entities completeness tags.
 	Components.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::GDK_KNOWN_ENTITY_TAG_COMPONENT_ID));
+
+	// Presence component. Must be calculated after all other components have been added.
+	Components.Add(ComponentPresence(EntityFactory::GetComponentPresenceList(Components)).CreateComponentPresenceData());
 
 	SetEntityData(VirtualWorkerTranslator, Components);
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SnapshotGenerator/SpatialGDKEditorSnapshotGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SnapshotGenerator/SpatialGDKEditorSnapshotGenerator.cpp
@@ -75,11 +75,11 @@ bool CreateSpawnerEntity(Worker_SnapshotOutputStream* OutputStream)
 	Components.Add(EntityAcl(SpatialConstants::ClientOrServerPermission, ComponentWriteAcl).CreateEntityAclData());
 	Components.Add(PlayerSpawnerData);
 
-	// GDK known entities completeness tags
-	Components.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::GDK_KNOWN_ENTITY_TAG_COMPONENT_ID));
-
 	// Presence component. Must be calculated after all other components have been added.
 	Components.Add(ComponentPresence(EntityFactory::GetComponentPresenceList(Components)).CreateComponentPresenceData());
+
+	// GDK known entities completeness tags.
+	Components.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::GDK_KNOWN_ENTITY_TAG_COMPONENT_ID));
 
 	SetEntityData(SpawnerEntity, Components);
 
@@ -149,11 +149,11 @@ bool CreateGlobalStateManager(Worker_SnapshotOutputStream* OutputStream)
 	Components.Add(CreateStartupActorManagerData());
 	Components.Add(EntityAcl(ReadACL, ComponentWriteAcl).CreateEntityAclData());
 
-	// GDK known entities completeness tags
-	Components.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::GDK_KNOWN_ENTITY_TAG_COMPONENT_ID));
-
 	// Presence component. Must be calculated after all other components have been added.
 	Components.Add(ComponentPresence(EntityFactory::GetComponentPresenceList(Components)).CreateComponentPresenceData());
+
+	// GDK known entities completeness tags.
+	Components.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::GDK_KNOWN_ENTITY_TAG_COMPONENT_ID));
 
 	SetEntityData(GSM, Components);
 
@@ -192,11 +192,11 @@ bool CreateVirtualWorkerTranslator(Worker_SnapshotOutputStream* OutputStream)
 	Components.Add(CreateVirtualWorkerTranslatorData());
 	Components.Add(EntityAcl(ReadACL, ComponentWriteAcl).CreateEntityAclData());
 
-	// GDK known entities completeness tags
-	Components.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::GDK_KNOWN_ENTITY_TAG_COMPONENT_ID));
-
 	// Presence component. Must be calculated after all other components have been added.
 	Components.Add(ComponentPresence(EntityFactory::GetComponentPresenceList(Components)).CreateComponentPresenceData());
+
+	// GDK known entities completeness tags.
+	Components.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::GDK_KNOWN_ENTITY_TAG_COMPONENT_ID));
 
 	SetEntityData(VirtualWorkerTranslator, Components);
 


### PR DESCRIPTION
#### Description
Do not include entity completeness tags in component presence, otherwise they get delegated, and cause unintended workers to view them, which makes them think the associated entities are complete (e.g. wrt to the LB system).

#### Release note
n/a

#### Tests
Handover test now mostly works...

#### Documentation
n/a

#### Primary reviewers
@jacquese @m-samiec 
