### PR TITLE
UNR-4915 fix auto generated launch config for clients.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed EntityPool capacity overflow issue by removing the ability from the gdk settings to request a pool size larger than int32_max.
 - Fixed an issue where components added to a scene actor would be replicated incorrectly.
 - Fixed an issue where an actor channel was added to the wrong net connection.
+- Fixed an issue where an auto generated launch config was giving the client worker too many permissions.
 
 ## [`0.12.0`] - 2021-02-01
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
@@ -125,6 +125,11 @@ bool GenerateLaunchConfig(const FString& LaunchConfigPath, const FSpatialLaunchC
 		FWorkerTypeLaunchSection ClientWorker;
 		ClientWorker.NumEditorInstances = 0;
 		ClientWorker.WorkerTypeName = SpatialConstants::DefaultClientWorkerType;
+		ClientWorker.WorkerPermissions.bAllowEntityCreation = false;
+		ClientWorker.WorkerPermissions.bAllowEntityDeletion = false;
+		ClientWorker.WorkerPermissions.bDisconnectWorker = false;
+		ClientWorker.WorkerPermissions.bReserveEntityID = false;
+		ClientWorker.WorkerPermissions.bAllowEntityQuery = true;
 		WriteWorkerSection(Writer, ClientWorker);
 
 		// For cloud configs we always add the SimulatedPlayerCoordinator and DeploymentManager.


### PR DESCRIPTION
#### Description
Fix/limit default client permissions from auto generated launch config.

#### Release note
Added to release notes.
- Fixed an issue where an auto generated launch config was giving the client worker too many permissions.

