### PR TITLE
[UNR-5028] Send RPCs immediately again

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -733,10 +733,10 @@ bool USpatialSender::SendRingBufferedRPC(UObject* TargetObject, const SpatialGDK
 	const EPushRPCResult Result =
 		RPCService->PushRPC(TargetObjectRef.Entity, Sender, RPCInfo.Type, Payload, Channel->bCreatedEntity, TargetObject, Function);
 
-	// if (Result == EPushRPCResult::Success)
-	//{
-	//	FlushRPCService();
-	//}
+	if (Result == EPushRPCResult::Success)
+	{
+		FlushRPCService();
+	}
 
 #if !UE_BUILD_SHIPPING
 	if (Result == EPushRPCResult::Success || Result == EPushRPCResult::QueueOverflowed)


### PR DESCRIPTION
#### Description
Revert a change made in the RoutingWorker PR. Batching RPC updates together results in better throughput and potentially better data consistency, but also increased latency.
The data consistency benefits won't be there until the ComponentSet updates land in the runtime, and the latency NFR regressed. So we are reverting that change for now.