### PR TITLE
UNR-4319: Moved main deployment availability checking to WorkerCoordinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ These functions and structs can be referenced in both code and blueprints it may
 - Added cross-server variants of ability activation functions on the Ability System Component.
 - Added `SpatialSwitchHasAuthority` function to differentiate authoritative server, non-authoritative server, and clients. This can be called in code or used in blueprints that derive from actor.
 - Added blueprint callable function `GetMaxDynamicallyAttachedSubobjectsPerClass` to `USpatialStatics` that gets the maximum dynamically attached subobjects per class as set in `SpatialGDKSettings`
-
+- Simulated Player deployments no longer depend on DeploymentLauncher for readiness. You can now restart them via the Console and expect them to reconnect to your main deployment. DeploymentLauncher will also restart any crashed or incorrectly finished simulated players applications.
 
 ### Bug fixes:
 - Fixed a bug that stopped the travel URL being used for initial Spatial connection if the command line arguments could not be used.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@ These functions and structs can be referenced in both code and blueprints it may
 - Added `SpatialSwitchHasAuthority` function to differentiate authoritative server, non-authoritative server, and clients. This can be called in code or used in blueprints that derive from actor.
 - Added blueprint callable function `GetMaxDynamicallyAttachedSubobjectsPerClass` to `USpatialStatics` that gets the maximum dynamically attached subobjects per class as set in `SpatialGDKSettings`
 - Simulated Player deployments no longer depend on DeploymentLauncher for readiness. You can now restart them via the Console and expect them to reconnect to your main deployment. DeploymentLauncher will also restart any crashed or incorrectly finished simulated players applications.
-- Simulated Player applications now exit with a non-zero exit code if can't connect to a deployment or load a map - these are connected to TravelFailure and NetworkFailure in Unreal Engine
+- Simulated Player applications now exit with a non-zero exit code if they can't connect to a deployment or load a map - these are connected to TravelFailure and NetworkFailure in Unreal Engine
 
 ### Bug fixes:
 - Fixed a bug that stopped the travel URL being used for initial Spatial connection if the command line arguments could not be used.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ These functions and structs can be referenced in both code and blueprints it may
 - Added `SpatialSwitchHasAuthority` function to differentiate authoritative server, non-authoritative server, and clients. This can be called in code or used in blueprints that derive from actor.
 - Added blueprint callable function `GetMaxDynamicallyAttachedSubobjectsPerClass` to `USpatialStatics` that gets the maximum dynamically attached subobjects per class as set in `SpatialGDKSettings`
 - Simulated Player deployments no longer depend on DeploymentLauncher for readiness. You can now restart them via the Console and expect them to reconnect to your main deployment. DeploymentLauncher will also restart any crashed or incorrectly finished simulated players applications.
+- Simulated Player applications now exit with a non-zero exit code if can't connect to a deployment or load a map - these are connected to TravelFailure and NetworkFailure in Unreal Engine
 
 ### Bug fixes:
 - Fixed a bug that stopped the travel URL being used for initial Spatial connection if the command line arguments could not be used.
@@ -119,6 +120,7 @@ These functions and structs can be referenced in both code and blueprints it may
 - Fixed race condition in Spatial Test framework that would cause tests to time out with one or more workers not ready to begin the test.
 - Fixed client connection not being cleaned up when moving out of interest of a server.
 - Fixed an issue where GameMode values won't be replicated between server workers if it's outside their Interest
+- Fixed an issue where a NetworkFailure won't be reported when connecting to a deployment that doesn't support dev_login with a developer token, and in some other configuration-dependent cases
 
 ## [`0.11.0`] - 2020-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@ These functions and structs can be referenced in both code and blueprints it may
 - Added `SpatialSwitchHasAuthority` function to differentiate authoritative server, non-authoritative server, and clients. This can be called in code or used in blueprints that derive from actor.
 - Added blueprint callable function `GetMaxDynamicallyAttachedSubobjectsPerClass` to `USpatialStatics` that gets the maximum dynamically attached subobjects per class as set in `SpatialGDKSettings`
 - Simulated Player deployments no longer depend on DeploymentLauncher for readiness. You can now restart them via the Console and expect them to reconnect to your main deployment. DeploymentLauncher will also restart any crashed or incorrectly finished simulated players applications.
