### PR TITLE
[UNR-4708] Fix verifySlow and checkSlow in SetOwner

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -2364,9 +2364,9 @@ void USpatialReceiver::ResolveIncomingOperations(UObject* Object, const FUnrealO
 	UE_LOG(LogSpatialReceiver, Verbose, TEXT("Resolving incoming operations depending on object ref %s, resolved object: %s"),
 		   *ObjectRef.ToString(), *Object->GetName());
 
-	/* Rep-notify can modify ObjectRefToRepStateMap in some situations which can cause the TSet to access
-	invalid memory if a) the set is removed or b) the TMap containing the TSet is reallocated. So to fix this
-	we just gather the channel object pairs to inspect here, and only afterwards do we write the resolved objects and call Rep-notifies. */
+	/* Rep-notify can modify ObjectRefToRepStateMap in some situations which can cause the TSet to access invalid
+	memory if a) the set is removed or b) the TMap containing the TSet is reallocated. So to fix this we just gather
+	the channel-object-repstate tuples to inspect here, and only afterwards do we write the resolved objects and call Rep-notifies. */
 	TArray<ChannelObjectsToBeResolved> ObjectsToInspect;
 
 	for (auto ChannelObjectIter = TargetObjectSet->CreateIterator(); ChannelObjectIter; ++ChannelObjectIter)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -2426,15 +2426,15 @@ void USpatialReceiver::ResolveIncomingOperations(UObject* Object, const FUnrealO
 		ObjectsToInspect.Add(ChannelObjectsToBeResolved{ DependentChannel, ReplicatingObject, RepState });
 	}
 
-	for (const auto& Objects : ObjectsToInspect)
+	for (const auto& ObjectToInspect : ObjectsToInspect)
 	{
-		USpatialActorChannel* DependentChannel = Objects.Channel;
-		if (!Objects.Object.IsValid())
+		USpatialActorChannel* DependentChannel = ObjectToInspect.Channel;
+		if (!ObjectToInspect.Object.IsValid())
 		{
 			continue;
 		}
-		UObject* ReplicatingObject = Objects.Object.Get();
-		FSpatialObjectRepState* RepState = Objects.RepState;
+		UObject* ReplicatingObject = ObjectToInspect.Object.Get();
+		FSpatialObjectRepState* RepState = ObjectToInspect.RepState;
 		bool bSomeObjectsWereMapped = false;
 		TArray<GDK_PROPERTY(Property)*> RepNotifies;
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -2429,7 +2429,9 @@ void USpatialReceiver::ResolveIncomingOperations(UObject* Object, const FUnrealO
 	for (const auto& ObjectToInspect : ObjectsToInspect)
 	{
 		USpatialActorChannel* DependentChannel = ObjectToInspect.Channel;
-		if (!ObjectToInspect.Object.IsValid())
+		// Since the RepNotifies could theoretically destroy objects and close channels
+		// we will check here again to see if the object is still valid and the channel is open
+		if (!ObjectToInspect.Object.IsValid() || DependentChannel->Actor == nullptr)
 		{
 			continue;
 		}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialReceiver.cpp
@@ -2364,9 +2364,9 @@ void USpatialReceiver::ResolveIncomingOperations(UObject* Object, const FUnrealO
 	UE_LOG(LogSpatialReceiver, Verbose, TEXT("Resolving incoming operations depending on object ref %s, resolved object: %s"),
 		   *ObjectRef.ToString(), *Object->GetName());
 
-	/* Rep-notify can modify ObjectRefToRepStateMap in some situations which can cause the TSet to access invalid
-	memory if a) the set is removed or b) the TMap containing the TSet is reallocated. So to fix this we just gather
-	the channel-object-repstate tuples to inspect here, and only afterwards do we write the resolved objects and call Rep-notifies. */
+	// Rep-notify can modify ObjectRefToRepStateMap in some situations which can cause the TSet to access invalid
+	// memory if a) the set is removed or b) the TMap containing the TSet is reallocated. So to fix this we just gather
+	// the channel-object-repstate tuples to inspect here, and only afterwards do we write the resolved objects and call Rep-notifies.
 	TArray<ChannelObjectsToBeResolved> ObjectsToInspect;
 
 	for (auto ChannelObjectIter = TargetObjectSet->CreateIterator(); ChannelObjectIter; ++ChannelObjectIter)


### PR DESCRIPTION
#### Description
Fix verifySlow and checkSlow firing in SetOwner due to a misordering of PreNetReceive and PostNetReceive due to the previous bugfix for concurrent modification while iterating over the set.

#### Release note
Hmmmmmmmmm, is this in 0.12-rc?

#### Tests
Tested random maps in debug mode (where the slow checks would normally fire).

#### Documentation
N/A

#### Primary reviewers
@improbable-danny 
