### PR TITLE
UNR-4807: Fixed heartbeats potentially executing with destroyed controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ These functions and structs can be referenced in both code and blueprints it may
 - Fixed a bug where consecutive invocations of CookAndGenerateSchemaCommandlet for different levels could fail when running the schema compiler.
 - Fixed a crash that occured when opening the session frontend with VS 16.8.0 using the bundled dbghelp.dll.
 - Spatial debugger no longer consumes input.
+- Fixed an issue where heartbeats could be ran on a controller after its destruction
 
 ## [`0.11.0`] - 2020-09-03
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
@@ -183,9 +183,9 @@ void USpatialNetConnection::SetHeartbeatEventTimer()
 		},
 		GetDefault<USpatialGDKSettings>()->HeartbeatIntervalSeconds, true, 0.0f);
 
-	if (APlayerController* Controller = GetPlayerController(GetWorld()))
+	if (PlayerController)
 	{
-		Controller->OnDestroyed.AddDynamic(this, &USpatialNetConnection::OnControllerDestroyed);
+		PlayerController->OnDestroyed.AddDynamic(this, &USpatialNetConnection::OnControllerDestroyed);
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
@@ -228,7 +228,7 @@ void USpatialNetConnection::ClientNotifyClientHasQuit()
 	}
 	else
 	{
-		UE_LOG(LogSpatialNetConnection, Warning, TEXT("Quitting before Heartbeat component has been initialized: NetConnection %s"),
+		UE_LOG(LogSpatialNetConnection, Verbose, TEXT("Quitting before Heartbeat component has been initialized: NetConnection %s"),
 			   *GetName());
 	}
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetConnection.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetConnection.h
@@ -60,6 +60,7 @@ public:
 
 	void ClientNotifyClientHasQuit();
 
+	UFUNCTION()
 	void OnControllerDestroyed(AActor* DestroyedActor);
 
 	UPROPERTY()


### PR DESCRIPTION
#### Description
Fixed a missing `OnDestroyed` subscription due to `UPlayer::GetPlayerController(UWorld*)` returning `nullptr`, when called on a client from a `USpatialNetConnection`.

#### Tests
The repro steps I used are as follows:
* Start a cloud deployment with the GDK Shooter Example
* Connect to it from the Editor
* Start a packet shaper such as Clumsy with 100% packet loss
* Run around and shoot for ~10 seconds
* Stop the shaper; the controller should be destroyed after this.

#### Documentation
Added a release note to the changelog.