### PR TITLE
Bugfix/unr 4462 gamemode always relevant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ These functions and structs can be referenced in both code and blueprints it may
 - Server workers use TCP (instead of KCP) by default.
 - Fixed a rare crash where a RepNotify callback can modify a GDK data structure being iterated upon.
 - Fixed race condition in Spatial Test framework that would cause tests to time out with one or more workers not ready to begin the test.
+- Fixed an issue where GameMode values won't be replicated between server workers if it's outside their Interest
 
 ## [`0.11.0`] - 2020-09-03
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
@@ -14,6 +14,7 @@
 
 #include "EngineClasses/SpatialNetDriver.h"
 #include "EngineClasses/SpatialPendingNetGame.h"
+#include "GameFramework/GameModeBase.h"
 #include "Interop/Connection/SpatialConnectionManager.h"
 #include "Interop/Connection/SpatialWorkerConnection.h"
 #include "Interop/GlobalStateManager.h"
@@ -227,6 +228,19 @@ void USpatialGameInstance::Init()
 	{
 		FWorldDelegates::LevelInitializedNetworkActors.AddUObject(this, &USpatialGameInstance::OnLevelInitializedNetworkActors);
 	}
+}
+
+AGameModeBase* USpatialGameInstance::CreateGameModeForURL(FURL InURL, UWorld* InWorld)
+{
+	AGameModeBase* GameMode = Super::CreateGameModeForURL(InURL, InWorld);
+
+	if (IsValid(GameMode) && USpatialStatics::IsSpatialNetworkingEnabled())
+	{
+		// UNR-4462: Make sure GameModes are always relevant when using Spatial networking
+		GameMode->bAlwaysRelevant = true;
+	}
+
+	return GameMode;
 }
 
 void USpatialGameInstance::HandleOnConnected(const USpatialNetDriver& NetDriver)

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialGameInstance.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialGameInstance.h
@@ -41,6 +41,7 @@ public:
 
 	//~ Begin UGameInstance Interface
 	virtual void Init() override;
+	virtual AGameModeBase* CreateGameModeForURL(FURL InURL, UWorld* InWorld) override;
 	//~ End UGameInstance Interface
 
 	// The SpatiaConnectionManager must always be owned by the SpatialGameInstance and so must be created here to prevent TrimMemory from

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/GameModeReplicationTest/GameModeReplicationTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/GameModeReplicationTest/GameModeReplicationTest.cpp
@@ -1,0 +1,138 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "GameModeReplicationTest.h"
+
+#include "Net/UnrealNetwork.h"
+
+#include "GameFramework/GameStateBase.h"
+
+AGameModeReplicationTestGameMode::AGameModeReplicationTestGameMode()
+{
+	NetCullDistanceSquared = 0;
+}
+
+void AGameModeReplicationTestGameMode::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+	DOREPLIFETIME(AGameModeReplicationTestGameMode, ReplicatedValue);
+}
+
+bool AGameModeReplicationTestGameMode::IsNetRelevantFor(const AActor* RealViewer, const AActor* ViewTarget,
+														const FVector& SrcLocation) const
+{
+	return false;
+}
+
+/**
+ * This test checks that GameModes:
+ * * Only owned by a single worker
+ * * Replicate between servers
+ * * Don't replicate to clients
+ */
+
+AGameModeReplicationTest::AGameModeReplicationTest()
+{
+	Author = TEXT("Dmitrii");
+	Description = TEXT("Test GameMode replication");
+
+	bReplicates = true;
+	bAlwaysRelevant = true;
+}
+
+void AGameModeReplicationTest::MarkWorkerGameModeAuthority_Implementation(int WorkerId, bool bHasGameModeAuthority)
+{
+	ServerResponsesCount++;
+
+	if (bHasGameModeAuthority)
+	{
+		++AuthorityServersCount;
+	}
+}
+
+void AGameModeReplicationTest::PrepareTest()
+{
+	Super::PrepareTest();
+
+	check(GetWorld()->GetGameState()->GameModeClass == AGameModeReplicationTestGameMode::StaticClass());
+
+	AuthorityServersCount = 0;
+
+	AddStep(TEXT("Changing replicated value on the authoritative server"), FWorkerDefinition::AllServers, nullptr, [this]() {
+		AGameModeReplicationTestGameMode* GameMode = Cast<AGameModeReplicationTestGameMode>(GetWorld()->GetAuthGameMode());
+
+		check(IsValid(GameMode));
+
+		AssertEqual_Int(GameMode->ReplicatedValue, AGameModeReplicationTestGameMode::StartingValue,
+						TEXT("Value on the GameMode before changing it"));
+
+		const bool bHasAuthorityOverGameMode = GameMode->HasAuthority();
+
+		MarkWorkerGameModeAuthority(GetLocalWorkerId(), bHasAuthorityOverGameMode);
+
+		if (bHasAuthorityOverGameMode)
+		{
+			const FVector GameModeFarawayLocation(1000 * 1000 * 1000, 1000 * 1000 * 1000, 1000 * 1000 * 1000);
+
+			// GameModeBase hides this function so we upcast to AActor;
+			// this probably doesn't do anything as GameModes generally don't have RootComponents
+			// and no location as consequence
+			AActor* GameModeActor = GameMode;
+
+			GameModeActor->SetActorLocation(GameModeFarawayLocation);
+
+			// actually change the replicated value from the authority server
+			GameMode->ReplicatedValue = AGameModeReplicationTestGameMode::UpdatedValue;
+		}
+		else
+		{
+			AuthorityServersCount++;
+			AssertEqual_Int(AuthorityServersCount, 1, TEXT("Amount of servers having authority over the GameMode"));
+		}
+
+		FinishStep();
+	});
+
+	constexpr int CrossServerRpcExecutionTime = 1;
+
+	AddStep(
+		TEXT("Waiting for GameMode authority information"), FWorkerDefinition::AllServers, nullptr,
+		[this]() {
+			if (!HasAuthority())
+			{
+				FinishStep();
+			}
+		},
+		[this](float) {
+			if (ServerResponsesCount == GetNumberOfServerWorkers())
+			{
+				AssertEqual_Int(AuthorityServersCount, 1, TEXT("Count of servers holding authority over the GameMode"));
+
+				FinishStep();
+			}
+		},
+		CrossServerRpcExecutionTime);
+
+	constexpr int ValueReplicationTime = 1;
+
+	AddStep(
+		TEXT("Waiting for the GameMode value to be received on all servers"), FWorkerDefinition::AllServers, nullptr, nullptr,
+		[this](float DeltaTime) {
+			AGameModeReplicationTestGameMode* GameMode = Cast<AGameModeReplicationTestGameMode>(GetWorld()->GetAuthGameMode());
+
+			check(IsValid(GameMode));
+
+			if (GameMode->ReplicatedValue == AGameModeReplicationTestGameMode::UpdatedValue)
+			{
+				FinishStep();
+			}
+		},
+		ValueReplicationTime);
+
+	AddStep(TEXT("Checking that no clients have a GameMode"), FWorkerDefinition::AllClients, nullptr, [this]() {
+		for (AGameModeBase* GameModeActor : TActorRange<AGameModeBase>(GetWorld()))
+		{
+			AddError(FString::Printf(TEXT("Found a GameMode Actor %s on client!"), *GetNameSafe(GameModeActor)));
+		}
+
+		FinishStep();
+	});
+}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/GameModeReplicationTest/GameModeReplicationTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/GameModeReplicationTest/GameModeReplicationTest.cpp
@@ -82,11 +82,6 @@ void AGameModeReplicationTest::PrepareTest()
 			// actually change the replicated value from the authority server
 			GameMode->ReplicatedValue = AGameModeReplicationTestGameMode::UpdatedValue;
 		}
