### PR TITLE
Trigger boxes don't always work with low FPS 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ These functions and structs can be referenced in both code and blueprints it may
 - Fixed a bug where consecutive invocations of CookAndGenerateSchemaCommandlet for different levels could fail when running the schema compiler.
 - Fixed a crash that occured when opening the session frontend with VS 16.8.0 using the bundled dbghelp.dll.
 - Spatial debugger no longer consumes input.
+- Fixed an issue in the SpatialTestCharacterMigration test where trigger boxes sometimes wouldn't trigger at low framerates.
 
 ## [`0.11.0`] - 2020-09-03
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestCharacterMigration/SpatialTestCharacterMigration.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestCharacterMigration/SpatialTestCharacterMigration.cpp
@@ -8,6 +8,17 @@
 #include "SpatialFunctionalTestFlowController.h"
 #include "SpatialGDKFunctionalTests/SpatialGDK/TestActors/TestMovementCharacter.h"
 
+namespace
+{
+	float GetTargetDistanceOnLine(const FVector& From, const FVector& Target, const FVector& Location)
+	{
+		FVector Norm = (Target - From);
+		Norm.Normalize();
+		FVector RelativePosition = Location - Target;
+		return FVector::DotProduct(Norm, RelativePosition);
+	}
+}
+
 /**
  * This test moves a character backward and forward repeatedly between two workers, adding actors. Based on the SpatialTestCharacterMovement
  * test. This test requires the CharacterMovementTestGameMode, trying to run this test on a different game mode will fail.
@@ -22,22 +33,7 @@ ASpatialTestCharacterMigration::ASpatialTestCharacterMigration()
 	Author = "Victoria";
 	Description = TEXT("Test Character Migration");
 	TimeLimit = 300;
-}
-
-void ASpatialTestCharacterMigration::OnOverlapBeginDestination(AActor* OverlappedActor, AActor* OtherActor)
-{
-	if (Cast<ATestMovementCharacter>(OtherActor))
-	{
-		bCharacterReachedDestination = true;
-	}
-}
-
-void ASpatialTestCharacterMigration::OnOverlapBeginOrigin(AActor* OverlappedActor, AActor* OtherActor)
-{
-	if (Cast<ATestMovementCharacter>(OtherActor))
-	{
-		bCharacterReachedOrigin = true;
-	}
+	
 }
 
 void ASpatialTestCharacterMigration::PrepareTest()
@@ -82,6 +78,8 @@ void ASpatialTestCharacterMigration::PrepareTest()
 		ATestMovementCharacter* PlayerCharacter = Cast<ATestMovementCharacter>(PlayerController->GetPawn());
 
 		PlayerCharacter->AddMovementInput(FVector(1, 0, 0), 10.0f, true);
+		
+		bCharacterReachedDestination = GetTargetDistanceOnLine(Origin, Destination, PlayerCharacter->GetActorLocation()) > -20.0f; // 20cm overlap
 
 		if (bCharacterReachedDestination)
 		{
@@ -100,6 +98,8 @@ void ASpatialTestCharacterMigration::PrepareTest()
 
 		PlayerCharacter->AddMovementInput(FVector(-1, 0, 0), 10.0f, true);
 
+		bCharacterReachedOrigin = GetTargetDistanceOnLine(Destination, Origin, PlayerCharacter->GetActorLocation()) > -20.0f;; // 20cm overlap
+
 		if (bCharacterReachedOrigin)
 		{
 			AssertTrue(bCharacterReachedOrigin, TEXT("Player character has reached the origin on the autonomous proxy."));
@@ -112,31 +112,8 @@ void ASpatialTestCharacterMigration::PrepareTest()
 		bCharacterReachedDestination = false;
 		bCharacterReachedOrigin = false;
 
-		// Setup the destination trigger box
-		ATriggerBox* TriggerBoxDestination =
-			GetWorld()->SpawnActor<ATriggerBox>(FVector(132.0f, 0.0f, 40.0f), FRotator::ZeroRotator, FActorSpawnParameters());
-		TriggerBoxDestination->Tags.Add("Destination");
-
-		if (UBoxComponent* BoxComponentDestination = Cast<UBoxComponent>(TriggerBoxDestination->GetCollisionComponent()))
-		{
-			BoxComponentDestination->SetBoxExtent(FVector(10.0f, 1.0f, 1.0f));
-		}
-
-		TriggerBoxDestination->OnActorBeginOverlap.AddDynamic(this, &ASpatialTestCharacterMigration::OnOverlapBeginDestination);
-		RegisterAutoDestroyActor(TriggerBoxDestination);
-
-		// Setup the origin trigger box
-		ATriggerBox* TriggerBoxOrigin =
-			GetWorld()->SpawnActor<ATriggerBox>(FVector(-132.0f, 0.0f, 40.0f), FRotator::ZeroRotator, FActorSpawnParameters());
-		TriggerBoxDestination->Tags.Add("Origin");
-
-		if (UBoxComponent* BoxComponentOrigin = Cast<UBoxComponent>(TriggerBoxOrigin->GetCollisionComponent()))
-		{
-			BoxComponentOrigin->SetBoxExtent(FVector(10.0f, 1.0f, 1.0f));
-		}
-
-		TriggerBoxOrigin->OnActorBeginOverlap.AddDynamic(this, &ASpatialTestCharacterMigration::OnOverlapBeginOrigin);
-		RegisterAutoDestroyActor(TriggerBoxOrigin);
+		Destination = FVector(132.0f, 0.0f, 40.0f);
+		Origin = FVector(-132.0f, 0.0f, 40.0f);
 
 		FinishStep();
 	});

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestCharacterMigration/SpatialTestCharacterMigration.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestCharacterMigration/SpatialTestCharacterMigration.cpp
@@ -10,14 +10,14 @@
 
 namespace
 {
-	float GetTargetDistanceOnLine(const FVector& From, const FVector& Target, const FVector& Location)
-	{
-		FVector Norm = (Target - From);
-		Norm.Normalize();
-		FVector RelativePosition = Location - Target;
-		return FVector::DotProduct(Norm, RelativePosition);
-	}
+float GetTargetDistanceOnLine(const FVector& From, const FVector& Target, const FVector& Location)
+{
+	FVector Norm = (Target - From);
+	Norm.Normalize();
+	FVector RelativePosition = Location - Target;
+	return FVector::DotProduct(Norm, RelativePosition);
 }
+} // namespace
 
 /**
  * This test moves a character backward and forward repeatedly between two workers, adding actors. Based on the SpatialTestCharacterMovement
@@ -33,7 +33,6 @@ ASpatialTestCharacterMigration::ASpatialTestCharacterMigration()
 	Author = "Victoria";
 	Description = TEXT("Test Character Migration");
 	TimeLimit = 300;
-	
 }
 
 void ASpatialTestCharacterMigration::PrepareTest()
@@ -78,8 +77,9 @@ void ASpatialTestCharacterMigration::PrepareTest()
 		ATestMovementCharacter* PlayerCharacter = Cast<ATestMovementCharacter>(PlayerController->GetPawn());
 
 		PlayerCharacter->AddMovementInput(FVector(1, 0, 0), 10.0f, true);
-		
-		bCharacterReachedDestination = GetTargetDistanceOnLine(Origin, Destination, PlayerCharacter->GetActorLocation()) > -20.0f; // 20cm overlap
+
+		bCharacterReachedDestination =
+			GetTargetDistanceOnLine(Origin, Destination, PlayerCharacter->GetActorLocation()) > -20.0f; // 20cm overlap
 
 		if (bCharacterReachedDestination)
 		{
@@ -98,7 +98,8 @@ void ASpatialTestCharacterMigration::PrepareTest()
 
 		PlayerCharacter->AddMovementInput(FVector(-1, 0, 0), 10.0f, true);
 
-		bCharacterReachedOrigin = GetTargetDistanceOnLine(Destination, Origin, PlayerCharacter->GetActorLocation()) > -20.0f;; // 20cm overlap
+		bCharacterReachedOrigin = GetTargetDistanceOnLine(Destination, Origin, PlayerCharacter->GetActorLocation()) > -20.0f;
+		; // 20cm overlap
 
 		if (bCharacterReachedOrigin)
 		{

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestCharacterMigration/SpatialTestCharacterMigration.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestCharacterMigration/SpatialTestCharacterMigration.h
@@ -16,11 +16,9 @@ public:
 
 	virtual void PrepareTest() override;
 
+	FVector Origin;
+	FVector Destination;
+
 	bool bCharacterReachedDestination;
 	bool bCharacterReachedOrigin;
-
-	UFUNCTION()
-	void OnOverlapBeginDestination(AActor* OverlappedActor, AActor* OtherActor);
-	UFUNCTION()
-	void OnOverlapBeginOrigin(AActor* OverlappedActor, AActor* OtherActor);
 };


### PR DESCRIPTION
#### Description
The movement can sometimes become unstable and fall off the map and not trigger the trigger boxes which are spawned. This method works a lot more reliably at low FPS 

#### Primary reviewers
@MatthewSandfordImprobable 