### PR TITLE
Fixing merge component event trace test

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/SpatialRPCService.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/SpatialRPCService.cpp
@@ -187,7 +187,7 @@ TArray<SpatialRPCService::UpdateToSend> SpatialRPCService::GetRPCsAndAcksToSend(
 		{
 			TOptional<Trace_SpanId> SpanId = EventTracer->CreateSpan(It.Value.SpanIds.GetData(), It.Value.SpanIds.Num());
 			EventTracer->TraceEvent(
-				FSpatialTraceEventBuilder::CreateMergeComponentUpdate(UpdateToSend.EntityId, UpdateToSend.Update.component_id), SpanId);
+				FSpatialTraceEventBuilder::CreateMergeSendRPCs(UpdateToSend.EntityId, UpdateToSend.Update.component_id), SpanId);
 			UpdateToSend.SpanId = SpanId;
 		}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/SpatialRPCService.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/SpatialRPCService.cpp
@@ -186,8 +186,8 @@ TArray<SpatialRPCService::UpdateToSend> SpatialRPCService::GetRPCsAndAcksToSend(
 		if (EventTracer != nullptr)
 		{
 			TOptional<Trace_SpanId> SpanId = EventTracer->CreateSpan(It.Value.SpanIds.GetData(), It.Value.SpanIds.Num());
-			EventTracer->TraceEvent(
-				FSpatialTraceEventBuilder::CreateMergeSendRPCs(UpdateToSend.EntityId, UpdateToSend.Update.component_id), SpanId);
+			EventTracer->TraceEvent(FSpatialTraceEventBuilder::CreateMergeSendRPCs(UpdateToSend.EntityId, UpdateToSend.Update.component_id),
+									SpanId);
 			UpdateToSend.SpanId = SpanId;
 		}
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/EventTracingTests/EventTracingTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/EventTracingTests/EventTracingTest.cpp
@@ -121,6 +121,7 @@ void AEventTracingTest::GatherData()
 	{
 		GatherDataFromFile(FileCreationTimes[0].FilePath);
 		GatherDataFromFile(FileCreationTimes[1].FilePath);
+		GatherDataFromFile(FileCreationTimes[2].FilePath);
 	}
 
 	FinishStep();

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/EventTracingTests/EventTracingTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/EventTracingTests/EventTracingTest.cpp
@@ -33,7 +33,7 @@ AEventTracingTest::AEventTracingTest()
 	Author = "Matthew Sandford";
 	Description = TEXT("Base class for event tracing tests");
 
-	SetNumRequiredClients(2);
+	SetNumRequiredClients(1);
 }
 
 void AEventTracingTest::PrepareTest()
@@ -121,7 +121,6 @@ void AEventTracingTest::GatherData()
 	{
 		GatherDataFromFile(FileCreationTimes[0].FilePath);
 		GatherDataFromFile(FileCreationTimes[1].FilePath);
-		GatherDataFromFile(FileCreationTimes[2].FilePath);
 	}
 
 	FinishStep();

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/EventTracingTests/EventTracingTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/EventTracingTests/EventTracingTest.cpp
@@ -33,7 +33,7 @@ AEventTracingTest::AEventTracingTest()
 	Author = "Matthew Sandford";
 	Description = TEXT("Base class for event tracing tests");
 
-	SetNumRequiredClients(1);
+	SetNumRequiredClients(2);
 }
 
 void AEventTracingTest::PrepareTest()


### PR DESCRIPTION
Fixing up a failure in event tracing tests. The wrong event was being fired in the GDK.