### PR TITLE
UNR-4541 Cross Server possession implemented in UnrealGDK

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPossession.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPossession.cpp
@@ -21,7 +21,7 @@ void USpatialPossession::RemotePossess(AController* Controller, APawn* Pawn)
 	else
 	{
 		USpatialNetDriver* NetDriver = Cast<USpatialNetDriver>(Controller->GetNetDriver());
-		if (NetDriver->LockingPolicy->IsLocked(Controller))
+		if (NetDriver->LockingPolicy && NetDriver->LockingPolicy->IsLocked(Controller))
 		{
 			Controller->OnPossessFailed(ERemotePossessFailure::ControllerLocked);
 			return;

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPossession.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPossession.cpp
@@ -33,7 +33,6 @@ void USpatialPossession::RemotePossess(AController* Controller, APawn* Pawn)
 
 		Controller->ForceNetUpdate();
 	}
-
 }
 
 void USpatialPossession::PossessAfterMigration(AController& Controller)

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPossession.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPossession.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "EngineClasses/SpatialPossession.h"
+
+#include "EngineClasses/SpatialNetDriver.h"
+
+void USpatialPossession::RemotePossess(AController* Controller, APawn* Pawn)
+{
+	ensure(Controller);
+	// If we're calling RemotePossess on a null pointer return
+	if (Pawn == nullptr)
+	{
+		return;
+	}
+
+	// If the pawn we want to possess is authoritative on this worker just possess it
+	if (Pawn->HasAuthority())
+	{
+		Controller->Possess(Pawn);
+	}
+	else
+	{
+		USpatialNetDriver* NetDriver = Cast<USpatialNetDriver>(Controller->GetNetDriver());
+		if (NetDriver->LockingPolicy->IsLocked(Controller))
+		{
+			Controller->OnPossessFailed(ERemotePossessFailure::ControllerLocked);
+			return;
+		}
+		Controller->IntendedPawnToPossess = Pawn;
+		Controller->IntendedPossessionCount = Pawn->PossessionCount;
+		// We force unpossess because it appears even though we own this pawn it won't migrate (at least not right away)
+		Controller->UnPossess();
+
+		Controller->ForceNetUpdate();
+	}
+
+}
+
+void USpatialPossession::PossessAfterMigration(AController& Controller)
+{
+	if (Controller.IntendedPawnToPossess->HasAuthority())
+	{
+		if (Controller.IntendedPossessionCount == Controller.IntendedPawnToPossess->PossessionCount)
+		{
+			Controller.Possess(Controller.IntendedPawnToPossess);
+		}
+		else
+		{
+			Controller.OnPossessFailed(ERemotePossessFailure::PossessionStateChanged);
+		}
+		Controller.IntendedPawnToPossess = nullptr;
+	}
+}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -688,6 +688,13 @@ void USpatialReceiver::HandleActorAuthority(const Worker_ComponentSetAuthorityCh
 
 					// We still want to call OnAuthorityGained if the Actor migrated to this worker or was loaded from a snapshot.
 					Actor->OnAuthorityGained();
+
+					// If we are AController attempting possession of a Pawn via the IntendedPawnToPossess field, then invoke the possession case
+					// this action is performed after notification of gaining authority
+					if (AController* Controller = Cast<AController>(Actor))
+					{
+						Controller->PossessAfterMigration();
+					}
 				}
 				else
 				{

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -693,7 +693,10 @@ void USpatialReceiver::HandleActorAuthority(const Worker_ComponentSetAuthorityCh
 					// case this action is performed after notification of gaining authority
 					if (AController* Controller = Cast<AController>(Actor))
 					{
-						Controller->PossessAfterMigration();
+						if (Controller->IntendedPawnToPossess)
+						{
+							Controller->PossessAfterMigration();
+						}
 					}
 				}
 				else

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -693,10 +693,7 @@ void USpatialReceiver::HandleActorAuthority(const Worker_ComponentSetAuthorityCh
 					// case this action is performed after notification of gaining authority
 					if (AController* Controller = Cast<AController>(Actor))
 					{
-						if (Controller->IntendedPawnToPossess)
-						{
-							Controller->PossessAfterMigration();
-						}
+						Controller->PossessAfterMigration();
 					}
 				}
 				else

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -15,6 +15,7 @@
 #include "EngineClasses/SpatialNetConnection.h"
 #include "EngineClasses/SpatialNetDriverDebugContext.h"
 #include "EngineClasses/SpatialPackageMapClient.h"
+#include "EngineClasses/SpatialPossession.h"
 #include "EngineClasses/SpatialVirtualWorkerTranslator.h"
 #include "Interop/Connection/SpatialEventTracer.h"
 #include "Interop/Connection/SpatialTraceEventBuilder.h"
@@ -693,7 +694,10 @@ void USpatialReceiver::HandleActorAuthority(const Worker_ComponentSetAuthorityCh
 					// case this action is performed after notification of gaining authority
 					if (AController* Controller = Cast<AController>(Actor))
 					{
-						Controller->PossessAfterMigration();
+						if (Controller->IntendedPawnToPossess != nullptr)
+						{
+							USpatialPossession::PossessAfterMigration(*Controller);
+						}
 					}
 				}
 				else

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -689,8 +689,8 @@ void USpatialReceiver::HandleActorAuthority(const Worker_ComponentSetAuthorityCh
 					// We still want to call OnAuthorityGained if the Actor migrated to this worker or was loaded from a snapshot.
 					Actor->OnAuthorityGained();
 
-					// If we are AController attempting possession of a Pawn via the IntendedPawnToPossess field, then invoke the possession case
-					// this action is performed after notification of gaining authority
+					// If we are AController attempting possession of a Pawn via the IntendedPawnToPossess field, then invoke the possession
+					// case this action is performed after notification of gaining authority
 					if (AController* Controller = Cast<AController>(Actor))
 					{
 						Controller->PossessAfterMigration();

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
@@ -110,6 +110,14 @@ VirtualWorkerId UGridBasedLBStrategy::WhoShouldHaveAuthority(const AActor& Actor
 		return SpatialConstants::INVALID_VIRTUAL_WORKER_ID;
 	}
 
+	if (const AController* Controller = Cast<AController>(&Actor))
+	{
+		if (Controller->IntendedPawnToPossess)
+		{
+			return WhoShouldHaveAuthority(*Controller->IntendedPawnToPossess);
+		}
+	}
+
 	const FVector2D Actor2DLocation = FVector2D(SpatialGDK::GetActorSpatialPosition(&Actor));
 
 	check(VirtualWorkerIds.Num() == WorkerCells.Num());

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
@@ -97,6 +97,14 @@ bool UGridBasedLBStrategy::ShouldHaveAuthority(const AActor& Actor) const
 		return false;
 	}
 
+	if (const AController* Controller = Cast<AController>(&Actor))
+	{
+		if (Controller->IntendedPawnToPossess)
+		{
+			return ShouldHaveAuthority(*Controller->IntendedPawnToPossess);
+		}
+	}
+
 	const FVector2D Actor2DLocation = FVector2D(SpatialGDK::GetActorSpatialPosition(&Actor));
 	return IsInside(WorkerCells[LocalCellId], Actor2DLocation);
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialPossession.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialPossession.h
@@ -1,0 +1,17 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "SpatialPossession.generated.h"
+
+UCLASS()
+class SPATIALGDK_API USpatialPossession : public UBlueprintFunctionLibrary
+{
+	GENERATED_BODY()
+
+public:
+	UFUNCTION(BlueprintCallable, Category = "Possession")
+	static void RemotePossess(AController* Controller, APawn* Pawn);
+
+	static void PossessAfterMigration(AController& Controller);
+};

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
@@ -19,8 +19,9 @@
 /**
  * This test tests multi clients possession over 1 pawns.
  *
- * The test includes a 2x2 gridbase servers and at least two client workers. The client workers begin with a player controller and their default pawns,
- * which they initially possess. The flow is as follows:
+ * The test includes 2x2 gridbase servers and at least two client workers.
+ * The client workers begin with a player controller and their default pawns, which they initially possess.
+ * The flow is as follows:
  *  - Setup:
  *    - Specify `GameMode Override` as ACrossServerPossessionGameMode
  *    - Specify `Multi Worker Settings Class` as Zoning 2x2(e.g. BP_Possession_Settings_Zoning2_2 of UnrealGDKTestGyms)

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
@@ -16,6 +16,19 @@
 #include "TestPossessionPlayerController.h"
 #include "Utils/SpatialStatics.h"
 
+/**
+ * This test tests multi clients possession over 1 pawns.
+ *
+ * The test includes a 2x2 gridbase servers and at least two client workers. The client workers begin with a player controller and their default pawns,
+ * which they initially possess. The flow is as follows:
+ *  - Setup:
+ *    - Specify `GameMode Override` as ACrossServerPossessionGameMode
+ *    - Specify `Multi Worker Settings Class` as Zoning 2x2(e.g. BP_Possession_Settings_Zoning2_2 of UnrealGDKTestGyms)
+ *	  - Set `Num Required Clients` as 3
+ *  - Test:
+ *    - One of Controller possessed the Pawn and others failed
+ */
+
 const float ACrossServerMultiPossessionTest::MaxWaitTime = 2.0f;
 
 ACrossServerMultiPossessionTest::ACrossServerMultiPossessionTest()
@@ -118,7 +131,9 @@ void ACrossServerMultiPossessionTest::PrepareTest()
 			AssertTrue(Pawn->GetController() != nullptr, TEXT("GetController of Pawn to check if possessed on server"), Pawn);
 
 			AssertTrue(ATestPossessionPlayerController::OnPossessCalled == 1, TEXT("OnPossess should be called 1 time"));
-			AssertTrue(ATestPossessionPlayerController::OnPossessFailedCalled == 2, TEXT("OnPossessFailed should be called 2 times"));
+			int OnPossessFailedCalled = GetNumRequiredClients() - 1;
+			AssertTrue(ATestPossessionPlayerController::OnPossessFailedCalled == OnPossessFailedCalled,
+					   FString::Printf(TEXT("OnPossessFailed should be called %d times"), OnPossessFailedCalled));
 		}
 		else
 		{

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
@@ -107,7 +107,7 @@ void ACrossServerMultiPossessionTest::PrepareTest()
 		{
 			if (AController* Controller = Pawn->GetController())
 			{
-				LogStep(ELogVerbosity::Log, FString::Printf(TEXT("%s possessed the Pawn"), *Controller->GetFullName()));
+				AssertTrue(Pawn->GetController() != nullptr, TEXT("Succeed possessed"), Pawn);
 			}
 			else
 			{
@@ -126,7 +126,7 @@ void ACrossServerMultiPossessionTest::PrepareTest()
 		{
 			if (AController* Controller = Pawn->GetController())
 			{
-				LogStep(ELogVerbosity::Log, FString::Printf(TEXT("%s possessed the Pawn"), *Controller->GetFullName()));
+				AssertTrue(Pawn->GetController() != nullptr, TEXT("Succeed possessed"), Pawn);
 			}
 			else
 			{
@@ -191,6 +191,7 @@ void ACrossServerMultiPossessionTest::RemotePossess(int Index)
 						FString::Printf(TEXT("%s try to remote possess %s"), *Controller->GetFullName(), *Pawn->GetFullName()));
 				Controller->OnPossessEvent.AddDynamic(this, &ACrossServerMultiPossessionTest::OnPossess);
 				Controller->OnUnPossessEvent.AddDynamic(this, &ACrossServerMultiPossessionTest::OnUnPossess);
+				Controller->OnPossessFailureEvent.AddDynamic(this, &ACrossServerMultiPossessionTest::OnPossessFailure);
 				USpatialPossession::RemotePossess(Controller, Pawn);
 			}
 		}
@@ -208,10 +209,16 @@ void ACrossServerMultiPossessionTest::RemotePossess(int Index)
 void ACrossServerMultiPossessionTest::OnPossess(APawn* Pawn, APlayerController* Controller)
 {
 	LogStep(ELogVerbosity::Log,
-			FString::Printf(TEXT("Controller:%s OnPossess Pawn:%s "), *Controller->GetFullName(), *Pawn->GetFullName()));
+			FString::Printf(TEXT("Controller:%s OnPossess Pawn:%s"), *Controller->GetFullName(), *Pawn->GetFullName()));
 }
 
 void ACrossServerMultiPossessionTest::OnUnPossess(APlayerController* Controller)
 {
 	LogStep(ELogVerbosity::Log, FString::Printf(TEXT("Controller:%s OnUnPossess"), *Controller->GetFullName()));
+}
+
+void ACrossServerMultiPossessionTest::OnPossessFailure(ERemotePossessFailure* FailureReason, APlayerController* Controller)
+{
+	LogStep(ELogVerbosity::Log,
+			FString::Printf(TEXT("Controller:%s OnPossessFailure:%d"), *Controller->GetFullName(), *FailureReason));
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
@@ -1,0 +1,217 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "CrossServerMultiPossessionTest.h"
+
+#include "Containers/Array.h"
+#include "EngineClasses/SpatialNetDriver.h"
+#include "EngineClasses/SpatialPossession.h"
+#include "GameFramework/GameModeBase.h"
+#include "GameFramework/PlayerController.h"
+#include "GameMapsSettings.h"
+#include "Kismet/GameplayStatics.h"
+#include "LoadBalancing/LayeredLBStrategy.h"
+#include "SpatialFunctionalTestFlowController.h"
+#include "SpatialGDKFunctionalTests/SpatialGDK/TestActors/TestMovementCharacter.h"
+#include "TestPossessionPawn.h"
+#include "TestPossessionPlayerController.h"
+#include "Utils/SpatialStatics.h"
+
+const float ACrossServerMultiPossessionTest::MaxWaitTime = 1.0f;
+
+ACrossServerMultiPossessionTest::ACrossServerMultiPossessionTest()
+	: Super()
+	, WaitTime(0.0f)
+{
+	Author = "Ken.Yu";
+	Description = TEXT("Test Cross-Server 3 Controllers Possess 1 Pawn");
+}
+
+void ACrossServerMultiPossessionTest::PrepareTest()
+{
+	Super::PrepareTest();
+
+	AddStep(TEXT("EnsureSpatialOS"), FWorkerDefinition::AllServers, nullptr, [this]() {
+		ULayeredLBStrategy* LoadBalanceStrategy = GetLoadBalancingStrategy();
+		if (LoadBalanceStrategy == nullptr)
+		{
+			FinishTest(EFunctionalTestResult::Error, TEXT("Test requires SpatialOS enabled with Load-Balancing Strategy"));
+		}
+		else
+		{
+			if (AGameModeBase* GameMode = Cast<AGameModeBase>(AGameModeBase::StaticClass()->GetDefaultObject()))
+			{
+				LogStep(ELogVerbosity::Log, FString::Printf(TEXT("GameMode:%s"), *GameMode->GetFullName()));
+			}
+			FinishStep();
+		}
+	});
+
+	AddStep(TEXT("Cross-Server Possession: Create Pawn"), FWorkerDefinition::Server(1), nullptr, [this]() {
+		ATestPossessionPawn* Pawn =
+			GetWorld()->SpawnActor<ATestPossessionPawn>(FVector(500.0f, 500.0f, 50.0f), FRotator::ZeroRotator, FActorSpawnParameters());
+		RegisterAutoDestroyActor(Pawn);
+		FinishStep();
+	});
+
+	AddStep(TEXT("Cross-Server Possession: Shown who should have authority"), FWorkerDefinition::Server(1), nullptr, nullptr,
+			[this](float DeltaTime) {
+				ULayeredLBStrategy* LoadBalanceStrategy = GetLoadBalancingStrategy();
+				if (LoadBalanceStrategy != nullptr)
+				{
+					if (ATestPossessionPawn* Pawn = GetPawn())
+					{
+						for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
+						{
+							AController* Controller = Cast<AController>(FlowController->GetOwner());
+							if (Controller != nullptr)
+							{
+								uint32 WorkerId = LoadBalanceStrategy->WhoShouldHaveAuthority(*Controller);
+								LogStep(ELogVerbosity::Log, FString::Printf(TEXT("Controller:%s authoritatived in worker: %d"),
+																			*Controller->GetFullName(), WorkerId));
+							}
+						}
+
+						uint32 WorkerId = LoadBalanceStrategy->WhoShouldHaveAuthority(*Pawn);
+						LogStep(ELogVerbosity::Log,
+								FString::Printf(TEXT("Pawn:%s authoritatived in worker: %d"), *GetPawn()->GetFullName(), WorkerId));
+					}
+					else
+					{
+						FinishTest(EFunctionalTestResult::Error, TEXT("Couldn't found pawn for possession"));
+					}
+				}
+				else
+				{
+					FinishTest(EFunctionalTestResult::Error, TEXT("Test requires SpatialOS enabled with Load-Balancing Strategy"));
+				}
+				FinishStep();
+			});
+
+	AddStep(TEXT("Cross-Server Possession: controller remote possess"), FWorkerDefinition::AllServers, nullptr, [this]() {
+		RemotePossess(1);
+		RemotePossess(2);
+		RemotePossess(3);
+		FinishStep();
+	});
+
+	AddStep(TEXT("Cross-Server Possession: Wait"), FWorkerDefinition::Server(1), nullptr, nullptr, [this](float DeltaTime) {
+		if (WaitTime > MaxWaitTime)
+		{
+			FinishStep();
+		}
+		WaitTime += DeltaTime;
+	});
+
+	AddStep(TEXT("Cross-Server Possession: Check results"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float DeltaTime) {
+		if (ATestPossessionPawn* Pawn = GetPawn())
+		{
+			if (AController* Controller = Pawn->GetController())
+			{
+				LogStep(ELogVerbosity::Log, FString::Printf(TEXT("%s possessed the Pawn"), *Controller->GetFullName()));
+			}
+			else
+			{
+				LogStep(ELogVerbosity::Log, TEXT("Possess failed!"));
+			}
+		}
+		else
+		{
+			LogStep(ELogVerbosity::Log, TEXT("Couldn't found pawn for possession"));
+		}
+		FinishStep();
+	});
+
+	AddStep(TEXT("Cross-Server Possession: Check results"), FWorkerDefinition::AllClients, nullptr, nullptr, [this](float DeltaTime) {
+		if (ATestPossessionPawn* Pawn = GetPawn())
+		{
+			if (AController* Controller = Pawn->GetController())
+			{
+				LogStep(ELogVerbosity::Log, FString::Printf(TEXT("%s possessed the Pawn"), *Controller->GetFullName()));
+			}
+			else
+			{
+				LogStep(ELogVerbosity::Log, TEXT("Possess failed!"));
+			}
+		}
+		else
+		{
+			LogStep(ELogVerbosity::Log, TEXT("Couldn't found pawn for possession"));
+		}
+		FinishStep();
+	});
+}
+
+ATestPossessionPawn* ACrossServerMultiPossessionTest::GetPawn()
+{
+	return Cast<ATestPossessionPawn>(UGameplayStatics::GetActorOfClass(GetWorld(), ATestPossessionPawn::StaticClass()));
+}
+
+void ACrossServerMultiPossessionTest::CreateController(int Index, FVector Position)
+{
+	ASpatialFunctionalTestFlowController* FlowController = GetFlowController(ESpatialFunctionalTestWorkerType::Client, Index);
+	ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
+	if (IsValid(PlayerController))
+	{
+		ATestMovementCharacter* Character =
+			GetWorld()->SpawnActor<ATestMovementCharacter>(Position, FRotator::ZeroRotator, FActorSpawnParameters());
+		RegisterAutoDestroyActor(Character);
+		USpatialPossession::RemotePossess(PlayerController, Character);
+	}
+	else
+	{
+		FinishTest(EFunctionalTestResult::Error, TEXT("Failed to get PlayerController"));
+	}
+}
+
+void ACrossServerMultiPossessionTest::CheckControllerHasAuthority(int Index)
+{
+	ASpatialFunctionalTestFlowController* FlowController = GetFlowController(ESpatialFunctionalTestWorkerType::Client, Index);
+	ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
+	if (IsValid(PlayerController))
+	{
+		AssertTrue(PlayerController->HasAuthority(), TEXT("PlayerController HasAuthority"), PlayerController);
+	}
+	else
+	{
+		FinishTest(EFunctionalTestResult::Error, TEXT("Failed to get PlayerController"));
+	}
+}
+
+void ACrossServerMultiPossessionTest::RemotePossess(int Index)
+{
+	if (ATestPossessionPawn* Pawn = GetPawn())
+	{
+		ASpatialFunctionalTestFlowController* FlowController = GetFlowController(ESpatialFunctionalTestWorkerType::Client, Index);
+		ATestPossessionPlayerController* Controller = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
+		if (IsValid(Controller))
+		{
+			if (Controller->HasAuthority())
+			{
+				LogStep(ELogVerbosity::Log,
+						FString::Printf(TEXT("%s try to remote possess %s"), *Controller->GetFullName(), *Pawn->GetFullName()));
+				Controller->OnPossessEvent.AddDynamic(this, &ACrossServerMultiPossessionTest::OnPossess);
+				Controller->OnUnPossessEvent.AddDynamic(this, &ACrossServerMultiPossessionTest::OnUnPossess);
+				USpatialPossession::RemotePossess(Controller, Pawn);
+			}
+		}
+		else
+		{
+			FinishTest(EFunctionalTestResult::Error, TEXT("Failed to get PlayerController"));
+		}
+	}
+	else
+	{
+		FinishTest(EFunctionalTestResult::Error, TEXT("Failed to get the pawn for possession"));
+	}
+}
+
+void ACrossServerMultiPossessionTest::OnPossess(APawn* Pawn, APlayerController* Controller)
+{
+	LogStep(ELogVerbosity::Log,
+			FString::Printf(TEXT("Controller:%s OnPossess Pawn:%s "), *Controller->GetFullName(), *Pawn->GetFullName()));
+}
+
+void ACrossServerMultiPossessionTest::OnUnPossess(APlayerController* Controller)
+{
+	LogStep(ELogVerbosity::Log, FString::Printf(TEXT("Controller:%s OnUnPossess"), *Controller->GetFullName()));
+}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.h
@@ -21,18 +21,12 @@ public:
 
 private:
 	ATestPossessionPawn* GetPawn();
+
 	void CreateController(int Index, FVector Position);
+
 	void CheckControllerHasAuthority(int Index);
-	void RemotePossess(int Index);
 
-	UFUNCTION()
-	void OnPossess(APawn* Pawn, APlayerController* Controller);
-
-	UFUNCTION()
-	void OnUnPossess(APlayerController* Controller);
-
-	UFUNCTION()
-	void OnPossessFailed(ERemotePossessFailure FailureReason, APlayerController* Controller);
+	void AddWaitStep(const FWorkerDefinition& Worker);
 
 	float WaitTime;
 	const static float MaxWaitTime;

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.h
@@ -31,6 +31,9 @@ private:
 	UFUNCTION()
 	void OnUnPossess(APlayerController* Controller);
 
+	UFUNCTION()
+	void OnPossessFailure(ERemotePossessFailure FailureReason, APlayerController* Controller);
+
 	float WaitTime;
 	const static float MaxWaitTime;
 };

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.h
@@ -32,7 +32,7 @@ private:
 	void OnUnPossess(APlayerController* Controller);
 
 	UFUNCTION()
-	void OnPossessFailure(ERemotePossessFailure FailureReason, APlayerController* Controller);
+	void OnPossessFailed(ERemotePossessFailure FailureReason, APlayerController* Controller);
 
 	float WaitTime;
 	const static float MaxWaitTime;

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.h
@@ -1,0 +1,36 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "SpatialFunctionalTest.h"
+
+#include "CrossServerMultiPossessionTest.generated.h"
+
+class ATestPossessionPawn;
+
+UCLASS()
+class SPATIALGDKFUNCTIONALTESTS_API ACrossServerMultiPossessionTest : public ASpatialFunctionalTest
+{
+	GENERATED_BODY()
+
+public:
+	ACrossServerMultiPossessionTest();
+
+	virtual void PrepareTest() override;
+
+private:
+	ATestPossessionPawn* GetPawn();
+	void CreateController(int Index, FVector Position);
+	void CheckControllerHasAuthority(int Index);
+	void RemotePossess(int Index);
+
+	UFUNCTION()
+	void OnPossess(APawn* Pawn, APlayerController* Controller);
+
+	UFUNCTION()
+	void OnUnPossess(APlayerController* Controller);
+
+	float WaitTime;
+	const static float MaxWaitTime;
+};

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionGameMode.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionGameMode.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "CrossServerPossessionGameMode.h"
+
+#include "GameFramework/PlayerStart.h"
+#include "TestPossessionPlayerController.h"
+
+ACrossServerPossessionGameMode::ACrossServerPossessionGameMode()
+	: PlayersSpawned(0)
+	, bInitializedSpawnPoints(false)
+{
+	PlayerControllerClass = ATestPossessionPlayerController::StaticClass();
+}
+
+AActor* ACrossServerPossessionGameMode::FindPlayerStart_Implementation(AController* Player, const FString& IncomingName)
+{
+	Generate_SpawnPoints();
+
+	if (Player == nullptr)
+	{
+		return SpawnPoints[PlayersSpawned % SpawnPoints.Num()];
+	}
+
+	const int32 PlayerUniqueID = Player->GetUniqueID();
+	AActor** SpawnPoint = PlayerIdToSpawnPointMap.Find(PlayerUniqueID);
+	if (SpawnPoint != nullptr)
+	{
+		return *SpawnPoint;
+	}
+
+	AActor* ChosenSpawnPoint = SpawnPoints[PlayersSpawned % SpawnPoints.Num()];
+	PlayerIdToSpawnPointMap.Add(PlayerUniqueID, ChosenSpawnPoint);
+
+	PlayersSpawned++;
+
+	return ChosenSpawnPoint;
+}
+
+void ACrossServerPossessionGameMode::Generate_SpawnPoints()
+{
+	if (false == bInitializedSpawnPoints)
+	{
+		UWorld* World = GetWorld();
+
+		FActorSpawnParameters SpawnInfo{};
+		SpawnInfo.Owner = this;
+		SpawnInfo.Instigator = NULL;
+		SpawnInfo.bDeferConstruction = false;
+		SpawnInfo.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+
+		SpawnPoints.Add(World->SpawnActor<APlayerStart>(APlayerStart::StaticClass(), FVector(-500.0f, -500.0f, 50.0f),
+														FRotator::ZeroRotator, SpawnInfo));
+		SpawnPoints.Add(World->SpawnActor<APlayerStart>(APlayerStart::StaticClass(), FVector(500.0f, -500.0f, 50.0f), FRotator::ZeroRotator,
+														SpawnInfo));
+		SpawnPoints.Add(World->SpawnActor<APlayerStart>(APlayerStart::StaticClass(), FVector(-500.0f, 500.0f, 50.0f), FRotator::ZeroRotator,
+														SpawnInfo));
+
+		bInitializedSpawnPoints = true;
+	}
+}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionGameMode.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionGameMode.h
@@ -1,0 +1,24 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/GameModeBase.h"
+#include "CrossServerPossessionGameMode.generated.h"
+
+UCLASS()
+class ACrossServerPossessionGameMode : public AGameModeBase
+{
+	GENERATED_BODY()
+public:
+	ACrossServerPossessionGameMode();
+	AActor* FindPlayerStart_Implementation(AController* Player, const FString& IncomingName) override;
+
+private:
+	void Generate_SpawnPoints();
+
+	int32 PlayersSpawned;
+	bool bInitializedSpawnPoints;
+	TArray<AActor*> SpawnPoints;
+	TMap<int32, AActor*> PlayerIdToSpawnPointMap;
+};

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
@@ -1,0 +1,103 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "CrossServerPossessionTest.h"
+
+#include "Containers/Array.h"
+#include "EngineClasses/SpatialNetDriver.h"
+#include "EngineClasses/SpatialPossession.h"
+#include "GameFramework/GameModeBase.h"
+#include "GameFramework/PlayerController.h"
+#include "GameMapsSettings.h"
+#include "Kismet/GameplayStatics.h"
+#include "LoadBalancing/LayeredLBStrategy.h"
+#include "SpatialFunctionalTestFlowController.h"
+#include "SpatialGDKFunctionalTests/SpatialGDK/TestActors/TestMovementCharacter.h"
+#include "TestPossessionPawn.h"
+#include "TestPossessionPlayerController.h"
+#include "Utils/SpatialStatics.h"
+
+const float ACrossServerPossessionTest::MaxWaitTime = 1.0f;
+
+ACrossServerPossessionTest::ACrossServerPossessionTest()
+	: WaitTime(0.0f)
+{
+	Author = "Ken.Yu";
+	Description = TEXT("Test Cross-Server Possession");
+}
+
+
+void ACrossServerPossessionTest::PrepareTest()
+{
+	Super::PrepareTest();
+
+	AddStep(TEXT("EnsureSpatialOS"), FWorkerDefinition::AllServers, nullptr, [this]() {
+		ULayeredLBStrategy* LoadBalanceStrategy = GetLoadBalancingStrategy();
+		if (LoadBalanceStrategy == nullptr)
+		{
+			FinishTest(EFunctionalTestResult::Error, TEXT("Test requires SpatialOS enabled with Load-Balancing Strategy"));
+		}
+		else
+		{
+			if (AGameModeBase* GameMode = Cast<AGameModeBase>(AGameModeBase::StaticClass()->GetDefaultObject()))
+			{
+				LogStep(ELogVerbosity::Log, FString::Printf(TEXT("GameMode:%s"), *GameMode->GetFullName()));
+			}
+			FinishStep();
+		}
+	});
+
+	AddStep(TEXT("Cross-Server Possession check client 03 authority"), FWorkerDefinition::Server(3), nullptr, nullptr, [this](float) {
+		ULayeredLBStrategy* LoadBalanceStrategy = GetLoadBalancingStrategy();
+		ATestPossessionPawn* Pawn03 =
+			GetWorld()->SpawnActor<ATestPossessionPawn>(FVector(-100.0f, 100.0f, 50.0f), FRotator::ZeroRotator, FActorSpawnParameters());
+		uint32 WorkerId03 = LoadBalanceStrategy->WhoShouldHaveAuthority(*Pawn03);
+		LogStep(ELogVerbosity::Log, FString::Printf(TEXT("QQQQ %d"), WorkerId03));
+
+		ASpatialFunctionalTestFlowController* FlowController = GetFlowController(ESpatialFunctionalTestWorkerType::Client, 1);
+		APlayerController* PlayerController = Cast<APlayerController>(FlowController->GetOwner());
+		if (PlayerController) {
+			uint32 WorkerId = LoadBalanceStrategy->WhoShouldHaveAuthority(*PlayerController);
+			LogStep(ELogVerbosity::Log, FString::Printf(TEXT("PlayerController %d"), WorkerId));
+		}
+		FinishStep();
+	});
+
+	AddStep(TEXT("Cross-Server Possession"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
+		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
+		{
+			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
+			{
+				APlayerController* PlayerController = Cast<APlayerController>(FlowController->GetOwner());
+				if (PlayerController && PlayerController->HasAuthority())
+				{
+					ATestPossessionPawn* Pawn =
+						Cast<ATestPossessionPawn>(UGameplayStatics::GetActorOfClass(GetWorld(), ATestPossessionPawn::StaticClass()));
+
+					AssertTrue(PlayerController->HasAuthority(), TEXT("PlayerController should HasAuthority"), PlayerController);
+					AssertFalse(Pawn->HasAuthority(), TEXT("Pawn shouldn't HasAuthority"), Pawn);
+					USpatialPossession::RemotePossess(PlayerController, Pawn);
+				}
+			}
+		}		
+		FinishStep();
+	});
+
+	AddStep(TEXT("Cross-Server Possession: Wait"), FWorkerDefinition::Server(1), nullptr, nullptr, [this](float DeltaTime) {
+		if (WaitTime > MaxWaitTime)
+		{
+			FinishStep();
+		}
+		WaitTime += DeltaTime;
+	});
+
+	AddStep(TEXT("check"), FWorkerDefinition::Server(1), nullptr, nullptr, [this](float) {
+		ASpatialFunctionalTestFlowController* FlowController = GetFlowController(ESpatialFunctionalTestWorkerType::Client, 1);
+		APlayerController* PlayerController = Cast<APlayerController>(FlowController->GetOwner());
+		ATestPossessionPawn* Pawn111 =
+			Cast<ATestPossessionPawn>(UGameplayStatics::GetActorOfClass(GetWorld(), ATestPossessionPawn::StaticClass()));
+
+		AssertTrue(Pawn111->Controller == PlayerController, TEXT("PlayerController HasAuthority02"), PlayerController);
+
+		FinishStep();
+	});
+}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
@@ -25,7 +25,6 @@ ACrossServerPossessionTest::ACrossServerPossessionTest()
 	Description = TEXT("Test Cross-Server Possession");
 }
 
-
 void ACrossServerPossessionTest::PrepareTest()
 {
 	Super::PrepareTest();
@@ -48,17 +47,11 @@ void ACrossServerPossessionTest::PrepareTest()
 
 	AddStep(TEXT("Cross-Server Possession check client 03 authority"), FWorkerDefinition::Server(3), nullptr, nullptr, [this](float) {
 		ULayeredLBStrategy* LoadBalanceStrategy = GetLoadBalancingStrategy();
-		ATestPossessionPawn* Pawn03 =
+		ATestPossessionPawn* Pawn =
 			GetWorld()->SpawnActor<ATestPossessionPawn>(FVector(-100.0f, 100.0f, 50.0f), FRotator::ZeroRotator, FActorSpawnParameters());
-		uint32 WorkerId03 = LoadBalanceStrategy->WhoShouldHaveAuthority(*Pawn03);
-		LogStep(ELogVerbosity::Log, FString::Printf(TEXT("QQQQ %d"), WorkerId03));
+		uint32 WorkerId03 = LoadBalanceStrategy->WhoShouldHaveAuthority(*Pawn);
+		LogStep(ELogVerbosity::Log, FString::Printf(TEXT("Worker %d has the authority of the Pawn"), WorkerId03));
 
-		ASpatialFunctionalTestFlowController* FlowController = GetFlowController(ESpatialFunctionalTestWorkerType::Client, 1);
-		APlayerController* PlayerController = Cast<APlayerController>(FlowController->GetOwner());
-		if (PlayerController) {
-			uint32 WorkerId = LoadBalanceStrategy->WhoShouldHaveAuthority(*PlayerController);
-			LogStep(ELogVerbosity::Log, FString::Printf(TEXT("PlayerController %d"), WorkerId));
-		}
 		FinishStep();
 	});
 
@@ -78,7 +71,7 @@ void ACrossServerPossessionTest::PrepareTest()
 					USpatialPossession::RemotePossess(PlayerController, Pawn);
 				}
 			}
