### PR TITLE
[UNR-4524] Fix for entity pool int32 overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed incorrect allocation of entity ID from a non-authoritative server sending a cross-server RPC to a replicated level actor that hasn't been received from runtime.
 - Fixed a regression where bReplicates would not be handed over correctly when dynamically set.
 - Fixed an issue where resetting handover property to default value would be omitted during handover value replication
+- Fixed EntityPool capacity overflow issue.
 
 ## [`0.12.0`] - 2021-02-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed incorrect allocation of entity ID from a non-authoritative server sending a cross-server RPC to a replicated level actor that hasn't been received from runtime.
 - Fixed a regression where bReplicates would not be handed over correctly when dynamically set.
 - Fixed an issue where resetting handover property to default value would be omitted during handover value replication
-- Fixed EntityPool capacity overflow issue.
+- Fixed EntityPool capacity overflow issue by removing the ability from the gdk settings to request a pool size larger than int32_max.
 
 ## [`0.12.0`] - 2021-02-01
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityPool.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityPool.cpp
@@ -27,6 +27,9 @@ void UEntityPool::ReserveEntityIDs(uint32 EntitiesToReserve)
 
 	checkf(!bIsAwaitingResponse, TEXT("Trying to reserve Entity IDs while another reserve request is in flight"));
 
+	// TODO: UNR-4979 Allow full range of uint32 when SQD-1150 is fixed
+	EntitiesToReserve = FMath::Clamp(EntitiesToReserve, 0u, static_cast<uint32>(MAX_int32));
+
 	// Set up reserve IDs delegate
 	ReserveEntityIDsDelegate CacheEntityIDsDelegate;
 	CacheEntityIDsDelegate.BindLambda([EntitiesToReserve, this](const Worker_ReserveEntityIdsResponseOp& Op) {

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityPool.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityPool.cpp
@@ -28,7 +28,11 @@ void UEntityPool::ReserveEntityIDs(uint32 EntitiesToReserve)
 	checkf(!bIsAwaitingResponse, TEXT("Trying to reserve Entity IDs while another reserve request is in flight"));
 
 	// TODO: UNR-4979 Allow full range of uint32 when SQD-1150 is fixed
-	EntitiesToReserve = FMath::Clamp(EntitiesToReserve, 0u, static_cast<uint32>(MAX_int32));
+	const uint32 TempMaxEntitiesToReserve = static_cast<uint32>(MAX_int32);
+	if (EntitiesToReserve > TempMaxEntitiesToReserve) {
+		UE_LOG(LogSpatialEntityPool, Log, TEXT("Clamping requested 'EntitiesToReserve' to MAX_int32 (from %u to %d)"), EntitiesToReserve, MAX_int32);
+		EntitiesToReserve = TempMaxEntitiesToReserve;
+	}
 
 	// Set up reserve IDs delegate
 	ReserveEntityIDsDelegate CacheEntityIDsDelegate;

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityPool.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityPool.cpp
@@ -29,8 +29,10 @@ void UEntityPool::ReserveEntityIDs(uint32 EntitiesToReserve)
 
 	// TODO: UNR-4979 Allow full range of uint32 when SQD-1150 is fixed
 	const uint32 TempMaxEntitiesToReserve = static_cast<uint32>(MAX_int32);
-	if (EntitiesToReserve > TempMaxEntitiesToReserve) {
-		UE_LOG(LogSpatialEntityPool, Log, TEXT("Clamping requested 'EntitiesToReserve' to MAX_int32 (from %u to %d)"), EntitiesToReserve, MAX_int32);
+	if (EntitiesToReserve > TempMaxEntitiesToReserve)
+	{
+		UE_LOG(LogSpatialEntityPool, Log, TEXT("Clamping requested 'EntitiesToReserve' to MAX_int32 (from %u to %d)"), EntitiesToReserve,
+			   MAX_int32);
 		EntitiesToReserve = TempMaxEntitiesToReserve;
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityPool.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityPool.cpp
@@ -21,7 +21,7 @@ void UEntityPool::Init(USpatialNetDriver* InNetDriver, FTimerManager* InTimerMan
 	ReserveEntityIDs(GetDefault<USpatialGDKSettings>()->EntityPoolInitialReservationCount);
 }
 
-void UEntityPool::ReserveEntityIDs(int32 EntitiesToReserve)
+void UEntityPool::ReserveEntityIDs(uint32 EntitiesToReserve)
 {
 	UE_LOG(LogSpatialEntityPool, Verbose, TEXT("Sending bulk entity ID Reservation Request for %d IDs"), EntitiesToReserve);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -74,7 +74,8 @@ public:
 	 * reserved is greater than the number of Actors that you expect the server-worker instances to spawn at game deployment
 	 */
 	// TODO: UNR-4979 Allow full range of uint32 when SQD-1150 is fixed
-	UPROPERTY(EditAnywhere, config, Category = "Entity Pool", meta = (DisplayName = "Initial Entity ID Reservation Count", ClampMax = 0x7fffffff))
+	UPROPERTY(EditAnywhere, config, Category = "Entity Pool",
+			  meta = (DisplayName = "Initial Entity ID Reservation Count", ClampMax = 0x7fffffff))
 	uint32 EntityPoolInitialReservationCount;
 
 	/**

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -73,7 +73,8 @@ public:
 	 * The number of entity IDs to be reserved when the entity pool is first created. Ensure that the number of entity IDs
 	 * reserved is greater than the number of Actors that you expect the server-worker instances to spawn at game deployment
 	 */
-	UPROPERTY(EditAnywhere, config, Category = "Entity Pool", meta = (DisplayName = "Initial Entity ID Reservation Count"))
+	// TODO: UNR-4979 Allow full range of uint32 when SQD-1150 is fixed
+	UPROPERTY(EditAnywhere, config, Category = "Entity Pool", meta = (DisplayName = "Initial Entity ID Reservation Count", ClampMax=0x7fffffff))
 	uint32 EntityPoolInitialReservationCount;
 
 	/**

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -74,7 +74,7 @@ public:
 	 * reserved is greater than the number of Actors that you expect the server-worker instances to spawn at game deployment
 	 */
 	// TODO: UNR-4979 Allow full range of uint32 when SQD-1150 is fixed
-	UPROPERTY(EditAnywhere, config, Category = "Entity Pool", meta = (DisplayName = "Initial Entity ID Reservation Count", ClampMax=0x7fffffff))
+	UPROPERTY(EditAnywhere, config, Category = "Entity Pool", meta = (DisplayName = "Initial Entity ID Reservation Count", ClampMax = 0x7fffffff))
 	uint32 EntityPoolInitialReservationCount;
 
 	/**

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/EntityPool.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/EntityPool.h
@@ -34,7 +34,7 @@ class SPATIALGDK_API UEntityPool : public UObject
 
 public:
 	void Init(USpatialNetDriver* InNetDriver, FTimerManager* TimerManager);
-	void ReserveEntityIDs(int32 EntitiesToReserve);
+	void ReserveEntityIDs(uint32 EntitiesToReserve);
 	Worker_EntityId GetNextEntityId();
 	FEntityPoolReadyEvent& GetEntityPoolReadyDelegate();
 


### PR DESCRIPTION
#### Description
Fixed entitypool capacity overflow issue by removing the ability to request a pool size larger than max_int32

#### Tests
I did a manual test with a high value.