### PR TITLE
Feature/add player disconnect command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ These functions and structs can be referenced in both code and blueprints it may
   1. `BindToOnWorkerFlagsUpdated` is changed to `RegisterAnyFlagUpdatedCallback` to better differentiate it from the newly added functions for register callbacks. 
   2. `RegisterFlagUpdatedCallback` is added to register callbacks for individual flag updates
   3. `RegisterAndInvokeAnyFlagUpdatedCallback` & `RegisterAndInvokeFlagUpdatedCallback` variants are added that will invoke the callback if the flag was previously set.
+- The SpatialNetDriver can now disconnect a client worker when given a worker id and will do so when `GameMode::PreLogin` returns with a non-empty error message. 
 
 ### Bug fixes:
 - Fixed a bug that stopped the travel URL being used for initial Spatial connection if the command line arguments could not be used.

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -2068,6 +2068,12 @@ bool USpatialNetDriver::CreateSpatialNetConnection(const FURL& InUrl, const FUni
 	if (!ErrorMsg.IsEmpty())
 	{
 		UE_LOG(LogSpatialOSNetDriver, Error, TEXT("PreLogin failure: %s"), *ErrorMsg);
+		
+		if (TOptional<FString> WorkerId = ExtractWorkerIDFromAttribute(SpatialConnection->ConnectionOwningWorkerId))
+		{
+			DisconnectPlayer(WorkerId.GetValue());
+		}
+		
 		// TODO: Destroy connection. UNR-584
 		return false;
 	}
@@ -2078,6 +2084,43 @@ bool USpatialNetDriver::CreateSpatialNetConnection(const FURL& InUrl, const FUni
 	GameMode->GameWelcomePlayer(SpatialConnection, RedirectURL);
 
 	return true;
+}
+
+void USpatialNetDriver::QueryWorkerEntityByWorkerId(const FString& WorkerId, const FWorkerEntityByWorkerIdComplete& Callback)
+{
+	Worker_ComponentConstraint WorkerComponentConstraint{};
+	WorkerComponentConstraint.component_id = SpatialConstants::WORKER_COMPONENT_ID;
+
+	Worker_Constraint WorkerConstraint{};
+	WorkerConstraint.constraint_type = WORKER_CONSTRAINT_TYPE_COMPONENT;
+	WorkerConstraint.constraint.component_constraint = WorkerComponentConstraint;
+
+	Worker_EntityQuery WorkerQuery{};
+	WorkerQuery.constraint = WorkerConstraint;
+	WorkerQuery.result_type = WORKER_RESULT_TYPE_SNAPSHOT;
+
+	Worker_RequestId RequestId;
+	RequestId = Connection->SendEntityQueryRequest(&WorkerQuery);
+
+	EntityQueryDelegate WorkerQueryDelegate;
+	WorkerQueryDelegate.BindLambda([this, WorkerIdCopy = WorkerId, CallbackCopy = Callback](const Worker_EntityQueryResponseOp& Op) {
+		if (Op.status_code != WORKER_STATUS_CODE_SUCCESS)
+		{
+			UE_LOG(LogSpatialOSNetDriver, Error, TEXT("Could not locate worker entities via entity query: %s"), UTF8_TO_TCHAR(Op.message));
+		}
+		else
+		{
+			const Worker_EntityId RequestedWorkerEntityId = USpatialStatics::FindEntityIdForWorkerId(TArray<Worker_Entity>(Op.results, Op.result_count), WorkerIdCopy);
+			if (RequestedWorkerEntityId == SpatialConstants::INVALID_ENTITY_ID)
+			{
+				UE_LOG(LogSpatialOSNetDriver, Warning, TEXT("Could not locate the worker entity with worker id %s"), *WorkerIdCopy);
+				return;
+			}
+			CallbackCopy.ExecuteIfBound(RequestedWorkerEntityId);
+		}
+	});
+
+	Receiver->AddEntityQueryDelegate(RequestId, WorkerQueryDelegate);	
 }
 
 void USpatialNetDriver::CleanUpClientConnection(USpatialNetConnection* ConnectionCleanedUp)
@@ -2194,6 +2237,31 @@ void USpatialNetDriver::PostSpawnPlayerController(APlayerController* PlayerContr
 	PlayerController->SetReplicates(true);
 	PlayerController->Role = OriginalRole;
 	PlayerController->SetPlayer(OwnershipConnection);
+}
+
+void USpatialNetDriver::DisconnectPlayer(const FString& WorkerId)
+{
+	FWorkerEntityByWorkerIdComplete WorkerEntityQueryDelegate;
+	WorkerEntityQueryDelegate.BindWeakLambda(this, [this, WorkerIdCopy = WorkerId](const Worker_EntityId EntityId) {
+		Worker_CommandRequest Request = {};
+		Request.component_id = SpatialConstants::WORKER_COMPONENT_ID;
+		Request.command_index = SpatialConstants::WORKER_DISCONNECT_COMMAND_ID;
+		Request.schema_type = Schema_CreateCommandRequest();
+		Worker_RequestId RequestId = Connection->SendCommandRequest(EntityId, &Request, SpatialConstants::WORKER_DISCONNECT_COMMAND_ID);
+
+		SystemEntityCommandDelegate CommandResponseDelegate;
+		CommandResponseDelegate.BindWeakLambda(this, [this, WorkerIdCopy](const Worker_CommandResponseOp& Op) {
+			TWeakObjectPtr<USpatialNetConnection> ClientConnection = FindClientConnectionFromWorkerId(WorkerIdCopy);
+			if (ClientConnection.IsValid())
+			{
+				ClientConnection->CleanUp();
+			}
+		});
+
+		Receiver->AddSystemEntityCommandDelegate(RequestId, CommandResponseDelegate);
+	});
+
+	QueryWorkerEntityByWorkerId(WorkerId, WorkerEntityQueryDelegate);
 }
 
 bool USpatialNetDriver::Exec(UWorld* InWorld, const TCHAR* Cmd, FOutputDevice& Ar)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -52,6 +52,7 @@ DECLARE_CYCLE_STAT(TEXT("Receiver AuthorityChange"), STAT_ReceiverAuthChange, ST
 DECLARE_CYCLE_STAT(TEXT("Receiver ReserveEntityIds"), STAT_ReceiverReserveEntityIds, STATGROUP_SpatialNet);
 DECLARE_CYCLE_STAT(TEXT("Receiver CreateEntityResponse"), STAT_ReceiverCreateEntityResponse, STATGROUP_SpatialNet);
 DECLARE_CYCLE_STAT(TEXT("Receiver EntityQueryResponse"), STAT_ReceiverEntityQueryResponse, STATGROUP_SpatialNet);
+DECLARE_CYCLE_STAT(TEXT("Receiver SystemEntityCommandResponse"), STAT_ReceiverSystemEntityCommandResponse, STATGROUP_SpatialNet);
 DECLARE_CYCLE_STAT(TEXT("Receiver FlushRemoveComponents"), STAT_ReceiverFlushRemoveComponents, STATGROUP_SpatialNet);
 DECLARE_CYCLE_STAT(TEXT("Receiver ReceiveActor"), STAT_ReceiverReceiveActor, STATGROUP_SpatialNet);
 DECLARE_CYCLE_STAT(TEXT("Receiver RemoveActor"), STAT_ReceiverRemoveActor, STATGROUP_SpatialNet);
@@ -1879,12 +1880,18 @@ void USpatialReceiver::OnCommandResponse(const Worker_Op& Op)
 
 		return;
 	}
-	if (Op.op.command_response.response.component_id == SpatialConstants::WORKER_COMPONENT_ID
+	else if (Op.op.command_response.response.component_id == SpatialConstants::WORKER_COMPONENT_ID
 		&& Op.op.command_response.response.command_index == SpatialConstants::WORKER_CLAIM_PARTITION_COMMAND_ID)
 	{
 		ReceiveClaimPartitionResponse(Op.op.command_response);
 		return;
 	}
+	else if (Op.response.component_id == SpatialConstants::WORKER_COMPONENT_ID)
+	{
+		OnSystemEntityCommandResponse(Op);
+		return;
+	}
+	
 
 	ReceiveCommandResponse(Op);
 }
@@ -2167,6 +2174,30 @@ void USpatialReceiver::OnEntityQueryResponse(const Worker_EntityQueryResponseOp&
 	}
 }
 