-		}		
+		}
 		FinishStep();
 	});
 
@@ -90,13 +83,13 @@ void ACrossServerPossessionTest::PrepareTest()
 		WaitTime += DeltaTime;
 	});
 
-	AddStep(TEXT("check"), FWorkerDefinition::Server(1), nullptr, nullptr, [this](float) {
+	AddStep(TEXT("Cross-Server Possession: Check test result"), FWorkerDefinition::Server(1), nullptr, nullptr, [this](float) {
 		ASpatialFunctionalTestFlowController* FlowController = GetFlowController(ESpatialFunctionalTestWorkerType::Client, 1);
 		APlayerController* PlayerController = Cast<APlayerController>(FlowController->GetOwner());
-		ATestPossessionPawn* Pawn111 =
+		ATestPossessionPawn* Pawn =
 			Cast<ATestPossessionPawn>(UGameplayStatics::GetActorOfClass(GetWorld(), ATestPossessionPawn::StaticClass()));
 
-		AssertTrue(Pawn111->Controller == PlayerController, TEXT("PlayerController HasAuthority02"), PlayerController);
+		AssertTrue(Pawn->Controller == PlayerController, TEXT("PlayerController has possessed the pawn"), PlayerController);
 
 		FinishStep();
 	});

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.h
@@ -1,0 +1,23 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "SpatialFunctionalTest.h"
+
+#include "CrossServerPossessionTest.generated.h"
+
+UCLASS()
+class SPATIALGDKFUNCTIONALTESTS_API ACrossServerPossessionTest : public ASpatialFunctionalTest
+{
+	GENERATED_BODY()
+
+public:
+	ACrossServerPossessionTest();
+
+	virtual void PrepareTest() override;
+
+private:
+	float WaitTime;
+	const static float MaxWaitTime;
+};

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.cpp
@@ -1,0 +1,118 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "SpatialTestRemotePossession.h"
+#include "Containers/Array.h"
+#include "GameFramework/PlayerController.h"
+#include "EngineClasses/SpatialNetDriver.h"
+#include "EngineClasses/SpatialPossession.h"
+#include "Net/UnrealNetwork.h"
+#include "SpatialFunctionalTestFlowController.h"
+#include "TestPossessionPawn.h"
+#include "TestPossessionPlayerController.h"
+
+/**
+ * This test tests client possession over pawns in other zones.
+ *
+ * The test includes two servers and two client workers. The client workers begin with a player controller and their default pawns,
+ * which they initially possess. The flow is as follows:
+ *  - Setup:
+ *    - Two test pawn actors are spawned, one for each client, with an offset in the y direction for easy visualisation
+ *    - The controllers for each client  possess the spawned test pawn actors
+ *  - Test:
+ *    - The clients  assert that the pawn they currently possess are test pawns
+ *  - Cleanup:
+ *    - The clients repossess their default pawns
+ *    - The test pawns are destroyed
+ */
+
+ASpatialTestRemotePossession::ASpatialTestRemotePossession()
+	: Super()
+{
+	Author = "Jay";
+	Description = TEXT("Test Actor Remote Possession");
+
+}
+
+void ASpatialTestRemotePossession::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+
+	DOREPLIFETIME(ASpatialTestRemotePossession, OriginalPawns);
+}
+
+void ASpatialTestRemotePossession::PrepareTest()
+{
+	Super::PrepareTest();
+
+	static FVector start[3] = { FVector{30.0f, 30.0f, 20.0f}, FVector{-30.0f, 30.0f, 20.0f}, FVector{-30.0f, -30.0f, 20.0f} };
+	AddStep(TEXT("First step"), FWorkerDefinition::Server(1), nullptr, nullptr, [this](float) {
+		int i = 0;
+		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
+		{
+			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Server)
+			{
+				continue;
+			}
+			ATestPossessionPawn* TestPawn = GetWorld()->SpawnActor<ATestPossessionPawn>(start[i % 3], FRotator::ZeroRotator, FActorSpawnParameters());
+			OriginalPawns.Add(TestPawn);
+			++i;
+			RegisterAutoDestroyActor(TestPawn);
+
+			AController* PlayerController = Cast<AController>(FlowController->GetOwner());
+			USpatialPossession::RemotePossess(PlayerController, TestPawn);
+		}
+		FinishStep();
+	});
+
+	AddStep(TEXT("Tick Step"), FWorkerDefinition::Server(1), nullptr, nullptr, [this](float DeltaTime) {
+		static float deltaTotal{ 0.f };
+		deltaTotal += DeltaTime;
+		if (deltaTotal > 3.f)
+		{
+			FinishStep();
+		}
+	});
+
+	AddStep(TEXT("Check"), FWorkerDefinition::Server(2), nullptr, nullptr, [this](float) {
+
+		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
+		{
+			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Server)
+			{
+				continue;
+			}
+			AController* PlayerController = Cast<AController>(FlowController->GetOwner());
+			if (PlayerController->HasAuthority())
+			{
+				USpatialPossession::RemotePossess(PlayerController, OriginalPawns[0]);
+			}
+			//
+		}
+
+		FinishStep();
+	});
+
+	AddStep(TEXT("Check"), FWorkerDefinition::Server(3), nullptr, nullptr, [this](float) {
+
+		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
+		{
+			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Server)
+			{
+				continue;
+			}
+			ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
+			ensure(PlayerController);
+			if (PlayerController->HasAuthority())
+			{
+				USpatialNetDriver* NetDriver = Cast<USpatialNetDriver>(GetNetDriver());
+				NetDriver->LockingPolicy->AcquireLock(PlayerController, TEXT("TestLock"));
+				USpatialPossession::RemotePossess(PlayerController, OriginalPawns[0]);
+				AssertValue_Int(PlayerController->OnPossessFailedCalled, EComparisonMethod::Equal_To, 1, TEXT("OnPossessionFailed Called"));
+			}
+			//
+		}
+
+		FinishStep();
+		});
+
+}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.cpp
@@ -2,9 +2,9 @@
 
 #include "SpatialTestRemotePossession.h"
 #include "Containers/Array.h"
