### PR TITLE
UNR-4504: fix version parse

### DIFF
--- a/Setup.sh
+++ b/Setup.sh
@@ -10,7 +10,7 @@ fi
 
 pushd "$(dirname "$0")"
 
-PINNED_CORE_SDK_VERSION=$(head -n 1 ./SpatialGDK/Extras/core-sdk.version)
+PINNED_CORE_SDK_VERSION=$(head -n 1 ./SpatialGDK/Extras/core-sdk.version  | tr -d '\r')
 PINNED_SPOT_VERSION=$(cat ./SpatialGDK/Extras/spot.version)
 BUILD_DIR="$(pwd)/SpatialGDK/Build"
 CORE_SDK_DIR="${BUILD_DIR}/core_sdk"


### PR DESCRIPTION
#### Description
Cut \r from version now that the version file has CRLF file endings

#### Testing
Passing macOS build: https://buildkite.com/improbable/unrealgdk-premerge/builds/19595