### PR TITLE
Move RPC logic from sender into RPC service

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -303,7 +303,6 @@ bool USpatialActorChannel::CleanUp(const bool bForDestroy, EChannelCloseReason C
 		if (CloseReason == EChannelCloseReason::Destroyed || CloseReason == EChannelCloseReason::LevelUnloaded)
 		{
 			NetDriver->GetRPCService()->ClearPendingRPCs(EntityId);
-			Sender->ClearPendingRPCs(EntityId);
 		}
 		NetDriver->RemoveActorChannel(EntityId, *this);
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -2242,7 +2242,7 @@ void USpatialNetDriver::TickFlush(float DeltaTime)
 
 	if (RPCService != nullptr)
 	{
-		RPCService->Flush();
+		RPCService->PushUpdates();
 	}
 
 	if (IsServer())

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1761,7 +1761,7 @@ void USpatialNetDriver::ProcessRPC(AActor* Actor, UObject* SubObject, UFunction*
 	}
 
 	const FRPCInfo& Info = ClassInfoManager->GetRPCInfo(CallingObject, Function);
-	RPCPayload Payload = Sender->CreateRPCPayloadFromParams(CallingObject, CallingObjectRef, Function, Info.Type, Parameters);
+	RPCPayload Payload = RPCService->CreateRPCPayloadFromParams(CallingObject, CallingObjectRef, Function, Info.Type, Parameters);
 
 	const USpatialGDKSettings* Settings = GetDefault<USpatialGDKSettings>();
 	SpatialGDK::RPCSender SenderInfo;
@@ -1817,7 +1817,7 @@ void USpatialNetDriver::ProcessRPC(AActor* Actor, UObject* SubObject, UFunction*
 		}
 	}
 
-	Sender->ProcessOrQueueOutgoingRPC(CallingObjectRef, SenderInfo, MoveTemp(Payload));
+	RPCService->ProcessOrQueueOutgoingRPC(CallingObjectRef, SenderInfo, MoveTemp(Payload));
 }
 
 // SpatialGDK: This is a modified and simplified version of UNetDriver::ServerReplicateActors.
@@ -2240,9 +2240,9 @@ void USpatialNetDriver::TickFlush(float DeltaTime)
 #endif // WITH_SERVER_CODE
 	}
 
-	if (Sender != nullptr)
+	if (RPCService != nullptr)
 	{
-		Sender->FlushRPCService();
+		RPCService->Flush();
 	}
 
 	if (IsServer())

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -512,7 +512,7 @@ void USpatialNetDriver::CreateAndInitializeCoreClasses()
 		ClientConnectionManager = MakeUnique<SpatialGDK::ClientConnectionManager>(SystemEntitySubview, this);
 
 		Dispatcher->Init(Receiver, StaticComponentView, SpatialMetrics, SpatialWorkerFlags);
-		Sender->Init(this, &TimerManager, RPCService.Get(), Connection->GetEventTracer());
+		Sender->Init(this, &TimerManager, Connection->GetEventTracer());
 		Receiver->Init(this, Connection->GetEventTracer());
 		GlobalStateManager->Init(this);
 		SnapshotManager->Init(Connection, GlobalStateManager, Receiver);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
@@ -1692,7 +1692,7 @@ void ActorSystem::CreateTombstoneEntity(AActor* Actor)
 
 	CreateEntityWithRetries(EntityId, Actor->GetName(), MoveTemp(Components));
 