-#include "GameFramework/PlayerController.h"
 #include "EngineClasses/SpatialNetDriver.h"
 #include "EngineClasses/SpatialPossession.h"
+#include "GameFramework/PlayerController.h"
 #include "Net/UnrealNetwork.h"
 #include "SpatialFunctionalTestFlowController.h"
 #include "TestPossessionPawn.h"
@@ -30,7 +30,6 @@ ASpatialTestRemotePossession::ASpatialTestRemotePossession()
 {
 	Author = "Jay";
 	Description = TEXT("Test Actor Remote Possession");
-
 }
 
 void ASpatialTestRemotePossession::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
@@ -44,7 +43,7 @@ void ASpatialTestRemotePossession::PrepareTest()
 {
 	Super::PrepareTest();
 
-	static FVector start[3] = { FVector{30.0f, 30.0f, 20.0f}, FVector{-30.0f, 30.0f, 20.0f}, FVector{-30.0f, -30.0f, 20.0f} };
+	static FVector start[3] = { FVector{ 30.0f, 30.0f, 20.0f }, FVector{ -30.0f, 30.0f, 20.0f }, FVector{ -30.0f, -30.0f, 20.0f } };
 	AddStep(TEXT("First step"), FWorkerDefinition::Server(1), nullptr, nullptr, [this](float) {
 		int i = 0;
 		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
@@ -53,7 +52,8 @@ void ASpatialTestRemotePossession::PrepareTest()
 			{
 				continue;
 			}
-			ATestPossessionPawn* TestPawn = GetWorld()->SpawnActor<ATestPossessionPawn>(start[i % 3], FRotator::ZeroRotator, FActorSpawnParameters());
+			ATestPossessionPawn* TestPawn =
+				GetWorld()->SpawnActor<ATestPossessionPawn>(start[i % 3], FRotator::ZeroRotator, FActorSpawnParameters());
 			OriginalPawns.Add(TestPawn);
 			++i;
 			RegisterAutoDestroyActor(TestPawn);
@@ -74,7 +74,6 @@ void ASpatialTestRemotePossession::PrepareTest()
 	});
 
 	AddStep(TEXT("Check"), FWorkerDefinition::Server(2), nullptr, nullptr, [this](float) {
-
 		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
 		{
 			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Server)
@@ -93,7 +92,6 @@ void ASpatialTestRemotePossession::PrepareTest()
 	});
 
 	AddStep(TEXT("Check"), FWorkerDefinition::Server(3), nullptr, nullptr, [this](float) {
-
 		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
 		{
 			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Server)
@@ -113,6 +111,5 @@ void ASpatialTestRemotePossession::PrepareTest()
 		}
 
 		FinishStep();
-		});
-
+	});
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.h
@@ -1,0 +1,23 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "SpatialFunctionalTest.h"
+#include "SpatialTestRemotePossession.generated.h"
+
+UCLASS()
+class SPATIALGDKFUNCTIONALTESTS_API ASpatialTestRemotePossession : public ASpatialFunctionalTest
+{
+	GENERATED_BODY()
+public:
+	ASpatialTestRemotePossession();
+
+	virtual void PrepareTest() override;
+
+	static void HandlePossessionFailed(ERemotePossessFailure Failure);
+
+	// To save original Pawns and possess them back at the end
+	UPROPERTY(replicated)
+	TArray<APawn*> OriginalPawns;
+};

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
@@ -20,5 +20,5 @@ void ATestPossessionPlayerController::OnUnPossess()
 void ATestPossessionPlayerController::OnPossessFailed(ERemotePossessFailure FailureReason)
 {
 	Super::OnPossessFailed(FailureReason);
-	OnPossessFailureEvent.Broadcast(FailureReason, this);
+	OnPossessFailedEvent.Broadcast(FailureReason, this);
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
@@ -2,23 +2,45 @@
 
 #include "TestPossessionPlayerController.h"
 #include "Engine/World.h"
+#include "EngineClasses/SpatialPossession.h"
+#include "Utils/SpatialStatics.h"
 
-ATestPossessionPlayerController::ATestPossessionPlayerController() {}
+DEFINE_LOG_CATEGORY(LogTestPossessionPlayerController);
+
+int32 ATestPossessionPlayerController::OnPossessCalled = 0;
+int32 ATestPossessionPlayerController::OnPossessFailedCalled = 0;
+
+ATestPossessionPlayerController::ATestPossessionPlayerController()
+{
+}
 
 void ATestPossessionPlayerController::OnPossess(APawn* InPawn)
 {
 	Super::OnPossess(InPawn);
-	OnPossessEvent.Broadcast(InPawn, this);
+	++OnPossessCalled;
+	UE_LOG(LogTestPossessionPlayerController, Log, TEXT("%s OnPossess(%s) OnPossessCalled:%d"), *GetName(), *InPawn->GetName(), OnPossessCalled);
 }
 
 void ATestPossessionPlayerController::OnUnPossess()
 {
 	Super::OnUnPossess();
-	OnUnPossessEvent.Broadcast(this);
+	UE_LOG(LogTestPossessionPlayerController, Log, TEXT("%s OnUnPossess()"), *GetName());
 }
 
 void ATestPossessionPlayerController::OnPossessFailed(ERemotePossessFailure FailureReason)
 {
 	Super::OnPossessFailed(FailureReason);
-	OnPossessFailedEvent.Broadcast(FailureReason, this);
+	++OnPossessFailedCalled;
+	UE_LOG(LogTestPossessionPlayerController, Log, TEXT("%s OnPossessFailed(%d) OnPossessFailedCalled:%d"), *GetName(), FailureReason, OnPossessFailedCalled);
+}
+
+void ATestPossessionPlayerController::RemotePossess_Implementation(APawn* InPawn)
+{
+	USpatialPossession::RemotePossess(this, InPawn);
+}
+
+void ATestPossessionPlayerController::ResetCalledCounter()
+{
+	OnPossessCalled = 0;
+	OnPossessFailedCalled = 0;
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "TestPossessionPlayerController.h"
+#include "Engine/World.h"
+
+ATestPossessionPlayerController::ATestPossessionPlayerController() {}
+
+void ATestPossessionPlayerController::OnPossess(APawn* InPawn)
+{
+	Super::OnPossess(InPawn);
+	OnPossessEvent.Broadcast(InPawn, this);
+}
+
+void ATestPossessionPlayerController::OnUnPossess()
+{
+	Super::OnUnPossess();
+	OnUnPossessEvent.Broadcast(this);
+}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
@@ -10,15 +10,14 @@ DEFINE_LOG_CATEGORY(LogTestPossessionPlayerController);
 int32 ATestPossessionPlayerController::OnPossessCalled = 0;
 int32 ATestPossessionPlayerController::OnPossessFailedCalled = 0;
 
-ATestPossessionPlayerController::ATestPossessionPlayerController()
-{
-}
+ATestPossessionPlayerController::ATestPossessionPlayerController() {}
 
 void ATestPossessionPlayerController::OnPossess(APawn* InPawn)
 {
 	Super::OnPossess(InPawn);
 	++OnPossessCalled;
-	UE_LOG(LogTestPossessionPlayerController, Log, TEXT("%s OnPossess(%s) OnPossessCalled:%d"), *GetName(), *InPawn->GetName(), OnPossessCalled);
+	UE_LOG(LogTestPossessionPlayerController, Log, TEXT("%s OnPossess(%s) OnPossessCalled:%d"), *GetName(), *InPawn->GetName(),
+		   OnPossessCalled);
 }
 
 void ATestPossessionPlayerController::OnUnPossess()
@@ -31,7 +30,8 @@ void ATestPossessionPlayerController::OnPossessFailed(ERemotePossessFailure Fail
 {
 	Super::OnPossessFailed(FailureReason);
 	++OnPossessFailedCalled;
-	UE_LOG(LogTestPossessionPlayerController, Log, TEXT("%s OnPossessFailed(%d) OnPossessFailedCalled:%d"), *GetName(), FailureReason, OnPossessFailedCalled);
+	UE_LOG(LogTestPossessionPlayerController, Log, TEXT("%s OnPossessFailed(%d) OnPossessFailedCalled:%d"), *GetName(), FailureReason,
+		   OnPossessFailedCalled);
 }
 
 void ATestPossessionPlayerController::RemotePossess_Implementation(APawn* InPawn)

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
@@ -16,3 +16,9 @@ void ATestPossessionPlayerController::OnUnPossess()
 	Super::OnUnPossess();
 	OnUnPossessEvent.Broadcast(this);
 }
+
+void ATestPossessionPlayerController::OnPossessFailed(ERemotePossessFailure FailureReason)
+{
+	Super::OnPossessFailed(FailureReason);
+	OnPossessFailureEvent.Broadcast(FailureReason, this);
+}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
@@ -6,7 +6,7 @@
 #include "TestPossessionPlayerController.generated.h"
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnPossess, APawn*, Pawn, APlayerController*, Controller);
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnPossessFailure, ERemotePossessFailure, FailureReason, APlayerController*, Controller);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnPossessFailed, ERemotePossessFailure, FailureReason, APlayerController*, Controller);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnUnPossess, APlayerController*, Controller);
 
 UCLASS()