-		else
-		{
-			AuthorityServersCount++;
-			AssertEqual_Int(AuthorityServersCount, 1, TEXT("Amount of servers having authority over the GameMode"));
-		}
 
 		FinishStep();
 	});

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/GameModeReplicationTest/GameModeReplicationTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/GameModeReplicationTest/GameModeReplicationTest.h
@@ -1,0 +1,52 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+#include "SpatialCommonTypes.h"
+#include "SpatialFunctionalTest.h"
+
+#include "GameFramework/GameModeBase.h"
+
+#include "GameModeReplicationTest.generated.h"
+
+UCLASS(BlueprintType)
+class SPATIALGDKFUNCTIONALTESTS_API AGameModeReplicationTestGameMode : public AGameModeBase
+{
+public:
+	GENERATED_BODY()
+
+	AGameModeReplicationTestGameMode();
+
+	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
+
+	virtual bool IsNetRelevantFor(const AActor* RealViewer, const AActor* ViewTarget, const FVector& SrcLocation) const override;
+
+	constexpr static int StartingValue = 0;
+
+	constexpr static int UpdatedValue = 500;
+
+	UPROPERTY(Replicated, Transient)
+	int ReplicatedValue = StartingValue;
+};
+
+UCLASS(BlueprintType, SpatialType)
+class SPATIALGDKFUNCTIONALTESTS_API AGameModeReplicationTest : public ASpatialFunctionalTest
+{
+	GENERATED_BODY()
+
+public:
+	AGameModeReplicationTest();
+
+	UFUNCTION(CrossServer, Reliable)
+	void MarkWorkerGameModeAuthority(int WorkerId, bool bHasGameModeAuthority);
+
+	virtual void PrepareTest() override;
+
+	int AuthorityServersCount = 0;
+
+	int ServerResponsesCount = 0;
+
+	float TimeWaited = 0;
+};


### PR DESCRIPTION
#### Description
There is an issue where a GameMode won't be relevant between servers if they have zoning enabled, and if Interest Border is low; a map and a functional test were added to the Gym repo.
The fix to this issue is setting the GameMode to be always relevant; this is achieved either via an engine change (setting `bAlwaysRelevant` in `PostInitializeProperties`), or via the plugin change (overriding `CreateGameModeForURL` and mutating the GameMode there). The second approach was encouraged by @ImprobableNic, so it was implemented in this PR.

#### Tests
A new automated test was added to reproduce the initial issue and check the fix.

#### Documentation
Added a note to CHANGELIST.
