### PR TITLE
[UNR-5078] Fix for cross server RPC intermittent test failure

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestCrossServerRPC/SpatialTestCrossServerRPC.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestCrossServerRPC/SpatialTestCrossServerRPC.cpp
@@ -170,6 +170,27 @@ void ASpatialTestCrossServerRPC::PrepareTest()
 
 	int NumCubes = CubesLocations.Num();
 
+	// Check actors are ready on each server
+	AddStep(
+		TEXT("Dynamic actor tests: TestReadyActors"), FWorkerDefinition::AllServers,
+		[this, NumCubes]() -> bool {
+			TArray<AActor*> TestCubes;
+			UGameplayStatics::GetAllActorsOfClass(GetWorld(), ACrossServerRPCCube::StaticClass(), TestCubes);
+
+			bool AreReady = true;
+
+			for (const AActor* Cube : TestCubes)
+			{
+				check(Cube);
+				AreReady &= Cube->IsActorReady();
+			}
+
+			return AreReady;
+		},
+		[this]() {
+			FinishStep();
+		});
+
 	// Each server sends an RPC to all cubes that it is NOT authoritive over.
 	AddStep(
 		TEXT("Dynamic actor tests: ServerSendRPCs"), FWorkerDefinition::AllServers,

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestCrossServerRPC/SpatialTestCrossServerRPC.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/UNR-3761/SpatialTestCrossServerRPC/SpatialTestCrossServerRPC.cpp
@@ -170,27 +170,6 @@ void ASpatialTestCrossServerRPC::PrepareTest()
 
 	int NumCubes = CubesLocations.Num();
 
-	// Check actors are ready on each server
-	AddStep(
-		TEXT("Dynamic actor tests: TestReadyActors"), FWorkerDefinition::AllServers,
-		[this, NumCubes]() -> bool {
-			TArray<AActor*> TestCubes;
-			UGameplayStatics::GetAllActorsOfClass(GetWorld(), ACrossServerRPCCube::StaticClass(), TestCubes);
-
-			bool AreReady = true;
-
-			for (const AActor* Cube : TestCubes)
-			{
-				check(Cube);
-				AreReady &= Cube->IsActorReady();
-			}
-
-			return AreReady;
-		},
-		[this]() {
-			FinishStep();
-		});
-
 	// Each server sends an RPC to all cubes that it is NOT authoritive over.
 	AddStep(
 		TEXT("Dynamic actor tests: ServerSendRPCs"), FWorkerDefinition::AllServers,
@@ -206,6 +185,8 @@ void ASpatialTestCrossServerRPC::PrepareTest()
 			int LocalWorkerId = GetLocalWorkerId();
 			int NumCubesWithAuthority = 0;
 			int NumCubesShouldHaveAuthority = 0;
+			int NumCubesReady = 0;
+
 			for (AActor* Cube : TestCubes)
 			{
 				if (Cube->HasAuthority())
@@ -216,10 +197,15 @@ void ASpatialTestCrossServerRPC::PrepareTest()
 				{
 					NumCubesShouldHaveAuthority += 1;
 				}
+				if (Cube->IsActorReady())
+				{
+					NumCubesReady += 1;
+				}
 			}
 
 			// So only when we have all cubes present and we only have authority over the one we should we can progress.
-			return TestCubes.Num() == NumCubes && NumCubesWithAuthority == 1 && NumCubesShouldHaveAuthority == 1;
+			return TestCubes.Num() == NumCubes && NumCubesWithAuthority == 1 && NumCubesShouldHaveAuthority == 1
+				   && NumCubesReady == NumCubes;
 		},
 		[this]() {
 			TArray<AActor*> TestCubes;


### PR DESCRIPTION
#### Description
Added an "ActorReady" test step before RPCs are sent, to ensure RPCs are not lost.

#### Tests
Fix for an existing automated test, which failed intermittently.