### PR TITLE
[UNR-4794] Fix scan for manual worker launch

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -351,6 +351,7 @@ bool USpatialGDKEditorSettings::IsManualWorkerConnectionSet(const FString& Launc
 
 		if (!ConfigFile)
 		{
+			UE_LOG(LogSpatialEditorSettings, Error, TEXT("Configuration file is missing at path %s"), *LaunchConfigPath);
 			return false;
 		}
 
@@ -368,13 +369,13 @@ bool USpatialGDKEditorSettings::IsManualWorkerConnectionSet(const FString& Launc
 	}
 
 	const TSharedPtr<FJsonObject>* LoadBalancingField;
-	if (!(*LaunchConfigJsonRootObject)->TryGetObjectField("load_balancing", LoadBalancingField))
+	if (!(*LaunchConfigJsonRootObject)->TryGetObjectField("loadBalancing", LoadBalancingField))
 	{
 		return false;
 	}
 
 	const TArray<TSharedPtr<FJsonValue>>* LayerConfigurations;
-	if (!(*LoadBalancingField)->TryGetArrayField("layer_configurations", LayerConfigurations))
+	if (!(*LoadBalancingField)->TryGetArrayField("layerConfigurations", LayerConfigurations))
 	{
 		return false;
 	}
@@ -388,8 +389,7 @@ bool USpatialGDKEditorSettings::IsManualWorkerConnectionSet(const FString& Launc
 
 			// Check manual_worker_connection flag, if it exists.
 			if (LayerConfiguration->TryGetObjectField("options", OptionsField)
-				&& (*OptionsField)->TryGetBoolField("manual_worker_connection_only", ManualWorkerConnectionFlag)
-				&& ManualWorkerConnectionFlag)
+				&& (*OptionsField)->TryGetBoolField("manualWorkerConnectionOnly", ManualWorkerConnectionFlag) && ManualWorkerConnectionFlag)
 			{
 				FString WorkerName;
 				if (LayerConfiguration->TryGetStringField("layer", WorkerName))
@@ -463,6 +463,11 @@ bool USpatialGDKEditorSettings::IsDeploymentConfigurationValid() const
 		}
 	}
 
+	return bValid;
+}
+
+bool USpatialGDKEditorSettings::CheckManualWorkerConnectionOnLaunch() const
+{
 	TArray<FString> WorkersManuallyLaunched;
 	if (IsManualWorkerConnectionSet(GetPrimaryLaunchConfigPath(), WorkersManuallyLaunched))
 	{
@@ -482,7 +487,7 @@ bool USpatialGDKEditorSettings::IsDeploymentConfigurationValid() const
 		}
 	}
 
-	return bValid;
+	return true;
 }
 
 void USpatialGDKEditorSettings::SetDevelopmentAuthenticationToken(const FString& Token)

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -661,6 +661,7 @@ public:
 	}
 
 	bool IsDeploymentConfigurationValid() const;
+	bool CheckManualWorkerConnectionOnLaunch() const;
 
 	void SetDevelopmentAuthenticationToken(const FString& Token);
 

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -1352,6 +1352,13 @@ FReply FSpatialGDKEditorToolbarModule::OnStartCloudDeployment()
 		GenerateCloudConfigFromCurrentMap();
 	}
 
+	if (!SpatialGDKSettings->CheckManualWorkerConnectionOnLaunch())
+	{
+		OnShowFailedNotification(TEXT("Launch halted because of unexpected workers requiring manual launch."));
+
+		return FReply::Unhandled();
+	}
+
 	AddDeploymentTagIfMissing(SpatialConstants::DEV_LOGIN_TAG);
 
 	CloudDeploymentConfiguration.InitFromSettings();


### PR DESCRIPTION
#### Description
Code was designed to handle both automatic and manual configuration, but the check for manual worker connection was done before actually generating the configuration (if it was needed).
The format was also outdated and needed to be updated.

#### Release note

#### Tests
