### PR TITLE
Don't fetch spatial bundles if spatial is not enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ These functions and structs can be referenced in both code and blueprints it may
 - Fixed a bug where consecutive invocations of CookAndGenerateSchemaCommandlet for different levels could fail when running the schema compiler.
 - Fixed a crash that occured when opening the session frontend with VS 16.8.0 using the bundled dbghelp.dll.
 - Spatial debugger no longer consumes input.
+- Spatial no longer requests bundles if `bSpatialNetworking` is disabled.
 
 ## [`0.11.0`] - 2020-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,7 @@ These functions and structs can be referenced in both code and blueprints it may
 - Fixed a bug where consecutive invocations of CookAndGenerateSchemaCommandlet for different levels could fail when running the schema compiler.
 - Fixed a crash that occured when opening the session frontend with VS 16.8.0 using the bundled dbghelp.dll.
 - Spatial debugger no longer consumes input.
-- Spatial no longer requests bundles if `UGeneralProjectSettings::bSpatialNetworking` is disabled.
+- Spatial no longer requests bundles on startup if `UGeneralProjectSettings::bSpatialNetworking` is disabled.
 
 ## [`0.11.0`] - 2020-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,7 @@ These functions and structs can be referenced in both code and blueprints it may
 - Fixed a bug where consecutive invocations of CookAndGenerateSchemaCommandlet for different levels could fail when running the schema compiler.
 - Fixed a crash that occured when opening the session frontend with VS 16.8.0 using the bundled dbghelp.dll.
 - Spatial debugger no longer consumes input.
-- Spatial no longer requests bundles on startup if `UGeneralProjectSettings::bSpatialNetworking` is disabled.
+- Spatial bundles no longer requested startup if `UGeneralProjectSettings::bSpatialNetworking` is disabled.
 
 ## [`0.11.0`] - 2020-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,7 @@ These functions and structs can be referenced in both code and blueprints it may
 - Fixed a bug where consecutive invocations of CookAndGenerateSchemaCommandlet for different levels could fail when running the schema compiler.
 - Fixed a crash that occured when opening the session frontend with VS 16.8.0 using the bundled dbghelp.dll.
 - Spatial debugger no longer consumes input.
-- Spatial bundles no longer requested startup if `UGeneralProjectSettings::bSpatialNetworking` is disabled.
+- Spatial bundles no longer requested at startup if `UGeneralProjectSettings::bSpatialNetworking` is disabled.
 
 ## [`0.11.0`] - 2020-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,7 @@ These functions and structs can be referenced in both code and blueprints it may
 - Fixed a bug where consecutive invocations of CookAndGenerateSchemaCommandlet for different levels could fail when running the schema compiler.
 - Fixed a crash that occured when opening the session frontend with VS 16.8.0 using the bundled dbghelp.dll.
 - Spatial debugger no longer consumes input.
-- Spatial no longer requests bundles if `bSpatialNetworking` is disabled.
+- Spatial no longer requests bundles if `UGeneralProjectSettings::bSpatialNetworking` is disabled.
 
 ## [`0.11.0`] - 2020-09-03
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -52,6 +52,7 @@
 #include "Utils/GDKPropertyMacros.h"
 #include "Utils/LaunchConfigurationEditor.h"
 #include "Utils/SpatialDebugger.h"
+#include "Utils/SpatialStatics.h"
 
 DEFINE_LOG_CATEGORY(LogSpatialGDKEditorToolbar);
 
@@ -138,17 +139,20 @@ void FSpatialGDKEditorToolbarModule::StartupModule()
 	const FString RuntimeVersion = SpatialGDKEditorSettings->GetSelectedRuntimeVariantVersion().GetVersionForLocal();
 	const FString InspectorVersion = SpatialGDKEditorSettings->GetInspectorVersion();
 
-	AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [this, RuntimeVersion, InspectorVersion] {
-		if (!FetchRuntimeBinaryWrapper(RuntimeVersion))
-		{
-			UE_LOG(LogSpatialGDKEditorToolbar, Error, TEXT("Attempted to cache the local runtime binary but failed!"));
-		}
+	if (USpatialStatics::IsSpatialNetworkingEnabled())
+	{
+		AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [this, RuntimeVersion, InspectorVersion] {
+			if (!FetchRuntimeBinaryWrapper(RuntimeVersion))
+			{
+				UE_LOG(LogSpatialGDKEditorToolbar, Error, TEXT("Attempted to cache the local runtime binary but failed!"));
+			}
 
-		if (!FetchInspectorBinaryWrapper(InspectorVersion))
-		{
-			UE_LOG(LogSpatialGDKEditorToolbar, Error, TEXT("Attempted to cache the local inspector binary but failed!"));
-		}
-	});
+			if (!FetchInspectorBinaryWrapper(InspectorVersion))
+			{
+				UE_LOG(LogSpatialGDKEditorToolbar, Error, TEXT("Attempted to cache the local inspector binary but failed!"));
+			}
+		});
+	}
 }
 
 void FSpatialGDKEditorToolbarModule::ShutdownModule()

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -135,12 +135,12 @@ void FSpatialGDKEditorToolbarModule::StartupModule()
 	FLevelEditorModule& LevelEditorModule = FModuleManager::LoadModuleChecked<FLevelEditorModule>("LevelEditor");
 	FDelegateHandle OnMapChangedHandle = LevelEditorModule.OnMapChanged().AddRaw(this, &FSpatialGDKEditorToolbarModule::MapChanged);
 
-	// Grab the runtime and inspector binaries ahead of time so they are ready when the user wants them.
-	const FString RuntimeVersion = SpatialGDKEditorSettings->GetSelectedRuntimeVariantVersion().GetVersionForLocal();
-	const FString InspectorVersion = SpatialGDKEditorSettings->GetInspectorVersion();
-
 	if (USpatialStatics::IsSpatialNetworkingEnabled())
 	{
+		// Grab the runtime and inspector binaries ahead of time so they are ready when the user wants them.
+		const FString RuntimeVersion = SpatialGDKEditorSettings->GetSelectedRuntimeVariantVersion().GetVersionForLocal();
+		const FString InspectorVersion = SpatialGDKEditorSettings->GetInspectorVersion();
+
 		AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [this, RuntimeVersion, InspectorVersion] {
 			if (!FetchRuntimeBinaryWrapper(RuntimeVersion))
 			{


### PR DESCRIPTION
#### Description
Spatial bundles should not be requested when running with spatial disabled

#### Release note


#### Tests
- Unauth spatial, boot editor with/without the setting enabled. Ensure that spatial does not fetch a cached bundle as this doesn't require auth and silently executes the command.
- Launch the editor with spatial disabled, enable spatial and attempt to run a deployment. Ensure that this attempts to auth and download the runtime binaries 

STRONGLY SUGGESTED: How can this be verified by QA?
^

#### Primary reviewers
@MatthewSandfordImprobable @jnicholas-io 
