### PR TITLE
Feature/unr 4029 spike sender cross server rpc

### DIFF
--- a/SpatialGDK/Extras/schema/global_state_manager.schema
+++ b/SpatialGDK/Extras/schema/global_state_manager.schema
@@ -21,6 +21,7 @@ component DeploymentMap {
 component StartupActorManager {
     id = 9993;
     bool can_begin_play = 1;
+    string routing_worker = 2;
 }
 
 component GSMShutdown {

--- a/SpatialGDK/Extras/schema/rpc_payload.schema
+++ b/SpatialGDK/Extras/schema/rpc_payload.schema
@@ -12,3 +12,7 @@ type UnrealRPCPayload {
     bytes rpc_payload = 3;
     option<TracePayload> rpc_trace = 4;
 }
+
+type ACKList {
+    list<uint64> acks = 1;
+}

--- a/SpatialGDK/Extras/schema/rpc_payload.schema
+++ b/SpatialGDK/Extras/schema/rpc_payload.schema
@@ -16,3 +16,9 @@ type UnrealRPCPayload {
 type ACKList {
     list<uint64> acks = 1;
 }
+
+type ACKItem {
+    EntityId sender = 1;
+    uint64 rpc_id = 2;
+    uint64 sender_revision = 3;
+}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1576,21 +1576,21 @@ void USpatialNetDriver::ProcessRPC(AActor* Actor, UObject* SubObject, UFunction*
 	AActor* SenderActor = nullptr;
 	if (Function->FunctionFlags & FUNC_NetCrossServer)
 	{
-		UProperty* SenderProp = nullptr;
-		for (auto It = TFieldIterator<UProperty>(Function); It; ++It)
-		{
-			if (It->GetPropertyFlags() & CPF_CrossServerSender)
-			{
-				SenderProp = *It;
-			}
-		}
-		if (SenderProp)
-		{
-			UObjectProperty* obj = Cast<UObjectProperty>(SenderProp);
-			check(obj != nullptr);
-
-			SenderActor = Cast<AActor>(obj->GetObjectPropertyValue((uint8*)Parameters + obj->GetOffset_ForUFunction()));
-		}
+		// UProperty* SenderProp = nullptr;
+		// for (auto It = TFieldIterator< UProperty >(Function); It; ++It)
+		//{
+		//	if (It->GetPropertyFlags() & CPF_CrossServerSender)
+		//	{
+		//		SenderProp = *It;
+		//	}
+		//}
+		// if (SenderProp)
+		//{
+		//	UObjectProperty* obj = Cast<UObjectProperty>(SenderProp);
+		//	check(obj != nullptr);
+		//
+		//	SenderActor = Cast<AActor>(obj->GetObjectPropertyValue((uint8*)Parameters + obj->GetOffset_ForUFunction()));
+		//}
 	}
 
 	FUnrealObjectRef SenderObjectRef;

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1573,7 +1573,32 @@ void USpatialNetDriver::ProcessRPC(AActor* Actor, UObject* SubObject, UFunction*
 	}
 	RPCPayload Payload = Sender->CreateRPCPayloadFromParams(CallingObject, CallingObjectRef, Function, Parameters);
 
-	Sender->ProcessOrQueueOutgoingRPC(CallingObjectRef, MoveTemp(Payload));
+	AActor* SenderActor = nullptr;
+	if (Function->FunctionFlags & FUNC_NetCrossServer)
+	{
+		UProperty* SenderProp = nullptr;
+		for (auto It = TFieldIterator< UProperty >(Function); It; ++It)
+		{
+			if (It->GetPropertyFlags() & CPF_CrossServerSender)
+			{
+				SenderProp = *It;
+			}
+		}
+		if (SenderProp)
+		{
+			UObjectProperty* obj = Cast<UObjectProperty>(SenderProp);
+			check(obj != nullptr);
+			
+			SenderActor = Cast<AActor>(obj->GetObjectPropertyValue((uint8*)Parameters + obj->GetOffset_ForUFunction()));
+		}
+	}
+
+	FUnrealObjectRef SenderObjectRef;
+	if (SenderActor)
+	{
+		SenderObjectRef = PackageMap->GetUnrealObjectRefFromObject(SenderActor);
+	}
+	Sender->ProcessOrQueueOutgoingRPC(CallingObjectRef, SenderObjectRef, MoveTemp(Payload));
 }
 
 // SpatialGDK: This is a modified and simplified version of UNetDriver::ServerReplicateActors.
@@ -2589,6 +2614,11 @@ void USpatialNetDriver::TryFinishStartup()
 		bIsReadyToStart = true;
 		Connection->SetStartupComplete();
 	}
+
+	if (bIsReadyToStart)
+	{
+		Sender->UpdateServerWorkerVisibility();
+	}
 }
 
 // This should only be called once on each client, in the SpatialMetricsDisplay constructor after the class is replicated to each client.
@@ -2650,4 +2680,17 @@ void USpatialNetDriver::InitializeVirtualWorkerTranslationManager()
 	VirtualWorkerTranslationManager =
 		MakeUnique<SpatialVirtualWorkerTranslationManager>(Receiver, Connection, VirtualWorkerTranslator.Get());
 	VirtualWorkerTranslationManager->SetNumberOfVirtualWorkers(LoadBalanceStrategy->GetMinimumRequiredWorkers());
+}
+
+const FString& USpatialNetDriver::GetRoutingWorkerId()
+{
+	return GlobalStateManager->GetRoutingWorkerId();
+}
+
+bool USpatialNetDriver::IsRoutingWorker()
+{
+	FString WorkerId = Connection->GetWorkerId();
+	FString RoutingWorker = GlobalStateManager->GetRoutingWorkerId();
+
+	return IsServer() && WorkerId == RoutingWorker;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1577,7 +1577,7 @@ void USpatialNetDriver::ProcessRPC(AActor* Actor, UObject* SubObject, UFunction*
 	if (Function->FunctionFlags & FUNC_NetCrossServer)
 	{
 		UProperty* SenderProp = nullptr;
-		for (auto It = TFieldIterator< UProperty >(Function); It; ++It)
+		for (auto It = TFieldIterator<UProperty>(Function); It; ++It)
 		{
 			if (It->GetPropertyFlags() & CPF_CrossServerSender)
 			{
@@ -1588,7 +1588,7 @@ void USpatialNetDriver::ProcessRPC(AActor* Actor, UObject* SubObject, UFunction*
 		{
 			UObjectProperty* obj = Cast<UObjectProperty>(SenderProp);
 			check(obj != nullptr);
-			
+
 			SenderActor = Cast<AActor>(obj->GetObjectPropertyValue((uint8*)Parameters + obj->GetOffset_ForUFunction()));
 		}
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
@@ -82,7 +82,7 @@ ERPCType GetRPCType(UFunction* RemoteFunction)
 	}
 	else if (RemoteFunction->HasAnyFunctionFlags(FUNC_NetCrossServer))
 	{
-		return ERPCType::CrossServer;
+		return ERPCType::CrossServerSender;
 	}
 	else if (RemoteFunction->HasAnyFunctionFlags(FUNC_NetReliable))
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialRPCService.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialRPCService.cpp
@@ -11,726 +11,716 @@
 
 DEFINE_LOG_CATEGORY(LogSpatialRPCService);
 
-#pragma optimize ("", off)
+#pragma optimize("", off)
 
 namespace SpatialGDK
 {
-	SpatialRPCService::SpatialRPCService(ExtractRPCDelegate ExtractRPCCallback, const USpatialStaticComponentView* View,
-		USpatialLatencyTracer* SpatialLatencyTracer)
-		: ExtractRPCCallback(ExtractRPCCallback)
-		, View(View)
-		, SpatialLatencyTracer(SpatialLatencyTracer)
+SpatialRPCService::SpatialRPCService(ExtractRPCDelegate ExtractRPCCallback, const USpatialStaticComponentView* View,
+									 USpatialLatencyTracer* SpatialLatencyTracer)
+	: ExtractRPCCallback(ExtractRPCCallback)
+	, View(View)
+	, SpatialLatencyTracer(SpatialLatencyTracer)
+{
+	CrossServerMailbox.SetNumZeroed(RPCRingBufferUtils::GetRingBufferSize(ERPCType::CrossServerSender));
+}
+
+EPushRPCResult SpatialRPCService::PushRPC(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType Type, RPCPayload Payload,
+										  bool bCreatedEntity)
+{
+	EntityRPCType EntityType = EntityRPCType(EntityId, Type);
+
+	EPushRPCResult Result = EPushRPCResult::Success;
+
+	if (RPCRingBufferUtils::ShouldQueueOverflowed(Type) && OverflowedRPCs.Contains(EntityType))
 	{
-		CrossServerMailbox.SetNumZeroed(RPCRingBufferUtils::GetRingBufferSize(ERPCType::CrossServerSender));
+		// Already has queued RPCs of this type, queue until those are pushed.
+		AddOverflowedRPC(EntityType, MoveTemp(Payload));
+		Result = EPushRPCResult::QueueOverflowed;
 	}
-
-	EPushRPCResult SpatialRPCService::PushRPC(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType Type, RPCPayload Payload, bool bCreatedEntity)
+	else
 	{
-		EntityRPCType EntityType = EntityRPCType(EntityId, Type);
+		Result = PushRPCInternal(EntityId, Counterpart, Type, MoveTemp(Payload), bCreatedEntity);
 
-		EPushRPCResult Result = EPushRPCResult::Success;
-
-		if (RPCRingBufferUtils::ShouldQueueOverflowed(Type) && OverflowedRPCs.Contains(EntityType))
+		if (Result == EPushRPCResult::QueueOverflowed)
 		{
-			// Already has queued RPCs of this type, queue until those are pushed.
 			AddOverflowedRPC(EntityType, MoveTemp(Payload));
-			Result = EPushRPCResult::QueueOverflowed;
 		}
-		else
-		{
-			Result = PushRPCInternal(EntityId, Counterpart, Type, MoveTemp(Payload), bCreatedEntity);
-
-			if (Result == EPushRPCResult::QueueOverflowed)
-			{
-				AddOverflowedRPC(EntityType, MoveTemp(Payload));
-			}
-		}
+	}
 
 #if TRACE_LIB_ACTIVE
-		ProcessResultToLatencyTrace(Result, Payload.Trace);
+	ProcessResultToLatencyTrace(Result, Payload.Trace);
 #endif
 
-		return Result;
-	}
+	return Result;
+}
 
-	EPushRPCResult SpatialRPCService::PushRPCInternal(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType Type, RPCPayload&& Payload, bool bCreatedEntity)
+EPushRPCResult SpatialRPCService::PushRPCInternal(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType Type,
+												  RPCPayload&& Payload, bool bCreatedEntity)
+{
+	const Worker_ComponentId RingBufferComponentId = RPCRingBufferUtils::GetRingBufferComponentId(Type);
+
+	const EntityComponentId EntityComponent = { EntityId, RingBufferComponentId };
+	const EntityRPCType EntityType = EntityRPCType(EntityId, Type);
+
+	Schema_Object* EndpointObject;
+	uint64 LastAckedRPCId;
+	if (View->HasComponent(EntityId, RingBufferComponentId))
 	{
-		const Worker_ComponentId RingBufferComponentId = RPCRingBufferUtils::GetRingBufferComponentId(Type);
-
-		const EntityComponentId EntityComponent = { EntityId, RingBufferComponentId };
-		const EntityRPCType EntityType = EntityRPCType(EntityId, Type);
-
-		Schema_Object* EndpointObject;
-		uint64 LastAckedRPCId;
-		if (View->HasComponent(EntityId, RingBufferComponentId))
-		{
-			if (!View->HasAuthority(EntityId, RingBufferComponentId))
-			{
-				if (bCreatedEntity)
-				{
-					return EPushRPCResult::EntityBeingCreated;
-				}
-				return EPushRPCResult::NoRingBufferAuthority;
-			}
-
-			EndpointObject = Schema_GetComponentUpdateFields(GetOrCreateComponentUpdate(EntityComponent));
-
-			if (Type == ERPCType::NetMulticast)
-			{
-				// Assume all multicast RPCs are auto-acked.
-				LastAckedRPCId = LastSentRPCIds.FindRef(EntityType);
-			}
-			else
-			{
-				// Ignore these while the routing worker can be anyone.
-				if (Type != ERPCType::CrossServerSender && Type != ERPCType::CrossServerReceiver)
-				{
-					// We shouldn't have authority over the component that has the acks.
-					if (View->HasAuthority(EntityId, RPCRingBufferUtils::GetAckComponentId(Type)))
-					{
-						return EPushRPCResult::HasAckAuthority;
-					}
-					LastAckedRPCId = GetAckFromView(EntityId, Type);
-				}
-			}
-		}
-		else
+		if (!View->HasAuthority(EntityId, RingBufferComponentId))
 		{
 			if (bCreatedEntity)
 			{
 				return EPushRPCResult::EntityBeingCreated;
 			}
-			// If the entity isn't in the view, we assume this RPC was called before
-			// CreateEntityRequest, so we put it into a component data object.
-			EndpointObject = Schema_GetComponentDataFields(GetOrCreateComponentData(EntityComponent));
-
-			LastAckedRPCId = 0;
+			return EPushRPCResult::NoRingBufferAuthority;
 		}
 
-		uint64 NewRPCId = LastSentRPCIds.FindRef(EntityType) + 1;
-		EPushRPCResult Result = EPushRPCResult::Success;
+		EndpointObject = Schema_GetComponentUpdateFields(GetOrCreateComponentUpdate(EntityComponent));
 
-		if (Type == ERPCType::CrossServerSender)
+		if (Type == ERPCType::NetMulticast)
 		{
-			TOptional<uint32> Slot = FindFreeSlotForCrossServerSender();
-			if (Slot)
+			// Assume all multicast RPCs are auto-acked.
+			LastAckedRPCId = LastSentRPCIds.FindRef(EntityType);
+		}
+		else
+		{
+			// Ignore these while the routing worker can be anyone.
+			if (Type != ERPCType::CrossServerSender && Type != ERPCType::CrossServerReceiver)
 			{
-				int32 SlotIdx = Slot.GetValue();
-
-				RPCRingBufferDescriptor Descriptor = RPCRingBufferUtils::GetRingBufferDescriptor(Type);
-				uint32 Field = Descriptor.GetRingBufferElementFieldId(ERPCType::CrossServerSender, SlotIdx + 1);
-
-				Schema_Object* RPCObject = Schema_AddObject(EndpointObject, Field);
-				Payload.WriteToSchemaObject(RPCObject);
-
-				FUnrealObjectRef Target = Counterpart;
-				Target.Offset = NewRPCId;
-				AddObjectRefToSchema(EndpointObject, Field + 1, Target);
-
-				Schema_ClearField(EndpointObject, Descriptor.LastSentRPCFieldId);
-				Schema_AddUint64(EndpointObject, Descriptor.LastSentRPCFieldId, NewRPCId);
-
-				CrossServerEndpointSender* Sender = View->GetComponentData<CrossServerEndpointSender>(EntityId);
-				if (ensure(Sender != nullptr))
+				// We shouldn't have authority over the component that has the acks.
+				if (View->HasAuthority(EntityId, RPCRingBufferUtils::GetAckComponentId(Type)))
 				{
-					RPCRingBuffer& Buffer = Sender->ReliableRPCBuffer;
-					Buffer.RingBuffer[SlotIdx].Emplace(Payload);
-					Buffer.Counterpart[SlotIdx].Emplace(Target);
+					return EPushRPCResult::HasAckAuthority;
+				}
+				LastAckedRPCId = GetAckFromView(EntityId, Type);
+			}
+		}
+	}
+	else
+	{
+		if (bCreatedEntity)
+		{
+			return EPushRPCResult::EntityBeingCreated;
+		}
+		// If the entity isn't in the view, we assume this RPC was called before
+		// CreateEntityRequest, so we put it into a component data object.
+		EndpointObject = Schema_GetComponentDataFields(GetOrCreateComponentData(EntityComponent));
 
-					SentRPCEntry& Entry = CrossServerMailbox[SlotIdx];
-					Entry.RPCId = NewRPCId;
-					Entry.Target = Target.Entity;
-					Entry.Timestamp = FPlatformTime::Cycles64();
-				}
-				else
-				{
-					Result = EPushRPCResult::EntityBeingCreated;
-				}
+		LastAckedRPCId = 0;
+	}
+
+	uint64 NewRPCId = LastSentRPCIds.FindRef(EntityType) + 1;
+	EPushRPCResult Result = EPushRPCResult::Success;
+
+	if (Type == ERPCType::CrossServerSender)
+	{
+		TOptional<uint32> Slot = FindFreeSlotForCrossServerSender();
+		if (Slot)
+		{
+			int32 SlotIdx = Slot.GetValue();
+
+			RPCRingBufferDescriptor Descriptor = RPCRingBufferUtils::GetRingBufferDescriptor(Type);
+			uint32 Field = Descriptor.GetRingBufferElementFieldId(ERPCType::CrossServerSender, SlotIdx + 1);
+
+			Schema_Object* RPCObject = Schema_AddObject(EndpointObject, Field);
+			Payload.WriteToSchemaObject(RPCObject);
+
+			FUnrealObjectRef Target = Counterpart;
+			Target.Offset = NewRPCId;
+			AddObjectRefToSchema(EndpointObject, Field + 1, Target);
+
+			Schema_ClearField(EndpointObject, Descriptor.LastSentRPCFieldId);
+			Schema_AddUint64(EndpointObject, Descriptor.LastSentRPCFieldId, NewRPCId);
+
+			CrossServerEndpointSender* Sender = View->GetComponentData<CrossServerEndpointSender>(EntityId);
+			if (ensure(Sender != nullptr))
+			{
+				RPCRingBuffer& Buffer = Sender->ReliableRPCBuffer;
+				Buffer.RingBuffer[SlotIdx].Emplace(Payload);
+				Buffer.Counterpart[SlotIdx].Emplace(Target);
+
+				SentRPCEntry& Entry = CrossServerMailbox[SlotIdx];
+				Entry.RPCId = NewRPCId;
+				Entry.Target = Target.Entity;
+				Entry.Timestamp = FPlatformTime::Cycles64();
 			}
 			else
 			{
-				// Overflowed
-				if (RPCRingBufferUtils::ShouldQueueOverflowed(Type))
-				{
-					Result = EPushRPCResult::QueueOverflowed;
-				}
-				else
-				{
-					Result = EPushRPCResult::DropOverflowed;
-				}
+				Result = EPushRPCResult::EntityBeingCreated;
 			}
 		}
 		else
 		{
-			// Check capacity.
-			if (LastAckedRPCId + RPCRingBufferUtils::GetRingBufferSize(Type) >= NewRPCId)
+			// Overflowed
+			if (RPCRingBufferUtils::ShouldQueueOverflowed(Type))
 			{
-				RPCRingBufferUtils::WriteRPCToSchema(EndpointObject, Type, NewRPCId, Payload);
+				Result = EPushRPCResult::QueueOverflowed;
 			}
 			else
 			{
-				// Overflowed
-				if (RPCRingBufferUtils::ShouldQueueOverflowed(Type))
-				{
-					return EPushRPCResult::QueueOverflowed;
-				}
-				else
-				{
-					return EPushRPCResult::DropOverflowed;
-				}
+				Result = EPushRPCResult::DropOverflowed;
 			}
 		}
-
-		if (Result == EPushRPCResult::Success)
+	}
+	else
+	{
+		// Check capacity.
+		if (LastAckedRPCId + RPCRingBufferUtils::GetRingBufferSize(Type) >= NewRPCId)
 		{
-			LastSentRPCIds.Add(EntityType, NewRPCId);
-
-#if TRACE_LIB_ACTIVE
-			if (SpatialLatencyTracer != nullptr && Payload.Trace != InvalidTraceKey)
-			{
-				if (PendingTraces.Find(EntityComponent) == nullptr)
-				{
-					PendingTraces.Add(EntityComponent, Payload.Trace);
-				}
-				else
-				{
-					SpatialLatencyTracer->WriteAndEndTrace(Payload.Trace,
-						TEXT("Multiple rpc updates in single update, ending further stack tracing"), true);
-				}
-			}
-#endif
+			RPCRingBufferUtils::WriteRPCToSchema(EndpointObject, Type, NewRPCId, Payload);
 		}
-
-		return Result;
+		else
+		{
+			// Overflowed
+			if (RPCRingBufferUtils::ShouldQueueOverflowed(Type))
+			{
+				return EPushRPCResult::QueueOverflowed;
+			}
+			else
+			{
+				return EPushRPCResult::DropOverflowed;
+			}
+		}
 	}
 
-	void SpatialRPCService::PushOverflowedRPCs()
+	if (Result == EPushRPCResult::Success)
 	{
-		for (auto It = OverflowedRPCs.CreateIterator(); It; ++It)
+		LastSentRPCIds.Add(EntityType, NewRPCId);
+
+#if TRACE_LIB_ACTIVE
+		if (SpatialLatencyTracer != nullptr && Payload.Trace != InvalidTraceKey)
 		{
-			Worker_EntityId EntityId = It.Key().EntityId;
-			ERPCType Type = It.Key().Type;
-			TArray<RPCPayload>& OverflowedRPCArray = It.Value();
-
-			int NumProcessed = 0;
-			bool bShouldDrop = false;
-			for (RPCPayload& Payload : OverflowedRPCArray)
+			if (PendingTraces.Find(EntityComponent) == nullptr)
 			{
-				const EPushRPCResult Result = PushRPCInternal(EntityId, FUnrealObjectRef(), Type, MoveTemp(Payload), false);
+				PendingTraces.Add(EntityComponent, Payload.Trace);
+			}
+			else
+			{
+				SpatialLatencyTracer->WriteAndEndTrace(Payload.Trace,
+													   TEXT("Multiple rpc updates in single update, ending further stack tracing"), true);
+			}
+		}
+#endif
+	}
 
-				switch (Result)
-				{
-				case EPushRPCResult::Success:
-					NumProcessed++;
-					break;
-				case EPushRPCResult::QueueOverflowed:
-					UE_LOG(LogSpatialRPCService, Log,
-						TEXT("SpatialRPCService::PushOverflowedRPCs: Sent some but not all overflowed RPCs. RPCs sent %d, RPCs still "
+	return Result;
+}
+
+void SpatialRPCService::PushOverflowedRPCs()
+{
+	for (auto It = OverflowedRPCs.CreateIterator(); It; ++It)
+	{
+		Worker_EntityId EntityId = It.Key().EntityId;
+		ERPCType Type = It.Key().Type;
+		TArray<RPCPayload>& OverflowedRPCArray = It.Value();
+
+		int NumProcessed = 0;
+		bool bShouldDrop = false;
+		for (RPCPayload& Payload : OverflowedRPCArray)
+		{
+			const EPushRPCResult Result = PushRPCInternal(EntityId, FUnrealObjectRef(), Type, MoveTemp(Payload), false);
+
+			switch (Result)
+			{
+			case EPushRPCResult::Success:
+				NumProcessed++;
+				break;
+			case EPushRPCResult::QueueOverflowed:
+				UE_LOG(LogSpatialRPCService, Log,
+					   TEXT("SpatialRPCService::PushOverflowedRPCs: Sent some but not all overflowed RPCs. RPCs sent %d, RPCs still "
 							"overflowed: %d, Entity: %lld, RPC type: %s"),
-						NumProcessed, OverflowedRPCArray.Num() - NumProcessed, EntityId, *SpatialConstants::RPCTypeToString(Type));
-					break;
-				case EPushRPCResult::DropOverflowed:
-					checkf(false, TEXT("Shouldn't be able to drop on overflow for RPC type that was previously queued."));
-					break;
-				case EPushRPCResult::HasAckAuthority:
-					UE_LOG(LogSpatialRPCService, Warning,
-						TEXT("SpatialRPCService::PushOverflowedRPCs: Gained authority over ack component for RPC type that was overflowed. "
+					   NumProcessed, OverflowedRPCArray.Num() - NumProcessed, EntityId, *SpatialConstants::RPCTypeToString(Type));
+				break;
+			case EPushRPCResult::DropOverflowed:
+				checkf(false, TEXT("Shouldn't be able to drop on overflow for RPC type that was previously queued."));
+				break;
+			case EPushRPCResult::HasAckAuthority:
+				UE_LOG(LogSpatialRPCService, Warning,
+					   TEXT("SpatialRPCService::PushOverflowedRPCs: Gained authority over ack component for RPC type that was overflowed. "
 							"Entity: %lld, RPC type: %s"),
-						EntityId, *SpatialConstants::RPCTypeToString(Type));
-					bShouldDrop = true;
-					break;
-				case EPushRPCResult::NoRingBufferAuthority:
-					UE_LOG(LogSpatialRPCService, Warning,
-						TEXT("SpatialRPCService::PushOverflowedRPCs: Lost authority over ring buffer component for RPC type that was "
+					   EntityId, *SpatialConstants::RPCTypeToString(Type));
+				bShouldDrop = true;
+				break;
+			case EPushRPCResult::NoRingBufferAuthority:
+				UE_LOG(LogSpatialRPCService, Warning,
+					   TEXT("SpatialRPCService::PushOverflowedRPCs: Lost authority over ring buffer component for RPC type that was "
 							"overflowed. Entity: %lld, RPC type: %s"),
-						EntityId, *SpatialConstants::RPCTypeToString(Type));
-					bShouldDrop = true;
-					break;
-				default:
-					checkNoEntry();
-				}
+					   EntityId, *SpatialConstants::RPCTypeToString(Type));
+				bShouldDrop = true;
+				break;
+			default:
+				checkNoEntry();
+			}
 
 #if TRACE_LIB_ACTIVE
-				ProcessResultToLatencyTrace(Result, Payload.Trace);
+			ProcessResultToLatencyTrace(Result, Payload.Trace);
 #endif
 
-				// This includes the valid case of RPCs still overflowing (EPushRPCResult::QueueOverflowed), as well as the error cases.
-				if (Result != EPushRPCResult::Success)
-				{
-					break;
-				}
-			}
-
-			if (NumProcessed == OverflowedRPCArray.Num() || bShouldDrop)
+			// This includes the valid case of RPCs still overflowing (EPushRPCResult::QueueOverflowed), as well as the error cases.
+			if (Result != EPushRPCResult::Success)
 			{
-				It.RemoveCurrent();
-			}
-			else
-			{
-				OverflowedRPCArray.RemoveAt(0, NumProcessed);
+				break;
 			}
 		}
-	}
 
-	void SpatialRPCService::ClearOverflowedRPCs(Worker_EntityId EntityId)
-	{
-		for (uint8 RPCType = static_cast<uint8>(ERPCType::ClientReliable); RPCType <= static_cast<uint8>(ERPCType::NetMulticast); RPCType++)
+		if (NumProcessed == OverflowedRPCArray.Num() || bShouldDrop)
 		{
-			OverflowedRPCs.Remove(EntityRPCType(EntityId, static_cast<ERPCType>(RPCType)));
+			It.RemoveCurrent();
+		}
+		else
+		{
+			OverflowedRPCArray.RemoveAt(0, NumProcessed);
 		}
 	}
+}
 
-	TArray<SpatialRPCService::UpdateToSend> SpatialRPCService::GetRPCsAndAcksToSend()
+void SpatialRPCService::ClearOverflowedRPCs(Worker_EntityId EntityId)
+{
+	for (uint8 RPCType = static_cast<uint8>(ERPCType::ClientReliable); RPCType <= static_cast<uint8>(ERPCType::NetMulticast); RPCType++)
 	{
-		TArray<SpatialRPCService::UpdateToSend> UpdatesToSend;
+		OverflowedRPCs.Remove(EntityRPCType(EntityId, static_cast<ERPCType>(RPCType)));
+	}
+}
 
-		for (auto& It : PendingComponentUpdatesToSend)
+TArray<SpatialRPCService::UpdateToSend> SpatialRPCService::GetRPCsAndAcksToSend()
+{
+	TArray<SpatialRPCService::UpdateToSend> UpdatesToSend;
+
+	for (auto& It : PendingComponentUpdatesToSend)
+	{
+		SpatialRPCService::UpdateToSend& UpdateToSend = UpdatesToSend.AddZeroed_GetRef();
+		UpdateToSend.EntityId = It.Key.EntityId;
+		UpdateToSend.Update.component_id = It.Key.ComponentId;
+		UpdateToSend.Update.schema_type = It.Value;
+#if TRACE_LIB_ACTIVE
+		TraceKey Trace = InvalidTraceKey;
+		PendingTraces.RemoveAndCopyValue(It.Key, Trace);
+		UpdateToSend.Update.Trace = Trace;
+#endif
+	}
+
+	PendingComponentUpdatesToSend.Empty();
+
+	return UpdatesToSend;
+}
+
+TArray<FWorkerComponentData> SpatialRPCService::GetRPCComponentsOnEntityCreation(Worker_EntityId EntityId)
+{
+	static Worker_ComponentId EndpointComponentIds[] = { SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID,
+														 SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID,
+														 SpatialConstants::MULTICAST_RPCS_COMPONENT_ID };
+
+	TArray<FWorkerComponentData> Components;
+
+	for (Worker_ComponentId EndpointComponentId : EndpointComponentIds)
+	{
+		const EntityComponentId EntityComponent = { EntityId, EndpointComponentId };
+
+		FWorkerComponentData& Component = Components.Emplace_GetRef(FWorkerComponentData{});
+		Component.component_id = EndpointComponentId;
+		if (Schema_ComponentData** ComponentData = PendingRPCsOnEntityCreation.Find(EntityComponent))
 		{
-			SpatialRPCService::UpdateToSend& UpdateToSend = UpdatesToSend.AddZeroed_GetRef();
-			UpdateToSend.EntityId = It.Key.EntityId;
-			UpdateToSend.Update.component_id = It.Key.ComponentId;
-			UpdateToSend.Update.schema_type = It.Value;
+			// When sending initial multicast RPCs, write the number of RPCs into a separate field instead of
+			// last sent RPC ID field. When the server gains authority for the first time, it will copy the
+			// value over to last sent RPC ID, so the clients that checked out the entity process the initial RPCs.
+			if (EndpointComponentId == SpatialConstants::MULTICAST_RPCS_COMPONENT_ID)
+			{
+				RPCRingBufferUtils::MoveLastSentIdToInitiallyPresentCount(Schema_GetComponentDataFields(*ComponentData),
+																		  LastSentRPCIds[EntityRPCType(EntityId, ERPCType::NetMulticast)]);
+			}
+
+			if (EndpointComponentId == SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID)
+			{
+				UE_LOG(LogSpatialRPCService, Error,
+					   TEXT("SpatialRPCService::GetRPCComponentsOnEntityCreation: Initial RPCs present on ClientEndpoint! EntityId: %lld"),
+					   EntityId);
+			}
+
+			Component.schema_type = *ComponentData;
 #if TRACE_LIB_ACTIVE
 			TraceKey Trace = InvalidTraceKey;
-			PendingTraces.RemoveAndCopyValue(It.Key, Trace);
-			UpdateToSend.Update.Trace = Trace;
+			PendingTraces.RemoveAndCopyValue(EntityComponent, Trace);
+			Component.Trace = Trace;
 #endif
+			PendingRPCsOnEntityCreation.Remove(EntityComponent);
 		}
-
-		PendingComponentUpdatesToSend.Empty();
-
-		return UpdatesToSend;
-	}
-
-	TArray<FWorkerComponentData> SpatialRPCService::GetRPCComponentsOnEntityCreation(Worker_EntityId EntityId)
-	{
-		static Worker_ComponentId EndpointComponentIds[] = { SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID,
-															 SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID,
-															 SpatialConstants::MULTICAST_RPCS_COMPONENT_ID };
-
-		TArray<FWorkerComponentData> Components;
-
-		for (Worker_ComponentId EndpointComponentId : EndpointComponentIds)
+		else
 		{
-			const EntityComponentId EntityComponent = { EntityId, EndpointComponentId };
-
-			FWorkerComponentData& Component = Components.Emplace_GetRef(FWorkerComponentData{});
-			Component.component_id = EndpointComponentId;
-			if (Schema_ComponentData** ComponentData = PendingRPCsOnEntityCreation.Find(EntityComponent))
-			{
-				// When sending initial multicast RPCs, write the number of RPCs into a separate field instead of
-				// last sent RPC ID field. When the server gains authority for the first time, it will copy the
-				// value over to last sent RPC ID, so the clients that checked out the entity process the initial RPCs.
-				if (EndpointComponentId == SpatialConstants::MULTICAST_RPCS_COMPONENT_ID)
-				{
-					RPCRingBufferUtils::MoveLastSentIdToInitiallyPresentCount(Schema_GetComponentDataFields(*ComponentData),
-						LastSentRPCIds[EntityRPCType(EntityId, ERPCType::NetMulticast)]);
-				}
-
-				if (EndpointComponentId == SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID)
-				{
-					UE_LOG(LogSpatialRPCService, Error,
-						TEXT("SpatialRPCService::GetRPCComponentsOnEntityCreation: Initial RPCs present on ClientEndpoint! EntityId: %lld"),
-						EntityId);
-				}
-
-				Component.schema_type = *ComponentData;
-#if TRACE_LIB_ACTIVE
-				TraceKey Trace = InvalidTraceKey;
-				PendingTraces.RemoveAndCopyValue(EntityComponent, Trace);
-				Component.Trace = Trace;
-#endif
-				PendingRPCsOnEntityCreation.Remove(EntityComponent);
-			}
-			else
-			{
-				Component.schema_type = Schema_CreateComponentData();
-			}
+			Component.schema_type = Schema_CreateComponentData();
 		}
-
-		return Components;
 	}
 
-	void SpatialRPCService::ExtractRPCsForEntity(Worker_EntityId EntityId, Worker_ComponentId ComponentId)
+	return Components;
+}
+
+void SpatialRPCService::ExtractRPCsForEntity(Worker_EntityId EntityId, Worker_ComponentId ComponentId)
+{
+	switch (ComponentId)
 	{
-		switch (ComponentId)
+	case SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID:
+		if (View->HasAuthority(EntityId, SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID))
 		{
-		case SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID:
-			if (View->HasAuthority(EntityId, SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID))
-			{
-				ExtractRPCsForType(EntityId, ERPCType::ServerReliable);
-				ExtractRPCsForType(EntityId, ERPCType::ServerUnreliable);
-			}
-			break;
-		case SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID:
-			if (View->HasAuthority(EntityId, SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID))
-			{
-				ExtractRPCsForType(EntityId, ERPCType::ClientReliable);
-				ExtractRPCsForType(EntityId, ERPCType::ClientUnreliable);
-			}
-			break;
-		case SpatialConstants::MULTICAST_RPCS_COMPONENT_ID:
-			ExtractRPCsForType(EntityId, ERPCType::NetMulticast);
-			break;
-		case SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID:
-			ExtractCrossServerRPCsForType(EntityId, ERPCType::CrossServerSender);
-			break;
-		case SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID:
-			ExtractRPCsForType(EntityId, ERPCType::CrossServerReceiver);
-			break;
-		default:
-			checkNoEntry();
-			break;
+			ExtractRPCsForType(EntityId, ERPCType::ServerReliable);
+			ExtractRPCsForType(EntityId, ERPCType::ServerUnreliable);
 		}
+		break;
+	case SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID:
+		if (View->HasAuthority(EntityId, SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID))
+		{
+			ExtractRPCsForType(EntityId, ERPCType::ClientReliable);
+			ExtractRPCsForType(EntityId, ERPCType::ClientUnreliable);
+		}
+		break;
+	case SpatialConstants::MULTICAST_RPCS_COMPONENT_ID:
+		ExtractRPCsForType(EntityId, ERPCType::NetMulticast);
+		break;
+	case SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID:
+		ExtractCrossServerRPCsForType(EntityId, ERPCType::CrossServerSender);
+		break;
+	case SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID:
+		ExtractRPCsForType(EntityId, ERPCType::CrossServerReceiver);
+		break;
+	default:
+		checkNoEntry();
+		break;
+	}
+}
+
+void SpatialRPCService::OnCheckoutMulticastRPCComponentOnEntity(Worker_EntityId EntityId)
+{
+	const MulticastRPCs* Component = View->GetComponentData<MulticastRPCs>(EntityId);
+
+	if (!ensure(Component != nullptr))
+	{
+		UE_LOG(LogSpatialRPCService, Error,
+			   TEXT("Multicast RPC component for entity with ID %lld was not present at point of checking out the component."), EntityId);
+		return;
 	}
 
-	void SpatialRPCService::OnCheckoutMulticastRPCComponentOnEntity(Worker_EntityId EntityId)
+	// When checking out entity, ignore multicast RPCs that are already on the component.
+	LastSeenMulticastRPCIds.Add(EntityId, Component->MulticastRPCBuffer.LastSentRPCId);
+}
+
+void SpatialRPCService::OnRemoveMulticastRPCComponentForEntity(Worker_EntityId EntityId)
+{
+	LastSeenMulticastRPCIds.Remove(EntityId);
+}
+
+void SpatialRPCService::OnEndpointAuthorityGained(Worker_EntityId EntityId, Worker_ComponentId ComponentId)
+{
+	switch (ComponentId)
+	{
+	case SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID:
+	{
+		const ClientEndpoint* Endpoint = View->GetComponentData<ClientEndpoint>(EntityId);
+		LastSeenRPCIds.Add(EntityRPCType(EntityId, ERPCType::ClientReliable), Endpoint->ReliableRPCAck);
+		LastSeenRPCIds.Add(EntityRPCType(EntityId, ERPCType::ClientUnreliable), Endpoint->UnreliableRPCAck);
+		LastAckedRPCIds.Add(EntityRPCType(EntityId, ERPCType::ClientReliable), Endpoint->ReliableRPCAck);
+		LastAckedRPCIds.Add(EntityRPCType(EntityId, ERPCType::ClientUnreliable), Endpoint->UnreliableRPCAck);
+		LastSentRPCIds.Add(EntityRPCType(EntityId, ERPCType::ServerReliable), Endpoint->ReliableRPCBuffer.LastSentRPCId);
+		LastSentRPCIds.Add(EntityRPCType(EntityId, ERPCType::ServerUnreliable), Endpoint->UnreliableRPCBuffer.LastSentRPCId);
+		break;
+	}
+	case SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID:
+	{
+		const ServerEndpoint* Endpoint = View->GetComponentData<ServerEndpoint>(EntityId);
+		LastSeenRPCIds.Add(EntityRPCType(EntityId, ERPCType::ServerReliable), Endpoint->ReliableRPCAck);
+		LastSeenRPCIds.Add(EntityRPCType(EntityId, ERPCType::ServerUnreliable), Endpoint->UnreliableRPCAck);
+		LastAckedRPCIds.Add(EntityRPCType(EntityId, ERPCType::ServerReliable), Endpoint->ReliableRPCAck);
+		LastAckedRPCIds.Add(EntityRPCType(EntityId, ERPCType::ServerUnreliable), Endpoint->UnreliableRPCAck);
+		LastSentRPCIds.Add(EntityRPCType(EntityId, ERPCType::ClientReliable), Endpoint->ReliableRPCBuffer.LastSentRPCId);
+		LastSentRPCIds.Add(EntityRPCType(EntityId, ERPCType::ClientUnreliable), Endpoint->UnreliableRPCBuffer.LastSentRPCId);
+		break;
+	}
+	case SpatialConstants::MULTICAST_RPCS_COMPONENT_ID:
 	{
 		const MulticastRPCs* Component = View->GetComponentData<MulticastRPCs>(EntityId);
 
-		if (!ensure(Component != nullptr))
+		if (Component->MulticastRPCBuffer.LastSentRPCId == 0 && Component->InitiallyPresentMulticastRPCsCount > 0)
 		{
-			UE_LOG(LogSpatialRPCService, Error,
-				TEXT("Multicast RPC component for entity with ID %lld was not present at point of checking out the component."), EntityId);
-			return;
-		}
+			// Update last sent ID to the number of initially present RPCs so the clients who check out this entity
+			// as it's created can process the initial multicast RPCs.
+			LastSentRPCIds.Add(EntityRPCType(EntityId, ERPCType::NetMulticast), Component->InitiallyPresentMulticastRPCsCount);
 
-		// When checking out entity, ignore multicast RPCs that are already on the component.
-		LastSeenMulticastRPCIds.Add(EntityId, Component->MulticastRPCBuffer.LastSentRPCId);
-	}
-
-	void SpatialRPCService::OnRemoveMulticastRPCComponentForEntity(Worker_EntityId EntityId)
-	{
-		LastSeenMulticastRPCIds.Remove(EntityId);
-	}
-
-	void SpatialRPCService::OnEndpointAuthorityGained(Worker_EntityId EntityId, Worker_ComponentId ComponentId)
-	{
-		switch (ComponentId)
-		{
-		case SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID:
-		{
-			const ClientEndpoint* Endpoint = View->GetComponentData<ClientEndpoint>(EntityId);
-			LastSeenRPCIds.Add(EntityRPCType(EntityId, ERPCType::ClientReliable), Endpoint->ReliableRPCAck);
-			LastSeenRPCIds.Add(EntityRPCType(EntityId, ERPCType::ClientUnreliable), Endpoint->UnreliableRPCAck);
-			LastAckedRPCIds.Add(EntityRPCType(EntityId, ERPCType::ClientReliable), Endpoint->ReliableRPCAck);
-			LastAckedRPCIds.Add(EntityRPCType(EntityId, ERPCType::ClientUnreliable), Endpoint->UnreliableRPCAck);
-			LastSentRPCIds.Add(EntityRPCType(EntityId, ERPCType::ServerReliable), Endpoint->ReliableRPCBuffer.LastSentRPCId);
-			LastSentRPCIds.Add(EntityRPCType(EntityId, ERPCType::ServerUnreliable), Endpoint->UnreliableRPCBuffer.LastSentRPCId);
-			break;
-		}
-		case SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID:
-		{
-			const ServerEndpoint* Endpoint = View->GetComponentData<ServerEndpoint>(EntityId);
-			LastSeenRPCIds.Add(EntityRPCType(EntityId, ERPCType::ServerReliable), Endpoint->ReliableRPCAck);
-			LastSeenRPCIds.Add(EntityRPCType(EntityId, ERPCType::ServerUnreliable), Endpoint->UnreliableRPCAck);
-			LastAckedRPCIds.Add(EntityRPCType(EntityId, ERPCType::ServerReliable), Endpoint->ReliableRPCAck);
-			LastAckedRPCIds.Add(EntityRPCType(EntityId, ERPCType::ServerUnreliable), Endpoint->UnreliableRPCAck);
-			LastSentRPCIds.Add(EntityRPCType(EntityId, ERPCType::ClientReliable), Endpoint->ReliableRPCBuffer.LastSentRPCId);
-			LastSentRPCIds.Add(EntityRPCType(EntityId, ERPCType::ClientUnreliable), Endpoint->UnreliableRPCBuffer.LastSentRPCId);
-			break;
-		}
-		case SpatialConstants::MULTICAST_RPCS_COMPONENT_ID:
-		{
-			const MulticastRPCs* Component = View->GetComponentData<MulticastRPCs>(EntityId);
-
-			if (Component->MulticastRPCBuffer.LastSentRPCId == 0 && Component->InitiallyPresentMulticastRPCsCount > 0)
-			{
-				// Update last sent ID to the number of initially present RPCs so the clients who check out this entity
-				// as it's created can process the initial multicast RPCs.
-				LastSentRPCIds.Add(EntityRPCType(EntityId, ERPCType::NetMulticast), Component->InitiallyPresentMulticastRPCsCount);
-
-				RPCRingBufferDescriptor Descriptor = RPCRingBufferUtils::GetRingBufferDescriptor(ERPCType::NetMulticast);
-				Schema_Object* SchemaObject =
-					Schema_GetComponentUpdateFields(GetOrCreateComponentUpdate(EntityComponentId{ EntityId, ComponentId }));
-				Schema_AddUint64(SchemaObject, Descriptor.LastSentRPCFieldId, Component->InitiallyPresentMulticastRPCsCount);
-			}
-			else
-			{
-				LastSentRPCIds.Add(EntityRPCType(EntityId, ERPCType::NetMulticast), Component->MulticastRPCBuffer.LastSentRPCId);
-			}
-
-			break;
-		}
-		case SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID:
-		{
-
-			break;
-		}
-		case SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID:
-		{
-			const CrossServerEndpointSenderACK* Endpoint = View->GetComponentData<CrossServerEndpointSenderACK>(EntityId);
-			if (ensure(Endpoint != nullptr))
-			{
-				if (Endpoint->DottedRPCACK.Num() != 0)
-				{
-					this->ACKComponentsToTrack.Add(EntityId);
-				}
-			}
-			for (const auto& Entry : CrossServerMailbox)
-			{
-				if (Entry.Target == EntityId)
-				{
-					bShouldCheckSentRPCForLocalTarget = true;
-				}
-			}
-			break;
-		}
-		case SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID:
-		{
-
-			break;
-		}
-		case SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID:
-		{
-
-			break;
-		}
-		default:
-			checkNoEntry();
-			break;
-		}
-	}
-
-	void SpatialRPCService::OnEndpointAuthorityLost(Worker_EntityId EntityId, Worker_ComponentId ComponentId)
-	{
-		switch (ComponentId)
-		{
-		case SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID:
-		{
-			LastSeenRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ClientReliable));
-			LastSeenRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ClientUnreliable));
-			LastAckedRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ClientReliable));
-			LastAckedRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ClientUnreliable));
-			LastSentRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ServerReliable));
-			LastSentRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ServerUnreliable));
-
-			ClearOverflowedRPCs(EntityId);
-			break;
-		}
-		case SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID:
-		{
-			LastSeenRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ServerReliable));
-			LastSeenRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ServerUnreliable));
-			LastAckedRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ServerReliable));
-			LastAckedRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ServerUnreliable));
-			LastSentRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ClientReliable));
-			LastSentRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ClientUnreliable));
-			ClearOverflowedRPCs(EntityId);
-			break;
-		}
-		case SpatialConstants::MULTICAST_RPCS_COMPONENT_ID:
-		{
-			// Set last seen to last sent, so we don't process own RPCs after crossing the boundary.
-			LastSeenMulticastRPCIds.Add(EntityId, LastSentRPCIds[EntityRPCType(EntityId, ERPCType::NetMulticast)]);
-			LastSentRPCIds.Remove(EntityRPCType(EntityId, ERPCType::NetMulticast));
-			break;
-		}
-		case SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID:
-		{
-			break;
-		}
-		case SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID:
-		{
-			ACKComponentsToTrack.Remove(EntityId);
-			break;
-		}
-		case SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID:
-		{
-
-			break;
-		}
-		case SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID:
-		{
-
-			break;
-		}
-		default:
-			checkNoEntry();
-			break;
-		}
-	}
-
-	void SpatialRPCService::ExtractRPCsForType(Worker_EntityId EntityId, ERPCType Type)
-	{
-		uint64 LastSeenRPCId;
-		EntityRPCType EntityTypePair = EntityRPCType(EntityId, Type);
-
-		if (Type == ERPCType::NetMulticast)
-		{
-			LastSeenRPCId = LastSeenMulticastRPCIds[EntityId];
+			RPCRingBufferDescriptor Descriptor = RPCRingBufferUtils::GetRingBufferDescriptor(ERPCType::NetMulticast);
+			Schema_Object* SchemaObject =
+				Schema_GetComponentUpdateFields(GetOrCreateComponentUpdate(EntityComponentId{ EntityId, ComponentId }));
+			Schema_AddUint64(SchemaObject, Descriptor.LastSentRPCFieldId, Component->InitiallyPresentMulticastRPCsCount);
 		}
 		else
 		{
-			LastSeenRPCId = LastSeenRPCIds[EntityTypePair];
+			LastSentRPCIds.Add(EntityRPCType(EntityId, ERPCType::NetMulticast), Component->MulticastRPCBuffer.LastSentRPCId);
 		}
 
-		const RPCRingBuffer& Buffer = GetBufferFromView(EntityId, Type);
-
-		uint64 LastProcessedRPCId = LastSeenRPCId;
-		if (Buffer.LastSentRPCId >= LastSeenRPCId)
+		break;
+	}
+	case SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID:
+	{
+		break;
+	}
+	case SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID:
+	{
+		const CrossServerEndpointSenderACK* Endpoint = View->GetComponentData<CrossServerEndpointSenderACK>(EntityId);
+		if (ensure(Endpoint != nullptr))
 		{
-			uint64 FirstRPCIdToRead = LastSeenRPCId + 1;
+			if (Endpoint->DottedRPCACK.Num() != 0)
+			{
+				this->ACKComponentsToTrack.Add(EntityId);
+			}
+		}
+		for (const auto& Entry : CrossServerMailbox)
+		{
+			if (Entry.Target == EntityId)
+			{
+				bShouldCheckSentRPCForLocalTarget = true;
+			}
+		}
+		break;
+	}
+	case SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID:
+	{
+		break;
+	}
+	case SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID:
+	{
+		break;
+	}
+	default:
+		checkNoEntry();
+		break;
+	}
+}
 
-			uint32 BufferSize = RPCRingBufferUtils::GetRingBufferSize(Type);
-			if (Buffer.LastSentRPCId > LastSeenRPCId + BufferSize)
+void SpatialRPCService::OnEndpointAuthorityLost(Worker_EntityId EntityId, Worker_ComponentId ComponentId)
+{
+	switch (ComponentId)
+	{
+	case SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID:
+	{
+		LastSeenRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ClientReliable));
+		LastSeenRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ClientUnreliable));
+		LastAckedRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ClientReliable));
+		LastAckedRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ClientUnreliable));
+		LastSentRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ServerReliable));
+		LastSentRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ServerUnreliable));
+
+		ClearOverflowedRPCs(EntityId);
+		break;
+	}
+	case SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID:
+	{
+		LastSeenRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ServerReliable));
+		LastSeenRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ServerUnreliable));
+		LastAckedRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ServerReliable));
+		LastAckedRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ServerUnreliable));
+		LastSentRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ClientReliable));
+		LastSentRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ClientUnreliable));
+		ClearOverflowedRPCs(EntityId);
+		break;
+	}
+	case SpatialConstants::MULTICAST_RPCS_COMPONENT_ID:
+	{
+		// Set last seen to last sent, so we don't process own RPCs after crossing the boundary.
+		LastSeenMulticastRPCIds.Add(EntityId, LastSentRPCIds[EntityRPCType(EntityId, ERPCType::NetMulticast)]);
+		LastSentRPCIds.Remove(EntityRPCType(EntityId, ERPCType::NetMulticast));
+		break;
+	}
+	case SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID:
+	{
+		break;
+	}
+	case SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID:
+	{
+		ACKComponentsToTrack.Remove(EntityId);
+		break;
+	}
+	case SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID:
+	{
+		break;
+	}
+	case SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID:
+	{
+		break;
+	}
+	default:
+		checkNoEntry();
+		break;
+	}
+}
+
+void SpatialRPCService::ExtractRPCsForType(Worker_EntityId EntityId, ERPCType Type)
+{
+	uint64 LastSeenRPCId;
+	EntityRPCType EntityTypePair = EntityRPCType(EntityId, Type);
+
+	if (Type == ERPCType::NetMulticast)
+	{
+		LastSeenRPCId = LastSeenMulticastRPCIds[EntityId];
+	}
+	else
+	{
+		LastSeenRPCId = LastSeenRPCIds[EntityTypePair];
+	}
+
+	const RPCRingBuffer& Buffer = GetBufferFromView(EntityId, Type);
+
+	uint64 LastProcessedRPCId = LastSeenRPCId;
+	if (Buffer.LastSentRPCId >= LastSeenRPCId)
+	{
+		uint64 FirstRPCIdToRead = LastSeenRPCId + 1;
+
+		uint32 BufferSize = RPCRingBufferUtils::GetRingBufferSize(Type);
+		if (Buffer.LastSentRPCId > LastSeenRPCId + BufferSize)
+		{
+			UE_LOG(LogSpatialRPCService, Warning,
+				   TEXT("SpatialRPCService::ExtractRPCsForType: RPCs were overwritten without being processed! Entity: %lld, RPC type: %s, "
+						"last seen RPC ID: %d, last sent ID: %d, buffer size: %d"),
+				   EntityId, *SpatialConstants::RPCTypeToString(Type), LastSeenRPCId, Buffer.LastSentRPCId, BufferSize);
+			FirstRPCIdToRead = Buffer.LastSentRPCId - BufferSize + 1;
+		}
+
+		for (uint64 RPCId = FirstRPCIdToRead; RPCId <= Buffer.LastSentRPCId; RPCId++)
+		{
+			const TOptional<RPCPayload>& Element = Buffer.GetRingBufferElement(RPCId);
+			if (Element.IsSet())
+			{
+				FUnrealObjectRef Counterpart;
+				if (Buffer.Type == ERPCType::CrossServerSender)
+				{
+					Worker_EntityId TargetId = SpatialConstants::INVALID_ENTITY_ID;
+					const TOptional<FUnrealObjectRef>& Target = Buffer.GetRingBufferCounterpart(RPCId);
+					if (Target.IsSet())
+					{
+						TargetId = Target.GetValue().Entity;
+					}
+					Counterpart.Entity = TargetId;
+					Counterpart.Offset = RPCId;
+				}
+				const bool bKeepExtracting =
+					ExtractRPCCallback.Execute(EntityId, Counterpart, Type, Element.GetValue(), &Element - Buffer.RingBuffer.GetData());
+				if (!bKeepExtracting)
+				{
+					break;
+				}
+				LastProcessedRPCId = RPCId;
+			}
+			else
 			{
 				UE_LOG(LogSpatialRPCService, Warning,
-					TEXT("SpatialRPCService::ExtractRPCsForType: RPCs were overwritten without being processed! Entity: %lld, RPC type: %s, "
-						"last seen RPC ID: %d, last sent ID: %d, buffer size: %d"),
-					EntityId, *SpatialConstants::RPCTypeToString(Type), LastSeenRPCId, Buffer.LastSentRPCId, BufferSize);
-				FirstRPCIdToRead = Buffer.LastSentRPCId - BufferSize + 1;
-			}
-
-			for (uint64 RPCId = FirstRPCIdToRead; RPCId <= Buffer.LastSentRPCId; RPCId++)
-			{
-				const TOptional<RPCPayload>& Element = Buffer.GetRingBufferElement(RPCId);
-				if (Element.IsSet())
-				{
-					FUnrealObjectRef Counterpart;
-					if (Buffer.Type == ERPCType::CrossServerSender)
-					{
-						Worker_EntityId TargetId = SpatialConstants::INVALID_ENTITY_ID;
-						const TOptional<FUnrealObjectRef>& Target = Buffer.GetRingBufferCounterpart(RPCId);
-						if (Target.IsSet())
-						{
-							TargetId = Target.GetValue().Entity;
-						}
-						Counterpart.Entity = TargetId;
-						Counterpart.Offset = RPCId;
-					}
-					const bool bKeepExtracting = ExtractRPCCallback.Execute(EntityId, Counterpart, Type, Element.GetValue(), &Element - Buffer.RingBuffer.GetData());
-					if (!bKeepExtracting)
-					{
-						break;
-					}
-					LastProcessedRPCId = RPCId;
-				}
-				else
-				{
-					UE_LOG(LogSpatialRPCService, Warning,
-						TEXT("SpatialRPCService::ExtractRPCsForType: Ring buffer element empty. Entity: %lld, RPC type: %s, empty element "
+					   TEXT("SpatialRPCService::ExtractRPCsForType: Ring buffer element empty. Entity: %lld, RPC type: %s, empty element "
 							"RPC id: %d"),
-						EntityId, *SpatialConstants::RPCTypeToString(Type), RPCId);
-				}
-			}
-		}
-		else
-		{
-			UE_LOG(LogSpatialRPCService, Warning,
-				TEXT("SpatialRPCService::ExtractRPCsForType: Last sent RPC has smaller ID than last seen RPC. Entity: %lld, RPC type: %s, "
-					"last sent ID: %d, last seen ID: %d"),
-				EntityId, *SpatialConstants::RPCTypeToString(Type), Buffer.LastSentRPCId, LastSeenRPCId);
-		}
-
-		if (LastProcessedRPCId > LastSeenRPCId)
-		{
-			if (Type == ERPCType::NetMulticast)
-			{
-				LastSeenMulticastRPCIds[EntityId] = LastProcessedRPCId;
-			}
-			else
-			{
-				LastSeenRPCIds[EntityTypePair] = LastProcessedRPCId;
+					   EntityId, *SpatialConstants::RPCTypeToString(Type), RPCId);
 			}
 		}
 	}
+	else
+	{
+		UE_LOG(LogSpatialRPCService, Warning,
+			   TEXT("SpatialRPCService::ExtractRPCsForType: Last sent RPC has smaller ID than last seen RPC. Entity: %lld, RPC type: %s, "
+					"last sent ID: %d, last seen ID: %d"),
+			   EntityId, *SpatialConstants::RPCTypeToString(Type), Buffer.LastSentRPCId, LastSeenRPCId);
+	}
 
-	void SpatialRPCService::IncrementAckedRPCID(Worker_EntityId EntityId, ERPCType Type)
+	if (LastProcessedRPCId > LastSeenRPCId)
 	{
 		if (Type == ERPCType::NetMulticast)
 		{
-			return;
+			LastSeenMulticastRPCIds[EntityId] = LastProcessedRPCId;
 		}
-
-		EntityRPCType EntityTypePair = EntityRPCType(EntityId, Type);
-		uint64* LastAckedRPCId = LastAckedRPCIds.Find(EntityTypePair);
-		if (LastAckedRPCId == nullptr)
+		else
 		{
-			UE_LOG(LogSpatialRPCService, Warning,
-				TEXT("SpatialRPCService::IncrementAckedRPCID: Could not find last acked RPC id. Entity: %lld, RPC type: %s"), EntityId,
-				*SpatialConstants::RPCTypeToString(Type));
-			return;
+			LastSeenRPCIds[EntityTypePair] = LastProcessedRPCId;
 		}
+	}
+}
 
-		++(*LastAckedRPCId);
-
-		const EntityComponentId EntityComponentPair = { EntityId, RPCRingBufferUtils::GetAckComponentId(Type) };
-		Schema_Object* EndpointObject = Schema_GetComponentUpdateFields(GetOrCreateComponentUpdate(EntityComponentPair));
-
-		RPCRingBufferUtils::WriteAckToSchema(EndpointObject, Type, *LastAckedRPCId);
+void SpatialRPCService::IncrementAckedRPCID(Worker_EntityId EntityId, ERPCType Type)
+{
+	if (Type == ERPCType::NetMulticast)
+	{
+		return;
 	}
 
-	void SpatialRPCService::AddOverflowedRPC(EntityRPCType EntityType, RPCPayload&& Payload)
+	EntityRPCType EntityTypePair = EntityRPCType(EntityId, Type);
+	uint64* LastAckedRPCId = LastAckedRPCIds.Find(EntityTypePair);
+	if (LastAckedRPCId == nullptr)
 	{
-		OverflowedRPCs.FindOrAdd(EntityType).Add(MoveTemp(Payload));
+		UE_LOG(LogSpatialRPCService, Warning,
+			   TEXT("SpatialRPCService::IncrementAckedRPCID: Could not find last acked RPC id. Entity: %lld, RPC type: %s"), EntityId,
+			   *SpatialConstants::RPCTypeToString(Type));
+		return;
 	}
 
-	uint64 SpatialRPCService::GetAckFromView(Worker_EntityId EntityId, ERPCType Type)
-	{
-		switch (Type)
-		{
-		case ERPCType::ClientReliable:
-			return View->GetComponentData<ClientEndpoint>(EntityId)->ReliableRPCAck;
-		case ERPCType::ClientUnreliable:
-			return View->GetComponentData<ClientEndpoint>(EntityId)->UnreliableRPCAck;
-		case ERPCType::ServerReliable:
-			return View->GetComponentData<ServerEndpoint>(EntityId)->ReliableRPCAck;
-		case ERPCType::ServerUnreliable:
-			return View->GetComponentData<ServerEndpoint>(EntityId)->UnreliableRPCAck;
-		case ERPCType::CrossServerSender:
-			return View->GetComponentData<CrossServerEndpointSenderACK>(EntityId)->RPCAck;
-		case ERPCType::CrossServerReceiver:
-			return View->GetComponentData<CrossServerEndpointReceiverACK>(EntityId)->RPCAck;
-		}
+	++(*LastAckedRPCId);
 
-		checkNoEntry();
-		return 0;
+	const EntityComponentId EntityComponentPair = { EntityId, RPCRingBufferUtils::GetAckComponentId(Type) };
+	Schema_Object* EndpointObject = Schema_GetComponentUpdateFields(GetOrCreateComponentUpdate(EntityComponentPair));
+
+	RPCRingBufferUtils::WriteAckToSchema(EndpointObject, Type, *LastAckedRPCId);
+}
+
+void SpatialRPCService::AddOverflowedRPC(EntityRPCType EntityType, RPCPayload&& Payload)
+{
+	OverflowedRPCs.FindOrAdd(EntityType).Add(MoveTemp(Payload));
+}
+
+uint64 SpatialRPCService::GetAckFromView(Worker_EntityId EntityId, ERPCType Type)
+{
+	switch (Type)
+	{
+	case ERPCType::ClientReliable:
+		return View->GetComponentData<ClientEndpoint>(EntityId)->ReliableRPCAck;
+	case ERPCType::ClientUnreliable:
+		return View->GetComponentData<ClientEndpoint>(EntityId)->UnreliableRPCAck;
+	case ERPCType::ServerReliable:
+		return View->GetComponentData<ServerEndpoint>(EntityId)->ReliableRPCAck;
+	case ERPCType::ServerUnreliable:
+		return View->GetComponentData<ServerEndpoint>(EntityId)->UnreliableRPCAck;
+	case ERPCType::CrossServerSender:
+		return View->GetComponentData<CrossServerEndpointSenderACK>(EntityId)->RPCAck;
+	case ERPCType::CrossServerReceiver:
+		return View->GetComponentData<CrossServerEndpointReceiverACK>(EntityId)->RPCAck;
 	}
 
-	const RPCRingBuffer& SpatialRPCService::GetBufferFromView(Worker_EntityId EntityId, ERPCType Type)
+	checkNoEntry();
+	return 0;
+}
+
+const RPCRingBuffer& SpatialRPCService::GetBufferFromView(Worker_EntityId EntityId, ERPCType Type)
+{
+	switch (Type)
 	{
-		
-		// Merge nonsense -> Not in master, but I did not add it????
-		//if (!LastSeenMulticastRPCIds.Contains(EntityId))
-		//{
-		//	UE_LOG(LogSpatialRPCService, Warning,
-		//		   TEXT("Tried to extract RPCs but no entry in Last Seen Map! This can happen after server travel. Entity: %lld, type: "
-		//				"Multicast"),
-		//		   EntityId);
-		//	return;
-		//}
-		//LastSeenRPCId = LastSeenMulticastRPCIds[EntityId];
+		// Server sends Client RPCs, so ClientReliable & ClientUnreliable buffers live on ServerEndpoint.
+	case ERPCType::ClientReliable:
+		return View->GetComponentData<ServerEndpoint>(EntityId)->ReliableRPCBuffer;
+	case ERPCType::ClientUnreliable:
+		return View->GetComponentData<ServerEndpoint>(EntityId)->UnreliableRPCBuffer;
 
-		switch (Type)
-		{
-			// Server sends Client RPCs, so ClientReliable & ClientUnreliable buffers live on ServerEndpoint.
-		case ERPCType::ClientReliable:
-			return View->GetComponentData<ServerEndpoint>(EntityId)->ReliableRPCBuffer;
-		case ERPCType::ClientUnreliable:
-			return View->GetComponentData<ServerEndpoint>(EntityId)->UnreliableRPCBuffer;
+		// Client sends Server RPCs, so ServerReliable & ServerUnreliable buffers live on ClientEndpoint.
+	case ERPCType::ServerReliable:
+		return View->GetComponentData<ClientEndpoint>(EntityId)->ReliableRPCBuffer;
+	case ERPCType::ServerUnreliable:
+		return View->GetComponentData<ClientEndpoint>(EntityId)->UnreliableRPCBuffer;
 
-			// Client sends Server RPCs, so ServerReliable & ServerUnreliable buffers live on ClientEndpoint.
-		case ERPCType::ServerReliable:
-			return View->GetComponentData<ClientEndpoint>(EntityId)->ReliableRPCBuffer;
-		case ERPCType::ServerUnreliable:
-			return View->GetComponentData<ClientEndpoint>(EntityId)->UnreliableRPCBuffer;
-
-		case ERPCType::NetMulticast:
-			return View->GetComponentData<MulticastRPCs>(EntityId)->MulticastRPCBuffer;
-		case ERPCType::CrossServerSender:
-			return View->GetComponentData<CrossServerEndpointSender>(EntityId)->ReliableRPCBuffer;
-		case ERPCType::CrossServerReceiver:
-			return View->GetComponentData<CrossServerEndpointReceiver>(EntityId)->ReliableRPCBuffer;
-		}
-
-		checkNoEntry();
-		static const RPCRingBuffer DummyBuffer(ERPCType::Invalid);
-		return DummyBuffer;
+	case ERPCType::NetMulticast:
+		return View->GetComponentData<MulticastRPCs>(EntityId)->MulticastRPCBuffer;
+	case ERPCType::CrossServerSender:
+		return View->GetComponentData<CrossServerEndpointSender>(EntityId)->ReliableRPCBuffer;
+	case ERPCType::CrossServerReceiver:
+		return View->GetComponentData<CrossServerEndpointReceiver>(EntityId)->ReliableRPCBuffer;
 	}
 
-	Schema_ComponentUpdate* SpatialRPCService::GetOrCreateComponentUpdate(EntityComponentId EntityComponentIdPair)
+	checkNoEntry();
+	static const RPCRingBuffer DummyBuffer(ERPCType::Invalid);
+	return DummyBuffer;
+}
+
+Schema_ComponentUpdate* SpatialRPCService::GetOrCreateComponentUpdate(EntityComponentId EntityComponentIdPair)
+{
+	Schema_ComponentUpdate** ComponentUpdatePtr = PendingComponentUpdatesToSend.Find(EntityComponentIdPair);
+	if (ComponentUpdatePtr == nullptr)
 	{
+<<<<<<< HEAD
 <<<<<<< HEAD
 		if (!LastSeenRPCIds.Contains(EntityTypePair))
 		{
@@ -748,259 +738,261 @@ namespace SpatialGDK
 		}
 		return *ComponentUpdatePtr;
 >>>>>>> Cross Server RPC Spike
+=======
+		ComponentUpdatePtr = &PendingComponentUpdatesToSend.Add(EntityComponentIdPair, Schema_CreateComponentUpdate());
+>>>>>>> Missing stuff
 	}
+	return *ComponentUpdatePtr;
+}
 
-	Schema_ComponentData* SpatialRPCService::GetOrCreateComponentData(EntityComponentId EntityComponentIdPair)
+Schema_ComponentData* SpatialRPCService::GetOrCreateComponentData(EntityComponentId EntityComponentIdPair)
+{
+	Schema_ComponentData** ComponentDataPtr = PendingRPCsOnEntityCreation.Find(EntityComponentIdPair);
+	if (ComponentDataPtr == nullptr)
 	{
-		Schema_ComponentData** ComponentDataPtr = PendingRPCsOnEntityCreation.Find(EntityComponentIdPair);
-		if (ComponentDataPtr == nullptr)
-		{
-			ComponentDataPtr = &PendingRPCsOnEntityCreation.Add(EntityComponentIdPair, Schema_CreateComponentData());
-		}
-		return *ComponentDataPtr;
+		ComponentDataPtr = &PendingRPCsOnEntityCreation.Add(EntityComponentIdPair, Schema_CreateComponentData());
 	}
+	return *ComponentDataPtr;
+}
 
 #if TRACE_LIB_ACTIVE
-	void SpatialRPCService::ProcessResultToLatencyTrace(const EPushRPCResult Result, const TraceKey Trace)
+void SpatialRPCService::ProcessResultToLatencyTrace(const EPushRPCResult Result, const TraceKey Trace)
+{
+	if (SpatialLatencyTracer != nullptr && Trace != InvalidTraceKey)
 	{
-		if (SpatialLatencyTracer != nullptr && Trace != InvalidTraceKey)
+		bool bEndTrace = false;
+		FString TraceMsg;
+		switch (Result)
 		{
-			bool bEndTrace = false;
-			FString TraceMsg;
-			switch (Result)
-			{
-			case SpatialGDK::EPushRPCResult::Success:
-				// No further action
-				break;
-			case SpatialGDK::EPushRPCResult::QueueOverflowed:
-				TraceMsg = TEXT("Overflowed");
-				break;
-			case SpatialGDK::EPushRPCResult::DropOverflowed:
-				TraceMsg = TEXT("OverflowedAndDropped");
-				bEndTrace = true;
-				break;
-			case SpatialGDK::EPushRPCResult::HasAckAuthority:
-				TraceMsg = TEXT("NoAckAuth");
-				bEndTrace = true;
-				break;
-			case SpatialGDK::EPushRPCResult::NoRingBufferAuthority:
-				TraceMsg = TEXT("NoRingBufferAuth");
-				bEndTrace = true;
-				break;
-			default:
-				TraceMsg = TEXT("UnrecognisedResult");
-				break;
-			}
+		case SpatialGDK::EPushRPCResult::Success:
+			// No further action
+			break;
+		case SpatialGDK::EPushRPCResult::QueueOverflowed:
+			TraceMsg = TEXT("Overflowed");
+			break;
+		case SpatialGDK::EPushRPCResult::DropOverflowed:
+			TraceMsg = TEXT("OverflowedAndDropped");
+			bEndTrace = true;
+			break;
+		case SpatialGDK::EPushRPCResult::HasAckAuthority:
+			TraceMsg = TEXT("NoAckAuth");
+			bEndTrace = true;
+			break;
+		case SpatialGDK::EPushRPCResult::NoRingBufferAuthority:
+			TraceMsg = TEXT("NoRingBufferAuth");
+			bEndTrace = true;
+			break;
+		default:
+			TraceMsg = TEXT("UnrecognisedResult");
+			break;
+		}
 
-			if (bEndTrace)
-			{
-				// This RPC has been dropped, end the trace
-				SpatialLatencyTracer->WriteAndEndTrace(Trace, TraceMsg, false);
-			}
-			else if (!TraceMsg.IsEmpty())
-			{
-				// This RPC will be sent later
-				SpatialLatencyTracer->WriteToLatencyTrace(Trace, TraceMsg);
-			}
+		if (bEndTrace)
+		{
+			// This RPC has been dropped, end the trace
+			SpatialLatencyTracer->WriteAndEndTrace(Trace, TraceMsg, false);
+		}
+		else if (!TraceMsg.IsEmpty())
+		{
+			// This RPC will be sent later
+			SpatialLatencyTracer->WriteToLatencyTrace(Trace, TraceMsg);
 		}
 	}
+}
 #endif // TRACE_LIB_ACTIVE
 
+void SpatialRPCService::ExtractCrossServerRPCsForType(Worker_EntityId SenderId, ERPCType Type)
+{
+	const RPCRingBuffer& Buffer = GetBufferFromView(SenderId, Type);
 
-	void SpatialRPCService::ExtractCrossServerRPCsForType(Worker_EntityId SenderId, ERPCType Type)
+	uint64 MinRPCId = 0;
+	TSet<Worker_EntityId> Receivers;
+	for (uint32 Slot = 0; Slot < RPCRingBufferUtils::GetRingBufferSize(Type); ++Slot)
 	{
-		const RPCRingBuffer& Buffer = GetBufferFromView(SenderId, Type);
-
-		uint64 MinRPCId = 0;
-		TSet<Worker_EntityId> Receivers;
-		for (uint32 Slot = 0; Slot < RPCRingBufferUtils::GetRingBufferSize(Type); ++Slot)
+		const TOptional<RPCPayload>& Element = Buffer.RingBuffer[Slot];
+		if (Element.IsSet())
 		{
-			const TOptional<RPCPayload>& Element = Buffer.RingBuffer[Slot];
-			if (Element.IsSet())
+			Worker_EntityId TargetId = SpatialConstants::INVALID_ENTITY_ID;
+			const TOptional<FUnrealObjectRef>& Target = Buffer.Counterpart[Slot];
+			if (Target.IsSet())
 			{
-				Worker_EntityId TargetId = SpatialConstants::INVALID_ENTITY_ID;
-				const TOptional<FUnrealObjectRef>& Target = Buffer.Counterpart[Slot];
-				if (Target.IsSet())
+				TargetId = Target.GetValue().Entity;
+
+				uint64 RPCId = Target.GetValue().Offset;
+				if (Slot == 0)
 				{
-					TargetId = Target.GetValue().Entity;
+					MinRPCId = RPCId;
+				}
+				MinRPCId = FMath::Min(RPCId, MinRPCId);
 
-					uint64 RPCId = Target.GetValue().Offset;
-					if (Slot == 0)
+				if (View->HasAuthority(TargetId, SpatialConstants::POSITION_COMPONENT_ID))
+				{
+					CrossServerEndpointSenderACK* ACKComponent = View->GetComponentData<CrossServerEndpointSenderACK>(TargetId);
+					TArray<uint64>* DottedACKList = ACKComponent->DottedRPCACK.Find(SenderId);
+					if (DottedACKList == nullptr || (*DottedACKList)[Slot] < RPCId)
 					{
-						MinRPCId = RPCId;
-					}
-					MinRPCId = FMath::Min(RPCId, MinRPCId);
-
-					if (View->HasAuthority(TargetId, SpatialConstants::POSITION_COMPONENT_ID))
-					{
-						CrossServerEndpointSenderACK* ACKComponent = View->GetComponentData<CrossServerEndpointSenderACK>(TargetId);
-						TArray<uint64>* DottedACKList = ACKComponent->DottedRPCACK.Find(SenderId);
-						if (DottedACKList == nullptr || (*DottedACKList)[Slot] < RPCId)
+						Receivers.Add(TargetId);
+						FUnrealObjectRef Counterpart(SenderId, RPCId);
+						const bool bKeepExtracting = ExtractRPCCallback.Execute(TargetId, Counterpart, Type, Element.GetValue(), Slot);
+						if (!bKeepExtracting)
 						{
-							Receivers.Add(TargetId);
-							FUnrealObjectRef Counterpart(SenderId, RPCId);
-							const bool bKeepExtracting = ExtractRPCCallback.Execute(TargetId, Counterpart, Type, Element.GetValue(), Slot);
-							if (!bKeepExtracting)
-							{
-								break;
-							}
+							break;
 						}
 					}
 				}
 			}
 		}
-		if (Receivers.Num() != 0)
-		{
-			CleanupACKsFor(SenderId, MinRPCId, Receivers);
-		}
+	}
+	if (Receivers.Num() != 0)
+	{
+		CleanupACKsFor(SenderId, MinRPCId, Receivers);
+	}
+}
+
+void SpatialRPCService::WriteCrossServerACKFor(Worker_EntityId Receiver, Worker_EntityId Sender, uint64 RPCId, uint32 Slot)
+{
+	CrossServerEndpointSenderACK* ACKComponent = View->GetComponentData<CrossServerEndpointSenderACK>(Receiver);
+	TArray<uint64>* DottedACKList = ACKComponent->DottedRPCACK.Find(Sender);
+	if (DottedACKList == nullptr)
+	{
+		TArray<uint64> NewACKList;
+		NewACKList.SetNumZeroed(RPCRingBufferUtils::GetRingBufferSize(ERPCType::CrossServerSender));
+		DottedACKList = &ACKComponent->DottedRPCACK.Add(Sender, MoveTemp(NewACKList));
 	}
 
-	void SpatialRPCService::WriteCrossServerACKFor(Worker_EntityId Receiver, Worker_EntityId Sender, uint64 RPCId, uint32 Slot)
+	(*DottedACKList)[Slot] = RPCId;
+	ACKComponent->RPCAck++;
+
+	UE_LOG(LogSpatialRPCService, Log, TEXT("DEBUG_CS %llu ACKED RPC %i from %llu with count %i"), Receiver, RPCId, Sender,
+		   ACKComponent->RPCAck);
+
+	EntityComponentId Pair;
+	Pair.EntityId = Receiver;
+	Pair.ComponentId = RPCRingBufferUtils::GetAckComponentId(ERPCType::CrossServerSender);
+
+	if (Schema_ComponentUpdate** PendingUpdate = PendingComponentUpdatesToSend.Find(Pair))
 	{
-		CrossServerEndpointSenderACK* ACKComponent = View->GetComponentData<CrossServerEndpointSenderACK>(Receiver);
-		TArray<uint64>* DottedACKList = ACKComponent->DottedRPCACK.Find(Sender);
-		if (DottedACKList == nullptr)
-		{
-			TArray<uint64> NewACKList;
-			NewACKList.SetNumZeroed(RPCRingBufferUtils::GetRingBufferSize(ERPCType::CrossServerSender));
-			DottedACKList = &ACKComponent->DottedRPCACK.Add(Sender, MoveTemp(NewACKList));
-		}
-
-		(*DottedACKList)[Slot] = RPCId;
-		ACKComponent->RPCAck++;
-
-		UE_LOG(LogSpatialRPCService, Log, TEXT("DEBUG_CS %llu ACKED RPC %i from %llu with count %i"), Receiver, RPCId, Sender, ACKComponent->RPCAck);
-
-		EntityComponentId Pair;
-		Pair.EntityId = Receiver;
-		Pair.ComponentId = RPCRingBufferUtils::GetAckComponentId(ERPCType::CrossServerSender);
-
-
-		if (Schema_ComponentUpdate** PendingUpdate = PendingComponentUpdatesToSend.Find(Pair))
-		{
-			Schema_DestroyComponentUpdate(*PendingUpdate);
-			PendingComponentUpdatesToSend.Remove(Pair);
-		}
-
-		Schema_ComponentUpdate* Update = GetOrCreateComponentUpdate(Pair);
-		Schema_Object* UpdateObject = Schema_GetComponentUpdateFields(Update);
-
-		ACKComponent->CreateUpdate(Update);
-		ACKComponentsToTrack.Add(Receiver);
-
-		if (View->HasAuthority(Sender, SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID))
-		{
-			UpdateMergedACKs(Sender, Receiver);
-		}
+		Schema_DestroyComponentUpdate(*PendingUpdate);
+		PendingComponentUpdatesToSend.Remove(Pair);
 	}
 
-	void SpatialRPCService::UpdateMergedACKs(Worker_EntityId WorkerId, Worker_EntityId RemoteReceiver)
-	{
-		CrossServerEndpointSenderACK* ACKComponent = View->GetComponentData<CrossServerEndpointSenderACK>(RemoteReceiver);
-		if (TArray<uint64>* DottedACKList = ACKComponent->DottedRPCACK.Find(WorkerId))
-		{
-			for (int32 Slot = 0; Slot < DottedACKList->Num(); ++Slot)
-			{
-				SentRPCEntry& Entry = CrossServerMailbox[Slot];
-				Entry.MergedCrossServerACK = FMath::Max(Entry.MergedCrossServerACK, (*DottedACKList)[Slot]);
-				if (Entry.MergedCrossServerACK == Entry.RPCId)
-				{
-					Entry.EntityRequest.Reset();
-				}
-			}
-		}
-	}
+	Schema_ComponentUpdate* Update = GetOrCreateComponentUpdate(Pair);
+	Schema_Object* UpdateObject = Schema_GetComponentUpdateFields(Update);
 
-	TOptional<uint32_t> SpatialRPCService::FindFreeSlotForCrossServerSender()
+	ACKComponent->CreateUpdate(Update);
+	ACKComponentsToTrack.Add(Receiver);
+
+	if (View->HasAuthority(Sender, SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID))
 	{
-		uint64 LowestId;
-		TOptional<uint32_t> FreeSlot;
-		for (int32 Slot = 0; Slot < CrossServerMailbox.Num(); ++Slot)
+		UpdateMergedACKs(Sender, Receiver);
+	}
+}
+
+void SpatialRPCService::UpdateMergedACKs(Worker_EntityId WorkerId, Worker_EntityId RemoteReceiver)
+{
+	CrossServerEndpointSenderACK* ACKComponent = View->GetComponentData<CrossServerEndpointSenderACK>(RemoteReceiver);
+	if (TArray<uint64>* DottedACKList = ACKComponent->DottedRPCACK.Find(WorkerId))
+	{
+		for (int32 Slot = 0; Slot < DottedACKList->Num(); ++Slot)
 		{
 			SentRPCEntry& Entry = CrossServerMailbox[Slot];
-			uint64 CurSlotRPCId = Entry.RPCId;
-			if (CurSlotRPCId == Entry.MergedCrossServerACK)
+			Entry.MergedCrossServerACK = FMath::Max(Entry.MergedCrossServerACK, (*DottedACKList)[Slot]);
+			if (Entry.MergedCrossServerACK == Entry.RPCId)
 			{
-				if (!FreeSlot
-					|| CurSlotRPCId < LowestId)
-				{
-					FreeSlot = Slot;
-					LowestId = CurSlotRPCId;
-				}
+				Entry.EntityRequest.Reset();
 			}
-		}
-
-		return FreeSlot;
-	}
-
-	void SpatialRPCService::CleanupACKsFor(Worker_EntityId Sender, uint64 MinRPCId, TSet<Worker_EntityId> const& ReceiversToIgnore)
-	{
-		for (TSet<Worker_EntityId>::TIterator Iterator = ACKComponentsToTrack.CreateIterator(); Iterator; ++Iterator)
-		{
-			Worker_EntityId Receiver = *Iterator;
-			if (ReceiversToIgnore.Contains(Receiver))
-			{
-				continue;
-			}
-
-			CrossServerEndpointSenderACK* ACKComponent = View->GetComponentData<CrossServerEndpointSenderACK>(Receiver);
-			if (!ACKComponent)
-			{
-				continue;
-			}
-			if (TArray<uint64>* DottedACKList = ACKComponent->DottedRPCACK.Find(Sender))
-			{
-				bool bStillRelevant = false;
-				for (auto RPCId : *DottedACKList)
-				{
-					if (RPCId >= MinRPCId)
-					{
-						bStillRelevant = true;
-						break;
-					}
-				}
-				if (!bStillRelevant)
-				{
-					ACKComponent->DottedRPCACK.Remove(Sender);
-					if (ACKComponent->DottedRPCACK.Num() == 0)
-					{
-						Iterator.RemoveCurrent();
-					}
-
-					EntityComponentId Pair;
-					Pair.EntityId = Receiver;
-					Pair.ComponentId = RPCRingBufferUtils::GetAckComponentId(ERPCType::CrossServerSender);
-
-					if (Schema_ComponentUpdate** PendingUpdate = PendingComponentUpdatesToSend.Find(Pair))
-					{
-						Schema_DestroyComponentUpdate(*PendingUpdate);
-						PendingComponentUpdatesToSend.Remove(Pair);
-					}
-
-					Schema_ComponentUpdate* Update = GetOrCreateComponentUpdate(Pair);
-					Schema_Object* UpdateObject = Schema_GetComponentUpdateFields(Update);
-					ACKComponent->CreateUpdate(Update);
-				}
-			}
-		}
-	}
-
-	void SpatialRPCService::CheckLocalTargets(Worker_EntityId LocalWorkerEntityId)
-	{
-		if (bShouldCheckSentRPCForLocalTarget)
-		{
-			bShouldCheckSentRPCForLocalTarget = false;
-			ExtractCrossServerRPCsForType(LocalWorkerEntityId, ERPCType::CrossServerSender);
 		}
 	}
 }
+
+TOptional<uint32_t> SpatialRPCService::FindFreeSlotForCrossServerSender()
+{
+	uint64 LowestId;
+	TOptional<uint32_t> FreeSlot;
+	for (int32 Slot = 0; Slot < CrossServerMailbox.Num(); ++Slot)
+	{
+		SentRPCEntry& Entry = CrossServerMailbox[Slot];
+		uint64 CurSlotRPCId = Entry.RPCId;
+		if (CurSlotRPCId == Entry.MergedCrossServerACK)
+		{
+			if (!FreeSlot || CurSlotRPCId < LowestId)
+			{
+				FreeSlot = Slot;
+				LowestId = CurSlotRPCId;
+			}
+		}
+	}
+
+	return FreeSlot;
+}
+
+void SpatialRPCService::CleanupACKsFor(Worker_EntityId Sender, uint64 MinRPCId, TSet<Worker_EntityId> const& ReceiversToIgnore)
+{
+	for (TSet<Worker_EntityId>::TIterator Iterator = ACKComponentsToTrack.CreateIterator(); Iterator; ++Iterator)
+	{
+		Worker_EntityId Receiver = *Iterator;
+		if (ReceiversToIgnore.Contains(Receiver))
+		{
+			continue;
+		}
+
+		CrossServerEndpointSenderACK* ACKComponent = View->GetComponentData<CrossServerEndpointSenderACK>(Receiver);
+		if (!ACKComponent)
+		{
+			continue;
+		}
+		if (TArray<uint64>* DottedACKList = ACKComponent->DottedRPCACK.Find(Sender))
+		{
+			bool bStillRelevant = false;
+			for (auto RPCId : *DottedACKList)
+			{
+				if (RPCId >= MinRPCId)
+				{
+					bStillRelevant = true;
+					break;
+				}
+			}
+			if (!bStillRelevant)
+			{
+				ACKComponent->DottedRPCACK.Remove(Sender);
+				if (ACKComponent->DottedRPCACK.Num() == 0)
+				{
+					Iterator.RemoveCurrent();
+				}
+
+				EntityComponentId Pair;
+				Pair.EntityId = Receiver;
+				Pair.ComponentId = RPCRingBufferUtils::GetAckComponentId(ERPCType::CrossServerSender);
+
+				if (Schema_ComponentUpdate** PendingUpdate = PendingComponentUpdatesToSend.Find(Pair))
+				{
+					Schema_DestroyComponentUpdate(*PendingUpdate);
+					PendingComponentUpdatesToSend.Remove(Pair);
+				}
+
+				Schema_ComponentUpdate* Update = GetOrCreateComponentUpdate(Pair);
+				Schema_Object* UpdateObject = Schema_GetComponentUpdateFields(Update);
+				ACKComponent->CreateUpdate(Update);
+			}
+		}
+	}
+}
+
+void SpatialRPCService::CheckLocalTargets(Worker_EntityId LocalWorkerEntityId)
+{
+	if (bShouldCheckSentRPCForLocalTarget)
+	{
+		bShouldCheckSentRPCForLocalTarget = false;
+		ExtractCrossServerRPCsForType(LocalWorkerEntityId, ERPCType::CrossServerSender);
+	}
+}
+} // namespace SpatialGDK
 
 // 9/10 sur l'echelle du goret.
 #include "Interop/Connection/SpatialOSWorkerInterface.h"
 
 namespace SpatialGDK
 {
-
 void SpatialRPCService::HandleTimeout(SpatialOSWorkerInterface* Worker)
 {
 	uint64 Now = FPlatformTime::Cycles64();

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialRPCService.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialRPCService.cpp
@@ -4,449 +4,734 @@
 
 #include "Interop/SpatialStaticComponentView.h"
 #include "Schema/ClientEndpoint.h"
+#include "Schema/CrossServerEndpoint.h"
 #include "Schema/MulticastRPCs.h"
 #include "Schema/ServerEndpoint.h"
 #include "Utils/SpatialLatencyTracer.h"
 
 DEFINE_LOG_CATEGORY(LogSpatialRPCService);
 
+#pragma optimize ("", off)
+
 namespace SpatialGDK
 {
-SpatialRPCService::SpatialRPCService(ExtractRPCDelegate ExtractRPCCallback, const USpatialStaticComponentView* View,
-									 USpatialLatencyTracer* SpatialLatencyTracer)
-	: ExtractRPCCallback(ExtractRPCCallback)
-	, View(View)
-	, SpatialLatencyTracer(SpatialLatencyTracer)
-{
-}
-
-EPushRPCResult SpatialRPCService::PushRPC(Worker_EntityId EntityId, ERPCType Type, RPCPayload Payload, bool bCreatedEntity)
-{
-	EntityRPCType EntityType = EntityRPCType(EntityId, Type);
-
-	EPushRPCResult Result = EPushRPCResult::Success;
-
-	if (RPCRingBufferUtils::ShouldQueueOverflowed(Type) && OverflowedRPCs.Contains(EntityType))
+	SpatialRPCService::SpatialRPCService(ExtractRPCDelegate ExtractRPCCallback, const USpatialStaticComponentView* View,
+		USpatialLatencyTracer* SpatialLatencyTracer)
+		: ExtractRPCCallback(ExtractRPCCallback)
+		, View(View)
+		, SpatialLatencyTracer(SpatialLatencyTracer)
 	{
-		// Already has queued RPCs of this type, queue until those are pushed.
-		AddOverflowedRPC(EntityType, MoveTemp(Payload));
-		Result = EPushRPCResult::QueueOverflowed;
+		CrossServerMailbox.SetNumZeroed(RPCRingBufferUtils::GetRingBufferSize(ERPCType::CrossServerSender));
 	}
-	else
-	{
-		Result = PushRPCInternal(EntityId, Type, MoveTemp(Payload), bCreatedEntity);
 
-		if (Result == EPushRPCResult::QueueOverflowed)
+	EPushRPCResult SpatialRPCService::PushRPC(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType Type, RPCPayload Payload, bool bCreatedEntity)
+	{
+		EntityRPCType EntityType = EntityRPCType(EntityId, Type);
+
+		EPushRPCResult Result = EPushRPCResult::Success;
+
+		if (RPCRingBufferUtils::ShouldQueueOverflowed(Type) && OverflowedRPCs.Contains(EntityType))
 		{
+			// Already has queued RPCs of this type, queue until those are pushed.
 			AddOverflowedRPC(EntityType, MoveTemp(Payload));
+			Result = EPushRPCResult::QueueOverflowed;
 		}
-	}
+		else
+		{
+			Result = PushRPCInternal(EntityId, Counterpart, Type, MoveTemp(Payload), bCreatedEntity);
+
+			if (Result == EPushRPCResult::QueueOverflowed)
+			{
+				AddOverflowedRPC(EntityType, MoveTemp(Payload));
+			}
+		}
 
 #if TRACE_LIB_ACTIVE
-	ProcessResultToLatencyTrace(Result, Payload.Trace);
+		ProcessResultToLatencyTrace(Result, Payload.Trace);
 #endif
 
-	return Result;
-}
+		return Result;
+	}
 
-EPushRPCResult SpatialRPCService::PushRPCInternal(Worker_EntityId EntityId, ERPCType Type, RPCPayload&& Payload, bool bCreatedEntity)
-{
-	const Worker_ComponentId RingBufferComponentId = RPCRingBufferUtils::GetRingBufferComponentId(Type);
-
-	const EntityComponentId EntityComponent = { EntityId, RingBufferComponentId };
-	const EntityRPCType EntityType = EntityRPCType(EntityId, Type);
-
-	Schema_Object* EndpointObject;
-	uint64 LastAckedRPCId;
-	if (View->HasComponent(EntityId, RingBufferComponentId))
+	EPushRPCResult SpatialRPCService::PushRPCInternal(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType Type, RPCPayload&& Payload, bool bCreatedEntity)
 	{
-		if (!View->HasAuthority(EntityId, RingBufferComponentId))
+		const Worker_ComponentId RingBufferComponentId = RPCRingBufferUtils::GetRingBufferComponentId(Type);
+
+		const EntityComponentId EntityComponent = { EntityId, RingBufferComponentId };
+		const EntityRPCType EntityType = EntityRPCType(EntityId, Type);
+
+		Schema_Object* EndpointObject;
+		uint64 LastAckedRPCId;
+		if (View->HasComponent(EntityId, RingBufferComponentId))
+		{
+			if (!View->HasAuthority(EntityId, RingBufferComponentId))
+			{
+				if (bCreatedEntity)
+				{
+					return EPushRPCResult::EntityBeingCreated;
+				}
+				return EPushRPCResult::NoRingBufferAuthority;
+			}
+
+			EndpointObject = Schema_GetComponentUpdateFields(GetOrCreateComponentUpdate(EntityComponent));
+
+			if (Type == ERPCType::NetMulticast)
+			{
+				// Assume all multicast RPCs are auto-acked.
+				LastAckedRPCId = LastSentRPCIds.FindRef(EntityType);
+			}
+			else
+			{
+				// Ignore these while the routing worker can be anyone.
+				if (Type != ERPCType::CrossServerSender && Type != ERPCType::CrossServerReceiver)
+				{
+					// We shouldn't have authority over the component that has the acks.
+					if (View->HasAuthority(EntityId, RPCRingBufferUtils::GetAckComponentId(Type)))
+					{
+						return EPushRPCResult::HasAckAuthority;
+					}
+					LastAckedRPCId = GetAckFromView(EntityId, Type);
+				}
+			}
+		}
+		else
 		{
 			if (bCreatedEntity)
 			{
 				return EPushRPCResult::EntityBeingCreated;
 			}
-			return EPushRPCResult::NoRingBufferAuthority;
+			// If the entity isn't in the view, we assume this RPC was called before
+			// CreateEntityRequest, so we put it into a component data object.
+			EndpointObject = Schema_GetComponentDataFields(GetOrCreateComponentData(EntityComponent));
+
+			LastAckedRPCId = 0;
 		}
 
-		EndpointObject = Schema_GetComponentUpdateFields(GetOrCreateComponentUpdate(EntityComponent));
+		uint64 NewRPCId = LastSentRPCIds.FindRef(EntityType) + 1;
+		EPushRPCResult Result = EPushRPCResult::Success;
 
-		if (Type == ERPCType::NetMulticast)
+		if (Type == ERPCType::CrossServerSender)
 		{
-			// Assume all multicast RPCs are auto-acked.
-			LastAckedRPCId = LastSentRPCIds.FindRef(EntityType);
-		}
-		else
-		{
-			// We shouldn't have authority over the component that has the acks.
-			if (View->HasAuthority(EntityId, RPCRingBufferUtils::GetAckComponentId(Type)))
+			TOptional<uint32> Slot = FindFreeSlotForCrossServerSender();
+			if (Slot)
 			{
-				return EPushRPCResult::HasAckAuthority;
-			}
+				int32 SlotIdx = Slot.GetValue();
 
-			LastAckedRPCId = GetAckFromView(EntityId, Type);
-		}
-	}
-	else
-	{
-		if (bCreatedEntity)
-		{
-			return EPushRPCResult::EntityBeingCreated;
-		}
-		// If the entity isn't in the view, we assume this RPC was called before
-		// CreateEntityRequest, so we put it into a component data object.
-		EndpointObject = Schema_GetComponentDataFields(GetOrCreateComponentData(EntityComponent));
+				RPCRingBufferDescriptor Descriptor = RPCRingBufferUtils::GetRingBufferDescriptor(Type);
+				uint32 Field = Descriptor.GetRingBufferElementFieldId(ERPCType::CrossServerSender, SlotIdx + 1);
 
-		LastAckedRPCId = 0;
-	}
+				Schema_Object* RPCObject = Schema_AddObject(EndpointObject, Field);
+				Payload.WriteToSchemaObject(RPCObject);
 
-	uint64 NewRPCId = LastSentRPCIds.FindRef(EntityType) + 1;
+				FUnrealObjectRef Target = Counterpart;
+				Target.Offset = NewRPCId;
+				AddObjectRefToSchema(EndpointObject, Field + 1, Target);
 
-	// Check capacity.
-	if (LastAckedRPCId + RPCRingBufferUtils::GetRingBufferSize(Type) >= NewRPCId)
-	{
-		RPCRingBufferUtils::WriteRPCToSchema(EndpointObject, Type, NewRPCId, Payload);
+				Schema_ClearField(EndpointObject, Descriptor.LastSentRPCFieldId);
+				Schema_AddUint64(EndpointObject, Descriptor.LastSentRPCFieldId, NewRPCId);
 
-#if TRACE_LIB_ACTIVE
-		if (SpatialLatencyTracer != nullptr && Payload.Trace != InvalidTraceKey)
-		{
-			if (PendingTraces.Find(EntityComponent) == nullptr)
-			{
-				PendingTraces.Add(EntityComponent, Payload.Trace);
+				CrossServerEndpointSender* Sender = View->GetComponentData<CrossServerEndpointSender>(EntityId);
+				if (ensure(Sender != nullptr))
+				{
+					RPCRingBuffer& Buffer = Sender->ReliableRPCBuffer;
+					Buffer.RingBuffer[SlotIdx].Emplace(Payload);
+					Buffer.Counterpart[SlotIdx].Emplace(Target);
+
+					SentRPCEntry& Entry = CrossServerMailbox[SlotIdx];
+					Entry.RPCId = NewRPCId;
+					Entry.Target = Target.Entity;
+					Entry.Timestamp = FPlatformTime::Cycles64();
+				}
+				else
+				{
+					Result = EPushRPCResult::EntityBeingCreated;
+				}
 			}
 			else
 			{
-				SpatialLatencyTracer->WriteAndEndTrace(Payload.Trace,
-													   TEXT("Multiple rpc updates in single update, ending further stack tracing"), true);
+				// Overflowed
+				if (RPCRingBufferUtils::ShouldQueueOverflowed(Type))
+				{
+					Result = EPushRPCResult::QueueOverflowed;
+				}
+				else
+				{
+					Result = EPushRPCResult::DropOverflowed;
+				}
 			}
-		}
-#endif
-
-		LastSentRPCIds.Add(EntityType, NewRPCId);
-	}
-	else
-	{
-		// Overflowed
-		if (RPCRingBufferUtils::ShouldQueueOverflowed(Type))
-		{
-			return EPushRPCResult::QueueOverflowed;
 		}
 		else
 		{
-			return EPushRPCResult::DropOverflowed;
+			// Check capacity.
+			if (LastAckedRPCId + RPCRingBufferUtils::GetRingBufferSize(Type) >= NewRPCId)
+			{
+				RPCRingBufferUtils::WriteRPCToSchema(EndpointObject, Type, NewRPCId, Payload);
+			}
+			else
+			{
+				// Overflowed
+				if (RPCRingBufferUtils::ShouldQueueOverflowed(Type))
+				{
+					return EPushRPCResult::QueueOverflowed;
+				}
+				else
+				{
+					return EPushRPCResult::DropOverflowed;
+				}
+			}
 		}
+
+		if (Result == EPushRPCResult::Success)
+		{
+			LastSentRPCIds.Add(EntityType, NewRPCId);
+
+#if TRACE_LIB_ACTIVE
+			if (SpatialLatencyTracer != nullptr && Payload.Trace != InvalidTraceKey)
+			{
+				if (PendingTraces.Find(EntityComponent) == nullptr)
+				{
+					PendingTraces.Add(EntityComponent, Payload.Trace);
+				}
+				else
+				{
+					SpatialLatencyTracer->WriteAndEndTrace(Payload.Trace,
+						TEXT("Multiple rpc updates in single update, ending further stack tracing"), true);
+				}
+			}
+#endif
+		}
+
+		return Result;
 	}
 
-	return EPushRPCResult::Success;
-}
-
-void SpatialRPCService::PushOverflowedRPCs()
-{
-	for (auto It = OverflowedRPCs.CreateIterator(); It; ++It)
+	void SpatialRPCService::PushOverflowedRPCs()
 	{
-		Worker_EntityId EntityId = It.Key().EntityId;
-		ERPCType Type = It.Key().Type;
-		TArray<RPCPayload>& OverflowedRPCArray = It.Value();
-
-		int NumProcessed = 0;
-		bool bShouldDrop = false;
-		for (RPCPayload& Payload : OverflowedRPCArray)
+		for (auto It = OverflowedRPCs.CreateIterator(); It; ++It)
 		{
-			const EPushRPCResult Result = PushRPCInternal(EntityId, Type, MoveTemp(Payload), false);
+			Worker_EntityId EntityId = It.Key().EntityId;
+			ERPCType Type = It.Key().Type;
+			TArray<RPCPayload>& OverflowedRPCArray = It.Value();
 
-			switch (Result)
+			int NumProcessed = 0;
+			bool bShouldDrop = false;
+			for (RPCPayload& Payload : OverflowedRPCArray)
 			{
-			case EPushRPCResult::Success:
-				NumProcessed++;
-				break;
-			case EPushRPCResult::QueueOverflowed:
-				UE_LOG(LogSpatialRPCService, Log,
-					   TEXT("SpatialRPCService::PushOverflowedRPCs: Sent some but not all overflowed RPCs. RPCs sent %d, RPCs still "
+				const EPushRPCResult Result = PushRPCInternal(EntityId, FUnrealObjectRef(), Type, MoveTemp(Payload), false);
+
+				switch (Result)
+				{
+				case EPushRPCResult::Success:
+					NumProcessed++;
+					break;
+				case EPushRPCResult::QueueOverflowed:
+					UE_LOG(LogSpatialRPCService, Log,
+						TEXT("SpatialRPCService::PushOverflowedRPCs: Sent some but not all overflowed RPCs. RPCs sent %d, RPCs still "
 							"overflowed: %d, Entity: %lld, RPC type: %s"),
-					   NumProcessed, OverflowedRPCArray.Num() - NumProcessed, EntityId, *SpatialConstants::RPCTypeToString(Type));
-				break;
-			case EPushRPCResult::DropOverflowed:
-				checkf(false, TEXT("Shouldn't be able to drop on overflow for RPC type that was previously queued."));
-				break;
-			case EPushRPCResult::HasAckAuthority:
-				UE_LOG(LogSpatialRPCService, Warning,
-					   TEXT("SpatialRPCService::PushOverflowedRPCs: Gained authority over ack component for RPC type that was overflowed. "
+						NumProcessed, OverflowedRPCArray.Num() - NumProcessed, EntityId, *SpatialConstants::RPCTypeToString(Type));
+					break;
+				case EPushRPCResult::DropOverflowed:
+					checkf(false, TEXT("Shouldn't be able to drop on overflow for RPC type that was previously queued."));
+					break;
+				case EPushRPCResult::HasAckAuthority:
+					UE_LOG(LogSpatialRPCService, Warning,
+						TEXT("SpatialRPCService::PushOverflowedRPCs: Gained authority over ack component for RPC type that was overflowed. "
 							"Entity: %lld, RPC type: %s"),
-					   EntityId, *SpatialConstants::RPCTypeToString(Type));
-				bShouldDrop = true;
-				break;
-			case EPushRPCResult::NoRingBufferAuthority:
-				UE_LOG(LogSpatialRPCService, Warning,
-					   TEXT("SpatialRPCService::PushOverflowedRPCs: Lost authority over ring buffer component for RPC type that was "
+						EntityId, *SpatialConstants::RPCTypeToString(Type));
+					bShouldDrop = true;
+					break;
+				case EPushRPCResult::NoRingBufferAuthority:
+					UE_LOG(LogSpatialRPCService, Warning,
+						TEXT("SpatialRPCService::PushOverflowedRPCs: Lost authority over ring buffer component for RPC type that was "
 							"overflowed. Entity: %lld, RPC type: %s"),
-					   EntityId, *SpatialConstants::RPCTypeToString(Type));
-				bShouldDrop = true;
-				break;
-			default:
-				checkNoEntry();
-			}
+						EntityId, *SpatialConstants::RPCTypeToString(Type));
+					bShouldDrop = true;
+					break;
+				default:
+					checkNoEntry();
+				}
 
 #if TRACE_LIB_ACTIVE
-			ProcessResultToLatencyTrace(Result, Payload.Trace);
+				ProcessResultToLatencyTrace(Result, Payload.Trace);
 #endif
 
-			// This includes the valid case of RPCs still overflowing (EPushRPCResult::QueueOverflowed), as well as the error cases.
-			if (Result != EPushRPCResult::Success)
-			{
-				break;
-			}
-		}
-
-		if (NumProcessed == OverflowedRPCArray.Num() || bShouldDrop)
-		{
-			It.RemoveCurrent();
-		}
-		else
-		{
-			OverflowedRPCArray.RemoveAt(0, NumProcessed);
-		}
-	}
-}
-
-void SpatialRPCService::ClearOverflowedRPCs(Worker_EntityId EntityId)
-{
-	for (uint8 RPCType = static_cast<uint8>(ERPCType::ClientReliable); RPCType <= static_cast<uint8>(ERPCType::NetMulticast); RPCType++)
-	{
-		OverflowedRPCs.Remove(EntityRPCType(EntityId, static_cast<ERPCType>(RPCType)));
-	}
-}
-
-TArray<SpatialRPCService::UpdateToSend> SpatialRPCService::GetRPCsAndAcksToSend()
-{
-	TArray<SpatialRPCService::UpdateToSend> UpdatesToSend;
-
-	for (auto& It : PendingComponentUpdatesToSend)
-	{
-		SpatialRPCService::UpdateToSend& UpdateToSend = UpdatesToSend.AddZeroed_GetRef();
-		UpdateToSend.EntityId = It.Key.EntityId;
-		UpdateToSend.Update.component_id = It.Key.ComponentId;
-		UpdateToSend.Update.schema_type = It.Value;
-#if TRACE_LIB_ACTIVE
-		TraceKey Trace = InvalidTraceKey;
-		PendingTraces.RemoveAndCopyValue(It.Key, Trace);
-		UpdateToSend.Update.Trace = Trace;
-#endif
-	}
-
-	PendingComponentUpdatesToSend.Empty();
-
-	return UpdatesToSend;
-}
-
-TArray<FWorkerComponentData> SpatialRPCService::GetRPCComponentsOnEntityCreation(Worker_EntityId EntityId)
-{
-	static Worker_ComponentId EndpointComponentIds[] = { SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID,
-														 SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID,
-														 SpatialConstants::MULTICAST_RPCS_COMPONENT_ID };
-
-	TArray<FWorkerComponentData> Components;
-
-	for (Worker_ComponentId EndpointComponentId : EndpointComponentIds)
-	{
-		const EntityComponentId EntityComponent = { EntityId, EndpointComponentId };
-
-		FWorkerComponentData& Component = Components.Emplace_GetRef(FWorkerComponentData{});
-		Component.component_id = EndpointComponentId;
-		if (Schema_ComponentData** ComponentData = PendingRPCsOnEntityCreation.Find(EntityComponent))
-		{
-			// When sending initial multicast RPCs, write the number of RPCs into a separate field instead of
-			// last sent RPC ID field. When the server gains authority for the first time, it will copy the
-			// value over to last sent RPC ID, so the clients that checked out the entity process the initial RPCs.
-			if (EndpointComponentId == SpatialConstants::MULTICAST_RPCS_COMPONENT_ID)
-			{
-				RPCRingBufferUtils::MoveLastSentIdToInitiallyPresentCount(Schema_GetComponentDataFields(*ComponentData),
-																		  LastSentRPCIds[EntityRPCType(EntityId, ERPCType::NetMulticast)]);
+				// This includes the valid case of RPCs still overflowing (EPushRPCResult::QueueOverflowed), as well as the error cases.
+				if (Result != EPushRPCResult::Success)
+				{
+					break;
+				}
 			}
 
-			if (EndpointComponentId == SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID)
+			if (NumProcessed == OverflowedRPCArray.Num() || bShouldDrop)
 			{
-				UE_LOG(LogSpatialRPCService, Error,
-					   TEXT("SpatialRPCService::GetRPCComponentsOnEntityCreation: Initial RPCs present on ClientEndpoint! EntityId: %lld"),
-					   EntityId);
+				It.RemoveCurrent();
 			}
+			else
+			{
+				OverflowedRPCArray.RemoveAt(0, NumProcessed);
+			}
+		}
+	}
 
-			Component.schema_type = *ComponentData;
+	void SpatialRPCService::ClearOverflowedRPCs(Worker_EntityId EntityId)
+	{
+		for (uint8 RPCType = static_cast<uint8>(ERPCType::ClientReliable); RPCType <= static_cast<uint8>(ERPCType::NetMulticast); RPCType++)
+		{
+			OverflowedRPCs.Remove(EntityRPCType(EntityId, static_cast<ERPCType>(RPCType)));
+		}
+	}
+
+	TArray<SpatialRPCService::UpdateToSend> SpatialRPCService::GetRPCsAndAcksToSend()
+	{
+		TArray<SpatialRPCService::UpdateToSend> UpdatesToSend;
+
+		for (auto& It : PendingComponentUpdatesToSend)
+		{
+			SpatialRPCService::UpdateToSend& UpdateToSend = UpdatesToSend.AddZeroed_GetRef();
+			UpdateToSend.EntityId = It.Key.EntityId;
+			UpdateToSend.Update.component_id = It.Key.ComponentId;
+			UpdateToSend.Update.schema_type = It.Value;
 #if TRACE_LIB_ACTIVE
 			TraceKey Trace = InvalidTraceKey;
-			PendingTraces.RemoveAndCopyValue(EntityComponent, Trace);
-			Component.Trace = Trace;
+			PendingTraces.RemoveAndCopyValue(It.Key, Trace);
+			UpdateToSend.Update.Trace = Trace;
 #endif
-			PendingRPCsOnEntityCreation.Remove(EntityComponent);
 		}
-		else
+
+		PendingComponentUpdatesToSend.Empty();
+
+		return UpdatesToSend;
+	}
+
+	TArray<FWorkerComponentData> SpatialRPCService::GetRPCComponentsOnEntityCreation(Worker_EntityId EntityId)
+	{
+		static Worker_ComponentId EndpointComponentIds[] = { SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID,
+															 SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID,
+															 SpatialConstants::MULTICAST_RPCS_COMPONENT_ID };
+
+		TArray<FWorkerComponentData> Components;
+
+		for (Worker_ComponentId EndpointComponentId : EndpointComponentIds)
 		{
-			Component.schema_type = Schema_CreateComponentData();
+			const EntityComponentId EntityComponent = { EntityId, EndpointComponentId };
+
+			FWorkerComponentData& Component = Components.Emplace_GetRef(FWorkerComponentData{});
+			Component.component_id = EndpointComponentId;
+			if (Schema_ComponentData** ComponentData = PendingRPCsOnEntityCreation.Find(EntityComponent))
+			{
+				// When sending initial multicast RPCs, write the number of RPCs into a separate field instead of
+				// last sent RPC ID field. When the server gains authority for the first time, it will copy the
+				// value over to last sent RPC ID, so the clients that checked out the entity process the initial RPCs.
+				if (EndpointComponentId == SpatialConstants::MULTICAST_RPCS_COMPONENT_ID)
+				{
+					RPCRingBufferUtils::MoveLastSentIdToInitiallyPresentCount(Schema_GetComponentDataFields(*ComponentData),
+						LastSentRPCIds[EntityRPCType(EntityId, ERPCType::NetMulticast)]);
+				}
+
+				if (EndpointComponentId == SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID)
+				{
+					UE_LOG(LogSpatialRPCService, Error,
+						TEXT("SpatialRPCService::GetRPCComponentsOnEntityCreation: Initial RPCs present on ClientEndpoint! EntityId: %lld"),
+						EntityId);
+				}
+
+				Component.schema_type = *ComponentData;
+#if TRACE_LIB_ACTIVE
+				TraceKey Trace = InvalidTraceKey;
+				PendingTraces.RemoveAndCopyValue(EntityComponent, Trace);
+				Component.Trace = Trace;
+#endif
+				PendingRPCsOnEntityCreation.Remove(EntityComponent);
+			}
+			else
+			{
+				Component.schema_type = Schema_CreateComponentData();
+			}
 		}
+
+		return Components;
 	}
 
-	return Components;
-}
-
-void SpatialRPCService::ExtractRPCsForEntity(Worker_EntityId EntityId, Worker_ComponentId ComponentId)
-{
-	switch (ComponentId)
+	void SpatialRPCService::ExtractRPCsForEntity(Worker_EntityId EntityId, Worker_ComponentId ComponentId)
 	{
-	case SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID:
-		if (View->HasAuthority(EntityId, SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID))
+		switch (ComponentId)
 		{
-			ExtractRPCsForType(EntityId, ERPCType::ServerReliable);
-			ExtractRPCsForType(EntityId, ERPCType::ServerUnreliable);
+		case SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID:
+			if (View->HasAuthority(EntityId, SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID))
+			{
+				ExtractRPCsForType(EntityId, ERPCType::ServerReliable);
+				ExtractRPCsForType(EntityId, ERPCType::ServerUnreliable);
+			}
+			break;
+		case SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID:
+			if (View->HasAuthority(EntityId, SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID))
+			{
+				ExtractRPCsForType(EntityId, ERPCType::ClientReliable);
+				ExtractRPCsForType(EntityId, ERPCType::ClientUnreliable);
+			}
+			break;
+		case SpatialConstants::MULTICAST_RPCS_COMPONENT_ID:
+			ExtractRPCsForType(EntityId, ERPCType::NetMulticast);
+			break;
+		case SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID:
+			ExtractCrossServerRPCsForType(EntityId, ERPCType::CrossServerSender);
+			break;
+		case SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID:
+			ExtractRPCsForType(EntityId, ERPCType::CrossServerReceiver);
+			break;
+		default:
+			checkNoEntry();
+			break;
 		}
-		break;
-	case SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID:
-		if (View->HasAuthority(EntityId, SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID))
-		{
-			ExtractRPCsForType(EntityId, ERPCType::ClientReliable);
-			ExtractRPCsForType(EntityId, ERPCType::ClientUnreliable);
-		}
-		break;
-	case SpatialConstants::MULTICAST_RPCS_COMPONENT_ID:
-		ExtractRPCsForType(EntityId, ERPCType::NetMulticast);
-		break;
-	default:
-		checkNoEntry();
-		break;
-	}
-}
-
-void SpatialRPCService::OnCheckoutMulticastRPCComponentOnEntity(Worker_EntityId EntityId)
-{
-	const MulticastRPCs* Component = View->GetComponentData<MulticastRPCs>(EntityId);
-
-	if (!ensure(Component != nullptr))
-	{
-		UE_LOG(LogSpatialRPCService, Error,
-			   TEXT("Multicast RPC component for entity with ID %lld was not present at point of checking out the component."), EntityId);
-		return;
 	}
 
-	// When checking out entity, ignore multicast RPCs that are already on the component.
-	LastSeenMulticastRPCIds.Add(EntityId, Component->MulticastRPCBuffer.LastSentRPCId);
-}
-
-void SpatialRPCService::OnRemoveMulticastRPCComponentForEntity(Worker_EntityId EntityId)
-{
-	LastSeenMulticastRPCIds.Remove(EntityId);
-}
-
-void SpatialRPCService::OnEndpointAuthorityGained(Worker_EntityId EntityId, Worker_ComponentId ComponentId)
-{
-	switch (ComponentId)
-	{
-	case SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID:
-	{
-		const ClientEndpoint* Endpoint = View->GetComponentData<ClientEndpoint>(EntityId);
-		LastSeenRPCIds.Add(EntityRPCType(EntityId, ERPCType::ClientReliable), Endpoint->ReliableRPCAck);
-		LastSeenRPCIds.Add(EntityRPCType(EntityId, ERPCType::ClientUnreliable), Endpoint->UnreliableRPCAck);
-		LastAckedRPCIds.Add(EntityRPCType(EntityId, ERPCType::ClientReliable), Endpoint->ReliableRPCAck);
-		LastAckedRPCIds.Add(EntityRPCType(EntityId, ERPCType::ClientUnreliable), Endpoint->UnreliableRPCAck);
-		LastSentRPCIds.Add(EntityRPCType(EntityId, ERPCType::ServerReliable), Endpoint->ReliableRPCBuffer.LastSentRPCId);
-		LastSentRPCIds.Add(EntityRPCType(EntityId, ERPCType::ServerUnreliable), Endpoint->UnreliableRPCBuffer.LastSentRPCId);
-		break;
-	}
-	case SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID:
-	{
-		const ServerEndpoint* Endpoint = View->GetComponentData<ServerEndpoint>(EntityId);
-		LastSeenRPCIds.Add(EntityRPCType(EntityId, ERPCType::ServerReliable), Endpoint->ReliableRPCAck);
-		LastSeenRPCIds.Add(EntityRPCType(EntityId, ERPCType::ServerUnreliable), Endpoint->UnreliableRPCAck);
-		LastAckedRPCIds.Add(EntityRPCType(EntityId, ERPCType::ServerReliable), Endpoint->ReliableRPCAck);
-		LastAckedRPCIds.Add(EntityRPCType(EntityId, ERPCType::ServerUnreliable), Endpoint->UnreliableRPCAck);
-		LastSentRPCIds.Add(EntityRPCType(EntityId, ERPCType::ClientReliable), Endpoint->ReliableRPCBuffer.LastSentRPCId);
-		LastSentRPCIds.Add(EntityRPCType(EntityId, ERPCType::ClientUnreliable), Endpoint->UnreliableRPCBuffer.LastSentRPCId);
-		break;
-	}
-	case SpatialConstants::MULTICAST_RPCS_COMPONENT_ID:
+	void SpatialRPCService::OnCheckoutMulticastRPCComponentOnEntity(Worker_EntityId EntityId)
 	{
 		const MulticastRPCs* Component = View->GetComponentData<MulticastRPCs>(EntityId);
 
-		if (Component->MulticastRPCBuffer.LastSentRPCId == 0 && Component->InitiallyPresentMulticastRPCsCount > 0)
+		if (!ensure(Component != nullptr))
 		{
-			// Update last sent ID to the number of initially present RPCs so the clients who check out this entity
-			// as it's created can process the initial multicast RPCs.
-			LastSentRPCIds.Add(EntityRPCType(EntityId, ERPCType::NetMulticast), Component->InitiallyPresentMulticastRPCsCount);
+			UE_LOG(LogSpatialRPCService, Error,
+				TEXT("Multicast RPC component for entity with ID %lld was not present at point of checking out the component."), EntityId);
+			return;
+		}
 
-			RPCRingBufferDescriptor Descriptor = RPCRingBufferUtils::GetRingBufferDescriptor(ERPCType::NetMulticast);
-			Schema_Object* SchemaObject =
-				Schema_GetComponentUpdateFields(GetOrCreateComponentUpdate(EntityComponentId{ EntityId, ComponentId }));
-			Schema_AddUint64(SchemaObject, Descriptor.LastSentRPCFieldId, Component->InitiallyPresentMulticastRPCsCount);
+		// When checking out entity, ignore multicast RPCs that are already on the component.
+		LastSeenMulticastRPCIds.Add(EntityId, Component->MulticastRPCBuffer.LastSentRPCId);
+	}
+
+	void SpatialRPCService::OnRemoveMulticastRPCComponentForEntity(Worker_EntityId EntityId)
+	{
+		LastSeenMulticastRPCIds.Remove(EntityId);
+	}
+
+	void SpatialRPCService::OnEndpointAuthorityGained(Worker_EntityId EntityId, Worker_ComponentId ComponentId)
+	{
+		switch (ComponentId)
+		{
+		case SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID:
+		{
+			const ClientEndpoint* Endpoint = View->GetComponentData<ClientEndpoint>(EntityId);
+			LastSeenRPCIds.Add(EntityRPCType(EntityId, ERPCType::ClientReliable), Endpoint->ReliableRPCAck);
+			LastSeenRPCIds.Add(EntityRPCType(EntityId, ERPCType::ClientUnreliable), Endpoint->UnreliableRPCAck);
+			LastAckedRPCIds.Add(EntityRPCType(EntityId, ERPCType::ClientReliable), Endpoint->ReliableRPCAck);
+			LastAckedRPCIds.Add(EntityRPCType(EntityId, ERPCType::ClientUnreliable), Endpoint->UnreliableRPCAck);
+			LastSentRPCIds.Add(EntityRPCType(EntityId, ERPCType::ServerReliable), Endpoint->ReliableRPCBuffer.LastSentRPCId);
+			LastSentRPCIds.Add(EntityRPCType(EntityId, ERPCType::ServerUnreliable), Endpoint->UnreliableRPCBuffer.LastSentRPCId);
+			break;
+		}
+		case SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID:
+		{
+			const ServerEndpoint* Endpoint = View->GetComponentData<ServerEndpoint>(EntityId);
+			LastSeenRPCIds.Add(EntityRPCType(EntityId, ERPCType::ServerReliable), Endpoint->ReliableRPCAck);
+			LastSeenRPCIds.Add(EntityRPCType(EntityId, ERPCType::ServerUnreliable), Endpoint->UnreliableRPCAck);
+			LastAckedRPCIds.Add(EntityRPCType(EntityId, ERPCType::ServerReliable), Endpoint->ReliableRPCAck);
+			LastAckedRPCIds.Add(EntityRPCType(EntityId, ERPCType::ServerUnreliable), Endpoint->UnreliableRPCAck);
+			LastSentRPCIds.Add(EntityRPCType(EntityId, ERPCType::ClientReliable), Endpoint->ReliableRPCBuffer.LastSentRPCId);
+			LastSentRPCIds.Add(EntityRPCType(EntityId, ERPCType::ClientUnreliable), Endpoint->UnreliableRPCBuffer.LastSentRPCId);
+			break;
+		}
+		case SpatialConstants::MULTICAST_RPCS_COMPONENT_ID:
+		{
+			const MulticastRPCs* Component = View->GetComponentData<MulticastRPCs>(EntityId);
+
+			if (Component->MulticastRPCBuffer.LastSentRPCId == 0 && Component->InitiallyPresentMulticastRPCsCount > 0)
+			{
+				// Update last sent ID to the number of initially present RPCs so the clients who check out this entity
+				// as it's created can process the initial multicast RPCs.
+				LastSentRPCIds.Add(EntityRPCType(EntityId, ERPCType::NetMulticast), Component->InitiallyPresentMulticastRPCsCount);
+
+				RPCRingBufferDescriptor Descriptor = RPCRingBufferUtils::GetRingBufferDescriptor(ERPCType::NetMulticast);
+				Schema_Object* SchemaObject =
+					Schema_GetComponentUpdateFields(GetOrCreateComponentUpdate(EntityComponentId{ EntityId, ComponentId }));
+				Schema_AddUint64(SchemaObject, Descriptor.LastSentRPCFieldId, Component->InitiallyPresentMulticastRPCsCount);
+			}
+			else
+			{
+				LastSentRPCIds.Add(EntityRPCType(EntityId, ERPCType::NetMulticast), Component->MulticastRPCBuffer.LastSentRPCId);
+			}
+
+			break;
+		}
+		case SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID:
+		{
+
+			break;
+		}
+		case SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID:
+		{
+			const CrossServerEndpointSenderACK* Endpoint = View->GetComponentData<CrossServerEndpointSenderACK>(EntityId);
+			if (ensure(Endpoint != nullptr))
+			{
+				if (Endpoint->DottedRPCACK.Num() != 0)
+				{
+					this->ACKComponentsToTrack.Add(EntityId);
+				}
+			}
+			for (const auto& Entry : CrossServerMailbox)
+			{
+				if (Entry.Target == EntityId)
+				{
+					bShouldCheckSentRPCForLocalTarget = true;
+				}
+			}
+			break;
+		}
+		case SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID:
+		{
+
+			break;
+		}
+		case SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID:
+		{
+
+			break;
+		}
+		default:
+			checkNoEntry();
+			break;
+		}
+	}
+
+	void SpatialRPCService::OnEndpointAuthorityLost(Worker_EntityId EntityId, Worker_ComponentId ComponentId)
+	{
+		switch (ComponentId)
+		{
+		case SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID:
+		{
+			LastSeenRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ClientReliable));
+			LastSeenRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ClientUnreliable));
+			LastAckedRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ClientReliable));
+			LastAckedRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ClientUnreliable));
+			LastSentRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ServerReliable));
+			LastSentRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ServerUnreliable));
+
+			ClearOverflowedRPCs(EntityId);
+			break;
+		}
+		case SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID:
+		{
+			LastSeenRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ServerReliable));
+			LastSeenRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ServerUnreliable));
+			LastAckedRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ServerReliable));
+			LastAckedRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ServerUnreliable));
+			LastSentRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ClientReliable));
+			LastSentRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ClientUnreliable));
+			ClearOverflowedRPCs(EntityId);
+			break;
+		}
+		case SpatialConstants::MULTICAST_RPCS_COMPONENT_ID:
+		{
+			// Set last seen to last sent, so we don't process own RPCs after crossing the boundary.
+			LastSeenMulticastRPCIds.Add(EntityId, LastSentRPCIds[EntityRPCType(EntityId, ERPCType::NetMulticast)]);
+			LastSentRPCIds.Remove(EntityRPCType(EntityId, ERPCType::NetMulticast));
+			break;
+		}
+		case SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID:
+		{
+			break;
+		}
+		case SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID:
+		{
+			ACKComponentsToTrack.Remove(EntityId);
+			break;
+		}
+		case SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID:
+		{
+
+			break;
+		}
+		case SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID:
+		{
+
+			break;
+		}
+		default:
+			checkNoEntry();
+			break;
+		}
+	}
+
+	void SpatialRPCService::ExtractRPCsForType(Worker_EntityId EntityId, ERPCType Type)
+	{
+		uint64 LastSeenRPCId;
+		EntityRPCType EntityTypePair = EntityRPCType(EntityId, Type);
+
+		if (Type == ERPCType::NetMulticast)
+		{
+			LastSeenRPCId = LastSeenMulticastRPCIds[EntityId];
 		}
 		else
 		{
-			LastSentRPCIds.Add(EntityRPCType(EntityId, ERPCType::NetMulticast), Component->MulticastRPCBuffer.LastSentRPCId);
+			LastSeenRPCId = LastSeenRPCIds[EntityTypePair];
 		}
 
-		break;
-	}
-	default:
-		checkNoEntry();
-		break;
-	}
-}
+		const RPCRingBuffer& Buffer = GetBufferFromView(EntityId, Type);
 
-void SpatialRPCService::OnEndpointAuthorityLost(Worker_EntityId EntityId, Worker_ComponentId ComponentId)
-{
-	switch (ComponentId)
-	{
-	case SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID:
-	{
-		LastSeenRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ClientReliable));
-		LastSeenRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ClientUnreliable));
-		LastAckedRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ClientReliable));
-		LastAckedRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ClientUnreliable));
-		LastSentRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ServerReliable));
-		LastSentRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ServerUnreliable));
+		uint64 LastProcessedRPCId = LastSeenRPCId;
+		if (Buffer.LastSentRPCId >= LastSeenRPCId)
+		{
+			uint64 FirstRPCIdToRead = LastSeenRPCId + 1;
 
-		ClearOverflowedRPCs(EntityId);
-		break;
-	}
-	case SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID:
-	{
-		LastSeenRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ServerReliable));
-		LastSeenRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ServerUnreliable));
-		LastAckedRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ServerReliable));
-		LastAckedRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ServerUnreliable));
-		LastSentRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ClientReliable));
-		LastSentRPCIds.Remove(EntityRPCType(EntityId, ERPCType::ClientUnreliable));
-		ClearOverflowedRPCs(EntityId);
-		break;
-	}
-	case SpatialConstants::MULTICAST_RPCS_COMPONENT_ID:
-	{
-		// Set last seen to last sent, so we don't process own RPCs after crossing the boundary.
-		LastSeenMulticastRPCIds.Add(EntityId, LastSentRPCIds[EntityRPCType(EntityId, ERPCType::NetMulticast)]);
-		LastSentRPCIds.Remove(EntityRPCType(EntityId, ERPCType::NetMulticast));
-		break;
-	}
-	default:
-		checkNoEntry();
-		break;
-	}
-}
+			uint32 BufferSize = RPCRingBufferUtils::GetRingBufferSize(Type);
+			if (Buffer.LastSentRPCId > LastSeenRPCId + BufferSize)
+			{
+				UE_LOG(LogSpatialRPCService, Warning,
+					TEXT("SpatialRPCService::ExtractRPCsForType: RPCs were overwritten without being processed! Entity: %lld, RPC type: %s, "
+						"last seen RPC ID: %d, last sent ID: %d, buffer size: %d"),
+					EntityId, *SpatialConstants::RPCTypeToString(Type), LastSeenRPCId, Buffer.LastSentRPCId, BufferSize);
+				FirstRPCIdToRead = Buffer.LastSentRPCId - BufferSize + 1;
+			}
 
-void SpatialRPCService::ExtractRPCsForType(Worker_EntityId EntityId, ERPCType Type)
-{
-	uint64 LastSeenRPCId;
-	EntityRPCType EntityTypePair = EntityRPCType(EntityId, Type);
-
-	if (Type == ERPCType::NetMulticast)
-	{
-		if (!LastSeenMulticastRPCIds.Contains(EntityId))
+			for (uint64 RPCId = FirstRPCIdToRead; RPCId <= Buffer.LastSentRPCId; RPCId++)
+			{
+				const TOptional<RPCPayload>& Element = Buffer.GetRingBufferElement(RPCId);
+				if (Element.IsSet())
+				{
+					FUnrealObjectRef Counterpart;
+					if (Buffer.Type == ERPCType::CrossServerSender)
+					{
+						Worker_EntityId TargetId = SpatialConstants::INVALID_ENTITY_ID;
+						const TOptional<FUnrealObjectRef>& Target = Buffer.GetRingBufferCounterpart(RPCId);
+						if (Target.IsSet())
+						{
+							TargetId = Target.GetValue().Entity;
+						}
+						Counterpart.Entity = TargetId;
+						Counterpart.Offset = RPCId;
+					}
+					const bool bKeepExtracting = ExtractRPCCallback.Execute(EntityId, Counterpart, Type, Element.GetValue(), &Element - Buffer.RingBuffer.GetData());
+					if (!bKeepExtracting)
+					{
+						break;
+					}
+					LastProcessedRPCId = RPCId;
+				}
+				else
+				{
+					UE_LOG(LogSpatialRPCService, Warning,
+						TEXT("SpatialRPCService::ExtractRPCsForType: Ring buffer element empty. Entity: %lld, RPC type: %s, empty element "
+							"RPC id: %d"),
+						EntityId, *SpatialConstants::RPCTypeToString(Type), RPCId);
+				}
+			}
+		}
+		else
 		{
 			UE_LOG(LogSpatialRPCService, Warning,
-				   TEXT("Tried to extract RPCs but no entry in Last Seen Map! This can happen after server travel. Entity: %lld, type: "
-						"Multicast"),
-				   EntityId);
+				TEXT("SpatialRPCService::ExtractRPCsForType: Last sent RPC has smaller ID than last seen RPC. Entity: %lld, RPC type: %s, "
+					"last sent ID: %d, last seen ID: %d"),
+				EntityId, *SpatialConstants::RPCTypeToString(Type), Buffer.LastSentRPCId, LastSeenRPCId);
+		}
+
+		if (LastProcessedRPCId > LastSeenRPCId)
+		{
+			if (Type == ERPCType::NetMulticast)
+			{
+				LastSeenMulticastRPCIds[EntityId] = LastProcessedRPCId;
+			}
+			else
+			{
+				LastSeenRPCIds[EntityTypePair] = LastProcessedRPCId;
+			}
+		}
+	}
+
+	void SpatialRPCService::IncrementAckedRPCID(Worker_EntityId EntityId, ERPCType Type)
+	{
+		if (Type == ERPCType::NetMulticast)
+		{
 			return;
 		}
-		LastSeenRPCId = LastSeenMulticastRPCIds[EntityId];
+
+		EntityRPCType EntityTypePair = EntityRPCType(EntityId, Type);
+		uint64* LastAckedRPCId = LastAckedRPCIds.Find(EntityTypePair);
+		if (LastAckedRPCId == nullptr)
+		{
+			UE_LOG(LogSpatialRPCService, Warning,
+				TEXT("SpatialRPCService::IncrementAckedRPCID: Could not find last acked RPC id. Entity: %lld, RPC type: %s"), EntityId,
+				*SpatialConstants::RPCTypeToString(Type));
+			return;
+		}
+
+		++(*LastAckedRPCId);
+
+		const EntityComponentId EntityComponentPair = { EntityId, RPCRingBufferUtils::GetAckComponentId(Type) };
+		Schema_Object* EndpointObject = Schema_GetComponentUpdateFields(GetOrCreateComponentUpdate(EntityComponentPair));
+
+		RPCRingBufferUtils::WriteAckToSchema(EndpointObject, Type, *LastAckedRPCId);
 	}
-	else
+
+	void SpatialRPCService::AddOverflowedRPC(EntityRPCType EntityType, RPCPayload&& Payload)
 	{
+		OverflowedRPCs.FindOrAdd(EntityType).Add(MoveTemp(Payload));
+	}
+
+	uint64 SpatialRPCService::GetAckFromView(Worker_EntityId EntityId, ERPCType Type)
+	{
+		switch (Type)
+		{
+		case ERPCType::ClientReliable:
+			return View->GetComponentData<ClientEndpoint>(EntityId)->ReliableRPCAck;
+		case ERPCType::ClientUnreliable:
+			return View->GetComponentData<ClientEndpoint>(EntityId)->UnreliableRPCAck;
+		case ERPCType::ServerReliable:
+			return View->GetComponentData<ServerEndpoint>(EntityId)->ReliableRPCAck;
+		case ERPCType::ServerUnreliable:
+			return View->GetComponentData<ServerEndpoint>(EntityId)->UnreliableRPCAck;
+		case ERPCType::CrossServerSender:
+			return View->GetComponentData<CrossServerEndpointSenderACK>(EntityId)->RPCAck;
+		case ERPCType::CrossServerReceiver:
+			return View->GetComponentData<CrossServerEndpointReceiverACK>(EntityId)->RPCAck;
+		}
+
+		checkNoEntry();
+		return 0;
+	}
+
+	const RPCRingBuffer& SpatialRPCService::GetBufferFromView(Worker_EntityId EntityId, ERPCType Type)
+	{
+		
+		// Merge nonsense -> Not in master, but I did not add it????
+		//if (!LastSeenMulticastRPCIds.Contains(EntityId))
+		//{
+		//	UE_LOG(LogSpatialRPCService, Warning,
+		//		   TEXT("Tried to extract RPCs but no entry in Last Seen Map! This can happen after server travel. Entity: %lld, type: "
+		//				"Multicast"),
+		//		   EntityId);
+		//	return;
+		//}
+		//LastSeenRPCId = LastSeenMulticastRPCIds[EntityId];
+
+		switch (Type)
+		{
+			// Server sends Client RPCs, so ClientReliable & ClientUnreliable buffers live on ServerEndpoint.
+		case ERPCType::ClientReliable:
+			return View->GetComponentData<ServerEndpoint>(EntityId)->ReliableRPCBuffer;
+		case ERPCType::ClientUnreliable:
+			return View->GetComponentData<ServerEndpoint>(EntityId)->UnreliableRPCBuffer;
+
+			// Client sends Server RPCs, so ServerReliable & ServerUnreliable buffers live on ClientEndpoint.
+		case ERPCType::ServerReliable:
+			return View->GetComponentData<ClientEndpoint>(EntityId)->ReliableRPCBuffer;
+		case ERPCType::ServerUnreliable:
+			return View->GetComponentData<ClientEndpoint>(EntityId)->UnreliableRPCBuffer;
+
+		case ERPCType::NetMulticast:
+			return View->GetComponentData<MulticastRPCs>(EntityId)->MulticastRPCBuffer;
+		case ERPCType::CrossServerSender:
+			return View->GetComponentData<CrossServerEndpointSender>(EntityId)->ReliableRPCBuffer;
+		case ERPCType::CrossServerReceiver:
+			return View->GetComponentData<CrossServerEndpointReceiver>(EntityId)->ReliableRPCBuffer;
+		}
+
+		checkNoEntry();
+		static const RPCRingBuffer DummyBuffer(ERPCType::Invalid);
+		return DummyBuffer;
+	}
+
+	Schema_ComponentUpdate* SpatialRPCService::GetOrCreateComponentUpdate(EntityComponentId EntityComponentIdPair)
+	{
+<<<<<<< HEAD
 		if (!LastSeenRPCIds.Contains(EntityTypePair))
 		{
 			UE_LOG(LogSpatialRPCService, Warning,
@@ -455,204 +740,318 @@ void SpatialRPCService::ExtractRPCsForType(Worker_EntityId EntityId, ERPCType Ty
 			return;
 		}
 		LastSeenRPCId = LastSeenRPCIds[EntityTypePair];
+=======
+		Schema_ComponentUpdate** ComponentUpdatePtr = PendingComponentUpdatesToSend.Find(EntityComponentIdPair);
+		if (ComponentUpdatePtr == nullptr)
+		{
+			ComponentUpdatePtr = &PendingComponentUpdatesToSend.Add(EntityComponentIdPair, Schema_CreateComponentUpdate());
+		}
+		return *ComponentUpdatePtr;
+>>>>>>> Cross Server RPC Spike
 	}
 
-	const RPCRingBuffer& Buffer = GetBufferFromView(EntityId, Type);
-
-	uint64 LastProcessedRPCId = LastSeenRPCId;
-	if (Buffer.LastSentRPCId >= LastSeenRPCId)
+	Schema_ComponentData* SpatialRPCService::GetOrCreateComponentData(EntityComponentId EntityComponentIdPair)
 	{
-		uint64 FirstRPCIdToRead = LastSeenRPCId + 1;
-
-		uint32 BufferSize = RPCRingBufferUtils::GetRingBufferSize(Type);
-		if (Buffer.LastSentRPCId > LastSeenRPCId + BufferSize)
+		Schema_ComponentData** ComponentDataPtr = PendingRPCsOnEntityCreation.Find(EntityComponentIdPair);
+		if (ComponentDataPtr == nullptr)
 		{
-			UE_LOG(LogSpatialRPCService, Warning,
-				   TEXT("SpatialRPCService::ExtractRPCsForType: RPCs were overwritten without being processed! Entity: %lld, RPC type: %s, "
-						"last seen RPC ID: %d, last sent ID: %d, buffer size: %d"),
-				   EntityId, *SpatialConstants::RPCTypeToString(Type), LastSeenRPCId, Buffer.LastSentRPCId, BufferSize);
-			FirstRPCIdToRead = Buffer.LastSentRPCId - BufferSize + 1;
+			ComponentDataPtr = &PendingRPCsOnEntityCreation.Add(EntityComponentIdPair, Schema_CreateComponentData());
 		}
+		return *ComponentDataPtr;
+	}
 
-		for (uint64 RPCId = FirstRPCIdToRead; RPCId <= Buffer.LastSentRPCId; RPCId++)
+#if TRACE_LIB_ACTIVE
+	void SpatialRPCService::ProcessResultToLatencyTrace(const EPushRPCResult Result, const TraceKey Trace)
+	{
+		if (SpatialLatencyTracer != nullptr && Trace != InvalidTraceKey)
 		{
-			const TOptional<RPCPayload>& Element = Buffer.GetRingBufferElement(RPCId);
+			bool bEndTrace = false;
+			FString TraceMsg;
+			switch (Result)
+			{
+			case SpatialGDK::EPushRPCResult::Success:
+				// No further action
+				break;
+			case SpatialGDK::EPushRPCResult::QueueOverflowed:
+				TraceMsg = TEXT("Overflowed");
+				break;
+			case SpatialGDK::EPushRPCResult::DropOverflowed:
+				TraceMsg = TEXT("OverflowedAndDropped");
+				bEndTrace = true;
+				break;
+			case SpatialGDK::EPushRPCResult::HasAckAuthority:
+				TraceMsg = TEXT("NoAckAuth");
+				bEndTrace = true;
+				break;
+			case SpatialGDK::EPushRPCResult::NoRingBufferAuthority:
+				TraceMsg = TEXT("NoRingBufferAuth");
+				bEndTrace = true;
+				break;
+			default:
+				TraceMsg = TEXT("UnrecognisedResult");
+				break;
+			}
+
+			if (bEndTrace)
+			{
+				// This RPC has been dropped, end the trace
+				SpatialLatencyTracer->WriteAndEndTrace(Trace, TraceMsg, false);
+			}
+			else if (!TraceMsg.IsEmpty())
+			{
+				// This RPC will be sent later
+				SpatialLatencyTracer->WriteToLatencyTrace(Trace, TraceMsg);
+			}
+		}
+	}
+#endif // TRACE_LIB_ACTIVE
+
+
+	void SpatialRPCService::ExtractCrossServerRPCsForType(Worker_EntityId SenderId, ERPCType Type)
+	{
+		const RPCRingBuffer& Buffer = GetBufferFromView(SenderId, Type);
+
+		uint64 MinRPCId = 0;
+		TSet<Worker_EntityId> Receivers;
+		for (uint32 Slot = 0; Slot < RPCRingBufferUtils::GetRingBufferSize(Type); ++Slot)
+		{
+			const TOptional<RPCPayload>& Element = Buffer.RingBuffer[Slot];
 			if (Element.IsSet())
 			{
-				const bool bKeepExtracting = ExtractRPCCallback.Execute(EntityId, Type, Element.GetValue());
-				if (!bKeepExtracting)
+				Worker_EntityId TargetId = SpatialConstants::INVALID_ENTITY_ID;
+				const TOptional<FUnrealObjectRef>& Target = Buffer.Counterpart[Slot];
+				if (Target.IsSet())
 				{
-					break;
+					TargetId = Target.GetValue().Entity;
+
+					uint64 RPCId = Target.GetValue().Offset;
+					if (Slot == 0)
+					{
+						MinRPCId = RPCId;
+					}
+					MinRPCId = FMath::Min(RPCId, MinRPCId);
+
+					if (View->HasAuthority(TargetId, SpatialConstants::POSITION_COMPONENT_ID))
+					{
+						CrossServerEndpointSenderACK* ACKComponent = View->GetComponentData<CrossServerEndpointSenderACK>(TargetId);
+						TArray<uint64>* DottedACKList = ACKComponent->DottedRPCACK.Find(SenderId);
+						if (DottedACKList == nullptr || (*DottedACKList)[Slot] < RPCId)
+						{
+							Receivers.Add(TargetId);
+							FUnrealObjectRef Counterpart(SenderId, RPCId);
+							const bool bKeepExtracting = ExtractRPCCallback.Execute(TargetId, Counterpart, Type, Element.GetValue(), Slot);
+							if (!bKeepExtracting)
+							{
+								break;
+							}
+						}
+					}
 				}
-				LastProcessedRPCId = RPCId;
+			}
+		}
+		if (Receivers.Num() != 0)
+		{
+			CleanupACKsFor(SenderId, MinRPCId, Receivers);
+		}
+	}
+
+	void SpatialRPCService::WriteCrossServerACKFor(Worker_EntityId Receiver, Worker_EntityId Sender, uint64 RPCId, uint32 Slot)
+	{
+		CrossServerEndpointSenderACK* ACKComponent = View->GetComponentData<CrossServerEndpointSenderACK>(Receiver);
+		TArray<uint64>* DottedACKList = ACKComponent->DottedRPCACK.Find(Sender);
+		if (DottedACKList == nullptr)
+		{
+			TArray<uint64> NewACKList;
+			NewACKList.SetNumZeroed(RPCRingBufferUtils::GetRingBufferSize(ERPCType::CrossServerSender));
+			DottedACKList = &ACKComponent->DottedRPCACK.Add(Sender, MoveTemp(NewACKList));
+		}
+
+		(*DottedACKList)[Slot] = RPCId;
+		ACKComponent->RPCAck++;
+
+		UE_LOG(LogSpatialRPCService, Log, TEXT("DEBUG_CS %llu ACKED RPC %i from %llu with count %i"), Receiver, RPCId, Sender, ACKComponent->RPCAck);
+
+		EntityComponentId Pair;
+		Pair.EntityId = Receiver;
+		Pair.ComponentId = RPCRingBufferUtils::GetAckComponentId(ERPCType::CrossServerSender);
+
+
+		if (Schema_ComponentUpdate** PendingUpdate = PendingComponentUpdatesToSend.Find(Pair))
+		{
+			Schema_DestroyComponentUpdate(*PendingUpdate);
+			PendingComponentUpdatesToSend.Remove(Pair);
+		}
+
+		Schema_ComponentUpdate* Update = GetOrCreateComponentUpdate(Pair);
+		Schema_Object* UpdateObject = Schema_GetComponentUpdateFields(Update);
+
+		ACKComponent->CreateUpdate(Update);
+		ACKComponentsToTrack.Add(Receiver);
+
+		if (View->HasAuthority(Sender, SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID))
+		{
+			UpdateMergedACKs(Sender, Receiver);
+		}
+	}
+
+	void SpatialRPCService::UpdateMergedACKs(Worker_EntityId WorkerId, Worker_EntityId RemoteReceiver)
+	{
+		CrossServerEndpointSenderACK* ACKComponent = View->GetComponentData<CrossServerEndpointSenderACK>(RemoteReceiver);
+		if (TArray<uint64>* DottedACKList = ACKComponent->DottedRPCACK.Find(WorkerId))
+		{
+			for (int32 Slot = 0; Slot < DottedACKList->Num(); ++Slot)
+			{
+				SentRPCEntry& Entry = CrossServerMailbox[Slot];
+				Entry.MergedCrossServerACK = FMath::Max(Entry.MergedCrossServerACK, (*DottedACKList)[Slot]);
+				if (Entry.MergedCrossServerACK == Entry.RPCId)
+				{
+					Entry.EntityRequest.Reset();
+				}
+			}
+		}
+	}
+
+	TOptional<uint32_t> SpatialRPCService::FindFreeSlotForCrossServerSender()
+	{
+		uint64 LowestId;
+		TOptional<uint32_t> FreeSlot;
+		for (int32 Slot = 0; Slot < CrossServerMailbox.Num(); ++Slot)
+		{
+			SentRPCEntry& Entry = CrossServerMailbox[Slot];
+			uint64 CurSlotRPCId = Entry.RPCId;
+			if (CurSlotRPCId == Entry.MergedCrossServerACK)
+			{
+				if (!FreeSlot
+					|| CurSlotRPCId < LowestId)
+				{
+					FreeSlot = Slot;
+					LowestId = CurSlotRPCId;
+				}
+			}
+		}
+
+		return FreeSlot;
+	}
+
+	void SpatialRPCService::CleanupACKsFor(Worker_EntityId Sender, uint64 MinRPCId, TSet<Worker_EntityId> const& ReceiversToIgnore)
+	{
+		for (TSet<Worker_EntityId>::TIterator Iterator = ACKComponentsToTrack.CreateIterator(); Iterator; ++Iterator)
+		{
+			Worker_EntityId Receiver = *Iterator;
+			if (ReceiversToIgnore.Contains(Receiver))
+			{
+				continue;
+			}
+
+			CrossServerEndpointSenderACK* ACKComponent = View->GetComponentData<CrossServerEndpointSenderACK>(Receiver);
+			if (!ACKComponent)
+			{
+				continue;
+			}
+			if (TArray<uint64>* DottedACKList = ACKComponent->DottedRPCACK.Find(Sender))
+			{
+				bool bStillRelevant = false;
+				for (auto RPCId : *DottedACKList)
+				{
+					if (RPCId >= MinRPCId)
+					{
+						bStillRelevant = true;
+						break;
+					}
+				}
+				if (!bStillRelevant)
+				{
+					ACKComponent->DottedRPCACK.Remove(Sender);
+					if (ACKComponent->DottedRPCACK.Num() == 0)
+					{
+						Iterator.RemoveCurrent();
+					}
+
+					EntityComponentId Pair;
+					Pair.EntityId = Receiver;
+					Pair.ComponentId = RPCRingBufferUtils::GetAckComponentId(ERPCType::CrossServerSender);
+
+					if (Schema_ComponentUpdate** PendingUpdate = PendingComponentUpdatesToSend.Find(Pair))
+					{
+						Schema_DestroyComponentUpdate(*PendingUpdate);
+						PendingComponentUpdatesToSend.Remove(Pair);
+					}
+
+					Schema_ComponentUpdate* Update = GetOrCreateComponentUpdate(Pair);
+					Schema_Object* UpdateObject = Schema_GetComponentUpdateFields(Update);
+					ACKComponent->CreateUpdate(Update);
+				}
+			}
+		}
+	}
+
+	void SpatialRPCService::CheckLocalTargets(Worker_EntityId LocalWorkerEntityId)
+	{
+		if (bShouldCheckSentRPCForLocalTarget)
+		{
+			bShouldCheckSentRPCForLocalTarget = false;
+			ExtractCrossServerRPCsForType(LocalWorkerEntityId, ERPCType::CrossServerSender);
+		}
+	}
+}
+
+// 9/10 sur l'echelle du goret.
+#include "Interop/Connection/SpatialOSWorkerInterface.h"
+
+namespace SpatialGDK
+{
+
+void SpatialRPCService::HandleTimeout(SpatialOSWorkerInterface* Worker)
+{
+	uint64 Now = FPlatformTime::Cycles64();
+	uint64 CutoffTime = Now - (0.5 / FPlatformTime::GetSecondsPerCycle64());
+	// Consider timeouts.
+	for (int32 Slot = 0; Slot < CrossServerMailbox.Num(); ++Slot)
+	{
+		SentRPCEntry& Entry = CrossServerMailbox[Slot];
+		// RPC is in flight and overdue.
+		if (Entry.RPCId != Entry.MergedCrossServerACK && Entry.Timestamp < CutoffTime)
+		{
+			if (!Entry.EntityRequest)
+			{
+				Worker_EntityQuery query;
+				query.constraint.constraint_type = WORKER_CONSTRAINT_TYPE_ENTITY_ID;
+				query.constraint.constraint.entity_id_constraint.entity_id = Entry.Target;
+				// Count should be used, but will be deprecated ?? WOuld that be a reason to keep it ?
+				query.result_type = WORKER_RESULT_TYPE_SNAPSHOT;
+				query.snapshot_result_type_component_id_count = 1;
+				Worker_ComponentId componentResults[] = { SpatialConstants::POSITION_COMPONENT_ID };
+				query.snapshot_result_type_component_ids = componentResults;
+				Entry.EntityRequest = Worker->SendEntityQueryRequest(&query);
+			}
+		}
+	}
+}
+
+bool SpatialRPCService::OnEntityRequestResponse(Worker_RequestId Request, bool bEntityExists)
+{
+	for (int32 Slot = 0; Slot < CrossServerMailbox.Num(); ++Slot)
+	{
+		SentRPCEntry& Entry = CrossServerMailbox[Slot];
+		if (Entry.EntityRequest && Entry.EntityRequest.GetValue() == Request)
+		{
+			Entry.EntityRequest.Reset();
+			if (bEntityExists)
+			{
+				// Extend timeout
+				Entry.Timestamp = FPlatformTime::Cycles64();
 			}
 			else
 			{
-				UE_LOG(LogSpatialRPCService, Warning,
-					   TEXT("SpatialRPCService::ExtractRPCsForType: Ring buffer element empty. Entity: %lld, RPC type: %s, empty element "
-							"RPC id: %d"),
-					   EntityId, *SpatialConstants::RPCTypeToString(Type), RPCId);
+				// Clear slot
+				Entry.RPCId = 0;
+				Entry.MergedCrossServerACK = 0;
 			}
+			return true;
 		}
 	}
-	else
-	{
-		UE_LOG(LogSpatialRPCService, Warning,
-			   TEXT("SpatialRPCService::ExtractRPCsForType: Last sent RPC has smaller ID than last seen RPC. Entity: %lld, RPC type: %s, "
-					"last sent ID: %d, last seen ID: %d"),
-			   EntityId, *SpatialConstants::RPCTypeToString(Type), Buffer.LastSentRPCId, LastSeenRPCId);
-	}
 
-	if (LastProcessedRPCId > LastSeenRPCId)
-	{
-		if (Type == ERPCType::NetMulticast)
-		{
-			LastSeenMulticastRPCIds[EntityId] = LastProcessedRPCId;
-		}
-		else
-		{
-			LastSeenRPCIds[EntityTypePair] = LastProcessedRPCId;
-		}
-	}
+	return false;
 }
-
-void SpatialRPCService::IncrementAckedRPCID(Worker_EntityId EntityId, ERPCType Type)
-{
-	if (Type == ERPCType::NetMulticast)
-	{
-		return;
-	}
-
-	EntityRPCType EntityTypePair = EntityRPCType(EntityId, Type);
-	uint64* LastAckedRPCId = LastAckedRPCIds.Find(EntityTypePair);
-	if (LastAckedRPCId == nullptr)
-	{
-		UE_LOG(LogSpatialRPCService, Warning,
-			   TEXT("SpatialRPCService::IncrementAckedRPCID: Could not find last acked RPC id. Entity: %lld, RPC type: %s"), EntityId,
-			   *SpatialConstants::RPCTypeToString(Type));
-		return;
-	}
-
-	++(*LastAckedRPCId);
-
-	const EntityComponentId EntityComponentPair = { EntityId, RPCRingBufferUtils::GetAckComponentId(Type) };
-	Schema_Object* EndpointObject = Schema_GetComponentUpdateFields(GetOrCreateComponentUpdate(EntityComponentPair));
-
-	RPCRingBufferUtils::WriteAckToSchema(EndpointObject, Type, *LastAckedRPCId);
-}
-
-void SpatialRPCService::AddOverflowedRPC(EntityRPCType EntityType, RPCPayload&& Payload)
-{
-	OverflowedRPCs.FindOrAdd(EntityType).Add(MoveTemp(Payload));
-}
-
-uint64 SpatialRPCService::GetAckFromView(Worker_EntityId EntityId, ERPCType Type)
-{
-	switch (Type)
-	{
-	case ERPCType::ClientReliable:
-		return View->GetComponentData<ClientEndpoint>(EntityId)->ReliableRPCAck;
-	case ERPCType::ClientUnreliable:
-		return View->GetComponentData<ClientEndpoint>(EntityId)->UnreliableRPCAck;
-	case ERPCType::ServerReliable:
-		return View->GetComponentData<ServerEndpoint>(EntityId)->ReliableRPCAck;
-	case ERPCType::ServerUnreliable:
-		return View->GetComponentData<ServerEndpoint>(EntityId)->UnreliableRPCAck;
-	}
-
-	checkNoEntry();
-	return 0;
-}
-
-const RPCRingBuffer& SpatialRPCService::GetBufferFromView(Worker_EntityId EntityId, ERPCType Type)
-{
-	switch (Type)
-	{
-	// Server sends Client RPCs, so ClientReliable & ClientUnreliable buffers live on ServerEndpoint.
-	case ERPCType::ClientReliable:
-		return View->GetComponentData<ServerEndpoint>(EntityId)->ReliableRPCBuffer;
-	case ERPCType::ClientUnreliable:
-		return View->GetComponentData<ServerEndpoint>(EntityId)->UnreliableRPCBuffer;
-
-	// Client sends Server RPCs, so ServerReliable & ServerUnreliable buffers live on ClientEndpoint.
-	case ERPCType::ServerReliable:
-		return View->GetComponentData<ClientEndpoint>(EntityId)->ReliableRPCBuffer;
-	case ERPCType::ServerUnreliable:
-		return View->GetComponentData<ClientEndpoint>(EntityId)->UnreliableRPCBuffer;
-
-	case ERPCType::NetMulticast:
-		return View->GetComponentData<MulticastRPCs>(EntityId)->MulticastRPCBuffer;
-	}
-
-	checkNoEntry();
-	static const RPCRingBuffer DummyBuffer(ERPCType::Invalid);
-	return DummyBuffer;
-}
-
-Schema_ComponentUpdate* SpatialRPCService::GetOrCreateComponentUpdate(EntityComponentId EntityComponentIdPair)
-{
-	Schema_ComponentUpdate** ComponentUpdatePtr = PendingComponentUpdatesToSend.Find(EntityComponentIdPair);
-	if (ComponentUpdatePtr == nullptr)
-	{
-		ComponentUpdatePtr = &PendingComponentUpdatesToSend.Add(EntityComponentIdPair, Schema_CreateComponentUpdate());
-	}
-	return *ComponentUpdatePtr;
-}
-
-Schema_ComponentData* SpatialRPCService::GetOrCreateComponentData(EntityComponentId EntityComponentIdPair)
-{
-	Schema_ComponentData** ComponentDataPtr = PendingRPCsOnEntityCreation.Find(EntityComponentIdPair);
-	if (ComponentDataPtr == nullptr)
-	{
-		ComponentDataPtr = &PendingRPCsOnEntityCreation.Add(EntityComponentIdPair, Schema_CreateComponentData());
-	}
-	return *ComponentDataPtr;
-}
-
-#if TRACE_LIB_ACTIVE
-void SpatialRPCService::ProcessResultToLatencyTrace(const EPushRPCResult Result, const TraceKey Trace)
-{
-	if (SpatialLatencyTracer != nullptr && Trace != InvalidTraceKey)
-	{
-		bool bEndTrace = false;
-		FString TraceMsg;
-		switch (Result)
-		{
-		case SpatialGDK::EPushRPCResult::Success:
-			// No further action
-			break;
-		case SpatialGDK::EPushRPCResult::QueueOverflowed:
-			TraceMsg = TEXT("Overflowed");
-			break;
-		case SpatialGDK::EPushRPCResult::DropOverflowed:
-			TraceMsg = TEXT("OverflowedAndDropped");
-			bEndTrace = true;
-			break;
-		case SpatialGDK::EPushRPCResult::HasAckAuthority:
-			TraceMsg = TEXT("NoAckAuth");
-			bEndTrace = true;
-			break;
-		case SpatialGDK::EPushRPCResult::NoRingBufferAuthority:
-			TraceMsg = TEXT("NoRingBufferAuth");
-			bEndTrace = true;
-			break;
-		default:
-			TraceMsg = TEXT("UnrecognisedResult");
-			break;
-		}
-
-		if (bEndTrace)
-		{
-			// This RPC has been dropped, end the trace
-			SpatialLatencyTracer->WriteAndEndTrace(Trace, TraceMsg, false);
-		}
-		else if (!TraceMsg.IsEmpty())
-		{
-			// This RPC will be sent later
-			SpatialLatencyTracer->WriteToLatencyTrace(Trace, TraceMsg);
-		}
-	}
-}
-#endif // TRACE_LIB_ACTIVE
 
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialRPCService.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialRPCService.cpp
@@ -720,27 +720,7 @@ Schema_ComponentUpdate* SpatialRPCService::GetOrCreateComponentUpdate(EntityComp
 	Schema_ComponentUpdate** ComponentUpdatePtr = PendingComponentUpdatesToSend.Find(EntityComponentIdPair);
 	if (ComponentUpdatePtr == nullptr)
 	{
-<<<<<<< HEAD
-<<<<<<< HEAD
-		if (!LastSeenRPCIds.Contains(EntityTypePair))
-		{
-			UE_LOG(LogSpatialRPCService, Warning,
-				   TEXT("Tried to extract RPCs but no entry in Last Seen Map! This can happen after server travel. Entity: %lld, type: %s"),
-				   EntityId, *SpatialConstants::RPCTypeToString(Type));
-			return;
-		}
-		LastSeenRPCId = LastSeenRPCIds[EntityTypePair];
-=======
-		Schema_ComponentUpdate** ComponentUpdatePtr = PendingComponentUpdatesToSend.Find(EntityComponentIdPair);
-		if (ComponentUpdatePtr == nullptr)
-		{
-			ComponentUpdatePtr = &PendingComponentUpdatesToSend.Add(EntityComponentIdPair, Schema_CreateComponentUpdate());
-		}
-		return *ComponentUpdatePtr;
->>>>>>> Cross Server RPC Spike
-=======
 		ComponentUpdatePtr = &PendingComponentUpdatesToSend.Add(EntityComponentIdPair, Schema_CreateComponentUpdate());
->>>>>>> Missing stuff
 	}
 	return *ComponentUpdatePtr;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialRPCService.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialRPCService.cpp
@@ -806,7 +806,7 @@ void SpatialRPCService::ExtractCrossServerRPCsForType(Worker_EntityId SenderId, 
 	const RPCRingBuffer& Buffer = GetBufferFromView(SenderId, Type);
 
 	uint64 MinRPCId = 0;
-	TSet<Worker_EntityId> Receivers;
+	TSet<Worker_EntityId_Key> Receivers;
 	for (uint32 Slot = 0; Slot < RPCRingBufferUtils::GetRingBufferSize(Type); ++Slot)
 	{
 		const TOptional<RPCPayload>& Element = Buffer.RingBuffer[Slot];
@@ -862,9 +862,6 @@ void SpatialRPCService::WriteCrossServerACKFor(Worker_EntityId Receiver, Worker_
 
 	(*DottedACKList)[Slot] = RPCId;
 	ACKComponent->RPCAck++;
-
-	UE_LOG(LogSpatialRPCService, Log, TEXT("DEBUG_CS %llu ACKED RPC %i from %llu with count %i"), Receiver, RPCId, Sender,
-		   ACKComponent->RPCAck);
 
 	EntityComponentId Pair;
 	Pair.EntityId = Receiver;
@@ -926,9 +923,9 @@ TOptional<uint32_t> SpatialRPCService::FindFreeSlotForCrossServerSender()
 	return FreeSlot;
 }
 
-void SpatialRPCService::CleanupACKsFor(Worker_EntityId Sender, uint64 MinRPCId, TSet<Worker_EntityId> const& ReceiversToIgnore)
+void SpatialRPCService::CleanupACKsFor(Worker_EntityId Sender, uint64 MinRPCId, TSet<Worker_EntityId_Key> const& ReceiversToIgnore)
 {
-	for (TSet<Worker_EntityId>::TIterator Iterator = ACKComponentsToTrack.CreateIterator(); Iterator; ++Iterator)
+	for (TSet<Worker_EntityId_Key>::TIterator Iterator = ACKComponentsToTrack.CreateIterator(); Iterator; ++Iterator)
 	{
 		Worker_EntityId Receiver = *Iterator;
 		if (ReceiversToIgnore.Contains(Receiver))

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -350,6 +350,7 @@ void USpatialReceiver::OnRemoveEntity(const Worker_RemoveEntityOp& Op)
 	}
 
 	OnEntityRemovedDelegate.Broadcast(Op.entity_id);
+	RPCService->OnEntityRemoved(NetDriver->WorkerEntityId, Op.entity_id);
 
 	if (NetDriver->IsServer())
 	{
@@ -2360,7 +2361,7 @@ void USpatialReceiver::OnEntityQueryResponse(const Worker_EntityQueryResponseOp&
 	}
 	else
 	{
-		if (RPCService->OnEntityRequestResponse(Op.request_id, Op.result_count > 0))
+		if (RPCService->OnEntityRequestResponse(NetDriver->WorkerEntityId, Op.request_id, Op.result_count > 0))
 		{
 			return;
 		}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1730,7 +1730,6 @@ void USpatialReceiver::OnComponentUpdate(const Worker_ComponentUpdateOp& Op)
 	case SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID:
 		if (Settings->CrossServerRPCImplementation == ECrossServerRPCImplementation::WorkerEntityMailbox || NetDriver->IsRoutingWorker())
 		{
-			UE_LOG(LogSpatialReceiver, Log, TEXT("DEBUG_CS %llu received update from %llu"), NetDriver->WorkerEntityId, Op.entity_id);
 			HandleRPC(Op);
 			return;
 		}
@@ -2209,10 +2208,10 @@ FRPCErrorInfo USpatialReceiver::ApplyRPCInternal(UObject* TargetObject, UFunctio
 						RPCService->WriteCrossServerACKFor(PendingRPCParams.ObjectRef.Entity, PendingRPCParams.SenderObjectRef.Entity,
 														   PendingRPCParams.SenderObjectRef.Offset, PendingRPCParams.Slot);
 					}
-					else
-					{
-						RPCService->IncrementAckedRPCID(PendingRPCParams.ObjectRef.Entity, RPCType);
-					}
+					// if(Settings->CrossServerRPCImplementation == ECrossServerRPCImplementation::RoutingWorker)
+					//{
+					//	RPCService->IncrementAckedRPCID(PendingRPCParams.ObjectRef.Entity, RPCType);
+					//}
 				}
 				else
 				{

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -21,6 +21,7 @@
 #include "Interop/SpatialPlayerSpawner.h"
 #include "Interop/SpatialSender.h"
 #include "Schema/AuthorityIntent.h"
+#include "Schema/CrossServerEndpoint.h"
 #include "Schema/DynamicComponent.h"
 #include "Schema/RPCPayload.h"
 #include "Schema/SpawnData.h"
@@ -132,15 +133,6 @@ void USpatialReceiver::LeaveCriticalSection()
 			continue;
 		}
 
-		if (PendingAddComponent.ComponentId == SpatialConstants::GDK_DEBUG_COMPONENT_ID)
-		{
-			if (NetDriver->DebugCtx != nullptr)
-			{
-				NetDriver->DebugCtx->OnDebugComponentUpdateReceived(PendingAddComponent.EntityId);
-			}
-			continue;
-		}
-
 		USpatialActorChannel* Channel = NetDriver->GetActorChannelByEntityId(PendingAddComponent.EntityId);
 		if (Channel == nullptr)
 		{
@@ -206,6 +198,8 @@ void USpatialReceiver::OnAddComponent(const Worker_AddComponentOp& Op)
 		return RemoveComponentOp.entity_id == Op.entity_id && RemoveComponentOp.component_id == Op.data.component_id;
 	});
 
+	const USpatialGDKSettings* Settings = GetDefault<USpatialGDKSettings>();
+
 	switch (Op.data.component_id)
 	{
 	case SpatialConstants::METADATA_COMPONENT_ID:
@@ -229,8 +223,22 @@ void USpatialReceiver::OnAddComponent(const Worker_AddComponentOp& Op)
 	case SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID:
 	case SpatialConstants::SPATIAL_DEBUGGING_COMPONENT_ID:
 	case SpatialConstants::SERVER_WORKER_COMPONENT_ID:
+	case SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID:
+	case SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID:
 		// We either don't care about processing these components or we only need to store
 		// the data (which is handled by the SpatialStaticComponentView).
+		return;
+	case SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID:
+		if (Settings->CrossServerRPCImplementation == ECrossServerRPCImplementation::WorkerEntityMailbox)
+		{
+			
+		}
+		return;
+	case SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID:
+		if (Settings->CrossServerRPCImplementation == ECrossServerRPCImplementation::WorkerEntityMailbox)
+		{
+
+		}
 		return;
 	case SpatialConstants::UNREAL_METADATA_COMPONENT_ID:
 		// The UnrealMetadata component is used to indicate when an Actor needs to be created from the entity.
@@ -559,14 +567,28 @@ void USpatialReceiver::OnAuthorityChange(const Worker_AuthorityChangeOp& Op)
 		return;
 	}
 
+	const USpatialGDKSettings* Settings = GetDefault<USpatialGDKSettings>();
+
 	// Process authority gained event immediately, so if we're in a critical section, the RPCService will
 	// be correctly configured to process RPCs sent during Actor creation
-	if (GetDefault<USpatialGDKSettings>()->UseRPCRingBuffer() && RPCService != nullptr && Op.authority == WORKER_AUTHORITY_AUTHORITATIVE)
+	if (Settings->UseRPCRingBuffer() && RPCService != nullptr && Op.authority == WORKER_AUTHORITY_AUTHORITATIVE)
 	{
 		if (Op.component_id == SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID
 			|| Op.component_id == SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID
-			|| Op.component_id == SpatialConstants::MULTICAST_RPCS_COMPONENT_ID)
+			|| Op.component_id == SpatialConstants::MULTICAST_RPCS_COMPONENT_ID
+			|| Op.component_id == SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID
+			|| Op.component_id == SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID
+			|| Op.component_id == SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID
+			|| Op.component_id == SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID)
 		{
+			if (Settings->CrossServerRPCImplementation == ECrossServerRPCImplementation::RoutingWorker)
+			{
+				if (Op.component_id == SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID
+					|| Op.component_id == SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID)
+				{
+					check(NetDriver->IsRoutingWorker());
+				}
+			}
 			RPCService->OnEndpointAuthorityGained(Op.entity_id, Op.component_id);
 		}
 	}
@@ -622,6 +644,7 @@ void USpatialReceiver::HandleActorAuthority(const Worker_AuthorityChangeOp& Op)
 	if (GlobalStateManager->HandlesComponent(Op.component_id))
 	{
 		GlobalStateManager->AuthorityChanged(Op);
+		Sender->UpdateServerWorkerEntityInterestAndPosition();
 		return;
 	}
 
@@ -823,7 +846,11 @@ void USpatialReceiver::HandleActorAuthority(const Worker_AuthorityChangeOp& Op)
 
 	if (Op.component_id == SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID
 		|| Op.component_id == SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID
-		|| Op.component_id == SpatialConstants::MULTICAST_RPCS_COMPONENT_ID)
+		|| Op.component_id == SpatialConstants::MULTICAST_RPCS_COMPONENT_ID
+		|| Op.component_id == SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID
+		|| Op.component_id == SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID
+		|| Op.component_id == SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID
+		|| Op.component_id == SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID)
 	{
 		if (GetDefault<USpatialGDKSettings>()->UseRPCRingBuffer() && RPCService != nullptr)
 		{
@@ -833,10 +860,27 @@ void USpatialReceiver::HandleActorAuthority(const Worker_AuthorityChangeOp& Op)
 				{
 					// If we have just received authority over the client endpoint, then we are a client.  In that case,
 					// we want to scrape the server endpoint for any server -> client RPCs that are waiting to be called.
-					const Worker_ComponentId ComponentToExtractFrom = Op.component_id == SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID
-																		  ? SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID
-																		  : SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID;
-					RPCService->ExtractRPCsForEntity(Op.entity_id, ComponentToExtractFrom);
+					const Worker_ComponentId ComponentToExtractFrom = [&Op] () -> Worker_ComponentId
+					{
+						switch (Op.component_id)
+						{
+						case SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID:
+							return SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID;
+							break;
+						case SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID:
+							return SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID;
+							break;
+						case SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID:
+							return SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID;
+							break;
+						}
+						return SpatialConstants::INVALID_COMPONENT_ID;
+					}();
+
+					if (ComponentToExtractFrom != SpatialConstants::INVALID_COMPONENT_ID)
+					{
+						RPCService->ExtractRPCsForEntity(Op.entity_id, ComponentToExtractFrom);
+					}
 				}
 			}
 			else if (Op.authority == WORKER_AUTHORITY_NOT_AUTHORITATIVE)
@@ -1617,6 +1661,8 @@ void USpatialReceiver::ApplyComponentData(USpatialActorChannel& Channel, UObject
 
 void USpatialReceiver::OnComponentUpdate(const Worker_ComponentUpdateOp& Op)
 {
+	const USpatialGDKSettings* Settings = GetDefault<USpatialGDKSettings>();
+
 	SCOPE_CYCLE_COUNTER(STAT_ReceiverComponentUpdate);
 	if (IsEntityWaitingForAsyncLoad(Op.entity_id))
 	{
@@ -1680,12 +1726,32 @@ void USpatialReceiver::OnComponentUpdate(const Worker_ComponentUpdateOp& Op)
 	case SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID:
 	case SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID:
 	case SpatialConstants::MULTICAST_RPCS_COMPONENT_ID:
-		HandleRPC(Op);
-		return;
 	case SpatialConstants::GDK_DEBUG_COMPONENT_ID:
 		if (NetDriver->DebugCtx != nullptr)
 		{
 			NetDriver->DebugCtx->OnDebugComponentUpdateReceived(Op.entity_id);
+		}
+	case SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID:
+		HandleRPC(Op);
+		return;
+	case SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID:
+		if (Settings->CrossServerRPCImplementation == ECrossServerRPCImplementation::WorkerEntityMailbox
+			|| NetDriver->IsRoutingWorker())
+		{
+			UE_LOG(LogSpatialReceiver, Log, TEXT("DEBUG_CS %llu received update from %llu"), NetDriver->WorkerEntityId, Op.entity_id);
+			HandleRPC(Op);
+			return;
+		}
+	case SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID:
+		if (NetDriver->IsRoutingWorker())
+		{
+			// TODO: ACK RPC on counterpart.
+		}
+		return;
+	case SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID:
+		if (Settings->CrossServerRPCImplementation == ECrossServerRPCImplementation::WorkerEntityMailbox)
+		{
+			RPCService->UpdateMergedACKs(NetDriver->WorkerEntityId, Op.entity_id);
 		}
 		return;
 	}
@@ -1841,7 +1907,7 @@ void USpatialReceiver::ProcessRPCEventField(Worker_EntityId EntityId, const Work
 
 		if (UObject* TargetObject = PackageMap->GetObjectFromUnrealObjectRef(ObjectRef).Get())
 		{
-			ProcessOrQueueIncomingRPC(ObjectRef, MoveTemp(Payload));
+			ProcessOrQueueIncomingRPC(ObjectRef, FUnrealObjectRef(), MoveTemp(Payload), 0);
 		}
 	}
 }
@@ -1862,7 +1928,9 @@ void USpatialReceiver::HandleRPC(const Worker_ComponentUpdateOp& Op)
 	// to print errors if the role isn't Authority. Instead, we exit here, and the RPC will be processed by the server that receives
 	// authority.
 	const bool bIsServerRpc = Op.update.component_id == SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID;
-	if (bIsServerRpc && StaticComponentView->HasAuthority(Op.entity_id, SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID))
+	const bool bIsCrossServerRpc = Op.update.component_id == SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID;
+	if ((bIsServerRpc && StaticComponentView->HasAuthority(Op.entity_id, SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID))
+		|| (bIsCrossServerRpc && StaticComponentView->HasAuthority(Op.entity_id, SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID)))
 	{
 		const TWeakObjectPtr<UObject> ActorReceivingRPC = PackageMap->GetObjectFromEntityId(Op.entity_id);
 		if (!ActorReceivingRPC.IsValid())
@@ -1973,7 +2041,7 @@ void USpatialReceiver::OnCommandRequest(const Worker_CommandRequestOp& Op)
 	UE_LOG(LogSpatialReceiver, Verbose, TEXT("Received command request (entity: %lld, component: %d, function: %s)"), Op.entity_id,
 		   Op.request.component_id, *Function->GetName());
 
-	ProcessOrQueueIncomingRPC(ObjectRef, MoveTemp(Payload));
+	ProcessOrQueueIncomingRPC(ObjectRef, FUnrealObjectRef(), MoveTemp(Payload), 0);
 	Sender->SendEmptyCommandResponse(Op.request.component_id, CommandIndex, Op.request_id);
 }
 
@@ -1996,6 +2064,7 @@ void USpatialReceiver::OnCommandResponse(const Worker_CommandResponseOp& Op)
 
 void USpatialReceiver::FlushRetryRPCs()
 {
+	RPCService->CheckLocalTargets(NetDriver->WorkerEntityId);
 	Sender->FlushRetryRPCs();
 }
 
@@ -2094,11 +2163,14 @@ FRPCErrorInfo USpatialReceiver::ApplyRPCInternal(UObject* TargetObject, UFunctio
 	TSet<FUnrealObjectRef> UnresolvedRefs;
 	TSet<FUnrealObjectRef> MappedRefs;
 	RPCPayload PayloadCopy = PendingRPCParams.Payload;
-	FSpatialNetBitReader PayloadReader(PackageMap, PayloadCopy.PayloadData.GetData(), PayloadCopy.CountDataBits(), MappedRefs,
-									   UnresolvedRefs);
+	{
+		// Scope FSpatialNetBitReader because there could be recursive calls when flushing the RPC service?? :/ maybe we should try to avoid that.
+		FSpatialNetBitReader PayloadReader(PackageMap, PayloadCopy.PayloadData.GetData(), PayloadCopy.CountDataBits(), MappedRefs,
+			UnresolvedRefs);
 
-	TSharedPtr<FRepLayout> RepLayout = NetDriver->GetFunctionRepLayout(Function);
-	RepLayout_ReceivePropertiesForRPC(*RepLayout, PayloadReader, Parms);
+		TSharedPtr<FRepLayout> RepLayout = NetDriver->GetFunctionRepLayout(Function);
+		RepLayout_ReceivePropertiesForRPC(*RepLayout, PayloadReader, Parms);
+	}
 
 	const USpatialGDKSettings* SpatialSettings = GetDefault<USpatialGDKSettings>();
 
@@ -2133,10 +2205,25 @@ FRPCErrorInfo USpatialReceiver::ApplyRPCInternal(UObject* TargetObject, UFunctio
 		{
 			TargetObject->ProcessEvent(Function, Parms);
 
-			if (GetDefault<USpatialGDKSettings>()->UseRPCRingBuffer() && RPCService != nullptr && RPCType != ERPCType::CrossServer
+			if (GetDefault<USpatialGDKSettings>()->UseRPCRingBuffer() && RPCService != nullptr
 				&& RPCType != ERPCType::NetMulticast)
 			{
-				RPCService->IncrementAckedRPCID(PendingRPCParams.ObjectRef.Entity, RPCType);
+				if (RPCType == ERPCType::CrossServerSender)
+				{
+					USpatialGDKSettings const* Settings = GetDefault<USpatialGDKSettings>();
+					if (Settings->CrossServerRPCImplementation == ECrossServerRPCImplementation::WorkerEntityMailbox)
+					{
+						RPCService->WriteCrossServerACKFor(PendingRPCParams.ObjectRef.Entity, PendingRPCParams.SenderObjectRef.Entity, PendingRPCParams.SenderObjectRef.Offset, PendingRPCParams.Slot);
+					}
+					else
+					{
+						RPCService->IncrementAckedRPCID(PendingRPCParams.ObjectRef.Entity, RPCType);
+					}
+				}
+				else
+				{
+					RPCService->IncrementAckedRPCID(PendingRPCParams.ObjectRef.Entity, RPCType);
+				}
 			}
 
 			ErrorInfo.ErrorCode = ERPCResult::Success;
@@ -2279,6 +2366,11 @@ void USpatialReceiver::OnEntityQueryResponse(const Worker_EntityQueryResponseOp&
 	}
 	else
 	{
+		if (RPCService->OnEntityRequestResponse(Op.request_id, Op.result_count > 0))
+		{
+			return;
+		}
+
 		UE_LOG(LogSpatialReceiver, Warning,
 			   TEXT("Received EntityQueryResponse but with no delegate set, request id: %d, number of entities: %d, message: %s"),
 			   Op.request_id, Op.result_count, UTF8_TO_TCHAR(Op.message));
@@ -2327,7 +2419,7 @@ void USpatialReceiver::ProcessQueuedActorRPCsOnEntityCreation(Worker_EntityId En
 	for (auto& RPC : QueuedRPCs.RPCs)
 	{
 		const FUnrealObjectRef ObjectRef(EntityId, RPC.Offset);
-		ProcessOrQueueIncomingRPC(ObjectRef, MoveTemp(RPC));
+		ProcessOrQueueIncomingRPC(ObjectRef, FUnrealObjectRef(), MoveTemp(RPC), 0);
 	}
 }
 
@@ -2369,7 +2461,7 @@ void USpatialReceiver::ClearPendingRPCs(Worker_EntityId EntityId)
 	IncomingRPCs.DropForEntity(EntityId);
 }
 
-void USpatialReceiver::ProcessOrQueueIncomingRPC(const FUnrealObjectRef& InTargetObjectRef, SpatialGDK::RPCPayload InPayload)
+void USpatialReceiver::ProcessOrQueueIncomingRPC(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, SpatialGDK::RPCPayload InPayload, uint32 Slot)
 {
 	TWeakObjectPtr<UObject> TargetObjectWeakPtr = PackageMap->GetObjectFromUnrealObjectRef(InTargetObjectRef);
 	if (!TargetObjectWeakPtr.IsValid())
@@ -2398,12 +2490,29 @@ void USpatialReceiver::ProcessOrQueueIncomingRPC(const FUnrealObjectRef& InTarge
 	const FRPCInfo& RPCInfo = ClassInfoManager->GetRPCInfo(TargetObject, Function);
 	ERPCType Type = RPCInfo.Type;
 
-	IncomingRPCs.ProcessOrQueueRPC(InTargetObjectRef, Type, MoveTemp(InPayload));
+	if (Type == ERPCType::CrossServerSender)
+	{
+		//--> for routing worker.
+		//Type = ERPCType::CrossServerReceiver;
+	}
+	IncomingRPCs.ProcessOrQueueRPC(InTargetObjectRef, InSenderObjectRef, Type, MoveTemp(InPayload), Slot);
 }
 
-bool USpatialReceiver::OnExtractIncomingRPC(Worker_EntityId EntityId, ERPCType RPCType, const SpatialGDK::RPCPayload& Payload)
+bool USpatialReceiver::OnExtractIncomingRPC(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType RPCType, const SpatialGDK::RPCPayload& Payload, uint32 Slot)
 {
-	ProcessOrQueueIncomingRPC(FUnrealObjectRef(EntityId, Payload.Offset), Payload);
+	const USpatialGDKSettings* Settings = GetDefault<USpatialGDKSettings>();
+	if (Settings->CrossServerRPCImplementation == ECrossServerRPCImplementation::RoutingWorker)
+	{
+		if (NetDriver->IsRoutingWorker() && RPCType == ERPCType::CrossServerSender)
+		{
+			RPCService->PushRPC(Counterpart.Entity, FUnrealObjectRef(EntityId, Counterpart.Offset), ERPCType::CrossServerReceiver, Payload, false);
+			RPCService->IncrementAckedRPCID(EntityId, RPCType);
+			Sender->FlushRPCService();
+			return true;
+		}
+	}
+
+	ProcessOrQueueIncomingRPC(FUnrealObjectRef(EntityId, Payload.Offset), Counterpart, Payload, Slot);
 
 	return true;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -2505,7 +2505,7 @@ bool USpatialReceiver::OnExtractIncomingRPC(Worker_EntityId EntityId, const FUnr
 			RPCService->PushRPC(Counterpart.Entity, FUnrealObjectRef(EntityId, Counterpart.Offset), ERPCType::CrossServerReceiver, Payload,
 								false);
 			RPCService->IncrementAckedRPCID(EntityId, RPCType);
-			Sender->FlushRPCService();
+			
 			return true;
 		}
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -2189,7 +2189,8 @@ FRPCErrorInfo USpatialReceiver::ApplyRPCInternal(UObject* TargetObject, UFunctio
 		AActor* Actor = TargetObject->IsA<AActor>() ? Cast<AActor>(TargetObject) : TargetObject->GetTypedOuter<AActor>();
 		ERPCType RPCType = PendingRPCParams.Type;
 
-		if (Actor->Role == ROLE_SimulatedProxy && (RPCType == ERPCType::ServerReliable || RPCType == ERPCType::ServerUnreliable))
+		if (Actor->Role == ROLE_SimulatedProxy
+			&& (RPCType == ERPCType::ServerReliable || RPCType == ERPCType::ServerUnreliable || RPCType == ERPCType::CrossServerSender))
 		{
 			ErrorInfo.ErrorCode = ERPCResult::NoAuthority;
 			ErrorInfo.QueueProcessResult = ERPCQueueProcessResult::DropEntireQueue;

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -888,10 +888,10 @@ bool USpatialSender::SendCrossServerRPC(UObject* TargetObject, UFunction* Functi
 
 		const EPushRPCResult Result = RPCService->PushRPC(SenderEntity, TargetObjectRef, RPCInfo.Type, Payload, Channel->bCreatedEntity);
 
-		if (Result == EPushRPCResult::Success)
-		{
-			FlushRPCService();
-		}
+		//if (Result == EPushRPCResult::Success)
+		//{
+		//	FlushRPCService();
+		//}
 
 #if !UE_BUILD_SHIPPING
 		if (Result == EPushRPCResult::Success || Result == EPushRPCResult::QueueOverflowed)
@@ -998,10 +998,10 @@ bool USpatialSender::SendRingBufferedRPC(UObject* TargetObject, UFunction* Funct
 	const EPushRPCResult Result =
 		RPCService->PushRPC(TargetObjectRef.Entity, FUnrealObjectRef(), RPCInfo.Type, Payload, Channel->bCreatedEntity);
 
-	if (Result == EPushRPCResult::Success)
-	{
-		FlushRPCService();
-	}
+	//if (Result == EPushRPCResult::Success)
+	//{
+	//	FlushRPCService();
+	//}
 
 #if !UE_BUILD_SHIPPING
 	if (Result == EPushRPCResult::Success || Result == EPushRPCResult::QueueOverflowed)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -283,9 +283,10 @@ void USpatialSender::RetryServerWorkerEntityCreation(Worker_EntityId EntityId, i
 
 	// It is unlikely the load balance strategy would be set up at this point, but we call this function again later when it is ready in
 	// order to set the interest of the server worker according to the strategy.
-	Components.Add(
-		NetDriver->InterestFactory->CreateServerWorkerInterest(NetDriver->LoadBalanceStrategy, NetDriver->DebugCtx != nullptr /*bDebug*/, NetDriver->IsRoutingWorker() /*bIsRoutingWorker*/)
-			.CreateInterestData());
+	Components.Add(NetDriver->InterestFactory
+					   ->CreateServerWorkerInterest(NetDriver->LoadBalanceStrategy, NetDriver->DebugCtx != nullptr /*bDebug*/,
+													NetDriver->IsRoutingWorker() /*bIsRoutingWorker*/)
+					   .CreateInterestData());
 
 	// GDK known entities completeness tags
 	Components.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::SERVER_AUTH_GDK_KNOWN_ENTITY_TAG_COMPONENT_ID));
@@ -478,7 +479,9 @@ void USpatialSender::UpdateServerWorkerEntityInterestAndPosition()
 
 	// Update the interest. If it's ready and not null, also adds interest according to the load balancing strategy.
 	FWorkerComponentUpdate InterestUpdate =
-		NetDriver->InterestFactory->CreateServerWorkerInterest(NetDriver->LoadBalanceStrategy, NetDriver->DebugCtx != nullptr /*bDebug*/, NetDriver->IsRoutingWorker() /*bIsRoutingWorker*/)
+		NetDriver->InterestFactory
+			->CreateServerWorkerInterest(NetDriver->LoadBalanceStrategy, NetDriver->DebugCtx != nullptr /*bDebug*/,
+										 NetDriver->IsRoutingWorker() /*bIsRoutingWorker*/)
 			.CreateInterestUpdate();
 
 	Connection->SendComponentUpdate(NetDriver->WorkerEntityId, &InterestUpdate);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -569,6 +569,10 @@ void USpatialSender::FlushRPCService()
 				UE_LOG(LogSpatialSender, Verbose, TEXT("Sending ACK from %llu for entity %llu, RPCId : %llu"), NetDriver->WorkerEntityId,
 					   Update.EntityId, Comp->RPCAck);
 			}
+			if (!StaticComponentView->HasComponent(Update.EntityId, Update.Update.component_id))
+			{
+				continue;
+			}
 			Connection->SendComponentUpdate(Update.EntityId, &Update.Update);
 			if (Settings->CrossServerRPCImplementation == ECrossServerRPCImplementation::RoutingWorker)
 			{

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -20,6 +20,7 @@
 #include "Schema/AuthorityIntent.h"
 #include "Schema/ClientRPCEndpointLegacy.h"
 #include "Schema/ComponentPresence.h"
+#include "Schema/CrossServerEndpoint.h"
 #include "Schema/Interest.h"
 #include "Schema/RPCPayload.h"
 #include "Schema/ServerRPCEndpointLegacy.h"
@@ -253,6 +254,8 @@ void USpatialSender::CreateServerWorkerEntity()
 // Creates an entity authoritative on this server worker, ensuring it will be able to receive updates for the GSM.
 void USpatialSender::RetryServerWorkerEntityCreation(Worker_EntityId EntityId, int AttemptCounter)
 {
+	const USpatialGDKSettings* Settings = GetDefault<USpatialGDKSettings>();
+
 	const WorkerRequirementSet WorkerIdPermission{ { FString::Format(TEXT("workerId:{0}"), { Connection->GetWorkerId() }) } };
 
 	WriteAclMap ComponentWriteAcl;
@@ -262,18 +265,26 @@ void USpatialSender::RetryServerWorkerEntityCreation(Worker_EntityId EntityId, i
 	ComponentWriteAcl.Add(SpatialConstants::INTEREST_COMPONENT_ID, WorkerIdPermission);
 	ComponentWriteAcl.Add(SpatialConstants::SERVER_WORKER_COMPONENT_ID, WorkerIdPermission);
 	ComponentWriteAcl.Add(SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID, WorkerIdPermission);
+	if (Settings->CrossServerRPCImplementation == ECrossServerRPCImplementation::WorkerEntityMailbox)
+	{
+		ComponentWriteAcl.Add(SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID, WorkerIdPermission);
+	}
 
 	TArray<FWorkerComponentData> Components;
 	Components.Add(Position().CreatePositionData());
 	Components.Add(Metadata(FString::Format(TEXT("WorkerEntity:{0}"), { Connection->GetWorkerId() })).CreateMetadataData());
 	Components.Add(EntityAcl(WorkerIdPermission, ComponentWriteAcl).CreateEntityAclData());
 	Components.Add(ServerWorker(Connection->GetWorkerId(), false).CreateServerWorkerData());
+	if (Settings->CrossServerRPCImplementation == ECrossServerRPCImplementation::WorkerEntityMailbox)
+	{
+		Components.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID));
+	}
 	check(NetDriver != nullptr);
 
 	// It is unlikely the load balance strategy would be set up at this point, but we call this function again later when it is ready in
 	// order to set the interest of the server worker according to the strategy.
 	Components.Add(
-		NetDriver->InterestFactory->CreateServerWorkerInterest(NetDriver->LoadBalanceStrategy, NetDriver->DebugCtx != nullptr /*bDebug*/)
+		NetDriver->InterestFactory->CreateServerWorkerInterest(NetDriver->LoadBalanceStrategy, NetDriver->DebugCtx != nullptr /*bDebug*/, NetDriver->IsRoutingWorker() /*bIsRoutingWorker*/)
 			.CreateInterestData());
 
 	// GDK known entities completeness tags
@@ -412,6 +423,47 @@ void USpatialSender::CreateEntityWithRetries(Worker_EntityId EntityId, FString E
 	Receiver->AddCreateEntityDelegate(RequestId, MoveTemp(Delegate));
 }
 
+void USpatialSender::UpdateServerWorkerVisibility()
+{
+	if (NetDriver->WorkerEntityId == SpatialConstants::INVALID_ENTITY_ID)
+	{
+		// No worker entity to update.
+		return;
+	}
+
+	const USpatialGDKSettings* Settings = GetDefault<USpatialGDKSettings>();
+	const WorkerRequirementSet WorkerIdPermission{ { FString::Format(TEXT("workerId:{0}"), { Connection->GetWorkerId() }) } };
+
+	WriteAclMap ComponentWriteAcl;
+	ComponentWriteAcl.Add(SpatialConstants::POSITION_COMPONENT_ID, WorkerIdPermission);
+	ComponentWriteAcl.Add(SpatialConstants::METADATA_COMPONENT_ID, WorkerIdPermission);
+	ComponentWriteAcl.Add(SpatialConstants::ENTITY_ACL_COMPONENT_ID, WorkerIdPermission);
+	ComponentWriteAcl.Add(SpatialConstants::INTEREST_COMPONENT_ID, WorkerIdPermission);
+	ComponentWriteAcl.Add(SpatialConstants::SERVER_WORKER_COMPONENT_ID, WorkerIdPermission);
+	ComponentWriteAcl.Add(SpatialConstants::COMPONENT_PRESENCE_COMPONENT_ID, WorkerIdPermission);
+	if (Settings->CrossServerRPCImplementation == ECrossServerRPCImplementation::WorkerEntityMailbox)
+	{
+		ComponentWriteAcl.Add(SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID, WorkerIdPermission);
+	}
+	WorkerRequirementSet AnyServerRequirementSet = { SpatialConstants::UnrealServerAttributeSet };
+
+	SpatialGDK::EntityAcl EntityACL(AnyServerRequirementSet, ComponentWriteAcl); //= StaticComponentView->GetComponentData<SpatialGDK::EntityAcl>(NetDriver->WorkerEntityId);
+
+	EntityACL.ReadAcl = AnyServerRequirementSet;
+
+	FWorkerComponentUpdate Update = EntityACL.CreateEntityAclUpdate();
+	Connection->SendComponentUpdate(NetDriver->WorkerEntityId, &Update);
+
+	
+	//if (Settings->CrossServerRPCImplementation == ECrossServerRPCImplementation::WorkerEntityMailbox)
+	//{
+	//	TArray<FWorkerComponentData> Components;
+	//	Components.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID));
+	//
+	//	SendAddComponents(NetDriver->WorkerEntityId, Components);
+	//}
+}
+
 void USpatialSender::UpdateServerWorkerEntityInterestAndPosition()
 {
 	check(Connection != nullptr);
@@ -424,7 +476,7 @@ void USpatialSender::UpdateServerWorkerEntityInterestAndPosition()
 
 	// Update the interest. If it's ready and not null, also adds interest according to the load balancing strategy.
 	FWorkerComponentUpdate InterestUpdate =
-		NetDriver->InterestFactory->CreateServerWorkerInterest(NetDriver->LoadBalanceStrategy, NetDriver->DebugCtx != nullptr /*bDebug*/)
+		NetDriver->InterestFactory->CreateServerWorkerInterest(NetDriver->LoadBalanceStrategy, NetDriver->DebugCtx != nullptr /*bDebug*/, NetDriver->IsRoutingWorker() /*bIsRoutingWorker*/)
 			.CreateInterestUpdate();
 
 	Connection->SendComponentUpdate(NetDriver->WorkerEntityId, &InterestUpdate);
@@ -495,16 +547,47 @@ void USpatialSender::ProcessUpdatesQueuedUntilAuthority(Worker_EntityId EntityId
 	}
 }
 
+
 void USpatialSender::FlushRPCService()
 {
 	if (RPCService != nullptr)
 	{
 		RPCService->PushOverflowedRPCs();
+		RPCService->HandleTimeout(Connection);
+
+		const USpatialGDKSettings* Settings = GetDefault<USpatialGDKSettings>();
 
 		TArray<SpatialRPCService::UpdateToSend> RPCs = RPCService->GetRPCsAndAcksToSend();
+		
 		for (SpatialRPCService::UpdateToSend& Update : RPCs)
 		{
+			if (Update.Update.component_id == SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID)
+			{
+				CrossServerEndpointSenderACK* Comp = StaticComponentView->GetComponentData<CrossServerEndpointSenderACK>(Update.EntityId);
+
+				UE_LOG(LogSpatialSender, Verbose, TEXT("Sending ACK from %llu for entity %llu, RPCId : %llu"), NetDriver->WorkerEntityId, Update.EntityId, Comp->RPCAck);
+			}
 			Connection->SendComponentUpdate(Update.EntityId, &Update.Update);
+			if (Settings->CrossServerRPCImplementation == ECrossServerRPCImplementation::RoutingWorker)
+			{
+				if (NetDriver->IsRoutingWorker())
+				{
+					if (Update.Update.component_id == SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID
+						|| (Update.Update.component_id == SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID
+							&& StaticComponentView->HasAuthority(Update.EntityId, SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID))
+						|| (Update.Update.component_id == SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID
+							&& StaticComponentView->HasAuthority(Update.EntityId, SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID))
+						|| (Update.Update.component_id == SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID
+							&& StaticComponentView->HasAuthority(Update.EntityId, SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID)))
+					{
+						Worker_ComponentUpdateOp LoopbackUpdate;
+						LoopbackUpdate.update = Update.Update;
+						LoopbackUpdate.entity_id = Update.EntityId;
+						StaticComponentView->OnComponentUpdate(LoopbackUpdate);
+						Receiver->OnComponentUpdate(LoopbackUpdate);
+					}
+				}
+			}
 		}
 
 		if (RPCs.Num() && GetDefault<USpatialGDKSettings>()->bWorkerFlushAfterOutgoingNetworkOp)
@@ -625,7 +708,6 @@ void USpatialSender::SetAclWriteAuthority(const SpatialLoadBalanceEnforcer::AclW
 	check(StaticComponentView->HasComponent(Request.EntityId, SpatialConstants::ENTITY_ACL_COMPONENT_ID));
 
 	const FString& WriteWorkerId = FString::Printf(TEXT("workerId:%s"), *Request.OwningWorkerId);
-
 	const WorkerAttributeSet OwningServerWorkerAttributeSet = { WriteWorkerId };
 
 	EntityAcl* NewAcl = StaticComponentView->GetComponentData<EntityAcl>(Request.EntityId);
@@ -644,6 +726,22 @@ void USpatialSender::SetAclWriteAuthority(const SpatialLoadBalanceEnforcer::AclW
 		{
 			NewAcl->ComponentWriteAcl.Add(ComponentId, { SpatialConstants::UnrealServerAttributeSet });
 			continue;
+		}
+
+		const USpatialGDKSettings* Settings = GetDefault<USpatialGDKSettings>();
+		if (Settings->CrossServerRPCImplementation == ECrossServerRPCImplementation::RoutingWorker)
+		{
+			FString RoutingWorkerName = NetDriver->GetRoutingWorkerId();
+			check(!RoutingWorkerName.IsEmpty());
+
+			const WorkerAttributeSet RoutingWorkerRequirementSet = { FString::Format(TEXT("workerId:{0}"), { *RoutingWorkerName }) };
+			// Skip routing worker components.
+			if (ComponentId == SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID
+				|| ComponentId == SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID)
+			{
+				NewAcl->ComponentWriteAcl.Add(ComponentId, { RoutingWorkerRequirementSet });
+				continue;
+			}
 		}
 
 		NewAcl->ComponentWriteAcl.Add(ComponentId, { OwningServerWorkerAttributeSet });
@@ -684,10 +782,17 @@ FRPCErrorInfo USpatialSender::SendRPC(const FPendingRPCParams& Params)
 	const FRPCInfo& RPCInfo = ClassInfoManager->GetRPCInfo(TargetObject, Function);
 	bool bUseRPCRingBuffer = GetDefault<USpatialGDKSettings>()->UseRPCRingBuffer();
 
-	if (RPCInfo.Type == ERPCType::CrossServer)
+	if (RPCInfo.Type == ERPCType::CrossServerSender)
 	{
-		SendCrossServerRPC(TargetObject, Function, Params.Payload, Channel, Params.ObjectRef);
-		return FRPCErrorInfo{ TargetObject, Function, ERPCResult::Success };
+		if (SendCrossServerRPC(TargetObject, Function, Params.Payload, Channel, Params.ObjectRef, Params.SenderObjectRef))
+		{
+			return FRPCErrorInfo{ TargetObject, Function, ERPCResult::Success };
+		}
+		else
+		{
+			return FRPCErrorInfo{ TargetObject, Function, ERPCResult::RPCServiceFailure };
+		}
+		//return FRPCErrorInfo{ TargetObject, Function, ERPCResult::Success };
 	}
 
 	if (bUseRPCRingBuffer && RPCService != nullptr)
@@ -724,35 +829,102 @@ void USpatialSender::SendOnEntityCreationRPC(UObject* TargetObject, UFunction* F
 #endif // !UE_BUILD_SHIPPING
 }
 
-void USpatialSender::SendCrossServerRPC(UObject* TargetObject, UFunction* Function, const SpatialGDK::RPCPayload& Payload,
-										USpatialActorChannel* Channel, const FUnrealObjectRef& TargetObjectRef)
+bool USpatialSender::SendCrossServerRPC(UObject* TargetObject, UFunction* Function, const SpatialGDK::RPCPayload& Payload,
+										USpatialActorChannel* Channel, const FUnrealObjectRef& TargetObjectRef, const FUnrealObjectRef& SenderObjectRef)
 {
 	const FRPCInfo& RPCInfo = ClassInfoManager->GetRPCInfo(TargetObject, Function);
+	const USpatialGDKSettings* Settings = GetDefault<USpatialGDKSettings>();
 
-	Worker_ComponentId ComponentId = SpatialConstants::SERVER_TO_SERVER_COMMAND_ENDPOINT_COMPONENT_ID;
-
-	Worker_EntityId EntityId = SpatialConstants::INVALID_ENTITY_ID;
-	Worker_CommandRequest CommandRequest = CreateRPCCommandRequest(TargetObject, Payload, ComponentId, RPCInfo.Index, EntityId);
-
-	check(EntityId != SpatialConstants::INVALID_ENTITY_ID);
-	Worker_RequestId RequestId =
-		Connection->SendCommandRequest(EntityId, &CommandRequest, SpatialConstants::UNREAL_RPC_ENDPOINT_COMMAND_ID);
-
-	if (Function->HasAnyFunctionFlags(FUNC_NetReliable))
+	if (Settings->CrossServerRPCImplementation == ECrossServerRPCImplementation::SpatialCommand)
 	{
-		UE_LOG(LogSpatialSender, Verbose, TEXT("Sending reliable command request (entity: %lld, component: %d, function: %s, attempt: 1)"),
-			   EntityId, CommandRequest.component_id, *Function->GetName());
-		Receiver->AddPendingReliableRPC(
-			RequestId, MakeShared<FReliableRPCForRetry>(TargetObject, Function, ComponentId, RPCInfo.Index, Payload.PayloadData, 0));
-	}
-	else
-	{
-		UE_LOG(LogSpatialSender, Verbose, TEXT("Sending unreliable command request (entity: %lld, component: %d, function: %s)"), EntityId,
-			   CommandRequest.component_id, *Function->GetName());
-	}
+		Worker_ComponentId ComponentId = SpatialConstants::SERVER_TO_SERVER_COMMAND_ENDPOINT_COMPONENT_ID;
+
+		Worker_EntityId EntityId = SpatialConstants::INVALID_ENTITY_ID;
+		Worker_CommandRequest CommandRequest = CreateRPCCommandRequest(TargetObject, Payload, ComponentId, RPCInfo.Index, EntityId);
+
+		check(EntityId != SpatialConstants::INVALID_ENTITY_ID);
+		Worker_RequestId RequestId =
+			Connection->SendCommandRequest(EntityId, &CommandRequest, SpatialConstants::UNREAL_RPC_ENDPOINT_COMMAND_ID);
+
+		if (Function->HasAnyFunctionFlags(FUNC_NetReliable))
+		{
+			UE_LOG(LogSpatialSender, Verbose, TEXT("Sending reliable command request (entity: %lld, component: %d, function: %s, attempt: 1)"),
+				EntityId, CommandRequest.component_id, *Function->GetName());
+			Receiver->AddPendingReliableRPC(
+				RequestId, MakeShared<FReliableRPCForRetry>(TargetObject, Function, ComponentId, RPCInfo.Index, Payload.PayloadData, 0));
+		}
+		else
+		{
+			UE_LOG(LogSpatialSender, Verbose, TEXT("Sending unreliable command request (entity: %lld, component: %d, function: %s)"), EntityId,
+				CommandRequest.component_id, *Function->GetName());
+		}
 #if !UE_BUILD_SHIPPING
-	TrackRPC(Channel->Actor, Function, Payload, RPCInfo.Type);
+		TrackRPC(Channel->Actor, Function, Payload, RPCInfo.Type);
 #endif // !UE_BUILD_SHIPPING
+
+		return true;
+	}
+
+	if (Settings->CrossServerRPCImplementation == ECrossServerRPCImplementation::RoutingWorker
+		|| Settings->CrossServerRPCImplementation == ECrossServerRPCImplementation::WorkerEntityMailbox)
+	{
+		Worker_EntityId SenderEntity = Settings->CrossServerRPCImplementation == ECrossServerRPCImplementation::RoutingWorker
+			? SenderObjectRef.Entity
+			: NetDriver->WorkerEntityId;
+
+		const EPushRPCResult Result = RPCService->PushRPC(SenderEntity, TargetObjectRef, RPCInfo.Type, Payload, Channel->bCreatedEntity);
+
+		if (Result == EPushRPCResult::Success)
+		{
+			FlushRPCService();
+		}
+
+#if !UE_BUILD_SHIPPING
+		if (Result == EPushRPCResult::Success || Result == EPushRPCResult::QueueOverflowed)
+		{
+			TrackRPC(Channel->Actor, Function, Payload, RPCInfo.Type);
+		}
+#endif // !UE_BUILD_SHIPPING
+
+		switch (Result)
+		{
+		case EPushRPCResult::QueueOverflowed:
+			UE_LOG(LogSpatialSender, Log,
+				TEXT("USpatialSender::SendRingBufferedRPC: Ring buffer queue overflowed, queuing RPC locally. Actor: %s, entity: %lld, "
+					"function: %s"),
+				*TargetObject->GetPathName(), TargetObjectRef.Entity, *Function->GetName());
+			return true;
+		case EPushRPCResult::DropOverflowed:
+			UE_LOG(
+				LogSpatialSender, Log,
+				TEXT("USpatialSender::SendRingBufferedRPC: Ring buffer queue overflowed, dropping RPC. Actor: %s, entity: %lld, function: %s"),
+				*TargetObject->GetPathName(), TargetObjectRef.Entity, *Function->GetName());
+			return true;
+		case EPushRPCResult::HasAckAuthority:
+			UE_LOG(LogSpatialSender, Warning,
+				TEXT("USpatialSender::SendRingBufferedRPC: Worker has authority over ack component for RPC it is sending. RPC will not be "
+					"sent. Actor: %s, entity: %lld, function: %s"),
+				*TargetObject->GetPathName(), TargetObjectRef.Entity, *Function->GetName());
+			return true;
+		case EPushRPCResult::NoRingBufferAuthority:
+			// TODO: Change engine logic that calls Client RPCs from non-auth servers and change this to error. UNR-2517
+			UE_LOG(LogSpatialSender, Log,
+				TEXT("USpatialSender::SendRingBufferedRPC: Failed to send RPC because the worker does not have authority over ring buffer "
+					"component. Actor: %s, entity: %lld, function: %s"),
+				*TargetObject->GetPathName(), TargetObjectRef.Entity, *Function->GetName());
+			return true;
+		case EPushRPCResult::EntityBeingCreated:
+			UE_LOG(LogSpatialSender, Log,
+				TEXT("USpatialSender::SendRingBufferedRPC: RPC was called between entity creation and initial authority gain, so it will be "
+					"queued. Actor: %s, entity: %lld, function: %s"),
+				*TargetObject->GetPathName(), TargetObjectRef.Entity, *Function->GetName());
+			return false;
+		default:
+			return true;
+		}
+	}
+
+	return false;
 }
 
 FRPCErrorInfo USpatialSender::SendLegacyRPC(UObject* TargetObject, UFunction* Function, const RPCPayload& Payload,
@@ -805,7 +977,7 @@ bool USpatialSender::SendRingBufferedRPC(UObject* TargetObject, UFunction* Funct
 										 USpatialActorChannel* Channel, const FUnrealObjectRef& TargetObjectRef)
 {
 	const FRPCInfo& RPCInfo = ClassInfoManager->GetRPCInfo(TargetObject, Function);
-	const EPushRPCResult Result = RPCService->PushRPC(TargetObjectRef.Entity, RPCInfo.Type, Payload, Channel->bCreatedEntity);
+	const EPushRPCResult Result = RPCService->PushRPC(TargetObjectRef.Entity, FUnrealObjectRef(), RPCInfo.Type, Payload, Channel->bCreatedEntity);
 
 	if (Result == EPushRPCResult::Success)
 	{
@@ -970,7 +1142,7 @@ void USpatialSender::SendServerEndpointReadyUpdate(Worker_EntityId EntityId)
 	NetDriver->Connection->SendComponentUpdate(EntityId, &Update);
 }
 
-void USpatialSender::ProcessOrQueueOutgoingRPC(const FUnrealObjectRef& InTargetObjectRef, SpatialGDK::RPCPayload&& InPayload)
+void USpatialSender::ProcessOrQueueOutgoingRPC(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, SpatialGDK::RPCPayload&& InPayload)
 {
 	TWeakObjectPtr<UObject> TargetObjectWeakPtr = PackageMap->GetObjectFromUnrealObjectRef(InTargetObjectRef);
 	if (!TargetObjectWeakPtr.IsValid())
@@ -984,7 +1156,7 @@ void USpatialSender::ProcessOrQueueOutgoingRPC(const FUnrealObjectRef& InTargetO
 	UFunction* Function = ClassInfo.RPCs[InPayload.Index];
 	const FRPCInfo& RPCInfo = ClassInfoManager->GetRPCInfo(TargetObject, Function);
 
-	OutgoingRPCs.ProcessOrQueueRPC(InTargetObjectRef, RPCInfo.Type, MoveTemp(InPayload));
+	OutgoingRPCs.ProcessOrQueueRPC(InTargetObjectRef, InSenderObjectRef, RPCInfo.Type, MoveTemp(InPayload), 0);
 
 	// Try to send all pending RPCs unconditionally
 	OutgoingRPCs.ProcessRPCs();

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStaticComponentView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStaticComponentView.cpp
@@ -7,6 +7,7 @@
 #include "Schema/ClientRPCEndpointLegacy.h"
 #include "Schema/Component.h"
 #include "Schema/ComponentPresence.h"
+#include "Schema/CrossServerEndpoint.h"
 #include "Schema/DebugComponent.h"
 #include "Schema/Heartbeat.h"
 #include "Schema/Interest.h"
@@ -112,6 +113,18 @@ void USpatialStaticComponentView::OnAddComponent(const Worker_AddComponentOp& Op
 	case SpatialConstants::GDK_DEBUG_COMPONENT_ID:
 		Data = MakeUnique<SpatialGDK::DebugComponent>(Op.data);
 		break;
+	case SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID:
+		Data = MakeUnique<SpatialGDK::CrossServerEndpointSender>(Op.data);
+		break;
+	case SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID:
+		Data = MakeUnique<SpatialGDK::CrossServerEndpointSenderACK>(Op.data);
+		break;
+	case SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID:
+		Data = MakeUnique<SpatialGDK::CrossServerEndpointReceiver>(Op.data);
+		break;
+	case SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID:
+		Data = MakeUnique<SpatialGDK::CrossServerEndpointReceiverACK>(Op.data);
+		break;
 	default:
 		// Component is not hand written, but we still want to know the existence of it on this entity.
 		Data = nullptr;
@@ -174,6 +187,18 @@ void USpatialStaticComponentView::OnComponentUpdate(const Worker_ComponentUpdate
 		break;
 	case SpatialConstants::GDK_DEBUG_COMPONENT_ID:
 		Component = GetComponentData<SpatialGDK::DebugComponent>(Op.entity_id);
+		break;
+	case SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID:
+		Component = GetComponentData<SpatialGDK::CrossServerEndpointSender>(Op.entity_id);
+		break;
+	case SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID:
+		Component = GetComponentData<SpatialGDK::CrossServerEndpointSenderACK>(Op.entity_id);
+		break;
+	case SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID:
+		Component = GetComponentData<SpatialGDK::CrossServerEndpointReceiver>(Op.entity_id);
+		break;
+	case SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID:
+		Component = GetComponentData<SpatialGDK::CrossServerEndpointReceiverACK>(Op.entity_id);
 		break;
 	default:
 		return;

--- a/SpatialGDK/Source/SpatialGDK/Private/Schema/CrossServerEndpoint.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Schema/CrossServerEndpoint.cpp
@@ -76,7 +76,7 @@ void CrossServerEndpointSenderACK::CreateUpdate(Schema_ComponentUpdate* OutUpdat
 
 	Schema_AddUint64(Object, 1, RPCAck);
 
-	if(DottedRPCACK.Num() == 0)
+	if (DottedRPCACK.Num() == 0)
 	{
 		Schema_AddComponentUpdateClearedField(OutUpdate, 2);
 	}
@@ -88,7 +88,7 @@ void CrossServerEndpointSenderACK::CreateUpdate(Schema_ComponentUpdate* OutUpdat
 		Schema_AddEntityId(MapEntry, SCHEMA_MAP_KEY_FIELD_ID, ACKEntry.Key);
 		Schema_Object* ACKListObject = Schema_AddObject(MapEntry, SCHEMA_MAP_VALUE_FIELD_ID);
 
-		//Schema_AddUint64List(ACKListObject, 1, ACKEntry.Value.GetData(), ACKEntry.Value.Num());
+		// Schema_AddUint64List(ACKListObject, 1, ACKEntry.Value.GetData(), ACKEntry.Value.Num());
 
 		auto* buffer = Schema_AllocateBuffer(ACKListObject, ACKEntry.Value.Num() * sizeof(uint64));
 		FMemory::Memcpy(buffer, ACKEntry.Value.GetData(), ACKEntry.Value.Num() * sizeof(uint64));

--- a/SpatialGDK/Source/SpatialGDK/Private/Schema/CrossServerEndpoint.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Schema/CrossServerEndpoint.cpp
@@ -13,6 +13,20 @@ CrossServerEndpoint::CrossServerEndpoint(const Worker_ComponentData& Data, ERPCT
 void CrossServerEndpoint::ApplyComponentUpdate(const Worker_ComponentUpdate& Update)
 {
 	ReadFromSchema(Schema_GetComponentUpdateFields(Update.schema_type));
+	uint32 ClearCount = Schema_GetComponentUpdateClearedFieldCount(Update.schema_type);
+	TArray<Schema_FieldId> ClearedFields;
+	ClearedFields.SetNum(ClearCount);
+	Schema_GetComponentUpdateClearedFieldList(Update.schema_type, ClearedFields.GetData());
+
+	for (auto Field : ClearedFields)
+	{
+		uint32 SlotIdx = (Field - 1);
+		if (SlotIdx % 2 == 0)
+		{
+			ReliableRPCBuffer.RingBuffer[SlotIdx / 2].Reset();
+			ReliableRPCBuffer.Counterpart[SlotIdx / 2].Reset();
+		}
+	}
 }
 
 void CrossServerEndpoint::ReadFromSchema(Schema_Object* SchemaObject)

--- a/SpatialGDK/Source/SpatialGDK/Private/Schema/CrossServerEndpoint.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Schema/CrossServerEndpoint.cpp
@@ -64,7 +64,7 @@ void CrossServerEndpointSenderACK::ReadFromSchema(Schema_Object* SchemaObject)
 		uint32 ACKCount = Schema_GetUint64Count(ACKListObject, 1);
 		TArray<uint64> ACKList;
 		ACKList.SetNum(ACKCount);
-		Schema_GetUint64List(ACKListObject, 1, ACKList.GetData());
+		Schema_GetUint64List(ACKListObject, 1, reinterpret_cast<uint64_t*>(ACKList.GetData()));
 
 		DottedRPCACK.Add(Entity, MoveTemp(ACKList));
 	}
@@ -88,11 +88,7 @@ void CrossServerEndpointSenderACK::CreateUpdate(Schema_ComponentUpdate* OutUpdat
 		Schema_AddEntityId(MapEntry, SCHEMA_MAP_KEY_FIELD_ID, ACKEntry.Key);
 		Schema_Object* ACKListObject = Schema_AddObject(MapEntry, SCHEMA_MAP_VALUE_FIELD_ID);
 
-		// Schema_AddUint64List(ACKListObject, 1, ACKEntry.Value.GetData(), ACKEntry.Value.Num());
-
-		auto* buffer = Schema_AllocateBuffer(ACKListObject, ACKEntry.Value.Num() * sizeof(uint64));
-		FMemory::Memcpy(buffer, ACKEntry.Value.GetData(), ACKEntry.Value.Num() * sizeof(uint64));
-		Schema_AddUint64List(ACKListObject, 1, (uint64*)buffer, ACKEntry.Value.Num());
+		Schema_AddUint64List(ACKListObject, 1, reinterpret_cast<uint64_t const*>(ACKEntry.Value.GetData()), ACKEntry.Value.Num());
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Schema/CrossServerEndpoint.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Schema/CrossServerEndpoint.cpp
@@ -36,6 +36,20 @@ void CrossServerEndpointACK::ReadFromSchema(Schema_Object* SchemaObject)
 	RPCRingBufferUtils::ReadAckFromSchema(SchemaObject, Type, RPCAck);
 }
 
+void ACKItem::ReadFromSchema(Schema_Object* SchemaObject)
+{
+	Sender = Schema_GetEntityId(SchemaObject, 1);
+	RPCId = Schema_GetUint64(SchemaObject, 2);
+	SenderRevision = Schema_GetUint64(SchemaObject, 3);
+}
+
+void ACKItem::WriteToSchema(Schema_Object* SchemaObject)
+{
+	Schema_AddEntityId(SchemaObject, 1, Sender);
+	Schema_AddUint64(SchemaObject, 2, RPCId);
+	Schema_AddUint64(SchemaObject, 3, SenderRevision);
+}
+
 CrossServerEndpointSenderACK::CrossServerEndpointSenderACK(const Worker_ComponentData& Data)
 {
 	ReadFromSchema(Schema_GetComponentDataFields(Data.schema_type));
@@ -50,50 +64,64 @@ void CrossServerEndpointSenderACK::ReadFromSchema(Schema_Object* SchemaObject)
 {
 	RPCRingBufferUtils::ReadAckFromSchema(SchemaObject, ERPCType::CrossServerSender, RPCAck);
 
-	uint32 Count = Schema_GetObjectCount(SchemaObject, 2);
-
-	DottedRPCACK.Empty();
-	for (uint32 EntryIdx = 0; EntryIdx < Count; ++EntryIdx)
+	uint32 Count = RPCRingBufferUtils::GetRingBufferSize(ERPCType::CrossServerSender);
+	ACKArray.Empty(Count);
+	ACKArray.SetNum(Count);
+	for (uint32 ACKIdx = 0; ACKIdx < Count; ++ACKIdx)
 	{
-		Schema_Object* MapEntry = Schema_IndexObject(SchemaObject, 2, EntryIdx);
-
-		Worker_EntityId Entity = Schema_GetEntityId(MapEntry, SCHEMA_MAP_KEY_FIELD_ID);
-
-		Schema_Object* ACKListObject = Schema_GetObject(MapEntry, SCHEMA_MAP_VALUE_FIELD_ID);
-
-		uint32 ACKCount = Schema_GetUint64Count(ACKListObject, 1);
-		TArray<uint64> ACKList;
-		ACKList.SetNum(ACKCount);
-		Schema_GetUint64List(ACKListObject, 1, reinterpret_cast<uint64_t*>(ACKList.GetData()));
-
-		DottedRPCACK.Add(Entity, MoveTemp(ACKList));
+		uint32 OptCount = Schema_GetObjectCount(SchemaObject, 2 + ACKIdx);
+		if (OptCount > 0)
+		{
+			Schema_Object* ACKItemObject = Schema_GetObject(SchemaObject, 2 + ACKIdx);
+			ACKArray[ACKIdx].Emplace(ACKItem());
+			ACKArray[ACKIdx].GetValue().ReadFromSchema(ACKItemObject);
+		}
 	}
+
+	// uint32 Count = Schema_GetObjectCount(SchemaObject, 2);
+	//
+	// DottedRPCACK.Empty();
+	// for (uint32 EntryIdx = 0; EntryIdx < Count; ++EntryIdx)
+	//{
+	//	Schema_Object* MapEntry = Schema_IndexObject(SchemaObject, 2, EntryIdx);
+	//
+	//	Worker_EntityId Entity = Schema_GetEntityId(MapEntry, SCHEMA_MAP_KEY_FIELD_ID);
+	//
+	//	Schema_Object* ACKListObject = Schema_GetObject(MapEntry, SCHEMA_MAP_VALUE_FIELD_ID);
+	//
+	//	uint32 ACKCount = Schema_GetUint64Count(ACKListObject, 1);
+	//	TArray<uint64> ACKList;
+	//	ACKList.SetNum(ACKCount);
+	//	Schema_GetUint64List(ACKListObject, 1, reinterpret_cast<uint64_t*>(ACKList.GetData()));
+	//
+	//	DottedRPCACK.Add(Entity, MoveTemp(ACKList));
+	//}
 }
 
-void CrossServerEndpointSenderACK::CreateUpdate(Schema_ComponentUpdate* OutUpdate)
-{
-	Schema_Object* Object = Schema_GetComponentUpdateFields(OutUpdate);
-
-	Schema_AddUint64(Object, 1, RPCAck);
-
-	if (DottedRPCACK.Num() == 0)
-	{
-		Schema_AddComponentUpdateClearedField(OutUpdate, 2);
-	}
-
-	for (auto const& ACKEntry : DottedRPCACK)
-	{
-		Schema_Object* MapEntry = Schema_AddObject(Object, 2);
-
-		Schema_AddEntityId(MapEntry, SCHEMA_MAP_KEY_FIELD_ID, ACKEntry.Key);
-		Schema_Object* ACKListObject = Schema_AddObject(MapEntry, SCHEMA_MAP_VALUE_FIELD_ID);
-
-		//Schema_AddUint64List(ACKListObject, 1, reinterpret_cast<uint64_t const*>(ACKEntry.Value.GetData()), ACKEntry.Value.Num());
-
-		auto* buffer = Schema_AllocateBuffer(ACKListObject, ACKEntry.Value.Num() * sizeof(uint64));
-		FMemory::Memcpy(buffer, ACKEntry.Value.GetData(), ACKEntry.Value.Num() * sizeof(uint64));
-		Schema_AddUint64List(ACKListObject, 1, reinterpret_cast<uint64_t const*>(buffer), ACKEntry.Value.Num());
-	}
-}
+// void CrossServerEndpointSenderACK::CreateUpdate(Schema_ComponentUpdate* OutUpdate)
+//{
+//	Schema_Object* Object = Schema_GetComponentUpdateFields(OutUpdate);
+//
+//	Schema_AddUint64(Object, 1, RPCAck);
+//
+//	if (DottedRPCACK.Num() == 0)
+//	{
+//		Schema_AddComponentUpdateClearedField(OutUpdate, 2);
+//	}
+//
+//	for (auto const& ACKEntry : DottedRPCACK)
+//	{
+//		Schema_Object* MapEntry = Schema_AddObject(Object, 2);
+//
+//		Schema_AddEntityId(MapEntry, SCHEMA_MAP_KEY_FIELD_ID, ACKEntry.Key);
+//		Schema_Object* ACKListObject = Schema_AddObject(MapEntry, SCHEMA_MAP_VALUE_FIELD_ID);
+//
+//		// Schema_AddUint64List(ACKListObject, 1, reinterpret_cast<uint64_t const*>(ACKEntry.Value.GetData()), ACKEntry.Value.Num());
+//
+//		auto* buffer = Schema_AllocateBuffer(ACKListObject, ACKEntry.Value.Num() * sizeof(uint64));
+//		FMemory::Memcpy(buffer, ACKEntry.Value.GetData(), ACKEntry.Value.Num() * sizeof(uint64));
+//		Schema_AddUint64List(ACKListObject, 1, reinterpret_cast<uint64_t const*>(buffer), ACKEntry.Value.Num());
+//	}
+//}
 
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Private/Schema/CrossServerEndpoint.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Schema/CrossServerEndpoint.cpp
@@ -17,7 +17,7 @@ void CrossServerEndpoint::ApplyComponentUpdate(const Worker_ComponentUpdate& Upd
 	TArray<Schema_FieldId> ClearedFields;
 	ClearedFields.SetNum(ClearCount);
 	Schema_GetComponentUpdateClearedFieldList(Update.schema_type, ClearedFields.GetData());
-
+	
 	for (auto Field : ClearedFields)
 	{
 		uint32 SlotIdx = (Field - 1);

--- a/SpatialGDK/Source/SpatialGDK/Private/Schema/CrossServerEndpoint.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Schema/CrossServerEndpoint.cpp
@@ -88,7 +88,11 @@ void CrossServerEndpointSenderACK::CreateUpdate(Schema_ComponentUpdate* OutUpdat
 		Schema_AddEntityId(MapEntry, SCHEMA_MAP_KEY_FIELD_ID, ACKEntry.Key);
 		Schema_Object* ACKListObject = Schema_AddObject(MapEntry, SCHEMA_MAP_VALUE_FIELD_ID);
 
-		Schema_AddUint64List(ACKListObject, 1, reinterpret_cast<uint64_t const*>(ACKEntry.Value.GetData()), ACKEntry.Value.Num());
+		//Schema_AddUint64List(ACKListObject, 1, reinterpret_cast<uint64_t const*>(ACKEntry.Value.GetData()), ACKEntry.Value.Num());
+
+		auto* buffer = Schema_AllocateBuffer(ACKListObject, ACKEntry.Value.Num() * sizeof(uint64));
+		FMemory::Memcpy(buffer, ACKEntry.Value.GetData(), ACKEntry.Value.Num() * sizeof(uint64));
+		Schema_AddUint64List(ACKListObject, 1, reinterpret_cast<uint64_t const*>(buffer), ACKEntry.Value.Num());
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Schema/CrossServerEndpoint.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Schema/CrossServerEndpoint.cpp
@@ -1,0 +1,99 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "Schema/CrossServerEndpoint.h"
+
+namespace SpatialGDK
+{
+CrossServerEndpoint::CrossServerEndpoint(const Worker_ComponentData& Data, ERPCType Type)
+	: ReliableRPCBuffer(Type)
+{
+	ReadFromSchema(Schema_GetComponentDataFields(Data.schema_type));
+}
+
+void CrossServerEndpoint::ApplyComponentUpdate(const Worker_ComponentUpdate& Update)
+{
+	ReadFromSchema(Schema_GetComponentUpdateFields(Update.schema_type));
+}
+
+void CrossServerEndpoint::ReadFromSchema(Schema_Object* SchemaObject)
+{
+	RPCRingBufferUtils::ReadBufferFromSchema(SchemaObject, ReliableRPCBuffer);
+}
+
+CrossServerEndpointACK::CrossServerEndpointACK(const Worker_ComponentData& Data, ERPCType InType)
+	: Type(InType)
+{
+	ReadFromSchema(Schema_GetComponentDataFields(Data.schema_type));
+}
+
+void CrossServerEndpointACK::ApplyComponentUpdate(const Worker_ComponentUpdate& Update)
+{
+	ReadFromSchema(Schema_GetComponentUpdateFields(Update.schema_type));
+}
+
+void CrossServerEndpointACK::ReadFromSchema(Schema_Object* SchemaObject)
+{
+	RPCRingBufferUtils::ReadAckFromSchema(SchemaObject, Type, RPCAck);
+}
+
+CrossServerEndpointSenderACK::CrossServerEndpointSenderACK(const Worker_ComponentData& Data)
+{
+	ReadFromSchema(Schema_GetComponentDataFields(Data.schema_type));
+}
+
+void CrossServerEndpointSenderACK::ApplyComponentUpdate(const Worker_ComponentUpdate& Update)
+{
+	ReadFromSchema(Schema_GetComponentUpdateFields(Update.schema_type));
+}
+
+void CrossServerEndpointSenderACK::ReadFromSchema(Schema_Object* SchemaObject)
+{
+	RPCRingBufferUtils::ReadAckFromSchema(SchemaObject, ERPCType::CrossServerSender, RPCAck);
+
+	uint32 Count = Schema_GetObjectCount(SchemaObject, 2);
+
+	DottedRPCACK.Empty();
+	for (uint32 EntryIdx = 0; EntryIdx < Count; ++EntryIdx)
+	{
+		Schema_Object* MapEntry = Schema_IndexObject(SchemaObject, 2, EntryIdx);
+
+		Worker_EntityId Entity = Schema_GetEntityId(MapEntry, SCHEMA_MAP_KEY_FIELD_ID);
+
+		Schema_Object* ACKListObject = Schema_GetObject(MapEntry, SCHEMA_MAP_VALUE_FIELD_ID);
+
+		uint32 ACKCount = Schema_GetUint64Count(ACKListObject, 1);
+		TArray<uint64> ACKList;
+		ACKList.SetNum(ACKCount);
+		Schema_GetUint64List(ACKListObject, 1, ACKList.GetData());
+
+		DottedRPCACK.Add(Entity, MoveTemp(ACKList));
+	}
+}
+
+void CrossServerEndpointSenderACK::CreateUpdate(Schema_ComponentUpdate* OutUpdate)
+{
+	Schema_Object* Object = Schema_GetComponentUpdateFields(OutUpdate);
+
+	Schema_AddUint64(Object, 1, RPCAck);
+
+	if(DottedRPCACK.Num() == 0)
+	{
+		Schema_AddComponentUpdateClearedField(OutUpdate, 2);
+	}
+
+	for (auto const& ACKEntry : DottedRPCACK)
+	{
+		Schema_Object* MapEntry = Schema_AddObject(Object, 2);
+
+		Schema_AddEntityId(MapEntry, SCHEMA_MAP_KEY_FIELD_ID, ACKEntry.Key);
+		Schema_Object* ACKListObject = Schema_AddObject(MapEntry, SCHEMA_MAP_VALUE_FIELD_ID);
+
+		//Schema_AddUint64List(ACKListObject, 1, ACKEntry.Value.GetData(), ACKEntry.Value.Num());
+
+		auto* buffer = Schema_AllocateBuffer(ACKListObject, ACKEntry.Value.Num() * sizeof(uint64));
+		FMemory::Memcpy(buffer, ACKEntry.Value.GetData(), ACKEntry.Value.Num() * sizeof(uint64));
+		Schema_AddUint64List(ACKListObject, 1, (uint64*)buffer, ACKEntry.Value.Num());
+	}
+}
+
+} // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -110,6 +110,7 @@ USpatialGDKSettings::USpatialGDKSettings(const FObjectInitializer& ObjectInitial
 	, bUseRPCRingBuffers(true)
 	, DefaultRPCRingBufferSize(32)
 	, MaxRPCRingBufferSize(32)
+	, CrossServerRPCImplementation(ECrossServerRPCImplementation::SpatialCommand)
 	// TODO - UNR 2514 - These defaults are not necessarily optimal - readdress when we have better data
 	, bTcpNoDelay(false)
 	, UdpServerDownstreamUpdateIntervalMS(1)

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ComponentData.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/ComponentData.cpp
@@ -39,7 +39,15 @@ bool ComponentData::ApplyUpdate(const ComponentUpdate& Update)
 	check(Update.GetComponentId() == GetComponentId());
 	check(Update.GetUnderlying() != nullptr);
 
-	return Schema_ApplyComponentUpdateToData(Update.GetUnderlying(), Data.Get()) != 0;
+	bool bSuccess = Schema_ApplyComponentUpdateToData(Update.GetUnderlying(), Data.Get()) != 0;
+
+	if (!bSuccess)
+	{
+		FUTF8ToTCHAR conv(Schema_GetError(Schema_GetComponentDataFields(Data.Get())));
+		UE_LOG(LogTemp, Error, TEXT("ApplyUpdate : %s"), conv.Get());
+	}
+
+	return bSuccess;
 }
 
 Schema_Object* ComponentData::GetFields() const

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/RPCServiceTest.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/RPCServiceTest.cpp
@@ -57,7 +57,7 @@ constexpr Worker_EntityId RPCTestEntityId_2 = 42;
 const SpatialGDK::RPCPayload SimplePayload = SpatialGDK::RPCPayload(1, 0, TArray<uint8>({ 1 }, 1));
 
 ExtractRPCDelegate DefaultRPCDelegate =
-	ExtractRPCDelegate::CreateLambda([](Worker_EntityId EntityId, ERPCType RPCType, const SpatialGDK::RPCPayload& Payload) {
+	ExtractRPCDelegate::CreateLambda([](Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType RPCType, const SpatialGDK::RPCPayload& Payload, uint32 Slot) {
 		return true;
 	});
 
@@ -157,7 +157,7 @@ bool CompareRPCPayload(const SpatialGDK::RPCPayload& Payload1, const SpatialGDK:
 bool CompareSchemaObjectToSendAndPayload(Schema_Object* SchemaObject, const SpatialGDK::RPCPayload& Payload, ERPCType RPCType, uint64 RPCId)
 {
 	SpatialGDK::RPCRingBufferDescriptor Descriptor = SpatialGDK::RPCRingBufferUtils::GetRingBufferDescriptor(RPCType);
-	Schema_Object* RPCObject = Schema_GetObject(SchemaObject, Descriptor.GetRingBufferElementFieldId(RPCId));
+	Schema_Object* RPCObject = Schema_GetObject(SchemaObject, Descriptor.GetRingBufferElementFieldId(RPCType, RPCId));
 	return CompareRPCPayload(SpatialGDK::RPCPayload(RPCObject), Payload);
 }
 
@@ -199,7 +199,7 @@ FWorkerComponentData GetComponentDataOnEntityCreationFromRPCService(SpatialGDK::
 RPC_SERVICE_TEST(GIVEN_authority_over_server_endpoint_WHEN_push_client_reliable_rpcs_to_the_service_THEN_rpc_push_result_success)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, SERVER_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ClientReliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientReliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::Success));
 	return true;
 }
@@ -207,7 +207,7 @@ RPC_SERVICE_TEST(GIVEN_authority_over_server_endpoint_WHEN_push_client_reliable_
 RPC_SERVICE_TEST(GIVEN_authority_over_server_endpoint_WHEN_push_client_unreliable_rpcs_to_the_service_THEN_rpc_push_result_success)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, SERVER_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ClientUnreliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientUnreliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::Success));
 	return true;
 }
@@ -216,7 +216,7 @@ RPC_SERVICE_TEST(
 	GIVEN_authority_over_server_endpoint_WHEN_push_server_reliable_rpcs_to_the_service_THEN_rpc_push_result_no_buffer_authority)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, SERVER_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ServerReliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerReliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::NoRingBufferAuthority));
 	return true;
 }
@@ -225,7 +225,7 @@ RPC_SERVICE_TEST(
 	GIVEN_authority_over_server_endpoint_WHEN_push_server_unreliable_rpcs_to_the_service_THEN_rpc_push_result_no_buffer_authority)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, SERVER_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ServerUnreliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerUnreliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::NoRingBufferAuthority));
 	return true;
 }
@@ -234,7 +234,7 @@ RPC_SERVICE_TEST(
 	GIVEN_authority_over_client_endpoint_WHEN_push_client_reliable_rpcs_to_the_service_THEN_rpc_push_result_no_buffer_authority)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, CLIENT_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ClientReliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientReliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::NoRingBufferAuthority));
 	return true;
 }
@@ -243,7 +243,7 @@ RPC_SERVICE_TEST(
 	GIVEN_authority_over_client_endpoint_WHEN_push_client_unreliable_rpcs_to_the_service_THEN_rpc_push_result_no_buffer_authority)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, CLIENT_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ClientUnreliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientUnreliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::NoRingBufferAuthority));
 	return true;
 }
@@ -251,7 +251,7 @@ RPC_SERVICE_TEST(
 RPC_SERVICE_TEST(GIVEN_authority_over_client_endpoint_WHEN_push_server_reliable_rpcs_to_the_service_THEN_rpc_push_result_success)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, CLIENT_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ServerReliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerReliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::Success));
 	return true;
 }
@@ -259,7 +259,7 @@ RPC_SERVICE_TEST(GIVEN_authority_over_client_endpoint_WHEN_push_server_reliable_
 RPC_SERVICE_TEST(GIVEN_authority_over_client_endpoint_WHEN_push_server_unreliable_rpcs_to_the_service_THEN_rpc_push_result_success)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, CLIENT_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ServerUnreliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerUnreliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::Success));
 	return true;
 }
@@ -267,7 +267,7 @@ RPC_SERVICE_TEST(GIVEN_authority_over_client_endpoint_WHEN_push_server_unreliabl
 RPC_SERVICE_TEST(GIVEN_authority_over_client_endpoint_WHEN_push_multicast_rpcs_to_the_service_THEN_rpc_push_result_no_buffer_authority)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, CLIENT_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::NetMulticast, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::NetMulticast, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::NoRingBufferAuthority));
 	return true;
 }
@@ -275,7 +275,7 @@ RPC_SERVICE_TEST(GIVEN_authority_over_client_endpoint_WHEN_push_multicast_rpcs_t
 RPC_SERVICE_TEST(GIVEN_authority_over_server_endpoint_WHEN_push_multicast_rpcs_to_the_service_THEN_rpc_push_result_success)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, SERVER_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::NetMulticast, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::NetMulticast, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::Success));
 	return true;
 }
@@ -283,7 +283,7 @@ RPC_SERVICE_TEST(GIVEN_authority_over_server_endpoint_WHEN_push_multicast_rpcs_t
 RPC_SERVICE_TEST(GIVEN_authority_over_server_and_client_endpoint_WHEN_push_rpcs_to_the_service_THEN_rpc_push_result_has_ack_authority)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, SERVER_AND_CLIENT_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ClientReliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientReliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::HasAckAuthority));
 	return true;
 }
@@ -297,10 +297,10 @@ RPC_SERVICE_TEST(
 	uint32 RPCsToSend = GetDefault<USpatialGDKSettings>()->GetRPCRingBufferSize(ERPCType::ClientReliable);
 	for (uint32 i = 0; i < RPCsToSend; ++i)
 	{
-		RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ClientReliable, SimplePayload, false);
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientReliable, SimplePayload, false);
 	}
 
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ClientReliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientReliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::QueueOverflowed));
 	return true;
 }
@@ -314,10 +314,10 @@ RPC_SERVICE_TEST(
 	uint32 RPCsToSend = GetDefault<USpatialGDKSettings>()->GetRPCRingBufferSize(ERPCType::ClientUnreliable);
 	for (uint32 i = 0; i < RPCsToSend; ++i)
 	{
-		RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ClientUnreliable, SimplePayload, false);
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientUnreliable, SimplePayload, false);
 	}
 
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ClientUnreliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientUnreliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::DropOverflowed));
 	return true;
 }
@@ -331,10 +331,10 @@ RPC_SERVICE_TEST(
 	uint32 RPCsToSend = GetDefault<USpatialGDKSettings>()->GetRPCRingBufferSize(ERPCType::ServerReliable);
 	for (uint32 i = 0; i < RPCsToSend; ++i)
 	{
-		RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ServerReliable, SimplePayload, false);
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerReliable, SimplePayload, false);
 	}
 
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ServerReliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerReliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::QueueOverflowed));
 	return true;
 }
@@ -348,10 +348,10 @@ RPC_SERVICE_TEST(
 	uint32 RPCsToSend = GetDefault<USpatialGDKSettings>()->GetRPCRingBufferSize(ERPCType::ServerUnreliable);
 	for (uint32 i = 0; i < RPCsToSend; ++i)
 	{
-		RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ServerUnreliable, SimplePayload, false);
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerUnreliable, SimplePayload, false);
 	}
 
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ServerUnreliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerUnreliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::DropOverflowed));
 	return true;
 }
@@ -364,10 +364,10 @@ RPC_SERVICE_TEST(GIVEN_authority_over_server_endpoint_WHEN_push_overflow_multica
 	uint32 RPCsToSend = GetDefault<USpatialGDKSettings>()->GetRPCRingBufferSize(ERPCType::NetMulticast);
 	for (uint32 i = 0; i < RPCsToSend; ++i)
 	{
-		RPCService.PushRPC(RPCTestEntityId_1, ERPCType::NetMulticast, SimplePayload, false);
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::NetMulticast, SimplePayload, false);
 	}
 
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, ERPCType::NetMulticast, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::NetMulticast, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::Success));
 	return true;
 }
@@ -386,7 +386,7 @@ RPC_SERVICE_TEST(
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService(EntityIdArray, CLIENT_AUTH);
 	for (const EntityPayload& EntityPayloadItem : EntityPayloads)
 	{
-		RPCService.PushRPC(EntityPayloadItem.EntityId, ERPCType::ServerUnreliable, EntityPayloadItem.Payload, false);
+		RPCService.PushRPC(EntityPayloadItem.EntityId, FUnrealObjectRef(), ERPCType::ServerUnreliable, EntityPayloadItem.Payload, false);
 	}
 
 	TArray<SpatialGDK::SpatialRPCService::UpdateToSend> UpdateToSendArray = RPCService.GetRPCsAndAcksToSend();
@@ -417,7 +417,7 @@ RPC_SERVICE_TEST(GIVEN_no_authority_over_rpc_endpoint_WHEN_push_client_reliable_
 	// Create RPCService with empty component view
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({}, NO_AUTH);
 
-	RPCService.PushRPC(RPCTestEntityId_1, ERPCType::ClientReliable, SimplePayload, false);
+	RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientReliable, SimplePayload, false);
 
 	FWorkerComponentData ComponentData =
 		GetComponentDataOnEntityCreationFromRPCService(RPCService, RPCTestEntityId_1, ERPCType::ClientReliable);
@@ -432,8 +432,8 @@ RPC_SERVICE_TEST(GIVEN_no_authority_over_rpc_endpoint_WHEN_push_multicast_rpcs_t
 	// Create RPCService with empty component view
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({}, NO_AUTH);
 
-	RPCService.PushRPC(RPCTestEntityId_1, ERPCType::NetMulticast, SimplePayload, false);
-	RPCService.PushRPC(RPCTestEntityId_1, ERPCType::NetMulticast, SimplePayload, false);
+	RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::NetMulticast, SimplePayload, false);
+	RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::NetMulticast, SimplePayload, false);
 
 	FWorkerComponentData ComponentData =
 		GetComponentDataOnEntityCreationFromRPCService(RPCService, RPCTestEntityId_1, ERPCType::NetMulticast);
@@ -465,7 +465,7 @@ RPC_SERVICE_TEST(
 	int RPCsExtracted = 0;
 	bool bPayloadsMatch = true;
 	ExtractRPCDelegate RPCDelegate = ExtractRPCDelegate::CreateLambda(
-		[&RPCsExtracted, &bPayloadsMatch](Worker_EntityId EntityId, ERPCType RPCType, const SpatialGDK::RPCPayload& Payload) {
+		[&RPCsExtracted, &bPayloadsMatch](Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType RPCType, const SpatialGDK::RPCPayload& Payload, uint32 Slot){
 			RPCsExtracted++;
 			bPayloadsMatch &= CompareRPCPayload(Payload, SimplePayload);
 			bPayloadsMatch &= EntityId == RPCTestEntityId_1;

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/RPCServiceTest.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/RPCServiceTest.cpp
@@ -57,7 +57,8 @@ constexpr Worker_EntityId RPCTestEntityId_2 = 42;
 const SpatialGDK::RPCPayload SimplePayload = SpatialGDK::RPCPayload(1, 0, TArray<uint8>({ 1 }, 1));
 
 ExtractRPCDelegate DefaultRPCDelegate =
-	ExtractRPCDelegate::CreateLambda([](Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType RPCType, const SpatialGDK::RPCPayload& Payload, uint32 Slot) {
+	ExtractRPCDelegate::CreateLambda([](Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType RPCType,
+										const SpatialGDK::RPCPayload& Payload, uint32 Slot) {
 		return true;
 	});
 
@@ -199,7 +200,8 @@ FWorkerComponentData GetComponentDataOnEntityCreationFromRPCService(SpatialGDK::
 RPC_SERVICE_TEST(GIVEN_authority_over_server_endpoint_WHEN_push_client_reliable_rpcs_to_the_service_THEN_rpc_push_result_success)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, SERVER_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientReliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientReliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::Success));
 	return true;
 }
@@ -207,7 +209,8 @@ RPC_SERVICE_TEST(GIVEN_authority_over_server_endpoint_WHEN_push_client_reliable_
 RPC_SERVICE_TEST(GIVEN_authority_over_server_endpoint_WHEN_push_client_unreliable_rpcs_to_the_service_THEN_rpc_push_result_success)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, SERVER_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientUnreliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientUnreliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::Success));
 	return true;
 }
@@ -216,7 +219,8 @@ RPC_SERVICE_TEST(
 	GIVEN_authority_over_server_endpoint_WHEN_push_server_reliable_rpcs_to_the_service_THEN_rpc_push_result_no_buffer_authority)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, SERVER_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerReliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerReliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::NoRingBufferAuthority));
 	return true;
 }
@@ -225,7 +229,8 @@ RPC_SERVICE_TEST(
 	GIVEN_authority_over_server_endpoint_WHEN_push_server_unreliable_rpcs_to_the_service_THEN_rpc_push_result_no_buffer_authority)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, SERVER_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerUnreliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerUnreliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::NoRingBufferAuthority));
 	return true;
 }
@@ -234,7 +239,8 @@ RPC_SERVICE_TEST(
 	GIVEN_authority_over_client_endpoint_WHEN_push_client_reliable_rpcs_to_the_service_THEN_rpc_push_result_no_buffer_authority)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, CLIENT_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientReliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientReliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::NoRingBufferAuthority));
 	return true;
 }
@@ -243,7 +249,8 @@ RPC_SERVICE_TEST(
 	GIVEN_authority_over_client_endpoint_WHEN_push_client_unreliable_rpcs_to_the_service_THEN_rpc_push_result_no_buffer_authority)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, CLIENT_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientUnreliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientUnreliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::NoRingBufferAuthority));
 	return true;
 }
@@ -251,7 +258,8 @@ RPC_SERVICE_TEST(
 RPC_SERVICE_TEST(GIVEN_authority_over_client_endpoint_WHEN_push_server_reliable_rpcs_to_the_service_THEN_rpc_push_result_success)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, CLIENT_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerReliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerReliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::Success));
 	return true;
 }
@@ -259,7 +267,8 @@ RPC_SERVICE_TEST(GIVEN_authority_over_client_endpoint_WHEN_push_server_reliable_
 RPC_SERVICE_TEST(GIVEN_authority_over_client_endpoint_WHEN_push_server_unreliable_rpcs_to_the_service_THEN_rpc_push_result_success)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, CLIENT_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerUnreliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerUnreliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::Success));
 	return true;
 }
@@ -267,7 +276,8 @@ RPC_SERVICE_TEST(GIVEN_authority_over_client_endpoint_WHEN_push_server_unreliabl
 RPC_SERVICE_TEST(GIVEN_authority_over_client_endpoint_WHEN_push_multicast_rpcs_to_the_service_THEN_rpc_push_result_no_buffer_authority)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, CLIENT_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::NetMulticast, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::NetMulticast, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::NoRingBufferAuthority));
 	return true;
 }
@@ -275,7 +285,8 @@ RPC_SERVICE_TEST(GIVEN_authority_over_client_endpoint_WHEN_push_multicast_rpcs_t
 RPC_SERVICE_TEST(GIVEN_authority_over_server_endpoint_WHEN_push_multicast_rpcs_to_the_service_THEN_rpc_push_result_success)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, SERVER_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::NetMulticast, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::NetMulticast, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::Success));
 	return true;
 }
@@ -283,7 +294,8 @@ RPC_SERVICE_TEST(GIVEN_authority_over_server_endpoint_WHEN_push_multicast_rpcs_t
 RPC_SERVICE_TEST(GIVEN_authority_over_server_and_client_endpoint_WHEN_push_rpcs_to_the_service_THEN_rpc_push_result_has_ack_authority)
 {
 	SpatialGDK::SpatialRPCService RPCService = CreateRPCService({ RPCTestEntityId_1 }, SERVER_AND_CLIENT_AUTH);
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientReliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientReliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::HasAckAuthority));
 	return true;
 }
@@ -300,7 +312,8 @@ RPC_SERVICE_TEST(
 		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientReliable, SimplePayload, false);
 	}
 
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientReliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientReliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::QueueOverflowed));
 	return true;
 }
@@ -317,7 +330,8 @@ RPC_SERVICE_TEST(
 		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientUnreliable, SimplePayload, false);
 	}
 
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientUnreliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ClientUnreliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::DropOverflowed));
 	return true;
 }
@@ -334,7 +348,8 @@ RPC_SERVICE_TEST(
 		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerReliable, SimplePayload, false);
 	}
 
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerReliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerReliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::QueueOverflowed));
 	return true;
 }
@@ -351,7 +366,8 @@ RPC_SERVICE_TEST(
 		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerUnreliable, SimplePayload, false);
 	}
 
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerUnreliable, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::ServerUnreliable, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::DropOverflowed));
 	return true;
 }
@@ -367,7 +383,8 @@ RPC_SERVICE_TEST(GIVEN_authority_over_server_endpoint_WHEN_push_overflow_multica
 		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::NetMulticast, SimplePayload, false);
 	}
 
-	SpatialGDK::EPushRPCResult Result = RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::NetMulticast, SimplePayload, false);
+	SpatialGDK::EPushRPCResult Result =
+		RPCService.PushRPC(RPCTestEntityId_1, FUnrealObjectRef(), ERPCType::NetMulticast, SimplePayload, false);
 	TestTrue("Push RPC returned expected results", (Result == SpatialGDK::EPushRPCResult::Success));
 	return true;
 }
@@ -465,7 +482,8 @@ RPC_SERVICE_TEST(
 	int RPCsExtracted = 0;
 	bool bPayloadsMatch = true;
 	ExtractRPCDelegate RPCDelegate = ExtractRPCDelegate::CreateLambda(
-		[&RPCsExtracted, &bPayloadsMatch](Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType RPCType, const SpatialGDK::RPCPayload& Payload, uint32 Slot){
+		[&RPCsExtracted, &bPayloadsMatch](Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType RPCType,
+										  const SpatialGDK::RPCPayload& Payload, uint32 Slot) {
 			RPCsExtracted++;
 			bPayloadsMatch &= CompareRPCPayload(Payload, SimplePayload);
 			bPayloadsMatch &= EntityId == RPCTestEntityId_1;

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -85,11 +85,10 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 
 	FString RoutingWorkerName = NetDriver->GetRoutingWorkerId();
 
-	check(SpatialSettings->CrossServerRPCImplementation != ECrossServerRPCImplementation::RoutingWorker
-		|| !RoutingWorkerName.IsEmpty());
+	check(SpatialSettings->CrossServerRPCImplementation != ECrossServerRPCImplementation::RoutingWorker || !RoutingWorkerName.IsEmpty());
 
 	const WorkerRequirementSet AuthoritativeWorkerRequirementSet = { WorkerAttributeOrSpecificWorker };
-	const WorkerRequirementSet RoutingWorkerRequirementSet = { {FString::Format(TEXT("workerId:{0}"), { *RoutingWorkerName })} };
+	const WorkerRequirementSet RoutingWorkerRequirementSet = { { FString::Format(TEXT("workerId:{0}"), { *RoutingWorkerName }) } };
 
 	WorkerRequirementSet ReadAcl;
 	if (Class->HasAnySpatialClassFlags(SPATIALCLASS_ServerOnly))

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -148,10 +148,7 @@ Interest InterestFactory::CreateServerWorkerInterest(const UAbstractLBStrategy* 
 	// TODO UNR-3042 : Migrate the VirtualWorkerTranslationManager to use the checked-out worker components instead of making a query.
 
 	ServerQuery = Query();
-	ServerQuery.ResultComponentIds = SchemaResultType
-	{
-		SpatialConstants::WORKER_COMPONENT_ID
-	};
+	ServerQuery.ResultComponentIds = SchemaResultType{ SpatialConstants::WORKER_COMPONENT_ID };
 	ServerQuery.Constraint.ComponentConstraint = SpatialConstants::WORKER_COMPONENT_ID;
 	AddComponentQueryPairToInterestComponent(ServerInterest, SpatialConstants::POSITION_COMPONENT_ID, ServerQuery);
 
@@ -167,47 +164,33 @@ Interest InterestFactory::CreateServerWorkerInterest(const UAbstractLBStrategy* 
 	if (SpatialGDKSettings->CrossServerRPCImplementation == ECrossServerRPCImplementation::WorkerEntityMailbox)
 	{
 		ServerQuery = Query();
-		ServerQuery.ResultComponentIds = SchemaResultType
-		{
-			SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID
-		};
-		
+		ServerQuery.ResultComponentIds = SchemaResultType{ SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID };
+
 		ServerQuery.Constraint.ComponentConstraint = SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID;
 		AddComponentQueryPairToInterestComponent(ServerInterest, SpatialConstants::POSITION_COMPONENT_ID, ServerQuery);
 
 		ServerQuery = Query();
-		ServerQuery.ResultComponentIds = SchemaResultType
-		{
-			SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID
-		};
+		ServerQuery.ResultComponentIds = SchemaResultType{ SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID };
 
 		ServerQuery.Constraint.ComponentConstraint = SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID;
 		AddComponentQueryPairToInterestComponent(ServerInterest, SpatialConstants::POSITION_COMPONENT_ID, ServerQuery);
 	}
-	else if (SpatialGDKSettings->CrossServerRPCImplementation == ECrossServerRPCImplementation::RoutingWorker
-		&& bIsRoutingWorker)
+	else if (SpatialGDKSettings->CrossServerRPCImplementation == ECrossServerRPCImplementation::RoutingWorker && bIsRoutingWorker)
 	{
 		ServerQuery = Query();
-		ServerQuery.ResultComponentIds = SchemaResultType
-		{
-			SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID,
-			SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID
-		};
+		ServerQuery.ResultComponentIds = SchemaResultType{ SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID,
+														   SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID };
 		ServerQuery.Constraint.ComponentConstraint = SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID;
 
 		AddComponentQueryPairToInterestComponent(ServerInterest, SpatialConstants::POSITION_COMPONENT_ID, ServerQuery);
 
 		ServerQuery = Query();
-		ServerQuery.ResultComponentIds = SchemaResultType
-		{
-			SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID,
-			SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID
-		};
+		ServerQuery.ResultComponentIds = SchemaResultType{ SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID,
+														   SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID };
 		ServerQuery.Constraint.ComponentConstraint = SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID;
 
 		AddComponentQueryPairToInterestComponent(ServerInterest, SpatialConstants::POSITION_COMPONENT_ID, ServerQuery);
 	}
-
 
 	return ServerInterest;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCContainer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCContainer.cpp
@@ -87,16 +87,14 @@ void LogRPCError(const FRPCErrorInfo& ErrorInfo, ERPCQueueType QueueType, const 
 }
 } // namespace
 
-//FPendingRPCParams::FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, ERPCType InType, RPCPayload&& InPayload)
-//	: ObjectRef(InTargetObjectRef)
-//	, SenderObjectRef(InSenderObjectRef)
-//	, Payload(MoveTemp(InPayload))
-//	, Timestamp(FDateTime::Now())
-//	, Type(InType)
+// FPendingRPCParams::FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, ERPCType
+// InType, RPCPayload&& InPayload) 	: ObjectRef(InTargetObjectRef) 	, SenderObjectRef(InSenderObjectRef) 	, Payload(MoveTemp(InPayload)) 	,
+//Timestamp(FDateTime::Now()) 	, Type(InType)
 //{
 //}
 
-FPendingRPCParams::FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, ERPCType InType, RPCPayload&& InPayload, uint32 InSlot)
+FPendingRPCParams::FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, ERPCType InType,
+									 RPCPayload&& InPayload, uint32 InSlot)
 	: ObjectRef(InTargetObjectRef)
 	, SenderObjectRef(InSenderObjectRef)
 	, Payload(MoveTemp(InPayload))
@@ -106,7 +104,8 @@ FPendingRPCParams::FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, 
 {
 }
 
-void FRPCContainer::ProcessOrQueueRPC(const FUnrealObjectRef& TargetObjectRef, const FUnrealObjectRef& SenderObjectRef, ERPCType Type, RPCPayload&& Payload, uint32 Slot)
+void FRPCContainer::ProcessOrQueueRPC(const FUnrealObjectRef& TargetObjectRef, const FUnrealObjectRef& SenderObjectRef, ERPCType Type,
+									  RPCPayload&& Payload, uint32 Slot)
 {
 	FArrayOfParams& ArrayOfParams = QueuedRPCs.FindOrAdd(Type).FindOrAdd(TargetObjectRef.Entity);
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCContainer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCContainer.cpp
@@ -88,8 +88,8 @@ void LogRPCError(const FRPCErrorInfo& ErrorInfo, ERPCQueueType QueueType, const 
 } // namespace
 
 // FPendingRPCParams::FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, ERPCType
-// InType, RPCPayload&& InPayload) 	: ObjectRef(InTargetObjectRef) 	, SenderObjectRef(InSenderObjectRef) 	, Payload(MoveTemp(InPayload)) 	,
-//Timestamp(FDateTime::Now()) 	, Type(InType)
+// InType, RPCPayload&& InPayload) 	: ObjectRef(InTargetObjectRef) 	, SenderObjectRef(InSenderObjectRef) 	, Payload(MoveTemp(InPayload)) ,
+// Timestamp(FDateTime::Now()) 	, Type(InType)
 //{
 //}
 
@@ -98,9 +98,9 @@ FPendingRPCParams::FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, 
 	: ObjectRef(InTargetObjectRef)
 	, SenderObjectRef(InSenderObjectRef)
 	, Payload(MoveTemp(InPayload))
+	, Slot(InSlot)
 	, Timestamp(FDateTime::Now())
 	, Type(InType)
-	, Slot(InSlot)
 {
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCContainer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCContainer.cpp
@@ -87,17 +87,42 @@ void LogRPCError(const FRPCErrorInfo& ErrorInfo, ERPCQueueType QueueType, const 
 }
 } // namespace
 
-FPendingRPCParams::FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, ERPCType InType, RPCPayload&& InPayload)
+//FPendingRPCParams::FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, ERPCType InType, RPCPayload&& InPayload)
+//	: ObjectRef(InTargetObjectRef)
+//	, SenderObjectRef(InSenderObjectRef)
+//	, Payload(MoveTemp(InPayload))
+//	, Timestamp(FDateTime::Now())
+//	, Type(InType)
+//{
+//}
+
+FPendingRPCParams::FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, ERPCType InType, RPCPayload&& InPayload, uint32 InSlot)
 	: ObjectRef(InTargetObjectRef)
+	, SenderObjectRef(InSenderObjectRef)
 	, Payload(MoveTemp(InPayload))
 	, Timestamp(FDateTime::Now())
 	, Type(InType)
+	, Slot(InSlot)
 {
 }
 
-void FRPCContainer::ProcessOrQueueRPC(const FUnrealObjectRef& TargetObjectRef, ERPCType Type, RPCPayload&& Payload)
+void FRPCContainer::ProcessOrQueueRPC(const FUnrealObjectRef& TargetObjectRef, const FUnrealObjectRef& SenderObjectRef, ERPCType Type, RPCPayload&& Payload, uint32 Slot)
 {
-	FPendingRPCParams Params{ TargetObjectRef, Type, MoveTemp(Payload) };
+	FArrayOfParams& ArrayOfParams = QueuedRPCs.FindOrAdd(Type).FindOrAdd(TargetObjectRef.Entity);
+
+	if (Type == ERPCType::CrossServerSender)
+	{
+		for (auto const& Entry : ArrayOfParams)
+		{
+			if (Entry.SenderObjectRef == SenderObjectRef)
+			{
+				// Already queued RPC, can happen while reading RPC over several frames.
+				return;
+			}
+		}
+	}
+
+	FPendingRPCParams Params{ TargetObjectRef, SenderObjectRef, Type, MoveTemp(Payload), Slot };
 
 	if (!ObjectHasRPCsQueuedOfType(Params.ObjectRef.Entity, Params.Type))
 	{
@@ -110,7 +135,6 @@ void FRPCContainer::ProcessOrQueueRPC(const FUnrealObjectRef& TargetObjectRef, E
 		}
 	}
 
-	FArrayOfParams& ArrayOfParams = QueuedRPCs.FindOrAdd(Params.Type).FindOrAdd(Params.ObjectRef.Entity);
 	ArrayOfParams.Push(MoveTemp(Params));
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCRingBuffer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCRingBuffer.cpp
@@ -167,19 +167,11 @@ void ReadBufferFromSchema(Schema_Object* SchemaObject, RPCRingBuffer& OutBuffer)
 		{
 			OutBuffer.RingBuffer[RingBufferIndex].Emplace(Schema_GetObject(SchemaObject, FieldId));
 		}
-		else
-		{
-			OutBuffer.RingBuffer[RingBufferIndex].Reset();
-		}
 		if (OutBuffer.Type == ERPCType::CrossServerSender || OutBuffer.Type == ERPCType::CrossServerReceiver)
 		{
 			if (Schema_GetObjectCount(SchemaObject, FieldId + 1) > 0)
 			{
 				OutBuffer.Counterpart[RingBufferIndex].Emplace(GetObjectRefFromSchema(SchemaObject, FieldId + 1));
-			}
-			else
-			{
-				OutBuffer.Counterpart[RingBufferIndex].Reset();
 			}
 		}
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCRingBuffer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCRingBuffer.cpp
@@ -4,12 +4,18 @@
 
 #include "SpatialGDKSettings.h"
 
+#pragma optimize("", off)
+
 namespace SpatialGDK
 {
 RPCRingBuffer::RPCRingBuffer(ERPCType InType)
 	: Type(InType)
 {
 	RingBuffer.SetNum(RPCRingBufferUtils::GetRingBufferSize(Type));
+	if (InType == ERPCType::CrossServerReceiver || InType == ERPCType::CrossServerSender)
+	{
+		Counterpart.SetNum(RPCRingBufferUtils::GetRingBufferSize(Type));
+	}
 }
 
 namespace RPCRingBufferUtils
@@ -26,6 +32,10 @@ Worker_ComponentId GetRingBufferComponentId(ERPCType Type)
 		return SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID;
 	case ERPCType::NetMulticast:
 		return SpatialConstants::MULTICAST_RPCS_COMPONENT_ID;
+	case ERPCType::CrossServerSender:
+		return SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID;
+	case ERPCType::CrossServerReceiver:
+		return SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID;
 	default:
 		checkNoEntry();
 		return SpatialConstants::INVALID_COMPONENT_ID;
@@ -60,6 +70,11 @@ RPCRingBufferDescriptor GetRingBufferDescriptor(ERPCType Type)
 		Descriptor.SchemaFieldStart = 1 + MaxRingBufferSize + 1;
 		Descriptor.LastSentRPCFieldId = 1 + MaxRingBufferSize + 1 + MaxRingBufferSize;
 		break;
+	case ERPCType::CrossServerSender:
+	case ERPCType::CrossServerReceiver:
+		Descriptor.SchemaFieldStart = 1;
+		Descriptor.LastSentRPCFieldId = 1 + 2 * MaxRingBufferSize;
+		break;
 	default:
 		checkNoEntry();
 		break;
@@ -83,6 +98,10 @@ Worker_ComponentId GetAckComponentId(ERPCType Type)
 	case ERPCType::ServerReliable:
 	case ERPCType::ServerUnreliable:
 		return SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID;
+	case ERPCType::CrossServerSender:
+		return SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID;
+	case ERPCType::CrossServerReceiver:
+		return SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID;
 	default:
 		checkNoEntry();
 		return SpatialConstants::INVALID_COMPONENT_ID;
@@ -103,6 +122,9 @@ Schema_FieldId GetAckFieldId(ERPCType Type)
 	case ERPCType::ClientUnreliable:
 	case ERPCType::ServerUnreliable:
 		return 1 + 2 * (MaxRingBufferSize + 1) + 1;
+	case ERPCType::CrossServerSender:
+	case ERPCType::CrossServerReceiver:
+		return 1;
 	default:
 		checkNoEntry();
 		return 0;
@@ -127,6 +149,9 @@ bool ShouldQueueOverflowed(ERPCType Type)
 	case ERPCType::ServerUnreliable:
 	case ERPCType::NetMulticast:
 		return false;
+	case ERPCType::CrossServerSender:
+	case ERPCType::CrossServerReceiver:
+		return false;
 	default:
 		checkNoEntry();
 		return false;
@@ -139,10 +164,17 @@ void ReadBufferFromSchema(Schema_Object* SchemaObject, RPCRingBuffer& OutBuffer)
 
 	for (uint32 RingBufferIndex = 0; RingBufferIndex < Descriptor.RingBufferSize; RingBufferIndex++)
 	{
-		Schema_FieldId FieldId = Descriptor.SchemaFieldStart + RingBufferIndex;
+		Schema_FieldId FieldId = Descriptor.GetRingBufferElementFieldId(OutBuffer.Type, RingBufferIndex + 1);
 		if (Schema_GetObjectCount(SchemaObject, FieldId) > 0)
 		{
 			OutBuffer.RingBuffer[RingBufferIndex].Emplace(Schema_GetObject(SchemaObject, FieldId));
+		}
+		if (OutBuffer.Type == ERPCType::CrossServerSender || OutBuffer.Type == ERPCType::CrossServerReceiver)
+		{
+			if (Schema_GetObjectCount(SchemaObject, FieldId + 1) > 0)
+			{
+				OutBuffer.Counterpart[RingBufferIndex].Emplace(GetObjectRefFromSchema(SchemaObject, FieldId + 1));
+			}
 		}
 	}
 
@@ -166,7 +198,7 @@ void WriteRPCToSchema(Schema_Object* SchemaObject, ERPCType Type, uint64 RPCId, 
 {
 	RPCRingBufferDescriptor Descriptor = GetRingBufferDescriptor(Type);
 
-	Schema_Object* RPCObject = Schema_AddObject(SchemaObject, Descriptor.GetRingBufferElementFieldId(RPCId));
+	Schema_Object* RPCObject = Schema_AddObject(SchemaObject, Descriptor.GetRingBufferElementFieldId(Type, RPCId));
 	Payload.WriteToSchemaObject(RPCObject);
 
 	Schema_ClearField(SchemaObject, Descriptor.LastSentRPCFieldId);
@@ -179,6 +211,18 @@ void WriteAckToSchema(Schema_Object* SchemaObject, ERPCType Type, uint64 Ack)
 
 	Schema_ClearField(SchemaObject, AckFieldId);
 	Schema_AddUint64(SchemaObject, AckFieldId, Ack);
+}
+
+void WriteAckForSenderToSchema(Schema_Object* SchemaObject, ERPCType Type, TArray<FUnrealObjectRef> const& AckArray)
+{
+	Schema_FieldId AckArrayFieldId = GetAckFieldId(Type) + 1;
+
+	Schema_ClearField(SchemaObject, AckArrayFieldId);
+	//Schema_AddUint64(SchemaObject, AckFieldId, Ack);
+	for (auto const& Ref : AckArray)
+	{
+		AddObjectRefToSchema(SchemaObject, AckArrayFieldId, Ref);
+	}
 }
 
 void MoveLastSentIdToInitiallyPresentCount(Schema_Object* SchemaObject, uint64 LastSentId)

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCRingBuffer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCRingBuffer.cpp
@@ -218,7 +218,7 @@ void WriteAckForSenderToSchema(Schema_Object* SchemaObject, ERPCType Type, TArra
 	Schema_FieldId AckArrayFieldId = GetAckFieldId(Type) + 1;
 
 	Schema_ClearField(SchemaObject, AckArrayFieldId);
-	//Schema_AddUint64(SchemaObject, AckFieldId, Ack);
+	// Schema_AddUint64(SchemaObject, AckFieldId, Ack);
 	for (auto const& Ref : AckArray)
 	{
 		AddObjectRefToSchema(SchemaObject, AckArrayFieldId, Ref);

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCRingBuffer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCRingBuffer.cpp
@@ -4,8 +4,6 @@
 
 #include "SpatialGDKSettings.h"
 
-#pragma optimize("", off)
-
 namespace SpatialGDK
 {
 RPCRingBuffer::RPCRingBuffer(ERPCType InType)
@@ -169,11 +167,19 @@ void ReadBufferFromSchema(Schema_Object* SchemaObject, RPCRingBuffer& OutBuffer)
 		{
 			OutBuffer.RingBuffer[RingBufferIndex].Emplace(Schema_GetObject(SchemaObject, FieldId));
 		}
+		else
+		{
+			OutBuffer.RingBuffer[RingBufferIndex].Reset();
+		}
 		if (OutBuffer.Type == ERPCType::CrossServerSender || OutBuffer.Type == ERPCType::CrossServerReceiver)
 		{
 			if (Schema_GetObjectCount(SchemaObject, FieldId + 1) > 0)
 			{
 				OutBuffer.Counterpart[RingBufferIndex].Emplace(GetObjectRefFromSchema(SchemaObject, FieldId + 1));
+			}
+			else
+			{
+				OutBuffer.Counterpart[RingBufferIndex].Reset();
 			}
 		}
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetricsDisplay.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetricsDisplay.cpp
@@ -64,12 +64,12 @@ void ASpatialMetricsDisplay::Destroyed()
 	}
 }
 
-bool ASpatialMetricsDisplay::ServerUpdateWorkerStats_Validate(const float Time, const FWorkerStats& OneWorkerStats)
+bool ASpatialMetricsDisplay::ServerUpdateWorkerStats_Validate(AActor* Sender, const float Time, const FWorkerStats& OneWorkerStats)
 {
 	return true;
 }
 
-void ASpatialMetricsDisplay::ServerUpdateWorkerStats_Implementation(const float Time, const FWorkerStats& OneWorkerStats)
+void ASpatialMetricsDisplay::ServerUpdateWorkerStats_Implementation(AActor* Sender, const float Time, const FWorkerStats& OneWorkerStats)
 {
 	int32 StatsIndex = WorkerStats.Find(OneWorkerStats);
 
@@ -254,7 +254,7 @@ void ASpatialMetricsDisplay::Tick(float DeltaSeconds)
 	}
 #endif // USE_SERVER_PERF_COUNTERS
 
-	ServerUpdateWorkerStats(SpatialNetDriver->GetElapsedTime(), Stats);
+	ServerUpdateWorkerStats(nullptr, SpatialNetDriver->GetElapsedTime(), Stats);
 
 #endif // !UE_BUILD_SHIPPING
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -129,6 +129,8 @@ public:
 	void SetSpatialDebugger(ASpatialDebugger* InSpatialDebugger);
 	TWeakObjectPtr<USpatialNetConnection> FindClientConnectionFromWorkerId(const FString& WorkerId);
 	void CleanUpClientConnection(USpatialNetConnection* ClientConnection);
+	const FString& GetRoutingWorkerId();
+	bool IsRoutingWorker();
 
 	UPROPERTY()
 	USpatialWorkerConnection* Connection;

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/GlobalStateManager.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/GlobalStateManager.h
@@ -52,6 +52,7 @@ public:
 	FORCEINLINE bool GetAcceptingPlayers() const { return bAcceptingPlayers; }
 	FORCEINLINE int32 GetSessionId() const { return DeploymentSessionId; }
 	FORCEINLINE uint32 GetSchemaHash() const { return SchemaHash; }
+	FORCEINLINE const FString& GetRoutingWorkerId() const { return RoutingWorkerId; }
 
 	void AuthorityChanged(const Worker_AuthorityChangeOp& AuthChangeOp);
 	bool HandlesComponent(const Worker_ComponentId ComponentId) const;
@@ -76,6 +77,8 @@ private:
 	bool bAcceptingPlayers;
 	int32 DeploymentSessionId = 0;
 	uint32 SchemaHash;
+
+	FString RoutingWorkerId;
 
 	// Startup Actor Manager Component
 	bool bHasSentReadyForVirtualWorkerAssignment;

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialOSDispatcherInterface.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialOSDispatcherInterface.h
@@ -36,7 +36,7 @@ public:
 		PURE_VIRTUAL(SpatialOSDispatcherInterface::OnComponentUpdate, return;);
 	virtual void OnEntityQueryResponse(const Worker_EntityQueryResponseOp& Op)
 		PURE_VIRTUAL(SpatialOSDispatcherInterface::OnEntityQueryResponse, return;);
-	virtual bool OnExtractIncomingRPC(Worker_EntityId EntityId, ERPCType RPCType, const SpatialGDK::RPCPayload& Payload)
+	virtual bool OnExtractIncomingRPC(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType RPCType, const SpatialGDK::RPCPayload& Payload, uint32 Slot)
 		PURE_VIRTUAL(SpatialOSDispatcherInterface::OnExtractIncomingRPC, return false;);
 	virtual void OnCommandRequest(const Worker_CommandRequestOp& Op) PURE_VIRTUAL(SpatialOSDispatcherInterface::OnCommandRequest, return;);
 	virtual void OnCommandResponse(const Worker_CommandResponseOp& Op)

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialOSDispatcherInterface.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialOSDispatcherInterface.h
@@ -36,7 +36,8 @@ public:
 		PURE_VIRTUAL(SpatialOSDispatcherInterface::OnComponentUpdate, return;);
 	virtual void OnEntityQueryResponse(const Worker_EntityQueryResponseOp& Op)
 		PURE_VIRTUAL(SpatialOSDispatcherInterface::OnEntityQueryResponse, return;);
-	virtual bool OnExtractIncomingRPC(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType RPCType, const SpatialGDK::RPCPayload& Payload, uint32 Slot)
+	virtual bool OnExtractIncomingRPC(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType RPCType,
+									  const SpatialGDK::RPCPayload& Payload, uint32 Slot)
 		PURE_VIRTUAL(SpatialOSDispatcherInterface::OnExtractIncomingRPC, return false;);
 	virtual void OnCommandRequest(const Worker_CommandRequestOp& Op) PURE_VIRTUAL(SpatialOSDispatcherInterface::OnCommandRequest, return;);
 	virtual void OnCommandResponse(const Worker_CommandResponseOp& Op)

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialRPCService.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialRPCService.h
@@ -13,11 +13,13 @@
 
 DECLARE_LOG_CATEGORY_EXTERN(LogSpatialRPCService, Log, All);
 
+class SpatialOSWorkerInterface;
+
 class USpatialLatencyTracer;
 class USpatialStaticComponentView;
 struct RPCRingBuffer;
 
-DECLARE_DELEGATE_RetVal_ThreeParams(bool, ExtractRPCDelegate, Worker_EntityId, ERPCType, const SpatialGDK::RPCPayload&);
+DECLARE_DELEGATE_RetVal_FiveParams(bool, ExtractRPCDelegate, Worker_EntityId, const FUnrealObjectRef&, ERPCType, const SpatialGDK::RPCPayload&, uint32);
 
 namespace SpatialGDK
 {
@@ -60,7 +62,7 @@ public:
 	SpatialRPCService(ExtractRPCDelegate ExtractRPCCallback, const USpatialStaticComponentView* View,
 					  USpatialLatencyTracer* SpatialLatencyTracer);
 
-	EPushRPCResult PushRPC(Worker_EntityId EntityId, ERPCType Type, RPCPayload Payload, bool bCreatedEntity);
+	EPushRPCResult PushRPC(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType Type, RPCPayload Payload, bool bCreatedEntity);
 	void PushOverflowedRPCs();
 
 	struct UpdateToSend
@@ -70,6 +72,9 @@ public:
 	};
 	TArray<UpdateToSend> GetRPCsAndAcksToSend();
 	TArray<FWorkerComponentData> GetRPCComponentsOnEntityCreation(Worker_EntityId EntityId);
+	void CheckLocalTargets(Worker_EntityId LocalWorkerEntityId);
+	void HandleTimeout(SpatialOSWorkerInterface* Sender);
+	bool OnEntityRequestResponse(Worker_RequestId Request, bool bEntityExists);
 
 	// Calls ExtractRPCCallback for each RPC it extracts from a given component. If the callback returns false,
 	// stops retrieving RPCs.
@@ -84,14 +89,18 @@ public:
 	void OnEndpointAuthorityGained(Worker_EntityId EntityId, Worker_ComponentId ComponentId);
 	void OnEndpointAuthorityLost(Worker_EntityId EntityId, Worker_ComponentId ComponentId);
 
+	void WriteCrossServerACKFor(Worker_EntityId Receiver, Worker_EntityId Sender, uint64 RPCId, uint32 Slot);
+	void UpdateMergedACKs(Worker_EntityId WorkerId, Worker_EntityId RemoteReceiver);
+
 private:
 	// For now, we should drop overflowed RPCs when entity crosses the boundary.
 	// When locking works as intended, we should re-evaluate how this will work (drop after some time?).
 	void ClearOverflowedRPCs(Worker_EntityId EntityId);
 
-	EPushRPCResult PushRPCInternal(Worker_EntityId EntityId, ERPCType Type, RPCPayload&& Payload, bool bCreatedEntity);
+	EPushRPCResult PushRPCInternal(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType Type, RPCPayload&& Payload, bool bCreatedEntity);
 
 	void ExtractRPCsForType(Worker_EntityId EntityId, ERPCType Type);
+	void ExtractCrossServerRPCsForType(Worker_EntityId EntityId, ERPCType Type);
 
 	void AddOverflowedRPC(EntityRPCType EntityType, RPCPayload&& Payload);
 
@@ -102,6 +111,11 @@ private:
 	Schema_ComponentData* GetOrCreateComponentData(EntityComponentId EntityComponentIdPair);
 
 private:
+
+	TOptional<uint32_t> FindFreeSlotForCrossServerSender();
+
+	void CleanupACKsFor(Worker_EntityId Sender, uint64 MinRPCId, TSet<Worker_EntityId> const& ReceiversToIgnore);
+
 	ExtractRPCDelegate ExtractRPCCallback;
 	const USpatialStaticComponentView* View;
 	USpatialLatencyTracer* SpatialLatencyTracer;
@@ -119,10 +133,28 @@ private:
 	TMap<EntityComponentId, Schema_ComponentUpdate*> PendingComponentUpdatesToSend;
 	TMap<EntityRPCType, TArray<RPCPayload>> OverflowedRPCs;
 
+
+	struct SentRPCEntry
+	{
+		uint64 RPCId;
+		uint64 MergedCrossServerACK;
+		uint64 Timestamp;
+		Worker_EntityId Target;
+		TOptional<Worker_RequestId> EntityRequest;
+	};
+
+	// For sender
+	TArray<SentRPCEntry> CrossServerMailbox;
+
+	// For receiver
+	TSet<Worker_EntityId> ACKComponentsToTrack;
+
 #if TRACE_LIB_ACTIVE
 	void ProcessResultToLatencyTrace(const EPushRPCResult Result, const TraceKey Trace);
 	TMap<EntityComponentId, TraceKey> PendingTraces;
 #endif
+
+	bool bShouldCheckSentRPCForLocalTarget = false;
 };
 
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialRPCService.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialRPCService.h
@@ -78,7 +78,8 @@ public:
 	TArray<FWorkerComponentData> GetRPCComponentsOnEntityCreation(Worker_EntityId EntityId);
 	void CheckLocalTargets(Worker_EntityId LocalWorkerEntityId);
 	void HandleTimeout(SpatialOSWorkerInterface* Sender);
-	bool OnEntityRequestResponse(Worker_RequestId Request, bool bEntityExists);
+	bool OnEntityRequestResponse(Worker_EntityId LocalWorkerEntityId, Worker_RequestId Request, bool bEntityExists);
+	void OnEntityRemoved(Worker_EntityId LocalWorkerEntityId, Worker_EntityId Entity);
 
 	// Calls ExtractRPCCallback for each RPC it extracts from a given component. If the callback returns false,
 	// stops retrieving RPCs.
@@ -153,6 +154,7 @@ private:
 	// For sender
 	TMultiMap<Worker_EntityId_Key, SentRPCEntry> CrossServerMailbox;
 	TBitArray<FDefaultBitArrayAllocator> CrossServerOccupiedSlots;
+	TBitArray<FDefaultBitArrayAllocator> CrossServerSlotsToClear;
 
 	// For receiver
 	// Contains the number of available slots for acks for the given receiver.

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialRPCService.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialRPCService.h
@@ -19,7 +19,8 @@ class USpatialLatencyTracer;
 class USpatialStaticComponentView;
 struct RPCRingBuffer;
 
-DECLARE_DELEGATE_RetVal_FiveParams(bool, ExtractRPCDelegate, Worker_EntityId, const FUnrealObjectRef&, ERPCType, const SpatialGDK::RPCPayload&, uint32);
+DECLARE_DELEGATE_RetVal_FiveParams(bool, ExtractRPCDelegate, Worker_EntityId, const FUnrealObjectRef&, ERPCType,
+								   const SpatialGDK::RPCPayload&, uint32);
 
 namespace SpatialGDK
 {
@@ -62,7 +63,8 @@ public:
 	SpatialRPCService(ExtractRPCDelegate ExtractRPCCallback, const USpatialStaticComponentView* View,
 					  USpatialLatencyTracer* SpatialLatencyTracer);
 
-	EPushRPCResult PushRPC(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType Type, RPCPayload Payload, bool bCreatedEntity);
+	EPushRPCResult PushRPC(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType Type, RPCPayload Payload,
+						   bool bCreatedEntity);
 	void PushOverflowedRPCs();
 
 	struct UpdateToSend
@@ -97,7 +99,8 @@ private:
 	// When locking works as intended, we should re-evaluate how this will work (drop after some time?).
 	void ClearOverflowedRPCs(Worker_EntityId EntityId);
 
-	EPushRPCResult PushRPCInternal(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType Type, RPCPayload&& Payload, bool bCreatedEntity);
+	EPushRPCResult PushRPCInternal(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType Type, RPCPayload&& Payload,
+								   bool bCreatedEntity);
 
 	void ExtractRPCsForType(Worker_EntityId EntityId, ERPCType Type);
 	void ExtractCrossServerRPCsForType(Worker_EntityId EntityId, ERPCType Type);
@@ -111,7 +114,6 @@ private:
 	Schema_ComponentData* GetOrCreateComponentData(EntityComponentId EntityComponentIdPair);
 
 private:
-
 	TOptional<uint32_t> FindFreeSlotForCrossServerSender();
 
 	void CleanupACKsFor(Worker_EntityId Sender, uint64 MinRPCId, TSet<Worker_EntityId> const& ReceiversToIgnore);
@@ -132,7 +134,6 @@ private:
 
 	TMap<EntityComponentId, Schema_ComponentUpdate*> PendingComponentUpdatesToSend;
 	TMap<EntityRPCType, TArray<RPCPayload>> OverflowedRPCs;
-
 
 	struct SentRPCEntry
 	{

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialRPCService.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialRPCService.h
@@ -116,7 +116,7 @@ private:
 private:
 	TOptional<uint32_t> FindFreeSlotForCrossServerSender();
 
-	void CleanupACKsFor(Worker_EntityId Sender, uint64 MinRPCId, TSet<Worker_EntityId> const& ReceiversToIgnore);
+	void CleanupACKsFor(Worker_EntityId Sender, uint64 MinRPCId, TSet<Worker_EntityId_Key> const& ReceiversToIgnore);
 
 	ExtractRPCDelegate ExtractRPCCallback;
 	const USpatialStaticComponentView* View;
@@ -148,7 +148,7 @@ private:
 	TArray<SentRPCEntry> CrossServerMailbox;
 
 	// For receiver
-	TSet<Worker_EntityId> ACKComponentsToTrack;
+	TSet<Worker_EntityId_Key> ACKComponentsToTrack;
 
 #if TRACE_LIB_ACTIVE
 	void ProcessResultToLatencyTrace(const EPushRPCResult Result, const TraceKey Trace);

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -78,7 +78,8 @@ public:
 
 	// This gets bound to a delegate in SpatialRPCService and is called for each RPC extracted when calling
 	// SpatialRPCService::ExtractRPCsForEntity.
-	virtual bool OnExtractIncomingRPC(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType RPCType, const SpatialGDK::RPCPayload& Payload, uint32 Slot) override;
+	virtual bool OnExtractIncomingRPC(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType RPCType,
+									  const SpatialGDK::RPCPayload& Payload, uint32 Slot) override;
 
 	virtual void OnCommandRequest(const Worker_CommandRequestOp& Op) override;
 	virtual void OnCommandResponse(const Worker_CommandResponseOp& Op) override;
@@ -154,7 +155,8 @@ private:
 
 	bool IsReceivedEntityTornOff(Worker_EntityId EntityId);
 
-	void ProcessOrQueueIncomingRPC(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, SpatialGDK::RPCPayload InPayload, uint32 Slot);
+	void ProcessOrQueueIncomingRPC(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef,
+								   SpatialGDK::RPCPayload InPayload, uint32 Slot);
 
 	void ResolveIncomingOperations(UObject* Object, const FUnrealObjectRef& ObjectRef);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -78,7 +78,7 @@ public:
 
 	// This gets bound to a delegate in SpatialRPCService and is called for each RPC extracted when calling
 	// SpatialRPCService::ExtractRPCsForEntity.
-	virtual bool OnExtractIncomingRPC(Worker_EntityId EntityId, ERPCType RPCType, const SpatialGDK::RPCPayload& Payload) override;
+	virtual bool OnExtractIncomingRPC(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType RPCType, const SpatialGDK::RPCPayload& Payload, uint32 Slot) override;
 
 	virtual void OnCommandRequest(const Worker_CommandRequestOp& Op) override;
 	virtual void OnCommandResponse(const Worker_CommandResponseOp& Op) override;
@@ -154,7 +154,7 @@ private:
 
 	bool IsReceivedEntityTornOff(Worker_EntityId EntityId);
 
-	void ProcessOrQueueIncomingRPC(const FUnrealObjectRef& InTargetObjectRef, SpatialGDK::RPCPayload InPayload);
+	void ProcessOrQueueIncomingRPC(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, SpatialGDK::RPCPayload InPayload, uint32 Slot);
 
 	void ResolveIncomingOperations(UObject* Object, const FUnrealObjectRef& ObjectRef);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -7,6 +7,7 @@
 #include "EngineClasses/SpatialLoadBalanceEnforcer.h"
 #include "EngineClasses/SpatialNetBitWriter.h"
 #include "Interop/SpatialClassInfoManager.h"
+#include "Interop/SpatialOSDispatcherInterface.h"
 #include "Interop/SpatialRPCService.h"
 #include "Schema/RPCPayload.h"
 #include "TimerManager.h"
@@ -79,8 +80,8 @@ public:
 	FRPCErrorInfo SendRPC(const FPendingRPCParams& Params);
 	void SendOnEntityCreationRPC(UObject* TargetObject, UFunction* Function, const SpatialGDK::RPCPayload& Payload,
 								 USpatialActorChannel* Channel, const FUnrealObjectRef& TargetObjectRef);
-	void SendCrossServerRPC(UObject* TargetObject, UFunction* Function, const SpatialGDK::RPCPayload& Payload,
-							USpatialActorChannel* Channel, const FUnrealObjectRef& TargetObjectRef);
+	bool SendCrossServerRPC(UObject* TargetObject, UFunction* Function, const SpatialGDK::RPCPayload& Payload,
+							USpatialActorChannel* Channel, const FUnrealObjectRef& TargetObjectRef, const FUnrealObjectRef& SenderObjectRef);
 	FRPCErrorInfo SendLegacyRPC(UObject* TargetObject, UFunction* Function, const SpatialGDK::RPCPayload& Payload,
 								USpatialActorChannel* Channel, const FUnrealObjectRef& TargetObjectRef);
 	bool SendRingBufferedRPC(UObject* TargetObject, UFunction* Function, const SpatialGDK::RPCPayload& Payload,
@@ -118,7 +119,7 @@ public:
 	void UpdateClientAuthoritativeComponentAclEntries(Worker_EntityId EntityId, const FString& OwnerWorkerAttribute);
 	void UpdateInterestComponent(AActor* Actor);
 
-	void ProcessOrQueueOutgoingRPC(const FUnrealObjectRef& InTargetObjectRef, SpatialGDK::RPCPayload&& InPayload);
+	void ProcessOrQueueOutgoingRPC(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, SpatialGDK::RPCPayload&& InPayload);
 	void ProcessUpdatesQueuedUntilAuthority(Worker_EntityId EntityId, Worker_ComponentId ComponentId);
 
 	void FlushRPCService();
@@ -132,6 +133,7 @@ public:
 	void CreateServerWorkerEntity();
 	void RetryServerWorkerEntityCreation(Worker_EntityId EntityId, int AttemptCounte);
 	void UpdateServerWorkerEntityInterestAndPosition();
+	void UpdateServerWorkerVisibility();
 
 	void ClearPendingRPCs(const Worker_EntityId EntityId);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -81,7 +81,8 @@ public:
 	void SendOnEntityCreationRPC(UObject* TargetObject, UFunction* Function, const SpatialGDK::RPCPayload& Payload,
 								 USpatialActorChannel* Channel, const FUnrealObjectRef& TargetObjectRef);
 	bool SendCrossServerRPC(UObject* TargetObject, UFunction* Function, const SpatialGDK::RPCPayload& Payload,
-							USpatialActorChannel* Channel, const FUnrealObjectRef& TargetObjectRef, const FUnrealObjectRef& SenderObjectRef);
+							USpatialActorChannel* Channel, const FUnrealObjectRef& TargetObjectRef,
+							const FUnrealObjectRef& SenderObjectRef);
 	FRPCErrorInfo SendLegacyRPC(UObject* TargetObject, UFunction* Function, const SpatialGDK::RPCPayload& Payload,
 								USpatialActorChannel* Channel, const FUnrealObjectRef& TargetObjectRef);
 	bool SendRingBufferedRPC(UObject* TargetObject, UFunction* Function, const SpatialGDK::RPCPayload& Payload,
@@ -119,7 +120,8 @@ public:
 	void UpdateClientAuthoritativeComponentAclEntries(Worker_EntityId EntityId, const FString& OwnerWorkerAttribute);
 	void UpdateInterestComponent(AActor* Actor);
 
-	void ProcessOrQueueOutgoingRPC(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, SpatialGDK::RPCPayload&& InPayload);
+	void ProcessOrQueueOutgoingRPC(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef,
+								   SpatialGDK::RPCPayload&& InPayload);
 	void ProcessUpdatesQueuedUntilAuthority(Worker_EntityId EntityId, Worker_ComponentId ComponentId);
 
 	void FlushRPCService();

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/CrossServerEndpoint.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/CrossServerEndpoint.h
@@ -56,17 +56,28 @@ struct CrossServerEndpointReceiver : CrossServerEndpoint
 	}
 };
 
+struct ACKItem
+{
+	void ReadFromSchema(Schema_Object* SchemaObject);
+	void WriteToSchema(Schema_Object* SchemaObject);
+
+	Worker_EntityId Sender = SpatialConstants::INVALID_ENTITY_ID;
+	uint64 RPCId = 0;
+	uint64 SenderRevision = 0;
+};
+
 struct CrossServerEndpointSenderACK : Component
 {
 	static const Worker_ComponentId ComponentId = SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID;
 	CrossServerEndpointSenderACK(const Worker_ComponentData& Data);
 
-	void CreateUpdate(Schema_ComponentUpdate* OutUpdate);
+	// void CreateUpdate(Schema_ComponentUpdate* OutUpdate);
 
 	void ApplyComponentUpdate(const Worker_ComponentUpdate& Update) override;
 
 	uint64 RPCAck = 0;
-	TMap<Worker_EntityId_Key, TArray<uint64>> DottedRPCACK;
+	// TMap<Worker_EntityId_Key, TArray<uint64>> DottedRPCACK;
+	TArray<TOptional<ACKItem>> ACKArray;
 
 private:
 	void ReadFromSchema(Schema_Object* SchemaObject);

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/CrossServerEndpoint.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/CrossServerEndpoint.h
@@ -1,0 +1,84 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "Schema/Component.h"
+#include "SpatialConstants.h"
+#include "Utils/RPCRingBuffer.h"
+
+#include <WorkerSDK/improbable/c_schema.h>
+#include <WorkerSDK/improbable/c_worker.h>
+
+namespace SpatialGDK
+{
+
+struct CrossServerEndpoint : Component
+{
+	CrossServerEndpoint(const Worker_ComponentData& Data, ERPCType Type);
+
+	void ApplyComponentUpdate(const Worker_ComponentUpdate& Update) override;
+
+	RPCRingBuffer ReliableRPCBuffer;
+
+private:
+	void ReadFromSchema(Schema_Object* SchemaObject);
+};
+
+struct CrossServerEndpointACK : Component
+{
+	CrossServerEndpointACK(const Worker_ComponentData& Data, ERPCType Type);
+
+	void ApplyComponentUpdate(const Worker_ComponentUpdate& Update) override;
+
+	ERPCType Type;
+	uint64 RPCAck = 0;
+
+private:
+	void ReadFromSchema(Schema_Object* SchemaObject);
+};
+
+struct CrossServerEndpointSender : CrossServerEndpoint
+{
+	static const Worker_ComponentId ComponentId = SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID;
+
+	CrossServerEndpointSender(const Worker_ComponentData& Data)
+		: CrossServerEndpoint(Data, ERPCType::CrossServerSender)
+	{}
+};
+
+struct CrossServerEndpointReceiver : CrossServerEndpoint
+{
+	static const Worker_ComponentId ComponentId = SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID;
+
+	CrossServerEndpointReceiver(const Worker_ComponentData& Data)
+		: CrossServerEndpoint(Data, ERPCType::CrossServerReceiver)
+	{}
+};
+
+struct CrossServerEndpointSenderACK : Component
+{
+	static const Worker_ComponentId ComponentId = SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID;
+	CrossServerEndpointSenderACK(const Worker_ComponentData& Data);
+
+	void CreateUpdate(Schema_ComponentUpdate* OutUpdate);
+
+	void ApplyComponentUpdate(const Worker_ComponentUpdate& Update) override;
+
+	uint64_t RPCAck = 0;
+	TMap< Worker_EntityId, TArray<uint64>> DottedRPCACK;
+private:
+	void ReadFromSchema(Schema_Object* SchemaObject);
+};
+
+
+struct CrossServerEndpointReceiverACK : CrossServerEndpointACK
+{
+	static const Worker_ComponentId ComponentId = SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID;
+
+	CrossServerEndpointReceiverACK(const Worker_ComponentData& Data)
+		:CrossServerEndpointACK(Data, ERPCType::CrossServerReceiver)
+	{}
+};
+
+
+} // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/CrossServerEndpoint.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/CrossServerEndpoint.h
@@ -11,7 +11,6 @@
 
 namespace SpatialGDK
 {
-
 struct CrossServerEndpoint : Component
 {
 	CrossServerEndpoint(const Worker_ComponentData& Data, ERPCType Type);
@@ -43,7 +42,8 @@ struct CrossServerEndpointSender : CrossServerEndpoint
 
 	CrossServerEndpointSender(const Worker_ComponentData& Data)
 		: CrossServerEndpoint(Data, ERPCType::CrossServerSender)
-	{}
+	{
+	}
 };
 
 struct CrossServerEndpointReceiver : CrossServerEndpoint
@@ -52,7 +52,8 @@ struct CrossServerEndpointReceiver : CrossServerEndpoint
 
 	CrossServerEndpointReceiver(const Worker_ComponentData& Data)
 		: CrossServerEndpoint(Data, ERPCType::CrossServerReceiver)
-	{}
+	{
+	}
 };
 
 struct CrossServerEndpointSenderACK : Component
@@ -65,20 +66,20 @@ struct CrossServerEndpointSenderACK : Component
 	void ApplyComponentUpdate(const Worker_ComponentUpdate& Update) override;
 
 	uint64_t RPCAck = 0;
-	TMap< Worker_EntityId, TArray<uint64>> DottedRPCACK;
+	TMap<Worker_EntityId, TArray<uint64>> DottedRPCACK;
+
 private:
 	void ReadFromSchema(Schema_Object* SchemaObject);
 };
-
 
 struct CrossServerEndpointReceiverACK : CrossServerEndpointACK
 {
 	static const Worker_ComponentId ComponentId = SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID;
 
 	CrossServerEndpointReceiverACK(const Worker_ComponentData& Data)
-		:CrossServerEndpointACK(Data, ERPCType::CrossServerReceiver)
-	{}
+		: CrossServerEndpointACK(Data, ERPCType::CrossServerReceiver)
+	{
+	}
 };
-
 
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/CrossServerEndpoint.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/CrossServerEndpoint.h
@@ -65,8 +65,8 @@ struct CrossServerEndpointSenderACK : Component
 
 	void ApplyComponentUpdate(const Worker_ComponentUpdate& Update) override;
 
-	uint64_t RPCAck = 0;
-	TMap<Worker_EntityId, TArray<uint64>> DottedRPCACK;
+	uint64 RPCAck = 0;
+	TMap<Worker_EntityId_Key, TArray<uint64>> DottedRPCACK;
 
 private:
 	void ReadFromSchema(Schema_Object* SchemaObject);

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -23,7 +23,8 @@ enum class ERPCType : uint8
 	ServerReliable,
 	ServerUnreliable,
 	NetMulticast,
-	CrossServer
+	CrossServerSender,
+	CrossServerReceiver,
 };
 
 enum ESchemaComponentType : int32
@@ -57,8 +58,10 @@ inline FString RPCTypeToString(ERPCType RPCType)
 		return TEXT("Server, Unreliable");
 	case ERPCType::NetMulticast:
 		return TEXT("Multicast");
-	case ERPCType::CrossServer:
-		return TEXT("CrossServer");
+	case ERPCType::CrossServerSender:
+		return TEXT("CrossServerSender");
+	case ERPCType::CrossServerReceiver:
+		return TEXT("CrossServerReceiver");
 	}
 
 	checkNoEntry();
@@ -95,6 +98,7 @@ const Worker_ComponentId DEPLOYMENT_MAP_COMPONENT_ID = 9994;
 const Worker_ComponentId STARTUP_ACTOR_MANAGER_COMPONENT_ID = 9993;
 const Worker_ComponentId GSM_SHUTDOWN_COMPONENT_ID = 9992;
 const Worker_ComponentId HEARTBEAT_COMPONENT_ID = 9991;
+
 // Marking the event-based RPC components as legacy while the ring buffer
 // implementation is under a feature flag.
 const Worker_ComponentId CLIENT_RPC_ENDPOINT_COMPONENT_ID_LEGACY = 9990;
@@ -110,6 +114,11 @@ const Worker_ComponentId DORMANT_COMPONENT_ID = 9981;
 const Worker_ComponentId AUTHORITY_INTENT_COMPONENT_ID = 9980;
 const Worker_ComponentId VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID = 9979;
 const Worker_ComponentId VISIBLE_COMPONENT_ID = 9970;
+
+const Worker_ComponentId CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID = 9960;
+const Worker_ComponentId CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID = 9961;
+const Worker_ComponentId CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID = 9962;
+const Worker_ComponentId CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID = 9963;
 
 const Worker_ComponentId CLIENT_ENDPOINT_COMPONENT_ID = 9978;
 const Worker_ComponentId SERVER_ENDPOINT_COMPONENT_ID = 9977;
@@ -363,6 +372,9 @@ const TArray<Worker_ComponentId> REQUIRED_COMPONENTS_FOR_AUTH_SERVER_INTEREST =
 	TArray<Worker_ComponentId>{ // RPCs from clients
 								CLIENT_ENDPOINT_COMPONENT_ID, CLIENT_RPC_ENDPOINT_COMPONENT_ID_LEGACY,
 
+								// Cross server endpoint
+								CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID, CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID,
+
 								// Heartbeat
 								HEARTBEAT_COMPONENT_ID
 	};
@@ -371,7 +383,7 @@ inline Worker_ComponentId RPCTypeToWorkerComponentIdLegacy(ERPCType RPCType)
 {
 	switch (RPCType)
 	{
-	case ERPCType::CrossServer:
+	case ERPCType::CrossServerSender:
 	{
 		return SpatialConstants::SERVER_TO_SERVER_COMMAND_ENDPOINT_COMPONENT_ID;
 	}

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -45,12 +45,12 @@ enum Type
 UENUM()
 namespace ECrossServerRPCImplementation
 {
-	enum Type
-	{
-		SpatialCommand,
-		WorkerEntityMailbox,
-		RoutingWorker,
-	};
+enum Type
+{
+	SpatialCommand,
+	WorkerEntityMailbox,
+	RoutingWorker,
+};
 }
 
 USTRUCT(BlueprintType)

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -42,6 +42,17 @@ enum Type
 };
 }
 
+UENUM()
+namespace ECrossServerRPCImplementation
+{
+	enum Type
+	{
+		SpatialCommand,
+		WorkerEntityMailbox,
+		RoutingWorker,
+	};
+}
+
 USTRUCT(BlueprintType)
 struct FDistanceFrequencyPair
 {
@@ -281,6 +292,9 @@ public:
 	 */
 	UPROPERTY(EditAnywhere, Config, Category = "Replication", meta = (DisplayName = "Max RPC Ring Buffer Size"))
 	uint32 MaxRPCRingBufferSize;
+
+	UPROPERTY(EditAnywhere, Config, Category = "Replication", meta = (DisplayName = "Cross Server RPC Implementation"))
+	TEnumAsByte<ECrossServerRPCImplementation::Type> CrossServerRPCImplementation;
 
 	/** Only valid on Tcp connections - indicates if we should enable TCP_NODELAY - see c_worker.h */
 	UPROPERTY(Config)

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/InterestFactory.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/InterestFactory.h
@@ -46,7 +46,7 @@ public:
 	Worker_ComponentData CreateInterestData(AActor* InActor, const FClassInfo& InInfo, const Worker_EntityId InEntityId) const;
 	Worker_ComponentUpdate CreateInterestUpdate(AActor* InActor, const FClassInfo& InInfo, const Worker_EntityId InEntityId) const;
 
-	Interest CreateServerWorkerInterest(const UAbstractLBStrategy* LBStrategy, bool bDebug);
+	Interest CreateServerWorkerInterest(const UAbstractLBStrategy* LBStrategy, bool bDebug, bool bIsRoutingWorker);
 
 	// Returns false if we could not get an owner's entityId in the Actor's owner chain.
 	bool DoOwnersHaveEntityId(const AActor* Actor) const;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/RPCContainer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/RPCContainer.h
@@ -69,8 +69,10 @@ struct FRPCErrorInfo
 
 struct SPATIALGDK_API FPendingRPCParams
 {
-	//FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, ERPCType InType, SpatialGDK::RPCPayload&& InPayload);
-	FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, ERPCType InType, SpatialGDK::RPCPayload&& InPayload, uint32 Slot);
+	// FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, ERPCType InType,
+	// SpatialGDK::RPCPayload&& InPayload);
+	FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, ERPCType InType,
+					  SpatialGDK::RPCPayload&& InPayload, uint32 Slot);
 
 	// Moveable, not copyable.
 	FPendingRPCParams() = delete;
@@ -102,7 +104,8 @@ public:
 	~FRPCContainer() = default;
 
 	void BindProcessingFunction(const FProcessRPCDelegate& Function);
-	void ProcessOrQueueRPC(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, ERPCType InType, SpatialGDK::RPCPayload&& InPayload, uint32 Slot);
+	void ProcessOrQueueRPC(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, ERPCType InType,
+						   SpatialGDK::RPCPayload&& InPayload, uint32 Slot);
 	void ProcessRPCs();
 	void DropForEntity(const Worker_EntityId& EntityId);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/RPCContainer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/RPCContainer.h
@@ -69,7 +69,8 @@ struct FRPCErrorInfo
 
 struct SPATIALGDK_API FPendingRPCParams
 {
-	FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, ERPCType InType, SpatialGDK::RPCPayload&& InPayload);
+	//FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, ERPCType InType, SpatialGDK::RPCPayload&& InPayload);
+	FPendingRPCParams(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, ERPCType InType, SpatialGDK::RPCPayload&& InPayload, uint32 Slot);
 
 	// Moveable, not copyable.
 	FPendingRPCParams() = delete;
@@ -80,7 +81,9 @@ struct SPATIALGDK_API FPendingRPCParams
 	~FPendingRPCParams() = default;
 
 	FUnrealObjectRef ObjectRef;
+	FUnrealObjectRef SenderObjectRef;
 	SpatialGDK::RPCPayload Payload;
+	uint32 Slot;
 
 	FDateTime Timestamp;
 	ERPCType Type;
@@ -99,7 +102,7 @@ public:
 	~FRPCContainer() = default;
 
 	void BindProcessingFunction(const FProcessRPCDelegate& Function);
-	void ProcessOrQueueRPC(const FUnrealObjectRef& InTargetObjectRef, ERPCType InType, SpatialGDK::RPCPayload&& InPayload);
+	void ProcessOrQueueRPC(const FUnrealObjectRef& InTargetObjectRef, const FUnrealObjectRef& InSenderObjectRef, ERPCType InType, SpatialGDK::RPCPayload&& InPayload, uint32 Slot);
 	void ProcessRPCs();
 	void DropForEntity(const Worker_EntityId& EntityId);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetricsDisplay.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialMetricsDisplay.h
@@ -55,7 +55,7 @@ private:
 	const uint32 DropStatsIfNoUpdateForTime = 10; // seconds
 
 	UFUNCTION(CrossServer, Unreliable, WithValidation)
-	virtual void ServerUpdateWorkerStats(const float Time, const FWorkerStats& OneWorkerStats);
+	virtual void ServerUpdateWorkerStats(AActor* Sender, const float Time, const FWorkerStats& OneWorkerStats);
 
 	bool ShouldRemoveStats(const float CurrentTime, const FWorkerStats& OneWorkerStats) const;
 	void DrawDebug(class UCanvas* Canvas, APlayerController* Controller);

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SchemaGenerator.cpp
@@ -343,10 +343,15 @@ void GenerateRPCEndpoint(FCodeWriter& Writer, FString EndpointName, Worker_Compo
 
 	for (ERPCType AckedRPCType : AckedRPCTypes)
 	{
+		uint32 RingBufferSize = GetDefault<USpatialGDKSettings>()->MaxRPCRingBufferSize;
 		Writer.Printf("uint64 last_acked_{0}_rpc_id = {1};", GetRPCFieldPrefix(AckedRPCType), FieldId++);
 		if (AckedRPCType == ERPCType::CrossServerSender)
 		{
-			Writer.Printf("map<EntityId, ACKList> {0}_dotted_rpc_ack = {1};", GetRPCFieldPrefix(AckedRPCType), FieldId++);
+			// Writer.Printf("map<EntityId, ACKList> {0}_dotted_rpc_ack = {1};", GetRPCFieldPrefix(AckedRPCType), FieldId++);
+			for (uint32 RingBufferIndex = 0; RingBufferIndex < RingBufferSize; RingBufferIndex++)
+			{
+				Writer.Printf("option<ACKItem> {0}_ack_rpc_{1} = {2};", GetRPCFieldPrefix(AckedRPCType), RingBufferIndex, FieldId++);
+			}
 		}
 	}
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SchemaGenerator.cpp
@@ -687,11 +687,14 @@ void GenerateRPCEndpointsSchema(FString SchemaPath)
 	GenerateRPCEndpoint(Writer, TEXT("ServerEndpoint"), SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID,
 						{ ERPCType::ClientReliable, ERPCType::ClientUnreliable }, { ERPCType::ServerReliable, ERPCType::ServerUnreliable });
 	GenerateRPCEndpoint(Writer, TEXT("MulticastRPCs"), SpatialConstants::MULTICAST_RPCS_COMPONENT_ID, { ERPCType::NetMulticast }, {});
-	GenerateRPCEndpoint(Writer, TEXT("CrossServerSenderRPCs"), SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID, { ERPCType::CrossServerSender }, {});
-	GenerateRPCEndpoint(Writer, TEXT("CrossServerReceiverRPCs"), SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID, { ERPCType::CrossServerReceiver }, {});
-	GenerateRPCEndpoint(Writer, TEXT("CrossServerSenderACKRPCs"), SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID, {}, { ERPCType::CrossServerSender });
-	GenerateRPCEndpoint(Writer, TEXT("CrossServerReceiverACKRPCs"), SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID, {}, { ERPCType::CrossServerReceiver });
-
+	GenerateRPCEndpoint(Writer, TEXT("CrossServerSenderRPCs"), SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID,
+						{ ERPCType::CrossServerSender }, {});
+	GenerateRPCEndpoint(Writer, TEXT("CrossServerReceiverRPCs"), SpatialConstants::CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID,
+						{ ERPCType::CrossServerReceiver }, {});
+	GenerateRPCEndpoint(Writer, TEXT("CrossServerSenderACKRPCs"), SpatialConstants::CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID, {},
+						{ ERPCType::CrossServerSender });
+	GenerateRPCEndpoint(Writer, TEXT("CrossServerReceiverACKRPCs"), SpatialConstants::CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID, {},
+						{ ERPCType::CrossServerReceiver });
 
 	Writer.WriteToFile(FString::Printf(TEXT("%srpc_endpoints.schema"), *SchemaPath));
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
@@ -474,7 +474,8 @@ ASpatialFunctionalTestFlowController* ASpatialFunctionalTest::GetFlowController(
 	return nullptr;
 }
 
-void ASpatialFunctionalTest::CrossServerNotifyStepFinished_Implementation(AActor* Sender, ASpatialFunctionalTestFlowController* FlowController)
+void ASpatialFunctionalTest::CrossServerNotifyStepFinished_Implementation(AActor* Sender,
+																		  ASpatialFunctionalTestFlowController* FlowController)
 {
 	if (CurrentStepIndex < 0)
 	{

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
@@ -298,7 +298,7 @@ void ASpatialFunctionalTest::FinishTest(EFunctionalTestResult TestResult, const 
 	}
 }
 
-void ASpatialFunctionalTest::CrossServerFinishTest_Implementation(EFunctionalTestResult TestResult, const FString& Message)
+void ASpatialFunctionalTest::CrossServerFinishTest_Implementation(AActor* Sender, EFunctionalTestResult TestResult, const FString& Message)
 {
 	FinishTest(TestResult, Message);
 }
@@ -416,7 +416,7 @@ void ASpatialFunctionalTest::StartStep(const int StepIndex)
 					Msg.Append(TEXT(", "));
 				}
 
-				FlowController->CrossServerStartStep(CurrentStepIndex);
+				FlowController->CrossServerStartStep(nullptr, CurrentStepIndex);
 			}
 
 			UE_LOG(LogSpatialGDKFunctionalTests, Display, TEXT("%s"), *Msg);
@@ -474,7 +474,7 @@ ASpatialFunctionalTestFlowController* ASpatialFunctionalTest::GetFlowController(
 	return nullptr;
 }
 
-void ASpatialFunctionalTest::CrossServerNotifyStepFinished_Implementation(ASpatialFunctionalTestFlowController* FlowController)
+void ASpatialFunctionalTest::CrossServerNotifyStepFinished_Implementation(AActor* Sender, ASpatialFunctionalTestFlowController* FlowController)
 {
 	if (CurrentStepIndex < 0)
 	{

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestFlowController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestFlowController.cpp
@@ -60,7 +60,7 @@ void ASpatialFunctionalTestFlowController::Tick(float DeltaSeconds)
 	}
 }
 
-void ASpatialFunctionalTestFlowController::CrossServerSetWorkerId_Implementation(int NewWorkerId)
+void ASpatialFunctionalTestFlowController::CrossServerSetWorkerId_Implementation(AActor* Sender, int NewWorkerId)
 {
 	WorkerDefinition.Id = NewWorkerId;
 }
@@ -92,7 +92,7 @@ void ASpatialFunctionalTestFlowController::ServerSetReadyToRunTest_Implementatio
 	bIsReadyToRunTest = true;
 }
 
-void ASpatialFunctionalTestFlowController::CrossServerStartStep_Implementation(int StepIndex)
+void ASpatialFunctionalTestFlowController::CrossServerStartStep_Implementation(AActor* Sender, int StepIndex)
 {
 	if (WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Server)
 	{
@@ -110,7 +110,7 @@ void ASpatialFunctionalTestFlowController::NotifyStepFinished()
 	{
 		if (WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Server)
 		{
-			CrossServerNotifyStepFinished();
+			CrossServerNotifyStepFinished(nullptr);
 		}
 		else
 		{
@@ -199,15 +199,15 @@ void ASpatialFunctionalTestFlowController::ServerNotifyFinishTest_Implementation
 
 void ASpatialFunctionalTestFlowController::ServerNotifyFinishTestInternal(EFunctionalTestResult TestResult, const FString& Message)
 {
-	OwningTest->CrossServerFinishTest(TestResult, Message);
+	OwningTest->CrossServerFinishTest(nullptr, TestResult, Message);
 }
 
 void ASpatialFunctionalTestFlowController::ServerNotifyStepFinished_Implementation()
 {
-	OwningTest->CrossServerNotifyStepFinished(this);
+	OwningTest->CrossServerNotifyStepFinished(nullptr, this);
 }
 
-void ASpatialFunctionalTestFlowController::CrossServerNotifyStepFinished_Implementation()
+void ASpatialFunctionalTestFlowController::CrossServerNotifyStepFinished_Implementation(AActor* Sender)
 {
-	OwningTest->CrossServerNotifyStepFinished(this);
+	OwningTest->CrossServerNotifyStepFinished(nullptr, this);
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestFlowControllerSpawner.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestFlowControllerSpawner.cpp
@@ -74,7 +74,7 @@ void SpatialFunctionalTestFlowControllerSpawner::AssignClientFlowControllerId(AS
 		  && ClientFlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client
 		  && ClientFlowController->WorkerDefinition.Id == INVALID_FLOW_CONTROLLER_ID);
 
-	ClientFlowController->CrossServerSetWorkerId(NextClientControllerId++);
+	ClientFlowController->CrossServerSetWorkerId(nullptr, NextClientControllerId++);
 }
 
 uint8 SpatialFunctionalTestFlowControllerSpawner::OwningServerIntanceId(UWorld* World) const

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
@@ -80,10 +80,10 @@ public:
 	virtual void FinishTest(EFunctionalTestResult TestResult, const FString& Message) override;
 
 	UFUNCTION(CrossServer, Reliable)
-	void CrossServerFinishTest(EFunctionalTestResult TestResult, const FString& Message);
+	void CrossServerFinishTest(AActor* Sender, EFunctionalTestResult TestResult, const FString& Message);
 
 	UFUNCTION(CrossServer, Reliable)
-	void CrossServerNotifyStepFinished(ASpatialFunctionalTestFlowController* FlowController);
+	void CrossServerNotifyStepFinished(AActor* Sender, ASpatialFunctionalTestFlowController* FlowController);
 
 	// # FlowController related APIs
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTestFlowController.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTestFlowController.h
@@ -35,7 +35,7 @@ public:
 
 	// Locally triggers StepIndex Test Step to start
 	UFUNCTION(CrossServer, Reliable)
-	void CrossServerStartStep(int StepIndex);
+	void CrossServerStartStep(AActor* Sender, int StepIndex);
 
 	// Tells Test owner that the current Step is finished locally
 	void NotifyStepFinished();
@@ -63,7 +63,7 @@ public:
 	// Each server worker will assign local client ids, this function will be used by
 	// the Test owner server worker to guarantee they are all unique
 	UFUNCTION(CrossServer, Reliable)
-	void CrossServerSetWorkerId(int NewWorkerId);
+	void CrossServerSetWorkerId(AActor* Sender, int NewWorkerId);
 
 	UFUNCTION(BlueprintPure, Category = "Spatial Functional Test")
 	FWorkerDefinition GetWorkerDefinition() { return WorkerDefinition; }
@@ -95,7 +95,7 @@ private:
 	void ServerNotifyStepFinished();
 
 	UFUNCTION(CrossServer, Reliable)
-	void CrossServerNotifyStepFinished();
+	void CrossServerNotifyStepFinished(AActor* Sender);
 
 	UFUNCTION(Server, Reliable)
 	void ServerNotifyFinishTest(EFunctionalTestResult TestResult, const FString& Message);

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAndClientOrchestrationTest/CrossServerAndClientOrchestrationFlowController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAndClientOrchestrationTest/CrossServerAndClientOrchestrationFlowController.cpp
@@ -7,5 +7,5 @@
 void ACrossServerAndClientOrchestrationFlowController::ServerClientReadValueAck_Implementation()
 {
 	ACrossServerAndClientOrchestrationTest* Test = Cast<ACrossServerAndClientOrchestrationTest>(OwningTest);
-	Test->CrossServerSetTestValue(ESpatialFunctionalTestWorkerType::Client, WorkerDefinition.Id);
+	Test->CrossServerSetTestValue(nullptr, ESpatialFunctionalTestWorkerType::Client, WorkerDefinition.Id);
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAndClientOrchestrationTest/CrossServerAndClientOrchestrationTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAndClientOrchestrationTest/CrossServerAndClientOrchestrationTest.cpp
@@ -38,7 +38,7 @@ void ACrossServerAndClientOrchestrationTest::BeginPlay()
 		AddStep(TEXT("Servers_SetupSetValue"), FWorkerDefinition::AllServers, nullptr, [this]() {
 			// Send CrossServer RPC to Test actor to set the flag for this server flow controller instance
 			ASpatialFunctionalTestFlowController* FlowController = GetLocalFlowController();
-			CrossServerSetTestValue(FlowController->WorkerDefinition.Type, FlowController->WorkerDefinition.Id);
+			CrossServerSetTestValue(nullptr, FlowController->WorkerDefinition.Type, FlowController->WorkerDefinition.Id);
 			FinishStep();
 		});
 	}
@@ -114,7 +114,7 @@ void ACrossServerAndClientOrchestrationTest::BeginPlay()
 	}
 }
 
-void ACrossServerAndClientOrchestrationTest::CrossServerSetTestValue_Implementation(ESpatialFunctionalTestWorkerType ControllerType,
+void ACrossServerAndClientOrchestrationTest::CrossServerSetTestValue_Implementation(AActor* Sender, ESpatialFunctionalTestWorkerType ControllerType,
 																					uint8 ChangedInstance)
 {
 	uint8 FlagIndex = ChangedInstance - 1;

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAndClientOrchestrationTest/CrossServerAndClientOrchestrationTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAndClientOrchestrationTest/CrossServerAndClientOrchestrationTest.cpp
@@ -114,7 +114,8 @@ void ACrossServerAndClientOrchestrationTest::BeginPlay()
 	}
 }
 
-void ACrossServerAndClientOrchestrationTest::CrossServerSetTestValue_Implementation(AActor* Sender, ESpatialFunctionalTestWorkerType ControllerType,
+void ACrossServerAndClientOrchestrationTest::CrossServerSetTestValue_Implementation(AActor* Sender,
+																					ESpatialFunctionalTestWorkerType ControllerType,
 																					uint8 ChangedInstance)
 {
 	uint8 FlagIndex = ChangedInstance - 1;

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAndClientOrchestrationTest/CrossServerAndClientOrchestrationTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAndClientOrchestrationTest/CrossServerAndClientOrchestrationTest.h
@@ -25,7 +25,7 @@ public:
 	TArray<bool> ClientWorkerSetValues;
 
 	UFUNCTION(CrossServer, Reliable)
-	void CrossServerSetTestValue(ESpatialFunctionalTestWorkerType ControllerType, uint8 ChangedInstance);
+	void CrossServerSetTestValue(AActor* Sender, ESpatialFunctionalTestWorkerType ControllerType, uint8 ChangedInstance);
 
 	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const;
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestCrossServerRPC/CrossServerRPCCube.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestCrossServerRPC/CrossServerRPCCube.cpp
@@ -17,7 +17,7 @@ void ACrossServerRPCCube::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& 
 	DOREPLIFETIME(ACrossServerRPCCube, ReceivedCrossServerRPCS);
 }
 
-void ACrossServerRPCCube::CrossServerTestRPC_Implementation(int SendingServerID)
+void ACrossServerRPCCube::CrossServerTestRPC_Implementation(AActor* Sender, int SendingServerID)
 {
 	ReceivedCrossServerRPCS.Add(SendingServerID);
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestCrossServerRPC/CrossServerRPCCube.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestCrossServerRPC/CrossServerRPCCube.h
@@ -21,5 +21,5 @@ public:
 	TArray<int> ReceivedCrossServerRPCS;
 
 	UFUNCTION(CrossServer, Reliable)
-	void CrossServerTestRPC(int SendingServerID);
+	void CrossServerTestRPC(AActor* Sender, int SendingServerID);
 };

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestCrossServerRPC/SpatialTestCrossServerRPC.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestCrossServerRPC/SpatialTestCrossServerRPC.cpp
@@ -71,7 +71,7 @@ void ASpatialTestCrossServerRPC::BeginPlay()
 				}
 
 				ACrossServerRPCCube* CrossServerRPCCube = Cast<ACrossServerRPCCube>(Cube);
-				CrossServerRPCCube->CrossServerTestRPC(GetLocalFlowController()->GetWorkerDefinition().Id);
+				CrossServerRPCCube->CrossServerTestRPC(nullptr, GetLocalFlowController()->GetWorkerDefinition().Id);
 			}
 
 			FinishStep();

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/SpatialOSDispatcherInterface/SpatialOSDispatcherSpy.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/SpatialOSDispatcherInterface/SpatialOSDispatcherSpy.cpp
@@ -25,7 +25,7 @@ void SpatialOSDispatcherSpy::OnComponentUpdate(const Worker_ComponentUpdateOp& O
 
 // This gets bound to a delegate in SpatialRPCService and is called for each RPC extracted when calling
 // SpatialRPCService::ExtractRPCsForEntity.
-bool SpatialOSDispatcherSpy::OnExtractIncomingRPC(Worker_EntityId EntityId, ERPCType RPCType, const SpatialGDK::RPCPayload& Payload)
+bool SpatialOSDispatcherSpy::OnExtractIncomingRPC(Worker_EntityId EntityId, const FUnrealObjectRef&, ERPCType RPCType, const SpatialGDK::RPCPayload& Payload, uint32 Slot)
 {
 	return false;
 }

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/SpatialOSDispatcherInterface/SpatialOSDispatcherSpy.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/SpatialOSDispatcherInterface/SpatialOSDispatcherSpy.cpp
@@ -25,7 +25,8 @@ void SpatialOSDispatcherSpy::OnComponentUpdate(const Worker_ComponentUpdateOp& O
 
 // This gets bound to a delegate in SpatialRPCService and is called for each RPC extracted when calling
 // SpatialRPCService::ExtractRPCsForEntity.
-bool SpatialOSDispatcherSpy::OnExtractIncomingRPC(Worker_EntityId EntityId, const FUnrealObjectRef&, ERPCType RPCType, const SpatialGDK::RPCPayload& Payload, uint32 Slot)
+bool SpatialOSDispatcherSpy::OnExtractIncomingRPC(Worker_EntityId EntityId, const FUnrealObjectRef&, ERPCType RPCType,
+												  const SpatialGDK::RPCPayload& Payload, uint32 Slot)
 {
 	return false;
 }

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/SpatialOSDispatcherInterface/SpatialOSDispatcherSpy.h
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/SpatialOSDispatcherInterface/SpatialOSDispatcherSpy.h
@@ -31,7 +31,7 @@ public:
 
 	// This gets bound to a delegate in SpatialRPCService and is called for each RPC extracted when calling
 	// SpatialRPCService::ExtractRPCsForEntity.
-	virtual bool OnExtractIncomingRPC(Worker_EntityId EntityId, ERPCType RPCType, const SpatialGDK::RPCPayload& Payload) override;
+	virtual bool OnExtractIncomingRPC(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType RPCType, const SpatialGDK::RPCPayload& Payload, uint32 Slot) override;
 
 	virtual void OnCommandRequest(const Worker_CommandRequestOp& Op) override;
 	virtual void OnCommandResponse(const Worker_CommandResponseOp& Op) override;

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/SpatialOSDispatcherInterface/SpatialOSDispatcherSpy.h
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/SpatialOSDispatcherInterface/SpatialOSDispatcherSpy.h
@@ -31,7 +31,8 @@ public:
 
 	// This gets bound to a delegate in SpatialRPCService and is called for each RPC extracted when calling
 	// SpatialRPCService::ExtractRPCsForEntity.
-	virtual bool OnExtractIncomingRPC(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType RPCType, const SpatialGDK::RPCPayload& Payload, uint32 Slot) override;
+	virtual bool OnExtractIncomingRPC(Worker_EntityId EntityId, const FUnrealObjectRef& Counterpart, ERPCType RPCType,
+									  const SpatialGDK::RPCPayload& Payload, uint32 Slot) override;
 
 	virtual void OnCommandRequest(const Worker_CommandRequestOp& Op) override;
 	virtual void OnCommandResponse(const Worker_CommandResponseOp& Op) override;

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Utils/RPCContainer/RPCContainerTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Utils/RPCContainer/RPCContainerTest.cpp
@@ -40,7 +40,7 @@ FPendingRPCParams CreateMockParameters(UObject* TargetObject, ERPCType Type)
 
 	FUnrealObjectRef ObjectRef = GenerateObjectRef(TargetObject);
 
-	return FPendingRPCParams{ ObjectRef, Type, MoveTemp(Payload) };
+	return FPendingRPCParams{ ObjectRef, FUnrealObjectRef(), Type, MoveTemp(Payload), 0 };
 }
 } // anonymous namespace
 
@@ -62,7 +62,7 @@ RPCCONTAINER_TEST(GIVEN_a_container_WHEN_one_value_has_been_added_THEN_it_is_que
 	FRPCContainer RPCs(ERPCQueueType::Send);
 	RPCs.BindProcessingFunction(FProcessRPCDelegate::CreateUObject(TargetObject, &UObjectStub::ProcessRPC));
 
-	RPCs.ProcessOrQueueRPC(Params.ObjectRef, Params.Type, MoveTemp(Params.Payload));
+	RPCs.ProcessOrQueueRPC(Params.ObjectRef, Params.SenderObjectRef, Params.Type, MoveTemp(Params.Payload), 0);
 
 	TestTrue("Has queued RPCs", RPCs.ObjectHasRPCsQueuedOfType(Params.ObjectRef.Entity, AnySchemaComponentType));
 
@@ -77,8 +77,8 @@ RPCCONTAINER_TEST(GIVEN_a_container_WHEN_multiple_values_of_same_type_have_been_
 	FRPCContainer RPCs(ERPCQueueType::Send);
 	RPCs.BindProcessingFunction(FProcessRPCDelegate::CreateUObject(TargetObject, &UObjectStub::ProcessRPC));
 
-	RPCs.ProcessOrQueueRPC(Params1.ObjectRef, Params1.Type, MoveTemp(Params1.Payload));
-	RPCs.ProcessOrQueueRPC(Params2.ObjectRef, Params2.Type, MoveTemp(Params2.Payload));
+	RPCs.ProcessOrQueueRPC(Params1.ObjectRef, Params1.SenderObjectRef, Params1.Type, MoveTemp(Params1.Payload), 0);
+	RPCs.ProcessOrQueueRPC(Params2.ObjectRef, Params2.SenderObjectRef, Params2.Type, MoveTemp(Params2.Payload), 0);
 
 	TestTrue("Has queued RPCs", RPCs.ObjectHasRPCsQueuedOfType(Params1.ObjectRef.Entity, AnyOtherSchemaComponentType));
 
@@ -92,7 +92,7 @@ RPCCONTAINER_TEST(GIVEN_a_container_storing_one_value_WHEN_processed_once_THEN_n
 	FRPCContainer RPCs(ERPCQueueType::Send);
 	RPCs.BindProcessingFunction(FProcessRPCDelegate::CreateUObject(TargetObject, &UObjectDummy::ProcessRPC));
 
-	RPCs.ProcessOrQueueRPC(Params.ObjectRef, Params.Type, MoveTemp(Params.Payload));
+	RPCs.ProcessOrQueueRPC(Params.ObjectRef, Params.SenderObjectRef, Params.Type, MoveTemp(Params.Payload), 0);
 
 	TestFalse("Has queued RPCs", RPCs.ObjectHasRPCsQueuedOfType(Params.ObjectRef.Entity, AnySchemaComponentType));
 
@@ -107,8 +107,8 @@ RPCCONTAINER_TEST(GIVEN_a_container_storing_multiple_values_of_same_type_WHEN_pr
 	FRPCContainer RPCs(ERPCQueueType::Send);
 	RPCs.BindProcessingFunction(FProcessRPCDelegate::CreateUObject(TargetObject, &UObjectDummy::ProcessRPC));
 
-	RPCs.ProcessOrQueueRPC(Params1.ObjectRef, Params1.Type, MoveTemp(Params1.Payload));
-	RPCs.ProcessOrQueueRPC(Params2.ObjectRef, Params2.Type, MoveTemp(Params2.Payload));
+	RPCs.ProcessOrQueueRPC(Params1.ObjectRef, Params1.SenderObjectRef, Params1.Type, MoveTemp(Params1.Payload), 0);
+	RPCs.ProcessOrQueueRPC(Params2.ObjectRef, Params2.SenderObjectRef, Params2.Type, MoveTemp(Params2.Payload), 0);
 
 	TestFalse("Has queued RPCs", RPCs.ObjectHasRPCsQueuedOfType(Params1.ObjectRef.Entity, AnyOtherSchemaComponentType));
 
@@ -125,8 +125,8 @@ RPCCONTAINER_TEST(GIVEN_a_container_WHEN_multiple_values_of_different_type_have_
 	FRPCContainer RPCs(ERPCQueueType::Send);
 	RPCs.BindProcessingFunction(FProcessRPCDelegate::CreateUObject(TargetObject, &UObjectStub::ProcessRPC));
 
-	RPCs.ProcessOrQueueRPC(ParamsUnreliable.ObjectRef, ParamsUnreliable.Type, MoveTemp(ParamsUnreliable.Payload));
-	RPCs.ProcessOrQueueRPC(ParamsReliable.ObjectRef, ParamsReliable.Type, MoveTemp(ParamsReliable.Payload));
+	RPCs.ProcessOrQueueRPC(ParamsUnreliable.ObjectRef, ParamsUnreliable.SenderObjectRef, ParamsUnreliable.Type, MoveTemp(ParamsUnreliable.Payload), 0);
+	RPCs.ProcessOrQueueRPC(ParamsReliable.ObjectRef, ParamsReliable.SenderObjectRef, ParamsReliable.Type, MoveTemp(ParamsReliable.Payload), 0);
 
 	TestTrue("Has queued RPCs", RPCs.ObjectHasRPCsQueuedOfType(ParamsUnreliable.ObjectRef.Entity, AnyOtherSchemaComponentType));
 	TestTrue("Has queued RPCs", RPCs.ObjectHasRPCsQueuedOfType(ParamsReliable.ObjectRef.Entity, AnySchemaComponentType));
@@ -143,8 +143,8 @@ RPCCONTAINER_TEST(GIVEN_a_container_storing_multiple_values_of_different_type_WH
 	FRPCContainer RPCs(ERPCQueueType::Send);
 	RPCs.BindProcessingFunction(FProcessRPCDelegate::CreateUObject(TargetObject, &UObjectDummy::ProcessRPC));
 
-	RPCs.ProcessOrQueueRPC(ParamsUnreliable.ObjectRef, ParamsUnreliable.Type, MoveTemp(ParamsUnreliable.Payload));
-	RPCs.ProcessOrQueueRPC(ParamsReliable.ObjectRef, ParamsReliable.Type, MoveTemp(ParamsReliable.Payload));
+	RPCs.ProcessOrQueueRPC(ParamsUnreliable.ObjectRef, ParamsUnreliable.SenderObjectRef, ParamsUnreliable.Type, MoveTemp(ParamsUnreliable.Payload), 0);
+	RPCs.ProcessOrQueueRPC(ParamsReliable.ObjectRef, ParamsReliable.SenderObjectRef, ParamsReliable.Type, MoveTemp(ParamsReliable.Payload), 0);
 
 	TestFalse("Has queued RPCs", RPCs.ObjectHasRPCsQueuedOfType(ParamsUnreliable.ObjectRef.Entity, AnyOtherSchemaComponentType));
 	TestFalse("Has queued RPCs", RPCs.ObjectHasRPCsQueuedOfType(ParamsReliable.ObjectRef.Entity, AnySchemaComponentType));
@@ -169,8 +169,8 @@ RPCCONTAINER_TEST(GIVEN_a_container_storing_multiple_values_of_different_type_WH
 		RPCIndices.FindOrAdd(AnyOtherSchemaComponentType).Push(ParamsUnreliable.Payload.Index);
 		RPCIndices.FindOrAdd(AnySchemaComponentType).Push(ParamsReliable.Payload.Index);
 
-		RPCs.ProcessOrQueueRPC(ObjectRef, ParamsUnreliable.Type, MoveTemp(ParamsUnreliable.Payload));
-		RPCs.ProcessOrQueueRPC(ObjectRef, ParamsReliable.Type, MoveTemp(ParamsReliable.Payload));
+		RPCs.ProcessOrQueueRPC(ObjectRef, ParamsUnreliable.SenderObjectRef, ParamsUnreliable.Type, MoveTemp(ParamsUnreliable.Payload), 0);
+		RPCs.ProcessOrQueueRPC(ObjectRef, ParamsReliable.SenderObjectRef, ParamsReliable.Type, MoveTemp(ParamsReliable.Payload), 0);
 	}
 
 	bool bProcessedInOrder = true;
@@ -202,7 +202,7 @@ RPCCONTAINER_TEST(GIVEN_a_container_with_one_value_WHEN_processing_after_RPCQueu
 	FPendingRPCParams Params = CreateMockParameters(TargetObject, AnySchemaComponentType);
 	FRPCContainer RPCs(ERPCQueueType::Send);
 	RPCs.BindProcessingFunction(FProcessRPCDelegate::CreateUObject(TargetObject, &UObjectStub::ProcessRPC));
-	RPCs.ProcessOrQueueRPC(Params.ObjectRef, Params.Type, MoveTemp(Params.Payload));
+	RPCs.ProcessOrQueueRPC(Params.ObjectRef, Params.SenderObjectRef, Params.Type, MoveTemp(Params.Payload), 0);
 
 	AddExpectedError(TEXT("Unresolved Parameters"), EAutomationExpectedErrorFlags::Contains, 1);
 

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Utils/RPCContainer/RPCContainerTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Utils/RPCContainer/RPCContainerTest.cpp
@@ -125,8 +125,10 @@ RPCCONTAINER_TEST(GIVEN_a_container_WHEN_multiple_values_of_different_type_have_
 	FRPCContainer RPCs(ERPCQueueType::Send);
 	RPCs.BindProcessingFunction(FProcessRPCDelegate::CreateUObject(TargetObject, &UObjectStub::ProcessRPC));
 
-	RPCs.ProcessOrQueueRPC(ParamsUnreliable.ObjectRef, ParamsUnreliable.SenderObjectRef, ParamsUnreliable.Type, MoveTemp(ParamsUnreliable.Payload), 0);
-	RPCs.ProcessOrQueueRPC(ParamsReliable.ObjectRef, ParamsReliable.SenderObjectRef, ParamsReliable.Type, MoveTemp(ParamsReliable.Payload), 0);
+	RPCs.ProcessOrQueueRPC(ParamsUnreliable.ObjectRef, ParamsUnreliable.SenderObjectRef, ParamsUnreliable.Type,
+						   MoveTemp(ParamsUnreliable.Payload), 0);
+	RPCs.ProcessOrQueueRPC(ParamsReliable.ObjectRef, ParamsReliable.SenderObjectRef, ParamsReliable.Type, MoveTemp(ParamsReliable.Payload),
+						   0);
 
 	TestTrue("Has queued RPCs", RPCs.ObjectHasRPCsQueuedOfType(ParamsUnreliable.ObjectRef.Entity, AnyOtherSchemaComponentType));
 	TestTrue("Has queued RPCs", RPCs.ObjectHasRPCsQueuedOfType(ParamsReliable.ObjectRef.Entity, AnySchemaComponentType));
@@ -143,8 +145,10 @@ RPCCONTAINER_TEST(GIVEN_a_container_storing_multiple_values_of_different_type_WH
 	FRPCContainer RPCs(ERPCQueueType::Send);
 	RPCs.BindProcessingFunction(FProcessRPCDelegate::CreateUObject(TargetObject, &UObjectDummy::ProcessRPC));
 
-	RPCs.ProcessOrQueueRPC(ParamsUnreliable.ObjectRef, ParamsUnreliable.SenderObjectRef, ParamsUnreliable.Type, MoveTemp(ParamsUnreliable.Payload), 0);
-	RPCs.ProcessOrQueueRPC(ParamsReliable.ObjectRef, ParamsReliable.SenderObjectRef, ParamsReliable.Type, MoveTemp(ParamsReliable.Payload), 0);
+	RPCs.ProcessOrQueueRPC(ParamsUnreliable.ObjectRef, ParamsUnreliable.SenderObjectRef, ParamsUnreliable.Type,
+						   MoveTemp(ParamsUnreliable.Payload), 0);
+	RPCs.ProcessOrQueueRPC(ParamsReliable.ObjectRef, ParamsReliable.SenderObjectRef, ParamsReliable.Type, MoveTemp(ParamsReliable.Payload),
+						   0);
 
 	TestFalse("Has queued RPCs", RPCs.ObjectHasRPCsQueuedOfType(ParamsUnreliable.ObjectRef.Entity, AnyOtherSchemaComponentType));
 	TestFalse("Has queued RPCs", RPCs.ObjectHasRPCsQueuedOfType(ParamsReliable.ObjectRef.Entity, AnySchemaComponentType));


### PR DESCRIPTION
#### Description
This PR represents the prototype work done in [UNR-4189](https://improbableio.atlassian.net/browse/UNR-4189) Spike CrossServer RPC write to sending worker approach. It was never intended to merge, it's an experiment.

I think the correct way of doing that is to create and then close a PR. That was it doesn't appears in the user facing git branch selection but is immortalized in linkable PR form

#### Investigation conclusion

There was a big difference in CPU worker load, until I realized the Sender component updates were not batched per frame and individually sent (which caused them to be merged on reception, and was a costly CPU operation). Batching them resulted in CPU saving, and was also beneficial on the bandwidth side. But now it makes comparison to commands (which cannot be batched) a bit biased. And latency might be impacted.
In the end, the stateful RPC implementation ends up consuming less bandwidth and runtime CPU than commands for this particular test.

NB : In order to get the consistency we would like from cross-server RPC, batching updates would be necessary anyway.

