### PR TITLE
Added changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Servers now log a warning message when detecting a client has timed out.
 - Handover is now optional depending on whether the load balancing strategy implementations require it . See `RequiresHandoverData`
 - Improved the failed hierarchy migration logs. The logs now contain more specific reasons for the failure and the frequency of repeated logs is suppressed.
+- SpatialWorldSettings is now the default world settings in supported engine versions.
 
 ### Bug fixes:
 - Fixed a bug that stopped the travel URL being used for initial Spatial connection if the command line arguments could not be used.


### PR DESCRIPTION
#### Description
WorldSettings are by default set to the ASpatialWorldSettings, this is just a changelog noting the change in the supported engine versions 

Engine PR here
4.25 https://github.com/improbableio/UnrealEngine/pull/683

#### Release note
REQUIRED: Add a release note to the `##Unreleased` section of CHANGELOG.md. You can find guidance for writing useful release notes [here](../SpatialGDK/Extras/internal-documentation/how-to-write-good-release-notes.md). Documentation changes are exempt from this requirement.

#### Tests
How did you test these changes prior to submitting this pull request?
What automated tests are included in this PR?

STRONGLY SUGGESTED: How can this be verified by QA?

#### Documentation
May require changes @SPPWilliams 
https://documentation.improbable.io/gdk-for-unreal/docs/port-your-project-2-modify-and-build-your-project#step-6-enable-the-spatialos-multiserver-features
Step 6 > 2 should be set by default now unless already overridden by a ported game project 