### PR TITLE
UNR-3848 - hide snapshot button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ These functions and structs can be referenced in both code and blueprints it may
   - Inspector URL is now http://localhost:33333/inspector-v2
   - Inspector version can now be overridden in the SpatialGDKEditorSettings under `Inspector Version Override`
 - The SpatialNetDriver can now disconnect a client worker when given the system entity id for that client and will do so when `GameMode::PreLogin` returns with a non-empty error message. 
+  - The 'Snapshot' button is now hidden by default and can be toggled to be shown from the UnrealGDK Editor settings.
 
 ### Bug fixes:
 - Fixed a bug that stopped the travel URL being used for initial Spatial connection if the command line arguments could not be used.

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -39,6 +39,7 @@ const FString& FRuntimeVariantVersion::GetVersionForCloud() const
 
 USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
+	, bShowSnapshotButton(false)
 	, bDeleteDynamicEntities(true)
 	, bGenerateDefaultLaunchConfig(true)
 	, StandardRuntimeVersion(SpatialGDKServicesConstants::SpatialOSRuntimePinnedStandardVersion)

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -276,6 +276,10 @@ public:
 	virtual void PostInitProperties() override;
 
 public:
+	/** If checked, show the snapshot button on the GDK toolbar which is used to generate snapshots. */
+    UPROPERTY(EditAnywhere, config, Category = "General", meta = (DisplayName = "Show snapshot schema button"))
+    bool bShowSnapshotButton;
+
 	/** Select to delete all a server-worker instance’s dynamically-spawned entities when the server-worker instance shuts down. If NOT
 	 * selected, a new server-worker instance has all of these entities from the former server-worker instance’s session. */
 	UPROPERTY(EditAnywhere, config, Category = "Play in editor settings", meta = (DisplayName = "Delete dynamically spawned entities"))

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -232,7 +232,9 @@ void FSpatialGDKEditorToolbarModule::MapActions(TSharedPtr<class FUICommandList>
 
 	InPluginCommands->MapAction(FSpatialGDKEditorToolbarCommands::Get().CreateSpatialGDKSnapshot,
 								FExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::CreateSnapshotButtonClicked),
-								FCanExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::CanExecuteSnapshotGenerator));
+								FCanExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::CanExecuteSnapshotGenerator),
+								FIsActionChecked(),
+								FIsActionButtonVisible::CreateRaw(this, &FSpatialGDKEditorToolbarModule::SnapshotButtonIsVisible));
 
 	InPluginCommands->MapAction(FSpatialGDKEditorToolbarCommands::Get().StartNative, FExecuteAction(),
 								FCanExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::StartNativeCanExecute),
@@ -681,6 +683,11 @@ void FSpatialGDKEditorToolbarModule::ShowFailedNotification(const FString& Notif
 			GEditor->PlayEditorSound(ExecutionFailSound);
 		}
 	}
+}
+
+bool FSpatialGDKEditorToolbarModule::SnapshotButtonIsVisible()
+{
+	return GetDefault<USpatialGDKEditorSettings>()->bShowSnapshotButton;
 }
 
 void FSpatialGDKEditorToolbarModule::ToggleSpatialDebuggerEditor()

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -155,6 +155,8 @@ private:
 
 	void ShowFailedNotification(const FString& NotificationText);
 
+	bool SnapshotButtonIsVisible();
+
 	void GenerateSchema(bool bFullScan);
 
 	bool IsSnapshotGenerated() const;


### PR DESCRIPTION
#### Description
Add a setting which toggles the visibility of the snapshot button in the toolbar

#### Tests
- Launch Unreal Editor
- Open the GDK Editor settings
- Check/uncheck box and see the button in the toolbar become visible/invisible

#### Documentation
Screenshots in public tutorials will likely need re-doing