@@ -27,5 +27,5 @@ public:
 
 	FOnUnPossess OnUnPossessEvent;
 
-	FOnPossessFailure OnPossessFailureEvent;
+	FOnPossessFailed OnPossessFailedEvent;
 };

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
@@ -6,6 +6,7 @@
 #include "TestPossessionPlayerController.generated.h"
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnPossess, APawn*, Pawn, APlayerController*, Controller);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnPossessFailure, ERemotePossessFailure, FailureReason, APlayerController*, Controller);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnUnPossess, APlayerController*, Controller);
 
 UCLASS()
@@ -17,10 +18,14 @@ private:
 
 	virtual void OnUnPossess() override;
 
+	virtual void OnPossessFailed(ERemotePossessFailure FailureReason) override;
+
 public:
 	ATestPossessionPlayerController();
 
 	FOnPossess OnPossessEvent;
 
 	FOnUnPossess OnUnPossessEvent;
+
+	FOnPossessFailure OnPossessFailureEvent;
 };

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
@@ -5,9 +5,7 @@
 #include "CoreMinimal.h"
 #include "TestPossessionPlayerController.generated.h"
 
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnPossess, APawn*, Pawn, APlayerController*, Controller);
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnPossessFailed, ERemotePossessFailure, FailureReason, APlayerController*, Controller);
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnUnPossess, APlayerController*, Controller);
+DECLARE_LOG_CATEGORY_EXTERN(LogTestPossessionPlayerController, Log, All);
 
 UCLASS()
 class ATestPossessionPlayerController : public APlayerController
