### PR TITLE
UNR-988 Bugfix/cleanup zombie connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ These functions and structs can be referenced in both code and blueprints it may
 - Server workers use TCP (instead of KCP) by default.
 - Fixed a rare crash where a RepNotify callback can modify a GDK data structure being iterated upon.
 - Fixed race condition in Spatial Test framework that would cause tests to time out with one or more workers not ready to begin the test.
+- Fixed client connection not being cleaned up when moving out of interest of a server.
 
 ## [`0.11.0`] - 2020-09-03
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -559,7 +559,7 @@ void USpatialNetDriver::CleanUpServerConnectionForPC(APlayerController* PC)
 			return;
 		}
 	}
-	UE_LOG(LogSpatialOSNetDriver, Error, TEXT("Could not find client connection for this PlayerController"));
+	UE_LOG(LogSpatialOSNetDriver, Error, TEXT("While trying to clean up a PlayerController, its client connection was not found and thus cleanup was not performed"));
 }
 
 bool USpatialNetDriver::ClientCanSendPlayerSpawnRequests()

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -559,7 +559,8 @@ void USpatialNetDriver::CleanUpServerConnectionForPC(APlayerController* PC)
 			return;
 		}
 	}
-	UE_LOG(LogSpatialOSNetDriver, Error, TEXT("While trying to clean up a PlayerController, its client connection was not found and thus cleanup was not performed"));
+	UE_LOG(LogSpatialOSNetDriver, Error,
+		   TEXT("While trying to clean up a PlayerController, its client connection was not found and thus cleanup was not performed"));
 }
 
 bool USpatialNetDriver::ClientCanSendPlayerSpawnRequests()

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -1161,6 +1161,10 @@ void USpatialReceiver::DestroyActor(AActor* Actor, Worker_EntityId EntityId)
 		}
 	}
 
+	if (APlayerController* PC = Cast<APlayerController>(Actor))
+	{
+		NetDriver->CleanUpServerConnectionForPC(PC);
+	}
 	// It is safe to call AActor::Destroy even if the destruction has already started.
 	if (Actor != nullptr && !Actor->Destroy(true))
 	{

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -150,6 +150,7 @@ public:
 	void RegisterClientConnection(const Worker_EntityId WorkerEntityId, USpatialNetConnection* ClientConnection);
 	TWeakObjectPtr<USpatialNetConnection> FindClientConnectionFromWorkerEntityId(const Worker_EntityId InWorkerEntityId);
 	void CleanUpClientConnection(USpatialNetConnection* ClientConnection);
+	void CleanUpServerConnectionForPC(APlayerController* PC);
 
 	bool HasServerAuthority(Worker_EntityId EntityId) const;
 	bool HasClientAuthority(Worker_EntityId EntityId) const;

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialCleanupConnectionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialCleanupConnectionTest.cpp
@@ -1,6 +1,5 @@
 // Fill out your copyright notice in the Description page of Project Settings.
 
-
 #include "SpatialCleanupConnectionTest.h"
 
 #include "SpatialFunctionalTestFlowController.h"
@@ -37,47 +36,54 @@ void ASpatialCleanupConnectionTest::PrepareTest()
 		FinishStep();
 	});
 
-	AddStep(TEXT("Post spawn check connections on server 2"), FWorkerDefinition::Server(2), nullptr, nullptr, [this](float delta) {
-		USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
-		AssertIsValid(Driver, TEXT("Test is exclusive to using SpatialNetDriver"));
-		RequireEqual_Int(Driver->ClientConnections.Num(), 1, TEXT("Spawn expected 1 connection (base only)"));
-		FinishStep();
-	}, 5.0f);
-	
 	AddStep(
-		TEXT("Move player to location on server 1 that overlaps with interest border server 2"), FWorkerDefinition::Server(1), nullptr,
-		[this](){
-				USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
-				AssertIsValid(Driver, TEXT("Test is exclusive to using SpatialNetDriver"));
-				SpawnedPawn->SetActorLocation(Server1PositionAndInInterestBorderServer2);
-				AssertEqual_Int(Driver->ClientConnections.Num(), 2, TEXT("Move into server 2 interest: expected 2 connections (base + PC)"));
-				FinishStep();
-	});
+		TEXT("Post spawn check connections on server 2"), FWorkerDefinition::Server(2), nullptr, nullptr,
+		[this](float delta) {
+			USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
+			AssertIsValid(Driver, TEXT("Test is exclusive to using SpatialNetDriver"));
+			RequireEqual_Int(Driver->ClientConnections.Num(), 1, TEXT("Spawn expected 1 connection (base only)"));
+			FinishStep();
+		},
+		5.0f);
 
