### PR TITLE
[UNR-4440] Fix 'Could not find offset for component id' warning

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -925,7 +925,7 @@ void USpatialReceiver::ReceiveActor(Worker_EntityId EntityId)
 			continue;
 		}
 
-		if (PendingAddComponent.EntityId == EntityId)
+		if (PendingAddComponent.EntityId == EntityId && PendingAddComponent.ComponentId != SpatialConstants::GDK_DEBUG_COMPONENT_ID)
 		{
 			ApplyComponentDataOnActorCreation(EntityId, PendingAddComponent.Data->Data.GetWorkerComponentData(), *Channel, ActorClassInfo,
 											  ObjectsToResolvePendingOpsFor);


### PR DESCRIPTION
#### Description
Debug components get added to `PendingAddComponents` and then passed to `ApplyComponentDataOnActorCreation` in `ReceiveActor` but they don't represent a generated component so there's no corresponding class info, thus the warning gets printed.
Fix: don't pass them to `ApplyComponentDataOnActorCreation`.

#### Primary reviewers
@ImprobableNic @MatthewSandfordImprobable 
