### PR TITLE
Fix uninitialized variable warning

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCRingBuffer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCRingBuffer.cpp
@@ -53,7 +53,7 @@ Worker_ComponentId GetRingBufferAuthComponentSetId(ERPCType Type)
 
 RPCRingBufferDescriptor GetRingBufferDescriptor(ERPCType Type)
 {
-	RPCRingBufferDescriptor Descriptor;
+	RPCRingBufferDescriptor Descriptor = {};
 	Descriptor.RingBufferSize = GetRingBufferSize(Type);
 
 	const Schema_FieldId SchemaStart = 1;


### PR DESCRIPTION
#### Description
Fixed a warning due to using a variable that's uninitialized in `default` case.

#### Primary reviewers
@mironec 
