### PR TITLE
UNR-4221 fix: worker checks file ext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a crash that occurred when an actor subobject became invalid after applying initial component data.
 - Non-replicated Actors net roles are not touched during startup.
 - Fixed a bug which dropped component updates on authority delegation.
-- Worker configuration watcher only updates when `*.worker.json` files are changed.
+- Worker configuration watcher only rebuilds worker configs when `*.worker.json` files are changed.
 
 ## [`0.11.0`] - 2020-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking changes:
 - The condition for sending Spatial position updates has been changed, the two variables `PositionUpdateFrequency` and `PositionDistanceThreshold` have now been removed from the GDK settings. To update your project:
   1. Set the value of `PositionUpdateLowerThresholdCentimeters` to the value of `PositionDistanceThreshold` and  the value of `PositionUpdateLowerThresholdSeconds` to 60*(1/`PositionUpdateFrequency`). This will ensure that Actors send Spatial position updates as often as they did before this change.
-  2. Set the value of `PositionUpdateThresholdMaxCentimeters` and `PositionUpdateThresholdMaxSeconds` to larger values than the lower thresholds. 
+  2. Set the value of `PositionUpdateThresholdMaxCentimeters` and `PositionUpdateThresholdMaxSeconds` to larger values than the lower thresholds.
   NOTE: If your project does not use custom values for the `PositionUpdateFrequency` or `PositionDistanceThreshold`, then, by default, the updates will be sent with the same frequency as before and no action is required.
 - Removed the `OnAuthorityLossImminent` Actor event.
 - 'WorkerLogLevel' in Runtime Settings was split into two new settings - 'LocalWorkerLogLevel' and 'CloudWorkerLogLevel'. Update these values which will be set to 'Warning' by default.
@@ -63,8 +63,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - By default, only an Actor's replicated owner hierarchy will be used when determining which worker should have authority over an actor. Non-replicated Actors are now ignored.
 - Fixed a crash that would sometimes occur when connection to SpatialOS fails.
 - Fixed a crash that occurred when an actor subobject became invalid after applying initial component data.
-- Non-replicated Actors net roles are not touched during startup. 
+- Non-replicated Actors net roles are not touched during startup.
 - Fixed a bug which dropped component updates on authority delegation.
+- Worker configuration watcher only updates when `*.worker.json` files are changed.
 
 ## [`0.11.0`] - 2020-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking changes:
 - The condition for sending Spatial position updates has been changed, the two variables `PositionUpdateFrequency` and `PositionDistanceThreshold` have now been removed from the GDK settings. To update your project:
   1. Set the value of `PositionUpdateLowerThresholdCentimeters` to the value of `PositionDistanceThreshold` and  the value of `PositionUpdateLowerThresholdSeconds` to 60*(1/`PositionUpdateFrequency`). This will ensure that Actors send Spatial position updates as often as they did before this change.
-  2. Set the value of `PositionUpdateThresholdMaxCentimeters` and `PositionUpdateThresholdMaxSeconds` to larger values than the lower thresholds.
+  2. Set the value of `PositionUpdateThresholdMaxCentimeters` and `PositionUpdateThresholdMaxSeconds` to larger values than the lower thresholds. 
   NOTE: If your project does not use custom values for the `PositionUpdateFrequency` or `PositionDistanceThreshold`, then, by default, the updates will be sent with the same frequency as before and no action is required.
 - Removed the `OnAuthorityLossImminent` Actor event.
 - 'WorkerLogLevel' in Runtime Settings was split into two new settings - 'LocalWorkerLogLevel' and 'CloudWorkerLogLevel'. Update these values which will be set to 'Warning' by default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - By default, only an Actor's replicated owner hierarchy will be used when determining which worker should have authority over an actor. Non-replicated Actors are now ignored.
 - Fixed a crash that would sometimes occur when connection to SpatialOS fails.
 - Fixed a crash that occurred when an actor subobject became invalid after applying initial component data.