-- Simulated Player applications now exit with a non-zero exit code if they can't connect to a deployment or load a map - these are connected to TravelFailure and NetworkFailure in Unreal Engine
+- Added a `-FailOnNetworkFailure` flag that makes a Spatial-enabled game fail on any NetworkFailure
 
 ### Bug fixes:
 - Fixed a bug that stopped the travel URL being used for initial Spatial connection if the command line arguments could not be used.

--- a/RequireSetup
+++ b/RequireSetup
@@ -1,4 +1,4 @@
 Increment the below number whenever it is required to run Setup.bat as part of a new commit.
 Our git hooks will detect this file has been updated and automatically run Setup.bat on pull.
 
-74
+75

--- a/RequireSetup
+++ b/RequireSetup
@@ -1,4 +1,4 @@
 Increment the below number whenever it is required to run Setup.bat as part of a new commit.
 Our git hooks will detect this file has been updated and automatically run Setup.bat on pull.
 
-76
+77

--- a/RequireSetup
+++ b/RequireSetup
@@ -1,4 +1,4 @@
 Increment the below number whenever it is required to run Setup.bat as part of a new commit.
 Our git hooks will detect this file has been updated and automatically run Setup.bat on pull.
 
-75
+76

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/DeploymentLauncher/DeploymentLauncher.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/DeploymentLauncher/DeploymentLauncher.cs
@@ -21,7 +21,6 @@ namespace Improbable
     {
         private const string SIM_PLAYER_DEPLOYMENT_TAG = "simulated_players";
         private const string DEPLOYMENT_LAUNCHED_BY_LAUNCHER_TAG = "unreal_deployment_launcher";
-        private const string TARGET_DEPLOYMENT_READY_TAG = "target_deployment_ready";
 
         private const string CoordinatorWorkerName = "SimulatedPlayerCoordinator";
 
@@ -232,8 +231,7 @@ namespace Improbable
                         continue;
                     }
 
-                    Console.WriteLine($"Deployment startup complete! Setting its flags...");
-                    UpdateSimDeploymentFlags(simPlayerDeployment, true, deploymentServiceClient);
+                    Console.WriteLine($"Deployment startup complete!");
 
                     numSuccessfullyStartedSimDeployments++;
                 }
@@ -333,8 +331,7 @@ namespace Improbable
                     continue;
                 }
 
-                Console.WriteLine($"Deployment startup complete! Setting its flags...");
-                UpdateSimDeploymentFlags(simPlayerDeployment, autoConnect, deploymentServiceClient);
+                Console.WriteLine($"Deployment startup complete!");
 
                 numSuccessfullyStartedDeployments++;
             }
@@ -342,23 +339,6 @@ namespace Improbable
             Console.WriteLine($"Successfully started {numSuccessfullyStartedDeployments} out of {simDeploymentCreationOps.Count} simulated player deployments.");
 
             return 0;