-	AddStep(
-		TEXT("Post move player connections on server 2"), FWorkerDefinition::Server(2), nullptr, nullptr, [this](float delta) {
-		USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
-		AssertIsValid(Driver, TEXT("Test is exclusive to using SpatialNetDriver"));
-		RequireEqual_Int(Driver->ClientConnections.Num(), 2, TEXT("Move into server 2 interest: expected 2 connections (base + PC)"));
-		FinishStep();
-		}, 5.0f);
-
-	AddStep(
-		TEXT("Move player to location on server 1 outside of interest border server 2"), FWorkerDefinition::Server(1), nullptr,
+	AddStep(TEXT("Move player to location on server 1 that overlaps with interest border server 2"), FWorkerDefinition::Server(1), nullptr,
 			[this]() {
 				USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
 				AssertIsValid(Driver, TEXT("Test is exclusive to using SpatialNetDriver"));
-				SpawnedPawn->SetActorLocation(Server1Position);
-				AssertEqual_Int(Driver->ClientConnections.Num(), 2, TEXT("Move out of server 2 interest: expected 2 connections (base + PC)"));
+				SpawnedPawn->SetActorLocation(Server1PositionAndInInterestBorderServer2);
+				AssertEqual_Int(Driver->ClientConnections.Num(), 2,
+								TEXT("Move into server 2 interest: expected 2 connections (base + PC)"));
 				FinishStep();
-	});
+			});
 
-	AddStep(TEXT("Post move 2 player connections on server 2"), FWorkerDefinition::Server(2), nullptr, nullptr, [this](float delta) {
-		USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
-		AssertIsValid(Driver, TEXT("Test is exclusive to using SpatialNetDriver"));
-		RequireEqual_Int(Driver->ClientConnections.Num(), 1, TEXT("Move out of server 2 interest: expected 1 connection (base only)"));
-		FinishStep();
-		}, 5.0f);
+	AddStep(
+		TEXT("Post move player connections on server 2"), FWorkerDefinition::Server(2), nullptr, nullptr,
+		[this](float delta) {
+			USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
+			AssertIsValid(Driver, TEXT("Test is exclusive to using SpatialNetDriver"));
+			RequireEqual_Int(Driver->ClientConnections.Num(), 2, TEXT("Move into server 2 interest: expected 2 connections (base + PC)"));
+			FinishStep();
+		},
+		5.0f);
+
+	AddStep(
+		TEXT("Move player to location on server 1 outside of interest border server 2"), FWorkerDefinition::Server(1), nullptr, [this]() {
+			USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
+			AssertIsValid(Driver, TEXT("Test is exclusive to using SpatialNetDriver"));
+			SpawnedPawn->SetActorLocation(Server1Position);
+			AssertEqual_Int(Driver->ClientConnections.Num(), 2, TEXT("Move out of server 2 interest: expected 2 connections (base + PC)"));
+			FinishStep();
+		});
+
+	AddStep(
+		TEXT("Post move 2 player connections on server 2"), FWorkerDefinition::Server(2), nullptr, nullptr,
+		[this](float delta) {
+			USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
+			AssertIsValid(Driver, TEXT("Test is exclusive to using SpatialNetDriver"));
+			RequireEqual_Int(Driver->ClientConnections.Num(), 1, TEXT("Move out of server 2 interest: expected 1 connection (base only)"));
+			FinishStep();
+		},
+		5.0f);
 
 	AddStep(TEXT("SpatialTestNetReferenceServerCleanup"), FWorkerDefinition::Server(1), nullptr, [this]() {
 		// Possess the original pawn, so that other tests start from the expected, default set-up

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialCleanupConnectionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialCleanupConnectionTest.cpp
@@ -33,7 +33,7 @@ void ASpatialCleanupConnectionTest::PrepareTest()
 		PlayerController->Possess(SpawnedPawn);
 
 		AssertEqual_Int(Driver->ClientConnections.Num(), GetNumberOfClientWorkers() + 1,
-						TEXT("Spawn: expected 1 spatial connection + number of clients"));
+						TEXT("Spawn: expected all client connections and one spatial connection"));
 		FinishStep();
 	});
 
