### PR TITLE
Set delegation index fix

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
@@ -837,7 +837,7 @@ void ASpatialFunctionalTest::AddStepSetTagDelegation(FName Tag, int32 ServerWork
 	{
 		return;
 	}
-	if (ServerWorkerId >= GetNumExpectedServers())
+	if (ServerWorkerId > GetNumExpectedServers())
 	{
 		ServerWorkerId = 1; // Support for single worker environments.
 	}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
@@ -834,6 +834,7 @@ void ASpatialFunctionalTest::KeepActorOnCurrentWorker(AActor* Actor)
 
 void ASpatialFunctionalTest::AddStepSetTagDelegation(FName Tag, int32 ServerWorkerId /*= 1*/)
 {
+	// Valid ServerWorkerIDs range from 1 to NumExpectedServers, inclusive
 	if (!ensureMsgf(ServerWorkerId > 0, TEXT("Invalid Server Worker Id")))
 	{
 		return;

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
@@ -410,7 +410,8 @@ void ASpatialFunctionalTest::RegisterFlowController(ASpatialFunctionalTestFlowCo
 	{
 		if (LocalFlowController != nullptr)
 		{
-			checkf(LocalFlowController == FlowController, TEXT("OwningTest already had different LocalFlowController, this shouldn't happen"));
+			checkf(LocalFlowController == FlowController,
+				   TEXT("OwningTest already had different LocalFlowController, this shouldn't happen"));
 			return;
 		}
 


### PR DESCRIPTION
#### Description
Fixes an off-by-one error in AddStepSetTagDelegation.
ServerWorkerIDs in the testing framework start at 1, so the largest allowed index is equal to the number of workers in the deployment.

#### Tests
The existing debug interface doesn't actually use this function, which is why this did not get caught. 