### PR TITLE
[UNR-5036] Additional facilities to handle event tracing with the modularied RPC system.

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverRPC.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverRPC.cpp
@@ -1,0 +1,449 @@
+#include "EngineClasses/SpatialNetDriverRPC.h"
+#include "EngineClasses/SpatialNetBitReader.h"
+#include "EngineClasses/SpatialNetDriver.h"
+#include "EngineClasses/SpatialPackageMapClient.h"
+#include "Interop/Connection/SpatialTraceEventBuilder.h"
+#include "Utils/RepLayoutUtils.h"
+
+#include "Interop/RPCs/RPCQueues.h"
+
+using namespace SpatialGDK;
+
+void FRPCMetaData::ComputeSpanId(FName Name, SpatialGDK::SpatialEventTracer& Tracer, SpatialGDK::EntityComponentId EntityComponent,
+								 uint64 RPCId)
+{
+	TArray<FSpatialGDKSpanId> ComponentUpdateSpans = Tracer.GetAndConsumeSpansForComponent(EntityComponent);
+
+	SpanId = Tracer.TraceEvent(
+		FSpatialTraceEventBuilder::CreateReceiveRPC(EventTraceUniqueId::GenerateForNamedRPC(EntityComponent.EntityId, Name, RPCId)),
+		/* Causes */ reinterpret_cast<const Trace_SpanIdType*>(ComponentUpdateSpans.GetData()),
+		/* NumCauses */ ComponentUpdateSpans.Num());
+}
+
+void FRPCPayload::ReadFromSchema(Schema_Object* RPCObject)
+{
+	Offset = Schema_GetUint32(RPCObject, SpatialConstants::UNREAL_RPC_PAYLOAD_OFFSET_ID);
+	Index = Schema_GetUint32(RPCObject, SpatialConstants::UNREAL_RPC_PAYLOAD_RPC_INDEX_ID);
+	PayloadData = GetBytesFromSchema(RPCObject, SpatialConstants::UNREAL_RPC_PAYLOAD_RPC_PAYLOAD_ID);
+}
+
+void FRPCPayload::WriteToSchema(Schema_Object* RPCObject) const
+{
+	Schema_AddUint32(RPCObject, SpatialConstants::UNREAL_RPC_PAYLOAD_OFFSET_ID, Offset);
+	Schema_AddUint32(RPCObject, SpatialConstants::UNREAL_RPC_PAYLOAD_RPC_INDEX_ID, Index);
+	AddBytesToSchema(RPCObject, SpatialConstants::UNREAL_RPC_PAYLOAD_RPC_PAYLOAD_ID, PayloadData.GetData(), PayloadData.Num());
+}
+
+USpatialNetDriverRPC::USpatialNetDriverRPC() {}
+
+USpatialNetDriverRPC::StandardQueue::SentRPCCallback USpatialNetDriverRPC::MakeRPCSentCallback(TArray<UpdateToSend>& OutUpdates)
+{
+	return [&OutUpdates, this](FName Name, Worker_EntityId EntityId, Worker_ComponentId ComponentId, uint64 RPCId,
+							   const FSpatialGDKSpanId& SpanId) {
+		if (EventTracer != nullptr)
+		{
+			EventTraceUniqueId LinearTraceId = EventTraceUniqueId::GenerateForNamedRPC(EntityId, Name, RPCId);
+			FSpatialGDKSpanId NewSpanId = EventTracer->TraceEvent(FSpatialTraceEventBuilder::CreateSendRPC(LinearTraceId),
+																  /* Causes */ SpanId.GetConstId(), /* NumCauses */ 1);
+
+			if (OutUpdates.Num() == 0 || OutUpdates.Last().EntityId != EntityId || OutUpdates.Last().Update.component_id != ComponentId)
+			{
+				OutUpdates.AddDefaulted();
+				OutUpdates.Last().EntityId = EntityId;
+				OutUpdates.Last().Update.component_id = ComponentId;
+			}
+			OutUpdates.Last().Spans.Add(NewSpanId);
+		}
+	};
+}
+
+RPCCallbacks::DataWritten USpatialNetDriverRPC::MakeDataWriteCallback(TArray<FWorkerComponentData>& OutArray) const
+{
+	return [&OutArray](Worker_EntityId EntityId, Worker_ComponentId ComponentId, Schema_ComponentData* InData) {
+		if (ensure(InData != nullptr))
+		{
+			FWorkerComponentData Data;
+			Data.component_id = ComponentId;
+			Data.schema_type = InData;
+			OutArray.Add(Data);
+		}
+	};
+}
+
+RPCCallbacks::UpdateWritten USpatialNetDriverRPC::MakeUpdateWriteCallback(TArray<UpdateToSend>& OutUpdates) const
+{
+	return [&OutUpdates](Worker_EntityId EntityId, Worker_ComponentId ComponentId, Schema_ComponentUpdate* InUpdate) {
+		if (ensure(InUpdate != nullptr))
+		{
+			if (OutUpdates.Num() == 0 || OutUpdates.Last().EntityId != EntityId || OutUpdates.Last().Update.component_id != ComponentId)
+			{
+				OutUpdates.AddDefaulted();
+				OutUpdates.Last().EntityId = EntityId;
+				OutUpdates.Last().Update.component_id = ComponentId;
+			}
+			OutUpdates.Last().Update.schema_type = InUpdate;
+		}
+	};
+}
+
+void USpatialNetDriverRPC::Init(USpatialNetDriver* InNetDriver, const SpatialGDK::FSubView& InActorAuthSubView,
+								const SpatialGDK::FSubView& InActorNonAuthSubView)
+{
+	NetDriver = InNetDriver;
+	LatencyTracer = USpatialLatencyTracer::GetTracer(InNetDriver->GetWorld());
+	EventTracer = InNetDriver->Connection->GetEventTracer();
+	RPCService = MakeUnique<SpatialGDK::RPCService>(InActorNonAuthSubView, InActorAuthSubView);
+
+	{
+		// TODO
+		// MulticastReceiver =
+	}
+}
+
+void USpatialNetDriverRPC::AdvanceView()
+{
+	RPCService->AdvanceView();
+}
+
+void USpatialNetDriverRPC::ProcessReceivedRPCs()
+{
+	// MulticastReceiver->
+}
+
+TArray<FWorkerComponentData> USpatialNetDriverRPC::GetRPCComponentsOnEntityCreation(const Worker_EntityId EntityId)
+{
+	static TArray<Worker_ComponentId> EndpointComponentIds = {
+		SpatialConstants::CLIENT_ENDPOINT_COMPONENT_ID, SpatialConstants::SERVER_ENDPOINT_COMPONENT_ID,
+		/*SpatialConstants::MULTICAST_RPCS_COMPONENT_ID,
+		SpatialConstants::CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID*/
+	};
+
+	TArray<FWorkerComponentData> Components;
+	GetRPCComponentsOnEntityCreation(EntityId, Components);
+
+	for (auto EndpointId : EndpointComponentIds)
+	{
+		if (Components.FindByPredicate([EndpointId](const FWorkerComponentData& Data) {
+				return Data.component_id == EndpointId;
+			})
+			== nullptr)
+		{
+			FWorkerComponentData Data;
+			Data.component_id = EndpointId;
+			Data.schema_type = Schema_CreateComponentData();
+			Components.Add(Data);
+		}
+	}
+
+	return Components;
+}
+
+void USpatialNetDriverRPC::GetRPCComponentsOnEntityCreation(const Worker_EntityId EntityId, TArray<FWorkerComponentData>& OutData) {}
+
+void USpatialNetDriverRPC::FlushRPCUpdates()
+{
+	TMap<FName, RPCService::RPCReceiverDescription>& Receivers = RPCService->GetReceivers();
+	TArray<UpdateToSend> Updates;
+	for (auto Receiver : Receivers)
+	{
+		RPCWritingContext Ctx(Receiver.Key, MakeUpdateWriteCallback(Updates));
+		Receiver.Value.Receiver->FlushUpdates(Ctx);
+	}
+
+	FlushUpdates(Updates);
+}
+
+void USpatialNetDriverRPC::FlushRPCQueue(StandardQueue& Queue)
+{
+	TArray<UpdateToSend> Updates;
+	RPCWritingContext Ctx(Queue.Name, MakeUpdateWriteCallback(Updates));
+	Queue.FlushAll(Ctx, MakeRPCSentCallback(Updates));
+
+	FlushUpdates(Updates);
+}
+
+void USpatialNetDriverRPC::FlushRPCQueue(Worker_EntityId EntityId, StandardQueue& Queue)
+{
+	TArray<UpdateToSend> Updates;
+	RPCWritingContext Ctx(Queue.Name, MakeUpdateWriteCallback(Updates));
+	Queue.Flush(EntityId, Ctx, MakeRPCSentCallback(Updates));
+
+	FlushUpdates(Updates);
+}
+
+void USpatialNetDriverRPC::FlushUpdates(TArray<UpdateToSend>& Updates)
+{
+	const USpatialGDKSettings* Settings = GetDefault<USpatialGDKSettings>();
+
+	for (auto& Update : Updates)
+	{
+		FSpatialGDKSpanId SpanId;
+		if (EventTracer != nullptr)
+		{
+			SpanId = EventTracer->TraceEvent(FSpatialTraceEventBuilder::CreateMergeSendRPCs(Update.EntityId, Update.Update.component_id),
+											 /* Causes */ Update.Spans.GetData()->GetConstId(), /* NumCauses */ Update.Spans.Num());
+		}
+		NetDriver->Connection->SendComponentUpdate(Update.EntityId, &Update.Update, SpanId);
+	}
+
+	if (Updates.Num() > 0 && Settings->bWorkerFlushAfterOutgoingNetworkOp)
+	{
+		NetDriver->Connection->Flush();
+	}
+}
+
+bool USpatialNetDriverRPC::CanExtractRPC(Worker_EntityId EntityId)
+{
+	const TWeakObjectPtr<UObject> ActorReceivingRPC = NetDriver->PackageMap->GetObjectFromEntityId(EntityId);
+	if (!ActorReceivingRPC.IsValid())
+	{
+		UE_LOG(LogSpatialRPCService, Log,
+			   TEXT("Entity receiving ring buffer RPC does not exist in PackageMap, possibly due to corresponding actor getting "
+					"destroyed. Entity: %lld"),
+			   EntityId);
+		return false;
+	}
+	return true;
+}
+
+bool USpatialNetDriverRPC::CanExtractRPCOnServer(Worker_EntityId EntityId)
+{
+	const TWeakObjectPtr<UObject> ActorReceivingRPC = NetDriver->PackageMap->GetObjectFromEntityId(EntityId);
+	if (!ActorReceivingRPC.IsValid())
+	{
+		UE_LOG(LogSpatialRPCService, Log,
+			   TEXT("Entity receiving ring buffer RPC does not exist in PackageMap, possibly due to corresponding actor getting "
+					"destroyed. Entity: %lld"),
+			   EntityId);
+		return false;
+	}
+
+	const bool bActorRoleIsSimulatedProxy = Cast<AActor>(ActorReceivingRPC.Get())->Role == ROLE_SimulatedProxy;
+	if (bActorRoleIsSimulatedProxy)
+	{
+		UE_LOG(LogSpatialRPCService, Verbose,
+			   TEXT("Will not process server RPC, Actor role changed to SimulatedProxy. This happens on migration. Entity: %lld"),
+			   EntityId);
+		return false;
+	}
+	return true;
+}
+
+struct RAIIParamsHolder
+{
+	RAIIParamsHolder(UFunction* InFunction, uint8* Memory)
+		: Function(InFunction)
+	{
+		Parms = Memory;
+		FMemory::Memzero(Parms, Function->ParmsSize);
+	}
+
+	~RAIIParamsHolder()
+	{
+		// Destroy the parameters.
+		// warning: highly dependent on UObject::ProcessEvent freeing of parms!
+		for (TFieldIterator<GDK_PROPERTY(Property)> It(Function); It && It->HasAnyPropertyFlags(CPF_Parm); ++It)
+		{
+			It->DestroyValue_InContainer(Parms);
+		}
+	}
+
+	UFunction* Function;
+	uint8* Parms;
+};
+
+bool USpatialNetDriverRPC::ApplyRPC(Worker_EntityId EntityId, SpatialGDK::ReceivedRPC RPCData, const FRPCMetaData& MetaData)
+{
+	constexpr bool RPCConsumed = true;
+
+	FUnrealObjectRef ObjectRef(EntityId, RPCData.Offset);
+	TWeakObjectPtr<UObject> TargetObjectWeakPtr = NetDriver->PackageMap->GetObjectFromUnrealObjectRef(ObjectRef);
+	UObject* TargetObject = TargetObjectWeakPtr.Get();
+
+	const FClassInfo& ClassInfo = NetDriver->ClassInfoManager->GetOrCreateClassInfoByObject(TargetObjectWeakPtr.Get());
+	UFunction* Function = ClassInfo.RPCs[RPCData.Index];
+	if (Function == nullptr)
+	{
+		// return FRPCErrorInfo{ TargetObject, nullptr, ERPCResult::MissingFunctionInfo, ERPCQueueProcessResult::ContinueProcessing };
+		return RPCConsumed;
+	}
+
+	uint8* Parms = (uint8*)FMemory_Alloca(Function->ParmsSize);
+	RAIIParamsHolder ParamAlloc(Function, Parms);
+
+	TSet<FUnrealObjectRef> UnresolvedRefs;
+	{
+		// Scope for the SpatialNetBitReader lifecycle (only one should exist per thread).
+		TSet<FUnrealObjectRef> MappedRefs;
+
+		TArray<uint8> DataCopy(RPCData.PayloadData.GetData(), RPCData.PayloadData.Num());
+		FSpatialNetBitReader PayloadReader(NetDriver->PackageMap, DataCopy.GetData(), RPCData.PayloadData.Num() * 8, MappedRefs,
+										   UnresolvedRefs);
+
+		TSharedPtr<FRepLayout> RepLayout = NetDriver->GetFunctionRepLayout(Function);
+		RepLayout_ReceivePropertiesForRPC(*RepLayout, PayloadReader, Parms);
+	}
+
+	const USpatialGDKSettings* SpatialSettings = GetDefault<USpatialGDKSettings>();
+
+	const float TimeQueued = (FPlatformTime::Cycles64() - MetaData.Timestamp) * FPlatformTime::GetSecondsPerCycle64();
+	const int32 UnresolvedRefCount = UnresolvedRefs.Num();
+
+	if (UnresolvedRefCount == 0 || SpatialSettings->QueuedIncomingRPCWaitTime < TimeQueued)
+	{
+		// -> Use MetaData.ReceiverName to recover the RPC type.
+		if (UnresolvedRefCount > 0 /* && !SpatialSettings->ShouldRPCTypeAllowUnresolvedParameters(PendingRPCParams.Type)*/
+			&& (Function->SpatialFunctionFlags & SPATIALFUNC_AllowUnresolvedParameters) == 0)
+		{
+			const FString UnresolvedEntityIds = FString::JoinBy(UnresolvedRefs, TEXT(", "), [](const FUnrealObjectRef& Ref) {
+				return Ref.ToString();
+			});
+
+			UE_LOG(LogSpatialRPCService, Warning,
+				   TEXT("Executed RPC %s::%s with unresolved references (%s) after %.3f seconds of queueing. Owner name: %s"),
+				   *GetNameSafe(TargetObject), *GetNameSafe(Function), *UnresolvedEntityIds, TimeQueued,
+				   *GetNameSafe(TargetObject->GetOuter()));
+		}
+
+		// Get the RPC target Actor.
+		AActor* Actor = TargetObject->IsA<AActor>() ? Cast<AActor>(TargetObject) : TargetObject->GetTypedOuter<AActor>();
+
+		bool bUseEventTracer = EventTracer != nullptr;
+		if (bUseEventTracer)
+		{
+			FSpatialGDKSpanId SpanId = EventTracer->TraceEvent(FSpatialTraceEventBuilder::CreateApplyRPC(TargetObject, Function),
+															   /* Causes */ MetaData.SpanId.GetConstId(), /* NumCauses */ 1);
+			EventTracer->AddToStack(SpanId);
+		}
+
+		TargetObject->ProcessEvent(Function, Parms);
+
+		if (bUseEventTracer)
+		{
+			EventTracer->PopFromStack();
+		}
+
+		return RPCConsumed;
+	}
+
+	return !RPCConsumed;
+}
+
+void USpatialNetDriverRPC::MakeRingBufferWithACKSender(FName QueueName, ERPCType RPCType, Worker_ComponentSetId AuthoritySet,
+													   TUniquePtr<RPCBufferSender>& SenderPtr,
+													   TUniquePtr<TRPCQueue<FRPCPayload, FSpatialGDKSpanId>>& QueuePtr)
+{
+	// TODO
+}
+
+void USpatialNetDriverRPC::MakeRingBufferWithACKReceiver(FName ReceiverName, ERPCType RPCType, Worker_ComponentSetId AuthoritySet,
+														 TUniquePtr<TRPCBufferReceiver<FRPCPayload, TimestampAndETWrapper>>& ReceiverPtr)
+{
+	// TODO
+}
+
+USpatialNetDriverServerRPC::USpatialNetDriverServerRPC() {}
+
+void USpatialNetDriverServerRPC::FlushRPCUpdates()
+{
+	USpatialNetDriverRPC::FlushRPCUpdates();
+	FlushRPCQueue(*ClientReliableQueue);
+	FlushRPCQueue(*ClientUnreliableQueue);
+}
+
+void USpatialNetDriverServerRPC::ProcessReceivedRPCs()
+{
+	USpatialNetDriverRPC::ProcessReceivedRPCs();
+
+	auto CanExtractRPCs = [this](Worker_EntityId EntityId) {
+		return CanExtractRPCOnServer(EntityId);
+	};
+	auto ProcessRPC = [this](Worker_EntityId EntityId, ReceivedRPC RPCData, const FRPCMetaData& MetaData) {
+		return ApplyRPC(EntityId, RPCData, MetaData);
+	};
+
+	ServerReliableReceiver->ExtractReceivedRPCs(CanExtractRPCs, ProcessRPC);
+	ServerUnreliableReceiver->ExtractReceivedRPCs(CanExtractRPCs, ProcessRPC);
+}
+
+void USpatialNetDriverServerRPC::GetRPCComponentsOnEntityCreation(const Worker_EntityId EntityId, TArray<FWorkerComponentData>& OutData)
+{
+	USpatialNetDriverRPC::GetRPCComponentsOnEntityCreation(EntityId, OutData);
+
+	{
+		RPCWritingContext Ctx(ClientReliableQueue->Name, MakeDataWriteCallback(OutData));
+		ClientReliableQueue->Flush(EntityId, Ctx, StandardQueue::SentRPCCallback(), /*bIgnoreAdded*/ true);
+	}
+	{
+		RPCWritingContext Ctx(ClientUnreliableQueue->Name, MakeDataWriteCallback(OutData));
+		ClientUnreliableQueue->Flush(EntityId, Ctx, StandardQueue::SentRPCCallback(), /*bIgnoreAdded*/ true);
+	}
+}
+
+void USpatialNetDriverServerRPC::Init(USpatialNetDriver* InNetDriver, const SpatialGDK::FSubView& InActorAuthSubView,
+									  const SpatialGDK::FSubView& InActorNonAuthSubView)
+{
+	USpatialNetDriverRPC::Init(InNetDriver, InActorAuthSubView, InActorNonAuthSubView);
+	const USpatialGDKSettings* Settings = GetDefault<USpatialGDKSettings>();
+
+	auto constexpr RequiredAuth = SpatialConstants::SERVER_AUTH_COMPONENT_SET_ID;
+
+	MakeRingBufferWithACKSender("ClientReliable", ERPCType::ClientReliable, RequiredAuth, ClientReliableSender, ClientReliableQueue);
+	MakeRingBufferWithACKSender("ClientUnreliable", ERPCType::ClientUnreliable, RequiredAuth, ClientUnreliableSender,
+								ClientUnreliableQueue);
+
+	MakeRingBufferWithACKReceiver("ServerReliable", ERPCType::ServerReliable, RequiredAuth, ServerReliableReceiver);
+	MakeRingBufferWithACKReceiver("ServerUnreliable", ERPCType::ServerUnreliable, RequiredAuth, ServerUnreliableReceiver);
+
+	{
+		auto RPCType = ERPCType::NetMulticast;
+		auto RPCDesc = RPCRingBufferUtils::GetRingBufferDescriptor(RPCType);
+
+		// TODO
+	}
+}
+
+USpatialNetDriverClientRPC::USpatialNetDriverClientRPC() {}
+
+void USpatialNetDriverClientRPC::FlushRPCUpdates()
+{
+	USpatialNetDriverRPC::FlushRPCUpdates();
+	FlushRPCQueue(*ServerReliableQueue);
+	FlushRPCQueue(*ServerUnreliableQueue);
+}
+
+void USpatialNetDriverClientRPC::ProcessReceivedRPCs()
+{
+	USpatialNetDriverRPC::ProcessReceivedRPCs();
+
+	auto CanExtractRPCs = [this](Worker_EntityId EntityId) {
+		return CanExtractRPC(EntityId);
+	};
+	auto ProcessRPC = [this](Worker_EntityId EntityId, ReceivedRPC RPCData, const FRPCMetaData& MetaData) {
+		return ApplyRPC(EntityId, RPCData, MetaData);
+	};
+
+	ClientReliableReceiver->ExtractReceivedRPCs(CanExtractRPCs, ProcessRPC);
+	ClientUnreliableReceiver->ExtractReceivedRPCs(CanExtractRPCs, ProcessRPC);
+}
+
+void USpatialNetDriverClientRPC::GetRPCComponentsOnEntityCreation(const Worker_EntityId EntityId, TArray<FWorkerComponentData>& OutData)
+{
+	// Clients should not flush anything....
+	checkNoEntry();
+}
+
+void USpatialNetDriverClientRPC::Init(USpatialNetDriver* InNetDriver, const SpatialGDK::FSubView& InActorAuthSubView,
+									  const SpatialGDK::FSubView& InActorNonAuthSubView)
+{
+	USpatialNetDriverRPC::Init(InNetDriver, InActorAuthSubView, InActorNonAuthSubView);
+
+	auto constexpr RequiredAuth = SpatialConstants::CLIENT_AUTH_COMPONENT_SET_ID;
+
+	MakeRingBufferWithACKSender("ServerReliable", ERPCType::ServerReliable, RequiredAuth, ServerReliableSender, ServerReliableQueue);
+	MakeRingBufferWithACKSender("ServerUnreliable", ERPCType::ServerUnreliable, RequiredAuth, ServerUnreliableSender,
+								ServerUnreliableQueue);
+
+	MakeRingBufferWithACKReceiver("ClientReliable", ERPCType::ClientReliable, RequiredAuth, ClientReliableReceiver);
+	MakeRingBufferWithACKReceiver("ClientUnreliable", ERPCType::ClientUnreliable, RequiredAuth, ClientUnreliableReceiver);
+}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverRPC.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverRPC.cpp
@@ -88,10 +88,10 @@ FSpatialNetDriverRPC::StandardQueue::SentRPCCallback FSpatialNetDriverRPC::MakeR
 	check(bUpdateCacheInUse.load());
 	if (EventTracer != nullptr)
 	{
-		return [this](FName RPCName, Worker_EntityId EntityId, Worker_ComponentId ComponentId, uint64 RPCId,
-								   const FSpatialGDKSpanId& SpanId) {
-			return OnRPCSent(*EventTracer, UpdateToSend_Cache, RPCName, EntityId, ComponentId, RPCId, SpanId);
-		};
+		return
+			[this](FName RPCName, Worker_EntityId EntityId, Worker_ComponentId ComponentId, uint64 RPCId, const FSpatialGDKSpanId& SpanId) {
+				return OnRPCSent(*EventTracer, UpdateToSend_Cache, RPCName, EntityId, ComponentId, RPCId, SpanId);
+			};
 	}
 	return StandardQueue::SentRPCCallback();
 }