@@ -41,8 +41,7 @@ void ASpatialCleanupConnectionTest::PrepareTest()
 		TEXT("Post spawn check connections on server 2"), FWorkerDefinition::Server(2), nullptr, nullptr,
 		[this](float delta) {
 			USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
-			RequireEqual_Int(Driver->ClientConnections.Num(), GetNumberOfClientWorkers(),
-							 TEXT("Spawn: expected client connections only"));
+			RequireEqual_Int(Driver->ClientConnections.Num(), (GetNumberOfClientWorkers() - 1) + 1, TEXT("Spawn: expected one less client connection and one spatial connection"));
 			FinishStep();
 		},
 		5.0f);
@@ -52,7 +51,7 @@ void ASpatialCleanupConnectionTest::PrepareTest()
 				SpawnedPawn->SetActorLocation(Server1PositionAndInInterestBorderServer2);
 				USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
 				AssertEqual_Int(Driver->ClientConnections.Num(), GetNumberOfClientWorkers() + 1,
-								TEXT("Move into server 2 interest: expected 1 spatial connection + number of clients"));
+								TEXT("Move into server 2 interest: expected all client connections and one spatial connection"));
 				FinishStep();
 			});
 
@@ -61,7 +60,7 @@ void ASpatialCleanupConnectionTest::PrepareTest()
 		[this](float delta) {
 			USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
 			RequireEqual_Int(Driver->ClientConnections.Num(), GetNumberOfClientWorkers() + 1,
-							 TEXT("Move into server 2 interest: expected 1 spatial connection + number of clients"));
+							 TEXT("Move into server 2 interest: expected all client connections and one spatial connection"));
 			FinishStep();
 		},
 		5.0f);
@@ -71,7 +70,7 @@ void ASpatialCleanupConnectionTest::PrepareTest()
 				SpawnedPawn->SetActorLocation(Server1Position);
 				USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
 				AssertEqual_Int(Driver->ClientConnections.Num(), GetNumberOfClientWorkers() + 1,
-								TEXT("Move out of server 2 interest: expected 1 spatial connection + number of clients"));
+								TEXT("Move out of server 2 interest: expected all client connections and one spatial connection"));
 				FinishStep();
 			});
 
