### PR TITLE
Use GetComponents instead of GetComponentsByClass to fix a compile warning

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialComponentTest/SpatialComponentTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialComponentTest/SpatialComponentTest.cpp
@@ -228,7 +228,8 @@ bool ASpatialComponentTest::VerifyTestActorComponents(ASpatialComponentTestActor
 		return false;
 	}
 
-	TArray<UActorComponent*> FoundComponents = Actor->GetComponentsByClass(USpatialComponentTestDummyComponent::StaticClass());
+	TArray<UActorComponent*> FoundComponents;
+	Actor->GetComponents(USpatialComponentTestDummyComponent::StaticClass(), FoundComponents);
 	int FoundTestComponentCount = FoundComponents.Num();
 	return FoundTestComponentCount == ExpectedTestComponentCount;
 }


### PR DESCRIPTION
Fix a compile warning as:

1>C:\io\UE4\4.26\Engine\Plugins\UnrealGDK\SpatialGDK\Source\SpatialGDKFunctionalTests\SpatialGDK\SpatialComponentTest\SpatialComponentTest.cpp(231): warning C4996: 'AActor::GetComponentsByClass': Use one of the GetComponents implementations as appropriate Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.