### PR TITLE
UNR-4793 Schema generator test support cond_owneronly

### DIFF
--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SchemaGenObjectStub.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SchemaGenObjectStub.cpp
@@ -12,6 +12,14 @@ void USchemaGenObjectStub::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>&
 	DOREPLIFETIME(USchemaGenObjectStub, BoolValue);
 }
 
+void USchemaGenObjectStubCondOwnerOnly::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+
+	DOREPLIFETIME_CONDITION(USchemaGenObjectStubCondOwnerOnly, IntValue, COND_OwnerOnly);
+	DOREPLIFETIME_CONDITION(USchemaGenObjectStubCondOwnerOnly, BoolValue, COND_OwnerOnly);
+}
+
 ASpatialTypeActorWithActorComponent::ASpatialTypeActorWithActorComponent(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SchemaGenObjectStub.h
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SchemaGenObjectStub.h
@@ -29,6 +29,18 @@ public:
 	bool BoolValue;
 };
 
+UCLASS()
+class USchemaGenObjectStubHandOver : public UObject
+{
+	GENERATED_BODY()
+public:
+	UPROPERTY(Handover)
+	int IntValue;
+
+	UPROPERTY(Handover)
+	bool BoolValue;
+};
+
 UCLASS(SpatialType)
 class USpatialTypeObjectStub : public UObject
 {

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SchemaGenObjectStub.h
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SchemaGenObjectStub.h
@@ -17,6 +17,18 @@ public:
 	bool BoolValue;
 };
 
+UCLASS()
+class USchemaGenObjectStubCondOwnerOnly : public UObject
+{
+	GENERATED_BODY()
+public:
+	UPROPERTY(Replicated)
+	int IntValue;
+
+	UPROPERTY(Replicated)
+	bool BoolValue;
+};
+
 UCLASS(SpatialType)
 class USpatialTypeObjectStub : public UObject
 {

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
@@ -773,6 +773,8 @@ SCHEMA_GENERATOR_TEST(GIVEN_a_class_with_schema_generated_WHEN_schema_database_s
 	return true;
 }
 
+// This test tests AllTestClassesSet classes schema generation.
+//   Compare the loaded schema data with the saved schema to check if the given classes are fully supported.
 SCHEMA_GENERATOR_TEST(GIVEN_multiple_classes_with_schema_generated_WHEN_schema_database_saved_THEN_expected_schema_database_exists)
 {
 	SchemaTestFixture Fixture;

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
@@ -257,6 +257,7 @@ const TArray<UObject*>& AllTestClassesArray()
 {
 	static TArray<UObject*> TestClassesArray = { USchemaGenObjectStub::StaticClass(),
 												 USchemaGenObjectStubCondOwnerOnly::StaticClass(),
+												 USchemaGenObjectStubHandOver::StaticClass(),
 												 USpatialTypeObjectStub::StaticClass(),
 												 UChildOfSpatialTypeObjectStub::StaticClass(),
 												 UNotSpatialTypeObjectStub::StaticClass(),
@@ -277,6 +278,7 @@ const TSet<UClass*>& AllTestClassesSet()
 {
 	static TSet<UClass*> TestClassesSet = { USchemaGenObjectStub::StaticClass(),
 											USchemaGenObjectStubCondOwnerOnly::StaticClass(),
+											USchemaGenObjectStubHandOver::StaticClass(),
 											USpatialTypeObjectStub::StaticClass(),
 											UChildOfSpatialTypeObjectStub::StaticClass(),
 											UNotSpatialTypeObjectStub::StaticClass(),

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
@@ -102,7 +102,7 @@ ComponentNamesAndIds ParseAvailableNamesAndIdsFromSchemaFile(const TArray<FStrin
 	return ParsedNamesAndIds;
 }
 
-FString ComponentTypeToString(int Type)
+FString ComponentTypeToString(ESchemaComponentType Type)
 {
 	switch (Type)
 	{
@@ -189,17 +189,17 @@ bool TestEqualDatabaseEntryAndSchemaFile(const UClass* CurrentClass, const FStri
 			}
 
 			TArray<int32> SavedIds;
-			TMap<int32, TPair<int, int> > SavedIdType;
+			TMap<int32, TPair<int, ESchemaComponentType> > SavedIdType;
 			const uint32 DynamicComponentsPerClass = GetDefault<USpatialGDKSettings>()->MaxDynamicallyAttachedSubobjectsPerClass;
 			for (uint32 i = 0; i < DynamicComponentsPerClass; ++i)
 			{
-				for (int j = SCHEMA_Data; j < SCHEMA_Count; ++j)
+				for (int j = SCHEMA_Begin; j < SCHEMA_Count; ++j)
 				{
 					int32 Id = SubobjectSchemaData->DynamicSubobjectComponents[i].SchemaComponents[j];
 					if (Id != 0)
 					{
 						SavedIds.Push(Id);
-						SavedIdType.Emplace(Id, TPair<int, int>(i, j));
+						SavedIdType.Emplace(Id, TPair<int, ESchemaComponentType>(i, (ESchemaComponentType)j));
 					}
 				}
 			}
@@ -218,7 +218,7 @@ bool TestEqualDatabaseEntryAndSchemaFile(const UClass* CurrentClass, const FStri
 					return false;
 				}
 
-				const TPair<int, int>& IdType = SavedIdType[SavedIds[i]];
+				const TPair<int, ESchemaComponentType>& IdType = SavedIdType[SavedIds[i]];
 				FString ExpectedComponentName = SubobjectSchemaData->GeneratedSchemaName;
 				ExpectedComponentName += ComponentTypeToString(IdType.Value);
 				ExpectedComponentName += TEXT("Dynamic");

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
@@ -112,8 +112,6 @@ FString ComponentTypeToString(int Type)
 		return TEXT("OwnerOnly");
 	case SCHEMA_Handover:
 		return TEXT("Handover");
-	case SCHEMA_InitialOnly:
-		return TEXT("InitialOnly");
 	}
 	return TEXT("");
 }
@@ -191,7 +189,7 @@ bool TestEqualDatabaseEntryAndSchemaFile(const UClass* CurrentClass, const FStri
 			}
 
 			TArray<int32> SavedIds;
-			TMap<int32, TPair<int,int> > SavedIdType;
+			TMap<int32, TPair<int, int> > SavedIdType;
 			const uint32 DynamicComponentsPerClass = GetDefault<USpatialGDKSettings>()->MaxDynamicallyAttachedSubobjectsPerClass;
 			for (uint32 i = 0; i < DynamicComponentsPerClass; ++i)
 			{
@@ -207,8 +205,7 @@ bool TestEqualDatabaseEntryAndSchemaFile(const UClass* CurrentClass, const FStri
 			}
 			if (SavedIds.Num() != ParsedNamesAndIds.Ids.Num())
 			{
-				UE_LOG(LogSpatialGDKSchemaGeneratorTest, Error,
-					   TEXT("SavedIds.Num() is not equal with ParsedNamesAndIds.Ids.Num()"));
+				UE_LOG(LogSpatialGDKSchemaGeneratorTest, Error, TEXT("SavedIds.Num() is not equal with ParsedNamesAndIds.Ids.Num()"));
 				return false;
 			}
 


### PR DESCRIPTION
Add testing of `OwnerOnly` and `Handover` properties for schema generation.

Previously this test did not actually test all supported features, it now covers generation of all support property types.

TestEqualDatabaseEntryAndSchemaFile logging has been improved and should be more clearly specify what caused the test failure.

Passed snapshot:
![image](https://user-images.githubusercontent.com/30972673/104563624-d8543080-5684-11eb-9825-1333301d019a.png)