@@ -79,8 +78,8 @@ void ASpatialCleanupConnectionTest::PrepareTest()
 		TEXT("Post move 2 player connections on server 2"), FWorkerDefinition::Server(2), nullptr, nullptr,
 		[this](float delta) {
 			USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
-			RequireEqual_Int(Driver->ClientConnections.Num(), GetNumberOfClientWorkers(),
-							 TEXT("Move out of server 2 interest: expected client connections only"));
+			RequireEqual_Int(Driver->ClientConnections.Num(), (GetNumberOfClientWorkers() - 1) + 1,
+							 TEXT("Move out of server 2 interest: expected one less client connection and one spatial connection"));
 			FinishStep();
 		},
 		5.0f);

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialCleanupConnectionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialCleanupConnectionTest.cpp
@@ -1,0 +1,87 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "SpatialCleanupConnectionTest.h"
+
+#include "SpatialFunctionalTestFlowController.h"
+
+ASpatialCleanupConnectionTest::ASpatialCleanupConnectionTest()
+{
+	Author = "Simon Sarginson";
+	Description = TEXT("Tests if clients connections are cleaned up when leaving interest region of a non authorative server");
+
+	Server1Position = FVector(-500.0f, -500.0f, 50.0f);
+	Server1PositionAndInInterestBorderServer2 = FVector(-50.0f, -50.0f, 50.0f);
+	Server2Position = FVector(500.0f, -500.0f, 50.0f);
+
+	SetNumRequiredClients(1);
+}
+
+void ASpatialCleanupConnectionTest::PrepareTest()
+{
+	Super::PrepareTest();
+
+	AddStep(TEXT("Spawn player on server 1"), FWorkerDefinition::Server(1), nullptr, [this]() {
+		USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
+		AssertIsValid(Driver, TEXT("Test is exclusive to using SpatialNetDriver"));
+		ASpatialFunctionalTestFlowController* ClientOneFlowController = GetFlowController(ESpatialFunctionalTestWorkerType::Client, 1);
+		PlayerController = Cast<APlayerController>(ClientOneFlowController->GetOwner());
+		AssertIsValid(PlayerController, TEXT("Must have valid PlayerController for test"));
+		DefaultPawn = PlayerController->GetPawn();
+		PlayerController->UnPossess();
+		SpawnedPawn = GetWorld()->SpawnActor<ATestMovementCharacter>(Server1Position, FRotator::ZeroRotator, FActorSpawnParameters());
+		RegisterAutoDestroyActor(SpawnedPawn);
+		PlayerController->Possess(SpawnedPawn);
+
+		AssertEqual_Int(Driver->ClientConnections.Num(), 2, TEXT("Spawn expected 2 connections (base + PC)"));
+		FinishStep();
+	});
+
+	AddStep(TEXT("Post spawn check connections on server 2"), FWorkerDefinition::Server(2), nullptr, nullptr, [this](float delta) {
+		USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
+		AssertIsValid(Driver, TEXT("Test is exclusive to using SpatialNetDriver"));
+		RequireEqual_Int(Driver->ClientConnections.Num(), 1, TEXT("Spawn expected 1 connection (base only)"));
+		FinishStep();
+	}, 5.0f);
+	
+	AddStep(
+		TEXT("Move player to location on server 1 that overlaps with interest border server 2"), FWorkerDefinition::Server(1), nullptr,
+		[this](){
+				USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
+				AssertIsValid(Driver, TEXT("Test is exclusive to using SpatialNetDriver"));
+				SpawnedPawn->SetActorLocation(Server1PositionAndInInterestBorderServer2);
+				AssertEqual_Int(Driver->ClientConnections.Num(), 2, TEXT("Move into server 2 interest: expected 2 connections (base + PC)"));
+				FinishStep();
+	});
+
+	AddStep(
+		TEXT("Post move player connections on server 2"), FWorkerDefinition::Server(2), nullptr, nullptr, [this](float delta) {
+		USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
+		AssertIsValid(Driver, TEXT("Test is exclusive to using SpatialNetDriver"));
+		RequireEqual_Int(Driver->ClientConnections.Num(), 2, TEXT("Move into server 2 interest: expected 2 connections (base + PC)"));
+		FinishStep();
+		}, 5.0f);
+
+	AddStep(
+		TEXT("Move player to location on server 1 outside of interest border server 2"), FWorkerDefinition::Server(1), nullptr,
+			[this]() {
+				USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
+				AssertIsValid(Driver, TEXT("Test is exclusive to using SpatialNetDriver"));
+				SpawnedPawn->SetActorLocation(Server1Position);
+				AssertEqual_Int(Driver->ClientConnections.Num(), 2, TEXT("Move out of server 2 interest: expected 2 connections (base + PC)"));
+				FinishStep();
+	});
+
+	AddStep(TEXT("Post move 2 player connections on server 2"), FWorkerDefinition::Server(2), nullptr, nullptr, [this](float delta) {
+		USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
+		AssertIsValid(Driver, TEXT("Test is exclusive to using SpatialNetDriver"));
+		RequireEqual_Int(Driver->ClientConnections.Num(), 1, TEXT("Move out of server 2 interest: expected 1 connection (base only)"));
+		FinishStep();
+		}, 5.0f);
+
+	AddStep(TEXT("SpatialTestNetReferenceServerCleanup"), FWorkerDefinition::Server(1), nullptr, [this]() {
+		// Possess the original pawn, so that other tests start from the expected, default set-up
+		PlayerController->Possess(DefaultPawn);
+		FinishStep();
+	});
+}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialCleanupConnectionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialCleanupConnectionTest.cpp
@@ -21,7 +21,7 @@ void ASpatialCleanupConnectionTest::PrepareTest()
 	Super::PrepareTest();
 
 	// Note that we always have at least one client connection which is not a client connection at all but the connection to SpatialOS, 
