### PR TITLE
UNR-2162 fix: display regex errors for simplayers deployment name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a crash that occurred when an actor subobject became invalid after applying initial component data.
 - Non-replicated Actors net roles are not touched during startup. 
 - Fixed a bug which dropped component updates on authority delegation.
+- The DeploymentLauncher checks the validity of the simulated players deployment name.
 
 ## [`0.11.0`] - 2020-09-03
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKCloudDeploymentConfiguration.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKCloudDeploymentConfiguration.cpp
@@ -86,6 +86,8 @@ void SSpatialGDKCloudDeploymentConfiguration::Construct(const FArguments& InArgs
 	AssemblyNameInputErrorReporting->SetError(TEXT(""));
 	DeploymentNameInputErrorReporting = SNew(SPopupErrorText);
 	DeploymentNameInputErrorReporting->SetError(TEXT(""));
+	SimulatedPlayersDeploymentNameInputErrorReporting = SNew(SPopupErrorText);
+	SimulatedPlayersDeploymentNameInputErrorReporting->SetError(TEXT(""));
 	ChildSlot
 		[SNew(SBorder)
 			 .HAlign(HAlign_Fill)
@@ -379,6 +381,7 @@ void SSpatialGDKCloudDeploymentConfiguration::Construct(const FArguments& InArgs
 																					   &SSpatialGDKCloudDeploymentConfiguration::
 																						   OnSimulatedPlayerDeploymentNameCommited,
 																					   ETextCommit::Default)
+																		.ErrorReporting(SimulatedPlayersDeploymentNameInputErrorReporting)
 																		.IsEnabled_UObject(
 																			SpatialGDKSettings,
 																			&USpatialGDKEditorSettings::IsSimulatedPlayersEnabled)]]
@@ -779,8 +782,16 @@ void SSpatialGDKCloudDeploymentConfiguration::OnSimulatedPlayerDeploymentRegionC
 
 void SSpatialGDKCloudDeploymentConfiguration::OnSimulatedPlayerDeploymentNameCommited(const FText& InText, ETextCommit::Type InCommitType)
 {
+	const FString& InputSimulatedPlayersDeploymentName = InText.ToString();
+	if (!USpatialGDKEditorSettings::IsDeploymentNameValid(InputSimulatedPlayersDeploymentName))
+	{
+		SimulatedPlayersDeploymentNameInputErrorReporting->SetError(SpatialConstants::DeploymentPatternHint);
+		return;
+	}
+	SimulatedPlayersDeploymentNameInputErrorReporting->SetError(TEXT(""));
+
 	USpatialGDKEditorSettings* SpatialGDKSettings = GetMutableDefault<USpatialGDKEditorSettings>();
-	SpatialGDKSettings->SetSimulatedPlayerDeploymentName(InText.ToString());
+	SpatialGDKSettings->SetSimulatedPlayerDeploymentName(InputSimulatedPlayersDeploymentName);
 }
 
 void SSpatialGDKCloudDeploymentConfiguration::OnNumberOfSimulatedPlayersCommited(uint32 NewValue)

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKCloudDeploymentConfiguration.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKCloudDeploymentConfiguration.h
@@ -44,6 +44,7 @@ private:
 	TSharedPtr<IErrorReportingWidget> ProjectNameInputErrorReporting;
 	TSharedPtr<IErrorReportingWidget> AssemblyNameInputErrorReporting;
 	TSharedPtr<IErrorReportingWidget> DeploymentNameInputErrorReporting;
+	TSharedPtr<IErrorReportingWidget> SimulatedPlayersDeploymentNameInputErrorReporting;
 
 	/** Delegate to commit project name */
 	void OnProjectNameCommitted(const FText& InText, ETextCommit::Type InCommitType);


### PR DESCRIPTION
#### Description
Similarly to the handling of the deployment name, the deployment launcher displays the hint for the simulated players deployment name, if it does not conform to the regex format.

#### Tests
Checked by launching UE4 and attempting to start a cloud deployment, with simulated players, where the simulated players deployment name is invalid (e.g. > 32 chars)

#### Documentation
Documentation not required as it is visible by user
