### PR TITLE
UNR-4852 Make the RemotePossession Functional tests workes for together and fix bug bout SetReplicates warning message issue

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
@@ -44,6 +44,8 @@ ASpatialFunctionalTest::ASpatialFunctionalTest()
 	PrimaryActorTick.TickInterval = 0.0f;
 
 	PreparationTimeLimit = 30.0f;
+	bReadyToSpawnServerControllers = false;
+	CachedTestResult = EFunctionalTestResult::Default;
 }
 
 void ASpatialFunctionalTest::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestFlowController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestFlowController.cpp
@@ -27,6 +27,10 @@ ASpatialFunctionalTestFlowController::ASpatialFunctionalTestFlowController(const
 #else
 	SetReplicatingMovement(false);
 #endif
+	OwningTest = nullptr;
+	bHasAckFinishedTest = true;
+	bReadyToRegisterWithTest = false;
+	bIsReadyToRunTest = false;
 }
 
 void ASpatialFunctionalTestFlowController::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
@@ -19,7 +19,7 @@
  * This test expects a 2x2 load balancing grid and ACrossServerPossessionGameMode
  * The client workers begin with a player controller and their default pawns, which they initially possess.
  * The flow is as follows:
- *	Recommend to use PossessionGym.umap in UnrealGDKTestGyms project which ready for tests.
+ *	Recommend to use MultiControllerPossessPawnGym.umap in UnrealGDKTestGyms project which ready for tests.
  *  - Setup:
  *    - Specify `GameMode Override` as ACrossServerPossessionGameMode
  *    - Specify `Multi Worker Settings Class` as Zoning 2x2(e.g. BP_Possession_Settings_Zoning2_2 of UnrealGDKTestGyms)
@@ -75,7 +75,7 @@ void ACrossServerMultiPossessionTest::PrepareTest()
 					ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
 					if (PlayerController && PlayerController->HasAuthority())
 					{
-						AssertTrue(PlayerController->IsMigration(), TEXT("PlayerController should migration"), PlayerController);
+						AssertTrue(PlayerController->HasMigrated(), TEXT("PlayerController should have migrated"), PlayerController);
 					}
 				}
 			}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
@@ -12,9 +12,10 @@
  * This test tests 1 locked Controller remote possess over 1 pawn.
  *
  * This test expects a load balancing grid and ACrossServerPossessionGameMode
- * Recommand to use 2*2 load balancing grid because the position of Pawn was written in the code
+ * Recommend to use 2*2 load balancing grid because the position of Pawn was written in the code
  * The client workers begin with a player controller and their default pawns, which they initially possess.
  * The flow is as follows:
+ *  Recommend to use LockedControllerPossessPawnGym.umap in UnrealGDKTestGyms project which ready for tests.
  *  - Setup:
  *    - Specify `GameMode Override` as ACrossServerPossessionGameMode
  *    - Specify `Multi Worker Settings Class` as Zoning 2x2(e.g. BP_Possession_Settings_Zoning2_2 of UnrealGDKTestGyms)

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
@@ -17,7 +17,7 @@
  * Recommend to use 2*2 load balancing grid because the position is written in the code
  * The client workers begin with a player controller and their default pawns, which they initially possess.
  * The flow is as follows:
- *	Recommend to use PossessionGym.umap in UnrealGDKTestGyms project which ready for tests.
+ *	Recommend to use ControllerPossessPawnGym.umap in UnrealGDKTestGyms project which ready for tests.
  *  - Setup:
  *    - Specify `GameMode Override` as ACrossServerPossessionGameMode
  *    - Specify `Multi Worker Settings Class` as Zoning 2x2(e.g. BP_Possession_Settings_Zoning2_2 of UnrealGDKTestGyms)
@@ -28,7 +28,7 @@
  *	  - Wait for Pawn in right worker.
  *	  -	The Controller possess the Pawn in server-side
  *	- Result Check:
- *    - ATestPossessionPlayerController::OnPossess should be called >= 1 times
+ *    - ATestPossessionPlayerController::OnPossess should be called == 1 times
  */
 
 ACrossServerPossessionTest::ACrossServerPossessionTest()
@@ -53,6 +53,7 @@ void ACrossServerPossessionTest::PrepareTest()
 				{
 					AssertTrue(PlayerController->HasAuthority(), TEXT("PlayerController should HasAuthority"), PlayerController);
 					AssertFalse(Pawn->HasAuthority(), TEXT("Pawn shouldn't HasAuthority"), Pawn);
+					PlayerController->UnPossess();
 					PlayerController->RemotePossessOnServer(Pawn);
 				}
 			}
