### PR TITLE
[UNR-4603] When async loading, avoid queuing components that are handled through static component view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ These functions and structs can be referenced in both code and blueprints it may
 - Server workers use TCP (instead of KCP) by default.
 - Fixed a rare crash where a RepNotify callback can modify a GDK data structure being iterated upon.
 - Fixed race condition in Spatial Test framework that would cause tests to time out with one or more workers not ready to begin the test.
+- Fixed a assertion being triggered on async loaded entities due to queuing some component addition
 
 ## [`0.11.0`] - 2020-09-03
 


### PR DESCRIPTION
#### Description
In a rare case, when an entity that was loaded asynchronously, it could happen that we receive a second component add on UNREAL_METADATA_COMPONENT. Most likely caused by interest flickering (remove-add being given as an add after going through SpatialView)
These add would then trigger an assertion when dequeuing the ops later. It turns out that a lot of components do not need to be queued, so we avoid doing that for the problematic component as well.

#### Release note

#### Tests
