### PR TITLE
UNR-4933: Modify worker coordinator to support lifetime management.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a button to generate functional test maps from the editor. It can be found under **Window** > **Generate test maps**.
 - Added versioning to snapshots. Attempting to load an incompatible snapshot will fail, and output error logs that request the snapshot be regenerated.
 - Add feature flag bEnableInitialOnlyReplicationCondition for COND_InitialOnly support.
+- Added a function that allows the worker coordinator to periodically restart the simulated player clients with a bunch of parameters. This feature is disabled by default and can be enabled via `max_lifetime` setting.
 
 ### Bug fixes:
 - Fixed the exception that was thrown when adding and removing components in Spatial component callbacks.

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Build/Build.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Build/Build.cs
@@ -227,6 +227,7 @@ exit /b !ERRORLEVEL!";
                 ForceSpatialNetworkingUnlessPakSpecified(additionalUATArgs, linuxSimulatedPlayerPath, baseGameName);
 
                 LinuxScripts.WriteWithLinuxLineEndings(LinuxScripts.GetSimulatedPlayerWorkerShellScript(baseGameName), Path.Combine(linuxSimulatedPlayerPath, "StartSimulatedClient.sh"));
+                LinuxScripts.WriteWithLinuxLineEndings(LinuxScripts.GetStopSimulatedPlayerWorkerShellScript(baseGameName), Path.Combine(linuxSimulatedPlayerPath, "StopSimulatedClient.sh"));
                 LinuxScripts.WriteWithLinuxLineEndings(LinuxScripts.GetSimulatedPlayerCoordinatorShellScript(baseGameName), Path.Combine(linuxSimulatedPlayerPath, "StartCoordinator.sh"));
 
                 // Coordinator files are located in      ./UnrealGDK/SpatialGDK/Binaries/ThirdParty/Improbable/Programs/WorkerCoordinator/.

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Common/LinuxScripts.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/Common/LinuxScripts.cs
@@ -61,6 +61,7 @@ sleep 5
 
 chmod +x WorkerCoordinator.exe
 chmod +x StartSimulatedClient.sh
+chmod +x StopSimulatedClient.sh
 chmod +x {0}.sh
 
 NEW_USER=unrealworker
@@ -69,6 +70,11 @@ chown -R $NEW_USER:$NEW_USER $(pwd) 2> /improbable/logs/CoordinatorErrors.log
 chmod -R o+rw /improbable/logs 2> /improbable/logs/CoordinatorErrors.log
 
 mono WorkerCoordinator.exe $@ 2> /improbable/logs/CoordinatorErrors.log";
+
+        public const string StopSimulatedPlayerWorkerShellScript =
+@"#!/bin/bash
+PLAYER_ID=$1
+ps -ef | grep $PLAYER_ID | grep -v grep | grep -v .sh | awk '{print $2'} | xargs kill -9";
 
         // Returns a version of UnrealWorkerShellScript with baseGameName templated into the right places.
         // baseGameName should be the base name of your Unreal game.
