### PR TITLE
fix ordering

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/MulticastRPCService.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/MulticastRPCService.cpp
@@ -27,14 +27,20 @@ void MulticastRPCService::Advance()
 		switch (Delta.Type)
 		{
 		case EntityDelta::UPDATE:
-		{
-			for (const ComponentChange& Change : Delta.ComponentUpdates)
 			{
-				ComponentUpdate(Delta.EntityId, Change.ComponentId, Change.Update);
+			for (const AuthorityChange& Change : Delta.AuthorityLostTemporarily)
+			{
+				// We process auth lost temporarily twice. Once before updates and once after, so as not
+				// to process updates that we received while we think we are still authoritiative.
+				AuthorityLost(Delta.EntityId, Change.ComponentId);
 			}
 			for (const AuthorityChange& Change : Delta.AuthorityLost)
 			{
 				AuthorityLost(Delta.EntityId, Change.ComponentId);
+			}
+			for (const ComponentChange& Change : Delta.ComponentUpdates)
+			{
+				ComponentUpdate(Delta.EntityId, Change.ComponentId, Change.Update);
 			}
 			for (const AuthorityChange& Change : Delta.AuthorityGained)
 			{
@@ -42,7 +48,8 @@ void MulticastRPCService::Advance()
 			}
 			for (const AuthorityChange& Change : Delta.AuthorityLostTemporarily)
 			{
-				AuthorityLost(Delta.EntityId, Change.ComponentId);
+				// Updates that we could have received while we weren't authoritative have now been processed.
+				// Regain authority.
 				AuthorityGained(Delta.EntityId, Change.ComponentId);
 			}
 			break;

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/MulticastRPCService.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/MulticastRPCService.cpp
@@ -27,7 +27,7 @@ void MulticastRPCService::Advance()
 		switch (Delta.Type)
 		{
 		case EntityDelta::UPDATE:
-			{
+		{
 			for (const AuthorityChange& Change : Delta.AuthorityLostTemporarily)
 			{
 				// We process auth lost temporarily twice. Once before updates and once after, so as not


### PR DESCRIPTION
The order we process authority wrt updates does matter. This PR reflects that for the multicast rpc service where we can lose and gain authority over components we care about.
