### PR TITLE
UNR-4873 Fix issue of playercontroller removed before authority loss after migration

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
@@ -43,8 +43,8 @@ void USpatialNetConnection::CleanUp()
 	if (PlayerControllerEntity != SpatialConstants::INVALID_ENTITY_ID)
 	{
 		UE_LOG(LogSpatialNetConnection, Warning,
-			   TEXT("Disable is not called before CleanUp: NetConnection %s, PlayerController entity %lld"),
-			   *GetName(), PlayerControllerEntity);
+			   TEXT("Disable is not called before CleanUp: NetConnection %s, PlayerController entity %lld"), *GetName(),
+			   PlayerControllerEntity);
 	}
 	if (USpatialNetDriver* SpatialNetDriver = Cast<USpatialNetDriver>(Driver))
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
@@ -40,6 +40,12 @@ void USpatialNetConnection::BeginDestroy()
 
 void USpatialNetConnection::CleanUp()
 {
+	if (PlayerControllerEntity != SpatialConstants::INVALID_ENTITY_ID)
+	{
+		UE_LOG(LogSpatialNetConnection, Warning,
+			   TEXT("Disable is not called before CleanUp: NetConnection %s, PlayerController entity %lld"),
+			   *GetName(), PlayerControllerEntity);
+	}
 	if (USpatialNetDriver* SpatialNetDriver = Cast<USpatialNetDriver>(Driver))
 	{
 		SpatialNetDriver->ClientConnectionManager->CleanUpClientConnection(this);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
@@ -108,7 +108,7 @@ void ActorSystem::Advance()
 			{
 				continue;
 			}
-			UE_LOG(LogSpatialReceiver, Verbose, TEXT("The received actor with entity ID %lld was tombstoned. The actor will be deleted."),
+			UE_LOG(LogActorSystem, Verbose, TEXT("The received actor with entity ID %lld was tombstoned. The actor will be deleted."),
 				   Delta.EntityId);
 			// We must first Resolve the EntityId to the Actor in order for RemoveActor to succeed.
 			NetDriver->PackageMap->ResolveEntityActor(EntityActor, Delta.EntityId);
@@ -891,7 +891,7 @@ void ActorSystem::ResolveIncomingOperations(UObject* Object, const FUnrealObject
 		{
 			if (AsActor->GetTearOff())
 			{
-				UE_LOG(LogSpatialActorChannel, Log,
+				UE_LOG(LogActorSystem, Log,
 					   TEXT("Actor to be resolved was torn off, so ignoring incoming operations. Object ref: %s, resolved object: %s"),
 					   *ObjectRef.ToString(), *Object->GetName());
 				DependentChannel->ObjectReferenceMap.Remove(ChannelObjectIter->Value);
@@ -902,7 +902,7 @@ void ActorSystem::ResolveIncomingOperations(UObject* Object, const FUnrealObject
 		{
 			if (OuterActor->GetTearOff())
 			{
-				UE_LOG(LogSpatialActorChannel, Log,
+				UE_LOG(LogActorSystem, Log,
 					   TEXT("Owning Actor of the object to be resolved was torn off, so ignoring incoming operations. Object ref: %s, "
 							"resolved object: %s"),
 					   *ObjectRef.ToString(), *Object->GetName());
@@ -1598,6 +1598,10 @@ void ActorSystem::RemoveActor(const Worker_EntityId EntityId)
 	if (APlayerController* PC = Cast<APlayerController>(Actor))
 	{
 		// Force APlayerController::DestroyNetworkActorHandled to return false
+		if (USpatialNetConnection* Connection = Cast<USpatialNetConnection>(PC->GetNetConnection()))
+		{
+			Connection->Disable();
+		}
 		PC->Player = nullptr;
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
@@ -1532,6 +1532,11 @@ void ActorSystem::RemoveActor(const Worker_EntityId EntityId)
 		return;
 	}
 
+	if (Actor->HasAuthority())
+	{
+		Actor->OnAuthorityLost();
+	}
+
 	if (USpatialActorChannel* ActorChannel = NetDriver->GetActorChannelByEntityId(EntityId))
 	{
 		if (NetDriver->GetWorld() != nullptr && !NetDriver->GetWorld()->IsPendingKillOrUnreachable())

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetConnection.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetConnection.h
@@ -64,9 +64,6 @@ public:
 	// the PlayerController as a partition entity for the client worker.
 	Worker_EntityId ConnectionClientWorkerSystemEntityId;
 
-	class FTimerManager* TimerManager;
-
 	// Player lifecycle
 	Worker_EntityId PlayerControllerEntity;
-	FTimerHandle HeartbeatTimer;
 };


### PR DESCRIPTION
We have a potential risk in this case:
![image](https://user-images.githubusercontent.com/30972673/108586889-0b789680-738c-11eb-99b4-635202f3c9aa.png)

The worker lost the playercontroller receive 	
```
Line 3: [2021.02.18-09.27.39:704][154]LogTemp: GetOpListFromConnection WORKER_OP_TYPE_COMPONENT_SET_AUTHORITY_CHANGE Ops[2] 16 3006, 0
Line 5: [2021.02.18-09.27.39:704][154]LogTemp: GetOpListFromConnection REMOVE_ENTITY Ops[45] 6 3006
```
in the same tick. Authority lost first and Remove entity next.

But in ActorSystem, it called Remove entity first and handle authority next.

What this PR do?
1. Call OnAuthorityLost before the actor removed in ActorSystem
2. Call SpatialNetConnection::Disable before the PlayerController removed in ActorSystem
3. Log category mistake in ActorSystem.

Move information in:https://docs.google.com/document/d/1hw7Ji9GKt8pt1tdqLYUiIXKlCEKxQ8EE8e5TuJL2FTE/edit

ticket:https://improbableio.atlassian.net/browse/UNR-4873

Successful build:https://buildkite.com/improbable/unrealgdk-nfr/builds/3681

