### PR TITLE
UNR-4873 Disable heartbeat timer in SpatialNetConnection::CleanUp

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
@@ -124,6 +124,8 @@ void USpatialNetConnection::FlushDormancy(AActor* Actor)
 
 void USpatialNetConnection::InitHeartbeat(FTimerManager* InTimerManager, Worker_EntityId InPlayerControllerEntity)
 {
+	UE_LOG(LogSpatialNetConnection, Log, TEXT("Init Heartbeat component: PlayerController %s entity %lld"),
+		   *AActor::GetDebugName(PlayerController), InPlayerControllerEntity);
 	PlayerControllerEntity = InPlayerControllerEntity;
 	TimerManager = InTimerManager;
 
@@ -143,9 +145,6 @@ void USpatialNetConnection::SetHeartbeatTimeoutTimer()
 #if WITH_EDITOR
 	Timeout = GetDefault<USpatialGDKSettings>()->HeartbeatTimeoutWithEditorSeconds;
 #endif
-
-	UE_LOG(LogSpatialNetConnection, Log, TEXT("InitHeartbeat for PlayerController %s entity %lld"), *AActor::GetDebugName(PlayerController),
-		   PlayerControllerEntity);
 
 	TimerManager->SetTimer(
 		HeartbeatTimer,

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetConnection.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetConnection.h
@@ -60,6 +60,7 @@ public:
 
 	void ClientNotifyClientHasQuit();
 
+	UFUNCTION()
 	void OnControllerDestroyed(AActor* DestroyedActor);
 
 	UPROPERTY()


### PR DESCRIPTION
Diable the heartbeat timer in SpatialNetConnection::CleanUp to prevent it. 
And also change some logs(Change the SpatialNetConnection name to PlayerController name and entity id) in SpatialNetConnection to make the log readable for analysis.

had put the context in the ticket:https://improbableio.atlassian.net/browse/UNR-4873

The successful build in bk:https://buildkite.com/improbable/unrealgdk-nfr/builds/3574

