### PR TITLE
Removing use of GWorld.

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialEventTracerUserInterface.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialEventTracerUserInterface.cpp
@@ -165,8 +165,8 @@ USpatialNetDriver* USpatialEventTracerUserInterface::GetSpatialNetDriver(UObject
 	if (World == nullptr)
 	{
 		UE_LOG(LogSpatialEventTracerUserInterface, Error,
-			   TEXT("USpatialEventTracerUserInterface::GetSpatialNetDriver - World is null, will use GWorld instead"));
-		World = GWorld;
+			   TEXT("USpatialEventTracerUserInterface::GetSpatialNetDriver - World is null."));
+		return nullptr;
 	}
 
 	USpatialNetDriver* NetDriver = Cast<USpatialNetDriver>(World->GetNetDriver());


### PR DESCRIPTION
Android clients do not seem to have GWorld defined. This is causing CI issues in the example project. I don't think including it here is providing us any value. Additionally I believe GWorld should be used only in totally necessary cases so I think we can just remove it.