### PR TITLE
Add LogSpatialFunctionalTest

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialGDKFunctionalTestsModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialGDKFunctionalTestsModule.cpp
@@ -3,10 +3,12 @@
 #include "SpatialGDKFunctionalTestsModule.h"
 
 #include "SpatialGDKFunctionalTestsPrivate.h"
+#include "LogSpatialFunctionalTest.h"
 
 #define LOCTEXT_NAMESPACE "FSpatialGDKFunctionalTestsModule"
 
 DEFINE_LOG_CATEGORY(LogSpatialGDKFunctionalTests);
+DEFINE_LOG_CATEGORY(LogSpatialFunctionalTest);
 
 IMPLEMENT_MODULE(FSpatialGDKFunctionalTestsModule, SpatialGDKFunctionalTests);
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialGDKFunctionalTestsModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialGDKFunctionalTestsModule.cpp
@@ -2,8 +2,8 @@
 
 #include "SpatialGDKFunctionalTestsModule.h"
 
-#include "SpatialGDKFunctionalTestsPrivate.h"
 #include "LogSpatialFunctionalTest.h"
+#include "SpatialGDKFunctionalTestsPrivate.h"
 
 #define LOCTEXT_NAMESPACE "FSpatialGDKFunctionalTestsModule"
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialGDKFunctionalTestsPrivate.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialGDKFunctionalTestsPrivate.h
@@ -4,4 +4,5 @@
 
 #include "Logging/LogMacros.h"
 
+// Intended for logging from the testing framework
 DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKFunctionalTests, Log, All);

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/LogSpatialFunctionalTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/LogSpatialFunctionalTest.h
@@ -1,0 +1,7 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "Logging/LogMacros.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogSpatialFunctionalTest, Log, All);

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/LogSpatialFunctionalTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/LogSpatialFunctionalTest.h
@@ -4,4 +4,5 @@
 
 #include "Logging/LogMacros.h"
 
+// Intended for logging from test implementations
 DECLARE_LOG_CATEGORY_EXTERN(LogSpatialFunctionalTest, Log, All);


### PR DESCRIPTION
#### Description
Adds an outwardly accessible `LogSpatialFunctionalTest` category, to be used for logs in functional test implementations (as opposed to `LogSpatialGDKFunctionalTests`, which is used for logging in the functional test framework itself).

*Alternative solutions:*
- Don't add a category. Have every test define its own category if it needs to.
- Expose the existing `LogSpatialGDKFunctionalTests` and use it both for the framework implementation and in test implementations.

*Request for bikeshedding:* This is almost certainly a terrible name since it's so similar to `LogSpatialGDKFunctionalTests`. Other ideas welcome (either for a different name, or for different solutions altogether).

#### Release note
N/A I believe?