-        }
-
-        private static void UpdateSimDeploymentFlags(Deployment deployment, bool autoConnect, DeploymentServiceClient deploymentServiceClient)
-        {
-            // Update coordinator worker flag for simulated player deployment to notify target deployment is ready.
-            deployment.WorkerFlags.Add(new WorkerFlag
-            {
-                Key = TARGET_DEPLOYMENT_READY_TAG,
-                Value = autoConnect.ToString().ToLower(),
-                WorkerType = CoordinatorWorkerName
-            });
-            deploymentServiceClient.UpdateDeployment(new UpdateDeploymentRequest { Deployment = deployment });
-
-            if (autoConnect)
-            {
-                Console.WriteLine($"Simulated players from this deployment '{deployment.Name}' will start to connect to the target deployment");
-            }
         }
 
         // Determines the name for a simulated player deployment. The first index is assumed to be 1.

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/AbstractWorkerCoordinator.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/AbstractWorkerCoordinator.cs
@@ -78,6 +78,7 @@ namespace Improbable.WorkerCoordinator
 
                 foreach (var process in incorrectlyFinishedProcesses)
                 {
+                    Logger.WriteLog($"Restarting simulated player after it failed with exit code {process.ExitCode}");
                     process.Start();
                 }
 

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/AbstractWorkerCoordinator.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/AbstractWorkerCoordinator.cs
@@ -17,6 +17,8 @@ namespace Improbable.WorkerCoordinator
     {
         private const int PollSimulatedPlayerProcessIntervalMillis = 5000;
 
+        private const string AdditionalProcessArguments = "-FailOnNetworkFailure";
+
         protected Logger Logger;
         private List<Process> ActiveProcesses = new List<Process>();
 
@@ -35,14 +37,19 @@ namespace Improbable.WorkerCoordinator
         /// <summary>
         /// Creates a new process that runs a simulated player, providing it with the specified arguments.
         /// </summary>
+        /// <param name="simulatedPlayerName">Simulated player instance name.</param>
         /// <param name="fileName">File name of the simulated player executable to start.</param>
         /// <param name="args">Arguments to pass to the started process.</param>
         /// <returns>The started simulated player process, or null if something went wrong.</returns>
-        protected Process CreateSimulatedPlayerProcess(string fileName, string args)
+        protected Process CreateSimulatedPlayerProcess(string simulatedPlayerName, string fileName, string args)
         {
             try
             {
-                var process = Process.Start(fileName, args);
+                var argsToStartWith = args + " " + AdditionalProcessArguments;
+
+                Logger.WriteLog("Starting worker " + simulatedPlayerName + " with args: " + argsToStartWith);
+
+                var process = Process.Start(fileName, argsToStartWith);
 
                 if (process != null)
                 {

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/ManagedWorkerCoordinator.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/ManagedWorkerCoordinator.cs
@@ -172,8 +172,7 @@ namespace Improbable.WorkerCoordinator
 
                     // Start the client
                     string flattenedArgs = string.Join(" ", simulatedPlayerArgs);
-                    Logger.WriteLog($"Starting simulated player {simulatedPlayerName} with args: {flattenedArgs}");
-                    CreateSimulatedPlayerProcess(SimulatedPlayerFilename, flattenedArgs); ;
+                    CreateSimulatedPlayerProcess(simulatedPlayerName, SimulatedPlayerFilename, flattenedArgs);
                 }
                 else
                 {

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/ManagedWorkerCoordinator.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/ManagedWorkerCoordinator.cs
@@ -23,10 +23,8 @@ namespace Improbable.WorkerCoordinator
         private const string DevAuthTokenWorkerFlag = "simulated_players_dev_auth_token";
         private const string TargetDeploymentWorkerFlag = "simulated_players_target_deployment";
         private const string DeploymentTotalNumSimulatedPlayersWorkerFlag = "total_num_simulated_players";
-        private const string TargetDeploymentReadyWorkerFlag = "target_deployment_ready";
 
         private const int AverageDelayMillisBetweenConnections = 1500;
-        private const int PollTargetDeploymentReadyIntervalMillis = 5000;
 
         // Argument placeholders for simulated players - these will be replaced by the coordinator by their actual values.
         private const string SimulatedPlayerWorkerNamePlaceholderArg = "<IMPROBABLE_SIM_PLAYER_WORKER_ID>";
@@ -117,20 +115,12 @@ namespace Improbable.WorkerCoordinator
         {
             var connection = CoordinatorConnection.ConnectAndKeepAlive(Logger, ReceptionistHost, ReceptionistPort, CoordinatorWorkerId, CoordinatorWorkerType);
 
-
-            Logger.WriteLog("Waiting for target deployment to become ready.");
-            var deploymentReadyTask = Task.Run(() => WaitForTargetDeploymentReady(connection));
-            if (!deploymentReadyTask.Wait(TimeSpan.FromMinutes(15)))
-            {
-                throw new TimeoutException("Timed out waiting for the deployment to be ready. Waited 15 minutes.");
-            }
-
             // Read worker flags.
             string devAuthToken = connection.GetWorkerFlag(DevAuthTokenWorkerFlag);
             string targetDeployment = connection.GetWorkerFlag(TargetDeploymentWorkerFlag);
             int deploymentTotalNumSimulatedPlayers = int.Parse(GetWorkerFlagOrDefault(connection, DeploymentTotalNumSimulatedPlayersWorkerFlag, "100"));
 
-            Logger.WriteLog($"Target deployment is ready. Starting {NumSimulatedPlayersToStart} simulated players.");
+            Logger.WriteLog($"Starting {NumSimulatedPlayersToStart} simulated players.");
             Thread.Sleep(InitialStartDelayMillis);
 
             var maxDelayMillis = deploymentTotalNumSimulatedPlayers * AverageDelayMillisBetweenConnections;
@@ -205,21 +195,6 @@ namespace Improbable.WorkerCoordinator
             }
 
             return defaultValue;
-        }
-
-        private void WaitForTargetDeploymentReady(Connection connection)
-        {
-            while (true)
-            {
-                string readyFlag = connection.GetWorkerFlag(TargetDeploymentReadyWorkerFlag);
-                if (String.Compare(readyFlag, "true", true) == 0)
-                {
-                    // Ready.
-                    break;
-                }
-
-                Thread.Sleep(PollTargetDeploymentReadyIntervalMillis);
-            }
         }
     }
 }

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/RegisseurWorkerCoordinator.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/RegisseurWorkerCoordinator.cs
@@ -79,8 +79,7 @@ namespace Improbable.WorkerCoordinator
             });
 
             string simulatedPlayerArgs = string.Join(" ", args);