@@ -19,13 +17,15 @@ private:
 	virtual void OnUnPossess() override;
 
 	virtual void OnPossessFailed(ERemotePossessFailure FailureReason) override;
-
 public:
 	ATestPossessionPlayerController();
 
-	FOnPossess OnPossessEvent;
+	UFUNCTION(Server, Reliable)
+	void RemotePossess(APawn* InPawn);
 
-	FOnUnPossess OnUnPossessEvent;
+	static void ResetCalledCounter();
 
-	FOnPossessFailed OnPossessFailedEvent;
+	static int32 OnPossessCalled;
+
+	static int32 OnPossessFailedCalled;
 };

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
@@ -17,6 +17,7 @@ private:
 	virtual void OnUnPossess() override;
 
 	virtual void OnPossessFailed(ERemotePossessFailure FailureReason) override;
+
 public:
 	ATestPossessionPlayerController();
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
@@ -1,0 +1,26 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "TestPossessionPlayerController.generated.h"
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnPossess, APawn*, Pawn, APlayerController*, Controller);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnUnPossess, APlayerController*, Controller);
+
+UCLASS()
+class ATestPossessionPlayerController : public APlayerController
+{
+	GENERATED_BODY()
+private:
+	virtual void OnPossess(APawn* InPawn) override;
+
+	virtual void OnUnPossess() override;
+
+public:
+	ATestPossessionPlayerController();
+
+	FOnPossess OnPossessEvent;
+
+	FOnUnPossess OnUnPossessEvent;
+};


