### PR TITLE
UNR-4703 Cleanup Android build warnings

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/SpatialGDK.Build.cs
+++ b/SpatialGDK/Source/SpatialGDK/SpatialGDK.Build.cs
@@ -65,11 +65,6 @@ public class SpatialGDK : ModuleRules
 
         var WorkerLibraryDir = Path.Combine(ModuleDirectory, "..", "..", "Binaries", "ThirdParty", "Improbable", Target.Platform.ToString());
 
-        var WorkerLibraryPaths = new List<string>
-            {
-                WorkerLibraryDir,
-            };
-
         string LibPrefix = "libimprobable_";
         string ImportLibSuffix = ".so";
         string SharedLibSuffix = ".so";
@@ -127,14 +122,12 @@ public class SpatialGDK : ModuleRules
         }
         else
         {
-            WorkerLibraryPaths.Clear();
-            WorkerSharedLib = System.String.Format("{0}worker{1}", LibPrefix, SharedLibSuffix);
-            WorkerLibraryPaths.AddRange(new string[]
+            var WorkerLibraryPaths = new List<string>
             {
                 Path.Combine(WorkerLibraryDir, "arm64-v8a"),
                 Path.Combine(WorkerLibraryDir, "armeabi-v7a"),
                 Path.Combine(WorkerLibraryDir, "x86_64"),
-            });
+            };
 
             string PluginPath = Utils.MakePathRelativeTo(ModuleDirectory, Target.RelativeEnginePath);
             AdditionalPropertiesForReceipt.Add("AndroidPlugin", Path.Combine(PluginPath, "SpatialGDK_APL.xml"));

--- a/SpatialGDK/Source/SpatialGDK/SpatialGDK.Build.cs
+++ b/SpatialGDK/Source/SpatialGDK/SpatialGDK.Build.cs
@@ -70,36 +70,31 @@ public class SpatialGDK : ModuleRules
                 WorkerLibraryDir,
             };
 
-        string LibPrefix = "improbable_";
-        string ImportLibSuffix = "";
-        string SharedLibSuffix = "";
+        string LibPrefix = "libimprobable_";
+        string ImportLibSuffix = ".so";
+        string SharedLibSuffix = ".so";
         bool bAddDelayLoad = false;
 
         if (Target.Platform == UnrealTargetPlatform.Win32 || Target.Platform == UnrealTargetPlatform.Win64)
         {
+            LibPrefix = "improbable_";
             ImportLibSuffix = ".lib";
             SharedLibSuffix = ".dll";
             bAddDelayLoad = true;
         }
         else if (Target.Platform == UnrealTargetPlatform.Mac)
         {
-            LibPrefix = "libimprobable_";
             ImportLibSuffix = SharedLibSuffix = ".dylib";
-        }
-        else if (Target.Platform == UnrealTargetPlatform.Linux)
-        {
-            LibPrefix = "libimprobable_";
-            ImportLibSuffix = SharedLibSuffix = ".so";
         }
         else if (Target.Platform == UnrealTargetPlatform.PS4)
         {
-            LibPrefix = "libimprobable_";
             ImportLibSuffix = "_stub.a";
             SharedLibSuffix = ".prx";
             bAddDelayLoad = true;
         }
         else if (Target.Platform == UnrealTargetPlatform.XboxOne)
         {
+            LibPrefix = "improbable_";
             ImportLibSuffix = ".lib";
             SharedLibSuffix = ".dll";
             // We don't set bAddDelayLoad = true here, because we get "unresolved external symbol __delayLoadHelper2".
@@ -107,23 +102,9 @@ public class SpatialGDK : ModuleRules
         }
         else if (Target.Platform == UnrealTargetPlatform.IOS)
         {
-            LibPrefix = "libimprobable_";
             ImportLibSuffix = SharedLibSuffix = "_static.a";
         }
-        else if (Target.Platform == UnrealTargetPlatform.Android)
-        {
-            LibPrefix = "improbable_";
-            WorkerLibraryPaths.AddRange(new string[]
-            {
-                Path.Combine(WorkerLibraryDir, "arm64-v8a"),
-                Path.Combine(WorkerLibraryDir, "armeabi-v7a"),
-                Path.Combine(WorkerLibraryDir, "x86_64"),
-            });
-
-            string PluginPath = Utils.MakePathRelativeTo(ModuleDirectory, Target.RelativeEnginePath);
-            AdditionalPropertiesForReceipt.Add("AndroidPlugin", Path.Combine(PluginPath, "SpatialGDK_APL.xml"));
-        }
-        else
+        else if(!(Target.Platform == UnrealTargetPlatform.Linux || Target.Platform == UnrealTargetPlatform.Android))
         {
             throw new System.Exception(System.String.Format("Unsupported platform {0}", Target.Platform.ToString()));
         }
@@ -142,13 +123,33 @@ public class SpatialGDK : ModuleRules
             WorkerImportLib = Path.Combine(WorkerLibraryDir, WorkerImportLib);
             PublicRuntimeLibraryPaths.Add(WorkerLibraryDir);
 
+            PublicAdditionalLibraries.Add(WorkerImportLib);
         }
         else
         {
-            PublicLibraryPaths.AddRange(WorkerLibraryPaths);
-        }
+            WorkerLibraryPaths.Clear();
+            WorkerSharedLib = System.String.Format("{0}worker{1}", LibPrefix, SharedLibSuffix);
+            WorkerLibraryPaths.AddRange(new string[]
+            {
+                Path.Combine(WorkerLibraryDir, "arm64-v8a"),
+                Path.Combine(WorkerLibraryDir, "armeabi-v7a"),
+                Path.Combine(WorkerLibraryDir, "x86_64"),
+            });
 
-        PublicAdditionalLibraries.Add(WorkerImportLib);
+            string PluginPath = Utils.MakePathRelativeTo(ModuleDirectory, Target.RelativeEnginePath);
+            AdditionalPropertiesForReceipt.Add("AndroidPlugin", Path.Combine(PluginPath, "SpatialGDK_APL.xml"));
+
+            PublicRuntimeLibraryPaths.AddRange(WorkerLibraryPaths);
+
+            var WorkerLibraries = new List<string>
+            {
+                Path.Combine(WorkerLibraryDir, "arm64-v8a", WorkerSharedLib),
+                Path.Combine(WorkerLibraryDir, "armeabi-v7a", WorkerSharedLib),
+                Path.Combine(WorkerLibraryDir, "x86_64", WorkerSharedLib),
+            };
+
+            PublicAdditionalLibraries.AddRange(WorkerLibraries);
+        }
 
         // Detect existence of trace library, if present add preprocessor
         string TraceStaticLibPath = "";


### PR DESCRIPTION
#### Description
Modified SpatialGDK.Build.cs to remove warnings related to Android build.

#### Release note
N/A

#### Tests
I built the example project for Android.
Also ran buildkite build of Android: [see results here](https://buildkite.com/improbable/unrealgdkexampleproject-nightly/builds/4161)

#### Documentation
N/A


