### PR TITLE
Fix for sampling mode strings 

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialEventTracer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialEventTracer.cpp
@@ -74,7 +74,7 @@ SpatialEventTracer::SpatialEventTracer(const FString& WorkerId)
 	SamplingParameters.sampling_mode = Trace_SamplingMode::TRACE_SAMPLING_MODE_PROBABILISTIC;
 
 	TArray<Trace_SpanSamplingProbability> SpanSamplingProbabilities;
-	TArray<std::string> AnsiStrings; // Worker requires ansi const char*
+	TArray<std::string> AnsiStrings; // // Worker requires platform ansi const char*
 
 	for (const auto& Pair : Settings->EventSamplingModeOverrides)
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialEventTracer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialEventTracer.cpp
@@ -145,7 +145,7 @@ FSpatialGDKSpanId SpatialEventTracer::TraceEvent(const FSpatialTraceEvent& Spati
 	}
 
 	// Worker requires ansi const char*
-	std::string MessageSrc = (const char*)TCHAR_TO_ANSI(*SpatialTraceEvent.Message); // Worker requires platform ansi const char*
+	std::string MessageSrc = (const char*)TCHAR_TO_ANSI(*SpatialTraceEvent.Message);	  // Worker requires platform ansi const char*
 	std::string TypeSrc = (const char*)TCHAR_TO_ANSI(*SpatialTraceEvent.Type.ToString()); // Worker requires platform ansi const char*
 
 	// We could add the data to this event if a custom sampling callback was used.

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialEventTracer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialEventTracer.cpp
@@ -74,12 +74,12 @@ SpatialEventTracer::SpatialEventTracer(const FString& WorkerId)
 	SamplingParameters.sampling_mode = Trace_SamplingMode::TRACE_SAMPLING_MODE_PROBABILISTIC;
 
 	TArray<Trace_SpanSamplingProbability> SpanSamplingProbabilities;
-	TArray<TStringConversion<TStringConvert<TCHAR, ANSICHAR>, 128>> AnsiTypes;
+	TArray<std::string> AnsiStrings;
 
 	for (const auto& Pair : Settings->EventSamplingModeOverrides)
 	{
-		int32 Index = AnsiTypes.Add(StringCast<ANSICHAR>(*Pair.Key.ToString()));
-		SpanSamplingProbabilities.Add({ AnsiTypes[Index].Get(), Pair.Value });
+		int32 Index = AnsiStrings.Add((const char*)TCHAR_TO_ANSI(*Pair.Key.ToString()));
+		SpanSamplingProbabilities.Add({ AnsiStrings[Index].c_str(), Pair.Value });
 	}
 
 	SamplingParameters.probabilistic_parameters.default_probability = Settings->SamplingProbability;

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialEventTracer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialEventTracer.cpp
@@ -74,7 +74,7 @@ SpatialEventTracer::SpatialEventTracer(const FString& WorkerId)
 	SamplingParameters.sampling_mode = Trace_SamplingMode::TRACE_SAMPLING_MODE_PROBABILISTIC;
 
 	TArray<Trace_SpanSamplingProbability> SpanSamplingProbabilities;
-	TArray<std::string> AnsiStrings; // // Worker requires platform ansi const char*
+	TArray<std::string> AnsiStrings; // Worker requires platform ansi const char*
 
 	for (const auto& Pair : Settings->EventSamplingModeOverrides)
 	{


### PR DESCRIPTION
#### Description
Fix for sampling mode strings, it looks like StringCast is pointing to the same internal memory so maybe it has a static conversion buffer or something. The result was that the string would be modified to the last entry 

#### Tests
Tested manually

STRONGLY SUGGESTED: How can this be verified by QA?

#### Primary reviewers
@MatthewSandfordImprobable 
