### PR TITLE
Change EActorMigrationResult to enum class to fix a naming collision

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -53,7 +53,7 @@ DECLARE_DWORD_ACCUMULATOR_STAT_EXTERN(TEXT("Consider List Size"), STAT_SpatialCo
 DECLARE_DWORD_ACCUMULATOR_STAT_EXTERN(TEXT("Num Relevant Actors"), STAT_SpatialActorsRelevant, STATGROUP_SpatialNet, );
 DECLARE_DWORD_ACCUMULATOR_STAT_EXTERN(TEXT("Num Changed Relevant Actors"), STAT_SpatialActorsChanged, STATGROUP_SpatialNet, );
 
-enum EActorMigrationResult : uint8
+enum class EActorMigrationResult : uint8
 {
 	Success,
 	NotAuthoritative,


### PR DESCRIPTION

#### Description
Change EActorMigrationResult to enum class to fix a naming collision with BrainComponent.h.

#### Tests
How did you test these changes prior to submitting this pull request? Compiled Windows editor and Linux server against a project that also uses BrainComponent.h.
What automated tests are included in this PR? N/A

STRONGLY SUGGESTED: How can this be verified by QA? N/A

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)? N/A