### PR TITLE
Warning -> Verbose

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
@@ -228,7 +228,7 @@ void USpatialNetConnection::ClientNotifyClientHasQuit()
 	}
 	else
 	{
-		UE_LOG(LogSpatialNetConnection, Warning, TEXT("Quitting before Heartbeat component has been initialized: NetConnection %s"),
+		UE_LOG(LogSpatialNetConnection, Verbose, TEXT("Quitting before Heartbeat component has been initialized: NetConnection %s"),
 			   *GetName());
 	}
 }


### PR DESCRIPTION
#### Description
This warning can occur under normal operation, for example when running tests.  This change downgrades it to verbose.

#### Release note
I don't think this change requires a release note, but let me know if i'm wrong.

#### Tests
n/a
#### Documentation
n/a

#### Reminders (IMPORTANT)
If your change relies on a breaking engine change:
* Increment `SPATIAL_ENGINE_VERSION` in `Engine\Source\Runtime\Launch\Resources\SpatialVersion.h` (in the engine fork) as well as `SPATIAL_GDK_VERSION` in `SpatialGDK\Source\SpatialGDK\Public\Utils\EngineVersionCheck.h`. This helps others by providing a more helpful message during compilation to make sure the GDK and the Engine are up to date.

If your change updates `Setup.bat`, `Setup.sh`, core SDK version, any C# tools in `SpatialGDK\Build\Programs\Improbable.Unreal.Scripts`, or hand-written schema in `SpatialGDK\Extras\schema`:
* Increment the number in `RequireSetup`. This will automatically run `Setup.bat` or `Setup.sh` when the GDK is next pulled.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
