### PR TITLE
[UNR-4540] Try to fix ensure in FlowControllers

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
@@ -244,7 +244,7 @@ void ASpatialFunctionalTest::FinishStep()
 	ensureMsgf(AuxLocalFlowController != nullptr, TEXT("Can't Find LocalFlowController"));
 	if (AuxLocalFlowController != nullptr)
 	{
-		AuxLocalFlowController->NotifyStepFinished();
+		AuxLocalFlowController->NotifyStepFinished(CurrentStepIndex);
 	}
 }
 
@@ -601,9 +601,10 @@ ASpatialFunctionalTestFlowController* ASpatialFunctionalTest::GetFlowController(
 	return nullptr;
 }
 
-void ASpatialFunctionalTest::CrossServerNotifyStepFinished_Implementation(ASpatialFunctionalTestFlowController* FlowController)
+void ASpatialFunctionalTest::CrossServerNotifyStepFinished_Implementation(ASpatialFunctionalTestFlowController* FlowController,
+																		  const int StepIndex)
 {
-	if (CurrentStepIndex < 0)
+	if (CurrentStepIndex < 0 || StepIndex != CurrentStepIndex)
 	{
 		return;
 	}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
@@ -609,13 +609,13 @@ void ASpatialFunctionalTest::CrossServerNotifyStepFinished_Implementation(ASpati
 		return;
 	}
 
-	const FString FLowControllerDisplayName = FlowController->GetDisplayName();
+	const FString FlowControllerDisplayName = FlowController->GetDisplayName();
 
-	UE_LOG(LogSpatialGDKFunctionalTests, Display, TEXT("%s finished Step"), *FLowControllerDisplayName);
+	UE_LOG(LogSpatialGDKFunctionalTests, Display, TEXT("%s finished Step"), *FlowControllerDisplayName);
 
 	if (FlowControllersExecutingStep.RemoveSwap(FlowController) == 0)
 	{
-		FString ErrorMsg = FString::Printf(TEXT("%s was not in list of workers executing"), *FLowControllerDisplayName);
+		FString ErrorMsg = FString::Printf(TEXT("%s was not in list of workers executing"), *FlowControllerDisplayName);
 		ensureMsgf(false, TEXT("%s"), *ErrorMsg);
 		FinishTest(EFunctionalTestResult::Error, ErrorMsg);
 	}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
@@ -42,6 +42,8 @@ ASpatialFunctionalTest::ASpatialFunctionalTest()
 	bAlwaysRelevant = true;
 
 	PrimaryActorTick.TickInterval = 0.0f;
+
+	PreparationTimeLimit = 30.0f;
 }
 
 void ASpatialFunctionalTest::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestFlowController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestFlowController.cpp
