### PR TITLE
[UNR-4862] Output load balancing and local worker info on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a message box notification when game is closed due to missing generated schema.
 - Adapted SpatialDebugger to use SubViews.
 - Added a function flag `AlwaysWrite` that allows specifying an RPC to use a separate channel and allow overwriting unacked RPC calls. This is currently limited to Unreliable Server RPCs on classes inheriting from AActor, and only one such RPC can be specified per actor. This feature is disabled by default and can be enabled via `bEnableAlwaysWriteRPCs` setting.
+- Enhanced server logging to include load balancing and local worker info on startup.
 
 ### Bug fixes:
 - Fixed the exception that was thrown when adding and removing components in Spatial component callbacks.

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslator.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslator.cpp
@@ -59,7 +59,7 @@ void SpatialVirtualWorkerTranslator::ApplyVirtualWorkerManagerData(Schema_Object
 	ApplyMappingFromSchema(ComponentObject);
 
 #if !NO_LOGGING
-	if ((VirtualToPhysicalWorkerMapping.Num() > 0) && LoadBalanceStrategy.IsValid() && LoadBalanceStrategy->IsReady())
+	if (LoadBalanceStrategy.IsValid() && LoadBalanceStrategy->IsReady())
 	{
 		UE_LOG(LogSpatialVirtualWorkerTranslator, Log, TEXT("\t-> Strategy: %s"), *LoadBalanceStrategy->ToString());
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslator.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslator.cpp
@@ -58,12 +58,10 @@ void SpatialVirtualWorkerTranslator::ApplyVirtualWorkerManagerData(Schema_Object
 	// The translation schema is a list of mappings, where each entry has a virtual and physical worker ID.
 	ApplyMappingFromSchema(ComponentObject);
 
-	if (VirtualToPhysicalWorkerMapping.Num() > 0)
+#if !NO_LOGGING
+	if ((VirtualToPhysicalWorkerMapping.Num() > 0) && LoadBalanceStrategy.IsValid() && LoadBalanceStrategy->IsReady())
 	{
-		if (LoadBalanceStrategy.IsValid() && LoadBalanceStrategy->IsReady())
-		{
-			UE_LOG(LogSpatialVirtualWorkerTranslator, Log, TEXT("\t-> Strategy: %s"), *LoadBalanceStrategy->ToString());
-		}
+		UE_LOG(LogSpatialVirtualWorkerTranslator, Log, TEXT("\t-> Strategy: %s"), *LoadBalanceStrategy->ToString());
 
 		for (const auto& Entry : VirtualToPhysicalWorkerMapping)
 		{
@@ -71,6 +69,7 @@ void SpatialVirtualWorkerTranslator::ApplyVirtualWorkerManagerData(Schema_Object
 				   Entry.Key, *(Entry.Value.WorkerName), Entry.Value.ServerWorkerEntityId);
 		}
 	}
+#endif //!NO_LOGGING
 }
 
 // The translation schema is a list of Mappings, where each entry has a virtual and physical worker ID.

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslator.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslator.cpp
@@ -58,7 +58,7 @@ void SpatialVirtualWorkerTranslator::ApplyVirtualWorkerManagerData(Schema_Object
 	// The translation schema is a list of mappings, where each entry has a virtual and physical worker ID.
 	ApplyMappingFromSchema(ComponentObject);
 
-	if (VirtualToPhysicalWorkerMapping.Num())
+	if (VirtualToPhysicalWorkerMapping.Num() > 0)
 	{
 		if (LoadBalanceStrategy.IsValid() && LoadBalanceStrategy->IsReady())
 		{

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslator.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslator.cpp
@@ -53,16 +53,23 @@ Worker_EntityId SpatialVirtualWorkerTranslator::GetServerWorkerEntityForVirtualW
 
 void SpatialVirtualWorkerTranslator::ApplyVirtualWorkerManagerData(Schema_Object* ComponentObject)
 {
-	UE_LOG(LogSpatialVirtualWorkerTranslator, Log, TEXT("(%s) ApplyVirtualWorkerManagerData"), *LocalPhysicalWorkerName);
+	UE_LOG(LogSpatialVirtualWorkerTranslator, Log, TEXT("ApplyVirtualWorkerManagerData for (%s):"), *LocalPhysicalWorkerName);
 
 	// The translation schema is a list of mappings, where each entry has a virtual and physical worker ID.
 	ApplyMappingFromSchema(ComponentObject);
 
-	for (const auto& Entry : VirtualToPhysicalWorkerMapping)
+	if (VirtualToPhysicalWorkerMapping.Num())
 	{
-		UE_LOG(LogSpatialVirtualWorkerTranslator, Verbose,
-			   TEXT("Translator assignment: Virtual Worker %d to %s with server worker entity: %lld"), Entry.Key, *(Entry.Value.WorkerName),
-			   Entry.Value.ServerWorkerEntityId);
+		if (LoadBalanceStrategy.IsValid() && LoadBalanceStrategy->IsReady())
+		{
+			UE_LOG(LogSpatialVirtualWorkerTranslator, Log, TEXT("\t-> Strategy: %s"), *LoadBalanceStrategy->ToString());
+		}
+
+		for (const auto& Entry : VirtualToPhysicalWorkerMapping)
+		{
+			UE_LOG(LogSpatialVirtualWorkerTranslator, Log, TEXT("\t-> Assignment: Virtual Worker %d to %s with server worker entity: %lld"),
+				   Entry.Key, *(Entry.Value.WorkerName), Entry.Value.ServerWorkerEntityId);
+		}
 	}
 }
 
@@ -87,10 +94,6 @@ void SpatialVirtualWorkerTranslator::ApplyMappingFromSchema(Schema_Object* Objec
 		const Worker_EntityId ServerWorkerEntityId = Schema_GetEntityId(MappingObject, SpatialConstants::MAPPING_SERVER_WORKER_ENTITY_ID);
 		const Worker_PartitionId PartitionEntityId = Schema_GetEntityId(MappingObject, SpatialConstants::MAPPING_PARTITION_ID);
 
-		UE_LOG(LogSpatialVirtualWorkerTranslator, Log,
-			   TEXT("Translator assignment: Virtual Worker %d to %s with server worker entity: %lld"), VirtualWorkerId, *WorkerName,
-			   ServerWorkerEntityId);
-
 		// Insert each into the provided map.
 		UpdateMapping(VirtualWorkerId, WorkerName, PartitionEntityId, ServerWorkerEntityId);
 	}
@@ -114,6 +117,6 @@ void SpatialVirtualWorkerTranslator::UpdateMapping(VirtualWorkerId Id, PhysicalW
 			LoadBalanceStrategy->SetLocalVirtualWorkerId(LocalVirtualWorkerId);
 		}
 
-		UE_LOG(LogSpatialVirtualWorkerTranslator, Log, TEXT("VirtualWorkerTranslator is now ready for loadbalancing."));
+		UE_LOG(LogSpatialVirtualWorkerTranslator, Log, TEXT("\t-> VirtualWorkerTranslator is now ready for loadbalancing."));
 	}
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslator.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslator.cpp
@@ -53,7 +53,7 @@ Worker_EntityId SpatialVirtualWorkerTranslator::GetServerWorkerEntityForVirtualW
 
 void SpatialVirtualWorkerTranslator::ApplyVirtualWorkerManagerData(Schema_Object* ComponentObject)
 {
-	UE_LOG(LogSpatialVirtualWorkerTranslator, Log, TEXT("ApplyVirtualWorkerManagerData for (%s):"), *LocalPhysicalWorkerName);
+	UE_LOG(LogSpatialVirtualWorkerTranslator, Log, TEXT("ApplyVirtualWorkerManagerData for %s:"), *LocalPhysicalWorkerName);
 
 	// The translation schema is a list of mappings, where each entry has a virtual and physical worker ID.
 	ApplyMappingFromSchema(ComponentObject);

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/DebugLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/DebugLBStrategy.cpp
@@ -16,6 +16,11 @@ void UDebugLBStrategy::InitDebugStrategy(USpatialNetDriverDebugContext* InDebugC
 	LocalVirtualWorkerId = InWrappedStrategy->GetLocalVirtualWorkerId();
 }
 
+FString UDebugLBStrategy::ToString() const
+{
+	return TEXT("Debug");
+}
+
 void UDebugLBStrategy::SetLocalVirtualWorkerId(VirtualWorkerId InLocalVirtualWorkerId)
 {
 	check(WrappedStrategy);

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
@@ -62,6 +62,11 @@ void UGridBasedLBStrategy::Init()
 	}
 }
 
+FString UGridBasedLBStrategy::ToString() const
+{
+	return TEXT("Grid");
+}
+
 void UGridBasedLBStrategy::SetLocalVirtualWorkerId(VirtualWorkerId InLocalVirtualWorkerId)
 {
 	if (!VirtualWorkerIds.Contains(InLocalVirtualWorkerId))

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
@@ -31,8 +31,10 @@ FString ULayeredLBStrategy::ToString() const
 		Description += TEXT(", LayerNamesPerVirtualWorkerId = {");
 		for (const auto& Entry : VirtualWorkerIdToLayerName)
 		{
-			Description += FString::Printf(TEXT("(%d/%s)"), Entry.Key, *Entry.Value.ToString());
+			Description += FString::Printf(TEXT("%d = %s, "), Entry.Key, *Entry.Value.ToString());
 		}
+		check(Description.Len() > 1);
+		Description.LeftChopInline(2);
 		Description += TEXT("}");
 	}
 	return Description;

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
@@ -17,6 +17,27 @@ ULayeredLBStrategy::ULayeredLBStrategy()
 {
 }
 
+FString ULayeredLBStrategy::ToString() const
+{
+	const FName LocalLayerName = GetLocalLayerName();
+	const UAbstractLBStrategy* const* LBStrategy = LayerNameToLBStrategy.Find(LocalLayerName);
+
+	FString Description =
+		FString::Printf(TEXT("Layered, LocalLayerName = %s, LocalVirtualWorkerId = %d, LayerStrategy = %s"), *LocalLayerName.ToString(),
+						LocalVirtualWorkerId, *LBStrategy ? *(*LBStrategy)->ToString() : TEXT("NoStrategy"));
+
+	if (VirtualWorkerIdToLayerName.Num() > 0)
+	{
+		Description += TEXT(", LayerNamesPerVirtualWorkerId = {");
+		for (const auto& Entry : VirtualWorkerIdToLayerName)
+		{
+			Description += FString::Printf(TEXT("(%d/%s)"), Entry.Key, *Entry.Value.ToString());
+		}
+		Description += TEXT("}");
+	}
+	return Description;
+}
+
 void ULayeredLBStrategy::SetLayers(const TArray<FLayerInfo>& WorkerLayers)
 {
 	check(WorkerLayers.Num() != 0);

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLBStrategy.h
@@ -38,6 +38,8 @@ public:
 	VirtualWorkerId GetLocalVirtualWorkerId() const { return LocalVirtualWorkerId; };
 	virtual void SetLocalVirtualWorkerId(VirtualWorkerId LocalVirtualWorkerId);
 
+	virtual FString ToString() const PURE_VIRTUAL(UAbstractLBStrategy::ToString, return TEXT("Abstract"););
+
 	// Deprecated: will be removed ASAP.
 	virtual TSet<VirtualWorkerId> GetVirtualWorkerIds() const PURE_VIRTUAL(UAbstractLBStrategy::GetVirtualWorkerIds, return {};);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/DebugLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/DebugLBStrategy.h
@@ -34,6 +34,8 @@ public:
 	/* UAbstractLBStrategy Interface */
 	virtual void Init() override{};
 
+	virtual FString ToString() const;
+
 	virtual void SetLocalVirtualWorkerId(VirtualWorkerId InLocalVirtualWorkerId) override;
 
 	virtual TSet<VirtualWorkerId> GetVirtualWorkerIds() const override;

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/GridBasedLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/GridBasedLBStrategy.h
@@ -39,6 +39,8 @@ public:
 	/* UAbstractLBStrategy Interface */
 	virtual void Init() override;
 
+	virtual FString ToString() const;
+
 	virtual void SetLocalVirtualWorkerId(VirtualWorkerId InLocalVirtualWorkerId) override;
 	virtual TSet<VirtualWorkerId> GetVirtualWorkerIds() const override;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LayeredLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LayeredLBStrategy.h
@@ -37,6 +37,8 @@ public:
 	/* UAbstractLBStrategy Interface */
 	virtual void Init() override{};
 
+	virtual FString ToString() const;
+
 	virtual void SetLocalVirtualWorkerId(VirtualWorkerId InLocalVirtualWorkerId) override;
 
 	virtual TSet<VirtualWorkerId> GetVirtualWorkerIds() const override;

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/AbstractLBStrategy/LBStrategyStub.h
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/LoadBalancing/AbstractLBStrategy/LBStrategyStub.h
@@ -17,4 +17,5 @@ class SPATIALGDKTESTS_API ULBStrategyStub : public UAbstractLBStrategy
 
 public:
 	VirtualWorkerId GetVirtualWorkerId() const { return LocalVirtualWorkerId; }
+	virtual FString ToString() const { return TEXT("StrategyStub"); }
 };


### PR DESCRIPTION
#### Description
Enhanced server logging to include load balancing and local worker info on startup.

#### Tests
Manual test of the "Offloading Gym" logged the following output in Unreal (only a sample included for brevity):
```
LogSpatialVirtualWorkerTranslator: ApplyVirtualWorkerManagerData for UnrealWorkerA643129A432C162875AF45B9D05DBD29:
LogSpatialVirtualWorkerTranslator:     -> VirtualWorkerTranslator is now ready for loadbalancing.
LogSpatialVirtualWorkerTranslator:     -> Strategy: Layered, LocalLayerName = DefaultLayer, LocalVirtualWorkerId = 1, LayerStrategy = Grid, LayerNamesPerVirtualWorkerId = {1 = DefaultLayer, 2 = DefaultLayer, 3 = DefaultLayer, 4 = DefaultLayer, 5 = Offloading}
LogSpatialVirtualWorkerTranslator:     -> Assignment: Virtual Worker 1 to UnrealWorkerA643129A432C162875AF45B9D05DBD29 with server worker entity: 3005
LogSpatialVirtualWorkerTranslator:     -> Assignment: Virtual Worker 2 to UnrealWorker62080F8248E547CA50A992AA521F6790 with server worker entity: 12005
LogSpatialVirtualWorkerTranslator:     -> Assignment: Virtual Worker 3 to UnrealWorker8A3827DD41A9A95A8EB88D8A4E013CF6 with server worker entity: 5
LogSpatialVirtualWorkerTranslator:     -> Assignment: Virtual Worker 4 to UnrealWorker9DAF546B4FB9E3172B5F0FAB4F501EB4 with server worker entity: 6005
LogSpatialVirtualWorkerTranslator:     -> Assignment: Virtual Worker 5 to UnrealWorker33A1D12A4BAE0723B4A883969DDE35A2 with server worker entity: 9005
```
