### PR TITLE
[UNR-4401] Drop component data only if the actor is not ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a crash that would sometimes occur when connection to SpatialOS fails.
 - Fixed a crash that occurred when an actor subobject became invalid after applying initial component data.
 - Non-replicated Actors net roles are not touched during startup. 
+- Fix a bug which dropped component updates on authority delegation
 
 ## [`0.11.0`] - 2020-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a crash that would sometimes occur when connection to SpatialOS fails.
 - Fixed a crash that occurred when an actor subobject became invalid after applying initial component data.
 - Non-replicated Actors net roles are not touched during startup. 
-- Fix a bug which dropped component updates on authority delegation
+- Fixed a bug which dropped component updates on authority delegation.
 
 ## [`0.11.0`] - 2020-09-03
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -250,17 +250,19 @@ void USpatialReceiver::OnAddComponent(const Worker_AddComponentOp& Op)
 		check(bInCriticalSection);
 
 		// PendingAddActor should only be populated with actors we actually want to check out.
-		// So a local and ready actor should not be considered as a actor pending addition.
+		// So a local and ready actor should not be considered as an actor pending addition.
 		// Nitty-gritty implementation side effect is also that we do not want to stomp
 		// the local state of a not ready-actor, because it is locally authoritative and will remain
 		// that way until it is marked as ready. Putting it in PendingAddActor has the side effect
 		// that the received component data will get dropped (likely outdated data), and is
 		// something we do not wish to happen for ready actor (likely new data received through
 		// a component refresh on authority delegation).
-		AActor* EntityActor = Cast<AActor>(PackageMap->GetObjectFromEntityId(Op.entity_id));
-		if (EntityActor == nullptr || !EntityActor->IsActorReady())
 		{
-			PendingAddActors.AddUnique(Op.entity_id);
+			AActor* EntityActor = Cast<AActor>(PackageMap->GetObjectFromEntityId(Op.entity_id));
+			if (EntityActor == nullptr || !EntityActor->IsActorReady())
+			{
+				PendingAddActors.AddUnique(Op.entity_id);
+			}
 		}
 		return;
 	case SpatialConstants::WORKER_COMPONENT_ID:
@@ -896,7 +898,7 @@ void USpatialReceiver::ReceiveActor(Worker_EntityId EntityId)
 		if (!EntityActor->IsActorReady())
 		{
 			UE_LOG(LogSpatialReceiver, Verbose, TEXT("%s: Entity %lld for Actor %s has been checked out on the worker which spawned it."),
-				*NetDriver->Connection->GetWorkerId(), EntityId, *EntityActor->GetName());
+				   *NetDriver->Connection->GetWorkerId(), EntityId, *EntityActor->GetName());
 		}
 
 		return;

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1072,8 +1072,6 @@ void USpatialReceiver::ReceiveActor(Worker_EntityId EntityId)
 	{
 		NetDriver->AddPendingDormantChannel(Channel);
 	}
-
-	return;
 }
 
 void USpatialReceiver::RemoveActor(Worker_EntityId EntityId)

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -122,7 +122,7 @@ private:
 	void EnterCriticalSection();
 	void LeaveCriticalSection();
 
-	AActor* ReceiveActor(Worker_EntityId EntityId);
+	void ReceiveActor(Worker_EntityId EntityId);
 	void DestroyActor(AActor* Actor, Worker_EntityId EntityId);
 
 	AActor* TryGetOrCreateActor(SpatialGDK::UnrealMetadata* UnrealMetadata, SpatialGDK::SpawnData* SpawnData,

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -122,7 +122,7 @@ private:
 	void EnterCriticalSection();
 	void LeaveCriticalSection();
 
-	void ReceiveActor(Worker_EntityId EntityId);
+	AActor* ReceiveActor(Worker_EntityId EntityId);
 	void DestroyActor(AActor* Actor, Worker_EntityId EntityId);
 
 	AActor* TryGetOrCreateActor(SpatialGDK::UnrealMetadata* UnrealMetadata, SpatialGDK::SpawnData* SpawnData,


### PR DESCRIPTION
#### Description
Drops a received actor's PendingAddComponent only if the actor is not ready, which means it is locally authoritative and awaiting its acknowledgement by the runtime.
The other case where it can happen is when the authority is delegated, we can received AddComponent for all the delegated components, which can contain new data.

#### Release note
 
#### Tests
Tested with the test contained in https://github.com/spatialos/UnrealGDK/pull/2636, which happened to frequently trip on this case