+void USpatialReceiver::OnSystemEntityCommandResponse(const Worker_CommandResponseOp& Op)
+{
+	SCOPE_CYCLE_COUNTER(STAT_ReceiverSystemEntityCommandResponse);
+	if (Op.status_code != WORKER_STATUS_CODE_SUCCESS)
+	{
+		UE_LOG(LogSpatialReceiver, Error, TEXT("SystemEntityCommand failed: request id: %d, message: %s"), Op.request_id,
+			   UTF8_TO_TCHAR(Op.message));
+	}
+
+	if (SystemEntityCommandDelegate* RequestDelegate = SystemEntityCommandDelegates.Find(Op.request_id))
+	{
+		UE_LOG(LogSpatialReceiver, Verbose,
+			   TEXT("Executing EntityQueryResponse with delegate, request id: %d, message: %s"),
+			   Op.request_id, UTF8_TO_TCHAR(Op.message));
+		RequestDelegate->ExecuteIfBound(Op);
+	}
+	else
+	{
+		UE_LOG(LogSpatialReceiver, Warning,
+			   TEXT("Received EntityQueryResponse but with no delegate set, request id: %d, message: %s"),
+			   Op.request_id, UTF8_TO_TCHAR(Op.message));
+	}
+}
+
 void USpatialReceiver::AddPendingActorRequest(Worker_RequestId RequestId, USpatialActorChannel* Channel)
 {
 	PendingActorRequests.Add(RequestId, Channel);
@@ -2190,6 +2221,11 @@ void USpatialReceiver::AddReserveEntityIdsDelegate(Worker_RequestId RequestId, R
 void USpatialReceiver::AddCreateEntityDelegate(Worker_RequestId RequestId, CreateEntityDelegate Delegate)
 {
 	CreateEntityDelegates.Add(RequestId, MoveTemp(Delegate));
+}
+
+void USpatialReceiver::AddSystemEntityCommandDelegate(Worker_RequestId RequestId, SystemEntityCommandDelegate Delegate)
+{
+	SystemEntityCommandDelegates.Add(RequestId, MoveTemp(Delegate));
 }
 
 TWeakObjectPtr<USpatialActorChannel> USpatialReceiver::PopPendingActorRequest(Worker_RequestId RequestId)

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
@@ -383,3 +383,19 @@ void USpatialStatics::SpatialDebuggerSetOnConfigUIClosedCallback(const UObject* 
 		SpatialNetDriver->SpatialDebugger->OnConfigUIClosed = Delegate;
 	}));
 }