-	// so all ClientConnections counts are effectively + 1
+	// so all client connections counts are + 1
 	AddStep(TEXT("Spawn player on server 1"), FWorkerDefinition::Server(1), nullptr, [this]() {
 		USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
 		AssertIsValid(Driver, TEXT("Test is exclusive to using SpatialNetDriver"));
@@ -34,7 +34,8 @@ void ASpatialCleanupConnectionTest::PrepareTest()
 		RegisterAutoDestroyActor(SpawnedPawn);
 		PlayerController->Possess(SpawnedPawn);
 
-		AssertEqual_Int(Driver->ClientConnections.Num(), 2, TEXT("Spawn expected 2 connections (spatial connection + PC)"));
+		AssertEqual_Int(Driver->ClientConnections.Num(), GetNumberOfClientWorkers() + 1,
+						TEXT("Spawn: expected 1 spatial connection + number of clients"));
 		FinishStep();
 	});
 
@@ -42,7 +43,7 @@ void ASpatialCleanupConnectionTest::PrepareTest()
 		TEXT("Post spawn check connections on server 2"), FWorkerDefinition::Server(2), nullptr, nullptr,
 		[this](float delta) {
 			USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
-			RequireEqual_Int(Driver->ClientConnections.Num(), 1, TEXT("Spawn expected 1 connection (spatial connection only)"));
+			RequireEqual_Int(Driver->ClientConnections.Num(), 1, TEXT("Spawn: expected 1 spatial connection only"));
 			FinishStep();
 		},
 		5.0f);
@@ -51,8 +52,8 @@ void ASpatialCleanupConnectionTest::PrepareTest()
 			[this]() {
 				SpawnedPawn->SetActorLocation(Server1PositionAndInInterestBorderServer2);
 				USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
-				AssertEqual_Int(Driver->ClientConnections.Num(), 2,
-								TEXT("Move into server 2 interest: expected 2 connections (spatial connection + PC)"));
+				AssertEqual_Int(Driver->ClientConnections.Num(), GetNumberOfClientWorkers() + 1,
+								TEXT("Move into server 2 interest: expected 1 spatial connection + number of clients"));
 				FinishStep();
 			});
 
@@ -60,7 +61,8 @@ void ASpatialCleanupConnectionTest::PrepareTest()
 		TEXT("Post move player connections on server 2"), FWorkerDefinition::Server(2), nullptr, nullptr,
 		[this](float delta) {
 			USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
-			RequireEqual_Int(Driver->ClientConnections.Num(), 2, TEXT("Move into server 2 interest: expected 2 connections (spatial connection + PC)"));
+			RequireEqual_Int(Driver->ClientConnections.Num(), GetNumberOfClientWorkers() + 1,
+							 TEXT("Move into server 2 interest: expected 1 spatial connection + number of clients"));
 			FinishStep();
 		},
 		5.0f);
@@ -69,7 +71,8 @@ void ASpatialCleanupConnectionTest::PrepareTest()
 		TEXT("Move player to location on server 1 outside of interest border server 2"), FWorkerDefinition::Server(1), nullptr, [this]() {
 			SpawnedPawn->SetActorLocation(Server1Position);
 			USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
-			AssertEqual_Int(Driver->ClientConnections.Num(), 2, TEXT("Move out of server 2 interest: expected 2 connections (spatial connection + PC)"));
+			AssertEqual_Int(Driver->ClientConnections.Num(), GetNumberOfClientWorkers() + 1,
+							TEXT("Move out of server 2 interest: expected 1 spatial connection + number of clients"));
 			FinishStep();
 		});
 
