### PR TITLE
UNR-4799: Fixed an error with launch config generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ These functions and structs can be referenced in both code and blueprints it may
 - Fixed a bug where consecutive invocations of CookAndGenerateSchemaCommandlet for different levels could fail when running the schema compiler.
 - Fixed a crash that occured when opening the session frontend with VS 16.8.0 using the bundled dbghelp.dll.
 - Spatial debugger no longer consumes input.
+- Fixed an issue that led to the launch config being left in non-classic style with certain engine and project path configurations
 
 ## [`0.11.0`] - 2020-09-03
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
@@ -204,7 +204,7 @@ bool ConvertToClassicConfig(const FString& LaunchConfigPath, const FSpatialLaunc
 	FString RuntimePath =
 		SpatialGDKServicesConstants::GetRuntimeExecutablePath(SpatialGDKEditor->GetSelectedRuntimeVariantVersion().GetVersionForLocal());
 
-	FSpatialGDKServicesModule::ExecuteAndReadOutput(RuntimePath, ConversionArgs, LaunchConfigDir, Output, ExitCode);
+	FSpatialGDKServicesModule::ExecuteAndReadOutput(RuntimePath, ConversionArgs, FPlatformProcess::BaseDir(), Output, ExitCode);
 
 	if (ExitCode != SpatialGDKServicesConstants::ExitCodeSuccess)
 	{


### PR DESCRIPTION
#### Description
The issue lies in Unreal converting every path to a path relative to `FPlatformProcess::BaseDir()`, so when we're launching the runtime exe to convert the non-classic config to a classic one, we pass in this relative path. The working dir of the runtime, however, is `%PROJECT_PATH%/spatial`, which leads to pathing issues.

So when the engine is at `D:/work/UnrealEngine/`, BaseDir would be `D:/work/UnrealEngine/Engine/Binaries/Win64/`. Project directory would be `D:/work/UnrealGDKTestGyms`, so the absolute config path is `D:/work/UnrealGDKTestGyms/spatial/Something.json`; the relative path is `../../../../UnrealGDKTestGyms/spatial/Something.json`. Before the changes, working directory of runtime is `D:/work/UnrealGDKTestGyms/spatial`, so after being combined with the relative path it points to a completely different location - outside of the disk, even.

This change sorts this out by passing BaseDir as working directory.

#### Tests
Manual retest with various project paths.

#### Documentation
Added a changelog entry.

