### PR TITLE
[UNR-4529] Cross-server ability activation functional test

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.cpp
@@ -2,13 +2,21 @@
 
 #include "CrossServerAbilityActivationTest.h"
 #include "GA_IncrementSpyValue.h"
+#include "GameplayTagContainer.h"
 
 ACrossServerAbilityActivationTest::ACrossServerAbilityActivationTest()
 {
 	Author = "Tilman Schmidt";
 	Description = TEXT("Tests that gameplay abilities can be activated across server boundaries.");
+	DuplicateActivationCheckWaitTime = 2.0f;
 
 	TargetActor = nullptr;
+	StepTimer = -1.0f;
+}
+
+bool TargetActorReadyForActivation(ASpyValueGASTestActor* Target)
+{
+	return Target->GetLocalRole() == ENetRole::ROLE_SimulatedProxy && Target->GetCounter() == 0;
 }
 
 void ACrossServerAbilityActivationTest::PrepareTest()
@@ -17,34 +25,101 @@ void ACrossServerAbilityActivationTest::PrepareTest()
 
 	FName TargetActorTag = FName(TEXT("Target"));
 
-	{ // Step 1 - Spawn Actor On Auth
-		AddStep(TEXT("SERVER_1_Spawn"), FWorkerDefinition::Server(1), nullptr, [this, TargetActorTag]() {
-			UWorld* World = GetWorld();
-			TargetActor = World->SpawnActor<ASpyValueGASTestActor>({ 0.0f, 0.0f, 0.0f }, FRotator::ZeroRotator);
-			AssertTrue(IsValid(TargetActor), TEXT("Target actor is valid."));
-			AddDebugTag(TargetActor, TargetActorTag);
-			RegisterAutoDestroyActor(TargetActor);
-			FinishStep();
-		});
-	}
+	// Step 1 - Spawn Actor On Auth
+	AddStep(TEXT("SERVER_1_Spawn"), FWorkerDefinition::Server(1), nullptr, [this, TargetActorTag]() {
+		UWorld* World = GetWorld();
+		TargetActor = World->SpawnActor<ASpyValueGASTestActor>({ 0.0f, 0.0f, 0.0f }, FRotator::ZeroRotator);
+		AssertTrue(IsValid(TargetActor), TEXT("Target actor is valid."));
+		AssertTrue(TargetActor->GetCounter() == 0, TEXT("Target actor spy counter starts at 0"));
+		AddDebugTag(TargetActor, TargetActorTag);
+		RegisterAutoDestroyActor(TargetActor);
+		FinishStep();
+	});
 
 	AddStepSetTagDelegation(TargetActorTag, 2);
 
-	{ // Step 2 - Trigger an ability by class, cross-server
-		AddStep(
-			TEXT("SERVER_1_ActivateAbility"), FWorkerDefinition::Server(1),
-			[this]() {
-				return TargetActor->GetLocalRole() == ENetRole::ROLE_SimulatedProxy;
-			},
-			[this]() {
-				UAbilitySystemComponent* ASC = TargetActor->GetAbilitySystemComponent();
-				AssertTrue(ASC != nullptr, TEXT("TargetActor has an ability system component."));
+	// Step 2 - Trigger an ability by class, cross-server, and confirm that it got activated
+	AddStep(
+		TEXT("SERVER_1_ActivateAbilityByClass"), FWorkerDefinition::Server(1),
+		[this]() {
+			return TargetActorReadyForActivation(TargetActor);
+		},
+		[this]() {
+			UAbilitySystemComponent* ASC = TargetActor->GetAbilitySystemComponent();
+			AssertTrue(ASC != nullptr, TEXT("TargetActor has an ability system component."));
 
-				UE_LOG(LogTemp, Log, TEXT("Activating ability"));
-				ASC->CrossServerTryActivateAbilityByClass(UGA_IncrementSpyValue::StaticClass());
-				// bool bDidActivate = ASC->TryActivateAbilityByClass(UGA_IncrementSpyValue::StaticClass());
-				// UE_LOG(LogTemp, Log, TEXT("Did activate: %s"), bDidActivate ? TEXT("True") : TEXT("False"));
+			UE_LOG(LogTemp, Log, TEXT("Activating ability"));
+			ASC->CrossServerTryActivateAbilityByClass(UGA_IncrementSpyValue::StaticClass());
+		},
+		[this](float DeltaTime) {
+			bool bShouldFinishStep = WaitForActivationConfirmation(DeltaTime);
+			if (bShouldFinishStep)
+			{
 				FinishStep();
-			});
+			}
+		});
+
+	// Step 3 - Same as 2, but trigger by tag
+	AddStep(
+		TEXT("SERVER_1_ActivateAbilityByTag"), FWorkerDefinition::Server(1),
+		[this]() {
+			return TargetActorReadyForActivation(TargetActor);
+		},
+		[this]() {
+			UAbilitySystemComponent* ASC = TargetActor->GetAbilitySystemComponent();
+			AssertTrue(ASC != nullptr, TEXT("TargetActor has an ability system component."));
+
+			UE_LOG(LogTemp, Log, TEXT("Activating ability"));
+			ASC->CrossServerTryActivateAbilitiesByTag(
+				FGameplayTagContainer(FGameplayTag::RequestGameplayTag(FName(TEXT("GameplayAbility.Trigger")))));
+		},
+		[this](float DeltaTime) {
+			bool bShouldFinishStep = WaitForActivationConfirmation(DeltaTime);
+			if (bShouldFinishStep)
+			{
+				FinishStep();
+			}
+		});
+}
+
+bool ACrossServerAbilityActivationTest::WaitForActivationConfirmation(float DeltaTime)
+{
+	// StepTimer == -1.0f signals that we have not yet see Counter be 1
+	if (StepTimer != -1.0f)
+	{
+		StepTimer += DeltaTime;
 	}
+
+	int Counter = TargetActor->GetCounter();
+	if (Counter == 0)
+	{
+		// The counter is allowed to be 0 while we are still waiting for the changed counter to replicated to us.
+		// However, if we've seen Counter at 1 before (and as a result started the timer), if we see it back at 0,
+		// it somehow got reset. This likely indicates a bug in the test implementation.
+		if (StepTimer != -1.0f)
+		{
+			FinishTest(EFunctionalTestResult::Invalid,
+					   TEXT("The spy actor counter was reset after being set to 1. This is probably a bug in this test implementation."));
+		}
+	}
+	else if (Counter == 1)
+	{
+		if (StepTimer == -1.0f)
+		{
+			StepTimer = 0.0f;
+		}
+		else if (StepTimer >= DuplicateActivationCheckWaitTime)
+		{
+			StepTimer = -1.0f;
+			TargetActor->ResetCounter();
+			return true;
+		}
+	}
+	else
+	{
+		FinishTest(EFunctionalTestResult::Failed,
+				   FString::Printf(TEXT("The ability was activated %d times. It should only be activated once."), Counter));
+	}
+
+	return false;
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.cpp
@@ -30,11 +30,6 @@ ACrossServerAbilityActivationTest::ACrossServerAbilityActivationTest()
 	bTimerStarted = false;
 }
 
-static bool TargetActorReadyForActivation(ASpyValueGASTestActor* Target)
-{
-	return Target->GetLocalRole() == ENetRole::ROLE_SimulatedProxy && Target->GetCounter() == 0;
-}
-
 void ACrossServerAbilityActivationTest::PrepareTest()
 {
 	Super::PrepareTest();
@@ -53,6 +48,10 @@ void ACrossServerAbilityActivationTest::PrepareTest()
 	});
 
 	AddStepSetTagDelegation(TargetActorTag, 2);