-	UE_LOG(LogSpatialSender, Log,
+	UE_LOG(LogActorSystem, Log,
 		   TEXT("Creating tombstone entity for actor. "
 				"Actor: %s. Entity ID: %d."),
 		   *Actor->GetName(), EntityId);
@@ -1710,12 +1710,12 @@ void ActorSystem::RetireEntity(Worker_EntityId EntityId, bool bIsNetStartupActor
 		// In the case that this is a startup actor, we won't actually delete the entity in SpatialOS.  Instead we'll Tombstone it.
 		if (!SubView->HasComponent(EntityId, SpatialConstants::TOMBSTONE_COMPONENT_ID))
 		{
-			UE_LOG(LogSpatialSender, Log, TEXT("Adding tombstone to entity: %lld"), EntityId);
+			UE_LOG(LogActorSystem, Log, TEXT("Adding tombstone to entity: %lld"), EntityId);
 			AddTombstoneToEntity(EntityId);
 		}
 		else
 		{
-			UE_LOG(LogSpatialSender, Verbose, TEXT("RetireEntity called on already retired entity: %lld"), EntityId);
+			UE_LOG(LogActorSystem, Verbose, TEXT("RetireEntity called on already retired entity: %lld"), EntityId);
 		}
 	}
 	else
@@ -1723,7 +1723,7 @@ void ActorSystem::RetireEntity(Worker_EntityId EntityId, bool bIsNetStartupActor
 		// Actor no longer guaranteed to be in package map, but still useful for additional logging info
 		AActor* Actor = Cast<AActor>(NetDriver->PackageMap->GetObjectFromEntityId(EntityId));
 
-		UE_LOG(LogSpatialSender, Log, TEXT("Sending delete entity request for %s with EntityId %lld, HasAuthority: %d"),
+		UE_LOG(LogActorSystem, Log, TEXT("Sending delete entity request for %s with EntityId %lld, HasAuthority: %d"),
 			   *GetPathNameSafe(Actor), EntityId, Actor != nullptr ? Actor->HasAuthority() : false);
 
 		if (EventTracer != nullptr)
@@ -1742,7 +1742,7 @@ void ActorSystem::SendComponentUpdates(UObject* Object, const FClassInfo& Info, 
 	SCOPE_CYCLE_COUNTER(STAT_ActorSystemSendComponentUpdates);
 	const Worker_EntityId EntityId = Channel->GetEntityId();
 
-	UE_LOG(LogSpatialSender, Verbose, TEXT("Sending component update (object: %s, entity: %lld)"), *Object->GetName(), EntityId);
+	UE_LOG(LogActorSystem, Verbose, TEXT("Sending component update (object: %s, entity: %lld)"), *Object->GetName(), EntityId);
 
 	USpatialLatencyTracer* Tracer = USpatialLatencyTracer::GetTracer(Object);
 	ComponentFactory UpdateFactory(Channel->GetInterestDirty(), NetDriver, Tracer);
@@ -1778,7 +1778,7 @@ void ActorSystem::SendComponentUpdates(UObject* Object, const FClassInfo& Info, 
 	// meantime we've kept the checking and queuing of updates, along with an error message.
 	if (!NetDriver->HasServerAuthority(EntityId))
 	{
-		UE_LOG(LogSpatialSender, Error, TEXT("Trying to send component update but don't have authority! entity: %lld"), EntityId);
+		UE_LOG(LogActorSystem, Error, TEXT("Trying to send component update but don't have authority! entity: %lld"), EntityId);
 		return;
 	}
 
@@ -1835,7 +1835,7 @@ void ActorSystem::UpdateInterestComponent(AActor* Actor)
 	Worker_EntityId EntityId = NetDriver->PackageMap->GetEntityIdFromObject(Actor);
 	if (EntityId == SpatialConstants::INVALID_ENTITY_ID)
 	{
-		UE_LOG(LogSpatialSender, Verbose, TEXT("Attempted to update interest for non replicated actor: %s"), *GetNameSafe(Actor));
+		UE_LOG(LogActorSystem, Verbose, TEXT("Attempted to update interest for non replicated actor: %s"), *GetNameSafe(Actor));
 		return;
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/SpatialRPCService.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/SpatialRPCService.cpp
@@ -78,7 +78,7 @@ void SpatialRPCService::ProcessChanges(const float NetDriverTime)
 	}
 }
 
-void SpatialRPCService::Flush()
+void SpatialRPCService::PushUpdates()
 {
 	const USpatialGDKSettings* Settings = GetDefault<USpatialGDKSettings>();
 
@@ -91,7 +91,7 @@ void SpatialRPCService::Flush()
 		NetDriver->Connection->SendComponentUpdate(Update.EntityId, &Update.Update, Update.SpanId);
 	}
 
-	if (RPCs.Num() && Settings->bWorkerFlushAfterOutgoingNetworkOp)
+	if (RPCs.Num() > 0 && Settings->bWorkerFlushAfterOutgoingNetworkOp)
 	{
 		NetDriver->Connection->Flush();
 	}
@@ -692,7 +692,7 @@ bool SpatialRPCService::SendRingBufferedRPC(UObject* TargetObject, const RPCSend
 
 	if (Result == EPushRPCResult::Success)
 	{
-		Flush();
+		PushUpdates();
 	}
 
 #if !UE_BUILD_SHIPPING

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/SpatialRPCService.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/SpatialRPCService.cpp
@@ -705,32 +705,32 @@ bool SpatialRPCService::SendRingBufferedRPC(UObject* TargetObject, const RPCSend
 	switch (Result)
 	{
 	case EPushRPCResult::QueueOverflowed:
-		UE_LOG(LogSpatialSender, Log,
+		UE_LOG(LogSpatialRPCService, Log,
 			   TEXT("USpatialSender::SendRingBufferedRPC: Ring buffer queue overflowed, queuing RPC locally. Actor: %s, entity: %lld, "
 					"function: %s"),
 			   *TargetObject->GetPathName(), TargetObjectRef.Entity, *Function->GetName());
 		return true;
 	case EPushRPCResult::DropOverflowed:
 		UE_LOG(
-			LogSpatialSender, Log,
+			LogSpatialRPCService, Log,
 			TEXT("USpatialSender::SendRingBufferedRPC: Ring buffer queue overflowed, dropping RPC. Actor: %s, entity: %lld, function: %s"),
 			*TargetObject->GetPathName(), TargetObjectRef.Entity, *Function->GetName());
 		return true;
 	case EPushRPCResult::HasAckAuthority:
-		UE_LOG(LogSpatialSender, Warning,
+		UE_LOG(LogSpatialRPCService, Warning,
 			   TEXT("USpatialSender::SendRingBufferedRPC: Worker has authority over ack component for RPC it is sending. RPC will not be "
 					"sent. Actor: %s, entity: %lld, function: %s"),
 			   *TargetObject->GetPathName(), TargetObjectRef.Entity, *Function->GetName());
 		return true;
 	case EPushRPCResult::NoRingBufferAuthority:
 		// TODO: Change engine logic that calls Client RPCs from non-auth servers and change this to error. UNR-2517
-		UE_LOG(LogSpatialSender, Log,
+		UE_LOG(LogSpatialRPCService, Log,
 			   TEXT("USpatialSender::SendRingBufferedRPC: Failed to send RPC because the worker does not have authority over ring buffer "
 					"component. Actor: %s, entity: %lld, function: %s"),
 			   *TargetObject->GetPathName(), TargetObjectRef.Entity, *Function->GetName());
 		return true;
 	case EPushRPCResult::EntityBeingCreated:
-		UE_LOG(LogSpatialSender, Log,
+		UE_LOG(LogSpatialRPCService, Log,
 			   TEXT("USpatialSender::SendRingBufferedRPC: RPC was called between entity creation and initial authority gain, so it will be "
 					"queued. Actor: %s, entity: %lld, function: %s"),
 			   *TargetObject->GetPathName(), TargetObjectRef.Entity, *Function->GetName());

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/SpatialRPCService.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/SpatialRPCService.cpp
@@ -2,15 +2,19 @@
 
 #include "Interop/RPCs/SpatialRPCService.h"
 
+#include "EngineClasses/SpatialActorChannel.h"
 #include "EngineClasses/SpatialNetBitReader.h"
 #include "EngineClasses/SpatialPackageMapClient.h"
 #include "Interop/Connection/SpatialTraceEventBuilder.h"
 #include "Interop/SpatialStaticComponentView.h"
+#include "Net/NetworkProfiler.h"
 #include "SpatialConstants.h"
 #include "Utils/RepLayoutUtils.h"
 #include "Utils/SpatialLatencyTracer.h"
 
 DEFINE_LOG_CATEGORY(LogSpatialRPCService);
+
+DECLARE_CYCLE_STAT(TEXT("SpatialRPCService SendRPC"), STAT_SpatialRPCServiceSendRPC, STATGROUP_SpatialNet);
 
 namespace SpatialGDK
 {
@@ -25,7 +29,8 @@ SpatialRPCService::SpatialRPCService(const FSubView& InActorAuthSubView, const F
 					   ExtractRPCDelegate::CreateRaw(this, &SpatialRPCService::ProcessOrQueueIncomingRPC), InActorAuthSubView, RPCStore)
 	, MulticastRPCs(ExtractRPCDelegate::CreateRaw(this, &SpatialRPCService::ProcessOrQueueIncomingRPC), InActorNonAuthSubView, RPCStore)
 	, AuthSubView(&InActorAuthSubView)
-	, LastProcessingTime(-GetDefault<USpatialGDKSettings>()->QueuedIncomingRPCRetryTime)
+	, LastIncomingProcessingTime(-GetDefault<USpatialGDKSettings>()->QueuedIncomingRPCRetryTime)
+	, LastOutgoingProcessingTime(-GetDefault<USpatialGDKSettings>()->QueuedOutgoingRPCRetryTime)
 {
 	const USpatialGDKSettings* Settings = GetDefault<USpatialGDKSettings>();
 	if (NetDriver != nullptr && NetDriver->IsServer()
@@ -36,6 +41,7 @@ SpatialRPCService::SpatialRPCService(const FSubView& InActorAuthSubView, const F
 													  InActorAuthSubView, RPCStore));
 	}
 	IncomingRPCs.BindProcessingFunction(FProcessRPCDelegate::CreateRaw(this, &SpatialRPCService::ApplyRPC));
+	OutgoingRPCs.BindProcessingFunction(FProcessRPCDelegate::CreateRaw(this, &SpatialRPCService::SendRPC));
 }
 
 void SpatialRPCService::AdvanceView()
@@ -57,16 +63,48 @@ void SpatialRPCService::ProcessChanges(const float NetDriverTime)
 		CrossServerRPCs->ProcessChanges();
 	}
 
-	if (NetDriverTime - LastProcessingTime > GetDefault<USpatialGDKSettings>()->QueuedIncomingRPCRetryTime)
+	const USpatialGDKSettings* Settings = GetDefault<USpatialGDKSettings>();
+
+	if (NetDriverTime - LastIncomingProcessingTime > Settings->QueuedIncomingRPCRetryTime)
 	{
-		LastProcessingTime = NetDriverTime;
+		LastIncomingProcessingTime = NetDriverTime;
 		ProcessIncomingRPCs();
+	}
+
+	if (NetDriverTime - LastOutgoingProcessingTime > Settings->QueuedOutgoingRPCRetryTime)
+	{
+		LastOutgoingProcessingTime = NetDriverTime;
+		ProcessOutgoingRPCs();
+	}
+}
+
+void SpatialRPCService::Flush()
+{
+	const USpatialGDKSettings* Settings = GetDefault<USpatialGDKSettings>();
+
+	PushOverflowedRPCs();
+
+	TArray<UpdateToSend> RPCs = GetRPCsAndAcksToSend();
+
+	for (UpdateToSend& Update : RPCs)
+	{
+		NetDriver->Connection->SendComponentUpdate(Update.EntityId, &Update.Update, Update.SpanId);
+	}
+
+	if (RPCs.Num() && Settings->bWorkerFlushAfterOutgoingNetworkOp)
+	{
+		NetDriver->Connection->Flush();
 	}
 }
 
 void SpatialRPCService::ProcessIncomingRPCs()
 {
 	IncomingRPCs.ProcessRPCs();
+}
+
+void SpatialRPCService::ProcessOutgoingRPCs()
+{
+	OutgoingRPCs.ProcessRPCs();
 }
 
 EPushRPCResult SpatialRPCService::PushRPC(const Worker_EntityId EntityId, const RPCSender& Sender, const ERPCType Type, RPCPayload Payload,
@@ -321,9 +359,31 @@ void SpatialRPCService::ProcessOrQueueIncomingRPC(const FUnrealObjectRef& InTarg
 	IncomingRPCs.ProcessOrQueueRPC(InTargetObjectRef, InSender, Type, MoveTemp(InPayload), SpanId);
 }
 
-void SpatialRPCService::ClearPendingRPCs(Worker_EntityId EntityId)
+void SpatialRPCService::ClearPendingRPCs(const Worker_EntityId EntityId)
 {
 	IncomingRPCs.DropForEntity(EntityId);
+	OutgoingRPCs.DropForEntity(EntityId);
+}
+
+RPCPayload SpatialRPCService::CreateRPCPayloadFromParams(UObject* TargetObject, const FUnrealObjectRef& TargetObjectRef,
+														 UFunction* Function, ERPCType Type, void* Params) const
+{
+	const FRPCInfo& RPCInfo = NetDriver->ClassInfoManager->GetRPCInfo(TargetObject, Function);
+
+	FSpatialNetBitWriter PayloadWriter = PackRPCDataToSpatialNetBitWriter(Function, Params);
+
+	TOptional<uint64> Id;
+	if (Type == ERPCType::CrossServer)
+	{
+		Id = FMath::RandRange(static_cast<int64>(0), INT64_MAX);
+	}
+
+#if TRACE_LIB_ACTIVE
+	return RPCPayload(TargetObjectRef.Offset, RPCInfo.Index, Id, TArray<uint8>(PayloadWriter.GetData(), PayloadWriter.GetNumBytes()),
+					  USpatialLatencyTracer::GetTracer(TargetObject)->RetrievePendingTrace(TargetObject, Function));
+#else
+	return RPCPayload(TargetObjectRef.Offset, RPCInfo.Index, Id, TArray<uint8>(PayloadWriter.GetData(), PayloadWriter.GetNumBytes()));
+#endif
 }
 
 EPushRPCResult SpatialRPCService::PushRPCInternal(const Worker_EntityId EntityId, const ERPCType Type, PendingRPCPayload Payload,
@@ -557,6 +617,173 @@ FRPCErrorInfo SpatialRPCService::ApplyRPCInternal(UObject* TargetObject, UFuncti
 	}
 
 	return ErrorInfo;
+}
+
+FRPCErrorInfo SpatialRPCService::SendRPC(const FPendingRPCParams& Params)
+{
+	SCOPE_CYCLE_COUNTER(STAT_SpatialRPCServiceSendRPC);
+
+	TWeakObjectPtr<UObject> TargetObjectWeakPtr = NetDriver->PackageMap->GetObjectFromUnrealObjectRef(Params.ObjectRef);
+	if (!TargetObjectWeakPtr.IsValid())
+	{
+		// Target object was destroyed before the RPC could be (re)sent
+		return FRPCErrorInfo{ nullptr, nullptr, ERPCResult::UnresolvedTargetObject, ERPCQueueProcessResult::DropEntireQueue };
+	}
+	UObject* TargetObject = TargetObjectWeakPtr.Get();
+
+	const FClassInfo& ClassInfo = NetDriver->ClassInfoManager->GetOrCreateClassInfoByObject(TargetObject);
+	UFunction* Function = ClassInfo.RPCs[Params.Payload.Index];
+	if (Function == nullptr)
+	{
+		return FRPCErrorInfo{ TargetObject, nullptr, ERPCResult::MissingFunctionInfo, ERPCQueueProcessResult::ContinueProcessing };
+	}
+
+	USpatialActorChannel* Channel = NetDriver->GetOrCreateSpatialActorChannel(TargetObject);
+	if (Channel == nullptr)
+	{
+		return FRPCErrorInfo{ TargetObject, Function, ERPCResult::NoActorChannel, ERPCQueueProcessResult::DropEntireQueue };
+	}
+
+	const FRPCInfo& RPCInfo = NetDriver->ClassInfoManager->GetRPCInfo(TargetObject, Function);
+	if (RPCInfo.Type == ERPCType::CrossServer)
+	{
+		if (SendCrossServerRPC(TargetObject, Params.SenderRPCInfo, Function, Params.Payload, Channel, Params.ObjectRef))
+		{
+			return FRPCErrorInfo{ TargetObject, Function, ERPCResult::Success };
+		}
+		else
+		{
+			return FRPCErrorInfo{ TargetObject, Function, ERPCResult::RPCServiceFailure };
+		}
+	}
+
+	if (SendRingBufferedRPC(TargetObject, RPCSender(), Function, Params.Payload, Channel, Params.ObjectRef, Params.SpanId))
+	{
+		return FRPCErrorInfo{ TargetObject, Function, ERPCResult::Success };
+	}
+	else
+	{
+		return FRPCErrorInfo{ TargetObject, Function, ERPCResult::RPCServiceFailure };
+	}
+}
+
+bool SpatialRPCService::SendCrossServerRPC(UObject* TargetObject, const RPCSender& Sender, UFunction* Function, const RPCPayload& Payload,
+										   USpatialActorChannel* Channel, const FUnrealObjectRef& TargetObjectRef)
+{
+	const USpatialGDKSettings* Settings = GetDefault<USpatialGDKSettings>();
+	const bool bHasValidSender = Sender.Entity != SpatialConstants::INVALID_ENTITY_ID;
+
+	check(Settings->CrossServerRPCImplementation == ECrossServerRPCImplementation::RoutingWorker);
+	if (bHasValidSender)
+	{
+		return SendRingBufferedRPC(TargetObject, Sender, Function, Payload, Channel, TargetObjectRef, {});
+	}
+
+	return false;
+}
+
+bool SpatialRPCService::SendRingBufferedRPC(UObject* TargetObject, const RPCSender& Sender, UFunction* Function, const RPCPayload& Payload,
+											USpatialActorChannel* Channel, const FUnrealObjectRef& TargetObjectRef,
+											const FSpatialGDKSpanId& SpanId)
+{
+	const FRPCInfo& RPCInfo = NetDriver->ClassInfoManager->GetRPCInfo(TargetObject, Function);
+	const EPushRPCResult Result =
+		PushRPC(TargetObjectRef.Entity, Sender, RPCInfo.Type, Payload, Channel->bCreatedEntity, TargetObject, Function, SpanId);
+
+	if (Result == EPushRPCResult::Success)
+	{
+		Flush();
+	}
+
+#if !UE_BUILD_SHIPPING
+	if (Result == EPushRPCResult::Success || Result == EPushRPCResult::QueueOverflowed)
+	{
+		TrackRPC(Channel->Actor, Function, Payload, RPCInfo.Type);
+	}
+#endif // !UE_BUILD_SHIPPING
+
+	switch (Result)
+	{
+	case EPushRPCResult::QueueOverflowed:
+		UE_LOG(LogSpatialSender, Log,
+			   TEXT("USpatialSender::SendRingBufferedRPC: Ring buffer queue overflowed, queuing RPC locally. Actor: %s, entity: %lld, "
+					"function: %s"),
+			   *TargetObject->GetPathName(), TargetObjectRef.Entity, *Function->GetName());
+		return true;
+	case EPushRPCResult::DropOverflowed:
+		UE_LOG(
+			LogSpatialSender, Log,
+			TEXT("USpatialSender::SendRingBufferedRPC: Ring buffer queue overflowed, dropping RPC. Actor: %s, entity: %lld, function: %s"),
+			*TargetObject->GetPathName(), TargetObjectRef.Entity, *Function->GetName());
+		return true;
+	case EPushRPCResult::HasAckAuthority:
+		UE_LOG(LogSpatialSender, Warning,
+			   TEXT("USpatialSender::SendRingBufferedRPC: Worker has authority over ack component for RPC it is sending. RPC will not be "
+					"sent. Actor: %s, entity: %lld, function: %s"),
+			   *TargetObject->GetPathName(), TargetObjectRef.Entity, *Function->GetName());
+		return true;
+	case EPushRPCResult::NoRingBufferAuthority:
+		// TODO: Change engine logic that calls Client RPCs from non-auth servers and change this to error. UNR-2517
+		UE_LOG(LogSpatialSender, Log,
+			   TEXT("USpatialSender::SendRingBufferedRPC: Failed to send RPC because the worker does not have authority over ring buffer "
+					"component. Actor: %s, entity: %lld, function: %s"),
+			   *TargetObject->GetPathName(), TargetObjectRef.Entity, *Function->GetName());
+		return true;
+	case EPushRPCResult::EntityBeingCreated:
+		UE_LOG(LogSpatialSender, Log,
+			   TEXT("USpatialSender::SendRingBufferedRPC: RPC was called between entity creation and initial authority gain, so it will be "
+					"queued. Actor: %s, entity: %lld, function: %s"),
+			   *TargetObject->GetPathName(), TargetObjectRef.Entity, *Function->GetName());
+		return false;
+	default:
+		return true;
+	}
+}
+
+#if !UE_BUILD_SHIPPING
+void SpatialRPCService::TrackRPC(AActor* Actor, UFunction* Function, const RPCPayload& Payload, const ERPCType RPCType) const
+{
+	NETWORK_PROFILER(GNetworkProfiler.TrackSendRPC(Actor, Function, 0, Payload.CountDataBits(), 0, NetDriver->GetSpatialOSNetConnection()));
+	NetDriver->SpatialMetrics->TrackSentRPC(Function, RPCType, Payload.PayloadData.Num());
+}
+#endif
+
+void SpatialRPCService::ProcessOrQueueOutgoingRPC(const FUnrealObjectRef& InTargetObjectRef, const RPCSender& InSenderInfo,
+												  RPCPayload&& InPayload)
+{
+	const TWeakObjectPtr<UObject> TargetObjectWeakPtr = NetDriver->PackageMap->GetObjectFromUnrealObjectRef(InTargetObjectRef);
+	if (!TargetObjectWeakPtr.IsValid())
+	{
+		// Target object was destroyed before the RPC could be (re)sent
+		return;
+	}
+
+	UObject* TargetObject = TargetObjectWeakPtr.Get();
+	const FClassInfo& ClassInfo = NetDriver->ClassInfoManager->GetOrCreateClassInfoByObject(TargetObject);
+	UFunction* Function = ClassInfo.RPCs[InPayload.Index];
+	const FRPCInfo& RPCInfo = NetDriver->ClassInfoManager->GetRPCInfo(TargetObject, Function);
+
+	FSpatialGDKSpanId SpanId;
+	if (EventTracer != nullptr)
+	{
+		SpanId = EventTracer->TraceEvent(FSpatialTraceEventBuilder::CreatePushRPC(TargetObject, Function),
+										 /* Causes */ EventTracer->GetFromStack().GetConstId(), /* NumCauses */ 1);
+	}
+
+	OutgoingRPCs.ProcessOrQueueRPC(InTargetObjectRef, InSenderInfo, RPCInfo.Type, MoveTemp(InPayload), SpanId);
+
+	// Try to send all pending RPCs unconditionally
+	OutgoingRPCs.ProcessRPCs();
+}
+
+FSpatialNetBitWriter SpatialRPCService::PackRPCDataToSpatialNetBitWriter(UFunction* Function, void* Parameters) const
+{
+	FSpatialNetBitWriter PayloadWriter(NetDriver->PackageMap);
+
+	const TSharedPtr<FRepLayout> RepLayout = NetDriver->GetFunctionRepLayout(Function);
+	RepLayout_SendPropertiesForRPC(*RepLayout, PayloadWriter, Parameters);
+
+	return PayloadWriter;
 }
 
 #if TRACE_LIB_ACTIVE

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -47,8 +47,7 @@ DECLARE_CYCLE_STAT(TEXT("Sender ResetOutgoingUpdate"), STAT_SpatialSenderResetOu
 DECLARE_CYCLE_STAT(TEXT("Sender QueueOutgoingUpdate"), STAT_SpatialSenderQueueOutgoingUpdate, STATGROUP_SpatialNet);
 DECLARE_CYCLE_STAT(TEXT("Sender UpdateInterestComponent"), STAT_SpatialSenderUpdateInterestComponent, STATGROUP_SpatialNet);
 
-void USpatialSender::Init(USpatialNetDriver* InNetDriver, FTimerManager* InTimerManager, SpatialGDK::SpatialRPCService* InRPCService,
-						  SpatialGDK::SpatialEventTracer* InEventTracer)
+void USpatialSender::Init(USpatialNetDriver* InNetDriver, FTimerManager* InTimerManager, SpatialEventTracer* InEventTracer)
 {
 	NetDriver = InNetDriver;
 	StaticComponentView = InNetDriver->StaticComponentView;
@@ -57,7 +56,6 @@ void USpatialSender::Init(USpatialNetDriver* InNetDriver, FTimerManager* InTimer
 	PackageMap = InNetDriver->PackageMap;
 	ClassInfoManager = InNetDriver->ClassInfoManager;
 	TimerManager = InTimerManager;
-	RPCService = InRPCService;
 	EventTracer = InEventTracer;
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -46,7 +46,6 @@ DECLARE_CYCLE_STAT(TEXT("Sender SendComponentUpdates"), STAT_SpatialSenderSendCo
 DECLARE_CYCLE_STAT(TEXT("Sender ResetOutgoingUpdate"), STAT_SpatialSenderResetOutgoingUpdate, STATGROUP_SpatialNet);
 DECLARE_CYCLE_STAT(TEXT("Sender QueueOutgoingUpdate"), STAT_SpatialSenderQueueOutgoingUpdate, STATGROUP_SpatialNet);
 DECLARE_CYCLE_STAT(TEXT("Sender UpdateInterestComponent"), STAT_SpatialSenderUpdateInterestComponent, STATGROUP_SpatialNet);
-DECLARE_CYCLE_STAT(TEXT("Sender SendRPC"), STAT_SpatialSenderSendRPC, STATGROUP_SpatialNet);
 
 void USpatialSender::Init(USpatialNetDriver* InNetDriver, FTimerManager* InTimerManager, SpatialGDK::SpatialRPCService* InRPCService,
 						  SpatialGDK::SpatialEventTracer* InEventTracer)
@@ -60,28 +59,6 @@ void USpatialSender::Init(USpatialNetDriver* InNetDriver, FTimerManager* InTimer
 	TimerManager = InTimerManager;
 	RPCService = InRPCService;
 	EventTracer = InEventTracer;
-
-	OutgoingRPCs.BindProcessingFunction(FProcessRPCDelegate::CreateUObject(this, &USpatialSender::SendRPC));
-
-	// Attempt to send RPCs that might have been queued while waiting for authority over entities this worker created.
-	if (GetDefault<USpatialGDKSettings>()->QueuedOutgoingRPCRetryTime > 0.0f)
-	{
-		PeriodicallyProcessOutgoingRPCs();
-	}
-}
-
-void USpatialSender::PeriodicallyProcessOutgoingRPCs()
-{
-	FTimerHandle Timer;
-	TimerManager->SetTimer(
-		Timer,
-		[WeakThis = TWeakObjectPtr<USpatialSender>(this)]() {
-			if (USpatialSender* SpatialSender = WeakThis.Get())
-			{
-				SpatialSender->OutgoingRPCs.ProcessRPCs();
-			}
-		},
-		GetDefault<USpatialGDKSettings>()->QueuedOutgoingRPCRetryTime, true);
 }
 
 void USpatialSender::CreateServerWorkerEntity()
@@ -176,11 +153,6 @@ void USpatialSender::RetryServerWorkerEntityCreation(Worker_EntityId EntityId, i
 	Receiver->AddCreateEntityDelegate(RequestId, MoveTemp(OnCreateWorkerEntityResponse));
 }
 
-void USpatialSender::ClearPendingRPCs(const Worker_EntityId EntityId)
-{
-	OutgoingRPCs.DropForEntity(EntityId);
-}
-
 bool USpatialSender::ValidateOrExit_IsSupportedClass(const FString& PathName)
 {
 	// Level blueprint classes could have a PIE prefix, this will remove it.
@@ -230,49 +202,6 @@ void USpatialSender::UpdatePartitionEntityInterestAndPosition()
 	Connection->SendComponentUpdate(PartitionId, &Update);
 }
 
-void USpatialSender::FlushRPCService()
-{
-	if (RPCService != nullptr)
-	{
-		const USpatialGDKSettings* Settings = GetDefault<USpatialGDKSettings>();
-
-		RPCService->PushOverflowedRPCs();
-
-		TArray<SpatialRPCService::UpdateToSend> RPCs = RPCService->GetRPCsAndAcksToSend();
-
-		for (SpatialRPCService::UpdateToSend& Update : RPCs)
-		{
-			Connection->SendComponentUpdate(Update.EntityId, &Update.Update, Update.SpanId);
-		}
-
-		if (RPCs.Num() && Settings->bWorkerFlushAfterOutgoingNetworkOp)
-		{
-			Connection->Flush();
-		}
-	}
-}
-
-RPCPayload USpatialSender::CreateRPCPayloadFromParams(UObject* TargetObject, const FUnrealObjectRef& TargetObjectRef, UFunction* Function,
-													  ERPCType Type, void* Params)
-{
-	const FRPCInfo& RPCInfo = ClassInfoManager->GetRPCInfo(TargetObject, Function);
-
-	FSpatialNetBitWriter PayloadWriter = PackRPCDataToSpatialNetBitWriter(Function, Params);
-
-	TOptional<uint64> Id;
-	if (Type == ERPCType::CrossServer)
-	{
-		Id = FMath::RandRange(static_cast<int64>(0), static_cast<int64>(INT64_MAX));
-	}
-
-#if TRACE_LIB_ACTIVE
-	return RPCPayload(TargetObjectRef.Offset, RPCInfo.Index, Id, TArray<uint8>(PayloadWriter.GetData(), PayloadWriter.GetNumBytes()),
-					  USpatialLatencyTracer::GetTracer(TargetObject)->RetrievePendingTrace(TargetObject, Function));
-#else
-	return RPCPayload(TargetObjectRef.Offset, RPCInfo.Index, Id, TArray<uint8>(PayloadWriter.GetData(), PayloadWriter.GetNumBytes()));
-#endif
-}
-
 void USpatialSender::SendAuthorityIntentUpdate(const AActor& Actor, VirtualWorkerId NewAuthoritativeVirtualWorkerId) const
 {
 	const Worker_EntityId EntityId = PackageMap->GetEntityIdFromObject(&Actor);
@@ -307,176 +236,6 @@ void USpatialSender::SendAuthorityIntentUpdate(const AActor& Actor, VirtualWorke
 	{
 		NetDriver->SpatialDebuggerSystem->ActorAuthorityIntentChanged(EntityId, NewAuthoritativeVirtualWorkerId);
 	}
-}
-
-FRPCErrorInfo USpatialSender::SendRPC(const FPendingRPCParams& Params)
-{
-	SCOPE_CYCLE_COUNTER(STAT_SpatialSenderSendRPC);
-
-	TWeakObjectPtr<UObject> TargetObjectWeakPtr = PackageMap->GetObjectFromUnrealObjectRef(Params.ObjectRef);
-	if (!TargetObjectWeakPtr.IsValid())
-	{
-		// Target object was destroyed before the RPC could be (re)sent
-		return FRPCErrorInfo{ nullptr, nullptr, ERPCResult::UnresolvedTargetObject, ERPCQueueProcessResult::DropEntireQueue };
-	}
-	UObject* TargetObject = TargetObjectWeakPtr.Get();
-
-	const FClassInfo& ClassInfo = ClassInfoManager->GetOrCreateClassInfoByObject(TargetObject);
-	UFunction* Function = ClassInfo.RPCs[Params.Payload.Index];
-	if (Function == nullptr)
-	{
-		return FRPCErrorInfo{ TargetObject, nullptr, ERPCResult::MissingFunctionInfo, ERPCQueueProcessResult::ContinueProcessing };
-	}
-
-	USpatialActorChannel* Channel = NetDriver->GetOrCreateSpatialActorChannel(TargetObject);
-	if (Channel == nullptr)
-	{
-		return FRPCErrorInfo{ TargetObject, Function, ERPCResult::NoActorChannel, ERPCQueueProcessResult::DropEntireQueue };
-	}
-
-	const FRPCInfo& RPCInfo = ClassInfoManager->GetRPCInfo(TargetObject, Function);
-	checkf(RPCService != nullptr, TEXT("RPCService is assumed to be valid."));
-	if (RPCInfo.Type == ERPCType::CrossServer)
-	{
-		if (SendCrossServerRPC(TargetObject, Params.SenderRPCInfo, Function, Params.Payload, Channel, Params.ObjectRef))
-		{
-			return FRPCErrorInfo{ TargetObject, Function, ERPCResult::Success };
-		}
-		else
-		{
-			return FRPCErrorInfo{ TargetObject, Function, ERPCResult::RPCServiceFailure };
-		}
-	}
-
-	if (SendRingBufferedRPC(TargetObject, RPCSender(), Function, Params.Payload, Channel, Params.ObjectRef, Params.SpanId))
-	{
-		return FRPCErrorInfo{ TargetObject, Function, ERPCResult::Success };
-	}
-	else
-	{
-		return FRPCErrorInfo{ TargetObject, Function, ERPCResult::RPCServiceFailure };
-	}
-}
-
-bool USpatialSender::SendCrossServerRPC(UObject* TargetObject, const SpatialGDK::RPCSender& Sender, UFunction* Function,
-										const SpatialGDK::RPCPayload& Payload, USpatialActorChannel* Channel,
-										const FUnrealObjectRef& TargetObjectRef)
-{
-	const FRPCInfo& RPCInfo = ClassInfoManager->GetRPCInfo(TargetObject, Function);
-	const USpatialGDKSettings* Settings = GetDefault<USpatialGDKSettings>();
-	const bool bHasValidSender = Sender.Entity != SpatialConstants::INVALID_ENTITY_ID;
-
-	check(Settings->CrossServerRPCImplementation == ECrossServerRPCImplementation::RoutingWorker);
-	if (bHasValidSender)
-	{
-		return SendRingBufferedRPC(TargetObject, Sender, Function, Payload, Channel, TargetObjectRef, {});
-	}
-
-	return false;
-}
-
-bool USpatialSender::SendRingBufferedRPC(UObject* TargetObject, const SpatialGDK::RPCSender& Sender, UFunction* Function,
-										 const SpatialGDK::RPCPayload& Payload, USpatialActorChannel* Channel,
-										 const FUnrealObjectRef& TargetObjectRef, const FSpatialGDKSpanId& SpanId)
-{
-	const FRPCInfo& RPCInfo = ClassInfoManager->GetRPCInfo(TargetObject, Function);
-	const EPushRPCResult Result =
-		RPCService->PushRPC(TargetObjectRef.Entity, Sender, RPCInfo.Type, Payload, Channel->bCreatedEntity, TargetObject, Function, SpanId);
-
-	if (Result == EPushRPCResult::Success)
-	{
-		FlushRPCService();
-	}
-
-#if !UE_BUILD_SHIPPING
-	if (Result == EPushRPCResult::Success || Result == EPushRPCResult::QueueOverflowed)
-	{
-		TrackRPC(Channel->Actor, Function, Payload, RPCInfo.Type);
-	}
-#endif // !UE_BUILD_SHIPPING
-
-	switch (Result)
-	{
-	case EPushRPCResult::QueueOverflowed:
-		UE_LOG(LogSpatialSender, Log,
-			   TEXT("USpatialSender::SendRingBufferedRPC: Ring buffer queue overflowed, queuing RPC locally. Actor: %s, entity: %lld, "
-					"function: %s"),
-			   *TargetObject->GetPathName(), TargetObjectRef.Entity, *Function->GetName());
-		return true;
-	case EPushRPCResult::DropOverflowed:
-		UE_LOG(
-			LogSpatialSender, Log,
-			TEXT("USpatialSender::SendRingBufferedRPC: Ring buffer queue overflowed, dropping RPC. Actor: %s, entity: %lld, function: %s"),
-			*TargetObject->GetPathName(), TargetObjectRef.Entity, *Function->GetName());
-		return true;
-	case EPushRPCResult::HasAckAuthority:
-		UE_LOG(LogSpatialSender, Warning,
-			   TEXT("USpatialSender::SendRingBufferedRPC: Worker has authority over ack component for RPC it is sending. RPC will not be "
-					"sent. Actor: %s, entity: %lld, function: %s"),
-			   *TargetObject->GetPathName(), TargetObjectRef.Entity, *Function->GetName());
-		return true;
-	case EPushRPCResult::NoRingBufferAuthority:
-		// TODO: Change engine logic that calls Client RPCs from non-auth servers and change this to error. UNR-2517
-		UE_LOG(LogSpatialSender, Log,
-			   TEXT("USpatialSender::SendRingBufferedRPC: Failed to send RPC because the worker does not have authority over ring buffer "
-					"component. Actor: %s, entity: %lld, function: %s"),
-			   *TargetObject->GetPathName(), TargetObjectRef.Entity, *Function->GetName());
-		return true;
-	case EPushRPCResult::EntityBeingCreated:
-		UE_LOG(LogSpatialSender, Log,
-			   TEXT("USpatialSender::SendRingBufferedRPC: RPC was called between entity creation and initial authority gain, so it will be "
-					"queued. Actor: %s, entity: %lld, function: %s"),
-			   *TargetObject->GetPathName(), TargetObjectRef.Entity, *Function->GetName());
-		return false;
-	default:
-		return true;
-	}
-}
-
-#if !UE_BUILD_SHIPPING
-void USpatialSender::TrackRPC(AActor* Actor, UFunction* Function, const RPCPayload& Payload, const ERPCType RPCType)
-{
-	NETWORK_PROFILER(GNetworkProfiler.TrackSendRPC(Actor, Function, 0, Payload.CountDataBits(), 0, NetDriver->GetSpatialOSNetConnection()));
-	NetDriver->SpatialMetrics->TrackSentRPC(Function, RPCType, Payload.PayloadData.Num());
-}
-#endif
-
-void USpatialSender::ProcessOrQueueOutgoingRPC(const FUnrealObjectRef& InTargetObjectRef, const SpatialGDK::RPCSender& InSenderInfo,
-											   RPCPayload&& InPayload)
-{
-	TWeakObjectPtr<UObject> TargetObjectWeakPtr = PackageMap->GetObjectFromUnrealObjectRef(InTargetObjectRef);
-	if (!TargetObjectWeakPtr.IsValid())
-	{
-		// Target object was destroyed before the RPC could be (re)sent
-		return;
-	}
-
-	UObject* TargetObject = TargetObjectWeakPtr.Get();
-	const FClassInfo& ClassInfo = ClassInfoManager->GetOrCreateClassInfoByObject(TargetObject);
-	UFunction* Function = ClassInfo.RPCs[InPayload.Index];
-	const FRPCInfo& RPCInfo = ClassInfoManager->GetRPCInfo(TargetObject, Function);
-
-	FSpatialGDKSpanId SpanId;
-	if (EventTracer != nullptr)
-	{
-		SpanId = EventTracer->TraceEvent(FSpatialTraceEventBuilder::CreatePushRPC(TargetObject, Function),
-										 /* Causes */ EventTracer->GetFromStack().GetConstId(), /* NumCauses */ 1);
-	}
-
-	OutgoingRPCs.ProcessOrQueueRPC(InTargetObjectRef, InSenderInfo, RPCInfo.Type, MoveTemp(InPayload), SpanId);
-
-	// Try to send all pending RPCs unconditionally
-	OutgoingRPCs.ProcessRPCs();
-}
-
-FSpatialNetBitWriter USpatialSender::PackRPCDataToSpatialNetBitWriter(UFunction* Function, void* Parameters) const
-{
-	FSpatialNetBitWriter PayloadWriter(PackageMap);
-
-	TSharedPtr<FRepLayout> RepLayout = NetDriver->GetFunctionRepLayout(Function);
-	RepLayout_SendPropertiesForRPC(*RepLayout, PayloadWriter, Parameters);
-
-	return PayloadWriter;
 }
 
 void USpatialSender::SendCommandResponse(Worker_RequestId RequestId, Worker_CommandResponse& Response, const FSpatialGDKSpanId& CauseSpanId)

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/SpatialRPCService.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/SpatialRPCService.h
@@ -6,6 +6,7 @@
 
 #include "ClientServerRPCService.h"
 #include "CrossServerRPCService.h"
+#include "EngineClasses/SpatialNetBitWriter.h"
 #include "Interop/Connection/SpatialEventTracer.h"
 #include "Interop/Connection/SpatialGDKSpanId.h"
 #include "Interop/SpatialClassInfoManager.h"
@@ -35,7 +36,10 @@ public:
 	void AdvanceView();
 	void ProcessChanges(const float NetDriverTime);
 
+	void Flush();
+
 	void ProcessIncomingRPCs();
+	void ProcessOutgoingRPCs();
 
 	void ProcessOrQueueIncomingRPC(const FUnrealObjectRef& InTargetObjectRef, const RPCSender& InSender, RPCPayload InPayload,
 								   TOptional<uint64> RPCIdForLinearEventTrace);
@@ -56,6 +60,10 @@ public:
 
 	void ClearPendingRPCs(Worker_EntityId EntityId);
 
+	RPCPayload CreateRPCPayloadFromParams(UObject* TargetObject, const FUnrealObjectRef& TargetObjectRef, UFunction* Function,
+										  ERPCType Type, void* Params) const;
+	void ProcessOrQueueOutgoingRPC(const FUnrealObjectRef& InTargetObjectRef, const RPCSender& InSenderInfo, RPCPayload&& InPayload);
+
 private:
 	EPushRPCResult PushRPCInternal(Worker_EntityId EntityId, ERPCType Type, PendingRPCPayload Payload, bool bCreatedEntity);
 
@@ -63,11 +71,21 @@ private:
 	// Note: It's like applying an RPC, but more secretive
 	FRPCErrorInfo ApplyRPCInternal(UObject* TargetObject, UFunction* Function, const FPendingRPCParams& PendingRPCParams);
 
+	FRPCErrorInfo SendRPC(const FPendingRPCParams& Params);
+	bool SendCrossServerRPC(UObject* TargetObject, const RPCSender& Sender, UFunction* Function, const RPCPayload& Payload,
+							USpatialActorChannel* Channel, const FUnrealObjectRef& TargetObjectRef);
+	bool SendRingBufferedRPC(UObject* TargetObject, const RPCSender& Sender, UFunction* Function, const RPCPayload& Payload,
+							 USpatialActorChannel* Channel, const FUnrealObjectRef& TargetObjectRef, const FSpatialGDKSpanId& SpanId);
+	void TrackRPC(AActor* Actor, UFunction* Function, const RPCPayload& Payload, ERPCType RPCType) const;
+	FSpatialNetBitWriter PackRPCDataToSpatialNetBitWriter(UFunction* Function, void* Parameters) const;
+
 	bool ActorCanExtractRPC(Worker_EntityId) const;
 
 	USpatialNetDriver* NetDriver;
 	USpatialLatencyTracer* SpatialLatencyTracer;
 	SpatialEventTracer* EventTracer;
+
+	FRPCContainer OutgoingRPCs{ ERPCQueueType::Send };
 	FRPCContainer IncomingRPCs{ ERPCQueueType::Receive };
 
 	FRPCStore RPCStore;
@@ -78,7 +96,8 @@ private:
 	// Keep around one of the passed subviews here in order to read the main view.
 	const FSubView* AuthSubView;
 
-	float LastProcessingTime;
+	float LastIncomingProcessingTime;
+	float LastOutgoingProcessingTime;
 
 #if TRACE_LIB_ACTIVE
 	void ProcessResultToLatencyTrace(const EPushRPCResult Result, const TraceKey Trace);

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/SpatialRPCService.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/SpatialRPCService.h
@@ -36,7 +36,7 @@ public:
 	void AdvanceView();
 	void ProcessChanges(const float NetDriverTime);
 
-	void Flush();
+	void PushUpdates();
 
 	void ProcessIncomingRPCs();
 	void ProcessOutgoingRPCs();

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -51,28 +51,10 @@ public:
 			  SpatialGDK::SpatialEventTracer* InEventTracer);
 
 	void SendAuthorityIntentUpdate(const AActor& Actor, VirtualWorkerId NewAuthoritativeVirtualWorkerId) const;
-	FRPCErrorInfo SendRPC(const FPendingRPCParams& Params);
-	bool SendCrossServerRPC(UObject* TargetObject, const SpatialGDK::RPCSender& Sender, UFunction* Function,
-							const SpatialGDK::RPCPayload& Payload, USpatialActorChannel* Channel, const FUnrealObjectRef& TargetObjectRef);
-	bool SendRingBufferedRPC(UObject* TargetObject, const SpatialGDK::RPCSender& Sender, UFunction* Function,
-							 const SpatialGDK::RPCPayload& Payload, USpatialActorChannel* Channel, const FUnrealObjectRef& TargetObjectRef,
-							 const FSpatialGDKSpanId& SpanId);
 	void SendCommandResponse(Worker_RequestId RequestId, Worker_CommandResponse& Response, const FSpatialGDKSpanId& CauseSpanId);
 	void SendEmptyCommandResponse(Worker_ComponentId ComponentId, Schema_FieldId CommandIndex, Worker_RequestId RequestId,
 								  const FSpatialGDKSpanId& CauseSpanId);
 	void SendCommandFailure(Worker_RequestId RequestId, const FString& Message, const FSpatialGDKSpanId& CauseSpanId);
-
-	void EnqueueRetryRPC(TSharedRef<FReliableRPCForRetry> RetryRPC);
-	void FlushRetryRPCs();
-	void RetryReliableRPC(TSharedRef<FReliableRPCForRetry> RetryRPC);
-
-	void ProcessOrQueueOutgoingRPC(const FUnrealObjectRef& InTargetObjectRef, const SpatialGDK::RPCSender& InSenderInfo,
-								   SpatialGDK::RPCPayload&& InPayload);
-
-	void FlushRPCService();
-
-	SpatialGDK::RPCPayload CreateRPCPayloadFromParams(UObject* TargetObject, const FUnrealObjectRef& TargetObjectRef, UFunction* Function,
-													  ERPCType Type, void* Params);
 
 	// Creates an entity authoritative on this server worker, ensuring it will be able to receive updates for the GSM.
 	UFUNCTION()
@@ -81,22 +63,9 @@ public:
 
 	void UpdatePartitionEntityInterestAndPosition();
 
-	void ClearPendingRPCs(const Worker_EntityId EntityId);
-
 	bool ValidateOrExit_IsSupportedClass(const FString& PathName);
 
 	void SendClaimPartitionRequest(Worker_EntityId SystemWorkerEntityId, Worker_PartitionId PartitionId) const;
-
-private:
-	void PeriodicallyProcessOutgoingRPCs();
-
-	// RPC Construction
-	FSpatialNetBitWriter PackRPCDataToSpatialNetBitWriter(UFunction* Function, void* Parameters) const;
-
-	// RPC Tracking
-#if !UE_BUILD_SHIPPING
-	void TrackRPC(AActor* Actor, UFunction* Function, const SpatialGDK::RPCPayload& Payload, const ERPCType RPCType);
-#endif
 
 private:
 	UPROPERTY()
@@ -120,8 +89,6 @@ private:
 	FTimerManager* TimerManager;
 
 	SpatialGDK::SpatialRPCService* RPCService;
-
-	FRPCContainer OutgoingRPCs{ ERPCQueueType::Send };
 
 	TArray<TSharedRef<FReliableRPCForRetry>> RetryRPCs;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialSender.h
@@ -47,8 +47,7 @@ class SPATIALGDK_API USpatialSender : public UObject
 	GENERATED_BODY()
 
 public:
-	void Init(USpatialNetDriver* InNetDriver, FTimerManager* InTimerManager, SpatialGDK::SpatialRPCService* InRPCService,
-			  SpatialGDK::SpatialEventTracer* InEventTracer);
+	void Init(USpatialNetDriver* InNetDriver, FTimerManager* InTimerManager, SpatialGDK::SpatialEventTracer* InEventTracer);
 
 	void SendAuthorityIntentUpdate(const AActor& Actor, VirtualWorkerId NewAuthoritativeVirtualWorkerId) const;
 	void SendCommandResponse(Worker_RequestId RequestId, Worker_CommandResponse& Response, const FSpatialGDKSpanId& CauseSpanId);
@@ -87,10 +86,6 @@ private:
 	USpatialClassInfoManager* ClassInfoManager;
 
 	FTimerManager* TimerManager;
-
-	SpatialGDK::SpatialRPCService* RPCService;
-
-	TArray<TSharedRef<FReliableRPCForRetry>> RetryRPCs;
 
 	SpatialGDK::SpatialEventTracer* EventTracer;
 };


### PR DESCRIPTION
Move RPC logic from sender into the RPC service. This PR is a subset of https://github.com/spatialos/UnrealGDK/pull/2879 because that one got too conflicty. This PR is entirely copy paste other than:
- Clearing RPC flows are now aligned for incoming and outgoing.
- Makes processing incoming and outgoing RPCs periodically uniform (not using timer manager)