@@ -105,6 +105,7 @@ void ASpatialFunctionalTestFlowController::CrossServerStartStep_Implementation(i
 	// Since we're starting a step, we mark as not Ack that we've finished the test. This is needed
 	// for the cases when we run multiple times the same test without a map reload.
 	bHasAckFinishedTest = false;
+	OwningTest->SetCurrentStepIndex(StepIndex); // Just in case we do not get the replication fast enough
 	if (WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Server)
 	{
 		StartStepInternal(StepIndex);
@@ -214,6 +215,7 @@ void ASpatialFunctionalTestFlowController::SetReadyToRunTest(bool bIsReady)
 
 void ASpatialFunctionalTestFlowController::ClientStartStep_Implementation(int StepIndex)
 {
+	OwningTest->SetCurrentStepIndex(StepIndex); // Just in case we do not get the replication fast enough
 	StartStepInternal(StepIndex);
 }
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestFlowController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestFlowController.cpp
@@ -115,17 +115,17 @@ void ASpatialFunctionalTestFlowController::CrossServerStartStep_Implementation(i
 	}
 }
 
-void ASpatialFunctionalTestFlowController::NotifyStepFinished()
+void ASpatialFunctionalTestFlowController::NotifyStepFinished(const int StepIndex)
 {
 	if (CurrentStep.bIsRunning)
 	{
 		if (WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Server)
 		{
-			CrossServerNotifyStepFinished();
+			CrossServerNotifyStepFinished(StepIndex);
 		}
 		else
 		{
-			ServerNotifyStepFinished();
+			ServerNotifyStepFinished(StepIndex);
 		}
 
 		StopStepInternal();
@@ -245,12 +245,12 @@ void ASpatialFunctionalTestFlowController::ServerAckFinishedTest_Implementation(
 	bHasAckFinishedTest = true;
 }
 
-void ASpatialFunctionalTestFlowController::ServerNotifyStepFinished_Implementation()
+void ASpatialFunctionalTestFlowController::ServerNotifyStepFinished_Implementation(const int StepIndex)
 {
-	OwningTest->CrossServerNotifyStepFinished(this);
+	OwningTest->CrossServerNotifyStepFinished(this, StepIndex);
 }
 
-void ASpatialFunctionalTestFlowController::CrossServerNotifyStepFinished_Implementation()
+void ASpatialFunctionalTestFlowController::CrossServerNotifyStepFinished_Implementation(const int StepIndex)
 {
-	OwningTest->CrossServerNotifyStepFinished(this);
+	OwningTest->CrossServerNotifyStepFinished(this, StepIndex);
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestFlowController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestFlowController.cpp
@@ -54,7 +54,7 @@ void ASpatialFunctionalTestFlowController::BeginPlay()
 				bReadyToRegisterWithTest = true;
 				OnReadyToRegisterWithTest();
 			},
-			0.5f, false);
+			1.0f, false);
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
@@ -97,7 +97,7 @@ public:
 	void CrossServerFinishTest(EFunctionalTestResult TestResult, const FString& Message);
 
 	UFUNCTION(CrossServer, Reliable)
-	void CrossServerNotifyStepFinished(ASpatialFunctionalTestFlowController* FlowController);
+	void CrossServerNotifyStepFinished(ASpatialFunctionalTestFlowController* FlowController, const int StepIndex);
 
 	// # FlowController related APIs.
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
@@ -172,6 +172,7 @@ public:
 	const FSpatialFunctionalTestStepDefinition GetStepDefinition(int StepIndex) const;
 
 	int GetCurrentStepIndex() { return CurrentStepIndex; }
+	void SetCurrentStepIndex(const int StepIndex) { CurrentStepIndex = StepIndex; }
 
 	// Convenience function that goes over all FlowControllers and counts how many are Servers.
 	UFUNCTION(BlueprintPure, Category = "Spatial Functional Test")

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTestFlowController.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTestFlowController.h
@@ -40,7 +40,7 @@ public:
 	void CrossServerStartStep(int StepIndex);
 
 	// Tells Test owner that the current Step is finished locally
-	void NotifyStepFinished();
+	void NotifyStepFinished(const int StepIndex);
 
 	// Tell the Test owner that we want to end the Test
 	void NotifyFinishTest(EFunctionalTestResult TestResult, const FString& Message);
@@ -105,10 +105,10 @@ private:
 	void StopStepInternal();
 
 	UFUNCTION(Server, Reliable)
-	void ServerNotifyStepFinished();
+	void ServerNotifyStepFinished(const int StepIndex);
 
 	UFUNCTION(CrossServer, Reliable)
-	void CrossServerNotifyStepFinished();
+	void CrossServerNotifyStepFinished(const int StepIndex);
 
 	UFUNCTION(Server, Reliable)
 	void ServerNotifyFinishTest(EFunctionalTestResult TestResult, const FString& Message);

--- a/ci/gdk_build.template.steps.yaml
+++ b/ci/gdk_build.template.steps.yaml
@@ -25,6 +25,7 @@ windows: &windows
     - "scaler_version=2"
     - "queue=${CI_WINDOWS_BUILDER_QUEUE:-v4-20-11-18-224740-bk17641-0c4125be-d}"
     - "boot_disk_size_gb=500"
+    - "node_stability=canary_miron"
   retry:
     automatic:
       - <<: *agent_transients

--- a/ci/gdk_build.template.steps.yaml
+++ b/ci/gdk_build.template.steps.yaml
@@ -59,7 +59,7 @@ steps:
     command: "${BUILD_COMMAND}"
     artifact_paths:
       - "../UnrealEngine/Engine/Programs/AutomationTool/Saved/Logs/*"
-      - "**/spatial/logs/**/*"
+      - "GDKTestGyms/spatial/logs/**/*"
     env:
       BUILD_ALL_CONFIGURATIONS: "${BUILD_ALL_CONFIGURATIONS}"
       ENGINE_COMMIT_HASH: "${ENGINE_COMMIT_HASH}"

--- a/ci/gdk_build.template.steps.yaml
+++ b/ci/gdk_build.template.steps.yaml
@@ -25,7 +25,6 @@ windows: &windows
     - "scaler_version=2"
     - "queue=${CI_WINDOWS_BUILDER_QUEUE:-v4-20-11-18-224740-bk17641-0c4125be-d}"
     - "boot_disk_size_gb=500"
-    - "node_stability=canary_miron"
   retry:
     automatic:
       - <<: *agent_transients


### PR DESCRIPTION
Internal.
The issue I think stems from some race conditions in the testing framework itself.
I work around this by attaching a StepIndex when completing a step, to avoid double-advancing a step.
That in turn requires slightly more robust replication for CurrentStepIndex, and this is an unfortunate thing - since even with my changes, there is still an extremely rare (hopefully) race condition where this will fail to replicate correctly. (RPC -> var -> onRep -> finishStep)