### PR TITLE
[UNR-5035] Add base infrastructure for modularised RPC service

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/RPCService.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/RPCService.cpp
@@ -1,0 +1,282 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "Interop/RPCs/RPCService.h"
+
+namespace SpatialGDK
+{
+RPCService::RPCService(const FSubView& InRemoteSubView, const FSubView& InLocalAuthSubView)
+	: RemoteSubView(&InRemoteSubView)
+	, LocalAuthSubView(&InLocalAuthSubView)
+{
+}
+
+void RPCService::AddRPCQueue(FName QueueName, RPCQueueDescription&& Desc)
+{
+	Queues.Add(QueueName, MoveTemp(Desc));
+}
+
+void RPCService::AddRPCReceiver(FName ReceiverName, RPCReceiverDescription&& Desc)
+{
+	Receivers.Add(ReceiverName, MoveTemp(Desc));
+}
+
+void RPCService::AdvanceView()
+{
+	auto HasReceiverAuthority = [](const RPCReceiverDescription& Desc, const EntityViewElement& ViewElement) {
+		return Desc.Authority == 0 || ViewElement.Authority.Contains(Desc.Authority);
+	};
+
+	for (const EntityDelta& Delta : RemoteSubView->GetViewDelta().EntityDeltas)
+	{
+		switch (Delta.Type)
+		{
+		case EntityDelta::UPDATE:
+		{
+			const EntityViewElement& ViewElement = RemoteSubView->GetView().FindChecked(Delta.EntityId);
+			for (const ComponentChange& Change : Delta.ComponentUpdates)
+			{
+				RPCReadingContext Ctx;
+				Ctx.EntityId = Delta.EntityId;
+				Ctx.ComponentId = Change.ComponentId;
+				Ctx.Update = Change.Update;
+				Ctx.Fields = Schema_GetComponentUpdateFields(Change.Update);
+
+				for (auto& Entry : Receivers)
+				{
+					if (HasReceiverAuthority(Entry.Value, ViewElement))
+					{
+						Entry.Value.Receiver->OnUpdate(Ctx);
+					}
+				}
+			}
+			for (const ComponentChange& Change : Delta.ComponentsRefreshed)
+			{
+				RPCReadingContext Ctx;
+				Ctx.EntityId = Delta.EntityId;
+				Ctx.ComponentId = Change.ComponentId;
+				Ctx.Fields = Schema_GetComponentDataFields(Change.CompleteUpdate.Data);
+
+				for (auto& Entry : Receivers)
+				{
+					if (HasReceiverAuthority(Entry.Value, ViewElement))
+					{
+						Entry.Value.Receiver->OnUpdate(Ctx);
+					}
+				}
+			}
+
+			for (const AuthorityChange& Change : Delta.AuthorityLost)
+			{
+				for (auto& Entry : Receivers)
+				{
+					if (!HasReceiverAuthority(Entry.Value, ViewElement))
+					{
+						Entry.Value.Receiver->OnRemoved(Delta.EntityId);
+					}
+				}
+			}
+			for (const AuthorityChange& Change : Delta.AuthorityLostTemporarily)
+			{
+				for (auto& Entry : Receivers)
+				{
+					if (!HasReceiverAuthority(Entry.Value, ViewElement))
+					{
+						Entry.Value.Receiver->OnRemoved(Delta.EntityId);
+					}
+				}
+			}
+			for (const AuthorityChange& Change : Delta.AuthorityGained)
+			{
+				for (auto& Entry : Receivers)
+				{
+					if (HasReceiverAuthority(Entry.Value, ViewElement))
+					{
+						Entry.Value.Receiver->OnAdded(Delta.EntityId, ViewElement);
+					}
+				}
+			}
+			for (const AuthorityChange& Change : Delta.AuthorityLostTemporarily)
+			{
+				for (auto& Entry : Receivers)
+				{
+					if (HasReceiverAuthority(Entry.Value, ViewElement))
+					{
+						Entry.Value.Receiver->OnAdded(Delta.EntityId, ViewElement);
+					}
+				}
+			}
+
+			break;
+		}
+		case EntityDelta::ADD:
+		{
+			const EntityViewElement& ViewElement = RemoteSubView->GetView().FindChecked(Delta.EntityId);
+			for (auto& Entry : Receivers)
+			{
+				if (HasReceiverAuthority(Entry.Value, ViewElement))
+				{
+					Entry.Value.Receiver->OnAdded(Delta.EntityId, ViewElement);
+				}
+			}
+		}
+		break;
+		case EntityDelta::REMOVE:
+			for (auto& Entry : Receivers)
+			{
+				Entry.Value.Receiver->OnRemoved(Delta.EntityId);
+			}
+			break;
+		case EntityDelta::TEMPORARILY_REMOVED:
+		{
+			const EntityViewElement& ViewElement = RemoteSubView->GetView().FindChecked(Delta.EntityId);
+			for (auto& Entry : Receivers)
+			{
+				Entry.Value.Receiver->OnRemoved(Delta.EntityId);
+				if (HasReceiverAuthority(Entry.Value, ViewElement))
+				{
+					Entry.Value.Receiver->OnAdded(Delta.EntityId, ViewElement);
+				}
+			}
+		}
+		}
+	}
+
+	for (const EntityDelta& Delta : LocalAuthSubView->GetViewDelta().EntityDeltas)
+	{
+		switch (Delta.Type)
+		{
+		case EntityDelta::UPDATE:
+		{
+			for (const ComponentChange& Change : Delta.ComponentUpdates)
+			{
+				RPCReadingContext Ctx;
+				Ctx.EntityId = Delta.EntityId;
+				Ctx.ComponentId = Change.ComponentId;
+				Ctx.Update = Change.Update;
+				Ctx.Fields = Schema_GetComponentUpdateFields(Change.Update);
+
+				for (auto& QueueEntry : Queues)
+				{
+					QueueEntry.Value.Sender->OnUpdate(Ctx);
+				}
+			}
+			for (const ComponentChange& Change : Delta.ComponentsRefreshed)
+			{
+				RPCReadingContext Ctx;
+				Ctx.EntityId = Delta.EntityId;
+				Ctx.ComponentId = Change.ComponentId;
+				Ctx.Fields = Schema_GetComponentDataFields(Change.CompleteUpdate.Data);
+
+				for (auto& QueueEntry : Queues)
+				{
+					QueueEntry.Value.Sender->OnUpdate(Ctx);
+				}
+			}
+			break;
+		}
+		case EntityDelta::ADD:
+		{
+			const EntityViewElement& ViewElement = LocalAuthSubView->GetView().FindChecked(Delta.EntityId);
+			for (auto& QueueEntry : Queues)
+			{
+				if (ViewElement.Authority.Contains(QueueEntry.Value.Authority))
+				{
+					QueueEntry.Value.Queue->OnAuthGained(Delta.EntityId, ViewElement);
+					QueueEntry.Value.Sender->OnAuthGained(Delta.EntityId, ViewElement);
+				}
+			}
+		}
+		break;
+		case EntityDelta::REMOVE:
+			for (auto& QueueEntry : Queues)
+			{
+				QueueEntry.Value.Queue->OnAuthLost(Delta.EntityId);
+				QueueEntry.Value.Sender->OnAuthLost(Delta.EntityId);
+			}
+			break;
+		case EntityDelta::TEMPORARILY_REMOVED:
+		{
+			const EntityViewElement& ViewElement = LocalAuthSubView->GetView().FindChecked(Delta.EntityId);
+			for (auto& QueueEntry : Queues)
+			{
+				QueueEntry.Value.Queue->OnAuthLost(Delta.EntityId);
+				QueueEntry.Value.Sender->OnAuthLost(Delta.EntityId);
+				if (ViewElement.Authority.Contains(QueueEntry.Value.Authority))
+				{
+					QueueEntry.Value.Queue->OnAuthGained(Delta.EntityId, ViewElement);
+					QueueEntry.Value.Sender->OnAuthGained(Delta.EntityId, ViewElement);
+				}
+			}
+		}
+		break;
+		default:
+			break;
+		}
+	}
+}
+
+TArray<RPCService::UpdateToSend> RPCService::GetRPCsAndAcksToSend()
+{
+	TArray<UpdateToSend> Updates;
+
+	RPCWritingContext Ctx(RPCWritingContext::DataKind::Update);
+	Ctx.UpdateWrittenCallback = [&Updates](Worker_EntityId EntityId, Worker_ComponentId ComponentId, Schema_ComponentUpdate* InUpdate) {
+		if (ensure(InUpdate != nullptr))
+		{
+			UpdateToSend Update;
+			Update.EntityId = EntityId;
+			Update.Update.component_id = ComponentId;
+			Update.Update.schema_type = InUpdate;
+			Updates.Add(Update);
+		}
+	};
+
+	Ctx.RPCWrittenCallback = [](Worker_EntityId Entity, Worker_ComponentId ComponentId, uint32 RPCId) {
+		// if (EventTracer != nullptr)
+		//{
+		//	EventTraceUniqueId LinearTraceId = EventTraceUniqueId::GenerateForRPC(EntityId, static_cast<uint8>(Type), NewRPCId);
+		//	FSpatialGDKSpanId SpanId = EventTracer->TraceEvent(FSpatialTraceEventBuilder::CreateSendRPC(LinearTraceId),
+		//		/* Causes */ Payload.SpanId.GetConstId(), /* NumCauses */ 1);
+		//	RPCStore.AddSpanIdForComponentUpdate(EntityComponent, SpanId);
+		//}
+	};
+
+	for (auto& QueueEntry : Queues)
+	{
+		RPCQueueDescription& Queue = QueueEntry.Value;
+		Queue.Queue->FlushAll(Ctx);
+	}
+
+	for (auto& Entry : Receivers)
+	{
+		RPCReceiverDescription& Receiver = Entry.Value;
+		Receiver.Receiver->FlushUpdates(Ctx);
+	}
+
+	return Updates;
+}
+
+TArray<FWorkerComponentData> RPCService::GetRPCComponentsOnEntityCreation(Worker_EntityId EntityId)
+{
+	TArray<FWorkerComponentData> CreationData;
+
+	RPCWritingContext Ctx(RPCWritingContext::DataKind::Data);
+	Ctx.DataWrittenCallback = [&CreationData](Worker_EntityId EntityId, Worker_ComponentId ComponentId, Schema_ComponentData* InData) {
+		if (ensure(InData != nullptr))
+		{
+			FWorkerComponentData Data;
+			Data.component_id = ComponentId;
+			Data.schema_type = InData;
+			CreationData.Add(Data);
+		}
+	};
+
+	for (auto& QueueEntry : Queues)
+	{
+		RPCQueueDescription& Queue = QueueEntry.Value;
+		Queue.Queue->Flush(EntityId, Ctx);
+	}
+	return CreationData;
+}
+
+} // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/RPCTypes.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/RPCTypes.cpp
@@ -8,8 +8,12 @@ RPCWritingContext::EntityWrite::EntityWrite(EntityWrite&& Write)
 	: EntityId(Write.EntityId)
 	, ComponentId(Write.ComponentId)
 	, Ctx(Write.Ctx)
