### PR TITLE
Add 1x2 worker settings in C++

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/Test1x2WorkerSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/Test1x2WorkerSettings.cpp
@@ -1,0 +1,10 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "Test1x2WorkerSettings.h"
+
+#include "Test1x2GridStrategy.h"
+
+UTest1x2WorkerSettings::UTest1x2WorkerSettings()
+{
+	WorkerLayers[0].LoadBalanceStrategy = UTest1x2GridStrategy::StaticClass();
+}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/Test1x2WorkerSettings.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/Test1x2WorkerSettings.h
@@ -1,0 +1,19 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "LoadBalancing/SpatialMultiWorkerSettings.h"
+#include "Test1x2WorkerSettings.generated.h"
+
+/**
+ * Uses the Test1x2GridStrategy, otherwise has default settings.
+ */
+UCLASS()
+class SPATIALGDKFUNCTIONALTESTS_API UTest1x2WorkerSettings : public USpatialMultiWorkerSettings
+{
+	GENERATED_BODY()
+
+public:
+	UTest1x2WorkerSettings();
+};


### PR DESCRIPTION
#### Description
Adds a C++ version of the 1x2 worker settings used in test maps.

Used in the SpatialZoningMap re-created here: https://github.com/spatialos/UnrealGDKTestGyms/pull/268