### PR TITLE
UNR-4456 Ensure the rpc data has been written before processing rpcs.

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1806,13 +1806,18 @@ void USpatialNetDriver::TickDispatch(float DeltaTime)
 
 		if (RPCService.IsValid())
 		{
-			RPCService->Advance(GetElapsedTime());
+			RPCService->AdvanceView();
 		}
 
 		{
 			SCOPE_CYCLE_COUNTER(STAT_SpatialProcessOps);
 			Dispatcher->ProcessOps(GetOpsFromEntityDeltas(Connection->GetEntityDeltas()));
 			Dispatcher->ProcessOps(Connection->GetWorkerMessages());
+		}
+
+		if (RPCService.IsValid())
+		{
+			RPCService->ProcessChanges(GetElapsedTime());
 		}
 
 		if (WellKnownEntitySystem.IsValid())

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/SpatialRPCService.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/SpatialRPCService.cpp
@@ -30,10 +30,16 @@ SpatialRPCService::SpatialRPCService(const FSubView& InActorAuthSubView, const F
 	IncomingRPCs.BindProcessingFunction(FProcessRPCDelegate::CreateRaw(this, &SpatialRPCService::ApplyRPC));
 }
 
-void SpatialRPCService::Advance(const float NetDriverTime)
+void SpatialRPCService::AdvanceView()
 {
-	ClientServerRPCs.Advance();
-	MulticastRPCs.Advance();
+	ClientServerRPCs.AdvanceView();
+	MulticastRPCs.AdvanceView();
+}
+
+void SpatialRPCService::ProcessChanges(const float NetDriverTime)
+{
+	ClientServerRPCs.ProcessChanges();
+	MulticastRPCs.ProcessChanges();
 
 	if (NetDriverTime - LastProcessingTime > GetDefault<USpatialGDKSettings>()->QueuedIncomingRPCRetryTime)
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/RPCServiceTest.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/RPCServiceTest.cpp
@@ -147,7 +147,8 @@ SpatialGDK::SpatialRPCService CreateRPCService(const TArray<Worker_EntityId>& En
 	AuthSubView.Advance(Delta);
 	NonAuthSubView.Advance(Delta);
 
-	RPCService.Advance(0);
+	RPCService.AdvanceView();
+	RPCService.ProcessChanges(0);
 
 	return RPCService;
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/ClientServerRPCService.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/ClientServerRPCService.h
@@ -35,7 +35,8 @@ public:
 	ClientServerRPCService(const ExtractRPCDelegate InExtractRPCCallback, const FSubView& InSubView, USpatialNetDriver* InNetDriver,
 						   FRPCStore& InRPCStore);
 
-	void Advance();
+	void AdvanceView();
+	void ProcessChanges();
 
 	// Public state functions for the main Spatial RPC service to expose bookkeeping around overflows and acks.
 	// Could be moved into RPCStore. Note: Needs revisiting at some point, this is a strange boundary.
@@ -46,6 +47,7 @@ public:
 	uint64 GetAckFromView(Worker_EntityId EntityId, ERPCType Type);
 
 private:
+	void SetEntityData(Worker_EntityId EntityId);
 	// Process relevant view delta changes.
 	void EntityAdded(const Worker_EntityId EntityId);
 	void ComponentUpdate(const Worker_EntityId EntityId, const Worker_ComponentId ComponentId, Schema_ComponentUpdate* Update);

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/MulticastRPCService.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/MulticastRPCService.h
@@ -23,7 +23,8 @@ class SPATIALGDK_API MulticastRPCService
 public:
 	MulticastRPCService(const ExtractRPCDelegate InExtractRPCCallback, const FSubView& InSubView, FRPCStore& InRPCStore);
 
-	void Advance();
+	void AdvanceView();
+	void ProcessChanges();
 
 private:
 	// Process relevant view delta changes.

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/SpatialRPCService.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/SpatialRPCService.h
@@ -30,7 +30,8 @@ public:
 							   USpatialLatencyTracer* InSpatialLatencyTracer, SpatialEventTracer* InEventTracer,
 							   USpatialNetDriver* InNetDriver);
 
-	void Advance(const float NetDriverTime);
+	void AdvanceView();
+	void ProcessChanges(const float NetDriverTime);
 
 	void ProcessIncomingRPCs();
 


### PR DESCRIPTION
Prevent RPCs being dropped by splitting the rpc system into view-like and update-like parts. The actor system relies on rpc data being initialised before it has the opportunity to try and send rpcs, and the rpc service relies on actors having been instantiated to receive rpcs.