@@ -77,7 +80,7 @@ void ASpatialCleanupConnectionTest::PrepareTest()
 		TEXT("Post move 2 player connections on server 2"), FWorkerDefinition::Server(2), nullptr, nullptr,
 		[this](float delta) {
 			USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
-			RequireEqual_Int(Driver->ClientConnections.Num(), 1, TEXT("Move out of server 2 interest: expected 1 connection (spatial connection only)"));
+			RequireEqual_Int(Driver->ClientConnections.Num(), 1, TEXT("Move out of server 2 interest: expected 1 spatial connection only"));
 			FinishStep();
 		},
 		5.0f);

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialCleanupConnectionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialCleanupConnectionTest.cpp
@@ -12,15 +12,13 @@ ASpatialCleanupConnectionTest::ASpatialCleanupConnectionTest()
 	Server1Position = FVector(-500.0f, -500.0f, 50.0f);
 	Server1PositionAndInInterestBorderServer2 = FVector(-50.0f, -50.0f, 50.0f);
 	Server2Position = FVector(500.0f, -500.0f, 50.0f);
-
-	SetNumRequiredClients(1);
 }
 
 void ASpatialCleanupConnectionTest::PrepareTest()
 {
 	Super::PrepareTest();
 
-	// Note that we always have at least one client connection which is not a client connection at all but the connection to SpatialOS, 
+	// Note that we always have at least one client connection which is not a client connection at all but the connection to SpatialOS,
 	// so all client connections counts are + 1
 	AddStep(TEXT("Spawn player on server 1"), FWorkerDefinition::Server(1), nullptr, [this]() {
 		USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
@@ -43,7 +41,8 @@ void ASpatialCleanupConnectionTest::PrepareTest()
 		TEXT("Post spawn check connections on server 2"), FWorkerDefinition::Server(2), nullptr, nullptr,
 		[this](float delta) {
 			USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
-			RequireEqual_Int(Driver->ClientConnections.Num(), 1, TEXT("Spawn: expected 1 spatial connection only"));
+			RequireEqual_Int(Driver->ClientConnections.Num(), GetNumberOfClientWorkers(),
+							 TEXT("Spawn: expected client connections only"));
 			FinishStep();
 		},
 		5.0f);
@@ -67,20 +66,21 @@ void ASpatialCleanupConnectionTest::PrepareTest()
 		},
 		5.0f);
 
-	AddStep(
-		TEXT("Move player to location on server 1 outside of interest border server 2"), FWorkerDefinition::Server(1), nullptr, [this]() {
-			SpawnedPawn->SetActorLocation(Server1Position);
-			USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
-			AssertEqual_Int(Driver->ClientConnections.Num(), GetNumberOfClientWorkers() + 1,
-							TEXT("Move out of server 2 interest: expected 1 spatial connection + number of clients"));
-			FinishStep();
-		});
+	AddStep(TEXT("Move player to location on server 1 outside of interest border server 2"), FWorkerDefinition::Server(1), nullptr,
+			[this]() {
+				SpawnedPawn->SetActorLocation(Server1Position);
+				USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
+				AssertEqual_Int(Driver->ClientConnections.Num(), GetNumberOfClientWorkers() + 1,
+								TEXT("Move out of server 2 interest: expected 1 spatial connection + number of clients"));
+				FinishStep();
+			});
 
 	AddStep(
 		TEXT("Post move 2 player connections on server 2"), FWorkerDefinition::Server(2), nullptr, nullptr,
 		[this](float delta) {
 			USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());
-			RequireEqual_Int(Driver->ClientConnections.Num(), 1, TEXT("Move out of server 2 interest: expected 1 spatial connection only"));
+			RequireEqual_Int(Driver->ClientConnections.Num(), GetNumberOfClientWorkers(),
+							 TEXT("Move out of server 2 interest: expected client connections only"));
 			FinishStep();
 		},
 		5.0f);

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialTest1x2GridSmallInterestStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialTest1x2GridSmallInterestStrategy.cpp
@@ -1,0 +1,8 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "SpatialTest1x2GridSmallInterestStrategy.h"
+
+USpatialTest1x2GridSmallInterestStrategy::USpatialTest1x2GridSmallInterestStrategy()
+{
+	InterestBorder = 150.0f;
+}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialCleanupConnectionTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialCleanupConnectionTest.h
@@ -3,13 +3,13 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "SpatialFunctionalTest.h"
 #include "EngineClasses/SpatialNetDriver.h"
