### PR TITLE
World settings fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed EntityPool capacity overflow issue by removing the ability from the gdk settings to request a pool size larger than int32_max.
 - Fixed an issue where components added to a scene actor would be replicated incorrectly.
 - Fixed an issue where an actor channel was added to the wrong net connection.
+- Fixed an issue where authority was not correctly delegated to sublevel world settings prior to BeginPlay being issued. This resulted in duplicate world settings entities being created.
 
 ## [`0.12.0`] - 2021-02-01
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
@@ -8,6 +8,7 @@
 #endif
 
 #include "Engine/Classes/AI/AISystemBase.h"
+#include "Engine/LevelStreaming.h"
 #include "Engine/World.h"
 #include "EngineClasses/SpatialActorChannel.h"
 #include "EngineClasses/SpatialNetConnection.h"
@@ -437,9 +438,17 @@ void UGlobalStateManager::TriggerBeginPlay()
 #endif
 
 	// If we're loading from a snapshot, we shouldn't try and call BeginPlay with authority.
-	for (TActorIterator<AActor> ActorIterator(NetDriver->World); ActorIterator; ++ActorIterator)
+	// We don't use TActorIterator here as it has custom code to ignore sublevel world settings actors, which we want to handle,
+	// so we just iterate over all level actors directly.
+	for (ULevel* Level : NetDriver->World->GetLevels())
 	{
-		HandleActorBasedOnLoadBalancer(*ActorIterator);
+		if (Level != nullptr)
+		{
+			for (AActor* Actor : Level->Actors)
+			{
+				HandleActorBasedOnLoadBalancer(Actor);
+			}
+		}
 	}
 
 	NetDriver->World->GetWorldSettings()->SetGSMReadyForPlay();

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
@@ -8,7 +8,6 @@
 #endif
 
 #include "Engine/Classes/AI/AISystemBase.h"
-#include "Engine/LevelStreaming.h"
 #include "Engine/World.h"
 #include "EngineClasses/SpatialActorChannel.h"
 #include "EngineClasses/SpatialNetConnection.h"


### PR DESCRIPTION
#### Description
Sublevel world-settings objects didn't have the correct authority set on them when begin play was called. This turned out to be a quirk of the ActorIterator which [explicitly ignores sublevel WorldSettings](https://github.com/improbableio/UnrealEngine/blob/bee929c9691fa4da724623d91ed12cf2124adaf8/Engine/Source/Runtime/Engine/Public/EngineUtils.h#L314). The impact of this was that multiple world settings entities (1 per server) would be created for each sublevel. 

The fix just involves iterating over all level actors directly instead of using the ActorIterator.

#### Release note
- Fixed an issue where authority was not correctly delegated to sublevel world settings prior to BeginPlay being issued. This resulted in duplicate world settings entities being created.

#### Tests
Running world comp gyms, I can now see the correct number of world settings in the inspector.

#### Primary reviewers
@alastairdglennie 
