### PR TITLE
UNR-4671 RemotePossessionComponent and TestCases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,8 @@ These functions and structs can be referenced in both code and blueprints it may
 - Simulated Player deployments no longer depend on DeploymentLauncher for readiness. You can now restart them via the Console and expect them to reconnect to your main deployment. DeploymentLauncher will also restart any crashed or incorrectly finished simulated players applications.
 - Added a `-FailOnNetworkFailure` flag that makes a Spatial-enabled game fail on any NetworkFailure.
 - Reworked schema generation (incremental + full) pop-ups to be clearer.
+- Added a `-FailOnNetworkFailure` flag that makes a Spatial-enabled game fail on any NetworkFailure
+- Added `URemotePossessionComponent` to deal with Cross-Server Possession. Add this componenet to an AController, it will possess the Target Pawn after OnAuthorityGained. It can be implemented in C++ and Blueprint.
 
 ### Bug fixes:
 - Fixed a bug that stopped the travel URL being used for initial Spatial connection if the command line arguments could not be used.

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/RemotePossessionComponent.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/RemotePossessionComponent.cpp
@@ -26,23 +26,27 @@ URemotePossessionComponent::URemotePossessionComponent(const FObjectInitializer&
 void URemotePossessionComponent::BeginPlay()
 {
 	Super::BeginPlay();
-	if (Target == nullptr)
+	if (GetOwner()->HasAuthority())
 	{
-		return;
-	}
-	USpatialNetDriver* SpatialNetDriver = Cast<USpatialNetDriver>(GetOwner()->GetNetDriver());
-	if (SpatialNetDriver != nullptr)
-	{
-		if (SpatialNetDriver->LockingPolicy->IsLocked(GetOwner()))
+		if (Target == nullptr)
 		{
-			UE_LOG(LogRemotePossessionComponent, Warning, TEXT("Actor %s cannot migrate because it is locked"), *GetOwner()->GetName());
+			OnInvalidTarget();
+			return;
+		}
+		USpatialNetDriver* SpatialNetDriver = Cast<USpatialNetDriver>(GetOwner()->GetNetDriver());
+		if (SpatialNetDriver != nullptr)
+		{
+			if (SpatialNetDriver->LockingPolicy->IsLocked(GetOwner()))
+			{
+				UE_LOG(LogRemotePossessionComponent, Warning, TEXT("Actor %s cannot migrate because it is locked"), *GetOwner()->GetName());
+				MarkToDestroy();
+			}
+		}
+		if (Target->HasAuthority())
+		{
+			Possess();
 			MarkToDestroy();
 		}
-	}
-	if (Target->HasAuthority())
-	{
-		Possess();
-		MarkToDestroy();
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/RemotePossessionComponent.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/RemotePossessionComponent.cpp
@@ -60,18 +60,9 @@ void URemotePossessionComponent::TickComponent(float DeltaTime, enum ELevelTick 
 	}
 }
 
-bool URemotePossessionComponent::EvaluatePossess()
+bool URemotePossessionComponent::EvaluatePossess_Implementation()
 {
-	if (GetClass()->HasAnyClassFlags(CLASS_CompiledFromBlueprint) || !GetClass()->HasAnyClassFlags(CLASS_Native))
-	{
-		return ReceiveEvaluatePossess();
-	}
-	else
-	{
-		if (Target->GetController() == nullptr)
-			return true;
-		return false;
-	}
+	return true;
 }
 
 void URemotePossessionComponent::MarkToDestroy()

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/RemotePossessionComponent.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/RemotePossessionComponent.cpp
@@ -21,6 +21,20 @@ URemotePossessionComponent::URemotePossessionComponent(const FObjectInitializer&
 #endif
 }
 
+void URemotePossessionComponent::BeginPlay()
+{
+	Super::BeginPlay();
+	if (Target == nullptr)
+	{
+		OnInvalidTarget();
+		return;
+	}
+	if (Target->HasAuthority())
+	{
+		Possess();
+	}
+}
+
 void URemotePossessionComponent::OnAuthorityGained()
 {
 	if (Target == nullptr)

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/RemotePossessionComponent.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/RemotePossessionComponent.cpp
@@ -105,9 +105,16 @@ void URemotePossessionComponent::TickComponent(float DeltaTime, enum ELevelTick 
 
 bool URemotePossessionComponent::EvaluatePossess()
 {
-	if (Target->GetController() == nullptr)
-		return true;
-	return false;
+	if (GetClass()->HasAnyClassFlags(CLASS_CompiledFromBlueprint) || !GetClass()->HasAnyClassFlags(CLASS_Native))
+	{
+		return ReceiveEvaluatePossess();
+	}
+	else
+	{
+		if (Target->GetController() == nullptr)
+			return true;
+		return false;
+	}
 }
 
 void URemotePossessionComponent::MarkToDestroy()

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/RemotePossessionComponent.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/RemotePossessionComponent.cpp
@@ -67,7 +67,8 @@ bool URemotePossessionComponent::EvaluatePossess_Implementation()
 
 void URemotePossessionComponent::OnInvalidTarget_Implementation()
 {
-	UE_LOG(LogRemotePossessionComponent, Error, TEXT("Target is invalid for remote possession component on actor %s"), *GetOwner()->GetName());
+	UE_LOG(LogRemotePossessionComponent, Error, TEXT("Target is invalid for remote possession component on actor %s"),
+		   *GetOwner()->GetName());
 }
 
 void URemotePossessionComponent::MarkToDestroy()

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/RemotePossessionComponent.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/RemotePossessionComponent.cpp
@@ -33,15 +33,6 @@ void URemotePossessionComponent::BeginPlay()
 			OnInvalidTarget();
 			return;
 		}
-		USpatialNetDriver* SpatialNetDriver = Cast<USpatialNetDriver>(GetOwner()->GetNetDriver());
-		if (SpatialNetDriver != nullptr)
-		{
-			if (SpatialNetDriver->LockingPolicy->IsLocked(GetOwner()))
-			{
-				UE_LOG(LogRemotePossessionComponent, Warning, TEXT("Actor %s cannot migrate because it is locked"), *GetOwner()->GetName());
-				MarkToDestroy();
-			}
-		}
 		if (Target->HasAuthority())
 		{
 			Possess();

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/RemotePossessionComponent.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/RemotePossessionComponent.cpp
@@ -27,7 +27,7 @@ void URemotePossessionComponent::OnAuthorityGained()
 	ensure(Controller);
 	if (Target == nullptr)
 	{
-		UE_LOG(LogRemotePossessionComponent, Error, TEXT("Target is null"));
+		OnInvalidTarget();		
 		return;
 	}
 	if (!Target->HasAuthority())
@@ -63,6 +63,11 @@ void URemotePossessionComponent::TickComponent(float DeltaTime, enum ELevelTick 
 bool URemotePossessionComponent::EvaluatePossess_Implementation()
 {
 	return true;
+}
+
+void URemotePossessionComponent::OnInvalidTarget_Implementation()
+{
+	UE_LOG(LogRemotePossessionComponent, Error, TEXT("Target is invalid"));
 }
 
 void URemotePossessionComponent::MarkToDestroy()

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/RemotePossessionComponent.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/RemotePossessionComponent.cpp
@@ -1,0 +1,111 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "EngineClasses/Components/RemotePossessionComponent.h"
+#include "LoadBalancing/AbstractLBStrategy.h"
+
+#include "Engine/World.h"
+
+DEFINE_LOG_CATEGORY(LogRemotePossessionComponent);
+
+URemotePossessionComponent::URemotePossessionComponent(const FObjectInitializer& ObjectInitializer)
+	: Super(ObjectInitializer)
+	, PendingDestroy(false)
+{
+	PrimaryComponentTick.bCanEverTick = true;
+	PrimaryComponentTick.bStartWithTickEnabled = true;
+
+#if ENGINE_MINOR_VERSION <= 23
+	bReplicates = true;
+#else
+	SetIsReplicatedByDefault(true);
+#endif
+}
+
+void URemotePossessionComponent::OnAuthorityGained()
+{
+	Possess();
+}
+
+void URemotePossessionComponent::Possess()
+{
+	UE_LOG(LogRemotePossessionComponent, Log, TEXT("OnAuthorityGained"));
+	AController* Controller = Cast<AController>(GetOwner());
+	if (ensure(Controller != nullptr))
+	{
+		if (Target == nullptr)
+		{
+			UE_LOG(LogRemotePossessionComponent, Log, TEXT("Target is null"));
+			return;
+		}
+		if (!Target->HasAuthority())
+		{
+			UE_LOG(LogRemotePossessionComponent, Log, TEXT("Target is hasn't authority"));
+			return;
+		}
+		else
+		{
+			if (EvaluatePossess(Controller, Target->GetController()))
+			{
+				UE_LOG(LogRemotePossessionComponent, Log, TEXT("Possess(%s)"), *Target->GetName());
+				Controller->Possess(Target);
+			}
+			else
+			{
+				UE_LOG(LogRemotePossessionComponent, Log, TEXT("EvaluatePossess(%s) failed"), *Target->GetName());
+			}
+			PendingDestroy = true;
+		}
+	}
+}
+
+bool URemotePossessionComponent::EvaluateMigration(UAbstractLBStrategy* LBStrategy, VirtualWorkerId& WorkerId)
+{
+	if (true == PendingDestroy)
+		return false;
+	if (Target != nullptr)
+	{
+		UE_LOG(LogRemotePossessionComponent, Log, TEXT("Component->Target is:%s"), *Target->GetName());
+		VirtualWorkerId ActorAuthVirtualWorkerId = LBStrategy->WhoShouldHaveAuthority(*GetOwner());
+		VirtualWorkerId TargetVirtualWorkerId = LBStrategy->WhoShouldHaveAuthority(*Target);
+
+		if (TargetVirtualWorkerId == SpatialConstants::INVALID_VIRTUAL_WORKER_ID)
+		{
+			UE_LOG(LogRemotePossessionComponent, Error, TEXT("Load Balancing Strategy returned invalid virtual worker for actor %s"),
+				   **GetOwner()->GetName());
+		}
+		else if (ActorAuthVirtualWorkerId != TargetVirtualWorkerId)
+		{
+			UE_LOG(LogRemotePossessionComponent, Log, TEXT("Migrate actor:%s to worker:%d"), *GetOwner()->GetName(), TargetVirtualWorkerId);
+			WorkerId = TargetVirtualWorkerId;
+			return true;
+		}
+		else
+		{
+			Possess();
+			UE_LOG(LogRemotePossessionComponent, Log, TEXT("Actor:%s and Target:%s are in same worker:%d"), *GetOwner()->GetName(),
+				   *Target->GetName(), TargetVirtualWorkerId);
+		}
+	}
+	else
+	{
+		UE_LOG(LogRemotePossessionComponent, Log, TEXT("Target is:null"));
+	}
+	return false;
+}
+
+void URemotePossessionComponent::TickComponent(float DeltaTime, enum ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
+{
+	Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
+	if (PendingDestroy)
+	{
+		UE_LOG(LogRemotePossessionComponent, Log, TEXT("DestroyComponent"));
+		DestroyComponent();
+	}
+}
+
+bool URemotePossessionComponent::EvaluatePossess(AController* CurrentController, AController* WantController)
+{
+	if (WantController == nullptr)
+		return true;
+	return false;
+}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/RemotePossessionComponent.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/RemotePossessionComponent.cpp
@@ -39,12 +39,12 @@ void URemotePossessionComponent::OnAuthorityGained()
 	{
 		if (EvaluatePossess())
 		{
-			UE_LOG(LogRemotePossessionComponent, Log, TEXT("Possess(%s)"), *Target->GetName());
+			UE_LOG(LogRemotePossessionComponent, Verbose, TEXT("Remote possession succesful on (%s)"), *Target->GetName());
 			Controller->Possess(Target);
 		}
 		else
 		{
-			UE_LOG(LogRemotePossessionComponent, Log, TEXT("EvaluatePossess(%s) failed"), *Target->GetName());
+			UE_LOG(LogRemotePossessionComponent, Verbose, TEXT("EvaluatePossess(%s) failed"), *Target->GetName());
 		}
 		MarkToDestroy();
 	}
@@ -55,7 +55,7 @@ void URemotePossessionComponent::TickComponent(float DeltaTime, enum ELevelTick 
 	Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
 	if (PendingDestroy)
 	{
-		UE_LOG(LogRemotePossessionComponent, Log, TEXT("DestroyComponent"));
+		UE_LOG(LogRemotePossessionComponent, Verbose, TEXT("Destroy RemotePossessionComponent"));
 		DestroyComponent();
 	}
 }
@@ -67,7 +67,7 @@ bool URemotePossessionComponent::EvaluatePossess_Implementation()
 
 void URemotePossessionComponent::OnInvalidTarget_Implementation()
 {
-	UE_LOG(LogRemotePossessionComponent, Error, TEXT("Target is invalid"));
+	UE_LOG(LogRemotePossessionComponent, Error, TEXT("Target is invalid for remote possession component on actor %s"), *GetOwner()->GetName());
 }
 
 void URemotePossessionComponent::MarkToDestroy()

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/RemotePossessionComponent.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/RemotePossessionComponent.cpp
@@ -27,7 +27,7 @@ void URemotePossessionComponent::OnAuthorityGained()
 	ensure(Controller);
 	if (Target == nullptr)
 	{
-		OnInvalidTarget();		
+		OnInvalidTarget();
 		return;
 	}
 	if (!Target->HasAuthority())

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/RemotePossessionComponent.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/RemotePossessionComponent.cpp
@@ -44,7 +44,7 @@ void URemotePossessionComponent::Possess()
 		}
 		else
 		{
-			if (EvaluatePossess(Controller, Target->GetController()))
+			if (EvaluatePossess())
 			{
 				UE_LOG(LogRemotePossessionComponent, Log, TEXT("Possess(%s)"), *Target->GetName());
 				Controller->Possess(Target);
@@ -53,7 +53,7 @@ void URemotePossessionComponent::Possess()
 			{
 				UE_LOG(LogRemotePossessionComponent, Log, TEXT("EvaluatePossess(%s) failed"), *Target->GetName());
 			}
-			PendingDestroy = true;
+			MarkToDestroy();
 		}
 	}
 }
@@ -103,9 +103,14 @@ void URemotePossessionComponent::TickComponent(float DeltaTime, enum ELevelTick 
 	}
 }
 
-bool URemotePossessionComponent::EvaluatePossess(AController* CurrentController, AController* WantController)
+bool URemotePossessionComponent::EvaluatePossess()
 {
-	if (WantController == nullptr)
+	if (Target->GetController() == nullptr)
 		return true;
 	return false;
+}
+
+void URemotePossessionComponent::MarkToDestroy()
+{
+	PendingDestroy = true;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/RemotePossessionComponent.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/RemotePossessionComponent.cpp
@@ -35,8 +35,7 @@ void URemotePossessionComponent::BeginPlay()
 	{
 		if (SpatialNetDriver->LockingPolicy->IsLocked(GetOwner()))
 		{
-			UE_LOG(LogRemotePossessionComponent, Warning, TEXT("Actor %s cannot migrate because it is locked"),
-				   *GetOwner()->GetName());
+			UE_LOG(LogRemotePossessionComponent, Warning, TEXT("Actor %s cannot migrate because it is locked"), *GetOwner()->GetName());
 			MarkToDestroy();
 		}
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
@@ -35,7 +35,96 @@ FSpatialLoadBalancingHandler::EvaluateActorResult FSpatialLoadBalancingHandler::
 		return EvaluateActorResult::None;
 	}
 
-	return EvaluateSingleActor_Impl(Actor, OutNetOwner, OutWorkerId);
+	UpdateSpatialDebugInfo(Actor, EntityId);
+
+	// If this object is in the list of actors to migrate, we have already processed its hierarchy.
+	// Remove it from the additional actors to process, and continue.
+	if (ActorsToMigrate.Contains(Actor))
+	{
+		return EvaluateActorResult::RemoveAdditional;
+	}
+
+	if (NetDriver->StaticComponentView->HasAuthority(EntityId, SpatialConstants::SERVER_AUTH_COMPONENT_SET_ID))
+	{
+		AActor* NetOwner = GetReplicatedHierarchyRoot(Actor);
+
+		if (AController* Controller = Cast<AController>(Actor))
+		{
+			TArray<UActorComponent*> Components;
+			Controller->GetComponents(URemotePossessionComponent::StaticClass(), Components);
+			if (Components.Num() == 1)
+			{
+				// Only deal with the first one
+				if (URemotePossessionComponent* Component = Cast<URemotePossessionComponent>(Components[0]))
+				{
+					VirtualWorkerId TargetVirtualWorkerId;
+					if (EvaluateRemoteMigrationComponent(Component->GetOwner(), Component->Target,
+														 NetDriver->LoadBalanceStrategy, TargetVirtualWorkerId))
+					{
+						OutNetOwner = NetOwner;
+						OutWorkerId = TargetVirtualWorkerId;
+						return EvaluateActorResult::Migrate;
+					}
+				}
+			}
+		}
+
+		const bool bNetOwnerHasAuth = NetOwner->HasAuthority();
+
+		// Load balance if we are not supposed to be on this worker, or if we are separated from our owner.
+		if ((!NetDriver->LoadBalanceStrategy->ShouldHaveAuthority(*NetOwner) || !bNetOwnerHasAuth)
+			&& !NetDriver->LockingPolicy->IsLocked(Actor))
+		{
+			uint64 HierarchyAuthorityReceivedTimestamp = GetLatestAuthorityChangeFromHierarchy(NetOwner);
+
+			const float TimeSinceReceivingAuthInSeconds =
+				double(FPlatformTime::Cycles64() - HierarchyAuthorityReceivedTimestamp) * FPlatformTime::GetSecondsPerCycle64();
+			const float MigrationBackoffTimeInSeconds = 1.0f;
+
+			if (TimeSinceReceivingAuthInSeconds < MigrationBackoffTimeInSeconds)
+			{
+				UE_LOG(LogSpatialLoadBalancingHandler, Verbose, TEXT("Tried to change auth too early for actor %s"), *Actor->GetName());
+			}
+			else
+			{
+				VirtualWorkerId NewAuthVirtualWorkerId = SpatialConstants::INVALID_VIRTUAL_WORKER_ID;
+				if (bNetOwnerHasAuth)
+				{
+					NewAuthVirtualWorkerId = NetDriver->LoadBalanceStrategy->WhoShouldHaveAuthority(*NetOwner);
+				}
+				else
+				{
+					// If we are separated from our owner, it could be prevented from migrating (if it has interest over the current actor),
+					// so the load balancing strategy could give us a worker different from where it should be.
+					// Instead, we read its currently assigned worker, which will eventually make us land where our owner is.
+					Worker_EntityId OwnerId = NetDriver->PackageMap->GetEntityIdFromObject(NetOwner);
+					if (AuthorityIntent* OwnerAuthIntent = NetDriver->StaticComponentView->GetComponentData<AuthorityIntent>(OwnerId))
+					{
+						NewAuthVirtualWorkerId = OwnerAuthIntent->VirtualWorkerId;
+					}
+					else
+					{
+						UE_LOG(LogSpatialLoadBalancingHandler, Error, TEXT("Actor %s (%llu) cannot join its owner %s (%llu)"),
+							   *Actor->GetName(), EntityId, *NetOwner->GetName(), OwnerId);
+					}
+				}
+
+				if (NewAuthVirtualWorkerId == SpatialConstants::INVALID_VIRTUAL_WORKER_ID)
+				{
+					UE_LOG(LogSpatialLoadBalancingHandler, Error,
+						   TEXT("Load Balancing Strategy returned invalid virtual worker for actor %s"), *Actor->GetName());
+				}
+				else
+				{
+					OutNetOwner = NetOwner;
+					OutWorkerId = NewAuthVirtualWorkerId;
+					return EvaluateActorResult::Migrate;
+				}
+			}
+		}
+	}
+
+	return EvaluateActorResult::None;
 }
 
 void FSpatialLoadBalancingHandler::ProcessMigrations()
@@ -151,91 +240,40 @@ void FSpatialLoadBalancingHandler::LogMigrationFailure(EActorMigrationResult Act
 	}
 }
 
-
-EvaluateActorResult FSpatialLoadBalancingHandler::EvaluateSingleActor_Impl(AActor* Actor, AActor*& OutNetOwner,
-																		   VirtualWorkerId& OutWorkerId)
+bool FSpatialLoadBalancingHandler::EvaluateRemoteMigrationComponent(const AActor* Owner, const AActor* Target,
+																	UAbstractLBStrategy* LBStrategy,
+																	VirtualWorkerId& WorkerId)
 {
-	UpdateSpatialDebugInfo(Actor, EntityId);
-
-	// If this object is in the list of actors to migrate, we have already processed its hierarchy.
-	// Remove it from the additional actors to process, and continue.
-	if (ActorsToMigrate.Contains(Actor))
+	if (Target != nullptr)
 	{
-		return EvaluateActorResult::RemoveAdditional;
-	}
+		UE_LOG(LogRemotePossessionComponent, Log, TEXT("Component->Target is:%s"), *Target->GetName());
+		VirtualWorkerId ActorAuthVirtualWorkerId = LBStrategy->WhoShouldHaveAuthority(*Owner);
+		VirtualWorkerId TargetVirtualWorkerId = LBStrategy->WhoShouldHaveAuthority(*Target);
 
-	if (NetDriver->StaticComponentView->HasAuthority(EntityId, SpatialConstants::SERVER_AUTH_COMPONENT_SET_ID))
-	{
-		AActor* NetOwner = GetReplicatedHierarchyRoot(Actor);
-
-		if (AController* Controller = Cast<AController>(Actor))
+		if (TargetVirtualWorkerId == SpatialConstants::INVALID_VIRTUAL_WORKER_ID)
 		{
-			TArray<UActorComponent*> Components;
-			Controller->GetComponents(URemotePossessionComponent::StaticClass(), Components);
-			if (Components.Num() == 1)
-			{
-				if (URemotePossessionComponent* Component = Cast<URemotePossessionComponent>(Components[0]))
-				{
-					VirtualWorkerId TargetVirtualWorkerId;
-					return EvaluateSingleActor_Impl(Component->Target, NetOwner, OutWorkerId);
-				}
-			}
+			UE_LOG(LogRemotePossessionComponent, Error, TEXT("Load Balancing Strategy returned invalid virtual worker for actor %s"),
+				   *Owner->GetName());
 		}
-
-		const bool bNetOwnerHasAuth = NetOwner->HasAuthority();
-
-		// Load balance if we are not supposed to be on this worker, or if we are separated from our owner.
-		if ((!NetDriver->LoadBalanceStrategy->ShouldHaveAuthority(*NetOwner) || !bNetOwnerHasAuth)
-			&& !NetDriver->LockingPolicy->IsLocked(Actor))
+		else if (ActorAuthVirtualWorkerId != TargetVirtualWorkerId)
 		{
-			uint64 HierarchyAuthorityReceivedTimestamp = GetLatestAuthorityChangeFromHierarchy(NetOwner);
-
-			const float TimeSinceReceivingAuthInSeconds =
-				double(FPlatformTime::Cycles64() - HierarchyAuthorityReceivedTimestamp) * FPlatformTime::GetSecondsPerCycle64();
-			const float MigrationBackoffTimeInSeconds = 1.0f;
-
-			if (TimeSinceReceivingAuthInSeconds < MigrationBackoffTimeInSeconds)
-			{
-				UE_LOG(LogSpatialLoadBalancingHandler, Verbose, TEXT("Tried to change auth too early for actor %s"), *Actor->GetName());
-			}
-			else
-			{
-				VirtualWorkerId NewAuthVirtualWorkerId = SpatialConstants::INVALID_VIRTUAL_WORKER_ID;
-				if (bNetOwnerHasAuth)
-				{
-					NewAuthVirtualWorkerId = NetDriver->LoadBalanceStrategy->WhoShouldHaveAuthority(*NetOwner);
-				}
-				else
-				{
-					// If we are separated from our owner, it could be prevented from migrating (if it has interest over the current actor),
-					// so the load balancing strategy could give us a worker different from where it should be.
-					// Instead, we read its currently assigned worker, which will eventually make us land where our owner is.
-					Worker_EntityId OwnerId = NetDriver->PackageMap->GetEntityIdFromObject(NetOwner);
-					if (AuthorityIntent* OwnerAuthIntent = NetDriver->StaticComponentView->GetComponentData<AuthorityIntent>(OwnerId))
-					{
-						NewAuthVirtualWorkerId = OwnerAuthIntent->VirtualWorkerId;
-					}
-					else
-					{
-						UE_LOG(LogSpatialLoadBalancingHandler, Error, TEXT("Actor %s (%llu) cannot join its owner %s (%llu)"),
-							   *Actor->GetName(), EntityId, *NetOwner->GetName(), OwnerId);
-					}
-				}
-
-				if (NewAuthVirtualWorkerId == SpatialConstants::INVALID_VIRTUAL_WORKER_ID)
-				{
-					UE_LOG(LogSpatialLoadBalancingHandler, Error,
-						   TEXT("Load Balancing Strategy returned invalid virtual worker for actor %s"), *Actor->GetName());
-				}
-				else
-				{
-					OutNetOwner = NetOwner;
-					OutWorkerId = NewAuthVirtualWorkerId;
-					return EvaluateActorResult::Migrate;
-				}
-			}
+			UE_LOG(LogRemotePossessionComponent, Log, TEXT("Migrate actor:%s to worker:%d"), *Owner->GetName(), TargetVirtualWorkerId);
+			WorkerId = TargetVirtualWorkerId;
+			return true;
+		}
+		else if (LBStrategy->GetLocalVirtualWorkerId() == TargetVirtualWorkerId)
+		{
+			UE_LOG(LogRemotePossessionComponent, Log, TEXT("Should call AController::Possess"));
+		}
+		else
+		{
+			UE_LOG(LogRemotePossessionComponent, Log,
+				   TEXT("Waiting Controller and Pawn both are OnAuthorityGained and then possessing"));
 		}
 	}
-
-	return EvaluateActorResult::None;
+	else
+	{
+		UE_LOG(LogRemotePossessionComponent, Log, TEXT("Target is:null"));
+	}
+	return false;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
@@ -244,6 +244,11 @@ bool FSpatialLoadBalancingHandler::EvaluateRemoteMigrationComponent(const AActor
 																	UAbstractLBStrategy* LBStrategy,
 																	VirtualWorkerId& WorkerId)
 {
+	if (NetDriver->LockingPolicy->IsLocked(Owner))
+	{
+		return false;
+	}
+
 	if (Target != nullptr)
 	{
 		UE_LOG(LogRemotePossessionComponent, Log, TEXT("Component->Target is:%s"), *Target->GetName());

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
@@ -64,12 +64,6 @@ FSpatialLoadBalancingHandler::EvaluateActorResult FSpatialLoadBalancingHandler::
 						return EvaluateActorResult::None;
 					}
 
-					if (Component->Target->HasAuthority())
-					{
-						Component->Possess();
-						return EvaluateActorResult::None;
-					}
-
 					VirtualWorkerId TargetVirtualWorkerId;
 					if (EvaluateRemoteMigrationComponent(NetOwner, Component->Target, TargetVirtualWorkerId))
 					{

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
@@ -151,6 +151,7 @@ void FSpatialLoadBalancingHandler::LogMigrationFailure(EActorMigrationResult Act
 	}
 }
 
+
 EvaluateActorResult FSpatialLoadBalancingHandler::EvaluateSingleActor_Impl(AActor* Actor, AActor*& OutNetOwner,
 																		   VirtualWorkerId& OutWorkerId)
 {

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
@@ -262,7 +262,8 @@ bool FSpatialLoadBalancingHandler::EvaluateRemoteMigrationComponent(const AActor
 
 		else
 		{
-			UE_LOG(LogSpatialLoadBalancingHandler, Verbose, TEXT("Migrate actor:%s to worker:%d"), *NetOwner->GetName(), TargetVirtualWorkerId);
+			UE_LOG(LogSpatialLoadBalancingHandler, Verbose, TEXT("Migrate actor:%s to worker:%d"), *NetOwner->GetName(),
+				   TargetVirtualWorkerId);
 			WorkerId = TargetVirtualWorkerId;
 			return true;
 		}

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
@@ -56,14 +56,6 @@ FSpatialLoadBalancingHandler::EvaluateActorResult FSpatialLoadBalancingHandler::
 			{
 				if (URemotePossessionComponent* Component = Cast<URemotePossessionComponent>(Components[0]))
 				{
-					if (NetDriver->LockingPolicy->IsLocked(Actor))
-					{
-						UE_LOG(LogSpatialLoadBalancingHandler, Warning, TEXT("Actor %s (%llu) cannot migrate because it is locked"),
-							   *Actor->GetName(), EntityId);
-						Component->DestroyComponent();
-						return EvaluateActorResult::None;
-					}
-
 					VirtualWorkerId TargetVirtualWorkerId;
 					if (EvaluateRemoteMigrationComponent(NetOwner, Component->Target, TargetVirtualWorkerId))
 					{

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
@@ -151,7 +151,6 @@ void FSpatialLoadBalancingHandler::LogMigrationFailure(EActorMigrationResult Act
 	}
 }
 
-
 EvaluateActorResult FSpatialLoadBalancingHandler::EvaluateSingleActor_Impl(AActor* Actor, AActor*& OutNetOwner,
 																		   VirtualWorkerId& OutWorkerId)
 {

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
@@ -58,7 +58,7 @@ FSpatialLoadBalancingHandler::EvaluateActorResult FSpatialLoadBalancingHandler::
 				{
 					if (NetDriver->LockingPolicy->IsLocked(Actor))
 					{
-						UE_LOG(LogRemotePossessionComponent, Warning, TEXT("Actor %s (%llu) cannot migration because of locked"),
+						UE_LOG(LogRemotePossessionComponent, Warning, TEXT("Actor %s (%llu) cannot migrate because it is locked"),
 							   *Actor->GetName(), EntityId);
 						Component->DestroyComponent();
 						return EvaluateActorResult::None;
@@ -259,9 +259,10 @@ bool FSpatialLoadBalancingHandler::EvaluateRemoteMigrationComponent(const AActor
 			UE_LOG(LogSpatialLoadBalancingHandler, Error, TEXT("Load Balancing Strategy returned invalid virtual worker for actor %s"),
 				   *TargetActor->GetName());
 		}
+
 		else
 		{
-			UE_LOG(LogSpatialLoadBalancingHandler, Log, TEXT("Migrate actor:%s to worker:%d"), *NetOwner->GetName(), TargetVirtualWorkerId);
+			UE_LOG(LogSpatialLoadBalancingHandler, Verbose, TEXT("Migrate actor:%s to worker:%d"), *NetOwner->GetName(), TargetVirtualWorkerId);
 			WorkerId = TargetVirtualWorkerId;
 			return true;
 		}

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
@@ -251,11 +251,6 @@ bool FSpatialLoadBalancingHandler::EvaluateRemoteMigrationComponent(const AActor
 {
 	if (TargetActor != nullptr)
 	{
-		if (TargetActor->HasAuthority())
-		{
-			UE_LOG(LogSpatialLoadBalancingHandler, Warning, TEXT("Should call AController::Possess"));
-			return false;
-		}
 		AActor* TargetNetOwner = GetReplicatedHierarchyRoot(TargetActor);
 		VirtualWorkerId TargetVirtualWorkerId = GetWorkerId(TargetNetOwner);
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
@@ -262,7 +262,6 @@ bool FSpatialLoadBalancingHandler::EvaluateRemoteMigrationComponent(const AActor
 {
 	if (TargetActor != nullptr)
 	{
-		
 		AActor* TargetNetOwner = GetReplicatedHierarchyRoot(TargetActor);
 		VirtualWorkerId TargetVirtualWorkerId = GetWorkerId(TargetNetOwner);
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
@@ -56,6 +56,12 @@ FSpatialLoadBalancingHandler::EvaluateActorResult FSpatialLoadBalancingHandler::
 			{
 				if (URemotePossessionComponent* Component = Cast<URemotePossessionComponent>(Components[0]))
 				{
+					if (NetDriver->LockingPolicy->IsLocked(Actor))
+					{
+						UE_LOG(LogSpatialLoadBalancingHandler, Verbose, TEXT("Actor %s (%llu) cannot migrate because it is locked"),
+							   *Actor->GetName(), EntityId);
+						return EvaluateActorResult::None;
+					}
 					VirtualWorkerId TargetVirtualWorkerId;
 					if (EvaluateRemoteMigrationComponent(NetOwner, Component->Target, TargetVirtualWorkerId))
 					{

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
@@ -256,7 +256,6 @@ bool FSpatialLoadBalancingHandler::EvaluateRemoteMigrationComponent(const AActor
 			UE_LOG(LogSpatialLoadBalancingHandler, Warning, TEXT("Should call AController::Possess"));
 			return false;
 		}
-		VirtualWorkerId ActorAuthVirtualWorkerId = GetWorkerId(NetOwner);
 		AActor* TargetNetOwner = GetReplicatedHierarchyRoot(TargetActor);
 		VirtualWorkerId TargetVirtualWorkerId = GetWorkerId(TargetNetOwner);
 
@@ -265,16 +264,11 @@ bool FSpatialLoadBalancingHandler::EvaluateRemoteMigrationComponent(const AActor
 			UE_LOG(LogSpatialLoadBalancingHandler, Error, TEXT("Load Balancing Strategy returned invalid virtual worker for actor %s"),
 				   *TargetActor->GetName());
 		}
-		else if (ActorAuthVirtualWorkerId != TargetVirtualWorkerId)
+		else
 		{
 			UE_LOG(LogSpatialLoadBalancingHandler, Log, TEXT("Migrate actor:%s to worker:%d"), *NetOwner->GetName(), TargetVirtualWorkerId);
 			WorkerId = TargetVirtualWorkerId;
 			return true;
-		}
-		else
-		{
-			UE_LOG(LogSpatialLoadBalancingHandler, Warning, TEXT("Actor:%s and Target:%s are in same worker %d"), *NetOwner->GetName(),
-				   *TargetActor->GetName(), TargetVirtualWorkerId);
 		}
 	}
 	else

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
@@ -24,18 +24,12 @@ FSpatialLoadBalancingHandler::FSpatialLoadBalancingHandler(USpatialNetDriver* In
 FSpatialLoadBalancingHandler::EvaluateActorResult FSpatialLoadBalancingHandler::EvaluateSingleActor(AActor* Actor, AActor*& OutNetOwner,
 																									VirtualWorkerId& OutWorkerId)
 {
-	const Worker_EntityId EntityId = NetDriver->PackageMap->GetEntityIdFromObject(Actor);
-	if (EntityId == SpatialConstants::INVALID_ENTITY_ID)
-	{
-		return EvaluateActorResult::None;
-	}
-
 	if (!Actor->HasAuthority())
 	{
 		return EvaluateActorResult::None;
 	}
 
-	return EvaluateSingleActor_Impl(Actor, OutNetOwner, OutWorkerId);
+	return EvaluateActor(Actor, OutNetOwner, OutWorkerId);
 }
 
 void FSpatialLoadBalancingHandler::ProcessMigrations()
@@ -151,9 +145,15 @@ void FSpatialLoadBalancingHandler::LogMigrationFailure(EActorMigrationResult Act
 	}
 }
 
-EvaluateActorResult FSpatialLoadBalancingHandler::EvaluateSingleActor_Impl(AActor* Actor, AActor*& OutNetOwner,
-																		   VirtualWorkerId& OutWorkerId)
+FSpatialLoadBalancingHandler::EvaluateActorResult FSpatialLoadBalancingHandler::EvaluateActor(AActor* Actor, AActor*& OutNetOwner,
+																							  VirtualWorkerId& OutWorkerId)
 {
+	const Worker_EntityId EntityId = NetDriver->PackageMap->GetEntityIdFromObject(Actor);
+	if (EntityId == SpatialConstants::INVALID_ENTITY_ID)
+	{
+		return EvaluateActorResult::None;
+	}
+
 	UpdateSpatialDebugInfo(Actor, EntityId);
 
 	// If this object is in the list of actors to migrate, we have already processed its hierarchy.
@@ -175,8 +175,7 @@ EvaluateActorResult FSpatialLoadBalancingHandler::EvaluateSingleActor_Impl(AActo
 			{
 				if (URemotePossessionComponent* Component = Cast<URemotePossessionComponent>(Components[0]))
 				{
-					VirtualWorkerId TargetVirtualWorkerId;
-					return EvaluateSingleActor_Impl(Component->Target, NetOwner, OutWorkerId);
+					return EvaluateActor(Component->Target, NetOwner, OutWorkerId);
 				}
 			}
 		}

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
@@ -58,8 +58,8 @@ FSpatialLoadBalancingHandler::EvaluateActorResult FSpatialLoadBalancingHandler::
 				if (URemotePossessionComponent* Component = Cast<URemotePossessionComponent>(Components[0]))
 				{
 					VirtualWorkerId TargetVirtualWorkerId;
-					if (EvaluateRemoteMigrationComponent(Component->GetOwner(), Component->Target,
-														 NetDriver->LoadBalanceStrategy, TargetVirtualWorkerId))
+					if (EvaluateRemoteMigrationComponent(Component->GetOwner(), Component->Target, NetDriver->LoadBalanceStrategy,
+														 TargetVirtualWorkerId))
 					{
 						OutNetOwner = NetOwner;
 						OutWorkerId = TargetVirtualWorkerId;
@@ -241,8 +241,7 @@ void FSpatialLoadBalancingHandler::LogMigrationFailure(EActorMigrationResult Act
 }
 
 bool FSpatialLoadBalancingHandler::EvaluateRemoteMigrationComponent(const AActor* Owner, const AActor* Target,
-																	UAbstractLBStrategy* LBStrategy,
-																	VirtualWorkerId& WorkerId)
+																	UAbstractLBStrategy* LBStrategy, VirtualWorkerId& WorkerId)
 {
 	if (NetDriver->LockingPolicy->IsLocked(Owner))
 	{
@@ -272,8 +271,7 @@ bool FSpatialLoadBalancingHandler::EvaluateRemoteMigrationComponent(const AActor
 		}
 		else
 		{
-			UE_LOG(LogRemotePossessionComponent, Log,
-				   TEXT("Waiting Controller and Pawn both are OnAuthorityGained and then possessing"));
+			UE_LOG(LogRemotePossessionComponent, Log, TEXT("Waiting Controller and Pawn both are OnAuthorityGained and then possessing"));
 		}
 	}
 	else

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
@@ -246,7 +246,8 @@ void FSpatialLoadBalancingHandler::LogMigrationFailure(EActorMigrationResult Act
 	}
 }
 
-bool FSpatialLoadBalancingHandler::EvaluateRemoteMigrationComponent(const AActor* NetOwner, const AActor* TargetActor, VirtualWorkerId& WorkerId)
+bool FSpatialLoadBalancingHandler::EvaluateRemoteMigrationComponent(const AActor* NetOwner, const AActor* TargetActor,
+																	VirtualWorkerId& WorkerId)
 {
 	if (TargetActor != nullptr)
 	{

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/RemotePossessionComponent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/RemotePossessionComponent.h
@@ -15,7 +15,7 @@ class UAbstractLBStrategy;
  A generic feature for Cross-Server Possession
  This component should be attached to a player controller.
  */
-UCLASS(ClassGroup = (SpatialGDK), Meta = (BlueprintSpawnableComponent))
+UCLASS(Blueprintable, ClassGroup = (SpatialGDK), meta = (DisplayName = "Remote Possession"), Meta = (BlueprintSpawnableComponent))
 class SPATIALGDK_API URemotePossessionComponent : public UActorComponent
 {
 	GENERATED_UCLASS_BODY()
@@ -24,16 +24,20 @@ public:
 
 	virtual bool EvaluatePossess();
 
-	virtual bool EvaluateMigration(UAbstractLBStrategy* LBStrategy, VirtualWorkerId& WorkerId);
+	bool EvaluateMigration(UAbstractLBStrategy* LBStrategy, VirtualWorkerId& WorkerId);
 
 	virtual void TickComponent(float DeltaTime, enum ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
 
 protected:
+	UFUNCTION(BlueprintImplementableEvent, meta = (DisplayName = "Evaluate Possess"))
+	bool ReceiveEvaluatePossess();
+
 	void Possess();
 
+	UFUNCTION(BlueprintCallable, Category = "Utilities")
 	void MarkToDestroy();
 public:
-	UPROPERTY(handover)
+	UPROPERTY(Category = Sprite, handover, EditAnywhere, BlueprintReadOnly)
 	APawn* Target;
 
 private:

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/RemotePossessionComponent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/RemotePossessionComponent.h
@@ -30,6 +30,7 @@ public:
 	UFUNCTION(BlueprintNativeEvent, Category = "RemotePossessionComponent", meta = (DisplayName = "OnInvalidTarget"))
 	void OnInvalidTarget();
 
+	void Possess();
 protected:
 	UFUNCTION(BlueprintCallable, Category = "Utilities")
 	void MarkToDestroy();
@@ -39,5 +40,5 @@ public:
 	APawn* Target;
 
 private:
-	bool PendingDestroy;
+	bool bPendingDestroy;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/RemotePossessionComponent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/RemotePossessionComponent.h
@@ -32,6 +32,8 @@ public:
 
 	void Possess();
 
+	virtual void BeginPlay() override;
+
 protected:
 	UFUNCTION(BlueprintCallable, Category = "Utilities")
 	void MarkToDestroy();

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/RemotePossessionComponent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/RemotePossessionComponent.h
@@ -22,14 +22,16 @@ class SPATIALGDK_API URemotePossessionComponent : public UActorComponent
 public:
 	virtual void OnAuthorityGained() override;
 
-	virtual void Possess();
-
-	virtual bool EvaluatePossess(AController* CurrentController, AController* WantController);
+	virtual bool EvaluatePossess();
 
 	virtual bool EvaluateMigration(UAbstractLBStrategy* LBStrategy, VirtualWorkerId& WorkerId);
 
 	virtual void TickComponent(float DeltaTime, enum ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
 
+protected:
+	void Possess();
+
+	void MarkToDestroy();
 public:
 	UPROPERTY(handover)
 	APawn* Target;

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/RemotePossessionComponent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/RemotePossessionComponent.h
@@ -27,6 +27,9 @@ public:
 
 	virtual void TickComponent(float DeltaTime, enum ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
 
+	UFUNCTION(BlueprintNativeEvent, Category = "RemotePossessionComponent", meta = (DisplayName = "OnInvalidTarget"))
+	void OnInvalidTarget();
+
 protected:
 	UFUNCTION(BlueprintCallable, Category = "Utilities")
 	void MarkToDestroy();

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/RemotePossessionComponent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/RemotePossessionComponent.h
@@ -36,6 +36,7 @@ protected:
 
 	UFUNCTION(BlueprintCallable, Category = "Utilities")
 	void MarkToDestroy();
+
 public:
 	UPROPERTY(Category = Sprite, handover, EditAnywhere, BlueprintReadOnly)
 	APawn* Target;

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/RemotePossessionComponent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/RemotePossessionComponent.h
@@ -22,14 +22,12 @@ class SPATIALGDK_API URemotePossessionComponent : public UActorComponent
 public:
 	virtual void OnAuthorityGained() override;
 
-	virtual bool EvaluatePossess();
+	UFUNCTION(BlueprintNativeEvent, Category = "RemotePossessionComponent", meta = (DisplayName = "Evaluate Possess"))
+	bool EvaluatePossess();
 
 	virtual void TickComponent(float DeltaTime, enum ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
 
 protected:
-	UFUNCTION(BlueprintImplementableEvent, meta = (DisplayName = "Evaluate Possess"))
-	bool ReceiveEvaluatePossess();
-
 	UFUNCTION(BlueprintCallable, Category = "Utilities")
 	void MarkToDestroy();
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/RemotePossessionComponent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/RemotePossessionComponent.h
@@ -24,21 +24,17 @@ public:
 
 	virtual bool EvaluatePossess();
 
-	bool EvaluateMigration(UAbstractLBStrategy* LBStrategy, VirtualWorkerId& WorkerId);
-
 	virtual void TickComponent(float DeltaTime, enum ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
 
 protected:
 	UFUNCTION(BlueprintImplementableEvent, meta = (DisplayName = "Evaluate Possess"))
 	bool ReceiveEvaluatePossess();
 
-	void Possess();
-
 	UFUNCTION(BlueprintCallable, Category = "Utilities")
 	void MarkToDestroy();
 
 public:
-	UPROPERTY(Category = Sprite, handover, EditAnywhere, BlueprintReadOnly)
+	UPROPERTY(Category = Sprite, handover, EditAnywhere, BlueprintReadWrite)
 	APawn* Target;
 
 private:

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/RemotePossessionComponent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/RemotePossessionComponent.h
@@ -1,0 +1,39 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "Components/ActorComponent.h"
+#include "CoreMinimal.h"
+#include "SpatialCommonTypes.h"
+
+#include "RemotePossessionComponent.generated.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogRemotePossessionComponent, Log, All);
+
+class UAbstractLBStrategy;
+/*
+ A generic feature for Cross-Server Possession
+ This component should be attached to a player controller.
+ */
+UCLASS(ClassGroup = (SpatialGDK), Meta = (BlueprintSpawnableComponent))
+class SPATIALGDK_API URemotePossessionComponent : public UActorComponent
+{
+	GENERATED_UCLASS_BODY()
+public:
+	virtual void OnAuthorityGained() override;
+
+	virtual void Possess();
+
+	virtual bool EvaluatePossess(AController* CurrentController, AController* WantController);
+
+	virtual bool EvaluateMigration(UAbstractLBStrategy* LBStrategy, VirtualWorkerId& WorkerId);
+
+	virtual void TickComponent(float DeltaTime, enum ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
+
+public:
+	UPROPERTY(handover)
+	APawn* Target;
+
+private:
+	bool PendingDestroy;
+};

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/RemotePossessionComponent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/RemotePossessionComponent.h
@@ -31,6 +31,7 @@ public:
 	void OnInvalidTarget();
 
 	void Possess();
+
 protected:
 	UFUNCTION(BlueprintCallable, Category = "Utilities")
 	void MarkToDestroy();

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLoadBalancingHandler.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLoadBalancingHandler.h
@@ -105,6 +105,9 @@ protected:
 
 	void LogMigrationFailure(EActorMigrationResult ActorMigrationResult, AActor* Actor);
 
+	bool EvaluateRemoteMigrationComponent(const AActor* Owner, const AActor* Target, UAbstractLBStrategy* LBStrategy,
+										  VirtualWorkerId& WorkerId);
+
 	USpatialNetDriver* NetDriver;
 
 	TMap<AActor*, VirtualWorkerId> ActorsToMigrate;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLoadBalancingHandler.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLoadBalancingHandler.h
@@ -105,7 +105,7 @@ protected:
 
 	void LogMigrationFailure(EActorMigrationResult ActorMigrationResult, AActor* Actor);
 
-	EvaluateActorResult EvaluateActor(AActor* Actor, AActor*& OutNetOwner, VirtualWorkerId& OutWorkerId);
+	EvaluateActorResult EvaluateSingleActor_Impl(AActor* Actor, AActor*& OutNetOwner, VirtualWorkerId& OutWorkerId);
 
 	USpatialNetDriver* NetDriver;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLoadBalancingHandler.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLoadBalancingHandler.h
@@ -105,8 +105,7 @@ protected:
 
 	void LogMigrationFailure(EActorMigrationResult ActorMigrationResult, AActor* Actor);
 
-	bool EvaluateRemoteMigrationComponent(const AActor* NetOwner, const AActor* Target,
-										  VirtualWorkerId& WorkerId);
+	bool EvaluateRemoteMigrationComponent(const AActor* NetOwner, const AActor* Target, VirtualWorkerId& WorkerId);
 
 	VirtualWorkerId GetWorkerId(const AActor* NetOwner);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLoadBalancingHandler.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLoadBalancingHandler.h
@@ -105,7 +105,7 @@ protected:
 
 	void LogMigrationFailure(EActorMigrationResult ActorMigrationResult, AActor* Actor);
 
-	EvaluateActorResult EvaluateSingleActor_Impl(AActor* Actor, AActor*& OutNetOwner, VirtualWorkerId& OutWorkerId);
+	EvaluateActorResult EvaluateActor(AActor* Actor, AActor*& OutNetOwner, VirtualWorkerId& OutWorkerId);
 
 	USpatialNetDriver* NetDriver;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLoadBalancingHandler.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLoadBalancingHandler.h
@@ -105,7 +105,8 @@ protected:
 
 	void LogMigrationFailure(EActorMigrationResult ActorMigrationResult, AActor* Actor);
 
-	EvaluateActorResult EvaluateSingleActor_Impl(AActor* Actor, AActor*& OutNetOwner, VirtualWorkerId& OutWorkerId);
+	bool EvaluateRemoteMigrationComponent(const AActor* Owner, const AActor* Target, UAbstractLBStrategy* LBStrategy,
+										  VirtualWorkerId& WorkerId);
 
 	USpatialNetDriver* NetDriver;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLoadBalancingHandler.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLoadBalancingHandler.h
@@ -105,7 +105,7 @@ protected:
 
 	void LogMigrationFailure(EActorMigrationResult ActorMigrationResult, AActor* Actor);
 
-	bool EvaluateRemoteMigrationComponent(const AActor* NetOwner, const AActor* Target, VirtualWorkerId& WorkerId);
+	bool EvaluateRemoteMigrationComponent(const AActor* NetOwner, const AActor* Target, VirtualWorkerId& OutWorkerId);
 
 	VirtualWorkerId GetWorkerId(const AActor* NetOwner);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLoadBalancingHandler.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLoadBalancingHandler.h
@@ -105,8 +105,10 @@ protected:
 
 	void LogMigrationFailure(EActorMigrationResult ActorMigrationResult, AActor* Actor);
 
-	bool EvaluateRemoteMigrationComponent(const AActor* Owner, const AActor* Target, UAbstractLBStrategy* LBStrategy,
+	bool EvaluateRemoteMigrationComponent(const AActor* NetOwner, const AActor* Target,
 										  VirtualWorkerId& WorkerId);
+
+	VirtualWorkerId GetWorkerId(const AActor* NetOwner);
 
 	USpatialNetDriver* NetDriver;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLoadBalancingHandler.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLoadBalancingHandler.h
@@ -105,8 +105,7 @@ protected:
 
 	void LogMigrationFailure(EActorMigrationResult ActorMigrationResult, AActor* Actor);
 
-	bool EvaluateRemoteMigrationComponent(const AActor* Owner, const AActor* Target, UAbstractLBStrategy* LBStrategy,
-										  VirtualWorkerId& WorkerId);
+	EvaluateActorResult EvaluateSingleActor_Impl(AActor* Actor, AActor*& OutNetOwner, VirtualWorkerId& OutWorkerId);
 
 	USpatialNetDriver* NetDriver;
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
@@ -20,6 +20,7 @@
  * This test expects a 2x2 load balancing grid and ACrossServerPossessionGameMode
  * The client workers begin with a player controller and their default pawns, which they initially possess.
  * The flow is as follows:
+ *	Recommend to use PossessionGym.umap in UnrealGDKTestGyms project which ready for tests.
  *  - Setup:
  *    - Specify `GameMode Override` as ACrossServerPossessionGameMode
  *    - Specify `Multi Worker Settings Class` as Zoning 2x2(e.g. BP_Possession_Settings_Zoning2_2 of UnrealGDKTestGyms)
@@ -39,7 +40,8 @@ void ACrossServerMultiPossessionTest::PrepareTest()
 {
 	ASpatialTestRemotePossession::PrepareTest();
 
-	AddStep(TEXT("Controller remote possess"), FWorkerDefinition::AllClients, nullptr, nullptr, [this](float DeltaTime) {
+	AddStep(TEXT("Controller remote possess"), FWorkerDefinition::AllClients, nullptr,nullptr,
+			[this](float DeltaTime) {
 		ATestPossessionPawn* Pawn = GetPawn();
 		AssertIsValid(Pawn, TEXT("Test requires a Pawn"));
 		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
@@ -56,17 +58,13 @@ void ACrossServerMultiPossessionTest::PrepareTest()
 		FinishStep();
 	});
 
-	// Make sure all the workers can check the results
-	AddWaitStep(FWorkerDefinition::AllServers);
-
-	AddStep(TEXT("Check results on all servers"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float DeltaTime) {
-		ATestPossessionPawn* Pawn = GetPawn();
-		AssertIsValid(Pawn, TEXT("Test requires a Pawn"));
-
-		AssertIsValid(Pawn->GetController(), TEXT("Pawn should have a controller"), Pawn);
-
-		AssertValue_Int(ATestPossessionPlayerController::OnPossessCalled, EComparisonMethod::Equal_To, 1,
-						TEXT("OnPossess should be called 1 time"));
+	AddStep(
+		TEXT("Check results on all servers"), FWorkerDefinition::AllServers,
+		[this]() -> bool {
+			return ATestPossessionPlayerController::OnPossessCalled == GetNumRequiredClients();
+		},
+		nullptr,
+		[this](float DeltaTime) {
 		FinishStep();
 	});
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
@@ -26,7 +26,12 @@
  *    - Specify `Multi Worker Settings Class` as Zoning 2x2(e.g. BP_Possession_Settings_Zoning2_2 of UnrealGDKTestGyms)
  *	  - Set `Num Required Clients` as 2 or more
  *  - Test:
- *    - One of Controller possessed the Pawn and others failed
+ *	  - Create a Pawn in first quadrant
+ *	  - Create Controllers in other quadrant, the position is determined by ACrossServerPossessionGameMode
+ *	  - Wait for Pawn and Controllers in right worker.
+ *	  -	The Controller possess the Pawn
+ *	- Result Check:
+ *    - ATestPossessionPlayerController::OnPossess should be called `Num Required Clients` times
  */
 
 ACrossServerMultiPossessionTest::ACrossServerMultiPossessionTest()
@@ -40,8 +45,7 @@ void ACrossServerMultiPossessionTest::PrepareTest()
 {
 	ASpatialTestRemotePossession::PrepareTest();
 
-	AddStep(TEXT("Controller remote possess"), FWorkerDefinition::AllClients, nullptr,nullptr,
-			[this](float DeltaTime) {
+	AddStep(TEXT("Controller remote possess"), FWorkerDefinition::AllClients, nullptr, nullptr, [this](float DeltaTime) {
 		ATestPossessionPawn* Pawn = GetPawn();
 		AssertIsValid(Pawn, TEXT("Test requires a Pawn"));
 		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
@@ -65,6 +69,6 @@ void ACrossServerMultiPossessionTest::PrepareTest()
 		},
 		nullptr,
 		[this](float DeltaTime) {
-		FinishStep();
-	});
+			FinishStep();
+		});
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
@@ -50,7 +50,7 @@ void ACrossServerMultiPossessionTest::PrepareTest()
 				if (Controller != nullptr)
 				{
 					Controller->RemotePossessOnClient(Pawn);
-				}				
+				}
 			}
 		}
 		FinishStep();

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
@@ -7,7 +7,6 @@
 #include "GameFramework/GameModeBase.h"
 #include "GameFramework/PlayerController.h"
 #include "GameMapsSettings.h"
-#include "LoadBalancing/LayeredLBStrategy.h"
 #include "SpatialFunctionalTestFlowController.h"
 #include "SpatialGDKFunctionalTests/SpatialGDK/TestActors/TestMovementCharacter.h"
 #include "TestPossessionPawn.h"
@@ -15,7 +14,7 @@
 #include "Utils/SpatialStatics.h"
 
 /**
- * This test tests multi Controllers possess over 1 Pawn.
+ * This test tests multi Controllers remote possess over 1 Pawn.
  *
  * This test expects a 2x2 load balancing grid and ACrossServerPossessionGameMode
  * The client workers begin with a player controller and their default pawns, which they initially possess.
@@ -69,6 +68,17 @@ void ACrossServerMultiPossessionTest::PrepareTest()
 		},
 		nullptr,
 		[this](float DeltaTime) {
+			for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
+			{
+				if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
+				{
+					ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
+					if (PlayerController && PlayerController->HasAuthority())
+					{
+						AssertTrue(PlayerController->IsMigration(), TEXT("PlayerController should migration"), PlayerController);
+					}
+				}
+			}
 			FinishStep();
 		});
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
@@ -15,15 +15,15 @@
 #include "Utils/SpatialStatics.h"
 
 /**
- * This test tests multi clients possession over 1 pawns.
+ * This test tests multi Controllers possess over 1 Pawn.
  *
- * The test includes 2x2 gridbase servers and at least two client workers.
+ * This test expects a 2x2 load balancing grid and ACrossServerPossessionGameMode
  * The client workers begin with a player controller and their default pawns, which they initially possess.
  * The flow is as follows:
  *  - Setup:
  *    - Specify `GameMode Override` as ACrossServerPossessionGameMode
  *    - Specify `Multi Worker Settings Class` as Zoning 2x2(e.g. BP_Possession_Settings_Zoning2_2 of UnrealGDKTestGyms)
- *	  - Set `Num Required Clients` as 3
+ *	  - Set `Num Required Clients` as 2 or more
  *  - Test:
  *    - One of Controller possessed the Pawn and others failed
  */

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
@@ -1,0 +1,191 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "CrossServerMultiPossessionTest.h"
+
+#include "Containers/Array.h"
+#include "EngineClasses/SpatialNetDriver.h"
+#include "GameFramework/GameModeBase.h"
+#include "GameFramework/PlayerController.h"
+#include "GameMapsSettings.h"
+#include "Kismet/GameplayStatics.h"
+#include "LoadBalancing/LayeredLBStrategy.h"
+#include "SpatialFunctionalTestFlowController.h"
+#include "SpatialGDKFunctionalTests/SpatialGDK/TestActors/TestMovementCharacter.h"
+#include "TestPossessionPawn.h"
+#include "TestPossessionPlayerController.h"
+#include "Utils/SpatialStatics.h"
+
+/**
+ * This test tests multi clients possession over 1 pawns.
+ *
+ * The test includes 2x2 gridbase servers and at least two client workers.
+ * The client workers begin with a player controller and their default pawns, which they initially possess.
+ * The flow is as follows:
+ *  - Setup:
+ *    - Specify `GameMode Override` as ACrossServerPossessionGameMode
+ *    - Specify `Multi Worker Settings Class` as Zoning 2x2(e.g. BP_Possession_Settings_Zoning2_2 of UnrealGDKTestGyms)
+ *	  - Set `Num Required Clients` as 3
+ *  - Test:
+ *    - One of Controller possessed the Pawn and others failed
+ */
+
+const float ACrossServerMultiPossessionTest::MaxWaitTime = 2.0f;
+
+ACrossServerMultiPossessionTest::ACrossServerMultiPossessionTest()
+	: Super()
+	, WaitTime(0.0f)
+{
+	Author = "Ken.Yu";
+	Description = TEXT("Test Cross-Server 3 Controllers Possess 1 Pawn");
+}
+
+void ACrossServerMultiPossessionTest::PrepareTest()
+{
+	Super::PrepareTest();
+
+	ATestPossessionPlayerController::ResetCalledCounter();
+
+	AddStep(TEXT("EnsureSpatialOS"), FWorkerDefinition::AllServers, nullptr, [this]() {
+		ULayeredLBStrategy* LoadBalanceStrategy = GetLoadBalancingStrategy();
+		if (LoadBalanceStrategy == nullptr)
+		{
+			FinishTest(EFunctionalTestResult::Error, TEXT("Test requires SpatialOS enabled with Load-Balancing Strategy"));
+		}
+		else
+		{
+			if (AGameModeBase* GameMode = Cast<AGameModeBase>(AGameModeBase::StaticClass()->GetDefaultObject()))
+			{
+				LogStep(ELogVerbosity::Log, FString::Printf(TEXT("GameMode:%s"), *GameMode->GetFullName()));
+			}
+			FinishStep();
+		}
+	});
+
+	AddStep(TEXT("Create Pawn"), FWorkerDefinition::Server(1), nullptr, nullptr, [this](float DeltaTime) {
+		ATestPossessionPawn* Pawn =
+			GetWorld()->SpawnActor<ATestPossessionPawn>(FVector(500.0f, 500.0f, 50.0f), FRotator::ZeroRotator, FActorSpawnParameters());
+		RegisterAutoDestroyActor(Pawn);
+		FinishStep();
+	});
+
+	// Make sure all the Controller and Pawn authoritative in right workers
+	AddWaitStep(FWorkerDefinition::AllClients);
+
+	AddStep(TEXT("Shown who should have authority"), FWorkerDefinition::Server(1), nullptr, nullptr, [this](float DeltaTime) {
+		ULayeredLBStrategy* LoadBalanceStrategy = GetLoadBalancingStrategy();
+		if (LoadBalanceStrategy != nullptr)
+		{
+			if (ATestPossessionPawn* Pawn = GetPawn())
+			{
+				for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
+				{
+					AController* Controller = Cast<AController>(FlowController->GetOwner());
+					if (Controller != nullptr)
+					{
+						uint32 WorkerId = LoadBalanceStrategy->WhoShouldHaveAuthority(*Controller);
+						LogStep(ELogVerbosity::Log,
+								FString::Printf(TEXT("Controller:%s authoritatived in worker: %d"), *Controller->GetFullName(), WorkerId));
+					}
+				}
+
+				uint32 WorkerId = LoadBalanceStrategy->WhoShouldHaveAuthority(*Pawn);
+				LogStep(ELogVerbosity::Log,
+						FString::Printf(TEXT("Pawn:%s authoritatived in worker: %d"), *GetPawn()->GetFullName(), WorkerId));
+			}
+			else
+			{
+				FinishTest(EFunctionalTestResult::Error, TEXT("Couldn't found pawn for possession"));
+			}
+		}
+		else
+		{
+			FinishTest(EFunctionalTestResult::Error, TEXT("Test requires SpatialOS enabled with Load-Balancing Strategy"));
+		}
+		FinishStep();
+	});
+
+	AddStep(TEXT("Controller remote possess"), FWorkerDefinition::AllClients, nullptr, nullptr, [this](float DeltaTime) {
+		if (ATestPossessionPawn* Pawn = GetPawn())
+		{
+			for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
+			{
+				if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
+				{
+					ATestPossessionPlayerController* Controller = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
+					if (Controller != nullptr)
+					{
+						Controller->RemotePossess(Pawn);
+					}
+				}
+			}
+		}
+		FinishStep();
+	});
+
+	// Make sure all the workers can check the results
+	AddWaitStep(FWorkerDefinition::AllServers);
+
+	AddStep(TEXT("Check results on all servers"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float DeltaTime) {
+		if (ATestPossessionPawn* Pawn = GetPawn())
+		{
+			AssertTrue(Pawn->GetController() != nullptr, TEXT("GetController of Pawn to check if possessed on server"), Pawn);
+
+			AssertTrue(ATestPossessionPlayerController::OnPossessCalled == 1, TEXT("OnPossess should be called 1 time"));
+			// int OnPossessFailedCalled = GetNumRequiredClients() - 1;
+			// AssertTrue(ATestPossessionPlayerController::OnPossessFailedCalled == OnPossessFailedCalled,
+			//		   FString::Printf(TEXT("OnPossessFailed should be called %d times"), OnPossessFailedCalled));
+		}
+		else
+		{
+			LogStep(ELogVerbosity::Log, TEXT("Couldn't found pawn for possession"));
+		}
+		FinishStep();
+	});
+}
+
+ATestPossessionPawn* ACrossServerMultiPossessionTest::GetPawn()
+{
+	return Cast<ATestPossessionPawn>(UGameplayStatics::GetActorOfClass(GetWorld(), ATestPossessionPawn::StaticClass()));
+}
+
+void ACrossServerMultiPossessionTest::CreateController(int Index, FVector Position)
+{
+	ASpatialFunctionalTestFlowController* FlowController = GetFlowController(ESpatialFunctionalTestWorkerType::Client, Index);
+	ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
+	if (IsValid(PlayerController))
+	{
+		ATestMovementCharacter* Character =
+			GetWorld()->SpawnActor<ATestMovementCharacter>(Position, FRotator::ZeroRotator, FActorSpawnParameters());
+		RegisterAutoDestroyActor(Character);
+		PlayerController->RemotePossessOnServer(Character);
+	}
+	else
+	{
+		FinishTest(EFunctionalTestResult::Error, TEXT("Failed to get PlayerController"));
+	}
+}
+
+void ACrossServerMultiPossessionTest::CheckControllerHasAuthority(int Index)
+{
+	ASpatialFunctionalTestFlowController* FlowController = GetFlowController(ESpatialFunctionalTestWorkerType::Client, Index);
+	ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
+	if (IsValid(PlayerController))
+	{
+		AssertTrue(PlayerController->HasAuthority(), TEXT("PlayerController HasAuthority"), PlayerController);
+	}
+	else
+	{
+		FinishTest(EFunctionalTestResult::Error, TEXT("Failed to get PlayerController"));
+	}
+}
+
+void ACrossServerMultiPossessionTest::AddWaitStep(const FWorkerDefinition& Worker)
+{
+	AddStep(TEXT("Wait"), Worker, nullptr, nullptr, [this](float DeltaTime) {
+		if (WaitTime > MaxWaitTime)
+		{
+			FinishStep();
+		}
+		WaitTime += DeltaTime;
+	});
+}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
@@ -7,7 +7,6 @@
 #include "GameFramework/GameModeBase.h"
 #include "GameFramework/PlayerController.h"
 #include "GameMapsSettings.h"
-#include "Kismet/GameplayStatics.h"
 #include "LoadBalancing/LayeredLBStrategy.h"
 #include "SpatialFunctionalTestFlowController.h"
 #include "SpatialGDKFunctionalTests/SpatialGDK/TestActors/TestMovementCharacter.h"
@@ -29,94 +28,27 @@
  *    - One of Controller possessed the Pawn and others failed
  */
 
-const float ACrossServerMultiPossessionTest::MaxWaitTime = 2.0f;
-
 ACrossServerMultiPossessionTest::ACrossServerMultiPossessionTest()
 	: Super()
-	, WaitTime(0.0f)
 {
 	Author = "Ken.Yu";
-	Description = TEXT("Test Cross-Server 3 Controllers Possess 1 Pawn");
+	Description = TEXT("Test Cross-Server Multi Controllers Possess 1 Pawn");
 }
 
 void ACrossServerMultiPossessionTest::PrepareTest()
 {
-	Super::PrepareTest();
-
-	ATestPossessionPlayerController::ResetCalledCounter();
-
-	AddStep(TEXT("EnsureSpatialOS"), FWorkerDefinition::AllServers, nullptr, [this]() {
-		ULayeredLBStrategy* LoadBalanceStrategy = GetLoadBalancingStrategy();
-		if (LoadBalanceStrategy == nullptr)
-		{
-			FinishTest(EFunctionalTestResult::Error, TEXT("Test requires SpatialOS enabled with Load-Balancing Strategy"));
-		}
-		else
-		{
-			if (AGameModeBase* GameMode = Cast<AGameModeBase>(AGameModeBase::StaticClass()->GetDefaultObject()))
-			{
-				LogStep(ELogVerbosity::Log, FString::Printf(TEXT("GameMode:%s"), *GameMode->GetFullName()));
-			}
-			FinishStep();
-		}
-	});
-
-	AddStep(TEXT("Create Pawn"), FWorkerDefinition::Server(1), nullptr, nullptr, [this](float DeltaTime) {
-		ATestPossessionPawn* Pawn =
-			GetWorld()->SpawnActor<ATestPossessionPawn>(FVector(500.0f, 500.0f, 50.0f), FRotator::ZeroRotator, FActorSpawnParameters());
-		RegisterAutoDestroyActor(Pawn);
-		FinishStep();
-	});
-
-	// Make sure all the Controller and Pawn authoritative in right workers
-	AddWaitStep(FWorkerDefinition::AllClients);
-
-	AddStep(TEXT("Shown who should have authority"), FWorkerDefinition::Server(1), nullptr, nullptr, [this](float DeltaTime) {
-		ULayeredLBStrategy* LoadBalanceStrategy = GetLoadBalancingStrategy();
-		if (LoadBalanceStrategy != nullptr)
-		{
-			if (ATestPossessionPawn* Pawn = GetPawn())
-			{
-				for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
-				{
-					AController* Controller = Cast<AController>(FlowController->GetOwner());
-					if (Controller != nullptr)
-					{
-						uint32 WorkerId = LoadBalanceStrategy->WhoShouldHaveAuthority(*Controller);
-						LogStep(ELogVerbosity::Log,
-								FString::Printf(TEXT("Controller:%s authoritatived in worker: %d"), *Controller->GetFullName(), WorkerId));
-					}
-				}
-
-				uint32 WorkerId = LoadBalanceStrategy->WhoShouldHaveAuthority(*Pawn);
-				LogStep(ELogVerbosity::Log,
-						FString::Printf(TEXT("Pawn:%s authoritatived in worker: %d"), *GetPawn()->GetFullName(), WorkerId));
-			}
-			else
-			{
-				FinishTest(EFunctionalTestResult::Error, TEXT("Couldn't found pawn for possession"));
-			}
-		}
-		else
-		{
-			FinishTest(EFunctionalTestResult::Error, TEXT("Test requires SpatialOS enabled with Load-Balancing Strategy"));
-		}
-		FinishStep();
-	});
+	ASpatialTestRemotePossession::PrepareTest();
 
 	AddStep(TEXT("Controller remote possess"), FWorkerDefinition::AllClients, nullptr, nullptr, [this](float DeltaTime) {
-		if (ATestPossessionPawn* Pawn = GetPawn())
+		ATestPossessionPawn* Pawn = GetPawn();
+		AssertIsValid(Pawn, TEXT("Test requires a Pawn"));
+		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
 		{
-			for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
+			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
 			{
-				if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
-				{
-					ATestPossessionPlayerController* Controller = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
-					if (Controller != nullptr)
-					{
-						Controller->RemotePossess(Pawn);
-					}
-				}
+				ATestPossessionPlayerController* Controller = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
+				AssertIsValid(Controller, TEXT("Test requires an ATestPossessionPlayerController"));
+				Controller->RemotePossessOnClient(Pawn);
 			}
 		}
 		FinishStep();
@@ -126,66 +58,13 @@ void ACrossServerMultiPossessionTest::PrepareTest()
 	AddWaitStep(FWorkerDefinition::AllServers);
 
 	AddStep(TEXT("Check results on all servers"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float DeltaTime) {
-		if (ATestPossessionPawn* Pawn = GetPawn())
-		{
-			AssertTrue(Pawn->GetController() != nullptr, TEXT("GetController of Pawn to check if possessed on server"), Pawn);
+		ATestPossessionPawn* Pawn = GetPawn();
+		AssertIsValid(Pawn, TEXT("Test requires a Pawn"));
 
-			AssertTrue(ATestPossessionPlayerController::OnPossessCalled == 1, TEXT("OnPossess should be called 1 time"));
-			// int OnPossessFailedCalled = GetNumRequiredClients() - 1;
-			// AssertTrue(ATestPossessionPlayerController::OnPossessFailedCalled == OnPossessFailedCalled,
-			//		   FString::Printf(TEXT("OnPossessFailed should be called %d times"), OnPossessFailedCalled));
-		}
-		else
-		{
-			LogStep(ELogVerbosity::Log, TEXT("Couldn't found pawn for possession"));
-		}
+		AssertTrue(Pawn->GetController() != nullptr, TEXT("GetController of Pawn to check if possessed on server"), Pawn);
+
+		AssertValue_Int(ATestPossessionPlayerController::OnPossessCalled, EComparisonMethod::Equal_To, 1,
+						TEXT("OnPossess should be called 1 time"));
 		FinishStep();
-	});
-}
-
-ATestPossessionPawn* ACrossServerMultiPossessionTest::GetPawn()
-{
-	return Cast<ATestPossessionPawn>(UGameplayStatics::GetActorOfClass(GetWorld(), ATestPossessionPawn::StaticClass()));
-}
-
-void ACrossServerMultiPossessionTest::CreateController(int Index, FVector Position)
-{
-	ASpatialFunctionalTestFlowController* FlowController = GetFlowController(ESpatialFunctionalTestWorkerType::Client, Index);
-	ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
-	if (IsValid(PlayerController))
-	{
-		ATestMovementCharacter* Character =
-			GetWorld()->SpawnActor<ATestMovementCharacter>(Position, FRotator::ZeroRotator, FActorSpawnParameters());
-		RegisterAutoDestroyActor(Character);
-		PlayerController->RemotePossessOnServer(Character);
-	}
-	else
-	{
-		FinishTest(EFunctionalTestResult::Error, TEXT("Failed to get PlayerController"));
-	}
-}
-
-void ACrossServerMultiPossessionTest::CheckControllerHasAuthority(int Index)
-{
-	ASpatialFunctionalTestFlowController* FlowController = GetFlowController(ESpatialFunctionalTestWorkerType::Client, Index);
-	ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
-	if (IsValid(PlayerController))
-	{
-		AssertTrue(PlayerController->HasAuthority(), TEXT("PlayerController HasAuthority"), PlayerController);
-	}
-	else
-	{
-		FinishTest(EFunctionalTestResult::Error, TEXT("Failed to get PlayerController"));
-	}
-}
-
-void ACrossServerMultiPossessionTest::AddWaitStep(const FWorkerDefinition& Worker)
-{
-	AddStep(TEXT("Wait"), Worker, nullptr, nullptr, [this](float DeltaTime) {
-		if (WaitTime > MaxWaitTime)
-		{
-			FinishStep();
-		}
-		WaitTime += DeltaTime;
 	});
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
@@ -49,7 +49,7 @@ void ACrossServerMultiPossessionTest::PrepareTest()
 				ATestPossessionPlayerController* Controller = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
 				if (Controller != nullptr)
 				{
-					Controller->RemotePossessOnClient(Pawn);
+					Controller->RemotePossessOnClient(Pawn, false);
 				}
 			}
 		}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
@@ -47,8 +47,10 @@ void ACrossServerMultiPossessionTest::PrepareTest()
 			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
 			{
 				ATestPossessionPlayerController* Controller = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
-				AssertIsValid(Controller, TEXT("Test requires an ATestPossessionPlayerController"));
-				Controller->RemotePossessOnClient(Pawn);
+				if (Controller != nullptr)
+				{
+					Controller->RemotePossessOnClient(Pawn);
+				}				
 			}
 		}
 		FinishStep();
@@ -61,7 +63,7 @@ void ACrossServerMultiPossessionTest::PrepareTest()
 		ATestPossessionPawn* Pawn = GetPawn();
 		AssertIsValid(Pawn, TEXT("Test requires a Pawn"));
 
-		AssertTrue(Pawn->GetController() != nullptr, TEXT("GetController of Pawn to check if possessed on server"), Pawn);
+		AssertIsValid(Pawn->GetController(), TEXT("Pawn should have a controller"), Pawn);
 
 		AssertValue_Int(ATestPossessionPlayerController::OnPossessCalled, EComparisonMethod::Equal_To, 1,
 						TEXT("OnPossess should be called 1 time"));

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.h
@@ -1,0 +1,33 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "SpatialFunctionalTest.h"
+
+#include "CrossServerMultiPossessionTest.generated.h"
+
+class ATestPossessionPawn;
+
+UCLASS()
+class SPATIALGDKFUNCTIONALTESTS_API ACrossServerMultiPossessionTest : public ASpatialFunctionalTest
+{
+	GENERATED_BODY()
+
+public:
+	ACrossServerMultiPossessionTest();
+
+	virtual void PrepareTest() override;
+
+private:
+	ATestPossessionPawn* GetPawn();
+
+	void CreateController(int Index, FVector Position);
+
+	void CheckControllerHasAuthority(int Index);
+
+	void AddWaitStep(const FWorkerDefinition& Worker);
+
+	float WaitTime;
+	const static float MaxWaitTime;
+};

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.h
@@ -4,10 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "SpatialTestRemotePossession.h"
-
 #include "CrossServerMultiPossessionTest.generated.h"
-
-class ATestPossessionPawn;
 
 UCLASS()
 class SPATIALGDKFUNCTIONALTESTS_API ACrossServerMultiPossessionTest : public ASpatialTestRemotePossession

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionGameMode.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionGameMode.cpp
@@ -50,10 +50,10 @@ void ACrossServerPossessionGameMode::Generate_SpawnPoints()
 
 		SpawnPoints.Add(World->SpawnActor<APlayerStart>(APlayerStart::StaticClass(), FVector(-500.0f, -500.0f, 50.0f),
 														FRotator::ZeroRotator, SpawnInfo));
-		SpawnPoints.Add(World->SpawnActor<APlayerStart>(APlayerStart::StaticClass(), FVector(500.0f, -500.0f, 50.0f), FRotator::ZeroRotator,
-														SpawnInfo));
-		SpawnPoints.Add(World->SpawnActor<APlayerStart>(APlayerStart::StaticClass(), FVector(-500.0f, 500.0f, 50.0f), FRotator::ZeroRotator,
-														SpawnInfo));
+		SpawnPoints.Add(World->SpawnActor<APlayerStart>(APlayerStart::StaticClass(), FVector(500.0f, -500.0f, 50.0f),
+														FRotator::ZeroRotator, SpawnInfo));
+		SpawnPoints.Add(World->SpawnActor<APlayerStart>(APlayerStart::StaticClass(), FVector(-500.0f, 500.0f, 50.0f),
+														FRotator::ZeroRotator, SpawnInfo));
 
 		bInitializedSpawnPoints = true;
 	}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionGameMode.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionGameMode.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "CrossServerPossessionGameMode.h"
+
+#include "GameFramework/PlayerStart.h"
+#include "TestPossessionPlayerController.h"
+
+ACrossServerPossessionGameMode::ACrossServerPossessionGameMode()
+	: PlayersSpawned(0)
+	, bInitializedSpawnPoints(false)
+{
+	PlayerControllerClass = ATestPossessionPlayerController::StaticClass();
+}
+
+AActor* ACrossServerPossessionGameMode::FindPlayerStart_Implementation(AController* Player, const FString& IncomingName)
+{
+	Generate_SpawnPoints();
+
+	if (Player == nullptr)
+	{
+		return SpawnPoints[PlayersSpawned % SpawnPoints.Num()];
+	}
+
+	const int32 PlayerUniqueID = Player->GetUniqueID();
+	AActor** SpawnPoint = PlayerIdToSpawnPointMap.Find(PlayerUniqueID);
+	if (SpawnPoint != nullptr)
+	{
+		return *SpawnPoint;
+	}
+
+	AActor* ChosenSpawnPoint = SpawnPoints[PlayersSpawned % SpawnPoints.Num()];
+	PlayerIdToSpawnPointMap.Add(PlayerUniqueID, ChosenSpawnPoint);
+
+	PlayersSpawned++;
+
+	return ChosenSpawnPoint;
+}
+
+void ACrossServerPossessionGameMode::Generate_SpawnPoints()
+{
+	if (false == bInitializedSpawnPoints)
+	{
+		UWorld* World = GetWorld();
+
+		FActorSpawnParameters SpawnInfo{};
+		SpawnInfo.Owner = this;
+		SpawnInfo.Instigator = NULL;
+		SpawnInfo.bDeferConstruction = false;
+		SpawnInfo.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+
+		SpawnPoints.Add(World->SpawnActor<APlayerStart>(APlayerStart::StaticClass(), FVector(-500.0f, -500.0f, 50.0f),
+														FRotator::ZeroRotator, SpawnInfo));
+		SpawnPoints.Add(World->SpawnActor<APlayerStart>(APlayerStart::StaticClass(), FVector(500.0f, -500.0f, 50.0f), FRotator::ZeroRotator,
+														SpawnInfo));
+		SpawnPoints.Add(World->SpawnActor<APlayerStart>(APlayerStart::StaticClass(), FVector(-500.0f, 500.0f, 50.0f), FRotator::ZeroRotator,
+														SpawnInfo));
+
+		bInitializedSpawnPoints = true;
+	}
+}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionGameMode.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionGameMode.cpp
@@ -50,10 +50,10 @@ void ACrossServerPossessionGameMode::Generate_SpawnPoints()
 
 		SpawnPoints.Add(World->SpawnActor<APlayerStart>(APlayerStart::StaticClass(), FVector(-500.0f, -500.0f, 50.0f),
 														FRotator::ZeroRotator, SpawnInfo));
-		SpawnPoints.Add(World->SpawnActor<APlayerStart>(APlayerStart::StaticClass(), FVector(500.0f, -500.0f, 50.0f),
-														FRotator::ZeroRotator, SpawnInfo));
-		SpawnPoints.Add(World->SpawnActor<APlayerStart>(APlayerStart::StaticClass(), FVector(-500.0f, 500.0f, 50.0f),
-														FRotator::ZeroRotator, SpawnInfo));
+		SpawnPoints.Add(World->SpawnActor<APlayerStart>(APlayerStart::StaticClass(), FVector(500.0f, -500.0f, 50.0f), FRotator::ZeroRotator,
+														SpawnInfo));
+		SpawnPoints.Add(World->SpawnActor<APlayerStart>(APlayerStart::StaticClass(), FVector(-500.0f, 500.0f, 50.0f), FRotator::ZeroRotator,
+														SpawnInfo));
 
 		bInitializedSpawnPoints = true;
 	}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionGameMode.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionGameMode.h
@@ -1,0 +1,24 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/GameModeBase.h"
+#include "CrossServerPossessionGameMode.generated.h"
+
+UCLASS()
+class ACrossServerPossessionGameMode : public AGameModeBase
+{
+	GENERATED_BODY()
+public:
+	ACrossServerPossessionGameMode();
+	AActor* FindPlayerStart_Implementation(AController* Player, const FString& IncomingName) override;
+
+private:
+	void Generate_SpawnPoints();
+
+	int32 PlayersSpawned;
+	bool bInitializedSpawnPoints;
+	TArray<AActor*> SpawnPoints;
+	TMap<int32, AActor*> PlayerIdToSpawnPointMap;
+};

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
@@ -9,7 +9,7 @@
 #include "TestPossessionPlayerController.h"
 
 /**
- * This test tests 1 locked Controller possess over 1 pawn.
+ * This test tests 1 locked Controller remote possess over 1 pawn.
  *
  * This test expects a load balancing grid and ACrossServerPossessionGameMode
  * Recommand to use 2*2 load balancing grid because the position of Pawn was written in the code

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
@@ -44,7 +44,7 @@ void ACrossServerPossessionLockTest::PrepareTest()
 				ATestPossessionPlayerController* Controller = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
 				if (Controller != nullptr)
 				{
-					Controller->RemotePossessOnClient(Pawn);
+					Controller->RemotePossessOnClient(Pawn, true);
 				}
 			}
 		}
@@ -56,7 +56,7 @@ void ACrossServerPossessionLockTest::PrepareTest()
 	AddStep(TEXT("Check test result"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
 		ATestPossessionPawn* Pawn = GetPawn();
 		AssertIsValid(Pawn, TEXT("Test requires a Pawn"));
-		AssertIsValid(Pawn->GetController(), TEXT("Pawn should have a controller"), Pawn);
+		AssertTrue(Pawn->GetController() == nullptr, TEXT("Pawn shouldn't have a controller"), Pawn);
 		FinishStep();
 	});
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
@@ -41,9 +41,11 @@ void ACrossServerPossessionLockTest::PrepareTest()
 		{
 			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
 			{
-				ATestPossessionPlayerController* Controller = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
-				AssertIsValid(Controller, TEXT("PlayerController not possessed the pawn"));
-				Controller->RemotePossessOnClient(Pawn);
+				ATestPossessionPlayerController* Controller = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());				
+				if (Controller != nullptr)
+				{
+					Controller->RemotePossessOnClient(Pawn);
+				}
 			}
 		}
 		FinishStep();
@@ -51,16 +53,10 @@ void ACrossServerPossessionLockTest::PrepareTest()
 
 	AddWaitStep(FWorkerDefinition::AllServers);
 
-	AddStep(TEXT("Check test result"), FWorkerDefinition::Server(1), nullptr, nullptr, [this](float) {
+	AddStep(TEXT("Check test result"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
 		ATestPossessionPawn* Pawn = GetPawn();
 		AssertIsValid(Pawn, TEXT("Test requires a Pawn"));
-		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
-		{
-			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Server)
-			{
-				AssertTrue(Pawn->Controller == nullptr, TEXT("PlayerController not possessed the pawn"), Pawn);
-			}
-		}
+		AssertIsValid(Pawn->GetController(), TEXT("Pawn should have a controller"), Pawn);
 		FinishStep();
 	});
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
@@ -20,14 +20,19 @@
  *    - Specify `Multi Worker Settings Class` as Zoning 2x2(e.g. BP_Possession_Settings_Zoning2_2 of UnrealGDKTestGyms)
  *	  - Set `Num Required Clients` as 1
  *  - Test:
- *    - Controller possess failed
+ *	  - Create a Pawn in first quadrant
+ *	  - Create Controller in other quadrant
+ *	  - Wait for Pawn in right worker.
+ *	  -	Lock the Controller and possess the Pawn
+ *	- Result Check:
+ *    - Pawn didn't have a Controller
  */
 
 ACrossServerPossessionLockTest::ACrossServerPossessionLockTest()
 	: Super()
 {
 	Author = "Jay";
-	Description = TEXT("Test Actor Remote Possession");
+	Description = TEXT("Test Locked Actor Cross-Server Possession");
 }
 
 void ACrossServerPossessionLockTest::PrepareTest()

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
@@ -9,18 +9,18 @@
 #include "TestPossessionPlayerController.h"
 
 /**
- * This test tests client possession over pawns in other zones.
+ * This test tests 1 locked Controller possess over 1 pawn.
  *
- * The test includes two servers and two client workers. The client workers begin with a player controller and their default pawns,
- * which they initially possess. The flow is as follows:
+ * This test expects a load balancing grid and ACrossServerPossessionGameMode
+ * Recommand to use 2*2 load balancing grid because the position of Pawn was written in the code
+ * The client workers begin with a player controller and their default pawns, which they initially possess.
+ * The flow is as follows:
  *  - Setup:
- *    - Two test pawn actors are spawned, one for each client, with an offset in the y direction for easy visualisation
- *    - The controllers for each client possess the spawned test pawn actors
+ *    - Specify `GameMode Override` as ACrossServerPossessionGameMode
+ *    - Specify `Multi Worker Settings Class` as Zoning 2x2(e.g. BP_Possession_Settings_Zoning2_2 of UnrealGDKTestGyms)
+ *	  - Set `Num Required Clients` as 1
  *  - Test:
- *    - The clients assert that the pawn they currently possess are test pawns
- *  - Cleanup:
- *    - The clients repossess their default pawns
- *    - The test pawns are destroyed
+ *    - Controller possess failed
  */
 
 ACrossServerPossessionLockTest::ACrossServerPossessionLockTest()

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "CrossServerPossessionLockTest.h"
+#include "EngineClasses/SpatialNetDriver.h"
+#include "GameFramework/PlayerController.h"
+#include "Net/UnrealNetwork.h"
+#include "SpatialFunctionalTestFlowController.h"
+#include "TestPossessionPawn.h"
+#include "TestPossessionPlayerController.h"
+
+/**
+ * This test tests client possession over pawns in other zones.
+ *
+ * The test includes two servers and two client workers. The client workers begin with a player controller and their default pawns,
+ * which they initially possess. The flow is as follows:
+ *  - Setup:
+ *    - Two test pawn actors are spawned, one for each client, with an offset in the y direction for easy visualisation
+ *    - The controllers for each client possess the spawned test pawn actors
+ *  - Test:
+ *    - The clients assert that the pawn they currently possess are test pawns
+ *  - Cleanup:
+ *    - The clients repossess their default pawns
+ *    - The test pawns are destroyed
+ */
+
+ACrossServerPossessionLockTest::ACrossServerPossessionLockTest()
+	: Super()
+{
+	Author = "Jay";
+	Description = TEXT("Test Actor Remote Possession");
+}
+
+void ACrossServerPossessionLockTest::PrepareTest()
+{
+	Super::PrepareTest();
+
+	AddStep(TEXT("Controller remote possess"), FWorkerDefinition::AllClients, nullptr, nullptr, [this](float DeltaTime) {
+		ATestPossessionPawn* Pawn = GetPawn();
+		AssertIsValid(Pawn, TEXT("Test requires a Pawn"));
+		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
+		{
+			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
+			{
+				ATestPossessionPlayerController* Controller = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
+				AssertIsValid(Controller, TEXT("PlayerController not possessed the pawn"));
+				Controller->RemotePossessOnClient(Pawn);
+			}
+		}
+		FinishStep();
+	});
+
+	AddWaitStep(FWorkerDefinition::AllServers);
+
+	AddStep(TEXT("Check test result"), FWorkerDefinition::Server(1), nullptr, nullptr, [this](float) {
+		ATestPossessionPawn* Pawn = GetPawn();
+		AssertIsValid(Pawn, TEXT("Test requires a Pawn"));
+		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
+		{
+			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Server)
+			{
+				AssertTrue(Pawn->Controller == nullptr, TEXT("PlayerController not possessed the pawn"), Pawn);
+			}
+		}
+		FinishStep();
+	});
+}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
@@ -41,7 +41,7 @@ void ACrossServerPossessionLockTest::PrepareTest()
 		{
 			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
 			{
-				ATestPossessionPlayerController* Controller = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());				
+				ATestPossessionPlayerController* Controller = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
 				if (Controller != nullptr)
 				{
 					Controller->RemotePossessOnClient(Pawn);

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.h
@@ -3,19 +3,18 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "SpatialFunctionalTest.h"
 #include "SpatialTestRemotePossession.h"
-
-#include "CrossServerMultiPossessionTest.generated.h"
+#include "CrossServerPossessionLockTest.generated.h"
 
 class ATestPossessionPawn;
 
 UCLASS()
-class SPATIALGDKFUNCTIONALTESTS_API ACrossServerMultiPossessionTest : public ASpatialTestRemotePossession
+class SPATIALGDKFUNCTIONALTESTS_API ACrossServerPossessionLockTest : public ASpatialTestRemotePossession
 {
 	GENERATED_BODY()
-
 public:
-	ACrossServerMultiPossessionTest();
+	ACrossServerPossessionLockTest();
 
 	virtual void PrepareTest() override;
 };

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.h
@@ -3,11 +3,8 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "SpatialFunctionalTest.h"
 #include "SpatialTestRemotePossession.h"
 #include "CrossServerPossessionLockTest.generated.h"
-
-class ATestPossessionPawn;
 
 UCLASS()
 class SPATIALGDKFUNCTIONALTESTS_API ACrossServerPossessionLockTest : public ASpatialTestRemotePossession

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
@@ -10,6 +10,21 @@
 #include "TestPossessionPawn.h"
 #include "TestPossessionPlayerController.h"
 
+/**
+ * This test tests 1 Controller possess over 1 Pawn.
+ *
+ * This test expects a load balancing grid and ACrossServerPossessionGameMode
+ * Recommand to use 2*2 load balancing grid because the position is written in the code
+ * The client workers begin with a player controller and their default pawns, which they initially possess.
+ * The flow is as follows:
+ *  - Setup:
+ *    - Specify `GameMode Override` as ACrossServerPossessionGameMode
+ *    - Specify `Multi Worker Settings Class` as Zoning 2x2(e.g. BP_Possession_Settings_Zoning2_2 of UnrealGDKTestGyms)
+ *	  - Set `Num Required Clients` as 1
+ *  - Test:
+ *    - Controller possessed the Pawn
+ */
+
 ACrossServerPossessionTest::ACrossServerPossessionTest()
 {
 	Author = "Ken.Yu";

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
@@ -29,7 +29,6 @@
  *	  -	The Controller possess the Pawn in server-side
  *	- Result Check:
  *    - ATestPossessionPlayerController::OnPossess should be called >= 1 times
- *	  - the reason why accept > 1 is even we set `Num Required Clients` as 1, but still have 3 instance of clients in this case
  */
 
 ACrossServerPossessionTest::ACrossServerPossessionTest()

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
@@ -1,0 +1,95 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "CrossServerPossessionTest.h"
+
+#include "Containers/Array.h"
+#include "EngineClasses/SpatialNetDriver.h"
+#include "GameFramework/GameModeBase.h"
+#include "GameFramework/PlayerController.h"
+#include "GameMapsSettings.h"
+#include "Kismet/GameplayStatics.h"
+#include "LoadBalancing/LayeredLBStrategy.h"
+#include "SpatialFunctionalTestFlowController.h"
+#include "SpatialGDKFunctionalTests/SpatialGDK/TestActors/TestMovementCharacter.h"
+#include "TestPossessionPawn.h"
+#include "TestPossessionPlayerController.h"
+#include "Utils/SpatialStatics.h"
+
+const float ACrossServerPossessionTest::MaxWaitTime = 1.0f;
+
+ACrossServerPossessionTest::ACrossServerPossessionTest()
+	: WaitTime(0.0f)
+{
+	Author = "Ken.Yu";
+	Description = TEXT("Test Cross-Server Possession");
+}
+
+void ACrossServerPossessionTest::PrepareTest()
+{
+	Super::PrepareTest();
+
+	AddStep(TEXT("EnsureSpatialOS"), FWorkerDefinition::AllServers, nullptr, [this]() {
+		ULayeredLBStrategy* LoadBalanceStrategy = GetLoadBalancingStrategy();
+		if (LoadBalanceStrategy == nullptr)
+		{
+			FinishTest(EFunctionalTestResult::Error, TEXT("Test requires SpatialOS enabled with Load-Balancing Strategy"));
+		}
+		else
+		{
+			if (AGameModeBase* GameMode = Cast<AGameModeBase>(AGameModeBase::StaticClass()->GetDefaultObject()))
+			{
+				LogStep(ELogVerbosity::Log, FString::Printf(TEXT("GameMode:%s"), *GameMode->GetFullName()));
+			}
+			FinishStep();
+		}
+	});
+
+	AddStep(TEXT("Cross-Server Possession check client 03 authority"), FWorkerDefinition::Server(3), nullptr, nullptr, [this](float) {
+		ULayeredLBStrategy* LoadBalanceStrategy = GetLoadBalancingStrategy();
+		ATestPossessionPawn* Pawn =
+			GetWorld()->SpawnActor<ATestPossessionPawn>(FVector(-100.0f, 100.0f, 50.0f), FRotator::ZeroRotator, FActorSpawnParameters());
+		uint32 WorkerId03 = LoadBalanceStrategy->WhoShouldHaveAuthority(*Pawn);
+		LogStep(ELogVerbosity::Log, FString::Printf(TEXT("Worker %d has the authority of the Pawn"), WorkerId03));
+
+		FinishStep();
+	});
+
+	AddStep(TEXT("Cross-Server Possession"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
+		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
+		{
+			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
+			{
+				ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
+				if (PlayerController && PlayerController->HasAuthority())
+				{
+					ATestPossessionPawn* Pawn =
+						Cast<ATestPossessionPawn>(UGameplayStatics::GetActorOfClass(GetWorld(), ATestPossessionPawn::StaticClass()));
+
+					AssertTrue(PlayerController->HasAuthority(), TEXT("PlayerController should HasAuthority"), PlayerController);
+					AssertFalse(Pawn->HasAuthority(), TEXT("Pawn shouldn't HasAuthority"), Pawn);
+					PlayerController->RemotePossessOnServer(Pawn);
+				}
+			}
+		}
+		FinishStep();
+	});
+
+	AddStep(TEXT("Cross-Server Possession: Wait"), FWorkerDefinition::Server(1), nullptr, nullptr, [this](float DeltaTime) {
+		if (WaitTime > MaxWaitTime)
+		{
+			FinishStep();
+		}
+		WaitTime += DeltaTime;
+	});
+
+	AddStep(TEXT("Cross-Server Possession: Check test result"), FWorkerDefinition::Server(1), nullptr, nullptr, [this](float) {
+		ASpatialFunctionalTestFlowController* FlowController = GetFlowController(ESpatialFunctionalTestWorkerType::Client, 1);
+		ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
+		ATestPossessionPawn* Pawn =
+			Cast<ATestPossessionPawn>(UGameplayStatics::GetActorOfClass(GetWorld(), ATestPossessionPawn::StaticClass()));
+
+		AssertTrue(Pawn->Controller == PlayerController, TEXT("PlayerController has possessed the pawn"), PlayerController);
+
+		FinishStep();
+	});
+}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
@@ -23,7 +23,13 @@
  *    - Specify `Multi Worker Settings Class` as Zoning 2x2(e.g. BP_Possession_Settings_Zoning2_2 of UnrealGDKTestGyms)
  *	  - Set `Num Required Clients` as 1
  *  - Test:
- *    - Controller possessed the Pawn
+ *	  - Create a Pawn in first quadrant
+ *	  - Create Controller in other quadrant, the position is determined by ACrossServerPossessionGameMode
+ *	  - Wait for Pawn in right worker.
+ *	  -	The Controller possess the Pawn in server-side
+ *	- Result Check:
+ *    - ATestPossessionPlayerController::OnPossess should be called >= 1 times
+ *	  - the reason why accept > 1 is even we set `Num Required Clients` as 1, but still have 3 instance of clients in this case
  */
 
 ACrossServerPossessionTest::ACrossServerPossessionTest()
@@ -61,6 +67,7 @@ void ACrossServerPossessionTest::PrepareTest()
 			return ATestPossessionPlayerController::OnPossessCalled >= 1;
 		},
 		nullptr,
-		[this](float) {	FinishStep(); }
-	);
+		[this](float) {
+			FinishStep();
+		});
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.h
@@ -3,12 +3,12 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "SpatialFunctionalTest.h"
+#include "SpatialTestRemotePossession.h"
 
 #include "CrossServerPossessionTest.generated.h"
 
 UCLASS()
-class SPATIALGDKFUNCTIONALTESTS_API ACrossServerPossessionTest : public ASpatialFunctionalTest
+class SPATIALGDKFUNCTIONALTESTS_API ACrossServerPossessionTest : public ASpatialTestRemotePossession
 {
 	GENERATED_BODY()
 
@@ -16,8 +16,4 @@ public:
 	ACrossServerPossessionTest();
 
 	virtual void PrepareTest() override;
-
-private:
-	float WaitTime;
-	const static float MaxWaitTime;
 };

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.h
@@ -4,7 +4,6 @@
 
 #include "CoreMinimal.h"
 #include "SpatialTestRemotePossession.h"
-
 #include "CrossServerPossessionTest.generated.h"
 
 UCLASS()

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.h
@@ -1,0 +1,23 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "SpatialFunctionalTest.h"
+
+#include "CrossServerPossessionTest.generated.h"
+
+UCLASS()
+class SPATIALGDKFUNCTIONALTESTS_API ACrossServerPossessionTest : public ASpatialFunctionalTest
+{
+	GENERATED_BODY()
+
+public:
+	ACrossServerPossessionTest();
+
+	virtual void PrepareTest() override;
+
+private:
+	float WaitTime;
+	const static float MaxWaitTime;
+};

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/NoneCrossServerPossessionTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/NoneCrossServerPossessionTest.h
@@ -1,0 +1,18 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "SpatialTestRemotePossession.h"
+#include "NoneCrossServerPossessionTest.generated.h"
+
+UCLASS()
+class SPATIALGDKFUNCTIONALTESTS_API ANoneCrossServerPossessionTest : public ASpatialTestRemotePossession
+{
+	GENERATED_BODY()
+
+public:
+	ANoneCrossServerPossessionTest();
+
+	virtual void PrepareTest() override;
+};

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.cpp
@@ -10,6 +10,7 @@ const float ASpatialTestRemotePossession::MaxWaitTime = 2.0f;
 
 ASpatialTestRemotePossession::ASpatialTestRemotePossession()
 	: Super()
+	, LocationOfPawn(500.0f, 500.0f, 50.0f)
 {
 	Author = "Jay";
 	Description = TEXT("Test Actor Remote Possession");
@@ -34,7 +35,7 @@ void ASpatialTestRemotePossession::PrepareTest()
 
 	AddStep(TEXT("Create Pawn"), FWorkerDefinition::Server(1), nullptr, nullptr, [this](float DeltaTime) {
 		ATestPossessionPawn* Pawn =
-			GetWorld()->SpawnActor<ATestPossessionPawn>(FVector(500.0f, 500.0f, 50.0f), FRotator::ZeroRotator, FActorSpawnParameters());
+			GetWorld()->SpawnActor<ATestPossessionPawn>(LocationOfPawn, FRotator::ZeroRotator, FActorSpawnParameters());
 		RegisterAutoDestroyActor(Pawn);
 		FinishStep();
 	});

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.cpp
@@ -1,0 +1,112 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "SpatialTestRemotePossession.h"
+#include "Containers/Array.h"
+#include "EngineClasses/Components/RemotePossessionComponent.h"
+#include "EngineClasses/SpatialNetDriver.h"
+#include "GameFramework/PlayerController.h"
+#include "Net/UnrealNetwork.h"
+#include "SpatialFunctionalTestFlowController.h"
+#include "TestPossessionPawn.h"
+#include "TestPossessionPlayerController.h"
+
+/**
+ * This test tests client possession over pawns in other zones.
+ *
+ * The test includes two servers and two client workers. The client workers begin with a player controller and their default pawns,
+ * which they initially possess. The flow is as follows:
+ *  - Setup:
+ *    - Two test pawn actors are spawned, one for each client, with an offset in the y direction for easy visualisation
+ *    - The controllers for each client  possess the spawned test pawn actors
+ *  - Test:
+ *    - The clients  assert that the pawn they currently possess are test pawns
+ *  - Cleanup:
+ *    - The clients repossess their default pawns
+ *    - The test pawns are destroyed
+ */
+
+ASpatialTestRemotePossession::ASpatialTestRemotePossession()
+	: Super()
+{
+	Author = "Jay";
+	Description = TEXT("Test Actor Remote Possession");
+}
+
+void ASpatialTestRemotePossession::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+
+	DOREPLIFETIME(ASpatialTestRemotePossession, OriginalPawns);
+}
+
+void ASpatialTestRemotePossession::PrepareTest()
+{
+	Super::PrepareTest();
+
+	static FVector start[3] = { FVector{ 30.0f, 30.0f, 20.0f }, FVector{ -30.0f, 30.0f, 20.0f }, FVector{ -30.0f, -30.0f, 20.0f } };
+	AddStep(TEXT("First step"), FWorkerDefinition::Server(1), nullptr, nullptr, [this](float) {
+		int i = 0;
+		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
+		{
+			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Server)
+			{
+				continue;
+			}
+			ATestPossessionPawn* TestPawn =
+				GetWorld()->SpawnActor<ATestPossessionPawn>(start[i % 3], FRotator::ZeroRotator, FActorSpawnParameters());
+			OriginalPawns.Add(TestPawn);
+			++i;
+			RegisterAutoDestroyActor(TestPawn);
+
+			ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
+			PlayerController->RemotePossessOnServer(TestPawn);
+		}
+		FinishStep();
+	});
+
+	AddStep(TEXT("Tick Step"), FWorkerDefinition::Server(1), nullptr, nullptr, [this](float DeltaTime) {
+		static float deltaTotal{ 0.f };
+		deltaTotal += DeltaTime;
+		if (deltaTotal > 3.f)
+		{
+			FinishStep();
+		}
+	});
+
+	AddStep(TEXT("Check"), FWorkerDefinition::Server(2), nullptr, nullptr, [this](float) {
+		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
+		{
+			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Server)
+			{
+				continue;
+			}
+			ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
+			if (PlayerController->HasAuthority())
+			{
+				PlayerController->RemotePossessOnServer(OriginalPawns[0]);
+			}
+		}
+
+		FinishStep();
+	});
+
+	AddStep(TEXT("Check"), FWorkerDefinition::Server(3), nullptr, nullptr, [this](float) {
+		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
+		{
+			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Server)
+			{
+				continue;
+			}
+			ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
+			ensure(PlayerController);
+			if (PlayerController->HasAuthority())
+			{
+				USpatialNetDriver* NetDriver = Cast<USpatialNetDriver>(GetNetDriver());
+				NetDriver->LockingPolicy->AcquireLock(PlayerController, TEXT("TestLock"));
+				PlayerController->RemotePossessOnServer(OriginalPawns[0]);
+			}
+		}
+
+		FinishStep();
+	});
+}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.cpp
@@ -10,7 +10,6 @@ const float ASpatialTestRemotePossession::MaxWaitTime = 2.0f;
 
 ASpatialTestRemotePossession::ASpatialTestRemotePossession()
 	: Super()
-	, WaitTime(0.0f)
 {
 	Author = "Jay";
 	Description = TEXT("Test Actor Remote Possession");
@@ -19,18 +18,6 @@ ASpatialTestRemotePossession::ASpatialTestRemotePossession()
 ATestPossessionPawn* ASpatialTestRemotePossession::GetPawn()
 {
 	return Cast<ATestPossessionPawn>(UGameplayStatics::GetActorOfClass(GetWorld(), ATestPossessionPawn::StaticClass()));
-}
-
-void ASpatialTestRemotePossession::AddWaitStep(const FWorkerDefinition& Worker)
-{
-	AddStep(TEXT("Wait"), Worker, nullptr, nullptr, [this](float DeltaTime) {
-		if (WaitTime > MaxWaitTime)
-		{
-			WaitTime = 0;
-			FinishStep();
-		}
-		WaitTime += DeltaTime;
-	});
 }
 
 void ASpatialTestRemotePossession::PrepareTest()
@@ -52,6 +39,24 @@ void ASpatialTestRemotePossession::PrepareTest()
 		FinishStep();
 	});
 
-	// Make sure all the Controller and Pawn authoritative in right workers
+	// Ensure that all Controllers are located on the right Worker
 	AddWaitStep(FWorkerDefinition::AllServers);
+}
+
+bool ASpatialTestRemotePossession::IsReadyForPossess()
+{
+	ATestPossessionPawn* Pawn = GetPawn();
+	return Pawn->Controller != nullptr;
+}
+
+void ASpatialTestRemotePossession::AddWaitStep(const FWorkerDefinition& Worker)
+{
+	AddStep(TEXT("Wait"), Worker, nullptr, nullptr, [this](float DeltaTime) {
+		if (WaitTime > MaxWaitTime)
+		{
+			WaitTime = 0;
+			FinishStep();
+		}
+		WaitTime += DeltaTime;
+	});
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.cpp
@@ -25,8 +25,6 @@ void ASpatialTestRemotePossession::PrepareTest()
 {
 	Super::PrepareTest();
 
-	ATestPossessionPlayerController::ResetCalledCounter();
-
 	AddStep(TEXT("EnsureSpatialOS"), FWorkerDefinition::AllServers, nullptr, [this]() {
 		ULayeredLBStrategy* LoadBalanceStrategy = GetLoadBalancingStrategy();
 		AssertTrue(LoadBalanceStrategy != nullptr, TEXT("Test requires SpatialOS enabled with Load-Balancing Strategy"));
@@ -42,6 +40,8 @@ void ASpatialTestRemotePossession::PrepareTest()
 
 	// Ensure that all Controllers are located on the right Worker
 	AddWaitStep(FWorkerDefinition::AllServers);
+
+	ATestPossessionPlayerController::ResetCalledCounter();
 }
 
 bool ASpatialTestRemotePossession::IsReadyForPossess()

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.h
@@ -6,6 +6,8 @@
 #include "SpatialFunctionalTest.h"
 #include "SpatialTestRemotePossession.generated.h"
 
+class ATestPossessionPawn;
+
 UCLASS()
 class SPATIALGDKFUNCTIONALTESTS_API ASpatialTestRemotePossession : public ASpatialFunctionalTest
 {
@@ -15,7 +17,10 @@ public:
 
 	virtual void PrepareTest() override;
 
-	// To save original Pawns and possess them back at the end
-	UPROPERTY(replicated)
-	TArray<APawn*> OriginalPawns;
+	ATestPossessionPawn* GetPawn();
+
+	void AddWaitStep(const FWorkerDefinition& Worker);
+private:
+	float WaitTime;
+	const static float MaxWaitTime;
 };

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.h
@@ -23,7 +23,8 @@ public:
 
 	void AddWaitStep(const FWorkerDefinition& Worker);
 
-private:
+protected:
+	FVector LocationOfPawn;
 	float WaitTime;
 	const static float MaxWaitTime;
 };

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.h
@@ -1,0 +1,21 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "SpatialFunctionalTest.h"
+#include "SpatialTestRemotePossession.generated.h"
+
+UCLASS()
+class SPATIALGDKFUNCTIONALTESTS_API ASpatialTestRemotePossession : public ASpatialFunctionalTest
+{
+	GENERATED_BODY()
+public:
+	ASpatialTestRemotePossession();
+
+	virtual void PrepareTest() override;
+
+	// To save original Pawns and possess them back at the end
+	UPROPERTY(replicated)
+	TArray<APawn*> OriginalPawns;
+};

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.h
@@ -19,7 +19,10 @@ public:
 
 	ATestPossessionPawn* GetPawn();
 
+	bool IsReadyForPossess();
+
 	void AddWaitStep(const FWorkerDefinition& Worker);
+
 private:
 	float WaitTime;
 	const static float MaxWaitTime;

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "TestPossessionPlayerController.h"
+#include "Engine/World.h"
+#include "EngineClasses/Components/RemotePossessionComponent.h"
+#include "Utils/SpatialStatics.h"
+
+DEFINE_LOG_CATEGORY(LogTestPossessionPlayerController);
+
+int32 ATestPossessionPlayerController::OnPossessCalled = 0;
+
+ATestPossessionPlayerController::ATestPossessionPlayerController() {}
+
+void ATestPossessionPlayerController::OnPossess(APawn* InPawn)
+{
+	Super::OnPossess(InPawn);
+	++OnPossessCalled;
+	UE_LOG(LogTestPossessionPlayerController, Log, TEXT("%s OnPossess(%s) OnPossessCalled:%d"), *GetName(), *InPawn->GetName(),
+		   OnPossessCalled);
+}
+
+void ATestPossessionPlayerController::OnUnPossess()
+{
+	Super::OnUnPossess();
+	UE_LOG(LogTestPossessionPlayerController, Log, TEXT("%s OnUnPossess()"), *GetName());
+}
+
+void ATestPossessionPlayerController::RemotePossess_Implementation(APawn* InPawn)
+{
+	UE_LOG(LogTestPossessionPlayerController, Log, TEXT("%s RemotePossess_Implementation:%s"), *GetName(), *InPawn->GetName());
+	RemotePossessOnServer(InPawn);
+}
+
+void ATestPossessionPlayerController::RemotePossessOnServer(APawn* InPawn)
+{
+	URemotePossessionComponent* Component =
+		NewObject<URemotePossessionComponent>(this, URemotePossessionComponent::StaticClass(), NAME_None);
+	Component->Target = InPawn;
+	Component->RegisterComponent();
+}
+
+void ATestPossessionPlayerController::ResetCalledCounter()
+{
+	OnPossessCalled = 0;
+}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
@@ -3,6 +3,7 @@
 #include "TestPossessionPlayerController.h"
 #include "Engine/World.h"
 #include "EngineClasses/Components/RemotePossessionComponent.h"
+#include "EngineClasses/SpatialNetDriver.h"
 #include "Utils/SpatialStatics.h"
 
 DEFINE_LOG_CATEGORY(LogTestPossessionPlayerController);
@@ -25,9 +26,17 @@ void ATestPossessionPlayerController::OnUnPossess()
 	UE_LOG(LogTestPossessionPlayerController, Log, TEXT("%s OnUnPossess()"), *GetName());
 }
 
-void ATestPossessionPlayerController::RemotePossessOnClient_Implementation(APawn* InPawn)
+void ATestPossessionPlayerController::RemotePossessOnClient_Implementation(APawn* InPawn, bool LockBefore)
 {
 	UE_LOG(LogTestPossessionPlayerController, Log, TEXT("%s RemotePossessOnClient_Implementation:%s"), *GetName(), *InPawn->GetName());
+	if (LockBefore)
+	{
+		USpatialNetDriver* NetDriver = Cast<USpatialNetDriver>(GetNetDriver());
+		if (NetDriver && NetDriver->LockingPolicy)
+		{
+			NetDriver->LockingPolicy->AcquireLock(this, TEXT("TestLock"));
+		}
+	}
 	RemotePossessOnServer(InPawn);
 }
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
@@ -26,13 +26,13 @@ void ATestPossessionPlayerController::OnUnPossess()
 	UE_LOG(LogTestPossessionPlayerController, Log, TEXT("%s OnUnPossess()"), *GetName());
 }
 
-void ATestPossessionPlayerController::RemotePossessOnClient_Implementation(APawn* InPawn, bool LockBefore)
+void ATestPossessionPlayerController::RemotePossessOnClient_Implementation(APawn* InPawn, bool bLockBefore)
 {
 	UE_LOG(LogTestPossessionPlayerController, Log, TEXT("%s RemotePossessOnClient_Implementation:%s"), *GetName(), *InPawn->GetName());
-	if (LockBefore)
+	if (bLockBefore)
 	{
 		USpatialNetDriver* NetDriver = Cast<USpatialNetDriver>(GetNetDriver());
-		if (NetDriver && NetDriver->LockingPolicy)
+		if (NetDriver != nullptr && NetDriver->LockingPolicy)
 		{
 			NetDriver->LockingPolicy->AcquireLock(this, TEXT("TestLock"));
 		}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
@@ -17,7 +17,8 @@ int32 ATestPossessionPlayerController::OnPossessCalled = 0;
 ATestPossessionPlayerController::ATestPossessionPlayerController()
 	: BeforePossessionWorkerId(SpatialConstants::INVALID_VIRTUAL_WORKER_ID)
 	, AfterPossessionWorkerId(SpatialConstants::INVALID_VIRTUAL_WORKER_ID)
-{}
+{
+}
 
 void ATestPossessionPlayerController::OnPossess(APawn* InPawn)
 {
@@ -31,8 +32,8 @@ void ATestPossessionPlayerController::OnPossess(APawn* InPawn)
 	}
 	else
 	{
-		UE_LOG(LogTestPossessionPlayerController, Error, TEXT("%s OnPossess(%s) OnPossessCalled:%d in different worker"), *GetName(), *InPawn->GetName(),
-			   OnPossessCalled);
+		UE_LOG(LogTestPossessionPlayerController, Error, TEXT("%s OnPossess(%s) OnPossessCalled:%d in different worker"), *GetName(),
+			   *InPawn->GetName(), OnPossessCalled);
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
@@ -4,20 +4,36 @@
 #include "Engine/World.h"
 #include "EngineClasses/Components/RemotePossessionComponent.h"
 #include "EngineClasses/SpatialNetDriver.h"
+#include "EngineClasses/SpatialNetDriverDebugContext.h"
+#include "LoadBalancing/AbstractLBStrategy.h"
+#include "LoadBalancing/DebugLBStrategy.h"
+#include "SpatialConstants.h"
 #include "Utils/SpatialStatics.h"
 
 DEFINE_LOG_CATEGORY(LogTestPossessionPlayerController);
 
 int32 ATestPossessionPlayerController::OnPossessCalled = 0;
 
-ATestPossessionPlayerController::ATestPossessionPlayerController() {}
+ATestPossessionPlayerController::ATestPossessionPlayerController()
+	: BeforePossessionWorkerId(SpatialConstants::INVALID_VIRTUAL_WORKER_ID)
+	, AfterPossessionWorkerId(SpatialConstants::INVALID_VIRTUAL_WORKER_ID)
+{}
 
 void ATestPossessionPlayerController::OnPossess(APawn* InPawn)
 {
 	Super::OnPossess(InPawn);
-	++OnPossessCalled;
-	UE_LOG(LogTestPossessionPlayerController, Log, TEXT("%s OnPossess(%s) OnPossessCalled:%d"), *GetName(), *InPawn->GetName(),
-		   OnPossessCalled);
+	if (HasAuthority() && InPawn->HasAuthority())
+	{
+		++OnPossessCalled;
+		AfterPossessionWorkerId = GetCurrentWorkerId();
+		UE_LOG(LogTestPossessionPlayerController, Log, TEXT("%s OnPossess(%s) OnPossessCalled:%d"), *GetName(), *InPawn->GetName(),
+			   OnPossessCalled);
+	}
+	else
+	{
+		UE_LOG(LogTestPossessionPlayerController, Error, TEXT("%s OnPossess(%s) OnPossessCalled:%d in different worker"), *GetName(), *InPawn->GetName(),
+			   OnPossessCalled);
+	}
 }
 
 void ATestPossessionPlayerController::OnUnPossess()
@@ -46,9 +62,30 @@ void ATestPossessionPlayerController::RemotePossessOnServer(APawn* InPawn)
 		NewObject<URemotePossessionComponent>(this, URemotePossessionComponent::StaticClass(), TEXT("CrossServer Possession"));
 	Component->Target = InPawn;
 	Component->RegisterComponent();
+	BeforePossessionWorkerId = GetCurrentWorkerId();
 }
 
 void ATestPossessionPlayerController::ResetCalledCounter()
 {
 	OnPossessCalled = 0;
+}
+
+VirtualWorkerId ATestPossessionPlayerController::GetCurrentWorkerId()
+{
+	UAbstractLBStrategy* LBStrategy = nullptr;
+	UWorld* World = GetWorld();
+	USpatialNetDriver* NetDriver = Cast<USpatialNetDriver>(World->GetNetDriver());
+	if (NetDriver->DebugCtx != nullptr)
+	{
+		LBStrategy = NetDriver->DebugCtx->DebugStrategy->GetWrappedStrategy();
+	}
+	else
+	{
+		LBStrategy = NetDriver->LoadBalanceStrategy;
+	}
+	if (LBStrategy != nullptr)
+	{
+		return LBStrategy->GetLocalVirtualWorkerId();
+	}
+	return SpatialConstants::INVALID_VIRTUAL_WORKER_ID;
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
@@ -25,16 +25,16 @@ void ATestPossessionPlayerController::OnUnPossess()
 	UE_LOG(LogTestPossessionPlayerController, Log, TEXT("%s OnUnPossess()"), *GetName());
 }
 
-void ATestPossessionPlayerController::RemotePossess_Implementation(APawn* InPawn)
+void ATestPossessionPlayerController::RemotePossessOnClient_Implementation(APawn* InPawn)
 {
-	UE_LOG(LogTestPossessionPlayerController, Log, TEXT("%s RemotePossess_Implementation:%s"), *GetName(), *InPawn->GetName());
+	UE_LOG(LogTestPossessionPlayerController, Log, TEXT("%s RemotePossessOnClient_Implementation:%s"), *GetName(), *InPawn->GetName());
 	RemotePossessOnServer(InPawn);
 }
 
 void ATestPossessionPlayerController::RemotePossessOnServer(APawn* InPawn)
 {
 	URemotePossessionComponent* Component =
-		NewObject<URemotePossessionComponent>(this, URemotePossessionComponent::StaticClass(), NAME_None);
+		NewObject<URemotePossessionComponent>(this, URemotePossessionComponent::StaticClass(), TEXT("CrossServer Possession"));
 	Component->Target = InPawn;
 	Component->RegisterComponent();
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
@@ -22,7 +22,7 @@ public:
 	void RemotePossessOnServer(APawn* InPawn);
 
 	UFUNCTION(Server, Reliable)
-	void RemotePossessOnClient(APawn* InPawn);
+	void RemotePossessOnClient(APawn* InPawn, bool LockBefore);
 
 	static void ResetCalledCounter();
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "SpatialCommonTypes.h"
 #include "TestPossessionPlayerController.generated.h"
 
 DECLARE_LOG_CATEGORY_EXTERN(LogTestPossessionPlayerController, Log, All);
@@ -24,7 +25,15 @@ public:
 	UFUNCTION(Server, Reliable)
 	void RemotePossessOnClient(APawn* InPawn, bool bLockBefore);
 
+	bool IsMigration() const { return BeforePossessionWorkerId != AfterPossessionWorkerId; }
+
 	static void ResetCalledCounter();
 
 	static int32 OnPossessCalled;
+
+private:
+	VirtualWorkerId GetCurrentWorkerId();
+
+	VirtualWorkerId BeforePossessionWorkerId;
+	VirtualWorkerId AfterPossessionWorkerId;
 };

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
@@ -22,7 +22,7 @@ public:
 	void RemotePossessOnServer(APawn* InPawn);
 
 	UFUNCTION(Server, Reliable)
-	void RemotePossess(APawn* InPawn);
+	void RemotePossessOnClient(APawn* InPawn);
 
 	static void ResetCalledCounter();
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
@@ -1,0 +1,30 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "TestPossessionPlayerController.generated.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogTestPossessionPlayerController, Log, All);
+
+UCLASS()
+class ATestPossessionPlayerController : public APlayerController
+{
+	GENERATED_BODY()
+private:
+	virtual void OnPossess(APawn* InPawn) override;
+
+	virtual void OnUnPossess() override;
+
+public:
+	ATestPossessionPlayerController();
+
+	void RemotePossessOnServer(APawn* InPawn);
+
+	UFUNCTION(Server, Reliable)
+	void RemotePossess(APawn* InPawn);
+
+	static void ResetCalledCounter();
+
+	static int32 OnPossessCalled;
+};

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
@@ -22,7 +22,7 @@ public:
 	void RemotePossessOnServer(APawn* InPawn);
 
 	UFUNCTION(Server, Reliable)
-	void RemotePossessOnClient(APawn* InPawn, bool LockBefore);
+	void RemotePossessOnClient(APawn* InPawn, bool bLockBefore);
 
 	static void ResetCalledCounter();
 


### PR DESCRIPTION
#### Description
RemotePossessionComponent for PlayerController to Cross-Server possession

A generic solution for Cross-Server Possession. 
The customer can add a RemotePossessionComponent to an AController if the AController wants to possess an APawn which authoritative in another worker. The AController will be migrated to that worker. The AController will possess the APawn after OnAuthorityGained.

We have 3 functional test cases for this feature.
1. 1 Controller possesses 1 Pawn. Contributed by @siliviali 
2. 3 Controllers possess 1 Pawn. Contributed by @yujunting 
3. 1 Locked Controller possesses 1 Pawn. Contributed by @jayprobable 

Jira ticket:https://improbableio.atlassian.net/browse/UNR-4671