-- Non-replicated Actors net roles are not touched during startup.
+- Non-replicated Actors net roles are not touched during startup. 
 - Fixed a bug which dropped component updates on authority delegation.
 - Worker configuration watcher only rebuilds worker configs when `*.worker.json` files are changed.
 

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
@@ -57,10 +57,10 @@ void ViewDelta::Project(FSubViewDelta& SubDelta, const TArray<Worker_EntityId>& 
 
 		// Find the intersection between complete entities and the entity IDs in the view delta, add them to this
 		// delta.
-		if (CompleteIt && DeltaIt && CompleteId == CurrentEntityId && DeltaId == CurrentEntityId)
+		if (CompleteId == CurrentEntityId && DeltaId == CurrentEntityId)
 		{
 			EntityDelta CompleteDelta = *DeltaIt;
-			if (TemporarilyIncompleteIt && *TemporarilyIncompleteIt == CurrentEntityId)
+			if (TemporarilyIncompleteId == CurrentEntityId)
 			{
 				// This is a delta for a complete entity which was also temporarily removed. Change its type to
 				// reflect that.
@@ -69,29 +69,29 @@ void ViewDelta::Project(FSubViewDelta& SubDelta, const TArray<Worker_EntityId>& 
 			}
 			SubDelta.EntityDeltas.Emplace(CompleteDelta);
 		}
+		// Temporarily incomplete entities which aren't present in the projecting view delta are represented as marker
+		// temporarily removed entities with no state.
+		else if (TemporarilyIncompleteId == CurrentEntityId)
+		{
+			SubDelta.EntityDeltas.Emplace(EntityDelta{ CurrentEntityId, EntityDelta::TEMPORARILY_REMOVED });
+			++TemporarilyIncompleteIt;
+		}
 		// Newly complete entities are represented as marker add entities with no state.
-		if (NewlyCompleteIt && NewlyCompleteId == CurrentEntityId)
+		else if (NewlyCompleteId == CurrentEntityId)
 		{
 			SubDelta.EntityDeltas.Emplace(EntityDelta{ CurrentEntityId, EntityDelta::ADD });
 			++NewlyCompleteIt;
 		}
 		// Newly incomplete entities are represented as marker remove entities with no state.
-		if (NewlyIncompleteIt && NewlyIncompleteId == CurrentEntityId)
+		else if (NewlyIncompleteId == CurrentEntityId)
 		{
 			SubDelta.EntityDeltas.Emplace(EntityDelta{ CurrentEntityId, EntityDelta::REMOVE });
 			++NewlyIncompleteIt;
 		}
-		// Temporarily incomplete entities which aren't present in the projecting view delta are represented as marker
-		// temporarily removed entities with no state.
-		if (TemporarilyIncompleteIt && TemporarilyIncompleteId == CurrentEntityId)
-		{
-			SubDelta.EntityDeltas.Emplace(EntityDelta{ CurrentEntityId, EntityDelta::TEMPORARILY_REMOVED });
-			++TemporarilyIncompleteIt;
-		}
 
 		// Logic for incrementing complete and delta iterators. If either iterator is done, null the other,
 		// as there can no longer be any intersection.
-		if (CompleteIt && CompleteId == CurrentEntityId)
+		if (CompleteId == CurrentEntityId)
 		{
 			++CompleteIt;
 			if (!CompleteIt)
@@ -99,7 +99,7 @@ void ViewDelta::Project(FSubViewDelta& SubDelta, const TArray<Worker_EntityId>& 
 				DeltaIt.SetToEnd();
 			}
 		}
-		if (DeltaIt && DeltaId == CurrentEntityId)
+		if (DeltaId == CurrentEntityId)
 		{
 			++DeltaIt;
 			if (!DeltaIt)

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
@@ -91,7 +91,7 @@ void ViewDelta::Project(FSubViewDelta& SubDelta, const TArray<Worker_EntityId>& 
 
 		// Logic for incrementing complete and delta iterators. If either iterator is done, null the other,
 		// as there can no longer be any intersection.
-		if (CompleteIt && CurrentEntityId)
+		if (CompleteIt && CompleteId == CurrentEntityId)
 		{
 			++CompleteIt;
 			if (!CompleteIt)

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
@@ -76,7 +76,7 @@ void ViewDelta::Project(FSubViewDelta& SubDelta, const TArray<Worker_EntityId>& 
 			++NewlyCompleteIt;
 		}
 		// Newly incomplete entities are represented as marker remove entities with no state.
-		if (NewlyCompleteIt && NewlyIncompleteId == CurrentEntityId)
+		if (NewlyIncompleteIt && NewlyIncompleteId == CurrentEntityId)
 		{
 			SubDelta.EntityDeltas.Emplace(EntityDelta{ CurrentEntityId, EntityDelta::REMOVE });
 			++NewlyIncompleteIt;
@@ -91,7 +91,7 @@ void ViewDelta::Project(FSubViewDelta& SubDelta, const TArray<Worker_EntityId>& 
 
 		// Logic for incrementing complete and delta iterators. If either iterator is done, null the other,
 		// as there can no longer be any intersection.
-		if (CompleteId == CurrentEntityId)
+		if (CompleteIt && CurrentEntityId)
 		{
 			++CompleteIt;
 			if (!CompleteIt)

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ViewDelta.cpp
@@ -57,10 +57,10 @@ void ViewDelta::Project(FSubViewDelta& SubDelta, const TArray<Worker_EntityId>& 
 
 		// Find the intersection between complete entities and the entity IDs in the view delta, add them to this
 		// delta.
-		if (CompleteId == CurrentEntityId && DeltaId == CurrentEntityId)
+		if (CompleteIt && DeltaIt && CompleteId == CurrentEntityId && DeltaId == CurrentEntityId)
 		{
 			EntityDelta CompleteDelta = *DeltaIt;
-			if (TemporarilyIncompleteId == CurrentEntityId)
+			if (TemporarilyIncompleteIt && *TemporarilyIncompleteIt == CurrentEntityId)
 			{
 				// This is a delta for a complete entity which was also temporarily removed. Change its type to
 				// reflect that.
@@ -69,24 +69,24 @@ void ViewDelta::Project(FSubViewDelta& SubDelta, const TArray<Worker_EntityId>& 
 			}
 			SubDelta.EntityDeltas.Emplace(CompleteDelta);
 		}
-		// Temporarily incomplete entities which aren't present in the projecting view delta are represented as marker
-		// temporarily removed entities with no state.
-		else if (TemporarilyIncompleteId == CurrentEntityId)
-		{
-			SubDelta.EntityDeltas.Emplace(EntityDelta{ CurrentEntityId, EntityDelta::TEMPORARILY_REMOVED });
-			++TemporarilyIncompleteIt;
-		}
 		// Newly complete entities are represented as marker add entities with no state.
-		else if (NewlyCompleteId == CurrentEntityId)
+		if (NewlyCompleteIt && NewlyCompleteId == CurrentEntityId)
 		{
 			SubDelta.EntityDeltas.Emplace(EntityDelta{ CurrentEntityId, EntityDelta::ADD });
 			++NewlyCompleteIt;
 		}
 		// Newly incomplete entities are represented as marker remove entities with no state.
-		else if (NewlyIncompleteId == CurrentEntityId)
+		if (NewlyCompleteIt && NewlyIncompleteId == CurrentEntityId)
 		{
 			SubDelta.EntityDeltas.Emplace(EntityDelta{ CurrentEntityId, EntityDelta::REMOVE });
 			++NewlyIncompleteIt;
+		}
+		// Temporarily incomplete entities which aren't present in the projecting view delta are represented as marker
+		// temporarily removed entities with no state.
+		if (TemporarilyIncompleteIt && TemporarilyIncompleteId == CurrentEntityId)
+		{
+			SubDelta.EntityDeltas.Emplace(EntityDelta{ CurrentEntityId, EntityDelta::TEMPORARILY_REMOVED });
+			++TemporarilyIncompleteIt;
 		}
 
 		// Logic for incrementing complete and delta iterators. If either iterator is done, null the other,
@@ -99,7 +99,7 @@ void ViewDelta::Project(FSubViewDelta& SubDelta, const TArray<Worker_EntityId>& 
 				DeltaIt.SetToEnd();
 			}
 		}
-		if (DeltaId == CurrentEntityId)
+		if (DeltaIt && DeltaId == CurrentEntityId)
 		{
 			++DeltaIt;
 			if (!DeltaIt)

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -123,7 +123,7 @@ void FLocalDeploymentManager::StartUpWorkerConfigDirectoryWatcher()
 
 void FLocalDeploymentManager::OnWorkerConfigDirectoryChanged(const TArray<FFileChangeData>& FileChanges)
 {
-	for (auto& FileChange : FileChanges)
+	for (const auto& FileChange : FileChanges)
 	{
 		if (FileChange.Filename.EndsWith(".worker.json"))
 		{

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -128,7 +128,7 @@ void FLocalDeploymentManager::OnWorkerConfigDirectoryChanged(const TArray<FFileC
 		if (FileChange.Filename.EndsWith(".worker.json"))
 		{
 			UE_LOG(LogSpatialDeploymentManager, Log,
-                   TEXT("Worker config files updated. Regenerating worker descriptors ('spatial worker build build-config')."));
+				TEXT("Worker config files updated. Regenerating worker descriptors ('spatial worker build build-config')."));
 
 			WorkerBuildConfigAsync();
 			return;

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -123,17 +123,14 @@ void FLocalDeploymentManager::StartUpWorkerConfigDirectoryWatcher()
 
 void FLocalDeploymentManager::OnWorkerConfigDirectoryChanged(const TArray<FFileChangeData>& FileChanges)
 {
-	const bool ShouldRebuild = FileChanges.ContainsByPredicate([&](FFileChangeData& FileChange)
-	{
+	const bool ShouldRebuild = FileChanges.ContainsByPredicate([](FFileChangeData& FileChange) {
 		return FileChange.Filename.EndsWith(".worker.json");
 	});
 
 	if (ShouldRebuild)
 	{
 		UE_LOG(LogSpatialDeploymentManager, Log,
-		       TEXT(
-			       "Worker config files updated. Regenerating worker descriptors ('spatial worker build build-config')."
-		       ));
+			   TEXT("Worker config files updated. Regenerating worker descriptors ('spatial worker build build-config')."));
 
 		WorkerBuildConfigAsync();
 	}

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -128,7 +128,7 @@ void FLocalDeploymentManager::OnWorkerConfigDirectoryChanged(const TArray<FFileC
 		if (FileChange.Filename.EndsWith(".worker.json"))
 		{
 			UE_LOG(LogSpatialDeploymentManager, Log,
-				TEXT("Worker config files updated. Regenerating worker descriptors ('spatial worker build build-config')."));
+				   TEXT("Worker config files updated. Regenerating worker descriptors ('spatial worker build build-config')."));
 
 			WorkerBuildConfigAsync();
 			return;

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -123,16 +123,19 @@ void FLocalDeploymentManager::StartUpWorkerConfigDirectoryWatcher()
 
 void FLocalDeploymentManager::OnWorkerConfigDirectoryChanged(const TArray<FFileChangeData>& FileChanges)
 {
-	for (const auto& FileChange : FileChanges)
+	const bool ShouldRebuild = FileChanges.ContainsByPredicate([&](FFileChangeData& FileChange)
 	{
-		if (FileChange.Filename.EndsWith(".worker.json"))
-		{
-			UE_LOG(LogSpatialDeploymentManager, Log,
-				   TEXT("Worker config files updated. Regenerating worker descriptors ('spatial worker build build-config')."));
+		return FileChange.Filename.EndsWith(".worker.json");
+	});
 
-			WorkerBuildConfigAsync();
-			return;
-		}
+	if (ShouldRebuild)
+	{
+		UE_LOG(LogSpatialDeploymentManager, Log,
+		       TEXT(
+			       "Worker config files updated. Regenerating worker descriptors ('spatial worker build build-config')."
+		       ));
+
+		WorkerBuildConfigAsync();
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -123,9 +123,17 @@ void FLocalDeploymentManager::StartUpWorkerConfigDirectoryWatcher()
 
 void FLocalDeploymentManager::OnWorkerConfigDirectoryChanged(const TArray<FFileChangeData>& FileChanges)
 {
-	UE_LOG(LogSpatialDeploymentManager, Log,
-		   TEXT("Worker config files updated. Regenerating worker descriptors ('spatial worker build build-config')."));
-	WorkerBuildConfigAsync();
+	for (auto& FileChange : FileChanges)
+	{
+		if (FileChange.Filename.EndsWith(".worker.json"))
+		{
+			UE_LOG(LogSpatialDeploymentManager, Log,
+                   TEXT("Worker config files updated. Regenerating worker descriptors ('spatial worker build build-config')."));
+
+			WorkerBuildConfigAsync();
+			return;
+		}
+	}
 }
 
 void FLocalDeploymentManager::WorkerBuildConfigAsync()


### PR DESCRIPTION
#### Description
The worker configuration file watcher checks the file extension and only updates if files with the `.worker.json` extension are changed.

#### Tests
Run UE4 and change the files in `UnrealGDKExampleProject\spatial\workers\`

![image](https://user-images.githubusercontent.com/26459030/98253340-cfebc500-1f72-11eb-9ce6-b5b0e3012bbb.png)

![image](https://user-images.githubusercontent.com/26459030/98253356-d5490f80-1f72-11eb-9e53-b18c9ddffea4.png)


