### PR TITLE
Spatial Tests Use FObject Initialization

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
@@ -31,8 +31,8 @@ namespace
 constexpr float FINISH_TEST_GRACE_PERIOD_DURATION = 2.0f;
 } // namespace
 
-ASpatialFunctionalTest::ASpatialFunctionalTest()
-	: Super()
+ASpatialFunctionalTest::ASpatialFunctionalTest(const FObjectInitializer& ObjectInitializer)
+	: Super(ObjectInitializer)
 	, FlowControllerSpawner(this, ASpatialFunctionalTestFlowController::StaticClass())
 {
 	bReplicates = true;

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTest.h
@@ -51,7 +51,7 @@ private:
 	uint8 bReadyToSpawnServerControllers : 1;
 
 public:
-	ASpatialFunctionalTest();
+	ASpatialFunctionalTest(const FObjectInitializer& ObjectInitializer);
 
 	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
 
@@ -375,6 +375,8 @@ protected:
 
 	void NotifyTestFinishedObserver() override;
 
+	void EndPlay(const EEndPlayReason::Type Reason) override;
+
 private:
 	bool bNotifyObserversCalled = false;
 
@@ -430,7 +432,6 @@ private:
 	void StartServerFlowControllerSpawn();
 
 	void SetupClientPlayerRegistrationFlow();
-	void EndPlay(const EEndPlayReason::Type Reason) override;
 
 	FDelegateHandle PostLoginDelegate;
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAndClientOrchestrationTest/CrossServerAndClientOrchestrationTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/CrossServerAndClientOrchestrationTest/CrossServerAndClientOrchestrationTest.cpp
@@ -19,6 +19,7 @@
  *    - Each server and client, individually, verifies they can read all values set by the other workers
  */
 ACrossServerAndClientOrchestrationTest::ACrossServerAndClientOrchestrationTest()
+	: Super(FObjectInitializer::Get())
 {
 	Author = "Jose";
 	Description = TEXT("Test the test flow in a zoned environment");

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/DebugInterface/SpatialDebugInterfaceTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/DebugInterface/SpatialDebugInterfaceTest.cpp
@@ -16,7 +16,7 @@
 */
 
 ASpatialDebugInterfaceTest::ASpatialDebugInterfaceTest()
-	: Super()
+	: Super(FObjectInitializer::Get())
 {
 	Author = "Nicolas";
 	Description = TEXT("Test Debug interface");

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/DormancyAndTombstoneTest/DormancyAndTombstoneTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/DormancyAndTombstoneTest/DormancyAndTombstoneTest.cpp
@@ -23,6 +23,7 @@
  *    - Note that this test cannot be rerun, as it relies on an actor placed in the level being deleted as part of the test.
  */
 ADormancyAndTombstoneTest::ADormancyAndTombstoneTest()
+	: Super(FObjectInitializer::Get())
 {
 	Author = "Miron";
 	Description = TEXT("Test Actor Dormancy and Tombstones");

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/DynamicSubobjectsTest/DynamicSubobjectsTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/DynamicSubobjectsTest/DynamicSubobjectsTest.cpp
@@ -36,7 +36,7 @@
 const static float StepTimeLimit = 10.0f;
 
 ADynamicSubobjectsTest::ADynamicSubobjectsTest()
-	: Super()
+	: Super(FObjectInitializer::Get())
 {
 	Author = "Evi";
 	Description = TEXT("Test Dynamic Subobjects Duplication in Client");

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/EventTracingTests/EventTracingTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/EventTracingTests/EventTracingTest.cpp
@@ -38,6 +38,7 @@ const FName AEventTracingTest::SendCrossServerRPCName = "unreal_gdk.send_cross_s
 const FName AEventTracingTest::ReceiveCrossServerRPCName = "unreal_gdk.receive_cross_server_rpc";
 
 AEventTracingTest::AEventTracingTest()
+	: Super(FObjectInitializer::Get())
 {
 	Author = "Matthew Sandford";
 	Description = TEXT("Base class for event tracing tests");

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/RegisterAutoDestroyActorsTest/RegisterAutoDestroyActorsTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/RegisterAutoDestroyActorsTest/RegisterAutoDestroyActorsTest.cpp
@@ -7,6 +7,7 @@
 #include "SpatialFunctionalTestFlowController.h"
 
 ARegisterAutoDestroyActorsTestPart1::ARegisterAutoDestroyActorsTestPart1()
+	: Super(FObjectInitializer::Get())
 {
 	Author = "Nuno";
 	Description = TEXT("Part1: Verify that server spawned a character and that is is visible to the clients");
@@ -92,6 +93,7 @@ void ARegisterAutoDestroyActorsTestPart1::PrepareTest()
 }
 
 ARegisterAutoDestroyActorsTestPart2::ARegisterAutoDestroyActorsTestPart2()
+	: Super(FObjectInitializer::Get())
 {
 	Author = "Nuno";
 	Description = TEXT("Part2: Verify that the actors have been destroyed across all workers");

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/RelevancyTest/RelevancyTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/RelevancyTest/RelevancyTest.cpp
@@ -23,7 +23,7 @@
 const static float StepTimeLimit = 5.0f;
 
 ARelevancyTest::ARelevancyTest()
-	: Super()
+	: Super(FObjectInitializer::Get())
 {
 	Author = "Mike";
 	Description = TEXT("Test Actor Relevancy");

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialAuthorityTest/SpatialAuthorityTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialAuthorityTest/SpatialAuthorityTest.cpp
@@ -32,6 +32,7 @@
  * You have some flexibility to change the Server Position properties to test in different Load-Balancing Strategies.
  */
 ASpatialAuthorityTest::ASpatialAuthorityTest()
+	: Super(FObjectInitializer::Get())
 {
 	Author = "Nuno Afonso";
 	Description = TEXT("Test HasAuthority under multi-worker setups. It also ensures it works in Native");

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialSnapshotTest/SpatialSnapshotDummyTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialSnapshotTest/SpatialSnapshotDummyTest.cpp
@@ -9,7 +9,7 @@
  */
 
 ASpatialSnapshotDummyTest::ASpatialSnapshotDummyTest()
-	: Super()
+	: Super(FObjectInitializer::Get())
 {
 	Author = "Nuno";
 	Description = TEXT("Dummy Test that just passes");

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialSnapshotTest/SpatialSnapshotTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialSnapshotTest/SpatialSnapshotTest.cpp
@@ -48,7 +48,7 @@
  */
 
 ASpatialSnapshotTest::ASpatialSnapshotTest()
-	: Super()
+	: Super(FObjectInitializer::Get())
 {
 	Author = "Nuno";
 	Description = TEXT(

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestCharacterMigration/SpatialTestCharacterMigration.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestCharacterMigration/SpatialTestCharacterMigration.cpp
@@ -33,7 +33,7 @@ float GetTargetDistanceOnLine(const FVector& From, const FVector& Target, const 
  */
 
 ASpatialTestCharacterMigration::ASpatialTestCharacterMigration()
-	: Super()
+	: Super(FObjectInitializer::Get())
 {
 	Author = "Victoria";
 	Description = TEXT("Test Character Migration");

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestCharacterMovement/SpatialTestCharacterMovement.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestCharacterMovement/SpatialTestCharacterMovement.cpp
@@ -30,7 +30,7 @@
  */
 
 ASpatialTestCharacterMovement::ASpatialTestCharacterMovement()
-	: Super()
+	: Super(FObjectInitializer::Get())
 {
 	Author = "Andrei";
 	Description = TEXT("Test Character Movement");

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPlayerControllerMigration/SpatialTestPlayerControllerHandover.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPlayerControllerMigration/SpatialTestPlayerControllerHandover.cpp
@@ -41,7 +41,7 @@ void ASpatialTestPlayerControllerHandover::GetLifetimeReplicatedProps(TArray<FLi
  */
 
 ASpatialTestPlayerControllerHandover::ASpatialTestPlayerControllerHandover()
-	: Super()
+	: Super(FObjectInitializer::Get())
 {
 	Author = "Nicolas";
 	Description = TEXT("Test player controller handover");

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestPossession.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestPossession.cpp
@@ -22,7 +22,7 @@
  */
 
 ASpatialTestPossession::ASpatialTestPossession()
-	: Super()
+	: Super(FObjectInitializer::Get())
 {
 	Author = "Miron";
 	Description = TEXT("Test Actor Possession");

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRepossession.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRepossession.cpp
@@ -17,7 +17,7 @@ void ASpatialTestRepossession::GetLifetimeReplicatedProps(TArray<FLifetimeProper
 }
 
 ASpatialTestRepossession::ASpatialTestRepossession()
-	: Super()
+	: Super(FObjectInitializer::Get())
 {
 	Author = "Improbable";
 	Description = TEXT("Test Actor Repossession");

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestRepNotify/SpatialTestRepNotify.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestRepNotify/SpatialTestRepNotify.cpp
@@ -22,7 +22,7 @@
  */
 
 ASpatialTestRepNotify::ASpatialTestRepNotify()
-	: Super()
+	: Super(FObjectInitializer::Get())
 {
 	Author = "Miron + Andrei";
 	Description = TEXT("Test RepNotify replication and shadow data");

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestShutdownPreparation/SpatialTestShutdownPreparationTrigger.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestShutdownPreparation/SpatialTestShutdownPreparationTrigger.cpp
@@ -6,6 +6,7 @@
 #include "TestPrepareShutdownListener.h"
 
 ASpatialTestShutdownPreparationTrigger::ASpatialTestShutdownPreparationTrigger()
+	: Super(FObjectInitializer::Get())
 {
 	Author = "Tilman Schmidt";
 	Description = TEXT("Trigger shutdown preparation via worker flags and make sure callbacks get called in C++ and Blueprints");

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestSingleServerDynamicComponents/SpatialTestSingleServerDynamicComponents.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestSingleServerDynamicComponents/SpatialTestSingleServerDynamicComponents.cpp
@@ -29,7 +29,7 @@
  *	- The TestActor is destroyed.
  */
 ASpatialTestSingleServerDynamicComponents::ASpatialTestSingleServerDynamicComponents()
-	: Super()
+	: Super(FObjectInitializer::Get())
 {
 	Author = "Miron + Andrei";
 	Description = TEXT("Test Dynamic Component Replication in a Single Server Context");

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestTearOff/SpatialTestTearOff.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestTearOff/SpatialTestTearOff.cpp
@@ -31,7 +31,7 @@
  */
 
 ASpatialTestTearOff::ASpatialTestTearOff()
-	: Super()
+	: Super(FObjectInitializer::Get())
 {
 	Author = "Andrei";
 	Description = TEXT("Test TearOff prevents Actors from replicating");

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3066/OwnerOnlyPropertyReplication.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3066/OwnerOnlyPropertyReplication.cpp
@@ -36,6 +36,7 @@ FString AssertStep(const FSpatialFunctionalTestStepDefinition& StepDefinition, c
  *    - No cleanup required, as the actor is deleted as part of the test.
  */
 AOwnerOnlyPropertyReplication::AOwnerOnlyPropertyReplication()
+	: Super(FObjectInitializer::Get())
 {
 	Author = "Andreas";
 	Description = TEXT("UNR-3066 OwnerOnly replication test");

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3157/RPCInInterfaceTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3157/RPCInInterfaceTest.cpp
@@ -12,6 +12,7 @@
  * It creates an actor, transfers ownership and then calls a client RPC on that actor. Finally, it verifies that the RPC was received.
  */
 ARPCInInterfaceTest::ARPCInInterfaceTest()
+	: Super(FObjectInitializer::Get())
 {
 	Author = "Andreas";
 	Description = TEXT("Test RPCs in interfaces");

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestClientNetOwnership/SpatialTestNetOwnership.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestClientNetOwnership/SpatialTestNetOwnership.cpp
@@ -38,7 +38,7 @@
  */
 
 ASpatialTestNetOwnership::ASpatialTestNetOwnership()
-	: Super()
+	: Super(FObjectInitializer::Get())
 {
 	Author = TEXT("Andrei");
 	Description = TEXT("Test Net Ownership");

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestCrossServerRPC/SpatialTestCrossServerRPC.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestCrossServerRPC/SpatialTestCrossServerRPC.cpp
@@ -37,7 +37,7 @@
  */
 
 ASpatialTestCrossServerRPC::ASpatialTestCrossServerRPC()
-	: Super()
+	: Super(FObjectInitializer::Get())
 {
 	Author = "Andrei / Victoria";
 	Description = TEXT("Test CrossServer RPCs");

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestHandover/SpatialTestHandover.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestHandover/SpatialTestHandover.cpp
@@ -31,7 +31,7 @@
  *	- The HandoverCube is destroyed.
  */
 ASpatialTestHandover::ASpatialTestHandover()
-	: Super()
+	: Super(FObjectInitializer::Get())
 {
 	Author = "Andrei";
 	Description = TEXT("Test Actor handover");

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestNetReference/SpatialTestNetReference.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestNetReference/SpatialTestNetReference.cpp
@@ -29,7 +29,7 @@
  */
 
 ASpatialTestNetReference::ASpatialTestNetReference()
-	: Super()
+	: Super(FObjectInitializer::Get())
 {
 	Author = "Andrei";
 	Description = TEXT("Test Net Reference");

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestReplicatedStartupActor/SpatialTestReplicatedStartupActor.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestReplicatedStartupActor/SpatialTestReplicatedStartupActor.cpp
@@ -38,7 +38,7 @@
  */
 
 ASpatialTestReplicatedStartupActor::ASpatialTestReplicatedStartupActor()
-	: Super()
+	: Super(FObjectInitializer::Get())
 {
 	Author = "Andrei";
 	Description = TEXT("Test Replicated Startup Actor Reference And Property Replication");

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestWorldComposition/SpatialTestWorldComposition.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestWorldComposition/SpatialTestWorldComposition.cpp
@@ -27,7 +27,7 @@
  *  - No clean-up is required.
  */
 ASpatialTestWorldComposition::ASpatialTestWorldComposition()
-	: Super()
+	: Super(FObjectInitializer::Get())
 {
 	Author = "Andrei";
 	Description = TEXT("Test World Composition");

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/VisibilityTest/VisibilityTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/VisibilityTest/VisibilityTest.cpp
@@ -36,7 +36,7 @@
 const static float StepTimeLimit = 10.0f;
 
 AVisibilityTest::AVisibilityTest()
-	: Super()
+	: Super(FObjectInitializer::Get())
 {
 	Author = "Evi";
 	Description = TEXT("Test Actor Visibility");


### PR DESCRIPTION
#### Description
* This will allow non-Spatial tests to be updated to be Spatial Functional Tests without maintaining two classes in this process, as their constructors will now be compatible with NWX's test framework &  blueprints should have more consistent behavior.
* Can update tests one by one to work with spatial features without duplicating them simply by adding steps/ correct overrides.
* Explicitly use explicit FObjectInitializer Initialization rather than lean on implicit FVTableHelper Initialization, this is the recommended way from what I can tell and follows developer patterns in the NWXFunctionalTest class.
![image](https://user-images.githubusercontent.com/10687703/108086382-8744ad00-7033-11eb-8720-8c40bdeefdb0.png)
![FVTableDocsBad](https://user-images.githubusercontent.com/10687703/108086448-9deb0400-7033-11eb-9f2b-fb86b92dcbea.png)

#### Release note
REQUIRED: Add a release note to the `##Unreleased` section of CHANGELOG.md. You can find guidance for writing useful release notes [here](../SpatialGDK/Extras/internal-documentation/how-to-write-good-release-notes.md). Documentation changes are exempt from this requirement.

#### Tests
How did you test these changes prior to submitting this pull request?
What automated tests are included in this PR?

STRONGLY SUGGESTED: How can this be verified by QA?

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

#### Reminders (IMPORTANT)
If your change relies on a breaking engine change:
* Increment `SPATIAL_ENGINE_VERSION` in `Engine\Source\Runtime\Launch\Resources\SpatialVersion.h` (in the engine fork) as well as `SPATIAL_GDK_VERSION` in `SpatialGDK\Source\SpatialGDK\Public\Utils\EngineVersionCheck.h`. This helps others by providing a more helpful message during compilation to make sure the GDK and the Engine are up to date.

If your change updates `Setup.bat`, `Setup.sh`, core SDK version, any C# tools in `SpatialGDK\Build\Programs\Improbable.Unreal.Scripts`, or hand-written schema in `SpatialGDK\Extras\schema`:
* Increment the number in `RequireSetup`. This will automatically run `Setup.bat` or `Setup.sh` when the GDK is next pulled.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
