### PR TITLE
[UNR-4630] Queue async loaded packages instead of processing them right away

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1822,6 +1822,7 @@ void USpatialNetDriver::TickDispatch(float DeltaTime)
 			SCOPE_CYCLE_COUNTER(STAT_SpatialProcessOps);
 			Dispatcher->ProcessOps(GetOpsFromEntityDeltas(Connection->GetEntityDeltas()));
 			Dispatcher->ProcessOps(Connection->GetWorkerMessages());
+			Receiver->ProcessActorsFromAsyncLoading();
 		}
 
 		if (RPCService.IsValid())

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -2704,40 +2704,53 @@ void USpatialReceiver::StartAsyncLoadingClass(const FString& ClassPath, Worker_E
 
 void USpatialReceiver::OnAsyncPackageLoaded(const FName& PackageName, UPackage* Package, EAsyncLoadingResult::Type Result)
 {
-	TArray<Worker_EntityId> Entities;
-	if (!AsyncLoadingPackages.RemoveAndCopyValue(PackageName, Entities))
-	{
-		UE_LOG(LogSpatialReceiver, Error,
-			   TEXT("USpatialReceiver::OnAsyncPackageLoaded: Package loaded but no entry in AsyncLoadingPackages. Package: %s"),
-			   *PackageName.ToString());
-		return;
-	}
-
 	if (Result != EAsyncLoadingResult::Succeeded)
 	{
 		UE_LOG(LogSpatialReceiver, Error, TEXT("USpatialReceiver::OnAsyncPackageLoaded: Package was not loaded successfully. Package: %s"),
 			   *PackageName.ToString());
+		AsyncLoadingPackages.Remove(PackageName);
 		return;
 	}
 
-	for (Worker_EntityId Entity : Entities)
+	LoadedPackages.Add(PackageName);
+}
+
+void USpatialReceiver::ProcessActorsFromAsyncLoading()
+{
+	static_assert(TContainerTraits<decltype(LoadedPackages)>::MoveWillEmptyContainer, "Moving the set won't empty it");
+	TSet<FName> PackagesToProcess = MoveTemp(LoadedPackages);
+
+	for (const auto& PackageName : PackagesToProcess)
 	{
-		if (IsEntityWaitingForAsyncLoad(Entity))
+		TArray<Worker_EntityId> Entities;
+		if (!AsyncLoadingPackages.RemoveAndCopyValue(PackageName, Entities))
 		{
-			UE_LOG(LogSpatialReceiver, Log, TEXT("Finished async loading package %s for entity %lld."), *PackageName.ToString(), Entity);
+			UE_LOG(LogSpatialReceiver, Error,
+				   TEXT("USpatialReceiver::OnAsyncPackageLoaded: Package loaded but no entry in AsyncLoadingPackages. Package: %s"),
+				   *PackageName.ToString());
+			return;
+		}
 
-			// Save critical section if we're in one and restore upon leaving this scope.
-			CriticalSectionSaveState CriticalSectionState(*this);
-
-			EntityWaitingForAsyncLoad AsyncLoadEntity = EntitiesWaitingForAsyncLoad.FindAndRemoveChecked(Entity);
-			PendingAddActors.Add(Entity);
-			PendingAddComponents = MoveTemp(AsyncLoadEntity.InitialPendingAddComponents);
-			LeaveCriticalSection();
-
-			OpList Ops = MoveTemp(AsyncLoadEntity.PendingOps).CreateOpList();
-			for (uint32 i = 0; i < Ops.Count; ++i)
+		for (Worker_EntityId Entity : Entities)
+		{
+			if (IsEntityWaitingForAsyncLoad(Entity))
 			{
-				HandleQueuedOpForAsyncLoad(Ops.Ops[i]);
+				UE_LOG(LogSpatialReceiver, Log, TEXT("Finished async loading package %s for entity %lld."), *PackageName.ToString(),
+					   Entity);
+
+				// Save critical section if we're in one and restore upon leaving this scope.
+				CriticalSectionSaveState CriticalSectionState(*this);
+
+				EntityWaitingForAsyncLoad AsyncLoadEntity = EntitiesWaitingForAsyncLoad.FindAndRemoveChecked(Entity);
+				PendingAddActors.Add(Entity);
+				PendingAddComponents = MoveTemp(AsyncLoadEntity.InitialPendingAddComponents);
+				LeaveCriticalSection();
+
+				OpList Ops = MoveTemp(AsyncLoadEntity.PendingOps).CreateOpList();
+				for (uint32 i = 0; i < Ops.Count; ++i)
+				{
+					HandleQueuedOpForAsyncLoad(Ops.Ops[i]);
+				}
 			}
 		}
 	}

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialReceiver.h
@@ -111,6 +111,7 @@ public:
 
 	void RetireWhenAuthoritive(Worker_EntityId EntityId, Worker_ComponentId ActorClassId, bool bIsNetStartup, bool bNeedsTearOff);
 
+	void ProcessActorsFromAsyncLoading();
 private:
 	void EnterCriticalSection();
 	void LeaveCriticalSection();
@@ -261,6 +262,7 @@ private:
 	};
 	TMap<Worker_EntityId_Key, EntityWaitingForAsyncLoad> EntitiesWaitingForAsyncLoad;
 	TMap<FName, TArray<Worker_EntityId>> AsyncLoadingPackages;
+	TSet<FName> LoadedPackages;
 	// END TODO
 
 	struct DeferredRetire


### PR DESCRIPTION
#### Description
Entities depending on a package being loaded in the background are processed as soon as we receive the callback on the package bein loaded.
This triggered a rare issue in UNR-4630 where this callback was sent while we were deserializing a component. This caused it to try to deserialize another component, and cased an assertion error in FSpatialNetBitReader which have the limitation that we can only have a single one per stack.
While we could remove that limitation, a better choice would be to remove this unecessary reentrancy, queue the packages that have been loaded, and process them later. This will make stacks less complicated.

#### Release note

#### Tests