@@ -82,6 +88,11 @@ mono WorkerCoordinator.exe $@ 2> /improbable/logs/CoordinatorErrors.log";
         public static string GetSimulatedPlayerWorkerShellScript(string baseGameName)
         {
             return string.Format(SimulatedPlayerWorkerShellScript, baseGameName);
+        }
+
+        public static string GetStopSimulatedPlayerWorkerShellScript(string baseGameName)
+        {
+            return StopSimulatedPlayerWorkerShellScript;
         }
 
         // Returns a version of SimulatedPlayerCoordinatorShellScript with baseGameName templated into the right places.

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/LifetimeComponent.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/LifetimeComponent.cs
@@ -1,0 +1,208 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+using System;
+using System.Threading;
+using System.Collections.Generic;
+
+namespace Improbable.WorkerCoordinator
+{
+    /// <summary>
+    /// Simulated player client's information.
+    /// The coordinator use this to start & restart simulated player clients.
+    /// </summary>
+    struct ClientInfo
+    {
+        public string ClientName;
+        public string DevAuthToken;
+        public string TargetDeployment;
+        public long StartTick;
+        public long EndTick;
+    }
+
+    internal interface ILifetimeComponentHost
+    {
+        void StartClient(ClientInfo clientInfo);
+        void StopClient(ClientInfo clientInfo);
+
+        void CheckPlayerStatus();
+    }
+
+    internal class LifetimeComponent
+    {
+        // Arguments for lifetime management.
+        public const string MaxLifetimeArg = "max_lifetime";
+        public const string MinLifetimeArg = "min_lifetime";
+        public const string RestartAfterSecondsArg = "restart_after_seconds";
+        public const string UseNewSimulatedPlayerArg = "use_new_simulated_player";
+
+        // Lifetime management parameters.
+        private ILifetimeComponentHost Host;
+        private bool UseNewSimulatedPlayer;
+        private int MaxLifetime;
+        private int MinLifetime;
+        private int RestartAfterSeconds;
+        private List<ClientInfo> WaitingList;
+        private List<ClientInfo> RunningList;
+
+        private int TickIntervalSeconds = 1;
+        private Logger Logger;
+        private Random Random;
+
+        // Temp variables to avoid allocate variable in tick method.
+        private long CurTicks;
+        private int Length;
+        private ClientInfo SimulatedClientInfo;
+
+        /// <summary>
+        /// Create lifetime component, will return null if max lifetime argument not in args.
+        /// </summary>
+        /// <param name="logger"></param>
+        /// <param name="args"></param>
+        /// <param name="numArgs"></param>
+        /// <returns></returns>
+        public static LifetimeComponent Create(Logger logger, string[] args, out int numArgs)
+        {
+            numArgs = 0;
+
+            // Max lifetime argument.
+            int maxLifetime = 0;
+            if (Util.HasIntegerArgument(args, MaxLifetimeArg))
+            {
+                maxLifetime = Util.GetIntegerArgument(args, MaxLifetimeArg);
+                numArgs++;
+            }
+
+            // Use max lifetime as default.
+            int minLifetime = maxLifetime;
+            if (Util.HasIntegerArgument(args, MinLifetimeArg))
+            {
+                minLifetime = Util.GetIntegerArgument(args, MinLifetimeArg);
+                numArgs++;
+            }
+
+            // Use 60 seconds as default.
+            int restartAfterSeconds = 60;
+            if (Util.HasIntegerArgument(args, RestartAfterSecondsArg))
+            {
+                restartAfterSeconds = Util.GetIntegerArgument(args, RestartAfterSecondsArg);
+                numArgs++;
+            }
+
+            // Default do not use new simulated player to restart.
+            int useNewSimulatedPlayer = 0;
+            if (Util.HasIntegerArgument(args, UseNewSimulatedPlayerArg))
+            {
+                useNewSimulatedPlayer = Util.GetIntegerArgument(args, UseNewSimulatedPlayerArg);
+                numArgs++;
+            }
+
+            // Disable function by do not define max lifetime.
+            if (maxLifetime > 0)
+            {
+                return new LifetimeComponent(maxLifetime, minLifetime, restartAfterSeconds, useNewSimulatedPlayer > 0, logger);
+            }
+
+            return null;
+        }
+
+        private LifetimeComponent(int maxLifetime, int minLifetime, int restartAfterSeconds, bool useNewSimulatedPlayer, Logger logger)
+        {
+            UseNewSimulatedPlayer = useNewSimulatedPlayer;
+            MaxLifetime = maxLifetime;
+            MinLifetime = minLifetime;
+            RestartAfterSeconds = restartAfterSeconds;
+            Logger = logger;
+
+            WaitingList = new List<ClientInfo>();
+            RunningList = new List<ClientInfo>();
+
+            Random = new Random(Guid.NewGuid().GetHashCode());
+        }
+
+        public void SetHost(ILifetimeComponentHost host)
+        {
+            Host = host;
+        }
+
+        public void AddSimulatedPlayer(ClientInfo clientInfo)
+        {
+            WaitingList.Add(clientInfo);
+
+            Logger.WriteLog($"[LifetimeComponent][{DateTime.Now.ToString("HH:mm:ss")}] Add client ClientName={clientInfo.ClientName}.");
+        }
+
+        private long NewLifetimeTicks()
+        {
+            return TimeSpan.FromMinutes(Random.Next(MinLifetime, MaxLifetime)).Ticks;
+        }
+
+        public void Start()
+        {
+            // Loop tick.
+            while (true)
+            {
+                Tick();
+
+                Thread.Sleep(TimeSpan.FromSeconds(TickIntervalSeconds));
+            }
+        }
+
+        private void Tick()
+        {
+            CurTicks = DateTime.Now.Ticks;
+
+            // Data flow is waiting list -> running list -> waiting list.
+            // Checking sequence is running list -> waiting list.
+
+            // Check player status, restart player client if it exit early.
+            Host?.CheckPlayerStatus();
+
+            // Running list.
+            Length = RunningList.Count;
+            for (int i = Length - 1; i >= 0; --i)
+            {
+                SimulatedClientInfo = RunningList[i];
+                if (CurTicks >= SimulatedClientInfo.EndTick)
+                {
+                    // End client.
+                    Host?.StopClient(SimulatedClientInfo);
+
+                    Logger.WriteLog($"[LifetimeComponent][{DateTime.Now.ToString("HH:mm:ss")}] Stop client ClientName={SimulatedClientInfo.ClientName}.");
+
+                    // Delay 10 seconds to restart.
+                    SimulatedClientInfo.StartTick = TimeSpan.FromSeconds(RestartAfterSeconds).Ticks + CurTicks;
+
+                    // Restart with new simulated player.
+                    if (UseNewSimulatedPlayer)
+                    {
+                        SimulatedClientInfo.ClientName = "SimulatedPlayer" + Guid.NewGuid();
+                    }
+
+                    // Move to wait list.
+                    RunningList.RemoveAt(i);
+                    WaitingList.Add(SimulatedClientInfo);
+                }
+            }
+
+            // Waiting list.
+            Length = WaitingList.Count;
+            for (int i = Length - 1; i >= 0; --i)
+            {
+                SimulatedClientInfo = WaitingList[i];
+                if (CurTicks >= SimulatedClientInfo.StartTick)
+                {
+                    // Start client.
+                    Host?.StartClient(SimulatedClientInfo);
+
+                    Logger.WriteLog($"[LifetimeComponent][{DateTime.Now.ToString("HH:mm:ss")}] Start client ClientName ={SimulatedClientInfo.ClientName}.");
+
+                    // Update lifetime.
+                    SimulatedClientInfo.EndTick = CurTicks + NewLifetimeTicks();
+
+                    // Move to running list.
+                    WaitingList.RemoveAt(i);
+                    RunningList.Add(SimulatedClientInfo);
+                }
+            }
+        }
+    }
+}

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/ManagedWorkerCoordinator.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/ManagedWorkerCoordinator.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Improbable.Worker.CInterop;
+using System.Diagnostics;
 
 namespace Improbable.WorkerCoordinator
 {
@@ -13,7 +14,7 @@ namespace Improbable.WorkerCoordinator
     /// Worker coordinator that connects and runs simulated players.
     /// The coordinator runs as a managed worker inside a hosting deployment (i.e. the simulated player deployment).
     /// </summary>
-    internal class ManagedWorkerCoordinator : AbstractWorkerCoordinator
+    internal class ManagedWorkerCoordinator : AbstractWorkerCoordinator, ILifetimeComponentHost
     {
         // Arguments for the coordinator.
         private const string SimulatedPlayerSpawnCountArg = "simulated_player_spawn_count";
@@ -33,6 +34,9 @@ namespace Improbable.WorkerCoordinator
 
         private const string CoordinatorWorkerType = "SimulatedPlayerCoordinator";
         private const string SimulatedPlayerFilename = "StartSimulatedClient.sh";
+        private const string StopSimulatedPlayerFilename = "StopSimulatedClient.sh";
+
+        private const int MillisToTicks = 10000;
 
         private static Random Random;
 
@@ -43,6 +47,9 @@ namespace Improbable.WorkerCoordinator
         private int NumSimulatedPlayersToStart;
         private int InitialStartDelayMillis;
         private string[] SimulatedPlayerArgs;
+
+        // Coordinator use this to restart simulated player clients.
+        private LifetimeComponent LifetimeComponent;
 
         /// <summary>
         /// The arguments to start the coordinator must begin with:
@@ -90,7 +97,10 @@ namespace Improbable.WorkerCoordinator
                 numArgsToSkip++;
             }
 
-            return new ManagedWorkerCoordinator(logger)
+            LifetimeComponent lifetimeComponent = LifetimeComponent.Create(logger, args, out int numArgs);
+            numArgsToSkip += numArgs;
+
+            ManagedWorkerCoordinator coordinator = new ManagedWorkerCoordinator(logger)
             {
                 // Receptionist args.
                 ReceptionistHost = args[1],
@@ -102,8 +112,18 @@ namespace Improbable.WorkerCoordinator
                 InitialStartDelayMillis = initialStartDelayMillis,
 
                 // Remove arguments that are only for the coordinator.
-                SimulatedPlayerArgs = args.Skip(numArgsToSkip).ToArray()
+                SimulatedPlayerArgs = args.Skip(numArgsToSkip).ToArray(),
+
+                // Lifetime component is an option.
+                LifetimeComponent = lifetimeComponent
             };
+
+            if (coordinator.LifetimeComponent != null)
+            {
+                coordinator.LifetimeComponent.SetHost(coordinator);
+            }
+
+            return coordinator;
         }
 
         private ManagedWorkerCoordinator(Logger logger) : base(logger)
