### PR TITLE
Remove RPC endpoints from static component view

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStaticComponentView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStaticComponentView.cpp
@@ -3,16 +3,13 @@
 #include "Interop/SpatialStaticComponentView.h"
 
 #include "Schema/AuthorityIntent.h"
-#include "Schema/ClientEndpoint.h"
 #include "Schema/Component.h"
 #include "Schema/DebugComponent.h"
 #include "Schema/Heartbeat.h"
 #include "Schema/Interest.h"
-#include "Schema/MulticastRPCs.h"
 #include "Schema/NetOwningClientWorker.h"
 #include "Schema/RPCPayload.h"
 #include "Schema/Restricted.h"
-#include "Schema/ServerEndpoint.h"
 #include "Schema/SpatialDebugging.h"
 #include "Schema/SpawnData.h"
 #include "Schema/StandardLibrary.h"
@@ -83,15 +80,6 @@ void USpatialStaticComponentView::OnAddComponent(const Worker_AddComponentOp& Op
 	case SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID:
 		Data = MakeUnique<SpatialGDK::AuthorityIntent>(Op.data);
 		break;
-	case SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID:
-		Data = MakeUnique<SpatialGDK::ClientEndpoint>(Op.data);
-		break;
-	case SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID:
-		Data = MakeUnique<SpatialGDK::ServerEndpoint>(Op.data);
-		break;
-	case SpatialConstants::MULTICAST_RPCS_COMPONENT_ID:
-		Data = MakeUnique<SpatialGDK::MulticastRPCs>(Op.data);
-		break;
 	case SpatialConstants::SPATIAL_DEBUGGING_COMPONENT_ID:
 		Data = MakeUnique<SpatialGDK::SpatialDebugging>(Op.data);
 		break;
@@ -136,15 +124,6 @@ void USpatialStaticComponentView::OnComponentUpdate(const Worker_ComponentUpdate
 		break;
 	case SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID:
 		Component = GetComponentData<SpatialGDK::AuthorityIntent>(Op.entity_id);
-		break;
-	case SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID:
-		Component = GetComponentData<SpatialGDK::ClientEndpoint>(Op.entity_id);
-		break;
-	case SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID:
-		Component = GetComponentData<SpatialGDK::ServerEndpoint>(Op.entity_id);
-		break;
-	case SpatialConstants::MULTICAST_RPCS_COMPONENT_ID:
-		Component = GetComponentData<SpatialGDK::MulticastRPCs>(Op.entity_id);
 		break;
 	case SpatialConstants::SPATIAL_DEBUGGING_COMPONENT_ID:
 		Component = GetComponentData<SpatialGDK::SpatialDebugging>(Op.entity_id);

--- a/SpatialGDK/Source/SpatialGDK/Private/Schema/ClientEndpoint.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Schema/ClientEndpoint.cpp
@@ -4,21 +4,11 @@
 
 namespace SpatialGDK
 {
-ClientEndpoint::ClientEndpoint(const Worker_ComponentData& Data)
-	: ClientEndpoint(Data.schema_type)
-{
-}
-
 ClientEndpoint::ClientEndpoint(Schema_ComponentData* Data)
 	: ReliableRPCBuffer(ERPCType::ServerReliable)
 	, UnreliableRPCBuffer(ERPCType::ServerUnreliable)
 {
 	ReadFromSchema(Schema_GetComponentDataFields(Data));
-}
-
-void ClientEndpoint::ApplyComponentUpdate(const Worker_ComponentUpdate& Update)
-{
-	ApplyComponentUpdate(Update.schema_type);
 }
 
 void ClientEndpoint::ApplyComponentUpdate(Schema_ComponentUpdate* Update)

--- a/SpatialGDK/Source/SpatialGDK/Private/Schema/MulticastRPCs.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Schema/MulticastRPCs.cpp
@@ -4,20 +4,10 @@
 
 namespace SpatialGDK
 {
-MulticastRPCs::MulticastRPCs(const Worker_ComponentData& Data)
-	: MulticastRPCs(Data.schema_type)
-{
-}
-
 MulticastRPCs::MulticastRPCs(Schema_ComponentData* Data)
 	: MulticastRPCBuffer(ERPCType::NetMulticast)
 {
 	ReadFromSchema(Schema_GetComponentDataFields(Data));
-}
-
-void MulticastRPCs::ApplyComponentUpdate(const Worker_ComponentUpdate& Update)
-{
-	ApplyComponentUpdate(Update.schema_type);
 }
 
 void MulticastRPCs::ApplyComponentUpdate(Schema_ComponentUpdate* Update)

--- a/SpatialGDK/Source/SpatialGDK/Private/Schema/ServerEndpoint.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Schema/ServerEndpoint.cpp
@@ -4,21 +4,11 @@
 
 namespace SpatialGDK
 {
-ServerEndpoint::ServerEndpoint(const Worker_ComponentData& Data)
-	: ServerEndpoint(Data.schema_type)
-{
-}
-
 ServerEndpoint::ServerEndpoint(Schema_ComponentData* Data)
 	: ReliableRPCBuffer(ERPCType::ClientReliable)
 	, UnreliableRPCBuffer(ERPCType::ClientUnreliable)
 {
 	ReadFromSchema(Schema_GetComponentDataFields(Data));
-}
-
-void ServerEndpoint::ApplyComponentUpdate(const Worker_ComponentUpdate& Update)
-{
-	ApplyComponentUpdate(Update.schema_type);
 }
 
 void ServerEndpoint::ApplyComponentUpdate(Schema_ComponentUpdate* Update)

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/ClientEndpoint.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/ClientEndpoint.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "Schema/Component.h"
 #include "SpatialConstants.h"
 #include "Utils/RPCRingBuffer.h"
 
@@ -11,14 +10,10 @@
 
 namespace SpatialGDK
 {
-struct ClientEndpoint : Component
+struct ClientEndpoint
 {
-	static const Worker_ComponentId ComponentId = SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID;
-
-	ClientEndpoint(const Worker_ComponentData& Data);
 	ClientEndpoint(Schema_ComponentData* Data);
 
-	void ApplyComponentUpdate(const Worker_ComponentUpdate& Update) override;
 	void ApplyComponentUpdate(Schema_ComponentUpdate* Update);
 
 	RPCRingBuffer ReliableRPCBuffer;

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/MulticastRPCs.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/MulticastRPCs.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "Schema/Component.h"
 #include "SpatialConstants.h"
 #include "Utils/RPCRingBuffer.h"
 
@@ -11,14 +10,10 @@
 
 namespace SpatialGDK
 {
-struct MulticastRPCs : Component
+struct MulticastRPCs
 {
-	static const Worker_ComponentId ComponentId = SpatialConstants::MULTICAST_RPCS_COMPONENT_ID;
-
-	MulticastRPCs(const Worker_ComponentData& Data);
 	MulticastRPCs(Schema_ComponentData* Data);
 
-	void ApplyComponentUpdate(const Worker_ComponentUpdate& Update) override;
 	void ApplyComponentUpdate(Schema_ComponentUpdate* Update);
 
 	RPCRingBuffer MulticastRPCBuffer;

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/ServerEndpoint.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/ServerEndpoint.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "Schema/Component.h"
 #include "SpatialConstants.h"
 #include "Utils/RPCRingBuffer.h"
 
@@ -11,14 +10,10 @@
 
 namespace SpatialGDK
 {
-struct ServerEndpoint : Component
+struct ServerEndpoint
 {
-	static const Worker_ComponentId ComponentId = SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID;
-
-	ServerEndpoint(const Worker_ComponentData& Data);
 	ServerEndpoint(Schema_ComponentData* Data);
 
-	void ApplyComponentUpdate(const Worker_ComponentUpdate& Update) override;
 	void ApplyComponentUpdate(Schema_ComponentUpdate* Update);
 
 	RPCRingBuffer ReliableRPCBuffer;


### PR DESCRIPTION
#### Description
RPC endpoints are no longer read from the static view, so remove that logic and clean up inheritance from `Component`.

#### Primary reviewers
@jacquese @MatthewSandfordImprobable 