### PR TITLE
Properly handle double-add for components received when async loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ These functions and structs can be referenced in both code and blueprints it may
 - Added support for FPredictionKey's conditional replication logic. GameplayCues now activate on all clients, instead of only the client that initiated them.
 - Fixed a bug where deployment would fail in the presence of trailing spaces in the `Flags` and `LegacyFlags` fields of the `SpatialGDKEditorSettings`.
 - Fixed a crash that would occur when performing multiple Client Travels at once.
+- Fix a crash that could happen when processing queued actors waiting for asynchronous package loading.
 
 ## [`0.11.0`] - 2020-09-03
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -2731,8 +2731,7 @@ void USpatialReceiver::QueueAddComponentOpForAsyncLoad(const Worker_AddComponent
 	{
 		// If it is a component we initially queued, replace it and drop pending updates.
 		AsyncLoadEntity.InitialPendingAddComponents[AddedComponentIndex].Data = MakeUnique<DynamicComponent>(Op.data);
-		AsyncLoadEntity.PendingOps.GetOpListData().UpdateStorage.RemoveAll([&Op](const SpatialGDK::ComponentUpdate& Update)
-		{
+		AsyncLoadEntity.PendingOps.GetOpListData().UpdateStorage.RemoveAll([&Op](const SpatialGDK::ComponentUpdate& Update) {
 			return Update.GetComponentId() == Op.data.component_id;
 		});
 	}

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -173,7 +173,7 @@ private:
 	void QueueComponentUpdateOpForAsyncLoad(const Worker_ComponentUpdateOp& Op);
 
 	TArray<PendingAddComponentWrapper> ExtractAddComponents(Worker_EntityId Entity);
-	SpatialGDK::EntityComponentOpListBuilder ExtractAuthorityOps(Worker_EntityId Entity);
+	SpatialGDK::EntityComponentOpListData ExtractAuthorityOps(Worker_EntityId Entity);
 
 	struct CriticalSectionSaveState
 	{
@@ -259,7 +259,7 @@ private:
 	{
 		FString ClassPath;
 		TArray<PendingAddComponentWrapper> InitialPendingAddComponents;
-		SpatialGDK::EntityComponentOpListBuilder PendingOps;
+		SpatialGDK::EntityComponentOpListData PendingOps;
 	};
 	TMap<Worker_EntityId_Key, EntityWaitingForAsyncLoad> EntitiesWaitingForAsyncLoad;
 	TMap<FName, TArray<Worker_EntityId>> AsyncLoadingPackages;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/OpList/EntityComponentOpList.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/OpList/EntityComponentOpList.h
@@ -54,6 +54,8 @@ public:
 
 	OpList CreateOpList() &&;
 
+	EntityComponentOpListData& GetOpListData() { return *OpListData; }
+
 private:
 	TUniquePtr<EntityComponentOpListData> OpListData;
 	const char* StoreString(StringStorage Message) const;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/OpList/EntityComponentOpList.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/OpList/EntityComponentOpList.h
@@ -54,8 +54,6 @@ public:
 
 	OpList CreateOpList() &&;
 
-	EntityComponentOpListData& GetOpListData() { return *OpListData; }
-
 private:
 	TUniquePtr<EntityComponentOpListData> OpListData;
 	const char* StoreString(StringStorage Message) const;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/OpUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/OpUtils.h
@@ -12,4 +12,113 @@ namespace SpatialGDK
 {
 Worker_ComponentId GetComponentId(const Worker_Op& Op);
 
+template <typename T>
+constexpr uint8 GetWorkerOpType();
+
+template <>
+constexpr uint8 GetWorkerOpType<Worker_DisconnectOp>()
+{
+	return WORKER_OP_TYPE_DISCONNECT;
+}
+
+template <>
+constexpr uint8 GetWorkerOpType<Worker_FlagUpdateOp>()
+{
+	return WORKER_OP_TYPE_FLAG_UPDATE;
+}
+
+template <>
+constexpr uint8 GetWorkerOpType<Worker_MetricsOp>()
+{
+	return WORKER_OP_TYPE_METRICS;
+}
+
+template <>
+constexpr uint8 GetWorkerOpType<Worker_CriticalSectionOp>()
+{
+	return WORKER_OP_TYPE_CRITICAL_SECTION;
+}
+
+template <>
+constexpr uint8 GetWorkerOpType<Worker_AddEntityOp>()
+{
+	return WORKER_OP_TYPE_ADD_ENTITY;
+}
+
+template <>
+constexpr uint8 GetWorkerOpType<Worker_RemoveEntityOp>()
+{
+	return WORKER_OP_TYPE_REMOVE_ENTITY;
+}
+
+template <>
+constexpr uint8 GetWorkerOpType<Worker_ReserveEntityIdsResponseOp>()
+{
+	return WORKER_OP_TYPE_RESERVE_ENTITY_IDS_RESPONSE;
+}
+
+template <>
+constexpr uint8 GetWorkerOpType<Worker_CreateEntityResponseOp>()
+{
+	return WORKER_OP_TYPE_CREATE_ENTITY_RESPONSE;
+}
+
+template <>
+constexpr uint8 GetWorkerOpType<Worker_DeleteEntityResponseOp>()
+{
+	return WORKER_OP_TYPE_DELETE_ENTITY_RESPONSE;
+}
+
+template <>
+constexpr uint8 GetWorkerOpType<Worker_EntityQueryResponseOp>()
+{
+	return WORKER_OP_TYPE_ENTITY_QUERY_RESPONSE;
+}
+
+template <>
+constexpr uint8 GetWorkerOpType<Worker_AddComponentOp>()
+{
+	return WORKER_OP_TYPE_ADD_COMPONENT;
+}
+
+template <>
+constexpr uint8 GetWorkerOpType<Worker_RemoveComponentOp>()
+{
+	return WORKER_OP_TYPE_REMOVE_COMPONENT;
+}
+
+template <>
+constexpr uint8 GetWorkerOpType<Worker_ComponentUpdateOp>()
+{
+	return WORKER_OP_TYPE_COMPONENT_UPDATE;
+}
+
+template <>
+constexpr uint8 GetWorkerOpType<Worker_CommandRequestOp>()
+{
+	return WORKER_OP_TYPE_COMMAND_REQUEST;
+}
+
+template <>
+constexpr uint8 GetWorkerOpType<Worker_CommandResponseOp>()
+{
+	return WORKER_OP_TYPE_COMMAND_RESPONSE;
+}
+
+template <>
+constexpr uint8 GetWorkerOpType<Worker_ComponentSetAuthorityChangeOp>()
+{
+	return WORKER_OP_TYPE_COMPONENT_SET_AUTHORITY_CHANGE;
+}
+
+template <typename T>
+Worker_Op CreateWorkerOp(const T& OpData)
+{
+	Worker_Op Op = {};
+	Op.op_type = GetWorkerOpType<T>();
+	reinterpret_cast<T&>(Op.op) = OpData;
+
+	return Op;
+}
+
 } // namespace SpatialGDK


### PR DESCRIPTION
#### Description
When doing async load of received entities, components initially received in a critical section will be queued in an array that will be processed in a critical section as well.
Components received afterward will be queued in another array that will be processed outside. Some of these components can include ones that need to be processed inside a critical section.
This fix make sure that components that were queued in a critical section initially will be dequeued in one as well.

#### Release note

#### Tests