@@ -136,21 +156,50 @@ namespace Improbable.WorkerCoordinator
             }
 
             Array.Sort(startDelaysMillis);
-            for (int i = 0; i < NumSimulatedPlayersToStart; i++)
+
+            if (LifetimeComponent == null)
             {
-                string clientName = "SimulatedPlayer" + Guid.NewGuid();
-                var timeToSleep = startDelaysMillis[i];
-                if (i > 0)
+                for (int i = 0; i < NumSimulatedPlayersToStart; i++)
                 {
-                    timeToSleep -= startDelaysMillis[i - 1];
+                    string clientName = "SimulatedPlayer" + Guid.NewGuid();
+                    var timeToSleep = startDelaysMillis[i];
+                    if (i > 0)
+                    {
+                        timeToSleep -= startDelaysMillis[i - 1];
+                    }
+
+                    Thread.Sleep(timeToSleep);
+                    StartSimulatedPlayer(clientName, devAuthToken, targetDeployment);
                 }
 
-                Thread.Sleep(timeToSleep);
-                StartSimulatedPlayer(clientName, devAuthToken, targetDeployment);
+                // Wait for all clients to exit.
+                WaitForPlayersToExit();
             }
+            else
+            {
+                long curTicks = DateTime.Now.Ticks;
+                for (int i = 0; i < NumSimulatedPlayersToStart; i++)
+                {
+                    string clientName = "SimulatedPlayer" + Guid.NewGuid();
+                    var timeToSleep = startDelaysMillis[i];
+                    if (i > 0)
+                    {
+                        timeToSleep -= startDelaysMillis[i - 1];
+                    }
 
-            // Wait for all clients to exit.
-            WaitForPlayersToExit();
+                    ClientInfo clientInfo = new ClientInfo()
+                    {
+                        ClientName = clientName,
+                        StartTick = timeToSleep * MillisToTicks + curTicks,
+                        DevAuthToken = devAuthToken,
+                        TargetDeployment = targetDeployment
+                    };
+
+                    LifetimeComponent.AddSimulatedPlayer(clientInfo);
+                }
+
+                LifetimeComponent.Start();
+            }
         }
 
         private void StartSimulatedPlayer(string simulatedPlayerName, string devAuthToken, string targetDeployment)
