### PR TITLE
UNR-4877: Spatial debugger is using FSubView now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking changes:
 
 ### Features:
+- Adapted SpatialDebugger to use SubViews
 
 ### Bug fixes:
 - Fixed the exception that was thrown when adding and removing components in Spatial component callbacks.

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1891,28 +1891,6 @@ void USpatialNetDriver::TickDispatch(float DeltaTime)
 			WellKnownEntitySystem->Advance();
 		}
 
-		if (SpatialDebugger != nullptr)
-		{
-			for (const auto& EntityDelta : Connection->GetCoordinator().GetViewDelta().GetEntityDeltas())
-			{
-				if (EntityDelta.Type == SpatialGDK::EntityDelta::ADD)
-				{
-					SpatialDebugger->OnEntityAdded(EntityDelta.EntityId);
-				}
-				if (EntityDelta.Type == SpatialGDK::EntityDelta::REMOVE)
-				{
-					SpatialDebugger->OnEntityRemoved(EntityDelta.EntityId);
-				}
-				for (const auto& Authority : EntityDelta.AuthorityGained)
-				{
-					if (Authority.ComponentSetId == SpatialConstants::SERVER_AUTH_COMPONENT_SET_ID)
-					{
-						SpatialDebugger->ActorAuthorityGained(EntityDelta.EntityId);
-					}
-				}
-			}
-		}
-
 		if (!bIsReadyToStart)
 		{
 			TryFinishStartup();

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
@@ -2,7 +2,6 @@
 
 #include "Utils/SpatialDebugger.h"
 
-#include "Editor.h"
 #include "EngineClasses/SpatialNetDriver.h"
 #include "EngineClasses/SpatialWorldSettings.h"
 #include "Interop/Connection/SpatialWorkerConnection.h"
@@ -27,6 +26,10 @@
 #include "Kismet/GameplayStatics.h"
 #include "Modules/ModuleManager.h"
 #include "Net/UnrealNetwork.h"
+
+#if UE_EDITOR
+#include "Editor.h"
+#endif
 
 using namespace SpatialGDK;
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
@@ -182,14 +182,9 @@ void ASpatialDebugger::OnEntityAdded(const Worker_EntityId EntityId)
 	check(NetDriver != nullptr);
 	if (NetDriver->IsServer())
 	{
-		USpatialActorChannel* ActorChannel = NetDriver->GetActorChannelByEntityId(EntityId);
-
-		if (ensure(IsValid(ActorChannel)) && ensure(IsValid(ActorChannel->GetActor())))
+		if (SubView->HasAuthority(EntityId, SpatialConstants::SERVER_AUTH_COMPONENT_SET_ID))
 		{
-			if (ActorChannel->GetActor()->HasAuthority())
-			{
-				ActorAuthorityGained(EntityId);
-			}
+			ActorAuthorityGained(EntityId);
 		}
 
 		return;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialDebugger.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialDebugger.h
@@ -37,6 +37,12 @@ DECLARE_CYCLE_STAT(TEXT("DrawText"), STAT_DrawText, STATGROUP_SpatialDebugger);
 DECLARE_CYCLE_STAT(TEXT("BuildText"), STAT_BuildText, STATGROUP_SpatialDebugger);
 DECLARE_CYCLE_STAT(TEXT("SortingActors"), STAT_SortingActors, STATGROUP_SpatialDebugger);
 
+namespace SpatialGDK
+{
+class FSubView;
+struct SpatialDebugging;
+} // namespace SpatialGDK
+
 USTRUCT()
 struct FWorkerRegionInfo
 {
@@ -227,9 +233,6 @@ public:
 	UFUNCTION(BlueprintCallable, Category = Visualization)
 	void SetShowWorkerRegions(const bool bNewShow);
 
-	void ActorAuthorityGained(const Worker_EntityId EntityId) const;
-	void ActorAuthorityIntentChanged(Worker_EntityId EntityId, VirtualWorkerId NewIntentVirtualWorkerId) const;
-
 #if WITH_EDITOR
 	void EditorRefreshWorkerRegions();
 	static void EditorRefreshDisplay();
@@ -237,7 +240,13 @@ public:
 	void EditorSpatialToggleDebugger(bool bEnabled);
 #endif
 
+	void ActorAuthorityIntentChanged(Worker_EntityId EntityId, VirtualWorkerId NewIntentVirtualWorkerId) const;
+
 private:
+	void ActorAuthorityGained(const Worker_EntityId EntityId) const;
+
+	TOptional<SpatialGDK::SpatialDebugging> GetDebuggingData(Worker_EntityId Entity) const;
+
 	void LoadIcons();
 
 	// FDebugDrawDelegate
@@ -288,6 +297,8 @@ private:
 	};
 
 	USpatialNetDriver* NetDriver;
+
+	SpatialGDK::FSubView* SubView;
 
 	// These mappings are maintained independently on each client
 	// Mapping of the entities a client has checked out


### PR DESCRIPTION
#### Description
Adapted ASpatialDebugger to use FSubView over SpatialStaticComponentView, code mostly lifted and adapted from USpatialNetDriverDebugContext.

Regrouped code in the .cpp so FSubView interactions are nearby.

#### Release note
REQUIRED: Add a release note to the `##Unreleased` section of CHANGELOG.md. You can find guidance for writing useful release notes [here](../SpatialGDK/Extras/internal-documentation/how-to-write-good-release-notes.md). Documentation changes are exempt from this requirement.

#### Tests
Walked around in the Gym, no automated tests applicable.

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?