+	, Fields(Write.Fields)
 {
+	Data = Write.Data;
 	Write.bActiveWriter = false;
+	Write.Fields = nullptr;
+	Write.Data = nullptr;
 }
 
 RPCWritingContext::EntityWrite::~EntityWrite()
@@ -57,7 +61,7 @@ Schema_ComponentUpdate* RPCWritingContext::EntityWrite::GetComponentUpdateToWrit
 
 Schema_Object* RPCWritingContext::EntityWrite::GetFieldsToWrite()
 {
-	if (Fields == nullptr)
+	if (ensure(bActiveWriter) && Fields == nullptr)
 	{
 		switch (Ctx.Kind)
 		{

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/RPCTypes.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/RPCTypes.cpp
@@ -20,13 +20,13 @@ RPCWritingContext::EntityWrite::~EntityWrite()
 		{
 		case DataKind::Generic:
 			break;
-		case DataKind::Data:
+		case DataKind::ComponentData:
 			if (Ctx.DataWrittenCallback)
 			{
 				Ctx.DataWrittenCallback(EntityId, ComponentId, Data);
 			}
 			break;
-		case DataKind::Update:
+		case DataKind::ComponentUpdate:
 			if (Ctx.UpdateWrittenCallback)
 			{
 				Ctx.UpdateWrittenCallback(EntityId, ComponentId, Update);
@@ -50,7 +50,7 @@ RPCWritingContext::EntityWrite::~EntityWrite()
 
 Schema_ComponentUpdate* RPCWritingContext::EntityWrite::GetComponentUpdateToWrite()
 {
-	check(Ctx.Kind == DataKind::Update);
+	check(Ctx.Kind == DataKind::ComponentUpdate);
 	GetFieldsToWrite();
 	return Update;
 }
@@ -65,11 +65,11 @@ Schema_Object* RPCWritingContext::EntityWrite::GetFieldsToWrite()
 			GenData = Schema_CreateGenericData();
 			Fields = Schema_GetGenericDataObject(GenData);
 			break;
-		case DataKind::Data:
+		case DataKind::ComponentData:
 			Data = Schema_CreateComponentData();
 			Fields = Schema_GetComponentDataFields(Data);
 			break;
-		case DataKind::Update:
+		case DataKind::ComponentUpdate:
 			Update = Schema_CreateComponentUpdate();
 			Fields = Schema_GetComponentUpdateFields(Update);
 			break;

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/RPCTypes.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/RPCTypes.cpp
@@ -90,12 +90,30 @@ Schema_Object* RPCWritingContext::EntityWrite::GetFieldsToWrite()
 	return Fields;
 }
 
-void RPCWritingContext::EntityWrite::RPCWritten(uint32 RPCId)
+void RPCWritingContext::EntityWrite::RPCWritten(uint32 RPCId) {}
+
+RPCWritingContext::RPCWritingContext(RPCCallbacks::DataWritten InDataWrittenCallback)
+	: DataWrittenCallback(InDataWrittenCallback)
+	, Kind(DataKind::ComponentData)
 {
-	if (Ctx.RPCWrittenCallback)
-	{
-		Ctx.RPCWrittenCallback(EntityId, ComponentId, RPCId);
-	}
+}
+
+RPCWritingContext::RPCWritingContext(RPCCallbacks::UpdateWritten InUpdateWrittenCallback)
+	: UpdateWrittenCallback(InUpdateWrittenCallback)
+	, Kind(DataKind::ComponentUpdate)
+{
+}
+
+RPCWritingContext::RPCWritingContext(RPCCallbacks::RequestWritten InRequestWrittenCallback)
+	: RequestWrittenCallback(InRequestWrittenCallback)
+	, Kind(DataKind::CommandRequest)
+{
+}
+
+RPCWritingContext::RPCWritingContext(RPCCallbacks::ResponseWritten InResponseWrittenCallback)
+	: ResponseWrittenCallback(InResponseWrittenCallback)
+	, Kind(DataKind::CommandResponse)
+{
 }
 
 RPCWritingContext::EntityWrite::EntityWrite(RPCWritingContext& InCtx, Worker_EntityId InEntityId, Worker_ComponentId InComponentID)
@@ -108,11 +126,6 @@ RPCWritingContext::EntityWrite::EntityWrite(RPCWritingContext& InCtx, Worker_Ent
 RPCWritingContext::EntityWrite RPCWritingContext::WriteTo(Worker_EntityId EntityId, Worker_ComponentId ComponentId)
 {
 	return EntityWrite(*this, EntityId, ComponentId);
-}
-
-RPCWritingContext::RPCWritingContext(DataKind InKind)
-	: Kind(InKind)
-{
 }
 
 void RPCBufferSender::OnAuthGained(Worker_EntityId EntityId, EntityViewElement const& Element)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/RPCTypes.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/RPCTypes.cpp
@@ -1,0 +1,161 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "Interop/RPCs/RPCTypes.h"
+
+namespace SpatialGDK
+{
+RPCWritingContext::EntityWrite::EntityWrite(EntityWrite&& Write)
+	: Ctx(Write.Ctx)
+	, EntityId(Write.EntityId)
+	, ComponentId(Write.ComponentId)
+{
+	Write.bActiveWriter = false;
+}
+
+RPCWritingContext::EntityWrite::~EntityWrite()
+{
+	if (bActiveWriter)
+	{
+		switch (Ctx.Kind)
+		{
+		case DataKind::Generic:
+			break;
+		case DataKind::Data:
+			if (Ctx.DataWrittenCallback)
+			{
+				Ctx.DataWrittenCallback(EntityId, ComponentId, Data);
+			}
+			break;
+		case DataKind::Update:
+			if (Ctx.UpdateWrittenCallback)
+			{
+				Ctx.UpdateWrittenCallback(EntityId, ComponentId, Update);
+			}
+			break;
+		case DataKind::CommandRequest:
+			if (Ctx.RequestWrittenCallback)
+			{
+				Ctx.RequestWrittenCallback(EntityId, Request);
+			}
+			break;
+		case DataKind::CommandResponse:
+			if (Ctx.ResponseWrittenCallback)
+			{
+				Ctx.ResponseWrittenCallback(EntityId, Response);
+			}
+			break;
+		}
+	}
+}
+
+Schema_ComponentUpdate* RPCWritingContext::EntityWrite::GetComponentUpdateToWrite()
+{
+	check(Ctx.Kind == DataKind::Update);
+	GetFieldsToWrite();
+	return Update;
+}
+
+Schema_Object* RPCWritingContext::EntityWrite::GetFieldsToWrite()
+{
+	if (Fields == nullptr)
+	{
+		switch (Ctx.Kind)
+		{
+		case DataKind::Generic:
+			GenData = Schema_CreateGenericData();
+			Fields = Schema_GetGenericDataObject(GenData);
+			break;
+		case DataKind::Data:
+			Data = Schema_CreateComponentData();
+			Fields = Schema_GetComponentDataFields(Data);
+			break;
+		case DataKind::Update:
+			Update = Schema_CreateComponentUpdate();
+			Fields = Schema_GetComponentUpdateFields(Update);
+			break;
+		case DataKind::CommandRequest:
+			Request = Schema_CreateCommandRequest();
+			Fields = Schema_GetCommandRequestObject(Request);
+			break;
+		case DataKind::CommandResponse:
+			Response = Schema_CreateCommandResponse();
+			Fields = Schema_GetCommandResponseObject(Response);
+			break;
+		}
+	}
+	return Fields;
+}
+
+void RPCWritingContext::EntityWrite::RPCWritten(uint32 RPCId)
+{
+	if (Ctx.RPCWrittenCallback)
+	{
+		Ctx.RPCWrittenCallback(EntityId, ComponentId, RPCId);
+	}
+}
+
+RPCWritingContext::EntityWrite::EntityWrite(RPCWritingContext& InCtx, Worker_EntityId InEntityId, Worker_ComponentId InComponentID)
+	: EntityId(InEntityId)
+	, ComponentId(InComponentID)
+	, Ctx(InCtx)
+{
+}
+
+RPCWritingContext::EntityWrite RPCWritingContext::WriteTo(Worker_EntityId EntityId, Worker_ComponentId ComponentId)
+{
+	return EntityWrite(*this, EntityId, ComponentId);
+}
+
+RPCWritingContext::RPCWritingContext(DataKind InKind)
+	: Kind(InKind)
+{
+}
+
+void RPCBufferSender::OnAuthGained(Worker_EntityId EntityId, EntityViewElement const& Element)
+{
+	RPCReadingContext readCtx;
+	readCtx.EntityId = EntityId;
+	for (const auto& Component : Element.Components)
+	{
+		if (ComponentsToReadOnAuthGained.Contains(Component.GetComponentId()))
+		{
+			readCtx.ComponentId = Component.GetComponentId();
+			readCtx.Fields = Schema_GetComponentDataFields(Component.GetUnderlying());
+
+			OnAuthGained_ReadComponent(readCtx);
+		}
+	}
+}
+
+void RPCBufferReceiver::OnAdded(Worker_EntityId EntityId, EntityViewElement const& Element)
+{
+	RPCReadingContext readCtx;
+	readCtx.EntityId = EntityId;
+	for (const auto& Component : Element.Components)
+	{
+		if (ComponentsToRead.Contains(Component.GetComponentId()))
+		{
+			readCtx.ComponentId = Component.GetComponentId();
+			readCtx.Fields = Schema_GetComponentDataFields(Component.GetUnderlying());
+
+			OnAdded_ReadComponent(readCtx);
+		}
+	}
+}
+
+void RPCQueue::OnAuthGained(Worker_EntityId EntityId, EntityViewElement const& Element)
+{
+	RPCReadingContext readCtx;
+	readCtx.EntityId = EntityId;
+	for (const auto& Component : Element.Components)
+	{
+		if (ComponentsToReadOnAuthGained.Contains(Component.GetComponentId()))
+		{
+			readCtx.ComponentId = Component.GetComponentId();
+			readCtx.Fields = Schema_GetComponentDataFields(Component.GetUnderlying());
+
+			OnAuthGained_ReadComponent(readCtx);
+		}
+	}
+}
+} // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/RPCTypes.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/RPCTypes.cpp
@@ -5,9 +5,9 @@
 namespace SpatialGDK
 {
 RPCWritingContext::EntityWrite::EntityWrite(EntityWrite&& Write)
-	: Ctx(Write.Ctx)
-	, EntityId(Write.EntityId)
+	: EntityId(Write.EntityId)
 	, ComponentId(Write.ComponentId)
+	, Ctx(Write.Ctx)
 {
 	Write.bActiveWriter = false;
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCService.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCService.h
@@ -42,6 +42,9 @@ public:
 	void AddRPCReceiver(FName ReceiverName, RPCReceiverDescription&& Desc);
 
 private:
+	void AdvanceSenderQueues();
+	void AdvanceReceivers();
+
 	const FSubView* RemoteSubView;
 	const FSubView* LocalAuthSubView;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCService.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCService.h
@@ -51,6 +51,18 @@ public:
 private:
 	void AdvanceSenderQueues();
 	void AdvanceReceivers();
+	void ProcessUpdatesToSender(Worker_EntityId EntityId, ComponentSpan<ComponentChange> Updates);
+	void ProcessUpdatesToReceivers(Worker_EntityId EntityId, const EntityViewElement& ViewElement, ComponentSpan<ComponentChange> Updates);
+	void HandleReceiverAuthorityGained(Worker_EntityId EntityId, const EntityViewElement& ViewElement,
+									   ComponentSpan<AuthorityChange> AuthChanges);
+	void HandleReceiverAuthorityLost(Worker_EntityId EntityId, ComponentSpan<AuthorityChange> AuthChanges);
+
+	// Receiver may or may not need authority to be able to receive RPCs (Client/Server vs Multicast).
+	// On the other hand, Senders always need some authority in order to write outgoing RPCs
+	// That is why there is not equivalent functions for the senders.
+	static constexpr Worker_ComponentSetId NoAuthorityNeeded = 0;
+	static bool HasReceiverAuthority(const RPCReceiverDescription& Desc, const EntityViewElement& ViewElement);
+	static bool IsReceiverAuthoritySet(const RPCReceiverDescription& Desc, Worker_ComponentSetId ComponentSet);
 
 	RPCCallbacks::DataWritten MakeDataWriteCallback(TArray<FWorkerComponentData>& OutArray) const;
 	RPCCallbacks::UpdateWritten MakeUpdateWriteCallback(TArray<UpdateToSend>& Updates) const;

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCService.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCService.h
@@ -34,15 +34,15 @@ public:
 	struct RPCQueueDescription
 	{
 		Worker_ComponentSetId Authority;
-		TSharedPtr<RPCBufferSender> Sender;
-		TSharedPtr<RPCQueue> Queue;
+		RPCBufferSender* Sender;
+		RPCQueue* Queue;
 	};
 
 	struct RPCReceiverDescription
 	{
 		// Can be 0, in which case the receiver will consider every entity in the view.
 		Worker_ComponentSetId Authority;
-		TSharedPtr<RPCBufferReceiver> Receiver;
+		RPCBufferReceiver* Receiver;
 	};
 
 	void AddRPCQueue(FName QueueName, RPCQueueDescription&& Desc);

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCService.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCService.h
@@ -1,0 +1,52 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "Interop/RPCs/RPCTypes.h"
+#include "SpatialView/SubView.h"
+
+class USpatialNetDriver;
+
+namespace SpatialGDK
+{
+class SPATIALGDK_API RPCService
+{
+public:
+	explicit RPCService(const FSubView& InRemoteSubView, const FSubView& InLocalAuthSubView);
+
+	void AdvanceView();
+
+	struct UpdateToSend
+	{
+		Worker_EntityId EntityId;
+		FWorkerComponentUpdate Update;
+		FSpatialGDKSpanId SpanId;
+	};
+	TArray<UpdateToSend> GetRPCsAndAcksToSend();
+	TArray<FWorkerComponentData> GetRPCComponentsOnEntityCreation(Worker_EntityId EntityId);
+
+	struct RPCQueueDescription
+	{
+		Worker_ComponentSetId Authority;
+		TSharedPtr<RPCBufferSender> Sender;
+		TSharedPtr<RPCQueue> Queue;
+	};
+
+	struct RPCReceiverDescription
+	{
+		Worker_ComponentSetId Authority;
+		TSharedPtr<RPCBufferReceiver> Receiver;
+	};
+
+	void AddRPCQueue(FName QueueName, RPCQueueDescription&& Desc);
+	void AddRPCReceiver(FName ReceiverName, RPCReceiverDescription&& Desc);
+
+private:
+	const FSubView* RemoteSubView;
+	const FSubView* LocalAuthSubView;
+
+	TMap<FName, RPCQueueDescription> Queues;
+	TMap<FName, RPCReceiverDescription> Receivers;
+};
+
+} // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCService.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCService.h
@@ -9,6 +9,11 @@ class USpatialNetDriver;
 
 namespace SpatialGDK
 {
+/**
+ * The RPCService aggregates Sender and Receiver in order to route updates and events to/from the network.
+ * It does not deal directly with actor concepts and RPC data, this is pushed to the user side and individual
+ * sender/receiver specialization.
+ */
 class SPATIALGDK_API RPCService
 {
 public:
@@ -23,6 +28,7 @@ public:
 		FSpatialGDKSpanId SpanId;
 	};
 	TArray<UpdateToSend> GetRPCsAndAcksToSend();
+	TArray<UpdateToSend> FlushSenderForEntity(Worker_EntityId);
 	TArray<FWorkerComponentData> GetRPCComponentsOnEntityCreation(Worker_EntityId EntityId);
 
 	struct RPCQueueDescription
@@ -34,6 +40,7 @@ public:
 
 	struct RPCReceiverDescription
 	{
+		// Can be 0, in which case the receiver will consider every entity in the view.
 		Worker_ComponentSetId Authority;
 		TSharedPtr<RPCBufferReceiver> Receiver;
 	};
@@ -44,6 +51,9 @@ public:
 private:
 	void AdvanceSenderQueues();
 	void AdvanceReceivers();
+
+	RPCCallbacks::DataWritten MakeDataWriteCallback(TArray<FWorkerComponentData>& OutArray) const;
+	RPCCallbacks::UpdateWritten MakeUpdateWriteCallback(TArray<UpdateToSend>& Updates) const;
 
 	const FSubView* RemoteSubView;
 	const FSubView* LocalAuthSubView;

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCTypes.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCTypes.h
@@ -1,0 +1,170 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Interop/Connection/SpatialGDKSpanId.h"
+#include "Schema/RPCPayload.h"
+#include "SpatialView/EntityView.h"
+
+namespace SpatialGDK
+{
+struct RPCReadingContext
+{
+	Worker_EntityId EntityId;
+	Worker_ComponentId ComponentId;
+
+	bool IsUpdate() const { return Update != nullptr; }
+
+	Schema_ComponentUpdate* Update = nullptr;
+	Schema_Object* Fields = nullptr;
+};
+
+struct RPCWritingContext
+{
+	enum class DataKind
+	{
+		Generic,
+		Data,
+		Update,
+		CommandRequest,
+		CommandResponse
+	};
+
+	class EntityWrite
+	{
+	public:
+		EntityWrite(const EntityWrite&) = delete;
+		EntityWrite& operator=(const EntityWrite&) = delete;
+		EntityWrite& operator=(EntityWrite&&) = delete;
+
+		EntityWrite(EntityWrite&& Write);
+		~EntityWrite();
+
+		Schema_ComponentUpdate* GetComponentUpdateToWrite();
+		Schema_Object* GetFieldsToWrite();
+
+		void RPCWritten(uint32 RPCId);
+
+		const Worker_EntityId EntityId;
+		const Worker_ComponentId ComponentId;
+
+	private:
+		union
+		{
+			Schema_GenericData* GenData;
+			Schema_ComponentData* Data;
+			Schema_ComponentUpdate* Update;
+			Schema_CommandRequest* Request;
+			Schema_CommandResponse* Response;
+		};
+
+		EntityWrite(RPCWritingContext& InCtx, Worker_EntityId InEntityId, Worker_ComponentId InComponentID);
+		friend RPCWritingContext;
+		RPCWritingContext& Ctx;
+		Schema_Object* Fields = nullptr;
+		bool bActiveWriter = true;
+	};
+
+	EntityWrite WriteTo(Worker_EntityId EntityId, Worker_ComponentId ComponentId);
+
+	RPCWritingContext(DataKind InKind);
+
+	TFunction<void(Worker_EntityId, Worker_ComponentId, Schema_ComponentData*)> DataWrittenCallback;
+	TFunction<void(Worker_EntityId, Worker_ComponentId, Schema_ComponentUpdate*)> UpdateWrittenCallback;
+	TFunction<void(Worker_EntityId, Schema_CommandRequest*)> RequestWrittenCallback;
+	TFunction<void(Worker_EntityId, Schema_CommandResponse*)> ResponseWrittenCallback;
+
+	TFunction<void(Worker_EntityId, Worker_ComponentId, uint32)> RPCWrittenCallback;
+
+protected:
+	DataKind Kind;
+};
+
+class RPCBufferSender
+{
+public:
+	virtual ~RPCBufferSender() = default;
+
+	virtual void OnUpdate(RPCReadingContext& iCtx) = 0;
+	virtual void OnAuthGained(Worker_EntityId EntityId, EntityViewElement const& Element);
+	virtual void OnAuthGained_ReadComponent(RPCReadingContext& iCtx) = 0;
+	virtual void OnAuthLost(Worker_EntityId) = 0;
+
+protected:
+	TSet<Worker_ComponentId> ComponentsToReadOnAuthGained;
+	TSet<Worker_ComponentId> ComponentsToReadOnUpdate;
+};
+
+using CanExtractRPCs = TFunction<bool(Worker_EntityId)>;
+using ProcessRPC = TFunction<bool(Worker_EntityId, const RPCPayload&)>;
+
+class RPCBufferReceiver
+{
+public:
+	virtual ~RPCBufferReceiver() = default;
+
+	virtual void OnAdded(Worker_EntityId EntityId, EntityViewElement const& Element);
+	virtual void OnAdded_ReadComponent(RPCReadingContext& iCtx) = 0;
+	virtual void OnRemoved(Worker_EntityId EntityId) = 0;
+	virtual void OnUpdate(RPCReadingContext& iCtx) = 0;
+	virtual void FlushUpdates(RPCWritingContext&) = 0;
+	virtual void ExtractReceivedRPCs(const CanExtractRPCs&, const ProcessRPC&) = 0;
+
+protected:
+	TSet<Worker_ComponentId> ComponentsToRead;
+};
+
+struct RPCQueue
+{
+	virtual ~RPCQueue() = default;
+	virtual void FlushAll(RPCWritingContext&) = 0;
+	virtual void Flush(Worker_EntityId EntityId, RPCWritingContext&) = 0;
+	virtual void OnAuthGained(Worker_EntityId EntityId, EntityViewElement const& Element);
+	virtual void OnAuthGained_ReadComponent(RPCReadingContext& iCtx) = 0;
+	virtual void OnAuthLost(Worker_EntityId) = 0;
+
+protected:
+	TSet<Worker_ComponentId> ComponentsToReadOnAuthGained;
+};
+
+template <typename PayloadType>
+struct TRPCBufferSender : RPCBufferSender
+{
+	virtual uint32 Write(RPCWritingContext& Ctx, Worker_EntityId EntityId, TArrayView<PayloadType> RPCs) = 0;
+};
+
+template <typename PayloadType>
+struct TRPCQueue : RPCQueue
+{
+	TRPCQueue(TRPCBufferSender<PayloadType>& InSender)
+		: Sender(InSender)
+	{
+	}
+
+	virtual void Push(Worker_EntityId EntityId, PayloadType&& Payload)
+	{
+		auto& Queue = Queues.FindOrAdd(EntityId);
+		if (Queue.bAdded)
+		{
+			Queue.RPCs.Emplace(MoveTemp(Payload));
+		}
+	}
+
+	void OnAuthGained(Worker_EntityId EntityId, EntityViewElement const& Element) override
+	{
+		RPCQueue::OnAuthGained(EntityId, Element);
+		Queues.FindOrAdd(EntityId).bAdded = true;
+	}
+
+	struct QueueData
+	{
+		TArray<PayloadType, TInlineAllocator<1>> RPCs;
+		bool bAdded = false;
+	};
+
+	TMap<Worker_EntityId, QueueData> Queues;
+	TRPCBufferSender<PayloadType>& Sender;
+};
+
+} // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCTypes.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCTypes.h
@@ -49,6 +49,11 @@ struct RPCWritingContext
 		CommandResponse
 	};
 
+	RPCWritingContext(RPCCallbacks::DataWritten DataWrittenCallback);
+	RPCWritingContext(RPCCallbacks::UpdateWritten UpdateWrittenCallback);
+	RPCWritingContext(RPCCallbacks::RequestWritten RequestWrittenCallback);
+	RPCWritingContext(RPCCallbacks::ResponseWritten ResponseWrittenCallback);
+
 	/**
 	 * RAII object to encapsulate writes to an entity/component couple.
 	 * It makes sure that the appropriate callback is executed when the write operation is done
@@ -94,16 +99,13 @@ struct RPCWritingContext
 
 	EntityWrite WriteTo(Worker_EntityId EntityId, Worker_ComponentId ComponentId);
 
-	RPCWritingContext(DataKind InKind);
-
+protected:
 	RPCCallbacks::DataWritten DataWrittenCallback;
 	RPCCallbacks::UpdateWritten UpdateWrittenCallback;
 	RPCCallbacks::RequestWritten RequestWrittenCallback;
 	RPCCallbacks::ResponseWritten ResponseWrittenCallback;
-	RPCCallbacks::RPCWritten RPCWrittenCallback;
 
-protected:
-	DataKind Kind;
+	const DataKind Kind;
 };
 
 /**

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCTypes.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCTypes.h
@@ -163,7 +163,7 @@ struct TRPCQueue : RPCQueue
 		bool bAdded = false;
 	};
 
-	TMap<Worker_EntityId, QueueData> Queues;
+	TMap<Worker_EntityId_Key, QueueData> Queues;
 	TRPCBufferSender<PayloadType>& Sender;
 };
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCTypes.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCTypes.h
@@ -9,6 +9,20 @@
 
 namespace SpatialGDK
 {
+namespace RPCCallbacks
+{
+using DataWritten = TFunction<void(Worker_EntityId, Worker_ComponentId, Schema_ComponentData*)>;
+using UpdateWritten = TFunction<void(Worker_EntityId, Worker_ComponentId, Schema_ComponentUpdate*)>;
+using RequestWritten = TFunction<void(Worker_EntityId, Schema_CommandRequest*)>;
+using ResponseWritten = TFunction<void(Worker_EntityId, Schema_CommandResponse*)>;
+using RPCWritten = TFunction<void(Worker_EntityId, Worker_ComponentId, uint32)>;
+
+using CanExtractRPCs = TFunction<bool(Worker_EntityId)>;
+using ProcessRPC = TFunction<bool(Worker_EntityId, const RPCPayload&)>;
+} // namespace RPCCallbacks
+/**
+ * Structure encapsulating a read operation
+ */
 struct RPCReadingContext
 {
 	Worker_EntityId EntityId;
@@ -20,6 +34,10 @@ struct RPCReadingContext
 	Schema_Object* Fields = nullptr;
 };
 
+/**
+ * Structure encapsulating a write operation.
+ * It serves as a factory for EntityWrites which encapsulate writes to a given entity/component pair
+ */
 struct RPCWritingContext
 {
 	enum class DataKind
@@ -31,6 +49,10 @@ struct RPCWritingContext
 		CommandResponse
 	};
 
+	/**
+	 * RAII object to encapsulate writes to an entity/component couple.
+	 * It makes sure that the appropriate callback is executed when the write operation is done
+	 */
 	class EntityWrite
 	{
 	public:
@@ -44,6 +66,8 @@ struct RPCWritingContext
 		Schema_ComponentUpdate* GetComponentUpdateToWrite();
 		Schema_Object* GetFieldsToWrite();
 
+		// Must be called by writers to allow any per-RPC operation to take place.
+		// The RPCId parameter is intended to be unique in the EntityId/ComponentId context.
 		void RPCWritten(uint32 RPCId);
 
 		const Worker_EntityId EntityId;
@@ -63,6 +87,8 @@ struct RPCWritingContext
 		friend RPCWritingContext;
 		RPCWritingContext& Ctx;
 		Schema_Object* Fields = nullptr;
+
+		// indicates if this object has been moved from, and if callback should be ran on destruction.
 		bool bActiveWriter = true;
 	};
 
@@ -70,70 +96,91 @@ struct RPCWritingContext
 
 	RPCWritingContext(DataKind InKind);
 
-	TFunction<void(Worker_EntityId, Worker_ComponentId, Schema_ComponentData*)> DataWrittenCallback;
-	TFunction<void(Worker_EntityId, Worker_ComponentId, Schema_ComponentUpdate*)> UpdateWrittenCallback;
-	TFunction<void(Worker_EntityId, Schema_CommandRequest*)> RequestWrittenCallback;
-	TFunction<void(Worker_EntityId, Schema_CommandResponse*)> ResponseWrittenCallback;
-
-	TFunction<void(Worker_EntityId, Worker_ComponentId, uint32)> RPCWrittenCallback;
+	RPCCallbacks::DataWritten DataWrittenCallback;
+	RPCCallbacks::UpdateWritten UpdateWrittenCallback;
+	RPCCallbacks::RequestWritten RequestWrittenCallback;
+	RPCCallbacks::ResponseWritten ResponseWrittenCallback;
+	RPCCallbacks::RPCWritten RPCWrittenCallback;
 
 protected:
 	DataKind Kind;
 };
 
+/**
+ * Class responsible for managing the sending side of a given RPC type
+ * It will operate on the locally authoritative view of the actors.
+ */
 class RPCBufferSender
 {
 public:
 	virtual ~RPCBufferSender() = default;
 
-	virtual void OnUpdate(RPCReadingContext& iCtx) = 0;
+	virtual void OnUpdate(const RPCReadingContext& iCtx) = 0;
 	virtual void OnAuthGained(Worker_EntityId EntityId, EntityViewElement const& Element);
-	virtual void OnAuthGained_ReadComponent(RPCReadingContext& iCtx) = 0;
+	virtual void OnAuthGained_ReadComponent(const RPCReadingContext& iCtx) = 0;
 	virtual void OnAuthLost(Worker_EntityId) = 0;
+
+	const TSet<Worker_ComponentId>& GetComponentsToReadOnUpdate() const { return ComponentsToReadOnUpdate; }
 
 protected:
 	TSet<Worker_ComponentId> ComponentsToReadOnAuthGained;
 	TSet<Worker_ComponentId> ComponentsToReadOnUpdate;
 };
 
-using CanExtractRPCs = TFunction<bool(Worker_EntityId)>;
-using ProcessRPC = TFunction<bool(Worker_EntityId, const RPCPayload&)>;
-
+/**
+ * Class responsible for managing the receiving side of a given RPC type
+ * It will operate on the actor view, on actors it may or may not have local authority on.
+ */
 class RPCBufferReceiver
 {
 public:
 	virtual ~RPCBufferReceiver() = default;
 
 	virtual void OnAdded(Worker_EntityId EntityId, EntityViewElement const& Element);
-	virtual void OnAdded_ReadComponent(RPCReadingContext& iCtx) = 0;
+	virtual void OnAdded_ReadComponent(const RPCReadingContext& iCtx) = 0;
 	virtual void OnRemoved(Worker_EntityId EntityId) = 0;
-	virtual void OnUpdate(RPCReadingContext& iCtx) = 0;
+	virtual void OnUpdate(const RPCReadingContext& iCtx) = 0;
 	virtual void FlushUpdates(RPCWritingContext&) = 0;
-	virtual void ExtractReceivedRPCs(const CanExtractRPCs&, const ProcessRPC&) = 0;
+	virtual void ExtractReceivedRPCs(const RPCCallbacks::CanExtractRPCs&, const RPCCallbacks::ProcessRPC&) = 0;
+
+	const TSet<Worker_ComponentId>& GetComponentsToRead() const { return ComponentsToRead; }
 
 protected:
 	TSet<Worker_ComponentId> ComponentsToRead;
 };
 
+/**
+ * Class responsible for the local queuing behaviour when sending.
+ * Local queuing is mostly useful when we are in the process of creating an entity and
+ * cannot send the RPCs right away, and when the ring buffer sender does not have capacity to send the RPCs.
+ */
 struct RPCQueue
 {
 	virtual ~RPCQueue() = default;
 	virtual void FlushAll(RPCWritingContext&) = 0;
 	virtual void Flush(Worker_EntityId EntityId, RPCWritingContext&) = 0;
-	virtual void OnAuthGained(Worker_EntityId EntityId, EntityViewElement const& Element);
-	virtual void OnAuthGained_ReadComponent(RPCReadingContext& iCtx) = 0;
+	virtual void OnAuthGained(Worker_EntityId EntityId, const EntityViewElement& Element);
+	virtual void OnAuthGained_ReadComponent(const RPCReadingContext& iCtx) = 0;
 	virtual void OnAuthLost(Worker_EntityId) = 0;
 
 protected:
 	TSet<Worker_ComponentId> ComponentsToReadOnAuthGained;
 };
 
+/**
+ * Specialization of a buffer sender for a given payload type
+ * It is paired with a matching queue.
+ */
 template <typename PayloadType>
 struct TRPCBufferSender : RPCBufferSender
 {
 	virtual uint32 Write(RPCWritingContext& Ctx, Worker_EntityId EntityId, TArrayView<PayloadType> RPCs) = 0;
 };
 
+/**
+ * Specialization of a sender queue for a given payload type
+ * It is paired with a matching sender.
+ */
 template <typename PayloadType>
 struct TRPCQueue : RPCQueue
 {
@@ -151,7 +198,7 @@ struct TRPCQueue : RPCQueue
 		}
 	}
 
-	void OnAuthGained(Worker_EntityId EntityId, EntityViewElement const& Element) override
+	void OnAuthGained(Worker_EntityId EntityId, const EntityViewElement& Element) override
 	{
 		RPCQueue::OnAuthGained(EntityId, Element);
 		Queues.FindOrAdd(EntityId).bAdded = true;
@@ -159,6 +206,8 @@ struct TRPCQueue : RPCQueue
 
 	struct QueueData
 	{
+		// Most RPCs are flushed right after queuing them,
+		// so a small array optimization looks useful in general.
 		TArray<PayloadType, TInlineAllocator<1>> RPCs;
 		bool bAdded = false;
 	};

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCTypes.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCTypes.h
@@ -25,8 +25,8 @@ struct RPCWritingContext
 	enum class DataKind
 	{
 		Generic,
-		Data,
-		Update,
+		ComponentData,
+		ComponentUpdate,
 		CommandRequest,
 		CommandResponse
 	};

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/RPCPayload.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/RPCPayload.h
@@ -71,7 +71,7 @@ struct RPCSender : CrossServerRPCInfo
 
 struct RPCPayload
 {
-	RPCPayload() = delete;
+	RPCPayload() = default;
 
 	RPCPayload(uint32 InOffset, uint32 InIndex, TOptional<uint64> InId, TArray<uint8>&& Data, TraceKey InTraceKey = InvalidTraceKey)
 		: Offset(InOffset)
@@ -82,7 +82,9 @@ struct RPCPayload
 	{
 	}
 
-	RPCPayload(Schema_Object* RPCObject)
+	RPCPayload(Schema_Object* RPCObject) { ReadFromSchema(RPCObject); }
+
+	void ReadFromSchema(Schema_Object* RPCObject)
 	{
 		Offset = Schema_GetUint32(RPCObject, SpatialConstants::UNREAL_RPC_PAYLOAD_OFFSET_ID);
 		Index = Schema_GetUint32(RPCObject, SpatialConstants::UNREAL_RPC_PAYLOAD_RPC_INDEX_ID);


### PR DESCRIPTION
#### Description
Add the basic infrastructure that will be used to implement the various types of RPCs we have.
The plan is to reimplement each type of RPC using it (tickets in https://improbableio.atlassian.net/browse/UNR-4839), and swap usage one by one until there is no remaining code that calls the previous SpatialRPCService.

#### Release note

#### Tests
Tests will be created for each individual RPC type.