@@ -194,6 +243,29 @@ namespace Improbable.WorkerCoordinator
             }
 
             return defaultValue;
+        }
+
+        private void KillProcess(string key)
+        {
+            try
+            {
+                Process process = Process.Start(StopSimulatedPlayerFilename, key);
+                process.WaitForExit();
+            }
+            catch(Exception e)
+            {
+                Logger.WriteError($"Failed to kill process with key={key}: {e.Message}");
+            }
+        }
+
+        public void StartClient(ClientInfo clientInfo)
+        {
+            StartSimulatedPlayer(clientInfo.ClientName, clientInfo.DevAuthToken, clientInfo.TargetDeployment);
+        }
+
+        public void StopClient(ClientInfo clientInfo)
+        {
+            KillProcess(clientInfo.ClientName);
         }
     }
 }

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/ManagedWorkerCoordinator.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/ManagedWorkerCoordinator.cs
@@ -151,20 +151,13 @@ namespace Improbable.WorkerCoordinator
 
             Array.Sort(startDelaysMillis);
 
-            long curTicks = DateTime.Now.Ticks;
+            DateTime curTime = DateTime.Now;
             for (int i = 0; i < NumSimulatedPlayersToStart; i++)
             {
-                string clientName = "SimulatedPlayer" + Guid.NewGuid();
-                var timeToSleep = startDelaysMillis[i];
-                if (i > 0)
-                {
-                    timeToSleep -= startDelaysMillis[i - 1];
-                }
-
                 ClientInfo clientInfo = new ClientInfo()
                 {
-                    ClientName = clientName,
-                    StartTick = timeToSleep * TimeSpan.TicksPerMillisecond + curTicks,
+                    ClientName = $"SimulatedPlayer{Guid.NewGuid()}",
+                    StartTime = curTime.AddMilliseconds(startDelaysMillis[i]),
                     DevAuthToken = devAuthToken,
                     TargetDeployment = targetDeployment
                 };

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/RegisseurWorkerCoordinator.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/RegisseurWorkerCoordinator.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Diagnostics;
 
 namespace Improbable.WorkerCoordinator
 {
@@ -13,7 +14,7 @@ namespace Improbable.WorkerCoordinator
     /// Runs as a standalone binary without creating a connection to a deployment, by connecting a configurable
     /// number of simulated players over configurable delays.
     /// </summary>
-    internal class RegisseurWorkerCoordinator : AbstractWorkerCoordinator
+    internal class RegisseurWorkerCoordinator : AbstractWorkerCoordinator, ILifetimeComponentHost
     {
         private const string SimulatedPlayerSpawnCountArg = "simulated_player_spawn_count";
         private const string InitialStartDelayArg = "coordinator_start_delay_millis";
@@ -21,12 +22,18 @@ namespace Improbable.WorkerCoordinator
         private const string SimulatedPlayerWorkerNamePlaceholderArg = "<IMPROBABLE_WORKER_ID>";
 
         private const string SimulatedPlayerFilename = "StartSimulatedClient.sh";
+        private const string StopSimulatedPlayerFilename = "StopSimulatedClient.sh";
+
+        private const int MillisToTicks = 10000;
 
         // Coordinator options.
         private int NumSimulatedPlayersToStart;
         private int InitialStartDelayMillis;
         private int StartIntervalMillis;
         private string[] SimulatedPlayerArgs;
+
+        // Lifetime management parameters.
+        LifetimeComponent LifetimeComponent;
 
         /// <summary>
         /// The arguments to start the coordinator must begin with:
@@ -42,17 +49,31 @@ namespace Improbable.WorkerCoordinator
         /// </summary>
         public static RegisseurWorkerCoordinator FromArgs(Logger logger, string[] args)
         {
-            return new RegisseurWorkerCoordinator(logger)
+            var numArgsToSkip = 3;
+
+            LifetimeComponent lifetimeComponent = LifetimeComponent.Create(logger, args, out int numArgs);
+            numArgsToSkip += numArgs;
+
+            RegisseurWorkerCoordinator coordinator = new RegisseurWorkerCoordinator(logger)
             {
                 NumSimulatedPlayersToStart = Util.GetIntegerArgumentOrDefault(args, SimulatedPlayerSpawnCountArg, 1),
                 InitialStartDelayMillis = Util.GetIntegerArgumentOrDefault(args, InitialStartDelayArg, 10000),
                 StartIntervalMillis = Util.GetIntegerArgumentOrDefault(args, SpawnIntervalArg, 1000),
 
+                LifetimeComponent = lifetimeComponent,
+
                 // First 3 arguments are for the coordinator worker only.
                 // The 4th argument (worker id) is consumed by the simulated player startup script,
                 // and not passed to the simulated player.
-                SimulatedPlayerArgs = args.Skip(3).ToArray()
+                SimulatedPlayerArgs = args.Skip(numArgsToSkip).ToArray()
             };
+
+            if (coordinator.LifetimeComponent != null)
+            {
+                coordinator.LifetimeComponent.SetHost(coordinator);
+            }
+
+            return coordinator;
         }
 
         private RegisseurWorkerCoordinator(Logger logger) : base(logger)
@@ -62,13 +83,38 @@ namespace Improbable.WorkerCoordinator
         public override void Run()
         {
             Thread.Sleep(InitialStartDelayMillis);
-            for (int i = 0; i < NumSimulatedPlayersToStart; i++)
-            {
-                StartSimulatedPlayer($"SimulatedPlayer{Guid.NewGuid()}");
-                Thread.Sleep(StartIntervalMillis);
-            }
 
-            WaitForPlayersToExit();
+            if (LifetimeComponent == null)
+            {
+                // Lifetime mode: off.
+                for (int i = 0; i < NumSimulatedPlayersToStart; i++)
+                {
+                    StartSimulatedPlayer($"SimulatedPlayer{Guid.NewGuid()}");
+
+                    Thread.Sleep(StartIntervalMillis);
+                }
+
+                WaitForPlayersToExit();
+            }
+            else
+            {
+                // Lifetime mode: on.
+                long curTicks = DateTime.Now.Ticks;
+
+                for (int i = 0; i < NumSimulatedPlayersToStart; i++)
+                {
+                    // Push into wait list.
+                    ClientInfo clientInfo = new ClientInfo()
+                    {
+                        ClientName = $"SimulatedPlayer{Guid.NewGuid()}",
+                        StartTick = curTicks + StartIntervalMillis * MillisToTicks
+                    };
+
+                    LifetimeComponent.AddSimulatedPlayer(clientInfo);
+                }
+
+                LifetimeComponent?.Start();
+            }
         }
 
         public void StartSimulatedPlayer(string name)
@@ -80,6 +126,28 @@ namespace Improbable.WorkerCoordinator
 
             string simulatedPlayerArgs = string.Join(" ", args);
             CreateSimulatedPlayerProcess(name, SimulatedPlayerFilename, simulatedPlayerArgs);
+        }
+        private void KillProcess(string key)
+        {
+            try
+            {
+                Process process = Process.Start(StopSimulatedPlayerFilename, key);
+                process.WaitForExit();
+            }
+            catch (Exception e)
+            {
+                Logger.WriteError($"Failed to kill process with key={key}: {e.Message}");
+            }
+        }
+
+        public void StartClient(ClientInfo clientInfo)
+        {
+            StartSimulatedPlayer(clientInfo.ClientName);
+        }
+
+        public void StopClient(ClientInfo clientInfo)
+        {
+            KillProcess(clientInfo.ClientName);
         }
     }
 }

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/RegisseurWorkerCoordinator.cs
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/RegisseurWorkerCoordinator.cs
@@ -79,7 +79,7 @@ namespace Improbable.WorkerCoordinator
         {
             Thread.Sleep(InitialStartDelayMillis);
 
-            long curTicks = DateTime.Now.Ticks;
+            DateTime curTime = DateTime.Now;
 
             for (int i = 0; i < NumSimulatedPlayersToStart; i++)
             {
@@ -87,7 +87,7 @@ namespace Improbable.WorkerCoordinator
                 ClientInfo clientInfo = new ClientInfo()
                 {
                     ClientName = $"SimulatedPlayer{Guid.NewGuid()}",
-                    StartTick = curTicks + StartIntervalMillis * TimeSpan.TicksPerMillisecond
+                    StartTime = curTime.AddMilliseconds(StartIntervalMillis * i)
                 };
 
                 LifetimeComponent.AddSimulatedPlayer(clientInfo);

--- a/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/WorkerCoordinator.csproj
+++ b/SpatialGDK/Build/Programs/Improbable.Unreal.Scripts/WorkerCoordinator/WorkerCoordinator.csproj
@@ -55,6 +55,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CoordinatorConnection.cs" />
+    <Compile Include="LifetimeComponent.cs" />
     <Compile Include="Logger.cs" />
     <Compile Include="Util.cs" />
     <Compile Include="RegisseurWorkerCoordinator.cs" />


### PR DESCRIPTION
#### Description
[UNR-4933 Modify Worker Coordinator to restart simplayers](https://improbableio.atlassian.net/browse/UNR-4933?atlOrigin=eyJpIjoiMWI1YTIwYjU3YTQzNDlkNjk5OWYyYzQ3ZTljNDkxZTIiLCJwIjoiaiJ9)

Modify worker coordinator to support lifetime management. 

Worker coordinator can periodically do these:

- Start a simulated player client with a random lifetime.
- Wait for the lifetime runs out.
- Stop the simulated player client and wait for it timeout at server.
- Restart the simulated player client.

Parameters:

- `max_lifetime` **Default is not to turn on this function.** Maximal random range about the client's lifetime in seconds.
- `min_lifetime` Minimal random range about the client's lifetime in seconds.
- `restart_after_seconds` When the client runs out of lifetime and ends, wait for seconds to restart it.
- `use_new_simulated_player` Default is restart the client with the same player id, set to 1 is restart it with new player id.

#### Release note
Add a function that allows the worker coordinator to periodically restart the simulated player clients with a bunch of parameters. This feature is disabled by default and can be enabled via `max_lifetime` setting.

#### Tests
Test this branch with NFR:

- UnrealEngine branch `4.26-SpatialOSUnrealGDK`
- TestGymBuildkite branch `feature/7days-uptime-coordinator-test`.
- Game branch `uptime_joann_pr`.
- Yaml: `gdk-7days-uptime-manual-coordinator-restart-player.yaml` or `gdk-7days-uptime-manual-coordinator-restart-new-player.yaml`

Test this branch with cloud deployment:

- UnrealEngine branch `4.26-SpatialOSUnrealGDK`
- UnrealGDKTestGyms branch `master`.
- Launch cloud deployment with simulated player clients.

#### Documentation
[Uptime - Worker Coordinator Changes: Design Doc](https://docs.google.com/document/d/1UX5Kg2eaFahu3-_oN0fM5Y8sXJfBVgRX8islu-3bJEU/edit?usp=sharing)

#### Reminders (IMPORTANT)
This updates changes C# tools in `SpatialGDK\Build\Programs\Improbable.Unreal.Scripts`:
* Increment the number in `RequireSetup`. This will automatically run `Setup.bat` or `Setup.sh` when the GDK is next pulled.

#### Primary reviewers
@jayprobable @m-samiec @improbable-valentyn @improbable-dmitrii @siliviali 
