### PR TITLE
Bugfix/add serveronlyalwaysrelevant schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ These functions and structs can be referenced in both code and blueprints it may
 - Added support for FPredictionKey's conditional replication logic. GameplayCues now activate on all clients, instead of only the client that initiated them.
 - Fixed a bug where deployment would fail in the presence of trailing spaces in the `Flags` and `LegacyFlags` fields of the `SpatialGDKEditorSettings`.
 - Fixed a crash that would occur when performing multiple Client Travels at once.
+- Add ServerOnlyAlwaysRelevant component and component set schema definitions
 
 ## [`0.11.0`] - 2020-09-03
 

--- a/RequireSetup
+++ b/RequireSetup
@@ -1,4 +1,4 @@
 Increment the below number whenever it is required to run Setup.bat as part of a new commit.
 Our git hooks will detect this file has been updated and automatically run Setup.bat on pull.
 
-72
+73

--- a/SpatialGDK/Extras/schema/relevant.schema
+++ b/SpatialGDK/Extras/schema/relevant.schema
@@ -5,6 +5,10 @@ component AlwaysRelevant {
     id = 9983;
 }
 
+component ServerOnlyAlwaysRelevant {
+    id = 9968;
+}
+
 component Dormant {
     id = 9981;
 }
@@ -17,6 +21,13 @@ component_set AlwaysRelevantSet {
 	id = 9983;
 	components = [
 		AlwaysRelevant
+	];
+}
+
+component_set ServerOnlyAlwaysRelevantSet {
+	id = 9968;
+	components = [
+		ServerOnlyAlwaysRelevant
 	];
 }
 


### PR DESCRIPTION
#### Description
Add ServerOnlyAlwaysRelevant component and component set schema definitions

#### Release note
Will add

#### Tests
Testing in progress.

STRONGLY SUGGESTED: How can this be verified by QA?
Run a cloud deployment and verify that the following warning is not present:
"Unknown component set (9968) found in the authority delegation of entity (92). This mapping will not be processed"

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

#### Reminders (IMPORTANT)
If your change relies on a breaking engine change:
* Increment `SPATIAL_ENGINE_VERSION` in `Engine\Source\Runtime\Launch\Resources\SpatialVersion.h` (in the engine fork) as well as `SPATIAL_GDK_VERSION` in `SpatialGDK\Source\SpatialGDK\Public\Utils\EngineVersionCheck.h`. This helps others by providing a more helpful message during compilation to make sure the GDK and the Engine are up to date.

If your change updates `Setup.bat`, `Setup.sh`, core SDK version, any C# tools in `SpatialGDK\Build\Programs\Improbable.Unreal.Scripts`, or hand-written schema in `SpatialGDK\Extras\schema`:
* Increment the number in `RequireSetup`. This will automatically run `Setup.bat` or `Setup.sh` when the GDK is next pulled.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
