### PR TITLE
Add missing break in MulticastRPCService

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/MulticastRPCService.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/MulticastRPCService.cpp
@@ -59,6 +59,7 @@ void MulticastRPCService::AdvanceView()
 				// Regain authority.
 				AuthorityGained(Delta.EntityId, Change.ComponentSetId);
 			}
+			break;
 		}
 		case EntityDelta::ADD:
 			PopulateDataStore(Delta.EntityId);


### PR DESCRIPTION
#### Description
Add missing break that meant we were calling `PopulateDataStore` every time an update came through. This doesn't seem to have affected correctness, although we probably did a bunch of extra copies.

#### Primary reviewers
@jacquese