### PR TITLE
Migration test timeout for multiple clients

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestCharacterMigration/SpatialTestCharacterMigration.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestCharacterMigration/SpatialTestCharacterMigration.cpp
@@ -59,13 +59,17 @@ void ASpatialTestCharacterMigration::PrepareTest()
 	AddActorStepDefinition.StepName = TEXT("Add actor to player controller");
 	AddActorStepDefinition.TimeLimit = 0.0f;
 	AddActorStepDefinition.NativeStartEvent.BindLambda([this]() {
-		AController* PlayerController = UGameplayStatics::GetPlayerController(this, 0);
+		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
+		{
+			AController* PlayerController = Cast<AController>(FlowController->GetOwner());
 
-		FActorSpawnParameters SpawnParams;
-		SpawnParams.Owner = PlayerController;
-		AActor* TestActor = GetWorld()->SpawnActor<AActor>(AActor::StaticClass(), FTransform(), SpawnParams);
-		TestActor->SetReplicates(true); // NOTE: this currently causes parent not to migrate after a delay and outputs a warning in the test
-		RegisterAutoDestroyActor(TestActor);
+			FActorSpawnParameters SpawnParams;
+			SpawnParams.Owner = PlayerController;
+			AActor* TestActor = GetWorld()->SpawnActor<AActor>(AActor::StaticClass(), FTransform(), SpawnParams);
+			TestActor->SetReplicates(
+				true); // NOTE: this currently causes parent not to migrate after a delay and outputs a warning in the test
+			RegisterAutoDestroyActor(TestActor);
+		}
 		FinishStep();
 	});
 
@@ -156,6 +160,10 @@ void ASpatialTestCharacterMigration::PrepareTest()
 			if (FlowControllerId == 1)
 			{
 				PlayerCharacter->SetActorLocation(FVector(0.0f, -25.0f, 50.0f));
+			}
+			else
+			{
+				PlayerCharacter->SetActorLocation(FVector(0.0f, 50.0f * FlowControllerId, 50.0f));
 			}
 		}
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestCharacterMigration/SpatialTestCharacterMigration.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestCharacterMigration/SpatialTestCharacterMigration.cpp
@@ -141,35 +141,6 @@ void ASpatialTestCharacterMigration::PrepareTest()
 		FinishStep();
 	});
 
-	// The server checks if the clients received a TestCharacterMovement and moves them to the mentioned locations
-	AddStep(TEXT("ServerSetupStep"), FWorkerDefinition::Server(1), nullptr, [this]() {
-		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
-		{
-			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Server)
-			{
-				continue;
-			}
-
-			AController* PlayerController = Cast<AController>(FlowController->GetOwner());
-			ATestMovementCharacter* PlayerCharacter = Cast<ATestMovementCharacter>(PlayerController->GetPawn());
-
-			checkf(PlayerCharacter, TEXT("Client did not receive a TestMovementCharacter"));
-
-			int FlowControllerId = FlowController->WorkerDefinition.Id;
-
-			if (FlowControllerId == 1)
-			{
-				PlayerCharacter->SetActorLocation(FVector(0.0f, -25.0f, 50.0f));
-			}
-			else
-			{
-				PlayerCharacter->SetActorLocation(FVector(0.0f, 50.0f * FlowControllerId, 50.0f));
-			}
-		}
-
-		FinishStep();
-	});
-
 	// Repeatedly move character forwards and backwards over the worker boundary and adding actors every time
 	for (int i = 0; i < 5; i++)
 	{


### PR DESCRIPTION
#### Description
Ensured the test only runs with one client by setting the Testing Mode to Detect in the WorldSettings on the corresponding test map and removed the step which to move multiple characters out of the way.

#### Tests
Run the automated test with 1 or 2 clients, a warning is expected in both cases: 
`LogSpatialLoadBalancingHandler: Warning: Prevented Actor TeleportingPlayerController_C_0 's hierarchy from migrating because Actor Actor_0 (9) does not have authority`

Corresponding test gym PR needed for this test to run correctly: https://github.com/spatialos/UnrealGDKTestGyms/pull/230