### PR TITLE
Remove MaxRPCRingBufferSize setting and use Default + Overrides instead

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -112,7 +112,6 @@ USpatialGDKSettings::USpatialGDKSettings(const FObjectInitializer& ObjectInitial
 	, CloudWorkerLogLevel(WorkerLogLevel)
 	, bEnableMultiWorker(true)
 	, DefaultRPCRingBufferSize(32)
-	, MaxRPCRingBufferSize(32)
 	// TODO - UNR 2514 - These defaults are not necessarily optimal - readdress when we have better data
 	, bTcpNoDelay(false)
 	, UdpServerDownstreamUpdateIntervalMS(1)
@@ -224,7 +223,7 @@ void USpatialGDKSettings::UpdateServicesRegionFile()
 
 uint32 USpatialGDKSettings::GetRPCRingBufferSize(ERPCType RPCType) const
 {
-	if (const uint32* Size = RPCRingBufferSizeMap.Find(RPCType))
+	if (const uint32* Size = RPCRingBufferSizeOverrides.Find(RPCType))
 	{
 		return *Size;
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCRingBuffer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCRingBuffer.cpp
@@ -73,21 +73,21 @@ RPCRingBufferDescriptor GetRingBufferDescriptor(ERPCType Type)
 		Descriptor.SchemaFieldStart = SchemaStart;
 		break;
 	case ERPCType::ClientUnreliable:
-		{
-			// Client Unreliable buffer starts after Client Reliable. Add 1 to account for the last sent ID field.
-			const uint32 ClientReliableBufferSize = GetRingBufferSize(ERPCType::ClientReliable) + 1;
+	{
+		// Client Unreliable buffer starts after Client Reliable. Add 1 to account for the last sent ID field.
+		const uint32 ClientReliableBufferSize = GetRingBufferSize(ERPCType::ClientReliable) + 1;
 
-			Descriptor.SchemaFieldStart = SchemaStart + ClientReliableBufferSize;
-		}
+		Descriptor.SchemaFieldStart = SchemaStart + ClientReliableBufferSize;
 		break;
+	}
 	case ERPCType::ServerUnreliable:
-		{
-			// Server Unreliable buffer starts after Server Reliable. Add 1 to account for the last sent ID field.
-			const uint32 ServerReliableBufferSize = GetRingBufferSize(ERPCType::ServerReliable) + 1;
+	{
+		// Server Unreliable buffer starts after Server Reliable. Add 1 to account for the last sent ID field.
+		const uint32 ServerReliableBufferSize = GetRingBufferSize(ERPCType::ServerReliable) + 1;
 
-			Descriptor.SchemaFieldStart = SchemaStart + ServerReliableBufferSize;
-		}
+		Descriptor.SchemaFieldStart = SchemaStart + ServerReliableBufferSize;
 		break;
+	}
 	default:
 		checkNoEntry();
 		break;
@@ -142,26 +142,26 @@ Schema_FieldId GetAckFieldId(ERPCType Type)
 	switch (Type)
 	{
 	case ERPCType::ClientReliable:
-		{
-			// Client acks follow Server Reliable and Unreliable buffers.
-			// Add 1 to each to account for the last sent ID fields.
-			const uint32 ServerReliableBufferSize = GetRingBufferSize(ERPCType::ServerReliable) + 1;
-			const uint32 ServerUnreliableBufferSize = GetRingBufferSize(ERPCType::ServerUnreliable) + 1;
+	{
+		// Client acks follow Server Reliable and Unreliable buffers.
+		// Add 1 to each to account for the last sent ID fields.
+		const uint32 ServerReliableBufferSize = GetRingBufferSize(ERPCType::ServerReliable) + 1;
+		const uint32 ServerUnreliableBufferSize = GetRingBufferSize(ERPCType::ServerUnreliable) + 1;
 
-			return SchemaStart + ServerReliableBufferSize + ServerUnreliableBufferSize;
-		}
+		return SchemaStart + ServerReliableBufferSize + ServerUnreliableBufferSize;
+	}
 	case ERPCType::ClientUnreliable:
 		// Client Unreliable ack directly follows Reliable ack.
 		return GetAckFieldId(ERPCType::ClientReliable) + 1;
 	case ERPCType::ServerReliable:
-		{
-			// Server acks follow Client Reliable and Unreliable buffers.
-			// Add 1 to each to account for the last sent ID fields.
-			const uint32 ClientReliableBufferSize = GetRingBufferSize(ERPCType::ClientReliable) + 1;
-			const uint32 ClientUnreliableBufferSize = GetRingBufferSize(ERPCType::ClientUnreliable) + 1;
+	{
+		// Server acks follow Client Reliable and Unreliable buffers.
+		// Add 1 to each to account for the last sent ID fields.
+		const uint32 ClientReliableBufferSize = GetRingBufferSize(ERPCType::ClientReliable) + 1;
+		const uint32 ClientUnreliableBufferSize = GetRingBufferSize(ERPCType::ClientUnreliable) + 1;
 
-			return SchemaStart + ClientReliableBufferSize + ClientUnreliableBufferSize;
-		}
+		return SchemaStart + ClientReliableBufferSize + ClientUnreliableBufferSize;
+	}
 	case ERPCType::ServerUnreliable:
 		// Server Unreliable ack directly follows Reliable ack.
 		return GetAckFieldId(ERPCType::ServerReliable) + 1;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -268,26 +268,23 @@ private:
 	void UpdateServicesRegionFile();
 #endif
 
+public:
+	/**
+	 * The number of RPCs that can be in flight, per type. Changing this will require schema to be regenerated and
+	 * break snapshot compatibility.
+	 */
 	UPROPERTY(EditAnywhere, Config, Category = "Replication", meta = (DisplayName = "Default RPC Ring Buffer Size"))
 	uint32 DefaultRPCRingBufferSize;
 
 	/** Overrides default ring buffer size. */
-	UPROPERTY(EditAnywhere, Config, Category = "Replication", meta = (DisplayName = "RPC Ring Buffer Size Map"))
-	TMap<ERPCType, uint32> RPCRingBufferSizeMap;
+	UPROPERTY(EditAnywhere, Config, Category = "Replication", meta = (DisplayName = "RPC Ring Buffer Size Overrides"))
+	TMap<ERPCType, uint32> RPCRingBufferSizeOverrides;
 
-public:
 	uint32 GetRPCRingBufferSize(ERPCType RPCType) const;
 
 	float GetSecondsBeforeWarning(const ERPCResult Result) const;
 
 	bool ShouldRPCTypeAllowUnresolvedParameters(const ERPCType Type) const;
-
-	/**
-	 * The number of fields that the endpoint schema components are generated with. Changing this will require schema to be regenerated and
-	 * break snapshot compatibility.
-	 */
-	UPROPERTY(EditAnywhere, Config, Category = "Replication", meta = (DisplayName = "Max RPC Ring Buffer Size"))
-	uint32 MaxRPCRingBufferSize;
 
 	/** Only valid on Tcp connections - indicates if we should enable TCP_NODELAY - see c_worker.h */
 	UPROPERTY(Config)

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -270,7 +270,7 @@ private:
 
 public:
 	/**
-	 * The number of RPCs that can be in flight, per type. Changing this will require schema to be regenerated and
+	 * The number of RPCs that can be in flight, per type. Changing this may require schema to be regenerated and
 	 * break snapshot compatibility.
 	 */
 	UPROPERTY(EditAnywhere, Config, Category = "Replication", meta = (DisplayName = "Default RPC Ring Buffer Size"))

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SchemaGenerator.cpp
@@ -327,7 +327,7 @@ void GenerateRPCEndpoint(FCodeWriter& Writer, FString EndpointName, Worker_Compo
 	Schema_FieldId FieldId = 1;
 	for (ERPCType SentRPCType : SentRPCTypes)
 	{
-		uint32 RingBufferSize = GetDefault<USpatialGDKSettings>()->MaxRPCRingBufferSize;
+		uint32 RingBufferSize = GetDefault<USpatialGDKSettings>()->GetRPCRingBufferSize(SentRPCType);
 
 		for (uint32 RingBufferIndex = 0; RingBufferIndex < RingBufferSize; RingBufferIndex++)
 		{

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
@@ -311,6 +311,7 @@ TMap<FString, FString> ExpectedContentsFilenames = {
 	{ "SpatialTypeActorWithMultipleObjectComponents", "SpatialTypeActorWithMultipleObjectComponents.schema" }
 };
 uint32 ExpectedRPCEndpointsRingBufferSize = 32;
+TMap<ERPCType, uint32> ExpectedRPCRingBufferSizeOverrides = {};
 FString ExpectedRPCEndpointsSchemaFilename = TEXT("rpc_endpoints.schema");
 
 class SchemaValidator
@@ -397,24 +398,28 @@ private:
 class SchemaRPCEndpointTestFixture : public SchemaTestFixture
 {
 public:
-	SchemaRPCEndpointTestFixture() { SetMaxRPCRingBufferSize(); }
-	~SchemaRPCEndpointTestFixture() { ResetMaxRPCRingBufferSize(); }
+	SchemaRPCEndpointTestFixture() { SetRPCRingBufferSize(); }
+	~SchemaRPCEndpointTestFixture() { ResetRPCRingBufferSize(); }
 
 private:
-	void SetMaxRPCRingBufferSize()
+	void SetRPCRingBufferSize()
 	{
 		USpatialGDKSettings* SpatialGDKSettings = GetMutableDefault<USpatialGDKSettings>();
-		CachedMaxRPCRingBufferSize = SpatialGDKSettings->MaxRPCRingBufferSize;
-		SpatialGDKSettings->MaxRPCRingBufferSize = ExpectedRPCEndpointsRingBufferSize;
+		CachedDefaultRPCRingBufferSize = SpatialGDKSettings->DefaultRPCRingBufferSize;
+		CachedRPCRingBufferSizeOverrides = SpatialGDKSettings->RPCRingBufferSizeOverrides;
+		SpatialGDKSettings->DefaultRPCRingBufferSize = ExpectedRPCEndpointsRingBufferSize;
+		SpatialGDKSettings->RPCRingBufferSizeOverrides = ExpectedRPCRingBufferSizeOverrides;
 	}
 
-	void ResetMaxRPCRingBufferSize()
+	void ResetRPCRingBufferSize()
 	{
 		USpatialGDKSettings* SpatialGDKSettings = GetMutableDefault<USpatialGDKSettings>();
-		SpatialGDKSettings->MaxRPCRingBufferSize = CachedMaxRPCRingBufferSize;
+		SpatialGDKSettings->DefaultRPCRingBufferSize = CachedDefaultRPCRingBufferSize;
+		SpatialGDKSettings->RPCRingBufferSizeOverrides = CachedRPCRingBufferSizeOverrides;
 	}
 
-	uint32 CachedMaxRPCRingBufferSize;
+	uint32 CachedDefaultRPCRingBufferSize;
+	TMap<ERPCType, uint32> CachedRPCRingBufferSizeOverrides;
 };
 
 } // anonymous namespace


### PR DESCRIPTION
#### Description
Describe your changes here.

#### Release note
REQUIRED: Add a release note to the `##Unreleased` section of CHANGELOG.md. You can find guidance for writing useful release notes [here](../SpatialGDK/Extras/internal-documentation/how-to-write-good-release-notes.md). Documentation changes are exempt from this requirement.

#### Tests
How did you test these changes prior to submitting this pull request?
What automated tests are included in this PR?

STRONGLY SUGGESTED: How can this be verified by QA?

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

#### Reminders (IMPORTANT)
If your change relies on a breaking engine change:
* Increment `SPATIAL_ENGINE_VERSION` in `Engine\Source\Runtime\Launch\Resources\SpatialVersion.h` (in the engine fork) as well as `SPATIAL_GDK_VERSION` in `SpatialGDK\Source\SpatialGDK\Public\Utils\EngineVersionCheck.h`. This helps others by providing a more helpful message during compilation to make sure the GDK and the Engine are up to date.

If your change updates `Setup.bat`, `Setup.sh`, core SDK version, any C# tools in `SpatialGDK\Build\Programs\Improbable.Unreal.Scripts`, or hand-written schema in `SpatialGDK\Extras\schema`:
* Increment the number in `RequireSetup`. This will automatically run `Setup.bat` or `Setup.sh` when the GDK is next pulled.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