@@ -63,7 +64,7 @@ void ACrossServerPossessionTest::PrepareTest()
 	AddStep(
 		TEXT("Check test result"), FWorkerDefinition::Server(1),
 		[this]() -> bool {
-			return ATestPossessionPlayerController::OnPossessCalled >= 1;
+			return ATestPossessionPlayerController::OnPossessCalled == 1;
 		},
 		nullptr,
 		[this](float) {
@@ -74,7 +75,7 @@ void ACrossServerPossessionTest::PrepareTest()
 					ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
 					if (PlayerController && PlayerController->HasAuthority())
 					{
-						AssertTrue(PlayerController->IsMigration(), TEXT("PlayerController should migration"), PlayerController);
+						AssertTrue(PlayerController->HasMigrated(), TEXT("PlayerController should have migrated"), PlayerController);
 					}
 				}
 			}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/NoneCrossServerPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/NoneCrossServerPossessionTest.cpp
@@ -13,10 +13,10 @@
  * This test tests 1 Controller possess over 1 Pawn.
  *
  * This test expects a load balancing grid and ACrossServerPossessionGameMode
- * Recommand to use 2*2 load balancing grid because the position is written in the code
+ * Recommend to use 2*2 load balancing grid because the position is written in the code
  * The client workers begin with a player controller and their default pawns, which they initially possess.
  * The flow is as follows:
- *	Recommend to use PossessionGym.umap in UnrealGDKTestGyms project which ready for tests.
+ *	Recommend to use LocalControllerPossessPawnGym.umap in UnrealGDKTestGyms project which ready for tests.
  *  - Setup:
  *    - Specify `GameMode Override` as ACrossServerPossessionGameMode
  *    - Specify `Multi Worker Settings Class` as Zoning 2x2(e.g. BP_Possession_Settings_Zoning2_2 of UnrealGDKTestGyms)
@@ -27,7 +27,7 @@
  *	  - Wait for Pawn in right worker.
  *	  -	The Controller possess the Pawn in server-side
  *	- Result Check:
- *    - ATestPossessionPlayerController::OnPossess should be called >= 1 times
+ *    - ATestPossessionPlayerController::OnPossess should be called == 1 times
  */
 
 ANoneCrossServerPossessionTest::ANoneCrossServerPossessionTest()
@@ -53,6 +53,7 @@ void ANoneCrossServerPossessionTest::PrepareTest()
 				{
 					AssertTrue(PlayerController->HasAuthority(), TEXT("PlayerController should HasAuthority"), PlayerController);
 					AssertTrue(Pawn->HasAuthority(), TEXT("Pawn should HasAuthority"), Pawn);
+					PlayerController->UnPossess();
 					PlayerController->RemotePossessOnServer(Pawn);
 				}
 			}
@@ -63,7 +64,7 @@ void ANoneCrossServerPossessionTest::PrepareTest()
 	AddStep(
 		TEXT("Check test result"), FWorkerDefinition::Server(1),
 		[this]() -> bool {
-			return ATestPossessionPlayerController::OnPossessCalled >= 1;
+			return ATestPossessionPlayerController::OnPossessCalled == 1;
 		},
 		nullptr,
 		[this](float) {
@@ -74,7 +75,7 @@ void ANoneCrossServerPossessionTest::PrepareTest()
 					ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
 					if (PlayerController && PlayerController->HasAuthority())
 					{
-						AssertFalse(PlayerController->IsMigration(), TEXT("PlayerController shouldn't migration"), PlayerController);
+						AssertFalse(PlayerController->HasMigrated(), TEXT("PlayerController shouldn't have migrated"), PlayerController);
 					}
 				}
 			}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
@@ -54,6 +54,7 @@ void ATestPossessionPlayerController::RemotePossessOnClient_Implementation(APawn
 			NetDriver->LockingPolicy->AcquireLock(this, TEXT("TestLock"));
 		}
 	}
+	UnPossess();
 	RemotePossessOnServer(InPawn);
 }
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
@@ -25,7 +25,7 @@ public:
 	UFUNCTION(Server, Reliable)
 	void RemotePossessOnClient(APawn* InPawn, bool bLockBefore);
 
-	bool IsMigration() const { return BeforePossessionWorkerId != AfterPossessionWorkerId; }
+	bool HasMigrated() const { return BeforePossessionWorkerId != AfterPossessionWorkerId; }
 
 	static void ResetCalledCounter();
 


### PR DESCRIPTION
1. Fix the SetReplicates warning message issue of RemotePossession test case.
    this issue coming from the Default Pawn of PlayerController, it was set as replicated, so when remote possess been called, `SetReplicates(true);` was called from APawn::PossessedBy(AController* NewController).
	To avoid this issue is UnPossess the Default Pawn before possess
2. Fix the issue on FunctionalTest, we hit a random issue only happened in server only tests.
	the reason is bHasAckFinishedTest wasn't installed in the constructor. So the client flow didn't start and stop so bHasAckFinishedTest is never changed, but by default, is maybe false, so the check acknowledges failed.
3. Update the introduction of each test.
4. Have some spell changes and name changes.

Successful tests:
![image](https://user-images.githubusercontent.com/30972673/106434494-99a7de00-64ac-11eb-82b7-dc55c5bec639.png)
