### PR TITLE
[UNR-4482] Change how bCanSpawnActorWithAuthority is set after an update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ These functions and structs can be referenced in both code and blueprints it may
 - Fixed a bug where deployment would fail in the presence of trailing spaces in the `Flags` and `LegacyFlags` fields of the `SpatialGDKEditorSettings`.
 - Fixed a crash that would occur when performing multiple Client Travels at once.
 - Add ServerOnlyAlwaysRelevant component and component set schema definitions
+- Fixed a snapshot reloading issue where worker would create extra actors, as if they were loading on a fresh deployment.
 
 ## [`0.11.0`] - 2020-09-03
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
@@ -226,8 +226,8 @@ void UGlobalStateManager::ApplyStartupActorManagerUpdate(Schema_ComponentUpdate*
 {
 	Schema_Object* ComponentObject = Schema_GetComponentUpdateFields(Update);
 
+	bCanSpawnWithAuthority = !bCanBeginPlay;
 	bCanBeginPlay = GetBoolFromSchema(ComponentObject, SpatialConstants::STARTUP_ACTOR_MANAGER_CAN_BEGIN_PLAY_ID);
-	bCanSpawnWithAuthority = true;
 }
 
 void UGlobalStateManager::SetDeploymentState()

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
@@ -226,6 +226,11 @@ void UGlobalStateManager::ApplyStartupActorManagerUpdate(Schema_ComponentUpdate*
 {
 	Schema_Object* ComponentObject = Schema_GetComponentUpdateFields(Update);
 
+	// The update can only happen after having read the initial GSM state.
+	// It is gated on the leader getting its VirtualWorkerId, gated in the Translation manager getting all the workers it need
+	// gated on all workers sending ReadyToBeginPlay, which happens in ApplyStartupActorManagerData.
+	// We are in the same situation as the leader when it is running AuthorityChanged on STARTUP_ACTOR_MANAGER_COMPONENT_ID.
+	// So we apply the same logic on setting bCanSpawnWithAuthority before reading the new value of bCanBeginPlay.
 	bCanSpawnWithAuthority = !bCanBeginPlay;
 	bCanBeginPlay = GetBoolFromSchema(ComponentObject, SpatialConstants::STARTUP_ACTOR_MANAGER_CAN_BEGIN_PLAY_ID);
 }


### PR DESCRIPTION
#### Description
Bump pinned runtime version to 15.0.0-preview-5 to fix an issue where snapshot were saved containing a partition component which could not be reloaded.
The issue is that when reloading from a snapshot, some workers recreate their startup actors. Namely, their singletons, GameState and GameMode. This was due to a race in the startup sequence on an update to the GSM.

Analysis : 
In UGlobalStateManager::ApplyStartupActorManagerUpdate, changing 

```
bCanBeginPlay = Schema_ReadBool(...
bCanSpawnWithAuth = true
```
to 

```
bCanSpawnWithAuth = !bCanBeginPlay
bCanBeginPlay = Schema_ReadBool(...
```

**StartupSequence :** 

Wait for GlobalStateManager->IsReady() == bCanBeginPlay || IsLeader()
Wait for WorkerTranslation->IsReady() (the worker translation manager waits for IsReadyToBeginPlay before assigning WorkerIds)
Wait for receiving auth over the partition.
TriggerBeginPlay (does the job of creating the startup actors, and is not supposed to do it if reloading from snapshots)

**Initial state :** 
bCanBeginPlay = false
bCanSpawnWithAuth = false

Receive GSM data with bCanBeginPlay == false (new deployment)

- SendReadyToBeginPlay
- TryFinishStartup gated on GlobalStateManager->IsReady() (except for the leader). Has to wait on an update from the Leader worker.
- The leader worker should be gated on reading its own worker id. The work on the worker translation manager continues in the background.
- The GSM update will be sent once the LeaderWorker triggers begin play.
- corollary : **No one can proceed further in the startup sequence unless all the workers have read the initial state.**
- Update sent, bCanSpawnWithAuth set to true, bCanBeginPlay set to true.
- TriggerBeginPlay spawns actors with auth

Receive GSM data with bCanBeginPlay = true (reload from snapshot)
- SendReadyToBeginPlay
- TryFinishStartup gated on virtual worker assignment. Once the leader has done its job of assigning partition, this is unlocked.
- (WHERE THE RACE WAS) Now we may or may not have received the Update to the GSM before triggering BeginPlay.
-- Before : If the update was received, it would have set bCanSpawnWithAuth to true.
-- Now : The update won't change bCanSpawnWithAuth.
- TriggerBeginPlay does not spawn actors with auth.


Question stemming form the change : Can it happen that on a fresh deployment a worker erroneously thinks it can not spawn with auth ?
Only possible if it reads the GSM initial state after an update has been made by the leader, which we showed cannot happen.


#### Release note

#### Tests
Tested in the snapshot test by adding more server and check the client's viewed game states.
https://github.com/spatialos/UnrealGDKTestGyms/pull/250
#### Documentation

