### PR TITLE
Fix PS4 Worker Lib file name

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKLoader.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKLoader.h
@@ -41,7 +41,7 @@ public:
 #endif // TRACE_LIB_ACTIVE
 
 #elif PLATFORM_PS4
-		WorkerLibraryHandle = FPlatformProcess::GetDllHandle(TEXT("libworker.prx"));
+		WorkerLibraryHandle = FPlatformProcess::GetDllHandle(TEXT("libimprobable_worker.prx"));
 #endif
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKLoader.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKLoader.h
@@ -42,6 +42,10 @@ public:
 
 #elif PLATFORM_PS4
 		WorkerLibraryHandle = FPlatformProcess::GetDllHandle(TEXT("libimprobable_worker.prx"));
+		if (WorkerLibraryHandle == nullptr)
+		{
+			UE_LOG(LogTemp, Fatal, TEXT("Failed to load libimprobable_worker.prx"));
+		}
 #endif
 	}
 


### PR DESCRIPTION
#### Description
SpatialGDKLoader is trying to load a non-existent .prx worker lib for PS4, eventually causing the console to crash on connection to Spatial.

Fixed by updating libworker.prx to libimprobable_worker.prx

#### Tests
Tested on PS4 by attempting to connect to a Spatial deployment, observed no crash after change.

#### Primary reviewers
@mironec @m-samiec @joshuahuburn 
