### PR TITLE
Fix snapshot reloading tests

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -414,6 +414,7 @@ TArray<FWorkerComponentData> EntityFactory::CreatePartitionEntityComponents(cons
 
 	TArray<FWorkerComponentData> Components;
 	Components.Add(Position().CreateComponentData());
+	Components.Add(Persistence().CreateComponentData());
 	Components.Add(Metadata(FString::Format(TEXT("PartitionEntity:{0}"), { VirtualWorker })).CreateComponentData());
 	Components.Add(InterestFactory->CreatePartitionInterest(LbStrategy, VirtualWorker, bDebugContextValid).CreateComponentData());
 	Components.Add(AuthorityDelegation(DelegationMap).CreateComponentData());


### PR DESCRIPTION
#### Description
Server worker partition entities should persist so they can be reclaimed when reloading.

#### Tests
Snapshot reloading tests (when run correctly) now work.

#### Primary reviewers
@mironec @Vix2021 