-            Logger.WriteLog("Starting worker " + name + " with args: " + simulatedPlayerArgs);
-            CreateSimulatedPlayerProcess(SimulatedPlayerFilename, simulatedPlayerArgs);
+            CreateSimulatedPlayerProcess(name, SimulatedPlayerFilename, simulatedPlayerArgs);
         }
     }
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
@@ -221,6 +221,12 @@ void USpatialGameInstance::Init()
 {
 	Super::Init();
 
+	if (IsSimulatedPlayer())
+	{
+		GetEngine()->OnTravelFailure().AddUObject(this, &USpatialGameInstance::HandleOnSimulatedPlayerTravelFailure);
+		GetEngine()->OnNetworkFailure().AddUObject(this, &USpatialGameInstance::HandleOnSimulatedPlayerNetworkFailure);
+	}
+
 	SpatialLatencyTracer = NewObject<USpatialLatencyTracer>(this);
 
 	if (HasSpatialNetDriver())
@@ -275,6 +281,25 @@ void USpatialGameInstance::HandleOnPlayerSpawnFailed(const FString& Reason)
 {
 	UE_LOG(LogSpatialGameInstance, Error, TEXT("Could not spawn the local player on SpatialOS. Reason: %s"), *Reason);
 	OnSpatialPlayerSpawnFailed.Broadcast(Reason);
+}
+
+void USpatialGameInstance::HandleOnSimulatedPlayerTravelFailure(UWorld* World, ETravelFailure::Type TravelType, const FString& Reason)
+{
+	UE_LOG(LogSpatialGameInstance, Log, TEXT("SimulatedPlayer failed to travel due to: %s"), *Reason);
+
+	constexpr uint8 SimPlayerExitCode = 128;
+
+	FPlatformMisc::RequestExitWithStatus(/*bForce =*/false, SimPlayerExitCode);
+}
+
+void USpatialGameInstance::HandleOnSimulatedPlayerNetworkFailure(UWorld* World, UNetDriver* NetDriver,
+																 ENetworkFailure::Type NetworkFailureType, const FString& Reason)
+{
+	UE_LOG(LogSpatialGameInstance, Log, TEXT("SimulatedPlayer network failure due to: %s"), *Reason);
+
+	constexpr uint8 SimPlayerExitCode = 128;
+
+	FPlatformMisc::RequestExitWithStatus(/*bForce =*/false, SimPlayerExitCode);
 }
 
 void USpatialGameInstance::OnLevelInitializedNetworkActors(ULevel* LoadedLevel, UWorld* OwningWorld) const

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
@@ -12,6 +12,8 @@
 #include "Settings/LevelEditorPlaySettings.h"
 #endif
 
+#include "Kismet/GameplayStatics.h"
+
 #include "EngineClasses/SpatialNetDriver.h"
 #include "EngineClasses/SpatialPendingNetGame.h"
 #include "Interop/Connection/SpatialConnectionManager.h"
@@ -221,13 +223,6 @@ namespace
 {
 constexpr uint8 SimPlayerErrorExitCode = 10;
 
-void HandleOnSimulatedPlayerTravelFailure(UWorld* World, ETravelFailure::Type TravelType, const FString& Reason)
-{
-	UE_LOG(LogSpatialGameInstance, Log, TEXT("SimulatedPlayer failed to travel due to: %s"), *Reason);
-
-	FPlatformMisc::RequestExitWithStatus(/*bForce =*/false, SimPlayerErrorExitCode);
-}
-
 void HandleOnSimulatedPlayerNetworkFailure(UWorld* World, UNetDriver* NetDriver, ENetworkFailure::Type NetworkFailureType,
 										   const FString& Reason)
 {
@@ -241,9 +236,8 @@ void USpatialGameInstance::Init()
 {
 	Super::Init();
 
-	if (IsSimulatedPlayer())
+	if (UGameplayStatics::HasLaunchOption(TEXT("FailOnNetworkFailure")))
 	{
-		GetEngine()->OnTravelFailure().AddStatic(&HandleOnSimulatedPlayerTravelFailure);
 		GetEngine()->OnNetworkFailure().AddStatic(&HandleOnSimulatedPlayerNetworkFailure);
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
@@ -283,13 +283,13 @@ void USpatialGameInstance::HandleOnPlayerSpawnFailed(const FString& Reason)
 	OnSpatialPlayerSpawnFailed.Broadcast(Reason);
 }
 
+constexpr static uint8 SimPlayerErrorExitCode = 10;
+
 void USpatialGameInstance::HandleOnSimulatedPlayerTravelFailure(UWorld* World, ETravelFailure::Type TravelType, const FString& Reason)
 {
 	UE_LOG(LogSpatialGameInstance, Log, TEXT("SimulatedPlayer failed to travel due to: %s"), *Reason);
 
-	constexpr uint8 SimPlayerExitCode = 128;
-
-	FPlatformMisc::RequestExitWithStatus(/*bForce =*/false, SimPlayerExitCode);
+	FPlatformMisc::RequestExitWithStatus(/*bForce =*/false, SimPlayerErrorExitCode);
 }
 
 void USpatialGameInstance::HandleOnSimulatedPlayerNetworkFailure(UWorld* World, UNetDriver* NetDriver,
@@ -297,9 +297,7 @@ void USpatialGameInstance::HandleOnSimulatedPlayerNetworkFailure(UWorld* World, 
 {
 	UE_LOG(LogSpatialGameInstance, Log, TEXT("SimulatedPlayer network failure due to: %s"), *Reason);
 
-	constexpr uint8 SimPlayerExitCode = 128;
-
-	FPlatformMisc::RequestExitWithStatus(/*bForce =*/false, SimPlayerExitCode);
+	FPlatformMisc::RequestExitWithStatus(/*bForce =*/false, SimPlayerErrorExitCode);
 }
 
 void USpatialGameInstance::OnLevelInitializedNetworkActors(ULevel* LoadedLevel, UWorld* OwningWorld) const

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
@@ -201,10 +201,16 @@ void USpatialConnectionManager::Connect(bool bInitAsClient, uint32 PlayInEditorI
 
 void USpatialConnectionManager::OnLoginTokens(void* UserData, const Worker_LoginTokensResponse* LoginTokens)
 {
+	USpatialConnectionManager* ConnectionManager = static_cast<USpatialConnectionManager*>(UserData);
+
 	if (LoginTokens->status.code != WORKER_CONNECTION_STATUS_CODE_SUCCESS)
 	{
 		UE_LOG(LogSpatialWorkerConnection, Error, TEXT("Failed to get login token, StatusCode: %d, Error: %s"), LoginTokens->status.code,
 			   UTF8_TO_TCHAR(LoginTokens->status.detail));
+
+		ConnectionManager->OnConnectionFailure(LoginTokens->status.code, FString::Printf(TEXT("Failed to get login token, Error: %s"),
+																						 UTF8_TO_TCHAR(LoginTokens->status.detail)));
+
 		return;
 	}
 
@@ -212,11 +218,12 @@ void USpatialConnectionManager::OnLoginTokens(void* UserData, const Worker_Login
 	{
 		UE_LOG(LogSpatialWorkerConnection, Warning,
 			   TEXT("No deployment found to connect to. Did you add the 'dev_login' tag to the deployment you want to connect to?"));
+
+		ConnectionManager->OnConnectionFailure(WORKER_CONNECTION_STATUS_CODE_REJECTED, TEXT("Zero login tokens received"));
 		return;
 	}
 
 	UE_LOG(LogSpatialWorkerConnection, Verbose, TEXT("Successfully received LoginTokens, Count: %d"), LoginTokens->login_token_count);
-	USpatialConnectionManager* ConnectionManager = static_cast<USpatialConnectionManager*>(UserData);
 	ConnectionManager->ProcessLoginTokensResponse(LoginTokens);
 }
 
@@ -294,15 +301,21 @@ void USpatialConnectionManager::RequestDeploymentLoginTokens()
 
 void USpatialConnectionManager::OnPlayerIdentityToken(void* UserData, const Worker_PlayerIdentityTokenResponse* PIToken)
 {
+	USpatialConnectionManager* ConnectionManager = static_cast<USpatialConnectionManager*>(UserData);
+
 	if (PIToken->status.code != WORKER_CONNECTION_STATUS_CODE_SUCCESS)
 	{
 		UE_LOG(LogSpatialWorkerConnection, Error, TEXT("Failed to get PlayerIdentityToken, StatusCode: %d, Error: %s"),
 			   PIToken->status.code, UTF8_TO_TCHAR(PIToken->status.detail));
+
+		ConnectionManager->OnConnectionFailure(PIToken->status.code,
+											   FString::Printf(TEXT("Failed to get PlayerIdentityToken, StatusCode: %d, Error: %s"),
+															   PIToken->status.code, UTF8_TO_TCHAR(PIToken->status.detail)));
+
 		return;
 	}
 
 	UE_LOG(LogSpatialWorkerConnection, Log, TEXT("Successfully received PIToken: %s"), UTF8_TO_TCHAR(PIToken->player_identity_token));
-	USpatialConnectionManager* ConnectionManager = static_cast<USpatialConnectionManager*>(UserData);
 	ConnectionManager->DevAuthConfig.PlayerIdentityToken = UTF8_TO_TCHAR(PIToken->player_identity_token);
 
 	ConnectionManager->RequestDeploymentLoginTokens();
@@ -350,6 +363,9 @@ void USpatialConnectionManager::ConnectToLocator(FLocatorConfig* InLocatorConfig
 	if (InLocatorConfig == nullptr)
 	{
 		UE_LOG(LogSpatialWorkerConnection, Error, TEXT("Trying to connect to locator with invalid locator config"));
+
+		OnConnectionFailure(WORKER_CONNECTION_STATUS_CODE_INVALID_ARGUMENT, TEXT("Invalid locator config"));
+
 		return;
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialGameInstance.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialGameInstance.h
@@ -59,6 +59,9 @@ public:
 	void HandleOnConnectionFailed(const FString& Reason);
 	void HandleOnPlayerSpawnFailed(const FString& Reason);
 
+	void HandleOnSimulatedPlayerTravelFailure(UWorld* World, ETravelFailure::Type TravelType, const FString& Reason);
+	void HandleOnSimulatedPlayerNetworkFailure(UWorld* World, UNetDriver* NetDriver, ENetworkFailure::Type NetworkFailureType, const FString& Reason);
+
 	UFUNCTION()
 	void HandlePrepareShutdownWorkerFlagUpdated(const FString& FlagName, const FString& FlagValue);
 
@@ -125,3 +128,4 @@ private:
 	// Whether shutdown preparation has been triggered.
 	bool bPreparingForShutdown;
 };
+

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialGameInstance.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialGameInstance.h
@@ -59,9 +59,6 @@ public:
 	void HandleOnConnectionFailed(const FString& Reason);
 	void HandleOnPlayerSpawnFailed(const FString& Reason);
 
-	void HandleOnSimulatedPlayerTravelFailure(UWorld* World, ETravelFailure::Type TravelType, const FString& Reason);
-	void HandleOnSimulatedPlayerNetworkFailure(UWorld* World, UNetDriver* NetDriver, ENetworkFailure::Type NetworkFailureType, const FString& Reason);
-
 	UFUNCTION()
 	void HandlePrepareShutdownWorkerFlagUpdated(const FString& FlagName, const FString& FlagValue);
 
@@ -128,4 +125,3 @@ private:
 	// Whether shutdown preparation has been triggered.
 	bool bPreparingForShutdown;
 };
-


### PR DESCRIPTION
#### Description
DeploymentLauncher no longer adds `target_deployment_ready` flag to the simplayer deployments; simplayer deployments, in turn, no longer check whether this flag is set.

Instead, WorkerCoordinator tries to launch simplayer executables as soon as it can, and restarts them should they fail.

Simplayer UE clients now finish with a nonzero exit code if they get a NetworkFailure or a TravelFailure.

Together, these changes solve the initial issue: simplayer deployments now can be restarted via the console.

Additionally, I've added some more NetworkFailures when SpatialConnectionManager errors out.

#### Release note
Added a release note.

#### Tests
No automated tests were added. To check, launch a cloud deployment with SimPlayers and restart them via the Console.

#### Documentation
Added a set of notes to CHANGELOG.