### PR TITLE
UNR-4459 Bugfix/dynamic components gym too many subobjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ These functions and structs can be referenced in both code and blueprints it may
 - Unreal Engine version 4.26.0 is now supported! Refer to https://documentation.improbable.io/gdk-for-unreal/docs/keep-your-gdk-up-to-date for versioning information and how to upgrade.
 - Added cross-server variants of ability activation functions on the Ability System Component.
 - Added `SpatialSwitchHasAuthority` function to differentiate authoritative server, non-authoritative server, and clients. This can be called in code or used in blueprints that derive from actor.
+- Added blue print callable function `GetMaxDynamicallyAttachedSubobjectsPerClass` to `USpatialStatics` that get the maximum dynamically attached subobjects per class as set in `SpatialGDKSettings`
 
 
 ### Bug fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@ These functions and structs can be referenced in both code and blueprints it may
 - Unreal Engine version 4.26.0 is now supported! Refer to https://documentation.improbable.io/gdk-for-unreal/docs/keep-your-gdk-up-to-date for versioning information and how to upgrade.
 - Added cross-server variants of ability activation functions on the Ability System Component.
 - Added `SpatialSwitchHasAuthority` function to differentiate authoritative server, non-authoritative server, and clients. This can be called in code or used in blueprints that derive from actor.
-- Added blue print callable function `GetMaxDynamicallyAttachedSubobjectsPerClass` to `USpatialStatics` that get the maximum dynamically attached subobjects per class as set in `SpatialGDKSettings`
+- Added blueprint callable function `GetMaxDynamicallyAttachedSubobjectsPerClass` to `USpatialStatics` that gets the maximum dynamically attached subobjects per class as set in `SpatialGDKSettings`
 
 
 ### Bug fixes:

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
@@ -350,6 +350,11 @@ FName USpatialStatics::GetLayerName(const UObject* WorldContextObject)
 	return LBStrategy->GetLocalLayerName();
 }
 
+int64 USpatialStatics::GetMaxDynamicallyAttachedSubobjectsPerClass()
+{
+	return GetDefault<USpatialGDKSettings>()->MaxDynamicallyAttachedSubobjectsPerClass;
+}
+
 void USpatialStatics::SpatialDebuggerSetOnConfigUIClosedCallback(const UObject* WorldContextObject, FOnConfigUIClosedDelegate Delegate)
 {
 	const UWorld* World = WorldContextObject->GetWorld();

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialStatics.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialStatics.h
@@ -181,7 +181,7 @@ public:
 	static FName GetLayerName(const UObject* WorldContextObject);
 
 	/**
-	 * Returns the Max Dynamically Attached Subobjects Per Class as per spatial OS settings
+	 * Returns the Max Dynamically Attached Subobjects Per Class as per Spatial GDK settings
 	 */
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "SpatialOS")
 	static int64 GetMaxDynamicallyAttachedSubobjectsPerClass();

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialStatics.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialStatics.h
@@ -180,6 +180,12 @@ public:
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "SpatialOS", meta = (WorldContext = "WorldContextObject"))
 	static FName GetLayerName(const UObject* WorldContextObject);
 
+	/**
+	 * Returns the Max Dynamically Attached Subobjects Per Class as per spatial OS settings
+	 */
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "SpatialOS")
+	static int64 GetMaxDynamicallyAttachedSubobjectsPerClass();
+
 	UFUNCTION(BlueprintCallable, Category = "SpatialGDK|Spatial Debugger", meta = (WorldContext = "WorldContextObject"))
 	static void SpatialDebuggerSetOnConfigUIClosedCallback(const UObject* WorldContextObject, FOnConfigUIClosedDelegate Delegate);
 


### PR DESCRIPTION
#### Description
Added blue print callable function `GetMaxDynamicallyAttachedSubobjectsPerClass` to `USpatialStatics` that get the maximum dynamically attached subobjects per class as set in `SpatialGDKSettings`.
To support fixing the dynamic components gym PR:
- https://github.com/spatialos/UnrealGDKTestGyms/pull/262

#### Release note
Added to release notes.
