### PR TITLE
Replace usage of deprecated bFasterWithoutUnity with bUseUnity

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/SpatialGDK.Build.cs
+++ b/SpatialGDK/Source/SpatialGDK/SpatialGDK.Build.cs
@@ -15,13 +15,7 @@ public class SpatialGDK : ModuleRules
     {
         bLegacyPublicIncludePaths = false;
         PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
-#pragma warning disable 0618
-        bFasterWithoutUnity = true;             // Deprecated in 4.24, replace with bUseUnity = false; once we drop support for 4.23
-        if (Target.Version.MinorVersion == 24)  // Due to a bug in 4.24, bFasterWithoutUnity is inversed, fixed in master, so should hopefully roll into the next release, remove this once it does
-        {
-            bFasterWithoutUnity = false;
-        }
-#pragma warning restore 0618
+        bUseUnity = false;
 
         PrivateIncludePaths.Add("SpatialGDK/Private");
 

--- a/SpatialGDK/Source/SpatialGDKEditor/SpatialGDKEditor.Build.cs
+++ b/SpatialGDK/Source/SpatialGDKEditor/SpatialGDKEditor.Build.cs
@@ -8,7 +8,7 @@ public class SpatialGDKEditor : ModuleRules
 	{
 		bLegacyPublicIncludePaths = false;
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        bUseUnity = false;
+		bUseUnity = false;
 
 		PrivateDependencyModuleNames.AddRange(
 			new string[] {
@@ -17,18 +17,18 @@ public class SpatialGDKEditor : ModuleRules
 				"DesktopPlatform",
 				"EditorStyle",
 				"Engine",
- 				"EngineSettings",
-                "FunctionalTesting",
-                "IOSRuntimeSettings",
- 				"LauncherServices",
- 				"Json",
+				"EngineSettings",
+				"FunctionalTesting",
+				"IOSRuntimeSettings",
+				"LauncherServices",
+				"Json",
 				"PropertyEditor",
 				"Slate",
 				"SlateCore",
 				"SpatialGDK",
 				"SpatialGDKFunctionalTests",
 				"SpatialGDKServices",
- 				"UATHelper",
+				"UATHelper",
 				"UnrealEd",
 				"DesktopPlatform",
 				"MessageLog",

--- a/SpatialGDK/Source/SpatialGDKEditor/SpatialGDKEditor.Build.cs
+++ b/SpatialGDK/Source/SpatialGDKEditor/SpatialGDKEditor.Build.cs
@@ -8,13 +8,7 @@ public class SpatialGDKEditor : ModuleRules
 	{
 		bLegacyPublicIncludePaths = false;
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-#pragma warning disable 0618
-		bFasterWithoutUnity = true;             // Deprecated in 4.24, replace with bUseUnity = false; once we drop support for 4.23
-		if (Target.Version.MinorVersion == 24)  // Due to a bug in 4.24, bFasterWithoutUnity is inversed, fixed in master, so should hopefully roll into the next release, remove this once it does
-		{
-			bFasterWithoutUnity = false;
-		}
-#pragma warning restore 0618
+        bUseUnity = false;
 
 		PrivateDependencyModuleNames.AddRange(
 			new string[] {

--- a/SpatialGDK/Source/SpatialGDKEditorCommandlet/SpatialGDKEditorCommandlet.Build.cs
+++ b/SpatialGDK/Source/SpatialGDKEditorCommandlet/SpatialGDKEditorCommandlet.Build.cs
@@ -8,9 +8,9 @@ public class SpatialGDKEditorCommandlet : ModuleRules
 	{
 		bLegacyPublicIncludePaths = false;
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        bUseUnity = false;
+		bUseUnity = false;
 
-        PrivateDependencyModuleNames.AddRange(
+		PrivateDependencyModuleNames.AddRange(
 			new string[] {
 				"Core",
 				"CoreUObject",

--- a/SpatialGDK/Source/SpatialGDKEditorCommandlet/SpatialGDKEditorCommandlet.Build.cs
+++ b/SpatialGDK/Source/SpatialGDKEditorCommandlet/SpatialGDKEditorCommandlet.Build.cs
@@ -8,15 +8,9 @@ public class SpatialGDKEditorCommandlet : ModuleRules
 	{
 		bLegacyPublicIncludePaths = false;
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-#pragma warning disable 0618
-		bFasterWithoutUnity = true;             // Deprecated in 4.24, replace with bUseUnity = false; once we drop support for 4.23
-		if (Target.Version.MinorVersion == 24)  // Due to a bug in 4.24, bFasterWithoutUnity is inversed, fixed in master, so should hopefully roll into the next release, remove this once it does
-		{
-			bFasterWithoutUnity = false;
-		}
-#pragma warning restore 0618
+        bUseUnity = false;
 
-		PrivateDependencyModuleNames.AddRange(
+        PrivateDependencyModuleNames.AddRange(
 			new string[] {
 				"Core",
 				"CoreUObject",

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/SpatialGDKEditorToolbar.Build.cs
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/SpatialGDKEditorToolbar.Build.cs
@@ -8,13 +8,7 @@ public class SpatialGDKEditorToolbar : ModuleRules
     {
         bLegacyPublicIncludePaths = false;
         PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
-#pragma warning disable 0618
-        bFasterWithoutUnity = true;             // Deprecated in 4.24, replace with bUseUnity = false; once we drop support for 4.23
-        if (Target.Version.MinorVersion == 24)  // Due to a bug in 4.24, bFasterWithoutUnity is inversed, fixed in master, so should hopefully roll into the next release, remove this once it does
-        {
-            bFasterWithoutUnity = false;
-        }
-#pragma warning restore 0618
+        bUseUnity = false;
 
         PrivateIncludePaths.Add("SpatialGDKEditorToolbar/Private");
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDKFunctionalTests.Build.cs
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDKFunctionalTests.Build.cs
@@ -8,13 +8,7 @@ public class SpatialGDKFunctionalTests : ModuleRules
     {
         bLegacyPublicIncludePaths = false;
         PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-#pragma warning disable 0618
-        bFasterWithoutUnity = true;             // Deprecated in 4.24, replace with bUseUnity = false; once we drop support for 4.23
-        if (Target.Version.MinorVersion == 24)  // Due to a bug in 4.24, bFasterWithoutUnity is inversed, fixed in master, so should hopefully roll into the next release, remove this once it does
-        {
-            bFasterWithoutUnity = false;
-        }
-#pragma warning restore 0618
+        bUseUnity = false;
 
         PrivateDependencyModuleNames.AddRange(
             new string[] {

--- a/SpatialGDK/Source/SpatialGDKServices/SpatialGDKServices.Build.cs
+++ b/SpatialGDK/Source/SpatialGDKServices/SpatialGDKServices.Build.cs
@@ -8,9 +8,9 @@ public class SpatialGDKServices : ModuleRules
 	{
 		bLegacyPublicIncludePaths = false;
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        bUseUnity = false;
+		bUseUnity = false;
 
-        PrivateDependencyModuleNames.AddRange(
+		PrivateDependencyModuleNames.AddRange(
 			new string[] {
 				"EditorStyle",
 				"Engine",

--- a/SpatialGDK/Source/SpatialGDKServices/SpatialGDKServices.Build.cs
+++ b/SpatialGDK/Source/SpatialGDKServices/SpatialGDKServices.Build.cs
@@ -8,15 +8,9 @@ public class SpatialGDKServices : ModuleRules
 	{
 		bLegacyPublicIncludePaths = false;
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-#pragma warning disable 0618
-		bFasterWithoutUnity = true;                 // Deprecated in 4.24, replace with bUseUnity = false; once we drop support for 4.23
-		if (Target.Version.MinorVersion == 24)  // Due to a bug in 4.24, bFasterWithoutUnity is inversed, fixed in master, so should hopefully roll into the next release, remove this once it does
-		{
-			bFasterWithoutUnity = false;
-		}
-#pragma warning restore 0618
+        bUseUnity = false;
 
-		PrivateDependencyModuleNames.AddRange(
+        PrivateDependencyModuleNames.AddRange(
 			new string[] {
 				"EditorStyle",
 				"Engine",

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKTests.Build.cs
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKTests.Build.cs
@@ -8,15 +8,9 @@ public class SpatialGDKTests : ModuleRules
 	{
 		bLegacyPublicIncludePaths = false;
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-#pragma warning disable 0618
-		bFasterWithoutUnity = true;             // Deprecated in 4.24, replace with bUseUnity = false; once we drop support for 4.23
-		if (Target.Version.MinorVersion == 24)  // Due to a bug in 4.24, bFasterWithoutUnity is inversed, fixed in master, so should hopefully roll into the next release, remove this once it does
-		{
-			bFasterWithoutUnity = false;
-		}
-#pragma warning restore 0618
+        bUseUnity = false;
 
-		PrivateDependencyModuleNames.AddRange(
+        PrivateDependencyModuleNames.AddRange(
 			new string[] {
 				"SpatialGDK",
 				"SpatialGDKEditor",

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKTests.Build.cs
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKTests.Build.cs
@@ -8,9 +8,9 @@ public class SpatialGDKTests : ModuleRules
 	{
 		bLegacyPublicIncludePaths = false;
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        bUseUnity = false;
+		bUseUnity = false;
 
-        PrivateDependencyModuleNames.AddRange(
+		PrivateDependencyModuleNames.AddRange(
 			new string[] {
 				"SpatialGDK",
 				"SpatialGDKEditor",


### PR DESCRIPTION
#### Description
`bFasterWithoutUnity` was deprecated a long time ago but we kept it around for 4.23 compatibility. We can replace its usage with `bUseUnity` now.

#### Primary reviewers
@joshuahuburn @mironec 
