### PR TITLE
Note that we don't support ServerTravel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [`0.12.0`] - 2020-12-14
 
 ### Breaking changes:
+- We no longer support Server Travel. This feature is being re-designed and will be reintroduced in a future version.
 - The condition for sending Spatial position updates has been changed, the two variables `PositionUpdateFrequency` and `PositionDistanceThreshold` have now been removed from the GDK settings. To update your project:
   1. Set the value of `PositionUpdateLowerThresholdCentimeters` to the value of `PositionDistanceThreshold` and  the value of `PositionUpdateLowerThresholdSeconds` to 60*(1/`PositionUpdateFrequency`). This will ensure that Actors send Spatial position updates as often as they did before this change.
   2. Set the value of `PositionUpdateThresholdMaxCentimeters` and `PositionUpdateThresholdMaxSeconds` to larger values than the lower thresholds.
@@ -131,7 +132,6 @@ These functions and structs can be referenced in both code and blueprints it may
 ## [`0.11.0`] - 2020-09-03
 
 ### Breaking changes:
-- We no longer support Server Travel. This feature is being re-designed and will be reintroduce in a future version.
 - We no longer support Unreal Engine version 4.23. We recommend that you upgrade to the newest version 4.25 to continue receiving updates. See [Unreal Engine Version Support](https://documentation.improbable.io/gdk-for-unreal/docs/versioning-scheme#section-unreal-engine-version-support) for more information on versions. Follow the instructions in [Update your GDK](https://documentation.improbable.io/gdk-for-unreal/docs/keep-your-gdk-up-to-date) to update to 4.25.
 - We have removed multi-worker settings from the `SpatialWorldSettings` properties and added them to a new class `USpatialMultiWorkerSettings`. To update your project, create a derived `USpatialMultiWorkerSettings` class mimicking your previous configuration. Then, in your level’s World settings, select that class as the `Multi-worker settings class` property.
 - The `-nocompile` flag used with `Buildworker.bat` is now split into two. Use the following flags:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ These functions and structs can be referenced in both code and blueprints it may
 ## [`0.11.0`] - 2020-09-03
 
 ### Breaking changes:
+- We no longer support Server Travel. This feature is being re-designed and will be reintroduce in a future version.
 - We no longer support Unreal Engine version 4.23. We recommend that you upgrade to the newest version 4.25 to continue receiving updates. See [Unreal Engine Version Support](https://documentation.improbable.io/gdk-for-unreal/docs/versioning-scheme#section-unreal-engine-version-support) for more information on versions. Follow the instructions in [Update your GDK](https://documentation.improbable.io/gdk-for-unreal/docs/keep-your-gdk-up-to-date) to update to 4.25.
 - We have removed multi-worker settings from the `SpatialWorldSettings` properties and added them to a new class `USpatialMultiWorkerSettings`. To update your project, create a derived `USpatialMultiWorkerSettings` class mimicking your previous configuration. Then, in your level’s World settings, select that class as the `Multi-worker settings class` property.
 - The `-nocompile` flag used with `Buildworker.bat` is now split into two. Use the following flags:


### PR DESCRIPTION
#### Description
* Notes that we don't support ServerTravel.
* This sits under `0.12.0` > `Breaking Changes`. It was a breaking change introduced in `0.11.0` but we forgot to document it when that release went out and our thinking is that:
1. It's more noticeably non-functional in `0.12.0` so we should flag it here.
1. Users today are more likely to read `0.12.0` release notes than `0.11.0`, and they need to know this.

#### Release note
This is an un-release note

#### Tests
Rendered the markdown, checked the language with @mironec, ran spellcheck.

#### Documentation
This is documentation.

#### Primary reviewers
@mironec 
