### PR TITLE
Use generated tag class name instead of object path

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -1499,7 +1499,13 @@ void SpatialGDKSanitizeGeneratedSchema()
 	TSet<FName> ValidClassNames;
 	for (const auto& Asset : Assets)
 	{
-		ValidClassNames.Add(FName(*Asset.ObjectPath.ToString()));
+		FAssetDataTagMapSharedView::FFindTagResult GeneratedClassPathResult = Asset.TagsAndValues.FindTag(TEXT("GeneratedClass"));
+		if (GeneratedClassPathResult.IsSet())
+		{
+			FString SanitizedClassPath = FPackageName::ExportTextPathToObjectPath(GeneratedClassPathResult.GetValue());
+			SanitizedClassPath.RemoveFromEnd(TEXT("_C"));
+			ValidClassNames.Add(FName(*SanitizedClassPath));
+		}
 	}
 
 	TArray<UObject*> AllClasses;


### PR DESCRIPTION
#### Description
Previously the schema database validator was using the asset registry's object path name for identifying asset classes that were still valid within a project. Turns out that although object path name is almost always == class path, it's not true 100% of the time. Specifically in Interpid, one of their levels contained some sublevels where this wasn't true for any of them. @alastairdglennie found the correct information in the "GeneratedClass" asset tag, which this PR switches to using.

#### Tests
Ran full schema gen on TestGyms/Interpid/Scavengers with no stale classes found.

#### Primary reviewers
@alastairdglennie 