+
+Worker_EntityId USpatialStatics::FindEntityIdForWorkerId(const TArray<Worker_Entity>& Entities, const FString& WorkerId)
+{
+	for (const Worker_Entity& Entity : Entities)
+	{
+		if (TOptional<SpatialGDK::Worker> WorkerComponent = USpatialStatics::GetComponentFromEntity<SpatialGDK::Worker>(Entity))
+		{
+			if (WorkerComponent->WorkerId == WorkerId)
+			{
+				return Entity.entity_id;
+			}
+		}
+	}
+
+	return SpatialConstants::INVALID_ENTITY_ID;
+}

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -122,6 +122,8 @@ public:
 						 const Worker_EntityId& ClientSystemEntityId);
 	void PostSpawnPlayerController(APlayerController* PlayerController);
 
+	void DisconnectPlayer(const FString& WorkerId);
+
 	void AddActorChannel(Worker_EntityId EntityId, USpatialActorChannel* Channel);
 	void RemoveActorChannel(Worker_EntityId EntityId, USpatialActorChannel& Channel);
 	TMap<Worker_EntityId_Key, USpatialActorChannel*>& GetEntityToActorChannelMap();
@@ -266,6 +268,9 @@ private:
 
 	void CreateServerSpatialOSNetConnection();
 	USpatialActorChannel* CreateSpatialActorChannel(AActor* Actor);
+	
+	DECLARE_DELEGATE_OneParam(FWorkerEntityByWorkerIdComplete, const Worker_EntityId);
+	void QueryWorkerEntityByWorkerId(const FString& WorkerId, const FWorkerEntityByWorkerIdComplete& Callback);
 
 	void QueryGSMToLoadMap();
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialOSDispatcherInterface.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialOSDispatcherInterface.h
@@ -13,6 +13,7 @@
 DECLARE_DELEGATE_OneParam(EntityQueryDelegate, const Worker_EntityQueryResponseOp&);
 DECLARE_DELEGATE_OneParam(ReserveEntityIDsDelegate, const Worker_ReserveEntityIdsResponseOp&);
 DECLARE_DELEGATE_OneParam(CreateEntityDelegate, const Worker_CreateEntityResponseOp&);
+DECLARE_DELEGATE_OneParam(SystemEntityCommandDelegate, const Worker_CommandResponseOp&);
 
 DECLARE_MULTICAST_DELEGATE_OneParam(FOnEntityAddedDelegate, const Worker_EntityId);
 DECLARE_MULTICAST_DELEGATE_OneParam(FOnEntityRemovedDelegate, const Worker_EntityId);
@@ -36,6 +37,8 @@ public:
 		PURE_VIRTUAL(SpatialOSDispatcherInterface::OnComponentUpdate, return;);
 	virtual void OnEntityQueryResponse(const Worker_EntityQueryResponseOp& Op)
 		PURE_VIRTUAL(SpatialOSDispatcherInterface::OnEntityQueryResponse, return;);
