### PR TITLE
UNR-3633 - Clarify options for number of workers launched

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -145,7 +145,7 @@ struct FWorkerTypeLaunchSection
 
 	/** Number of instances to launch when playing in editor. */
 	UPROPERTY(Category = "SpatialGDK", EditAnywhere, config,
-			  meta = (DisplayName = "Instances to launch in editor", ClampMin = "0", UIMin = "0",
+			  meta = (DisplayName = "Manual number of instances to launch in Editor", ClampMin = "0", UIMin = "0",
 					  EditCondition = "!bAutoNumEditorInstances"))
 	int32 NumEditorInstances;
 


### PR DESCRIPTION
#### Release note
Clarify the name of the manually entered number of server-worker to be launched in the editor option.