+
+	auto WaitForTargetReadyForActivation = [this]() {
+		return TargetActor->GetLocalRole() == ENetRole::ROLE_SimulatedProxy && TargetActor->GetCounter() == 0;
+	};
 
 	auto CheckActivationConfirmed = [this](float DeltaTime) {
 		if (bTimerStarted)
@@ -96,10 +95,7 @@ void ACrossServerAbilityActivationTest::PrepareTest()
 
 	// Step 2 - Trigger an ability by spec handle, cross-server, and confirm that it got activated
 	AddStep(
-		TEXT("Activate Ability by Spec Handle"), FWorkerDefinition::Server(1),
-		[this]() {
-			return TargetActorReadyForActivation(TargetActor);
-		},
+		TEXT("Activate Ability by Spec Handle"), FWorkerDefinition::Server(1), WaitForTargetReadyForActivation,
 		[this]() {
 			UAbilitySystemComponent* ASC = TargetActor->GetAbilitySystemComponent();
 			AssertIsValid(ASC, TEXT("TargetActor has an ability system component."));
@@ -117,10 +113,7 @@ void ACrossServerAbilityActivationTest::PrepareTest()
 
 	// Step 3 - Same as 2, but activate by class
 	AddStep(
-		TEXT("Activate Ability by Class"), FWorkerDefinition::Server(1),
-		[this]() {
-			return TargetActorReadyForActivation(TargetActor);
-		},
+		TEXT("Activate Ability by Class"), FWorkerDefinition::Server(1), WaitForTargetReadyForActivation,
 		[this]() {
 			UAbilitySystemComponent* ASC = TargetActor->GetAbilitySystemComponent();
 			AssertIsValid(ASC, TEXT("TargetActor has an ability system component."));
@@ -131,10 +124,7 @@ void ACrossServerAbilityActivationTest::PrepareTest()
 
 	// Step 4 - Same as 2, but activate by tag
 	AddStep(
-		TEXT("Activate Ability by Tag"), FWorkerDefinition::Server(1),
-		[this]() {
-			return TargetActorReadyForActivation(TargetActor);
-		},
+		TEXT("Activate Ability by Tag"), FWorkerDefinition::Server(1), WaitForTargetReadyForActivation,
 		[this]() {
 			UAbilitySystemComponent* ASC = TargetActor->GetAbilitySystemComponent();
 			AssertIsValid(ASC, TEXT("TargetActor has an ability system component."));
@@ -145,10 +135,7 @@ void ACrossServerAbilityActivationTest::PrepareTest()
 
 	// Step 5 - Activate by event.
 	AddStep(
-		TEXT("Activate Ability by Event"), FWorkerDefinition::Server(1),
-		[this]() {
-			return TargetActorReadyForActivation(TargetActor);
-		},
+		TEXT("Activate Ability by Event"), FWorkerDefinition::Server(1), WaitForTargetReadyForActivation,
 		[this]() {
 			UAbilitySystemComponent* ASC = TargetActor->GetAbilitySystemComponent();
 			AssertIsValid(ASC, TEXT("TargetActor has an ability system component."));

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.cpp
@@ -22,7 +22,7 @@
 
 ACrossServerAbilityActivationTest::ACrossServerAbilityActivationTest()
 {
-	Author = "Tilman Schmidt";
+	Author = TEXT("Tilman Schmidt");
 	Description = TEXT("Tests that gameplay abilities can be activated across server boundaries.");
 	DuplicateActivationCheckWaitTime = 2.0f;
 
@@ -30,7 +30,7 @@ ACrossServerAbilityActivationTest::ACrossServerAbilityActivationTest()
 	StepTimer = -1.0f;
 }
 
-bool TargetActorReadyForActivation(ASpyValueGASTestActor* Target)
+static bool TargetActorReadyForActivation(ASpyValueGASTestActor* Target)
 {
 	return Target->GetLocalRole() == ENetRole::ROLE_SimulatedProxy && Target->GetCounter() == 0;
 }
@@ -44,7 +44,7 @@ void ACrossServerAbilityActivationTest::PrepareTest()
 	// Step 1 - Spawn Actor On Auth
 	AddStep(TEXT("Spawn actor"), FWorkerDefinition::Server(1), nullptr, [this, TargetActorTag]() {
 		UWorld* World = GetWorld();
-		TargetActor = World->SpawnActor<ASpyValueGASTestActor>({ 0.0f, 0.0f, 0.0f }, FRotator::ZeroRotator);
+		TargetActor = World->SpawnActor<ASpyValueGASTestActor>(FVector::ZeroVector, FRotator::ZeroRotator);
 		AssertTrue(IsValid(TargetActor), TEXT("Target actor is valid."));
 		AssertTrue(TargetActor->GetCounter() == 0, TEXT("Target actor spy counter starts at 0"));
 		AddDebugTag(TargetActor, TargetActorTag);
@@ -53,6 +53,46 @@ void ACrossServerAbilityActivationTest::PrepareTest()
 	});
 
 	AddStepSetTagDelegation(TargetActorTag, 2);
+
+	auto CheckActivationConfirmed = [this](float DeltaTime) {
+		// StepTimer == -1.0f signals that we have not yet seen Counter be 1
+		if (StepTimer != -1.0f)
+		{
+			StepTimer += DeltaTime;
+		}
+
+		int Counter = TargetActor->GetCounter();
+		if (Counter == 0)
+		{
+			// The counter is allowed to be 0 while we are still waiting for the changed counter to replicated to us.
+			// However, if we've seen Counter at 1 before (and as a result started the timer), if we see it back at 0,
+			// it somehow got reset. This likely indicates a bug in the test implementation.
+			if (StepTimer != -1.0f)
+			{
+				FinishTest(
+					EFunctionalTestResult::Invalid,
+					TEXT("The spy actor counter was reset after being set to 1. This is probably a bug in this test implementation."));
+			}
+		}
+		else if (Counter == 1)
+		{
+			if (StepTimer == -1.0f)
+			{
+				StepTimer = 0.0f;
+			}
+			else if (StepTimer >= DuplicateActivationCheckWaitTime)
+			{
+				StepTimer = -1.0f;
+				TargetActor->ResetCounter();
+				FinishStep();
+			}
+		}
+		else
+		{
+			FinishTest(EFunctionalTestResult::Failed,
+					   FString::Printf(TEXT("The ability was activated %d times. It should only be activated once."), Counter));
+		}
+	};
 
 	// Step 2 - Trigger an ability by spec handle, cross-server, and confirm that it got activated
 	AddStep(
@@ -73,13 +113,7 @@ void ACrossServerAbilityActivationTest::PrepareTest()
 
 			ASC->CrossServerTryActivateAbility(AbilityHandle);
 		},
-		[this](float DeltaTime) {
-			bool bShouldFinishStep = WaitForActivationConfirmation(DeltaTime);
-			if (bShouldFinishStep)
-			{
-				FinishStep();
-			}
-		});
+		CheckActivationConfirmed);
 
 	// Step 3 - Same as 2, but activate by class
 	AddStep(
@@ -93,13 +127,7 @@ void ACrossServerAbilityActivationTest::PrepareTest()
 
 			ASC->CrossServerTryActivateAbilityByClass(UGA_IncrementSpyValue::StaticClass());
 		},
-		[this](float DeltaTime) {
-			bool bShouldFinishStep = WaitForActivationConfirmation(DeltaTime);
-			if (bShouldFinishStep)
-			{
-				FinishStep();
-			}
-		});
+		CheckActivationConfirmed);
 
 	// Step 4 - Same as 2, but activate by tag
 	AddStep(
@@ -113,13 +141,7 @@ void ACrossServerAbilityActivationTest::PrepareTest()
 
 			ASC->CrossServerTryActivateAbilitiesByTag(FGameplayTagContainer(UGA_IncrementSpyValue::GetTriggerTag()));
 		},
-		[this](float DeltaTime) {
-			bool bShouldFinishStep = WaitForActivationConfirmation(DeltaTime);
-			if (bShouldFinishStep)
-			{
-				FinishStep();
-			}
-		});
+		CheckActivationConfirmed);
 
 	// Step 5 - Activate by event.
 	AddStep(
@@ -134,53 +156,5 @@ void ACrossServerAbilityActivationTest::PrepareTest()
 			FGameplayEventData EventData;
 			ASC->CrossServerHandleGameplayEvent(UGA_IncrementSpyValue::GetTriggerTag(), EventData);
 		},
-		[this](float DeltaTime) {
-			bool bShouldFinishStep = WaitForActivationConfirmation(DeltaTime);
-			if (bShouldFinishStep)
-			{
-				FinishStep();
-			}
-		});
-}
-
-bool ACrossServerAbilityActivationTest::WaitForActivationConfirmation(float DeltaTime)
-{
-	// StepTimer == -1.0f signals that we have not yet seen Counter be 1
-	if (StepTimer != -1.0f)
-	{
-		StepTimer += DeltaTime;
-	}
-
-	int Counter = TargetActor->GetCounter();
-	if (Counter == 0)
-	{
-		// The counter is allowed to be 0 while we are still waiting for the changed counter to replicated to us.
-		// However, if we've seen Counter at 1 before (and as a result started the timer), if we see it back at 0,
-		// it somehow got reset. This likely indicates a bug in the test implementation.
-		if (StepTimer != -1.0f)
-		{
-			FinishTest(EFunctionalTestResult::Invalid,
-					   TEXT("The spy actor counter was reset after being set to 1. This is probably a bug in this test implementation."));
-		}
-	}
-	else if (Counter == 1)
-	{
-		if (StepTimer == -1.0f)
-		{
-			StepTimer = 0.0f;
-		}
-		else if (StepTimer >= DuplicateActivationCheckWaitTime)
-		{
-			StepTimer = -1.0f;
-			TargetActor->ResetCounter();
-			return true;
-		}
-	}
-	else
-	{
-		FinishTest(EFunctionalTestResult::Failed,
-				   FString::Printf(TEXT("The ability was activated %d times. It should only be activated once."), Counter));
-	}
-
-	return false;
+		CheckActivationConfirmed);
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.cpp
@@ -31,15 +31,20 @@ void ACrossServerAbilityActivationTest::PrepareTest()
 	AddStepSetTagDelegation(TargetActorTag, 2);
 
 	{ // Step 2 - Trigger an ability by class, cross-server
-		AddStep(TEXT("SERVER_1_ActivateAbility"), FWorkerDefinition::Server(1), nullptr, [this]() {
-			UAbilitySystemComponent* ASC = TargetActor->GetAbilitySystemComponent();
-			AssertTrue(ASC != nullptr, TEXT("TargetActor has an ability system component."));
+		AddStep(
+			TEXT("SERVER_1_ActivateAbility"), FWorkerDefinition::Server(1),
+			[this]() {
+				return TargetActor->GetLocalRole() == ENetRole::ROLE_SimulatedProxy;
+			},
+			[this]() {
+				UAbilitySystemComponent* ASC = TargetActor->GetAbilitySystemComponent();
+				AssertTrue(ASC != nullptr, TEXT("TargetActor has an ability system component."));
 
-			UE_LOG(LogTemp, Log, TEXT("Activating ability"));
-			ASC->CrossServerTryActivateAbilityByClass(UGA_IncrementSpyValue::StaticClass());
-			// bool bDidActivate = ASC->TryActivateAbilityByClass(UGA_IncrementSpyValue::StaticClass());
-			// UE_LOG(LogTemp, Log, TEXT("Did activate: %s"), bDidActivate ? TEXT("True") : TEXT("False"));
-			FinishStep();
-		});
+				UE_LOG(LogTemp, Log, TEXT("Activating ability"));
+				ASC->CrossServerTryActivateAbilityByClass(UGA_IncrementSpyValue::StaticClass());
+				// bool bDidActivate = ASC->TryActivateAbilityByClass(UGA_IncrementSpyValue::StaticClass());
+				// UE_LOG(LogTemp, Log, TEXT("Did activate: %s"), bDidActivate ? TEXT("True") : TEXT("False"));
+				FinishStep();
+			});
 	}
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "CrossServerAbilityActivationTest.h"
+#include "GA_IncrementSpyValue.h"
+
+ACrossServerAbilityActivationTest::ACrossServerAbilityActivationTest()
+{
+	Author = "Tilman Schmidt";
+	Description = TEXT("Tests that gameplay abilities can be activated across server boundaries.");
+
+	TargetActor = nullptr;
+}
+
+void ACrossServerAbilityActivationTest::PrepareTest()
+{
+	Super::PrepareTest();
+
+	FName TargetActorTag = FName(TEXT("Target"));
+
+	{ // Step 1 - Spawn Actor On Auth
+		AddStep(TEXT("SERVER_1_Spawn"), FWorkerDefinition::Server(1), nullptr, [this, TargetActorTag]() {
+			UWorld* World = GetWorld();
+			TargetActor = World->SpawnActor<ASpyValueGASTestActor>({ 0.0f, 0.0f, 0.0f }, FRotator::ZeroRotator);
+			AssertTrue(IsValid(TargetActor), TEXT("Target actor is valid."));
+			AddDebugTag(TargetActor, TargetActorTag);
+			RegisterAutoDestroyActor(TargetActor);
+			FinishStep();
+		});
+	}
+
+	AddStepSetTagDelegation(TargetActorTag, 2);
+
+	{ // Step 2 - Trigger an ability by class, cross-server
+		AddStep(TEXT("SERVER_1_ActivateAbility"), FWorkerDefinition::Server(1), nullptr, [this]() {
+			UAbilitySystemComponent* ASC = TargetActor->GetAbilitySystemComponent();
+			AssertTrue(ASC != nullptr, TEXT("TargetActor has an ability system component."));
+
+			UE_LOG(LogTemp, Log, TEXT("Activating ability"));
+			ASC->CrossServerTryActivateAbilityByClass(UGA_IncrementSpyValue::StaticClass());
+			// bool bDidActivate = ASC->TryActivateAbilityByClass(UGA_IncrementSpyValue::StaticClass());
+			// UE_LOG(LogTemp, Log, TEXT("Did activate: %s"), bDidActivate ? TEXT("True") : TEXT("False"));
+			FinishStep();
+		});
+	}
+}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.cpp
@@ -26,7 +26,7 @@ void ACrossServerAbilityActivationTest::PrepareTest()
 	FName TargetActorTag = FName(TEXT("Target"));
 
 	// Step 1 - Spawn Actor On Auth
-	AddStep(TEXT("SERVER_1_Spawn"), FWorkerDefinition::Server(1), nullptr, [this, TargetActorTag]() {
+	AddStep(TEXT("Spawn actor"), FWorkerDefinition::Server(1), nullptr, [this, TargetActorTag]() {
 		UWorld* World = GetWorld();
 		TargetActor = World->SpawnActor<ASpyValueGASTestActor>({ 0.0f, 0.0f, 0.0f }, FRotator::ZeroRotator);
 		AssertTrue(IsValid(TargetActor), TEXT("Target actor is valid."));
@@ -40,7 +40,7 @@ void ACrossServerAbilityActivationTest::PrepareTest()
 
 	// Step 2 - Trigger an ability by spec handle, cross-server, and confirm that it got activated
 	AddStep(
-		TEXT("SERVER_1_ActivateAbilityBySpecHandle"), FWorkerDefinition::Server(1),
+		TEXT("Activate Ability by Spec Handle"), FWorkerDefinition::Server(1),
 		[this]() {
 			return TargetActorReadyForActivation(TargetActor);
 		},
@@ -68,7 +68,7 @@ void ACrossServerAbilityActivationTest::PrepareTest()
 
 	// Step 3 - Same as 2, but activate by class
 	AddStep(
-		TEXT("SERVER_1_ActivateAbilityByClass"), FWorkerDefinition::Server(1),
+		TEXT("Activate Ability by Class"), FWorkerDefinition::Server(1),
 		[this]() {
 			return TargetActorReadyForActivation(TargetActor);
 		},
@@ -89,7 +89,7 @@ void ACrossServerAbilityActivationTest::PrepareTest()
 
 	// Step 4 - Same as 2, but activate by tag
 	AddStep(
-		TEXT("SERVER_1_ActivateAbilityByTag"), FWorkerDefinition::Server(1),
+		TEXT("Activate Ability by Tag"), FWorkerDefinition::Server(1),
 		[this]() {
 			return TargetActorReadyForActivation(TargetActor);
 		},
@@ -110,7 +110,7 @@ void ACrossServerAbilityActivationTest::PrepareTest()
 
 	// Step 5 - Activate by event.
 	AddStep(
-		TEXT("SERVER_1_ActivateAbilityByEvent"), FWorkerDefinition::Server(1),
+		TEXT("Activate Ability by Event"), FWorkerDefinition::Server(1),
 		[this]() {
 			return TargetActorReadyForActivation(TargetActor);
 		},

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.cpp
@@ -4,6 +4,22 @@
 #include "GA_IncrementSpyValue.h"
 #include "GameplayTagContainer.h"
 
+/**
+ * Tests that a gameplay ability can be activated on an actor from a non-auth server via the cross-server API.
+ * Activation by ability spec, class, tag, and gameplay event are tested.
+ * - Setup:
+ *	- Two servers, number of clients doesn't matter.
+ *	- One test actor is spawned, which has an Ability System Component (ASC) and the ability to be activated already granted to it.
+ *	- The test actor is force-delegated to server 2.
+ * - Test:
+ *	- Server one activates the ability on the actor via it's ability spec handle.
+ *	  Then it waits for confirmation that the ability got activated via a replicated property on the test actor which gets changed by the
+ *	  ability's code. If confirmation does not arrive within the step timeout, or if a double activation is detected, the test is failed.
+ *	- The above step is repeated for activation by class, gameplay tag and gameplay event.
+ * - Cleanup:
+ *	- The test actor is registered to be auto-destroyed by the test framework at test end.
+ */
+
 ACrossServerAbilityActivationTest::ACrossServerAbilityActivationTest()
 {
 	Author = "Tilman Schmidt";

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.cpp
@@ -27,7 +27,7 @@ ACrossServerAbilityActivationTest::ACrossServerAbilityActivationTest()
 	DuplicateActivationCheckWaitTime = 2.0f;
 
 	TargetActor = nullptr;
-	TimerStarted = false;
+	bTimerStarted = false;
 }
 
 static bool TargetActorReadyForActivation(ASpyValueGASTestActor* Target)
@@ -55,7 +55,7 @@ void ACrossServerAbilityActivationTest::PrepareTest()
 	AddStepSetTagDelegation(TargetActorTag, 2);
 
 	auto CheckActivationConfirmed = [this](float DeltaTime) {
-		if (TimerStarted)
+		if (bTimerStarted)
 		{
 			StepTimer += DeltaTime;
 		}
@@ -66,7 +66,7 @@ void ACrossServerAbilityActivationTest::PrepareTest()
 			// The counter is allowed to be 0 while we are still waiting for the changed counter to replicated to us.
 			// However, if we've seen Counter at 1 before (and as a result started the timer), if we see it back at 0,
 			// it somehow got reset. This likely indicates a bug in the test implementation.
-			if (TimerStarted)
+			if (bTimerStarted)
 			{
 				FinishTest(
 					EFunctionalTestResult::Invalid,
@@ -75,14 +75,14 @@ void ACrossServerAbilityActivationTest::PrepareTest()
 		}
 		else if (Counter == 1)
 		{
-			if (!TimerStarted)
+			if (!bTimerStarted)
 			{
-				TimerStarted = true;
+				bTimerStarted = true;
 			}
 			else if (StepTimer >= DuplicateActivationCheckWaitTime)
 			{
 				StepTimer = 0.0f;
-				TimerStarted = false;
+				bTimerStarted = false;
 				TargetActor->ResetCounter();
 				FinishStep();
 			}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.cpp
@@ -55,7 +55,6 @@ void ACrossServerAbilityActivationTest::PrepareTest()
 			FGameplayAbilitySpecHandle AbilityHandle = FoundAbilitySpecs[0]->Handle;
 			AssertTrue(AbilityHandle.IsValid(), TEXT("Activatable ability has a valid handle"));
 
-			UE_LOG(LogTemp, Log, TEXT("Activating ability"));
 			ASC->CrossServerTryActivateAbility(AbilityHandle);
 		},
 		[this](float DeltaTime) {
@@ -76,7 +75,6 @@ void ACrossServerAbilityActivationTest::PrepareTest()
 			UAbilitySystemComponent* ASC = TargetActor->GetAbilitySystemComponent();
 			AssertIsValid(ASC, TEXT("TargetActor has an ability system component."));
 
-			UE_LOG(LogTemp, Log, TEXT("Activating ability"));
 			ASC->CrossServerTryActivateAbilityByClass(UGA_IncrementSpyValue::StaticClass());
 		},
 		[this](float DeltaTime) {
@@ -97,7 +95,6 @@ void ACrossServerAbilityActivationTest::PrepareTest()
 			UAbilitySystemComponent* ASC = TargetActor->GetAbilitySystemComponent();
 			AssertIsValid(ASC, TEXT("TargetActor has an ability system component."));
 
-			UE_LOG(LogTemp, Log, TEXT("Activating ability"));
 			ASC->CrossServerTryActivateAbilitiesByTag(FGameplayTagContainer(UGA_IncrementSpyValue::GetTriggerTag()));
 		},
 		[this](float DeltaTime) {
@@ -117,8 +114,6 @@ void ACrossServerAbilityActivationTest::PrepareTest()
 		[this]() {
 			UAbilitySystemComponent* ASC = TargetActor->GetAbilitySystemComponent();
 			AssertIsValid(ASC, TEXT("TargetActor has an ability system component."));
-
-			UE_LOG(LogTemp, Log, TEXT("Activating ability"));
 
 			FGameplayEventData EventData;
 			ASC->CrossServerHandleGameplayEvent(UGA_IncrementSpyValue::GetTriggerTag(), EventData);

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.h
@@ -22,7 +22,4 @@ class SPATIALGDKFUNCTIONALTESTS_API ACrossServerAbilityActivationTest : public A
 private:
 	ASpyValueGASTestActor* TargetActor;
 	float StepTimer;
-
-	// Returns whether the caller should finish the step
-	bool WaitForActivationConfirmation(float DeltaTime);
 };

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.h
@@ -7,10 +7,6 @@
 #include "SpyValueGASTestActor.h"
 #include "CrossServerAbilityActivationTest.generated.h"
 
-/**
- * Tests that a gameplay ability can be activated on an actor across a server boundary.
- * Activation by ability spec, class, tag, and gameplay event are tested.
- */
 UCLASS()
 class SPATIALGDKFUNCTIONALTESTS_API ACrossServerAbilityActivationTest : public ASpatialFunctionalTest
 {

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.h
@@ -22,5 +22,5 @@ class SPATIALGDKFUNCTIONALTESTS_API ACrossServerAbilityActivationTest : public A
 private:
 	ASpyValueGASTestActor* TargetActor;
 	float StepTimer;
-	bool TimerStarted;
+	bool bTimerStarted;
 };

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.h
@@ -22,4 +22,5 @@ class SPATIALGDKFUNCTIONALTESTS_API ACrossServerAbilityActivationTest : public A
 private:
 	ASpyValueGASTestActor* TargetActor;
 	float StepTimer;
+	bool TimerStarted;
 };

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.h
@@ -1,0 +1,24 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "SpatialFunctionalTest.h"
+#include "SpyValueGASTestActor.h"
+#include "CrossServerAbilityActivationTest.generated.h"
+
+/**
+ * TODO
+ */
+UCLASS()
+class SPATIALGDKFUNCTIONALTESTS_API ACrossServerAbilityActivationTest : public ASpatialFunctionalTest
+{
+	GENERATED_BODY()
+
+	ACrossServerAbilityActivationTest();
+
+	virtual void PrepareTest() override;
+
+private:
+	ASpyValueGASTestActor* TargetActor;
+};

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.h
@@ -19,6 +19,13 @@ class SPATIALGDKFUNCTIONALTESTS_API ACrossServerAbilityActivationTest : public A
 
 	virtual void PrepareTest() override;
 
+	UPROPERTY(EditInstanceOnly, Category = "Test Settings")
+	float DuplicateActivationCheckWaitTime;
+
 private:
 	ASpyValueGASTestActor* TargetActor;
+	float StepTimer;
+
+	// Returns whether the caller should finish the step
+	bool WaitForActivationConfirmation(float DeltaTime);
 };

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/CrossServerAbilityActivationTest.h
@@ -8,7 +8,8 @@
 #include "CrossServerAbilityActivationTest.generated.h"
 
 /**
- * TODO
+ * Tests that a gameplay ability can be activated on an actor across a server boundary.
+ * Activation by ability spec, class, tag, and gameplay event are tested.
  */
 UCLASS()
 class SPATIALGDKFUNCTIONALTESTS_API ACrossServerAbilityActivationTest : public ASpatialFunctionalTest

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/GA_IncrementSpyValue.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/GA_IncrementSpyValue.cpp
@@ -2,6 +2,7 @@
 
 #include "GA_IncrementSpyValue.h"
 #include "GameplayTagContainer.h"
+#include "LogSpatialFunctionalTest.h"
 #include "SpyValueGASTestActor.h"
 
 UGA_IncrementSpyValue::UGA_IncrementSpyValue()
@@ -31,7 +32,8 @@ void UGA_IncrementSpyValue::ActivateAbility(const FGameplayAbilitySpecHandle Han
 		AActor* TestActor = ActorInfo->OwnerActor.Get();
 		if (TestActor == nullptr || !TestActor->IsA<ASpyValueGASTestActor>())
 		{
-			UE_LOG(LogTemp, Error, TEXT("UGA_IncrementSpyValue was activated with an invalid owner actor %s."), *GetNameSafe(TestActor));
+			UE_LOG(LogSpatialFunctionalTest, Error, TEXT("UGA_IncrementSpyValue was activated with an invalid owner actor %s."),
+				   *GetNameSafe(TestActor));
 			EndAbility(CurrentSpecHandle, CurrentActorInfo, CurrentActivationInfo, true, true);
 			return;
 		}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/GA_IncrementSpyValue.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/GA_IncrementSpyValue.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "GA_IncrementSpyValue.h"
+
+UGA_IncrementSpyValue::UGA_IncrementSpyValue()
+{
+	InstancingPolicy = EGameplayAbilityInstancingPolicy::NonInstanced;
+}
+
+void UGA_IncrementSpyValue::ActivateAbility(const FGameplayAbilitySpecHandle Handle, const FGameplayAbilityActorInfo* ActorInfo,
+											const FGameplayAbilityActivationInfo ActivationInfo, const FGameplayEventData* TriggerEventData)
+{
+	if (HasAuthorityOrPredictionKey(ActorInfo, &ActivationInfo))
+	{
+		if (!CommitAbility(Handle, ActorInfo, ActivationInfo))
+		{
+			EndAbility(CurrentSpecHandle, CurrentActorInfo, CurrentActivationInfo, true, true);
+		}
+		UE_LOG(LogTemp, Log, TEXT("Activated ability"));
+	}
+}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/GA_IncrementSpyValue.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/GA_IncrementSpyValue.cpp
@@ -31,12 +31,10 @@ void UGA_IncrementSpyValue::ActivateAbility(const FGameplayAbilitySpecHandle Han
 		ASpyValueGASTestActor* TestActor = static_cast<ASpyValueGASTestActor*>(ActorInfo->OwnerActor.Get());
 		if (TestActor == nullptr)
 		{
-			UE_LOG(LogTemp, Error, TEXT("Ability was activated with null OwnerActor"));
 			EndAbility(CurrentSpecHandle, CurrentActorInfo, CurrentActivationInfo, true, true);
 			return;
 		}
 
-		UE_LOG(LogTemp, Log, TEXT("Activated ability"));
 		TestActor->IncrementCounter();
 
 		EndAbility(CurrentSpecHandle, CurrentActorInfo, CurrentActivationInfo, true, true);

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/GA_IncrementSpyValue.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/GA_IncrementSpyValue.cpp
@@ -1,10 +1,15 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
 #include "GA_IncrementSpyValue.h"
+#include "GameplayTagContainer.h"
+#include "SpyValueGASTestActor.h"
 
 UGA_IncrementSpyValue::UGA_IncrementSpyValue()
 {
 	InstancingPolicy = EGameplayAbilityInstancingPolicy::NonInstanced;
+	NetExecutionPolicy = EGameplayAbilityNetExecutionPolicy::ServerOnly;
+
+	AbilityTags.AddTag(FGameplayTag::RequestGameplayTag(FName(TEXT("GameplayAbility.Trigger"))));
 }
 
 void UGA_IncrementSpyValue::ActivateAbility(const FGameplayAbilitySpecHandle Handle, const FGameplayAbilityActorInfo* ActorInfo,
@@ -15,7 +20,20 @@ void UGA_IncrementSpyValue::ActivateAbility(const FGameplayAbilitySpecHandle Han
 		if (!CommitAbility(Handle, ActorInfo, ActivationInfo))
 		{
 			EndAbility(CurrentSpecHandle, CurrentActorInfo, CurrentActivationInfo, true, true);
+			return;
 		}
+
+		ASpyValueGASTestActor* TestActor = static_cast<ASpyValueGASTestActor*>(ActorInfo->OwnerActor.Get());
+		if (TestActor == nullptr)
+		{
+			UE_LOG(LogTemp, Error, TEXT("Ability was activated with null OwnerActor"));
+			EndAbility(CurrentSpecHandle, CurrentActorInfo, CurrentActivationInfo, true, true);
+			return;
+		}
+
 		UE_LOG(LogTemp, Log, TEXT("Activated ability"));
+		TestActor->IncrementCounter();
+
+		EndAbility(CurrentSpecHandle, CurrentActorInfo, CurrentActivationInfo, true, true);
 	}
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/GA_IncrementSpyValue.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/GA_IncrementSpyValue.cpp
@@ -25,21 +25,21 @@ void UGA_IncrementSpyValue::ActivateAbility(const FGameplayAbilitySpecHandle Han
 	{
 		if (!CommitAbility(Handle, ActorInfo, ActivationInfo))
 		{
-			EndAbility(CurrentSpecHandle, CurrentActorInfo, CurrentActivationInfo, true, true);
+			EndAbility(CurrentSpecHandle, CurrentActorInfo, CurrentActivationInfo, false, true);
 			return;
 		}
 
 		AActor* TestActor = ActorInfo->OwnerActor.Get();
-		if (TestActor == nullptr || !TestActor->IsA<ASpyValueGASTestActor>())
+		if (ASpyValueGASTestActor* SpyValueActor = Cast<ASpyValueGASTestActor>(ActorInfo->OwnerActor.Get()))
+		{
+			SpyValueActor->IncrementCounter();
+		}
+		else
 		{
 			UE_LOG(LogSpatialFunctionalTest, Error, TEXT("UGA_IncrementSpyValue was activated with an invalid owner actor %s."),
 				   *GetNameSafe(TestActor));
-			EndAbility(CurrentSpecHandle, CurrentActorInfo, CurrentActivationInfo, true, true);
-			return;
 		}
 
-		static_cast<ASpyValueGASTestActor*>(TestActor)->IncrementCounter();
-
-		EndAbility(CurrentSpecHandle, CurrentActorInfo, CurrentActivationInfo, true, true);
+		EndAbility(CurrentSpecHandle, CurrentActorInfo, CurrentActivationInfo, false, false);
 	}
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/GA_IncrementSpyValue.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/GA_IncrementSpyValue.cpp
@@ -28,14 +28,15 @@ void UGA_IncrementSpyValue::ActivateAbility(const FGameplayAbilitySpecHandle Han
 			return;
 		}
 
-		ASpyValueGASTestActor* TestActor = static_cast<ASpyValueGASTestActor*>(ActorInfo->OwnerActor.Get());
-		if (TestActor == nullptr)
+		AActor* TestActor = ActorInfo->OwnerActor.Get();
+		if (TestActor == nullptr || !TestActor->IsA<ASpyValueGASTestActor>())
 		{
+			UE_LOG(LogTemp, Error, TEXT("UGA_IncrementSpyValue was activated with an invalid owner actor %s."), *GetNameSafe(TestActor));
 			EndAbility(CurrentSpecHandle, CurrentActorInfo, CurrentActivationInfo, true, true);
 			return;
 		}
 
-		TestActor->IncrementCounter();
+		static_cast<ASpyValueGASTestActor*>(TestActor)->IncrementCounter();
 
 		EndAbility(CurrentSpecHandle, CurrentActorInfo, CurrentActivationInfo, true, true);
 	}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/GA_IncrementSpyValue.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/GA_IncrementSpyValue.cpp
@@ -9,7 +9,12 @@ UGA_IncrementSpyValue::UGA_IncrementSpyValue()
 	InstancingPolicy = EGameplayAbilityInstancingPolicy::NonInstanced;
 	NetExecutionPolicy = EGameplayAbilityNetExecutionPolicy::ServerOnly;
 
-	AbilityTags.AddTag(FGameplayTag::RequestGameplayTag(FName(TEXT("GameplayAbility.Trigger"))));
+	AbilityTags.AddTag(UGA_IncrementSpyValue::GetTriggerTag());
+
+	FAbilityTriggerData Trigger;
+	Trigger.TriggerSource = EGameplayAbilityTriggerSource::GameplayEvent;
+	Trigger.TriggerTag = UGA_IncrementSpyValue::GetTriggerTag();
+	AbilityTriggers.Add(Trigger);
 }
 
 void UGA_IncrementSpyValue::ActivateAbility(const FGameplayAbilitySpecHandle Handle, const FGameplayAbilityActorInfo* ActorInfo,

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/GA_IncrementSpyValue.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/GA_IncrementSpyValue.h
@@ -1,0 +1,22 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "Abilities/GameplayAbility.h"
+#include "CoreMinimal.h"
+#include "GA_IncrementSpyValue.generated.h"
+
+/**
+ * TODO
+ */
+UCLASS()
+class SPATIALGDKFUNCTIONALTESTS_API UGA_IncrementSpyValue : public UGameplayAbility
+{
+	GENERATED_BODY()
+
+public:
+	UGA_IncrementSpyValue();
+
+	virtual void ActivateAbility(const FGameplayAbilitySpecHandle Handle, const FGameplayAbilityActorInfo* ActorInfo,
+								 const FGameplayAbilityActivationInfo ActivationInfo, const FGameplayEventData* TriggerEventData) override;
+};

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/GA_IncrementSpyValue.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/GA_IncrementSpyValue.h
@@ -21,5 +21,5 @@ public:
 	virtual void ActivateAbility(const FGameplayAbilitySpecHandle Handle, const FGameplayAbilityActorInfo* ActorInfo,
 								 const FGameplayAbilityActivationInfo ActivationInfo, const FGameplayEventData* TriggerEventData) override;
 
-	static FGameplayTag GetTriggerTag() { return FGameplayTag::RequestGameplayTag(FName(TEXT("GameplayAbility.Trigger"))); }
+	static FGameplayTag GetTriggerTag() { return FGameplayTag::RequestGameplayTag(TEXT("GameplayAbility.Trigger")); }
 };

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/GA_IncrementSpyValue.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/GA_IncrementSpyValue.h
@@ -8,7 +8,7 @@
 #include "GA_IncrementSpyValue.generated.h"
 
 /**
- * TODO
+ * Calls `IncrementCounter()` on its owner to signal that this ability ran. The owner must be an ASpyValueGASTestActor
  */
 UCLASS()
 class SPATIALGDKFUNCTIONALTESTS_API UGA_IncrementSpyValue : public UGameplayAbility

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/GA_IncrementSpyValue.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/GA_IncrementSpyValue.h
@@ -4,6 +4,7 @@
 
 #include "Abilities/GameplayAbility.h"
 #include "CoreMinimal.h"
+#include "GameplayTagContainer.h"
 #include "GA_IncrementSpyValue.generated.h"
 
 /**
@@ -19,4 +20,6 @@ public:
 
 	virtual void ActivateAbility(const FGameplayAbilitySpecHandle Handle, const FGameplayAbilityActorInfo* ActorInfo,
 								 const FGameplayAbilityActivationInfo ActivationInfo, const FGameplayEventData* TriggerEventData) override;
+
+	static FGameplayTag GetTriggerTag() { return FGameplayTag::RequestGameplayTag(FName(TEXT("GameplayAbility.Trigger"))); }
 };

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/SpyValueGASTestActor.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/SpyValueGASTestActor.cpp
@@ -14,7 +14,7 @@ void ASpyValueGASTestActor::IncrementCounter()
 	Counter++;
 }
 
-int ASpyValueGASTestActor::GetCounter()
+int ASpyValueGASTestActor::GetCounter() const
 {
 	return Counter;
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/SpyValueGASTestActor.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/SpyValueGASTestActor.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "SpyValueGASTestActor.h"
+#include "GA_IncrementSpyValue.h"
+
+ASpyValueGASTestActor::ASpyValueGASTestActor() {}
+
+void ASpyValueGASTestActor::OnAuthorityGained()
+{
+	Super::OnAuthorityGained();
+	UE_LOG(LogTemp, Log, TEXT("Auth gained on target actor."));
+}
+
+TArray<TSubclassOf<UGameplayAbility>> ASpyValueGASTestActor::GetInitialGrantedAbilities()
+{
+	return { UGA_IncrementSpyValue::StaticClass() };
+}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/SpyValueGASTestActor.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/SpyValueGASTestActor.cpp
@@ -2,8 +2,12 @@
 
 #include "SpyValueGASTestActor.h"
 #include "GA_IncrementSpyValue.h"
+#include "Net/UnrealNetwork.h"
 
-ASpyValueGASTestActor::ASpyValueGASTestActor() {}
+ASpyValueGASTestActor::ASpyValueGASTestActor()
+	: Counter(0)
+{
+}
 
 void ASpyValueGASTestActor::OnAuthorityGained()
 {
@@ -11,7 +15,28 @@ void ASpyValueGASTestActor::OnAuthorityGained()
 	UE_LOG(LogTemp, Log, TEXT("Auth gained on target actor."));
 }
 
+void ASpyValueGASTestActor::IncrementCounter()
+{
+	Counter++;
+}
+
+int ASpyValueGASTestActor::GetCounter()
+{
+	return Counter;
+}
+
+void ASpyValueGASTestActor::ResetCounter_Implementation()
+{
+	Counter = 0;
+}
+
 TArray<TSubclassOf<UGameplayAbility>> ASpyValueGASTestActor::GetInitialGrantedAbilities()
 {
 	return { UGA_IncrementSpyValue::StaticClass() };
+}
+
+void ASpyValueGASTestActor::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+	DOREPLIFETIME(ASpyValueGASTestActor, Counter);
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/SpyValueGASTestActor.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/SpyValueGASTestActor.cpp
@@ -9,12 +9,6 @@ ASpyValueGASTestActor::ASpyValueGASTestActor()
 {
 }
 
-void ASpyValueGASTestActor::OnAuthorityGained()
-{
-	Super::OnAuthorityGained();
-	UE_LOG(LogTemp, Log, TEXT("Auth gained on target actor."));
-}
-
 void ASpyValueGASTestActor::IncrementCounter()
 {
 	Counter++;

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/SpyValueGASTestActor.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/SpyValueGASTestActor.h
@@ -19,13 +19,13 @@ public:
 	ASpyValueGASTestActor();
 
 	void IncrementCounter();
-	int GetCounter();
+	int GetCounter() const;
 
 	UFUNCTION(CrossServer, Reliable)
 	void ResetCounter();
 
 private:
-	TArray<TSubclassOf<UGameplayAbility>> GetInitialGrantedAbilities() override;
+	virtual TArray<TSubclassOf<UGameplayAbility>> GetInitialGrantedAbilities() override;
 
 	UPROPERTY(Replicated)
 	int Counter;

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/SpyValueGASTestActor.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/SpyValueGASTestActor.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
+#include "../TestActors/GASTestActorBase.h"
 #include "CoreMinimal.h"
-#include "SpatialGDKFunctionalTests/SpatialGDK/TestActors/GASTestActorBase.h"
 #include "SpyValueGASTestActor.generated.h"
 
 /**

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/SpyValueGASTestActor.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/SpyValueGASTestActor.h
@@ -7,7 +7,7 @@
 #include "SpyValueGASTestActor.generated.h"
 
 /**
- * A replicated Actor with a Cube Mesh, used as a base for Actors used in spatial tests.
+ * An actor with a replicated counter. This allows an auth server to increment the counter when an action was taken, and a non-auth server to verify that the action took place
  */
 UCLASS()
 class ASpyValueGASTestActor : public AGASTestActorBase

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/SpyValueGASTestActor.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/SpyValueGASTestActor.h
@@ -7,7 +7,8 @@
 #include "SpyValueGASTestActor.generated.h"
 
 /**
- * An actor with a replicated counter. This allows an auth server to increment the counter when an action was taken, and a non-auth server to verify that the action took place
+ * An actor with a replicated counter. This allows an auth server to increment the counter when an action was taken, and a non-auth server
+ * to verify that the action took place
  */
 UCLASS()
 class ASpyValueGASTestActor : public AGASTestActorBase

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/SpyValueGASTestActor.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/SpyValueGASTestActor.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "../TestActors/GASTestActorBase.h"
+#include "SpatialGDKFunctionalTests/SpatialGDK/TestActors/GASTestActorBase.h"
 #include "CoreMinimal.h"
 #include "SpyValueGASTestActor.generated.h"
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/SpyValueGASTestActor.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/SpyValueGASTestActor.h
@@ -17,8 +17,17 @@ class ASpyValueGASTestActor : public AGASTestActorBase
 public:
 	ASpyValueGASTestActor();
 
-	void OnAuthorityGained() override;
+	void OnAuthorityGained() override; // TODO temp
+
+	void IncrementCounter();
+	int GetCounter();
+
+	UFUNCTION(CrossServer, Reliable)
+	void ResetCounter();
 
 private:
 	TArray<TSubclassOf<UGameplayAbility>> GetInitialGrantedAbilities() override;
+
+	UPROPERTY(Replicated)
+	int Counter;
 };

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/SpyValueGASTestActor.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/SpyValueGASTestActor.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
-#include "SpatialGDKFunctionalTests/SpatialGDK/TestActors/GASTestActorBase.h"
 #include "CoreMinimal.h"
+#include "SpatialGDKFunctionalTests/SpatialGDK/TestActors/GASTestActorBase.h"
 #include "SpyValueGASTestActor.generated.h"
 
 /**

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/SpyValueGASTestActor.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/SpyValueGASTestActor.h
@@ -1,0 +1,24 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "SpatialGDKFunctionalTests/SpatialGDK/TestActors/GASTestActorBase.h"
+#include "SpyValueGASTestActor.generated.h"
+
+/**
+ * A replicated Actor with a Cube Mesh, used as a base for Actors used in spatial tests.
+ */
+UCLASS()
+class ASpyValueGASTestActor : public AGASTestActorBase
+{
+	GENERATED_BODY()
+
+public:
+	ASpyValueGASTestActor();
+
+	void OnAuthorityGained() override;
+
+private:
+	TArray<TSubclassOf<UGameplayAbility>> GetInitialGrantedAbilities() override;
+};

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/SpyValueGASTestActor.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAbilityActivationTest/SpyValueGASTestActor.h
@@ -18,8 +18,6 @@ class ASpyValueGASTestActor : public AGASTestActorBase
 public:
 	ASpyValueGASTestActor();
 
-	void OnAuthorityGained() override; // TODO temp
-
 	void IncrementCounter();
 	int GetCounter();
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/TestActors/GASTestActorBase.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/TestActors/GASTestActorBase.cpp
@@ -1,0 +1,33 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "GASTestActorBase.h"
+
+AGASTestActorBase::AGASTestActorBase()
+{
+	AbilitySystemComponent = CreateDefaultSubobject<UAbilitySystemComponent>(TEXT("AbilitySystemComponent"));
+	AbilitySystemComponent->SetIsReplicated(true);
+}
+
+void AGASTestActorBase::BeginPlay()
+{
+	Super::BeginPlay();
+	GrantInitialAbilitiesIfNeeded();
+}
+
+void AGASTestActorBase::OnAuthorityGained()
+{
+	Super::OnAuthorityGained();
+	GrantInitialAbilitiesIfNeeded();
+}
+
+void AGASTestActorBase::GrantInitialAbilitiesIfNeeded()
+{
+	if (!bHasGrantedAbilities && HasAuthority())
+	{
+		for (const TSubclassOf<UGameplayAbility>& Ability : GetInitialGrantedAbilities())
+		{
+			FGameplayAbilitySpecHandle Handle = AbilitySystemComponent->GiveAbility(FGameplayAbilitySpec(Ability));
+			UE_LOG(LogTemp, Log, TEXT("Handle valid: %s"), Handle.IsValid() ? TEXT("true") : TEXT("false"));
+		}
+	}
+}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/TestActors/GASTestActorBase.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/TestActors/GASTestActorBase.cpp
@@ -27,7 +27,6 @@ void AGASTestActorBase::GrantInitialAbilitiesIfNeeded()
 		for (const TSubclassOf<UGameplayAbility>& Ability : GetInitialGrantedAbilities())
 		{
 			FGameplayAbilitySpecHandle Handle = AbilitySystemComponent->GiveAbility(FGameplayAbilitySpec(Ability));
-			UE_LOG(LogTemp, Log, TEXT("Handle valid: %s"), Handle.IsValid() ? TEXT("true") : TEXT("false"));
 		}
 
 		bHasGrantedAbilities = true;

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/TestActors/GASTestActorBase.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/TestActors/GASTestActorBase.cpp
@@ -11,7 +11,7 @@ AGASTestActorBase::AGASTestActorBase()
 void AGASTestActorBase::BeginPlay()
 {
 	Super::BeginPlay();
-	if(HasAuthority())
+	if (HasAuthority())
 	{
 		GrantInitialAbilitiesIfNeeded();
 	}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/TestActors/GASTestActorBase.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/TestActors/GASTestActorBase.cpp
@@ -29,5 +29,7 @@ void AGASTestActorBase::GrantInitialAbilitiesIfNeeded()
 			FGameplayAbilitySpecHandle Handle = AbilitySystemComponent->GiveAbility(FGameplayAbilitySpec(Ability));
 			UE_LOG(LogTemp, Log, TEXT("Handle valid: %s"), Handle.IsValid() ? TEXT("true") : TEXT("false"));
 		}
+
+		bHasGrantedAbilities = true;
 	}
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/TestActors/GASTestActorBase.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/TestActors/GASTestActorBase.cpp
@@ -11,7 +11,10 @@ AGASTestActorBase::AGASTestActorBase()
 void AGASTestActorBase::BeginPlay()
 {
 	Super::BeginPlay();
-	GrantInitialAbilitiesIfNeeded();
+	if(HasAuthority())
+	{
+		GrantInitialAbilitiesIfNeeded();
+	}
 }
 
 void AGASTestActorBase::OnAuthorityGained()
@@ -22,7 +25,7 @@ void AGASTestActorBase::OnAuthorityGained()
 
 void AGASTestActorBase::GrantInitialAbilitiesIfNeeded()
 {
-	if (!bHasGrantedAbilities && HasAuthority())
+	if (!bHasGrantedAbilities)
 	{
 		for (const TSubclassOf<UGameplayAbility>& Ability : GetInitialGrantedAbilities())
 		{

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/TestActors/GASTestActorBase.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/TestActors/GASTestActorBase.h
@@ -1,0 +1,39 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "Abilities/GameplayAbility.h"
+#include "AbilitySystemComponent.h"
+#include "AbilitySystemInterface.h"
+#include "CoreMinimal.h"
+#include "SpatialGDKFunctionalTests/SpatialGDK/TestActors/ReplicatedTestActorBase.h"
+#include "GASTestActorBase.generated.h"
+
+/**
+ * A replicated Actor with a Cube Mesh, used as a base for Actors used in spatial tests.
+ */
+UCLASS()
+class AGASTestActorBase : public AReplicatedTestActorBase, public IAbilitySystemInterface
+{
+	GENERATED_BODY()
+
+public:
+	// Implement IAbilitySystemInterface.
+	UAbilitySystemComponent* GetAbilitySystemComponent() const override { return AbilitySystemComponent; }
+
+	AGASTestActorBase();
+
+	virtual void BeginPlay() override;
+	virtual void OnAuthorityGained() override;
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = Abilities)
+	UAbilitySystemComponent* AbilitySystemComponent;
+
+private:
+	virtual TArray<TSubclassOf<UGameplayAbility>> GetInitialGrantedAbilities() { return {}; }
+
+	void GrantInitialAbilitiesIfNeeded();
+
+	UPROPERTY(Handover)
+	bool bHasGrantedAbilities;
+};

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/TestActors/GASTestActorBase.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/TestActors/GASTestActorBase.h
@@ -6,7 +6,7 @@
 #include "AbilitySystemComponent.h"
 #include "AbilitySystemInterface.h"
 #include "CoreMinimal.h"
-#include "SpatialGDKFunctionalTests/SpatialGDK/TestActors/ReplicatedTestActorBase.h"
+#include "ReplicatedTestActorBase.h"
 #include "GASTestActorBase.generated.h"
 
 /**

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDKFunctionalTests.Build.cs
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDKFunctionalTests.Build.cs
@@ -25,6 +25,7 @@ public class SpatialGDKFunctionalTests : ModuleRules
                 "Engine",
                 "FunctionalTesting",
                 "GameplayAbilities",
+                "GameplayTags",
                 "GameplayTasks",
                 "HTTP"
             });

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDKFunctionalTests.Build.cs
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDKFunctionalTests.Build.cs
@@ -24,6 +24,8 @@ public class SpatialGDKFunctionalTests : ModuleRules
                 "CoreUObject",
                 "Engine",
                 "FunctionalTesting",
+                "GameplayAbilities",
+                "GameplayTasks",
                 "HTTP"
             });
     }


### PR DESCRIPTION
Corresponding PR with the map containing this test: https://github.com/spatialos/UnrealGDKTestGyms/pull/259

#### Description
Adds a multi-server test for activating abilities from one server on another server, via handle/class/tag/event.

TODO:
- Unreal build tool gives a warning about the test module depending on GameplayAbilities while the GDK uplugin does not. The solution would be to add GameplayAbilities as a plugin dependency, but then the GDK as a whole requires that dependency. There does not appear to be a way to specify a plugin-level dependency as optional.

#### Release note
N/A I believe.

#### Tests
This is the test for https://github.com/improbableio/UnrealEngine/pull/692

#### Documentation
N/A