+	virtual void OnSystemEntityCommandResponse(const Worker_CommandResponseOp& Op)
+		PURE_VIRTUAL(SpatialOSDispatcherInterface::OnSystemEntityCommandResponse, return;);
 	virtual bool OnExtractIncomingRPC(Worker_EntityId EntityId, ERPCType RPCType, const SpatialGDK::RPCPayload& Payload)
 		PURE_VIRTUAL(SpatialOSDispatcherInterface::OnExtractIncomingRPC, return false;);
 	virtual void OnCommandRequest(const Worker_Op& Op) PURE_VIRTUAL(SpatialOSDispatcherInterface::OnCommandRequest, return;);
@@ -54,4 +57,6 @@ public:
 		PURE_VIRTUAL(SpatialOSDispatcherInterface::AddReserveEntityIdsDelegate, return;);
 	virtual void AddCreateEntityDelegate(Worker_RequestId RequestId, CreateEntityDelegate Delegate)
 		PURE_VIRTUAL(SpatialOSDispatcherInterface::AddCreateEntityDelegate, return;);
+	virtual void AddSystemEntityCommandDelegate(Worker_RequestId RequestId, SystemEntityCommandDelegate Delegate)
+		PURE_VIRTUAL(SpatialOSDispatcherInterface::AddSystemEntityCommandDelegate, return;);
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -92,8 +92,11 @@ public:
 	virtual void AddEntityQueryDelegate(Worker_RequestId RequestId, EntityQueryDelegate Delegate) override;
 	virtual void AddReserveEntityIdsDelegate(Worker_RequestId RequestId, ReserveEntityIDsDelegate Delegate) override;
 	virtual void AddCreateEntityDelegate(Worker_RequestId RequestId, CreateEntityDelegate Delegate) override;
+	virtual void AddSystemEntityCommandDelegate(Worker_RequestId RequestId, SystemEntityCommandDelegate Delegate) override;
 
 	virtual void OnEntityQueryResponse(const Worker_EntityQueryResponseOp& Op) override;
+	
+	virtual void OnSystemEntityCommandResponse(const Worker_CommandResponseOp& Op) override;
 
 	void ResolvePendingOperations(UObject* Object, const FUnrealObjectRef& ObjectRef);
 	void FlushRetryRPCs();
@@ -240,6 +243,7 @@ private:
 	TMap<Worker_RequestId_Key, EntityQueryDelegate> EntityQueryDelegates;
 	TMap<Worker_RequestId_Key, ReserveEntityIDsDelegate> ReserveEntityIDsDelegates;
 	TMap<Worker_RequestId_Key, CreateEntityDelegate> CreateEntityDelegates;
+	TMap<Worker_RequestId_Key, SystemEntityCommandDelegate> SystemEntityCommandDelegates;
 
 	// This will map PlayerController entities to the corresponding SpatialNetConnection
 	// for PlayerControllers that this server has authority over. This is used for player

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -201,6 +201,9 @@ const PhysicalWorkerName TRANSLATOR_UNSET_PHYSICAL_NAME = FString("UnsetWorkerNa
 // WorkerEntity Field IDs.
 const Schema_FieldId WORKER_ID_ID = 1;
 const Schema_FieldId WORKER_TYPE_ID = 2;
+
+// WorkerEntity command IDs
+const Schema_FieldId WORKER_DISCONNECT_COMMAND_ID = 1;
 const Schema_FieldId WORKER_CLAIM_PARTITION_COMMAND_ID = 2;
 
 // SpatialDebugger Field IDs.

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialStatics.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialStatics.h
@@ -174,6 +174,22 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "SpatialGDK|Spatial Debugger", meta = (WorldContext = "WorldContextObject"))
 	static void SpatialDebuggerSetOnConfigUIClosedCallback(const UObject* WorldContextObject, FOnConfigUIClosedDelegate Delegate);
 
+	template<typename T>
+	static TOptional<T> GetComponentFromEntity(const Worker_Entity& Entity)
+	{
+		for (const Worker_ComponentData& ComponentData : TArray<Worker_ComponentData>(Entity.components, Entity.component_count))
+		{
+			if (ComponentData.component_id == T::ComponentId)
+			{
+				return T(ComponentData);
+			}
+		}
+
+		return {};
+	}
+	
+	static Worker_EntityId FindEntityIdForWorkerId(const TArray<Worker_Entity>& Entities, const FString& WorkerId);
+
 private:
 	static FName GetCurrentWorkerType(const UObject* WorldContext);
 };


### PR DESCRIPTION
#### Description
Exposes the `Disconnect` command on the worker component via the NetDriver.

#### Release note
The SpatialNetDriver can now disconnect a client worker when given a worker id and will do so when `GameMode::PreLogin` returns with a non-empty error message. 

#### Tests
Local observation of desired behavior (rejecting logins in `GameMode::PreLogin` and seeing the client correctly have its connection removed)

#### Documentation
Release note