@@ -191,7 +191,8 @@ struct FSpatialNetDriverRPC::RAIIUpdateContext : FStackOnly
 			FSpatialGDKSpanId SpanId;
 			if (RPCSystem.EventTracer != nullptr)
 			{
-				SpanId = RPCSystem.EventTracer->TraceEvent(FSpatialTraceEventBuilder::CreateMergeSendRPCs(Update.EntityId, Update.Update.component_id),
+				SpanId = RPCSystem.EventTracer->TraceEvent(
+					FSpatialTraceEventBuilder::CreateMergeSendRPCs(Update.EntityId, Update.Update.component_id),
 					/* Causes */ Update.Spans.GetData()->GetConstId(), /* NumCauses */ Update.Spans.Num());
 			}
 			RPCSystem.NetDriver.Connection->SendComponentUpdate(Update.EntityId, &Update.Update, SpanId);
@@ -239,7 +240,6 @@ void FSpatialNetDriverRPC::FlushRPCQueueForEntity(Worker_EntityId EntityId, Stan
 	RPCWritingContext Ctx(Queue.Name, MakeUpdateWriteCallback());
 	Queue.Flush(EntityId, Ctx, MakeRPCSentCallback());
 }
-
 
 bool FSpatialNetDriverRPC::CanExtractRPC(Worker_EntityId EntityId) const
 {
@@ -316,8 +316,9 @@ bool FSpatialNetDriverRPC::ApplyRPC(Worker_EntityId EntityId, SpatialGDK::Receiv
 		const TWeakObjectPtr<UObject> ActorReceivingRPC = NetDriver.PackageMap->GetObjectFromEntityId(EntityId);
 		AActor* Actor = CastChecked<AActor>(ActorReceivingRPC.Get());
 		checkf(Actor != nullptr, TEXT("Receiving actor should have been checked in CanReceiveRPC"));
-		UE_LOG(LogSpatialNetDriverRPC, Error, TEXT("Failed to execute RPC on Actor %s (Entity %llu)'s Subobject %i because the Subobject is null"),
-			*Actor->GetName(), EntityId, RPCData.Offset);
+		UE_LOG(LogSpatialNetDriverRPC, Error,
+			   TEXT("Failed to execute RPC on Actor %s (Entity %llu)'s Subobject %i because the Subobject is null"), *Actor->GetName(),
+			   EntityId, RPCData.Offset);
 
 		return RPCConsumed;
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverRPC.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverRPC.cpp
@@ -227,7 +227,6 @@ void FSpatialNetDriverRPC::FlushRPCQueue(StandardQueue& Queue)
 {
 	RAIIUpdateContext UpdateCtx(*this);
 
-	TArray<UpdateToSend> Updates;
 	RPCWritingContext Ctx(Queue.Name, MakeUpdateWriteCallback());
 	Queue.FlushAll(Ctx, MakeRPCSentCallback());
 }
@@ -236,7 +235,6 @@ void FSpatialNetDriverRPC::FlushRPCQueueForEntity(Worker_EntityId EntityId, Stan
 {
 	RAIIUpdateContext UpdateCtx(*this);
 
-	TArray<UpdateToSend> Updates;
 	RPCWritingContext Ctx(Queue.Name, MakeUpdateWriteCallback());
 	Queue.Flush(EntityId, Ctx, MakeRPCSentCallback());
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialTraceUniqueId.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialTraceUniqueId.cpp
@@ -15,6 +15,12 @@ EventTraceUniqueId EventTraceUniqueId::GenerateForRPC(Worker_EntityId Entity, ui
 	return EventTraceUniqueId(ComputedHash);
 }
 
+EventTraceUniqueId EventTraceUniqueId::GenerateForNamedRPC(Worker_EntityId Entity, FName Name, uint64 Id)
+{
+	uint32 ComputedHash = HashCombine(HashCombine(GetTypeHash(static_cast<int64>(Entity)), GetTypeHash(Name.ToString())), GetTypeHash(Id));
+	return EventTraceUniqueId(ComputedHash);
+}
+
 EventTraceUniqueId EventTraceUniqueId::GenerateForProperty(Worker_EntityId Entity, const GDK_PROPERTY(Property) * Property)
 {
 	uint32 ComputedHash = HashCombine(GetTypeHash(static_cast<int64>(Entity)), GetTypeHash(Property->GetName()));

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/RPCTypes.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/RPCTypes.cpp
@@ -90,28 +90,30 @@ Schema_Object* RPCWritingContext::EntityWrite::GetFieldsToWrite()
 	return Fields;
 }
 
-void RPCWritingContext::EntityWrite::RPCWritten(uint32 RPCId) {}
-
-RPCWritingContext::RPCWritingContext(RPCCallbacks::DataWritten InDataWrittenCallback)
+RPCWritingContext::RPCWritingContext(FName InQueueName, RPCCallbacks::DataWritten InDataWrittenCallback)
 	: DataWrittenCallback(InDataWrittenCallback)
+	, QueueName(InQueueName)
 	, Kind(DataKind::ComponentData)
 {
 }
 
-RPCWritingContext::RPCWritingContext(RPCCallbacks::UpdateWritten InUpdateWrittenCallback)
+RPCWritingContext::RPCWritingContext(FName InQueueName, RPCCallbacks::UpdateWritten InUpdateWrittenCallback)
 	: UpdateWrittenCallback(InUpdateWrittenCallback)
+	, QueueName(InQueueName)
 	, Kind(DataKind::ComponentUpdate)
 {
 }
 
-RPCWritingContext::RPCWritingContext(RPCCallbacks::RequestWritten InRequestWrittenCallback)
+RPCWritingContext::RPCWritingContext(FName InQueueName, RPCCallbacks::RequestWritten InRequestWrittenCallback)
 	: RequestWrittenCallback(InRequestWrittenCallback)
+	, QueueName(InQueueName)
 	, Kind(DataKind::CommandRequest)
 {
 }
 
-RPCWritingContext::RPCWritingContext(RPCCallbacks::ResponseWritten InResponseWrittenCallback)
+RPCWritingContext::RPCWritingContext(FName InQueueName, RPCCallbacks::ResponseWritten InResponseWrittenCallback)
 	: ResponseWrittenCallback(InResponseWrittenCallback)
+	, QueueName(InQueueName)
 	, Kind(DataKind::CommandResponse)
 {
 }
@@ -144,9 +146,10 @@ void RPCBufferSender::OnAuthGained(Worker_EntityId EntityId, EntityViewElement c
 	}
 }
 
-void RPCBufferReceiver::OnAdded(Worker_EntityId EntityId, EntityViewElement const& Element)
+void RPCBufferReceiver::OnAdded(FName ReceiverName, Worker_EntityId EntityId, EntityViewElement const& Element)
 {
 	RPCReadingContext readCtx;
+	readCtx.ReaderName = ReceiverName;
 	readCtx.EntityId = EntityId;
 	for (const auto& Component : Element.Components)
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/RPCTypes.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/RPCTypes.cpp
@@ -49,6 +49,8 @@ RPCWritingContext::EntityWrite::~EntityWrite()
 			}
 			break;
 		}
+
+		Ctx.bWriterOpened = false;
 	}
 }
 
@@ -127,6 +129,8 @@ RPCWritingContext::EntityWrite::EntityWrite(RPCWritingContext& InCtx, Worker_Ent
 
 RPCWritingContext::EntityWrite RPCWritingContext::WriteTo(Worker_EntityId EntityId, Worker_ComponentId ComponentId)
 {
+	check(!bWriterOpened);
+	bWriterOpened = true;
 	return EntityWrite(*this, EntityId, ComponentId);
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriverRPC.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriverRPC.h
@@ -1,0 +1,192 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Interop/RPCs/RPCService.h"
+#include "SpatialView/EntityComponentId.h"
+#include "SpatialNetDriverRPC.generated.h"
+
+namespace SpatialGDK
+{
+class SpatialEventTracer;
+}
+
+struct FRPCPayload
+{
+	uint32 Offset;
+	uint32 Index;
+	TArray<uint8> PayloadData;
+
+	void ReadFromSchema(Schema_Object* RPCObject);
+	void WriteToSchema(Schema_Object* RPCObject) const;
+};
+
+struct FRPCCommandPayload : FRPCPayload
+{
+	uint64 UUID;
+};
+
+struct FRPCCrossServerPayload : FRPCPayload
+{
+	uint64 UUID;
+	Worker_EntityId Counterpart;
+};
+
+struct FRPCMetaData
+{
+	uint64 Timestamp;
+	FSpatialGDKSpanId SpanId;
+
+	void ComputeSpanId(FName Name, SpatialGDK::SpatialEventTracer& Tracer, SpatialGDK::EntityComponentId EntityComponent, uint64 RPCId);
+};
+
+template <typename T>
+struct TimestampAndETWrapper
+{
+	TimestampAndETWrapper(FName InRPCName, Worker_ComponentId InComponentId, SpatialGDK::SpatialEventTracer* InEventTracer = nullptr)
+		: RPCName(InRPCName)
+		, ComponentId(InComponentId)
+		, EventTracer(InEventTracer)
+	{
+	}
+
+	using AdditionalData = FRPCMetaData;
+	struct WrappedData
+	{
+		WrappedData() = default;
+		WrappedData(T&& InData)
+			: Data(MoveTemp(InData))
+		{
+		}
+
+		const T& GetData() const { return Data; }
+
+		const FRPCMetaData& GetAdditionalData() const { return MetaData; }
+
+		T Data;
+		FName ReceiverName;
+		FRPCMetaData MetaData;
+	};
+
+	WrappedData MakeWrappedData(Worker_EntityId EntityId, T&& Data, uint64 RPCId)
+	{
+		WrappedData wrapper(MoveTemp(Data));
+		wrapper.ReceiverName = RPCName;
+		wrapper.MetaData.Timestamp = FPlatformTime::Cycles64();
+		if (EventTracer)
+		{
+			wrapper.MetaData.ComputeSpanId(RPCName, *EventTracer, SpatialGDK::EntityComponentId(EntityId, ComponentId), RPCId);
+		}
+
+		return wrapper;
+	}
+
+	FName RPCName;
+	Worker_ComponentId ComponentId;
+	SpatialGDK::SpatialEventTracer* EventTracer = nullptr;
+};
+
+class USpatialLatencyTracer;
+
+UCLASS()
+class SPATIALGDK_API USpatialNetDriverRPC : public UObject
+{
+	GENERATED_BODY()
+public:
+	using StandardQueue = SpatialGDK::TWrappedRPCQueue<FSpatialGDKSpanId>;
+
+	USpatialNetDriverRPC();
+	virtual void Init(USpatialNetDriver* InNetDriver, const SpatialGDK::FSubView& InActorAuthSubView,
+					  const SpatialGDK::FSubView& InActorNonAuthSubView);
+
+	void AdvanceView();
+	virtual void ProcessReceivedRPCs();
+	virtual void FlushRPCUpdates();
+	void FlushRPCQueue(StandardQueue& Queue);
+	void FlushRPCQueue(Worker_EntityId, StandardQueue& Queue);
+	TArray<FWorkerComponentData> GetRPCComponentsOnEntityCreation(const Worker_EntityId EntityId);
+
+protected:
+	void MakeRingBufferWithACKSender(FName QueueName, ERPCType RPCType, Worker_ComponentSetId AuthoritySet,
+									 TUniquePtr<SpatialGDK::RPCBufferSender>& SenderPtr,
+									 TUniquePtr<SpatialGDK::TRPCQueue<FRPCPayload, FSpatialGDKSpanId>>& QueuePtr);
+
+	void MakeRingBufferWithACKReceiver(FName QueueName, ERPCType RPCType, Worker_ComponentSetId AuthoritySet,
+									   TUniquePtr<SpatialGDK::TRPCBufferReceiver<FRPCPayload, TimestampAndETWrapper>>& ReceiverPtr);
+
+	virtual void GetRPCComponentsOnEntityCreation(const Worker_EntityId EntityId, TArray<FWorkerComponentData>& OutData);
+
+	struct UpdateToSend
+	{
+		Worker_EntityId EntityId;
+		FWorkerComponentUpdate Update;
+		TArray<FSpatialGDKSpanId> Spans;
+	};
+
+	StandardQueue::SentRPCCallback MakeRPCSentCallback(TArray<UpdateToSend>& OutUpdates);
+	SpatialGDK::RPCCallbacks::DataWritten MakeDataWriteCallback(TArray<FWorkerComponentData>& OutArray) const;
+	SpatialGDK::RPCCallbacks::UpdateWritten MakeUpdateWriteCallback(TArray<UpdateToSend>& OutUpdates) const;
+
+	void FlushUpdates(TArray<UpdateToSend>&);
+	bool CanExtractRPC(Worker_EntityId);
+	bool CanExtractRPCOnServer(Worker_EntityId);
+	bool ApplyRPC(Worker_EntityId, SpatialGDK::ReceivedRPC, const FRPCMetaData& MetaData);
+
+	USpatialNetDriver* NetDriver;
+
+	USpatialLatencyTracer* LatencyTracer;
+	SpatialGDK::SpatialEventTracer* EventTracer;
+
+	TUniquePtr<SpatialGDK::RPCService> RPCService;
+	// TUniquePtr<SpatialGDK::TRPCBufferReceiver<FRPCPayload, TimestampAndETWrapper>> NetMulticastReceiver;
+};
+
+UCLASS()
+class SPATIALGDK_API USpatialNetDriverServerRPC : public USpatialNetDriverRPC
+{
+	GENERATED_BODY()
+public:
+	USpatialNetDriverServerRPC();
+	void Init(USpatialNetDriver* InNetDriver, const SpatialGDK::FSubView& InActorAuthSubView,
+			  const SpatialGDK::FSubView& InActorNonAuthSubView) override;
+
+	void ProcessReceivedRPCs() override;
+	void FlushRPCUpdates() override;
+
+	TUniquePtr<SpatialGDK::TRPCQueue<FRPCPayload, FSpatialGDKSpanId>> ClientReliableQueue;
+	TUniquePtr<SpatialGDK::TRPCQueue<FRPCPayload, FSpatialGDKSpanId>> ClientUnreliableQueue;
+	TUniquePtr<SpatialGDK::TRPCQueue<FRPCPayload, FSpatialGDKSpanId>> NetMulticastQueue;
+
+protected:
+	void GetRPCComponentsOnEntityCreation(const Worker_EntityId EntityId, TArray<FWorkerComponentData>& OutData) override;
+
+	TUniquePtr<SpatialGDK::RPCBufferSender> ClientReliableSender;
+	TUniquePtr<SpatialGDK::RPCBufferSender> ClientUnreliableSender;
+	TUniquePtr<SpatialGDK::TRPCBufferReceiver<FRPCPayload, TimestampAndETWrapper>> ServerReliableReceiver;
+	TUniquePtr<SpatialGDK::TRPCBufferReceiver<FRPCPayload, TimestampAndETWrapper>> ServerUnreliableReceiver;
+};
+
+UCLASS()
+class SPATIALGDK_API USpatialNetDriverClientRPC : public USpatialNetDriverRPC
+{
+	GENERATED_BODY()
+public:
+	USpatialNetDriverClientRPC();
+	void Init(USpatialNetDriver* InNetDriver, const SpatialGDK::FSubView& InActorAuthSubView,
+			  const SpatialGDK::FSubView& InActorNonAuthSubView) override;
+
+	void ProcessReceivedRPCs() override;
+	void FlushRPCUpdates() override;
+
+	TUniquePtr<SpatialGDK::TRPCQueue<FRPCPayload, FSpatialGDKSpanId>> ServerReliableQueue;
+	TUniquePtr<SpatialGDK::TRPCQueue<FRPCPayload, FSpatialGDKSpanId>> ServerUnreliableQueue;
+
+protected:
+	void GetRPCComponentsOnEntityCreation(const Worker_EntityId EntityId, TArray<FWorkerComponentData>& OutData) override;
+
+	TUniquePtr<SpatialGDK::RPCBufferSender> ServerReliableSender;
+	TUniquePtr<SpatialGDK::RPCBufferSender> ServerUnreliableSender;
+	TUniquePtr<SpatialGDK::TRPCBufferReceiver<FRPCPayload, TimestampAndETWrapper>> ClientReliableReceiver;
+	TUniquePtr<SpatialGDK::TRPCBufferReceiver<FRPCPayload, TimestampAndETWrapper>> ClientUnreliableReceiver;
+};

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriverRPC.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriverRPC.h
@@ -94,15 +94,15 @@ struct TimestampAndETWrapper
 
 	WrappedData MakeWrappedData(Worker_EntityId EntityId, T&& Data, uint64 RPCId)
 	{
-		WrappedData wrapper(MoveTemp(Data));
-		wrapper.ReceiverName = RPCName;
-		wrapper.MetaData.Timestamp = FPlatformTime::Cycles64();
-		if (EventTracer)
+		WrappedData Wrapper(MoveTemp(Data));
+		Wrapper.ReceiverName = RPCName;
+		Wrapper.MetaData.Timestamp = FPlatformTime::Cycles64();
+		if (EventTracer != nullptr)
 		{
-			wrapper.MetaData.ComputeSpanId(RPCName, *EventTracer, SpatialGDK::EntityComponentId(EntityId, ComponentId), RPCId);
+			Wrapper.MetaData.ComputeSpanId(RPCName, *EventTracer, SpatialGDK::EntityComponentId(EntityId, ComponentId), RPCId);
 		}
 
-		return wrapper;
+		return Wrapper;
 	}
 
 	FName RPCName;
@@ -159,6 +159,13 @@ protected:
 	StandardQueue::SentRPCCallback MakeRPCSentCallback(TArray<UpdateToSend>& OutUpdates);
 	SpatialGDK::RPCCallbacks::DataWritten MakeDataWriteCallback(TArray<FWorkerComponentData>& OutArray) const;
 	SpatialGDK::RPCCallbacks::UpdateWritten MakeUpdateWriteCallback(TArray<UpdateToSend>& OutUpdates) const;
+
+	static void OnRPCSent(SpatialGDK::SpatialEventTracer* EventTracer, TArray<UpdateToSend>& OutUpdates, FName Name,
+						  Worker_EntityId EntityId, Worker_ComponentId ComponentId, uint64 RPCId, const FSpatialGDKSpanId& SpanId);
+	static void OnDataWritten(TArray<FWorkerComponentData>& OutArray, Worker_EntityId EntityId, Worker_ComponentId ComponentId,
+							  Schema_ComponentData* InData);
+	static void OnUpdateWritten(TArray<UpdateToSend>& OutUpdates, Worker_EntityId EntityId, Worker_ComponentId ComponentId,
+								Schema_ComponentUpdate* InUpdate);
 
 	void FlushUpdates(TArray<UpdateToSend>&);
 	bool CanExtractRPC(Worker_EntityId);

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriverRPC.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriverRPC.h
@@ -172,7 +172,7 @@ protected:
 	USpatialNetDriver& NetDriver;
 	SpatialGDK::SpatialEventTracer* EventTracer = nullptr;
 	TUniquePtr<SpatialGDK::RPCService> RPCService;
-	
+
 	// Caching the array of updates to send, to avoid a reallocation each frame.
 	TArray<UpdateToSend> UpdateToSend_Cache;
 	std::atomic<bool> bUpdateCacheInUse;

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialTraceUniqueId.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialTraceUniqueId.h
@@ -26,6 +26,7 @@ public:
 	bool IsValid() const { return Hash != 0; }
 
 	static EventTraceUniqueId GenerateForRPC(Worker_EntityId Entity, uint8 Type, uint64 RPCId);
+	static EventTraceUniqueId GenerateForNamedRPC(Worker_EntityId Entity, FName Name, uint64 RPCId);
 	static EventTraceUniqueId GenerateForProperty(Worker_EntityId Entity, const GDK_PROPERTY(Property) * Property);
 	static EventTraceUniqueId GenerateForCrossServerRPC(Worker_EntityId Entity, uint64 UniqueRequestId);
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCQueues.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCQueues.h
@@ -1,0 +1,189 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "Interop/RPCs/RPCService.h"
+
+namespace SpatialGDK
+{
+template <typename Payload, typename AdditionalSendingData = EmptyData>
+struct TRPCLocalOverflowQueue : public TRPCQueue<Payload, AdditionalSendingData>
+{
+	TRPCLocalOverflowQueue(FName InName, TRPCBufferSender<Payload>& Sender)
+		: TRPCQueue<Payload, AdditionalSendingData>(InName, Sender)
+	{
+	}
+
+	void FlushAll(RPCWritingContext& Ctx, const typename TWrappedRPCQueue<AdditionalSendingData>::SentRPCCallback&) override;
+	void Flush(Worker_EntityId EntityId, RPCWritingContext& Ctx, const typename TWrappedRPCQueue<AdditionalSendingData>::SentRPCCallback&,
+			   bool bIgnoreAdded = false) override;
+	void OnAuthLost(Worker_EntityId EntityId) override;
+	void OnAuthGained_ReadComponent(const RPCReadingContext& iCtx) override;
+
+protected:
+	bool FlushQueue(Worker_EntityId EntityId, typename TRPCQueue<Payload, AdditionalSendingData>::QueueData& Queue, RPCWritingContext& Ctx,
+					const typename TWrappedRPCQueue<AdditionalSendingData>::SentRPCCallback&);
+};
+
+template <typename Payload, typename AdditionalSendingData>
+struct TRPCFixedCapacityQueue : public TRPCLocalOverflowQueue<Payload, AdditionalSendingData>
+{
+	TRPCFixedCapacityQueue(FName InName, TRPCBufferSender<Payload>& Sender, uint32 InCapacity)
+		: TRPCLocalOverflowQueue<Payload, AdditionalSendingData>(InName, Sender)
+		, Capacity(InCapacity)
+	{
+	}
+
+	int32 Capacity;
+
+	void Push(Worker_EntityId EntityId, Payload&& Data, AdditionalSendingData&& AddData) override;
+	void FlushAll(RPCWritingContext& Ctx, const typename TWrappedRPCQueue<AdditionalSendingData>::SentRPCCallback&) override;
+	void Flush(Worker_EntityId EntityId, RPCWritingContext& Ctx, const typename TWrappedRPCQueue<AdditionalSendingData>::SentRPCCallback&,
+			   bool bIgnoreAdded = false) override;
+};
+
+template <typename Payload, typename AdditionalSendingData = EmptyData>
+struct TRPCMostRecentQueue : public TRPCFixedCapacityQueue<Payload, AdditionalSendingData>
+{
+	TRPCMostRecentQueue(FName InName, TRPCBufferSender<Payload>& Sender, uint32 InCapacity)
+		: TRPCFixedCapacityQueue<Payload, AdditionalSendingData>(InName, Sender, InCapacity)
+	{
+	}
+
+	void Push(Worker_EntityId EntityId, Payload&& Data, AdditionalSendingData&& AddData) override;
+};
+
+template <typename Payload, typename AdditionalSendingData>
+void TRPCLocalOverflowQueue<Payload, AdditionalSendingData>::FlushAll(
+	RPCWritingContext& Ctx, const typename TWrappedRPCQueue<AdditionalSendingData>::SentRPCCallback& SentCallback)
+{
+	for (auto Iterator = this->Queues.CreateIterator(); Iterator; ++Iterator)
+	{
+		typename TRPCQueue<Payload, AdditionalSendingData>::QueueData& Queue = Iterator->Value;
+		if (Queue.bAdded)
+		{
+			FlushQueue(Iterator->Key, Queue, Ctx, SentCallback);
+		}
+	}
+}
+
+template <typename Payload, typename AdditionalSendingData>
+void TRPCLocalOverflowQueue<Payload, AdditionalSendingData>::Flush(
+	Worker_EntityId EntityId, RPCWritingContext& Ctx, const typename TWrappedRPCQueue<AdditionalSendingData>::SentRPCCallback& SentCallback,
+	bool bIgnoreAdded)
+{
+	typename TRPCQueue<Payload, AdditionalSendingData>::QueueData* Queue = this->Queues.Find(EntityId);
+	if (Queue == nullptr || (!Queue->bAdded && !bIgnoreAdded))
+	{
+		return;
+	}
+
+	FlushQueue(EntityId, *Queue, Ctx, SentCallback);
+}
+
+template <typename Payload, typename AdditionalSendingData>
+void TRPCLocalOverflowQueue<Payload, AdditionalSendingData>::OnAuthGained_ReadComponent(const RPCReadingContext& iCtx)
+{
+}
+
+template <typename Payload, typename AdditionalSendingData>
+void TRPCLocalOverflowQueue<Payload, AdditionalSendingData>::OnAuthLost(Worker_EntityId EntityId)
+{
+	this->Queues.Remove(EntityId);
+}
+
+template <typename Payload, typename AdditionalSendingData>
+bool TRPCLocalOverflowQueue<Payload, AdditionalSendingData>::FlushQueue(
+	Worker_EntityId EntityId, typename TRPCQueue<Payload, AdditionalSendingData>::QueueData& Queue, RPCWritingContext& Ctx,
+	const typename TWrappedRPCQueue<AdditionalSendingData>::SentRPCCallback& SentCallback)
+{
+	uint32_t QueuedRPCs = Queue.RPCs.Num();
+	uint32_t WrittenRPCs = 0;
+	auto WrittenCallback = [this, &Queue, EntityId, &SentCallback, &WrittenRPCs](Worker_ComponentId ComponentId, uint64 RPCId) {
+		if (SentCallback)
+		{
+			SentCallback(this->Name, EntityId, ComponentId, RPCId, Queue.AddData[WrittenRPCs]);
+		}
+		++WrittenRPCs;
+	};
+
+	this->Sender.Write(Ctx, EntityId, Queue.RPCs, WrittenCallback);
+
+	if (WrittenRPCs == QueuedRPCs)
+	{
+		Queue.RPCs.Empty();
+		Queue.AddData.Empty();
+		return true;
+	}
+	else
+	{
+		for (uint32 i = 0; i < WrittenRPCs; ++i)
+		{
+			Queue.RPCs[i] = MoveTemp(Queue.RPCs[i + WrittenRPCs]);
+			Queue.AddData[i] = MoveTemp(Queue.AddData[i + WrittenRPCs]);
+		}
+		Queue.RPCs.SetNum(QueuedRPCs - WrittenRPCs);
+		Queue.AddData.SetNum(QueuedRPCs - WrittenRPCs);
+	}
+
+	return false;
+}
+
+template <typename Payload, typename AdditionalSendingData>
+void TRPCFixedCapacityQueue<Payload, AdditionalSendingData>::Push(Worker_EntityId EntityId, Payload&& Data, AdditionalSendingData&& AddData)
+{
+	typename TRPCQueue<Payload, AdditionalSendingData>::QueueData& Queue = this->Queues.FindOrAdd(EntityId);
+
+	if (Queue.RPCs.Num() < Capacity)
+	{
+		Queue.RPCs.Add(MoveTemp(Data));
+		Queue.AddData.Add(AddData);
+	}
+}
+
+template <typename Payload, typename AdditionalSendingData>
+void TRPCFixedCapacityQueue<Payload, AdditionalSendingData>::FlushAll(
+	RPCWritingContext& Ctx, const typename TWrappedRPCQueue<AdditionalSendingData>::SentRPCCallback& SentCallback)
+{
+	for (auto Iterator = this->Queues.CreateIterator(); Iterator; ++Iterator)
+	{
+		typename TRPCQueue<Payload, AdditionalSendingData>::QueueData& Queue = Iterator->Value;
+		if (Queue.bAdded && Queue.RPCs.Num() > 0)
+		{
+			this->FlushQueue(Iterator->Key, Queue, Ctx, SentCallback);
+			Queue.RPCs.Empty();
+			Queue.AddData.Empty();
+		}
+	}
+}
+
+template <typename Payload, typename AdditionalSendingData>
+void TRPCFixedCapacityQueue<Payload, AdditionalSendingData>::Flush(
+	Worker_EntityId EntityId, RPCWritingContext& Ctx, const typename TWrappedRPCQueue<AdditionalSendingData>::SentRPCCallback& SentCallback,
+	bool bIgnoreAdded)
+{
+	typename TRPCQueue<Payload, AdditionalSendingData>::QueueData* Queue = this->Queues.Find(EntityId);
+	if (Queue == nullptr || (!Queue->bAdded && !bIgnoreAdded))
+	{
+		return;
+	}
+	this->FlushQueue(EntityId, *Queue, Ctx, SentCallback);
+	Queue->RPCs.Empty();
+	Queue->AddData.Empty();
+}
+
+template <typename Payload, typename AdditionalSendingData>
+void TRPCMostRecentQueue<Payload, AdditionalSendingData>::Push(Worker_EntityId EntityId, Payload&& Data, AdditionalSendingData&& AddData)
+{
+	typename TRPCQueue<Payload, AdditionalSendingData>::QueueData& Queue = this->Queues.FindOrAdd(EntityId);
+
+	if (Queue.RPCs.Num() == this->Capacity)
+	{
+		Queue.RPCs.RemoveAt(0);
+		Queue.AddData.RemoveAt(0);
+	}
+	Queue.RPCs.Add(MoveTemp(Data));
+	Queue.AddData.Add(MoveTemp(AddData));
+}
+
+} // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCQueues.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCQueues.h
@@ -6,7 +6,6 @@
 
 namespace SpatialGDK
 {
-
 /**
  * Unbounded queue.
  * Will try to flush everything each frame, and keep the Items that could not be flushed for later

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCQueues.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCQueues.h
@@ -97,8 +97,8 @@ bool TRPCLocalOverflowQueue<Payload, AdditionalSendingData>::FlushQueue(
 	Worker_EntityId EntityId, typename TRPCQueue<Payload, AdditionalSendingData>::QueueData& Queue, RPCWritingContext& Ctx,
 	const typename TWrappedRPCQueue<AdditionalSendingData>::SentRPCCallback& SentCallback)
 {
-	uint32_t QueuedRPCs = Queue.RPCs.Num();
-	uint32_t WrittenRPCs = 0;
+	uint32 QueuedRPCs = Queue.RPCs.Num();
+	uint32 WrittenRPCs = 0;
 	auto WrittenCallback = [this, &Queue, EntityId, &SentCallback, &WrittenRPCs](Worker_ComponentId ComponentId, uint64 RPCId) {
 		if (SentCallback)
 		{
@@ -107,7 +107,9 @@ bool TRPCLocalOverflowQueue<Payload, AdditionalSendingData>::FlushQueue(
 		++WrittenRPCs;
 	};
 
-	this->Sender.Write(Ctx, EntityId, Queue.RPCs, WrittenCallback);
+	const uint32 WrittenRPCsReported = this->Sender.Write(Ctx, EntityId, Queue.RPCs, WrittenCallback);
+
+	check(WrittenRPCs == WrittenRPCsReported);
 
 	if (WrittenRPCs == QueuedRPCs)
 	{

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCQueues.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCQueues.h
@@ -18,15 +18,29 @@ struct TRPCUnboundedQueue : public TRPCQueue<Payload, AdditionalSendingData>
 	{
 	}
 
-	void FlushAll(RPCWritingContext& Ctx, const typename TWrappedRPCQueue<AdditionalSendingData>::SentRPCCallback&) override;
-	void Flush(Worker_EntityId EntityId, RPCWritingContext& Ctx, const typename TWrappedRPCQueue<AdditionalSendingData>::SentRPCCallback&,
-			   bool bIgnoreAdded = false) override;
-	void OnAuthLost(Worker_EntityId EntityId) override;
-	void OnAuthGained_ReadComponent(const RPCReadingContext& iCtx) override;
+	void FlushAll(RPCWritingContext& Ctx, const typename TWrappedRPCQueue<AdditionalSendingData>::SentRPCCallback& SentCallback) override
+	{
+		for (auto Iterator = this->Queues.CreateIterator(); Iterator; ++Iterator)
+		{
+			typename TRPCQueue<Payload, AdditionalSendingData>::QueueData& Queue = Iterator->Value;
+			if (Queue.bAdded)
+			{
+				this->FlushQueue(Iterator->Key, Queue, Ctx, SentCallback);
+			}
+		}
+	}
 
-protected:
-	bool FlushQueue(Worker_EntityId EntityId, typename TRPCQueue<Payload, AdditionalSendingData>::QueueData& Queue, RPCWritingContext& Ctx,
-					const typename TWrappedRPCQueue<AdditionalSendingData>::SentRPCCallback&);
+	void Flush(Worker_EntityId EntityId, RPCWritingContext& Ctx,
+			   const typename TWrappedRPCQueue<AdditionalSendingData>::SentRPCCallback& SentCallback, bool bIgnoreAdded = false) override
+	{
+		typename TRPCQueue<Payload, AdditionalSendingData>::QueueData* Queue = this->Queues.Find(EntityId);
+		if (Queue == nullptr || (!Queue->bAdded && !bIgnoreAdded))
+		{
+			return;
+		}
+
+		this->FlushQueue(EntityId, *Queue, Ctx, SentCallback);
+	}
 };
 
 /**
@@ -35,7 +49,7 @@ protected:
  * It will drop all Items that were not sent when flushing.
  */
 template <typename Payload, typename AdditionalSendingData = RPCEmptyData>
-struct TRPCFixedCapacityQueue : public TRPCUnboundedQueue<Payload, AdditionalSendingData>
+struct TRPCFixedCapacityQueue : public TRPCQueue<Payload, AdditionalSendingData>
 {
 	TRPCFixedCapacityQueue(FName InName, TRPCBufferSender<Payload>& Sender, uint32 InCapacity)
 		: TRPCUnboundedQueue<Payload, AdditionalSendingData>(InName, Sender)
@@ -45,10 +59,43 @@ struct TRPCFixedCapacityQueue : public TRPCUnboundedQueue<Payload, AdditionalSen
 
 	int32 Capacity;
 
-	void Push(Worker_EntityId EntityId, Payload&& Data, AdditionalSendingData&& AddData) override;
-	void FlushAll(RPCWritingContext& Ctx, const typename TWrappedRPCQueue<AdditionalSendingData>::SentRPCCallback&) override;
-	void Flush(Worker_EntityId EntityId, RPCWritingContext& Ctx, const typename TWrappedRPCQueue<AdditionalSendingData>::SentRPCCallback&,
-			   bool bIgnoreAdded = false) override;
+	void Push(Worker_EntityId EntityId, Payload&& Data, AdditionalSendingData&& AddData) override
+	{
+		typename TRPCQueue<Payload, AdditionalSendingData>::QueueData& Queue = this->Queues.FindOrAdd(EntityId);
+
+		if (Queue.RPCs.Num() < Capacity)
+		{
+			Queue.RPCs.Add(MoveTemp(Data));
+			Queue.AddData.Add(AddData);
+		}
+	}
+
+	void FlushAll(RPCWritingContext& Ctx, const typename TWrappedRPCQueue<AdditionalSendingData>::SentRPCCallback& SentCallback) override
+	{
+		for (auto Iterator = this->Queues.CreateIterator(); Iterator; ++Iterator)
+		{
+			typename TRPCQueue<Payload, AdditionalSendingData>::QueueData& Queue = Iterator->Value;
+			if (Queue.bAdded && Queue.RPCs.Num() > 0)
+			{
+				this->FlushQueue(Iterator->Key, Queue, Ctx, SentCallback);
+				Queue.RPCs.Empty();
+				Queue.AddData.Empty();
+			}
+		}
+	}
+
+	void Flush(Worker_EntityId EntityId, RPCWritingContext& Ctx,
+			   const typename TWrappedRPCQueue<AdditionalSendingData>::SentRPCCallback& SentCallback, bool bIgnoreAdded = false) override
+	{
+		typename TRPCQueue<Payload, AdditionalSendingData>::QueueData* Queue = this->Queues.Find(EntityId);
+		if (Queue == nullptr || (!Queue->bAdded && !bIgnoreAdded))
+		{
+			return;
+		}
+		this->FlushQueue(EntityId, *Queue, Ctx, SentCallback);
+		Queue->RPCs.Empty();
+		Queue->AddData.Empty();
+	}
 };
 
 /**
@@ -63,143 +110,18 @@ struct TRPCMostRecentQueue : public TRPCFixedCapacityQueue<Payload, AdditionalSe
 	{
 	}
 
-	void Push(Worker_EntityId EntityId, Payload&& Data, AdditionalSendingData&& AddData) override;
-};
-
-template <typename Payload, typename AdditionalSendingData>
-void TRPCUnboundedQueue<Payload, AdditionalSendingData>::FlushAll(
-	RPCWritingContext& Ctx, const typename TWrappedRPCQueue<AdditionalSendingData>::SentRPCCallback& SentCallback)
-{
-	for (auto Iterator = this->Queues.CreateIterator(); Iterator; ++Iterator)
+	void Push(Worker_EntityId EntityId, Payload&& Data, AdditionalSendingData&& AddData) override
 	{
-		typename TRPCQueue<Payload, AdditionalSendingData>::QueueData& Queue = Iterator->Value;
-		if (Queue.bAdded)
+		typename TRPCQueue<Payload, AdditionalSendingData>::QueueData& Queue = this->Queues.FindOrAdd(EntityId);
+
+		if (Queue.RPCs.Num() == this->Capacity)
 		{
-			FlushQueue(Iterator->Key, Queue, Ctx, SentCallback);
+			Queue.RPCs.RemoveAt(0);
+			Queue.AddData.RemoveAt(0);
 		}
-	}
-}
-
-template <typename Payload, typename AdditionalSendingData>
-void TRPCUnboundedQueue<Payload, AdditionalSendingData>::Flush(
-	Worker_EntityId EntityId, RPCWritingContext& Ctx, const typename TWrappedRPCQueue<AdditionalSendingData>::SentRPCCallback& SentCallback,
-	bool bIgnoreAdded)
-{
-	typename TRPCQueue<Payload, AdditionalSendingData>::QueueData* Queue = this->Queues.Find(EntityId);
-	if (Queue == nullptr || (!Queue->bAdded && !bIgnoreAdded))
-	{
-		return;
-	}
-
-	FlushQueue(EntityId, *Queue, Ctx, SentCallback);
-}
-
-template <typename Payload, typename AdditionalSendingData>
-void TRPCUnboundedQueue<Payload, AdditionalSendingData>::OnAuthGained_ReadComponent(const RPCReadingContext& iCtx)
-{
-}
-
-template <typename Payload, typename AdditionalSendingData>
-void TRPCUnboundedQueue<Payload, AdditionalSendingData>::OnAuthLost(Worker_EntityId EntityId)
-{
-	this->Queues.Remove(EntityId);
-}
-
-template <typename Payload, typename AdditionalSendingData>
-bool TRPCUnboundedQueue<Payload, AdditionalSendingData>::FlushQueue(
-	Worker_EntityId EntityId, typename TRPCQueue<Payload, AdditionalSendingData>::QueueData& Queue, RPCWritingContext& Ctx,
-	const typename TWrappedRPCQueue<AdditionalSendingData>::SentRPCCallback& SentCallback)
-{
-	uint32 QueuedRPCs = Queue.RPCs.Num();
-	uint32 WrittenRPCs = 0;
-	auto WrittenCallback = [this, &Queue, EntityId, &SentCallback, &WrittenRPCs](Worker_ComponentId ComponentId, uint64 RPCId) {
-		if (SentCallback)
-		{
-			SentCallback(this->Name, EntityId, ComponentId, RPCId, Queue.AddData[WrittenRPCs]);
-		}
-		++WrittenRPCs;
-	};
-
-	const uint32 WrittenRPCsReported = this->Sender.Write(Ctx, EntityId, Queue.RPCs, WrittenCallback);
-
-	// Basic check that the written callback was called for every individual RPC.
-	check(WrittenRPCs == WrittenRPCsReported);
-
-	if (WrittenRPCs == QueuedRPCs)
-	{
-		Queue.RPCs.Empty();
-		Queue.AddData.Empty();
-		return true;
-	}
-	else
-	{
-		for (uint32 i = 0; i < WrittenRPCs; ++i)
-		{
-			Queue.RPCs[i] = MoveTemp(Queue.RPCs[i + WrittenRPCs]);
-			Queue.AddData[i] = MoveTemp(Queue.AddData[i + WrittenRPCs]);
-		}
-		Queue.RPCs.SetNum(QueuedRPCs - WrittenRPCs);
-		Queue.AddData.SetNum(QueuedRPCs - WrittenRPCs);
-	}
-
-	return false;
-}
-
-template <typename Payload, typename AdditionalSendingData>
-void TRPCFixedCapacityQueue<Payload, AdditionalSendingData>::Push(Worker_EntityId EntityId, Payload&& Data, AdditionalSendingData&& AddData)
-{
-	typename TRPCQueue<Payload, AdditionalSendingData>::QueueData& Queue = this->Queues.FindOrAdd(EntityId);
-
-	if (Queue.RPCs.Num() < Capacity)
-	{
 		Queue.RPCs.Add(MoveTemp(Data));
-		Queue.AddData.Add(AddData);
+		Queue.AddData.Add(MoveTemp(AddData));
 	}
-}
-
-template <typename Payload, typename AdditionalSendingData>
-void TRPCFixedCapacityQueue<Payload, AdditionalSendingData>::FlushAll(
-	RPCWritingContext& Ctx, const typename TWrappedRPCQueue<AdditionalSendingData>::SentRPCCallback& SentCallback)
-{
-	for (auto Iterator = this->Queues.CreateIterator(); Iterator; ++Iterator)
-	{
-		typename TRPCQueue<Payload, AdditionalSendingData>::QueueData& Queue = Iterator->Value;
-		if (Queue.bAdded && Queue.RPCs.Num() > 0)
-		{
-			this->FlushQueue(Iterator->Key, Queue, Ctx, SentCallback);
-			Queue.RPCs.Empty();
-			Queue.AddData.Empty();
-		}
-	}
-}
-
-template <typename Payload, typename AdditionalSendingData>
-void TRPCFixedCapacityQueue<Payload, AdditionalSendingData>::Flush(
-	Worker_EntityId EntityId, RPCWritingContext& Ctx, const typename TWrappedRPCQueue<AdditionalSendingData>::SentRPCCallback& SentCallback,
-	bool bIgnoreAdded)
-{
-	typename TRPCQueue<Payload, AdditionalSendingData>::QueueData* Queue = this->Queues.Find(EntityId);
-	if (Queue == nullptr || (!Queue->bAdded && !bIgnoreAdded))
-	{
-		return;
-	}
-	this->FlushQueue(EntityId, *Queue, Ctx, SentCallback);
-	Queue->RPCs.Empty();
-	Queue->AddData.Empty();
-}
-
-template <typename Payload, typename AdditionalSendingData>
-void TRPCMostRecentQueue<Payload, AdditionalSendingData>::Push(Worker_EntityId EntityId, Payload&& Data, AdditionalSendingData&& AddData)
-{
-	typename TRPCQueue<Payload, AdditionalSendingData>::QueueData& Queue = this->Queues.FindOrAdd(EntityId);
-
-	if (Queue.RPCs.Num() == this->Capacity)
-	{
-		Queue.RPCs.RemoveAt(0);
-		Queue.AddData.RemoveAt(0);
-	}
-	Queue.RPCs.Add(MoveTemp(Data));
-	Queue.AddData.Add(MoveTemp(AddData));
-}
+};
 
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCService.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCService.h
@@ -10,7 +10,7 @@ class USpatialNetDriver;
 namespace SpatialGDK
 {
 /**
- * The RPCService aggregates Sender and Receiver in order to route updates and events to/from the network.
+ * The RPCService aggregates Sender and Receiver in order to route updates and events from the network.
  * It does not deal directly with actor concepts and RPC data, this is pushed to the user side and individual
  * sender/receiver specialization.
  */
@@ -20,16 +20,6 @@ public:
 	explicit RPCService(const FSubView& InRemoteSubView, const FSubView& InLocalAuthSubView);
 
 	void AdvanceView();
-
-	struct UpdateToSend
-	{
-		Worker_EntityId EntityId;
-		FWorkerComponentUpdate Update;
-		FSpatialGDKSpanId SpanId;
-	};
-	TArray<UpdateToSend> GetRPCsAndAcksToSend();
-	TArray<UpdateToSend> FlushSenderForEntity(Worker_EntityId);
-	TArray<FWorkerComponentData> GetRPCComponentsOnEntityCreation(Worker_EntityId EntityId);
 
 	struct RPCQueueDescription
 	{
@@ -48,6 +38,8 @@ public:
 	void AddRPCQueue(FName QueueName, RPCQueueDescription&& Desc);
 	void AddRPCReceiver(FName ReceiverName, RPCReceiverDescription&& Desc);
 
+	TMap<FName, RPCReceiverDescription>& GetReceivers() { return Receivers; }
+
 private:
 	void AdvanceSenderQueues();
 	void AdvanceReceivers();
@@ -63,9 +55,6 @@ private:
 	static constexpr Worker_ComponentSetId NoAuthorityNeeded = 0;
 	static bool HasReceiverAuthority(const RPCReceiverDescription& Desc, const EntityViewElement& ViewElement);
 	static bool IsReceiverAuthoritySet(const RPCReceiverDescription& Desc, Worker_ComponentSetId ComponentSet);
-
-	RPCCallbacks::DataWritten MakeDataWriteCallback(TArray<FWorkerComponentData>& OutArray) const;
-	RPCCallbacks::UpdateWritten MakeUpdateWriteCallback(TArray<UpdateToSend>& Updates) const;
 
 	const FSubView* RemoteSubView;
 	const FSubView* LocalAuthSubView;

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCService.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCService.h
@@ -38,7 +38,7 @@ public:
 	void AddRPCQueue(FName QueueName, RPCQueueDescription&& Desc);
 	void AddRPCReceiver(FName ReceiverName, RPCReceiverDescription&& Desc);
 
-	TMap<FName, RPCReceiverDescription>& GetReceivers() { return Receivers; }
+	const TMap<FName, RPCReceiverDescription>& GetReceivers() { return Receivers; }
 
 private:
 	void AdvanceSenderQueues();

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCTypes.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCTypes.h
@@ -11,9 +11,14 @@ namespace SpatialGDK
 {
 struct ReceivedRPC
 {
-	uint32 Offset;
-	uint32 Index;
-	TArrayView<const uint8> PayloadData;
+	ReceivedRPC(uint32 InOffset, uint32 InIndex, TArrayView<const uint8> InPayloadData)
+		: Offset(InOffset)
+		, Index(InIndex)
+		, PayloadData(InPayloadData)
+	{}
+	const uint32 Offset;
+	const uint32 Index;
+	const TArrayView<const uint8> PayloadData;
 };
 
 namespace RPCCallbacks

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCTypes.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCTypes.h
@@ -185,7 +185,7 @@ struct NullReceiveWrapper
 
 		const AdditionalData& GetAdditionalData() const
 		{
-			static EmptyData s_Dummy;
+			static RPCEmptyData s_Dummy;
 			return s_Dummy;
 		}
 
@@ -258,7 +258,7 @@ struct TWrappedRPCQueue : public RPCQueue
 {
 	using SentRPCCallback = TFunction<void(FName, Worker_EntityId, Worker_ComponentId, uint64, const AdditionalSendingData&)>;
 
-	virtual void FlushAll(RPCWritingContext& Ctx, const SentRPCCallback&SentCallback) = 0;
+	virtual void FlushAll(RPCWritingContext& Ctx, const SentRPCCallback& SentCallback) = 0;
 	virtual void Flush(Worker_EntityId EntityId, RPCWritingContext& Ctx, const SentRPCCallback&, bool bIgnoreAdded = false) = 0;
 
 protected:

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCTypes.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCTypes.h
@@ -22,7 +22,6 @@ using DataWritten = TFunction<void(Worker_EntityId, Worker_ComponentId, Schema_C
 using UpdateWritten = TFunction<void(Worker_EntityId, Worker_ComponentId, Schema_ComponentUpdate*)>;
 using RequestWritten = TFunction<void(Worker_EntityId, Schema_CommandRequest*)>;
 using ResponseWritten = TFunction<void(Worker_EntityId, Schema_CommandResponse*)>;
-// using RPCExtracted = TFunction<void(FName, Worker_EntityId, Worker_ComponentId, uint64)>;
 using RPCWritten = TFunction<void(Worker_ComponentId, uint64)>;
 
 using CanExtractRPCs = TFunction<bool(Worker_EntityId)>;
@@ -43,8 +42,6 @@ struct RPCReadingContext
 	Schema_Object* Fields = nullptr;
 
 	void OnRPCExtracted(uint64 RPCId) const;
-
-	// RPCCallbacks::RPCExtracted ExtractedCallback;
 };
 
 /**
@@ -120,6 +117,8 @@ protected:
 
 	FName QueueName;
 	const DataKind Kind;
+
+	bool bWriterOpened = false;
 };
 
 /**
@@ -157,7 +156,6 @@ public:
 	virtual void OnRemoved(Worker_EntityId EntityId) = 0;
 	virtual void OnUpdate(const RPCReadingContext& iCtx) = 0;
 	virtual void FlushUpdates(RPCWritingContext&) = 0;
-	// virtual void ExtractReceivedRPCs(const RPCCallbacks::CanExtractRPCs&, const RPCCallbacks::ProcessRPC&) = 0;
 
 	const TSet<Worker_ComponentId>& GetComponentsToRead() const { return ComponentsToRead; }
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/ObjectAllocUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/ObjectAllocUtils.h
@@ -1,0 +1,30 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+/**
+ * Helper to declare that a type cannot be allocated on the heap
+ * (it can still be stored in an array though)
+ * This should be enough to prevent types from becoming polymorphic.
+ * (or if they become polymorphic, it should only be in a context where
+ * the code responsible for storing it knows its final type, hence not needing a virtual dtor)
+ */
+class FNoHeapAllocation
+{
+	void* operator new(size_t) = delete;
+	void* operator new[](size_t) = delete;
+	void operator delete(void*) = delete;
+	void operator delete[](void*) = delete;
+
+public:
+	void* operator new(size_t, void* Placement) { return Placement; }
+};
+
+/**
+ * Helper to declare that a type can only be stored on an auto-storage
+ * (stack most of the time because global storage should be discouraged)
+ */
+class FStackOnly : FNoHeapAllocation
+{
+	void* operator new(size_t, void*) = delete;
+};

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/ObjectAllocUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/ObjectAllocUtils.h
@@ -3,10 +3,10 @@
 #pragma once
 
 /**
- * Helper to declare that a type cannot be allocated on the heap
+ * Helper to declare that a type cannot be allocated on the heap (which remembers the allocation size)
  * (it can still be stored in an array though)
- * This should be enough to prevent types from becoming polymorphic.
- * (or if they become polymorphic, it should only be in a context where
+ * This should be enough to prevent types from requiring polymorphic destruction (calling delete on a base pointer).
+ * (if they become polymorphic, it should only be in a context where
  * the code responsible for storing it knows its final type, hence not needing a virtual dtor)
  */
 class FNoHeapAllocation


### PR DESCRIPTION
#### Description
The modularized RPC infrastructure needed additional facilities to accommodate the need for event tracing.
This boils down to two thing, triggering some behaviour at certain points of the pipeline, and storing some data alongside queued RPC (received/to send). 
To keep the system without opinion as to which types represent EventTracing data, this should be implemented in a way that the system would not need to be modified (too much) if we were to change all the EventTracing types, for instance.
A callback on given events is not enough, or it could be, but the storage would then be divided between queues, and some additional external storage for additional data. This would require additional callbacks for cleanup, and make bookeeping convoluted.
So another approach is to have RPC queues and RPC receivers takes an additional parameter which will specify which additional data needs to be stored alongside the pure RPC data.
The RPCQueue has an additional type that is stored in an array alongside the queued RPCs
The RPCReceiver has a "wrapper" handler, because it needs to compute some data when receiving a RPC.
I would have implemented the RPCQueue template parameter in the same way as the receiver if I had "strided" array views (in order to only expose a subset of the queued data to the writer, who does not need to know about it).

This PR also contains the "opinionated" part of the RPC system (the one tying it into Unreal) that I called "SpatialNetDriverRPC" (as in, the part of the NetDriver that deals with RPCs)

A complete implementation for ClientServer RPCs can be found in : https://github.com/spatialos/UnrealGDK/tree/feature/UNR-5036-add-event-tracing-to-modularised-service-proto2

#### Release note

#### Tests
Ran the EventTracing tests, and the NFR pipeline, with the prototype implementation of ClientServer RPCs.

#### Documentation