### PR DESCRIPTION
#### Description
Add SpatialPossession.h/cpp which contains blueprint callable function RemotePossess

#### Release note
REQUIRED: Add a release note to the `##Unreleased` section of CHANGELOG.md. You can find guidance for writing useful release notes [here](../SpatialGDK/Extras/internal-documentation/how-to-write-good-release-notes.md). Documentation changes are exempt from this requirement.

#### Tests
How did you test these changes prior to submitting this pull request?
What automated tests are included in this PR?

STRONGLY SUGGESTED: How can this be verified by QA?

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

#### Reminders (IMPORTANT)
If your change relies on a breaking engine change:
* Increment `SPATIAL_ENGINE_VERSION` in `Engine\Source\Runtime\Launch\Resources\SpatialVersion.h` (in the engine fork) as well as `SPATIAL_GDK_VERSION` in `SpatialGDK\Source\SpatialGDK\Public\Utils\EngineVersionCheck.h`. This helps others by providing a more helpful message during compilation to make sure the GDK and the Engine are up to date.

If your change updates `Setup.bat`, `Setup.sh`, core SDK version, any C# tools in `SpatialGDK\Build\Programs\Improbable.Unreal.Scripts`, or hand-written schema in `SpatialGDK\Extras\schema`:
* Increment the number in `RequireSetup`. This will automatically run `Setup.bat` or `Setup.sh` when the GDK is next pulled.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