+#include "SpatialFunctionalTest.h"
 #include "SpatialGDKFunctionalTests/SpatialGDK/TestActors/TestMovementCharacter.h"
 #include "SpatialCleanupConnectionTest.generated.h"
 
 /**
- * 
+ *
  */
 UCLASS()
 class SPATIALGDKFUNCTIONALTESTS_API ASpatialCleanupConnectionTest : public ASpatialFunctionalTest
@@ -34,7 +34,8 @@ public:
 	FVector Server1PositionAndInInterestBorderServer2;
 
 	UPROPERTY()
-	APawn* DefaultPawn; // Keep track of the original pawn, so  we can possess it when we cleanup and that other tests start from the expected, default set-up
+	APawn* DefaultPawn; // Keep track of the original pawn, so  we can possess it when we cleanup and that other tests start from the
+						// expected, default set-up
 
 	UPROPERTY()
 	ATestMovementCharacter* SpawnedPawn;

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialCleanupConnectionTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialCleanupConnectionTest.h
@@ -1,0 +1,44 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "SpatialFunctionalTest.h"
+#include "EngineClasses/SpatialNetDriver.h"
+#include "SpatialGDKFunctionalTests/SpatialGDK/TestActors/TestMovementCharacter.h"
+#include "SpatialCleanupConnectionTest.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class SPATIALGDKFUNCTIONALTESTS_API ASpatialCleanupConnectionTest : public ASpatialFunctionalTest
+{
+	GENERATED_BODY()
+
+public:
+	ASpatialCleanupConnectionTest();
+
+	virtual void PrepareTest() override;
+
+	// This needs to be a position that belongs to Server 1.
+	UPROPERTY(EditAnywhere, Category = "Default")
+	FVector Server1Position;
+
+	// This needs to be a position that belongs to Server 2.
+	UPROPERTY(EditAnywhere, Category = "Default")
+	FVector Server2Position;
+
+	// This needs to be a position that belongs to Server 1 and is in the interest border of Server 2.
+	UPROPERTY(EditAnywhere, Category = "Default")
+	FVector Server1PositionAndInInterestBorderServer2;
+
+	UPROPERTY()
+	APawn* DefaultPawn; // Keep track of the original pawn, so  we can possess it when we cleanup and that other tests start from the expected, default set-up
+
+	UPROPERTY()
+	ATestMovementCharacter* SpawnedPawn;
+
+	UPROPERTY()
+	APlayerController* PlayerController;
+};

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialTest1x2GridSmallInterestStrategy.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialTest1x2GridSmallInterestStrategy.h
@@ -1,0 +1,20 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Test1x2GridStrategy.h"
+#include "SpatialTest1x2GridSmallInterestStrategy.generated.h"
+
+/**
+ * A 1 by 2 (rows by columns) load balancing strategy for testing zoning features.
+ * Has a 150 unit interest border, a very small border to create a narrow range in which an actor is visible to both servers
+ */
+UCLASS()
+class SPATIALGDKFUNCTIONALTESTS_API USpatialTest1x2GridSmallInterestStrategy : public UTest1x2GridStrategy
+{
+	GENERATED_BODY()
+
+public:
+	USpatialTest1x2GridSmallInterestStrategy();
+};


### PR DESCRIPTION
#### Description
Fixed client connection not being cleaned up when moving out of interest of a server.

#### Release note
Fixed client connection not being cleaned up when moving out of interest of a server.

#### Tests
Added functional test to test number of connections when moving in and out of interest range of a server.

#### Documentation
Documentation in release notes
