### PR TITLE
Remove complex type instantation from SpatialConstants.h

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKModule.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKModule.cpp
@@ -2,6 +2,11 @@
 
 #include "SpatialGDKModule.h"
 
+// clang-format off
+#include "SpatialConstants.h"
+#include "SpatialConstants.cxx"
+// clang-format on
+
 #define LOCTEXT_NAMESPACE "FSpatialGDKModule"
 
 DEFINE_LOG_CATEGORY(LogSpatialGDKModule);

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.cxx
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.cxx
@@ -25,9 +25,10 @@ FString RPCTypeToString(ERPCType RPCType)
         return TEXT("Multicast");
     case ERPCType::CrossServer:
         return TEXT("CrossServer");
+    default:
+        checkNoEntry();
     }
 
-    checkNoEntry();
     return FString();
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.cxx
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.cxx
@@ -1,0 +1,249 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#define LOCTEXT_NAMESPACE "SpatialConstants"
+
+using namespace SpatialGDK;
+
+namespace SpatialConstants
+{
+
+FString RPCTypeToString(ERPCType RPCType)
+{
+    switch (RPCType)
+    {
+    case ERPCType::ClientReliable:
+        return TEXT("Client, Reliable");
+    case ERPCType::ClientUnreliable:
+        return TEXT("Client, Unreliable");
+    case ERPCType::ServerReliable:
+        return TEXT("Server, Reliable");
+    case ERPCType::ServerUnreliable:
+        return TEXT("Server, Unreliable");
+    case ERPCType::ServerAlwaysWrite:
+        return TEXT("Server, AlwaysWrite");
+    case ERPCType::NetMulticast:
+        return TEXT("Multicast");
+    case ERPCType::CrossServer:
+        return TEXT("CrossServer");
+    }
+
+    checkNoEntry();
+    return FString();
+}
+
+TOptional<ERPCType> RPCStringToType(const FString& String)
+{
+    static const TMap<FString, ERPCType> s_NamesMap = []
+    {
+        TMap<FString, ERPCType> NamesMap;
+        for (uint8 RPCTypeIdx = static_cast<uint8>(ERPCType::RingBufferTypeBegin);
+            RPCTypeIdx <= static_cast<uint8>(ERPCType::RingBufferTypeEnd); RPCTypeIdx++)
+        {
+            ERPCType RPCType = static_cast<ERPCType>(RPCTypeIdx);
+            NamesMap.Add(RPCTypeToString(RPCType), RPCType);
+        }
+        return NamesMap;
+    }();
+
+    const ERPCType* Entry = s_NamesMap.Find(String);
+
+    if (Entry)
+    {
+        return *Entry;
+    }
+
+    return {};
+}
+
+
+const FString SERVER_AUTH_COMPONENT_SET_NAME = TEXT("ServerAuthoritativeComponentSet");
+const FString CLIENT_AUTH_COMPONENT_SET_NAME = TEXT("ClientAuthoritativeComponentSet");
+const FString DATA_COMPONENT_SET_NAME = TEXT("DataComponentSet");
+const FString OWNER_ONLY_COMPONENT_SET_NAME = TEXT("OwnerOnlyComponentSet");
+const FString HANDOVER_COMPONENT_SET_NAME = TEXT("HandoverComponentSet");
+const FString ROUTING_WORKER_COMPONENT_SET_NAME = TEXT("RoutingWorkerComponentSet");
+const FString INITIAL_ONLY_COMPONENT_SET_NAME = TEXT("InitialOnlyComponentSet");
+
+const PhysicalWorkerName TRANSLATOR_UNSET_PHYSICAL_NAME = FString("UnsetWorkerName");
+
+const FName DefaultLayer = FName(TEXT("DefaultLayer"));
+
+const FName RoutingWorkerType(TEXT("RoutingWorker"));
+
+const FString ClientsStayConnectedURLOption = TEXT("clientsStayConnected");
+const FString SpatialSessionIdURLOption = TEXT("spatialSessionId=");
+
+const FString LOCATOR_HOST = TEXT("locator.improbable.io");
+const FString LOCATOR_HOST_CN = TEXT("locator.spatialoschina.com");
+
+const FString CONSOLE_HOST = TEXT("console.improbable.io");
+const FString CONSOLE_HOST_CN = TEXT("console.spatialoschina.com");
+
+const FString AssemblyPattern = TEXT("^[a-zA-Z0-9_.-]{5,64}$");
+const FText AssemblyPatternHint =
+LOCTEXT("AssemblyPatternHint",
+    "Assembly name may only contain alphanumeric characters, '_', '.', or '-', and must be between 5 and 64 characters long.");
+const FString ProjectPattern = TEXT("^[a-z0-9_]{3,32}$");
+const FText ProjectPatternHint =
+LOCTEXT("ProjectPatternHint",
+    "Project name may only contain lowercase alphanumeric characters or '_', and must be between 3 and 32 characters long.");
+const FString DeploymentPattern = TEXT("^[a-z0-9_]{2,32}$");
+const FText DeploymentPatternHint =
+LOCTEXT("DeploymentPatternHint",
+    "Deployment name may only contain lowercase alphanumeric characters or '_', and must be between 2 and 32 characters long.");
+const FString Ipv4Pattern = TEXT("^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$");
+
+
+const FString SPATIALOS_METRICS_DYNAMIC_FPS = TEXT("Dynamic.FPS");
+const FString RECONNECT_USING_COMMANDLINE_ARGUMENTS = TEXT("0.0.0.0");
+const FString URL_LOGIN_OPTION = TEXT("login=");
+const FString URL_PLAYER_IDENTITY_OPTION = TEXT("playeridentity=");
+const FString URL_DEV_AUTH_TOKEN_OPTION = TEXT("devauthtoken=");
+const FString URL_TARGET_DEPLOYMENT_OPTION = TEXT("deployment=");
+const FString URL_PLAYER_ID_OPTION = TEXT("playerid=");
+const FString URL_DISPLAY_NAME_OPTION = TEXT("displayname=");
+const FString URL_METADATA_OPTION = TEXT("metadata=");
+const FString URL_USE_EXTERNAL_IP_FOR_BRIDGE_OPTION = TEXT("useExternalIpForBridge");
+
+const FString SHUTDOWN_PREPARATION_WORKER_FLAG = TEXT("PrepareShutdown");
+
+const FString DEVELOPMENT_AUTH_PLAYER_ID = TEXT("Player Id");
+
+const FString SCHEMA_DATABASE_FILE_PATH = TEXT("Spatial/SchemaDatabase");
+const FString SCHEMA_DATABASE_ASSET_PATH = TEXT("/Game/Spatial/SchemaDatabase");
+
+const FString EMPTY_TEST_MAP_PATH = TEXT("/SpatialGDK/Maps/Empty");
+
+const FString DEV_LOGIN_TAG = TEXT("dev_login");
+
+const TArray<Worker_ComponentId> REQUIRED_COMPONENTS_FOR_NON_AUTH_CLIENT_INTEREST =
+TArray<Worker_ComponentId>{ // Actor components
+                            UNREAL_METADATA_COMPONENT_ID, SPAWN_DATA_COMPONENT_ID, TOMBSTONE_COMPONENT_ID, TOMBSTONE_TAG_COMPONENT_ID,
+                            DORMANT_COMPONENT_ID, INITIAL_ONLY_PRESENCE_COMPONENT_ID,
+
+                            // Multicast RPCs
+                            MULTICAST_RPCS_COMPONENT_ID,
+
+                            // Global state components
+                            DEPLOYMENT_MAP_COMPONENT_ID, STARTUP_ACTOR_MANAGER_COMPONENT_ID, GSM_SHUTDOWN_COMPONENT_ID,
+
+                            // Debugging information
+                            DEBUG_METRICS_COMPONENT_ID, SPATIAL_DEBUGGING_COMPONENT_ID,
+
+                            // Actor tag
+                            ACTOR_TAG_COMPONENT_ID
+};
+
+const TArray<Worker_ComponentId> REQUIRED_COMPONENTS_FOR_AUTH_CLIENT_INTEREST =
+TArray<Worker_ComponentId>{ // RPCs from the server
+                            SERVER_ENDPOINT_COMPONENT_ID,
+
+                            // Actor tags
+                            ACTOR_TAG_COMPONENT_ID, ACTOR_AUTH_TAG_COMPONENT_ID
+};
+
+const TArray<Worker_ComponentId> REQUIRED_COMPONENTS_FOR_NON_AUTH_SERVER_INTEREST = TArray<Worker_ComponentId>{
+    // Actor components
+    UNREAL_METADATA_COMPONENT_ID, SPAWN_DATA_COMPONENT_ID, TOMBSTONE_COMPONENT_ID, DORMANT_COMPONENT_ID,
+    NET_OWNING_CLIENT_WORKER_COMPONENT_ID,
+
+    // Multicast RPCs
+    MULTICAST_RPCS_COMPONENT_ID,
+
+    // Global state components
+    DEPLOYMENT_MAP_COMPONENT_ID, STARTUP_ACTOR_MANAGER_COMPONENT_ID, GSM_SHUTDOWN_COMPONENT_ID, SNAPSHOT_VERSION_COMPONENT_ID,
+
+    // Unreal load balancing components
+    VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID,
+
+    // Authority intent component to handle scattered hierarchies
+    AUTHORITY_INTENT_COMPONENT_ID,
+
+    // Tags: Well known entities, non-auth actors, and tombstone tags
+    GDK_KNOWN_ENTITY_TAG_COMPONENT_ID, ACTOR_TAG_COMPONENT_ID, TOMBSTONE_TAG_COMPONENT_ID,
+
+    PLAYER_CONTROLLER_COMPONENT_ID, PARTITION_COMPONENT_ID
+};
+
+const TArray<Worker_ComponentId> REQUIRED_COMPONENTS_FOR_AUTH_SERVER_INTEREST =
+TArray<Worker_ComponentId>{ // RPCs from clients
+                            CLIENT_ENDPOINT_COMPONENT_ID,
+
+                            // Player controller
+                            PLAYER_CONTROLLER_COMPONENT_ID,
+
+                            // Cross server endpoint
+                            CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID, CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID,
+
+                            // Actor tags
+                            ACTOR_TAG_COMPONENT_ID, ACTOR_AUTH_TAG_COMPONENT_ID,
+
+                            PARTITION_COMPONENT_ID
+};
+
+const TArray<FString> ServerAuthorityWellKnownSchemaImports = {
+    "improbable/standard_library.schema",
+    "unreal/gdk/authority_intent.schema",
+    "unreal/gdk/debug_component.schema",
+    "unreal/gdk/debug_metrics.schema",
+    "unreal/gdk/net_owning_client_worker.schema",
+    "unreal/gdk/not_streamed.schema",
+    "unreal/gdk/query_tags.schema",
+    "unreal/gdk/relevant.schema",
+    "unreal/gdk/rpc_components.schema",
+    "unreal/gdk/spatial_debugging.schema",
+    "unreal/gdk/spawndata.schema",
+    "unreal/gdk/tombstone.schema",
+    "unreal/gdk/unreal_metadata.schema",
+    "unreal/generated/rpc_endpoints.schema",
+    "unreal/generated/NetCullDistance/ncdcomponents.schema",
+};
+
+const TMap<Worker_ComponentId, FString> ServerAuthorityWellKnownComponents = {
+    { POSITION_COMPONENT_ID, "improbable.Position" },
+    { INTEREST_COMPONENT_ID, "improbable.Interest" },
+    { AUTHORITY_DELEGATION_COMPONENT_ID, "improbable.AuthorityDelegation" },
+    { AUTHORITY_INTENT_COMPONENT_ID, "unreal.AuthorityIntent" },
+    { GDK_DEBUG_COMPONENT_ID, "unreal.DebugComponent" },
+    { DEBUG_METRICS_COMPONENT_ID, "unreal.DebugMetrics" },
+    { NET_OWNING_CLIENT_WORKER_COMPONENT_ID, "unreal.NetOwningClientWorker" },
+    { NOT_STREAMED_COMPONENT_ID, "unreal.NotStreamed" },
+    { ALWAYS_RELEVANT_COMPONENT_ID, "unreal.AlwaysRelevant" },
+    { DORMANT_COMPONENT_ID, "unreal.Dormant" },
+    { VISIBLE_COMPONENT_ID, "unreal.Visible" },
+    { SERVER_TO_SERVER_COMMAND_ENDPOINT_COMPONENT_ID, "unreal.UnrealServerToServerCommandEndpoint" },
+    { SPATIAL_DEBUGGING_COMPONENT_ID, "unreal.SpatialDebugging" },
+    { SPAWN_DATA_COMPONENT_ID, "unreal.SpawnData" },
+    { TOMBSTONE_COMPONENT_ID, "unreal.Tombstone" },
+    { UNREAL_METADATA_COMPONENT_ID, "unreal.UnrealMetadata" },
+    { SERVER_ENDPOINT_COMPONENT_ID, "unreal.generated.UnrealServerEndpoint" },
+    { MULTICAST_RPCS_COMPONENT_ID, "unreal.generated.UnrealMulticastRPCs" },
+    { SERVER_ENDPOINT_COMPONENT_ID, "unreal.generated.UnrealServerEndpoint" },
+    { CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID, "unreal.generated.UnrealCrossServerSenderRPCs" },
+    { CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID, "unreal.generated.UnrealCrossServerReceiverACKRPCs" },
+};
+
+const TArray<FString> ClientAuthorityWellKnownSchemaImports = { "unreal/gdk/player_controller.schema", "unreal/gdk/rpc_components.schema",
+                                                                "unreal/generated/rpc_endpoints.schema" };
+
+const TMap<Worker_ComponentId, FString> ClientAuthorityWellKnownComponents = {
+    { PLAYER_CONTROLLER_COMPONENT_ID, "unreal.PlayerController" },
+    { CLIENT_ENDPOINT_COMPONENT_ID, "unreal.generated.UnrealClientEndpoint" },
+};
+
+const TMap<Worker_ComponentId, FString> RoutingWorkerComponents = {
+    { CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID, "unreal.generated.UnrealCrossServerSenderACKRPCs" },
+    { CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID, "unreal.generated.UnrealCrossServerReceiverRPCs" },
+};
+
+const TArray<FString> RoutingWorkerSchemaImports = { "unreal/gdk/rpc_components.schema", "unreal/generated/rpc_endpoints.schema" };
+
+const TArray<Worker_ComponentId> KnownEntityAuthorityComponents = { POSITION_COMPONENT_ID,		 METADATA_COMPONENT_ID,
+                                                                    INTEREST_COMPONENT_ID,		 PLAYER_SPAWNER_COMPONENT_ID,
+                                                                    DEPLOYMENT_MAP_COMPONENT_ID, STARTUP_ACTOR_MANAGER_COMPONENT_ID,
+                                                                    GSM_SHUTDOWN_COMPONENT_ID,	 VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID,
+                                                                    SERVER_WORKER_COMPONENT_ID };
+
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -12,8 +12,6 @@
 
 #include "SpatialConstants.generated.h"
 
-#define LOCTEXT_NAMESPACE "SpatialConstants"
-
 UENUM()
 enum class ERPCType : uint8
 {
@@ -28,7 +26,7 @@ enum class ERPCType : uint8
 
 	// Helpers to iterate RPC types with ring buffers
 	RingBufferTypeBegin = ClientReliable,
-	RingBufferTypeEnd = NetMulticast
+	RingBufferTypeEnd = CrossServer
 };
 
 enum ESchemaComponentType : int32
@@ -49,29 +47,8 @@ enum ESchemaComponentType : int32
 
 namespace SpatialConstants
 {
-inline FString RPCTypeToString(ERPCType RPCType)
-{
-	switch (RPCType)
-	{
-	case ERPCType::ClientReliable:
-		return TEXT("Client, Reliable");
-	case ERPCType::ClientUnreliable:
-		return TEXT("Client, Unreliable");
-	case ERPCType::ServerReliable:
-		return TEXT("Server, Reliable");
-	case ERPCType::ServerUnreliable:
-		return TEXT("Server, Unreliable");
-	case ERPCType::ServerAlwaysWrite:
-		return TEXT("Server, AlwaysWrite");
-	case ERPCType::NetMulticast:
-		return TEXT("Multicast");
-	case ERPCType::CrossServer:
-		return TEXT("CrossServer");
-	}
-
-	checkNoEntry();
-	return FString();
-}
+FString RPCTypeToString(ERPCType RPCType);
+TOptional<ERPCType> RPCStringToType(const FString& String);
 
 enum EntityIds
 {
@@ -121,13 +98,13 @@ const Worker_ComponentSetId GDK_KNOWN_ENTITY_AUTH_COMPONENT_SET_ID = 9905;
 const Worker_ComponentSetId ROUTING_WORKER_AUTH_COMPONENT_SET_ID = 9906;
 const Worker_ComponentSetId INITIAL_ONLY_COMPONENT_SET_ID = 9907;
 
-const FString SERVER_AUTH_COMPONENT_SET_NAME = TEXT("ServerAuthoritativeComponentSet");
-const FString CLIENT_AUTH_COMPONENT_SET_NAME = TEXT("ClientAuthoritativeComponentSet");
-const FString DATA_COMPONENT_SET_NAME = TEXT("DataComponentSet");
-const FString OWNER_ONLY_COMPONENT_SET_NAME = TEXT("OwnerOnlyComponentSet");
-const FString HANDOVER_COMPONENT_SET_NAME = TEXT("HandoverComponentSet");
-const FString ROUTING_WORKER_COMPONENT_SET_NAME = TEXT("RoutingWorkerComponentSet");
-const FString INITIAL_ONLY_COMPONENT_SET_NAME = TEXT("InitialOnlyComponentSet");
+extern const FString SERVER_AUTH_COMPONENT_SET_NAME;
+extern const FString CLIENT_AUTH_COMPONENT_SET_NAME;
+extern const FString DATA_COMPONENT_SET_NAME;
+extern const FString OWNER_ONLY_COMPONENT_SET_NAME;
+extern const FString HANDOVER_COMPONENT_SET_NAME;
+extern const FString ROUTING_WORKER_COMPONENT_SET_NAME;
+extern const FString INITIAL_ONLY_COMPONENT_SET_NAME;
 
 const Worker_ComponentId NOT_STREAMED_COMPONENT_ID = 9986;
 const Worker_ComponentId DEBUG_METRICS_COMPONENT_ID = 9984;
@@ -226,7 +203,7 @@ const Schema_FieldId MAPPING_VIRTUAL_WORKER_ID = 1;
 const Schema_FieldId MAPPING_PHYSICAL_WORKER_NAME_ID = 2;
 const Schema_FieldId MAPPING_SERVER_WORKER_ENTITY_ID = 3;
 const Schema_FieldId MAPPING_PARTITION_ID = 4;
-const PhysicalWorkerName TRANSLATOR_UNSET_PHYSICAL_NAME = FString("UnsetWorkerName");
+extern const PhysicalWorkerName TRANSLATOR_UNSET_PHYSICAL_NAME;
 
 // WorkerEntity Field IDs.
 const Schema_FieldId WORKER_ID_ID = 1;
@@ -299,35 +276,29 @@ const float FORWARD_PLAYER_SPAWN_COMMAND_WAIT_SECONDS = 0.2f;
 
 const VirtualWorkerId INVALID_VIRTUAL_WORKER_ID = 0;
 const ActorLockToken INVALID_ACTOR_LOCK_TOKEN = 0;
-const FString INVALID_WORKER_NAME = TEXT("");
+const FString INVALID_WORKER_NAME;
 
-static const FName DefaultLayer = FName(TEXT("DefaultLayer"));
+extern const FName DefaultLayer;
 
-const FName RoutingWorkerType(TEXT("RoutingWorker"));
+extern const FName RoutingWorkerType;
 
-const FString ClientsStayConnectedURLOption = TEXT("clientsStayConnected");
-const FString SpatialSessionIdURLOption = TEXT("spatialSessionId=");
+extern const FString ClientsStayConnectedURLOption;
+extern const FString SpatialSessionIdURLOption;
 
-const FString LOCATOR_HOST = TEXT("locator.improbable.io");
-const FString LOCATOR_HOST_CN = TEXT("locator.spatialoschina.com");
+extern const FString LOCATOR_HOST;
+extern const FString LOCATOR_HOST_CN;
 const uint16 LOCATOR_PORT = 443;
 
-const FString CONSOLE_HOST = TEXT("console.improbable.io");
-const FString CONSOLE_HOST_CN = TEXT("console.spatialoschina.com");
+extern const FString CONSOLE_HOST;
+extern const FString CONSOLE_HOST_CN;
 
-const FString AssemblyPattern = TEXT("^[a-zA-Z0-9_.-]{5,64}$");
-const FText AssemblyPatternHint =
-	LOCTEXT("AssemblyPatternHint",
-			"Assembly name may only contain alphanumeric characters, '_', '.', or '-', and must be between 5 and 64 characters long.");
-const FString ProjectPattern = TEXT("^[a-z0-9_]{3,32}$");
-const FText ProjectPatternHint =
-	LOCTEXT("ProjectPatternHint",
-			"Project name may only contain lowercase alphanumeric characters or '_', and must be between 3 and 32 characters long.");
-const FString DeploymentPattern = TEXT("^[a-z0-9_]{2,32}$");
-const FText DeploymentPatternHint =
-	LOCTEXT("DeploymentPatternHint",
-			"Deployment name may only contain lowercase alphanumeric characters or '_', and must be between 2 and 32 characters long.");
-const FString Ipv4Pattern = TEXT("^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$");
+extern const FString AssemblyPattern;
+extern const FText AssemblyPatternHint;
+extern const FString ProjectPattern;
+extern const FText ProjectPatternHint;
+extern const FString DeploymentPattern;
+extern const FText DeploymentPatternHint;
+extern const FString Ipv4Pattern;
 
 inline float GetCommandRetryWaitTimeSeconds(uint32 NumAttempts)
 {
@@ -346,102 +317,45 @@ const float ENTITY_QUERY_RETRY_WAIT_SECONDS = 3.0f;
 const Worker_ComponentId MIN_EXTERNAL_SCHEMA_ID = 1000;
 const Worker_ComponentId MAX_EXTERNAL_SCHEMA_ID = 2000;
 
-const FString SPATIALOS_METRICS_DYNAMIC_FPS = TEXT("Dynamic.FPS");
+extern const FString SPATIALOS_METRICS_DYNAMIC_FPS;
 
 // URL that can be used to reconnect using the command line arguments.
-const FString RECONNECT_USING_COMMANDLINE_ARGUMENTS = TEXT("0.0.0.0");
-const FString URL_LOGIN_OPTION = TEXT("login=");
-const FString URL_PLAYER_IDENTITY_OPTION = TEXT("playeridentity=");
-const FString URL_DEV_AUTH_TOKEN_OPTION = TEXT("devauthtoken=");
-const FString URL_TARGET_DEPLOYMENT_OPTION = TEXT("deployment=");
-const FString URL_PLAYER_ID_OPTION = TEXT("playerid=");
-const FString URL_DISPLAY_NAME_OPTION = TEXT("displayname=");
-const FString URL_METADATA_OPTION = TEXT("metadata=");
-const FString URL_USE_EXTERNAL_IP_FOR_BRIDGE_OPTION = TEXT("useExternalIpForBridge");
+extern const FString RECONNECT_USING_COMMANDLINE_ARGUMENTS;
+extern const FString URL_LOGIN_OPTION;
+extern const FString URL_PLAYER_IDENTITY_OPTION;
+extern const FString URL_DEV_AUTH_TOKEN_OPTION;
+extern const FString URL_TARGET_DEPLOYMENT_OPTION;
+extern const FString URL_PLAYER_ID_OPTION;
+extern const FString URL_DISPLAY_NAME_OPTION;
+extern const FString URL_METADATA_OPTION;
+extern const FString URL_USE_EXTERNAL_IP_FOR_BRIDGE_OPTION;
 
-const FString SHUTDOWN_PREPARATION_WORKER_FLAG = TEXT("PrepareShutdown");
+extern const FString SHUTDOWN_PREPARATION_WORKER_FLAG;
 
-const FString DEVELOPMENT_AUTH_PLAYER_ID = TEXT("Player Id");
+extern const FString DEVELOPMENT_AUTH_PLAYER_ID;
 
-const FString SCHEMA_DATABASE_FILE_PATH = TEXT("Spatial/SchemaDatabase");
-const FString SCHEMA_DATABASE_ASSET_PATH = TEXT("/Game/Spatial/SchemaDatabase");
+extern const FString SCHEMA_DATABASE_FILE_PATH;
+extern const FString SCHEMA_DATABASE_ASSET_PATH;
 
 // An empty map with the game mode override set to GameModeBase.
-const FString EMPTY_TEST_MAP_PATH = TEXT("/SpatialGDK/Maps/Empty");
+extern const FString EMPTY_TEST_MAP_PATH;
 
-const FString DEV_LOGIN_TAG = TEXT("dev_login");
+extern const FString DEV_LOGIN_TAG;
 
 // A list of components clients require on top of any generated data components in order to handle non-authoritative actors correctly.
-const TArray<Worker_ComponentId> REQUIRED_COMPONENTS_FOR_NON_AUTH_CLIENT_INTEREST =
-	TArray<Worker_ComponentId>{ // Actor components
-								UNREAL_METADATA_COMPONENT_ID, SPAWN_DATA_COMPONENT_ID, TOMBSTONE_COMPONENT_ID, TOMBSTONE_TAG_COMPONENT_ID,
-								DORMANT_COMPONENT_ID, INITIAL_ONLY_PRESENCE_COMPONENT_ID,
-
-								// Multicast RPCs
-								MULTICAST_RPCS_COMPONENT_ID,
-
-								// Global state components
-								DEPLOYMENT_MAP_COMPONENT_ID, STARTUP_ACTOR_MANAGER_COMPONENT_ID, GSM_SHUTDOWN_COMPONENT_ID,
-
-								// Debugging information
-								DEBUG_METRICS_COMPONENT_ID, SPATIAL_DEBUGGING_COMPONENT_ID,
-
-								// Actor tag
-								ACTOR_TAG_COMPONENT_ID
-	};
+extern const TArray<Worker_ComponentId> REQUIRED_COMPONENTS_FOR_NON_AUTH_CLIENT_INTEREST;
 
 // A list of components clients require on entities they are authoritative over on top of the components already checked out by the interest
 // query.
-const TArray<Worker_ComponentId> REQUIRED_COMPONENTS_FOR_AUTH_CLIENT_INTEREST =
-	TArray<Worker_ComponentId>{ // RPCs from the server
-								SERVER_ENDPOINT_COMPONENT_ID,
-
-								// Actor tags
-								ACTOR_TAG_COMPONENT_ID, ACTOR_AUTH_TAG_COMPONENT_ID
-	};
+extern const TArray<Worker_ComponentId> REQUIRED_COMPONENTS_FOR_AUTH_CLIENT_INTEREST;
 
 // A list of components servers require on top of any generated data and handover components in order to handle non-authoritative actors
 // correctly.
-const TArray<Worker_ComponentId> REQUIRED_COMPONENTS_FOR_NON_AUTH_SERVER_INTEREST = TArray<Worker_ComponentId>{
-	// Actor components
-	UNREAL_METADATA_COMPONENT_ID, SPAWN_DATA_COMPONENT_ID, TOMBSTONE_COMPONENT_ID, DORMANT_COMPONENT_ID,
-	NET_OWNING_CLIENT_WORKER_COMPONENT_ID,
-
-	// Multicast RPCs
-	MULTICAST_RPCS_COMPONENT_ID,
-
-	// Global state components
-	DEPLOYMENT_MAP_COMPONENT_ID, STARTUP_ACTOR_MANAGER_COMPONENT_ID, GSM_SHUTDOWN_COMPONENT_ID, SNAPSHOT_VERSION_COMPONENT_ID,
-
-	// Unreal load balancing components
-	VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID,
-
-	// Authority intent component to handle scattered hierarchies
-	AUTHORITY_INTENT_COMPONENT_ID,
-
-	// Tags: Well known entities, non-auth actors, and tombstone tags
-	GDK_KNOWN_ENTITY_TAG_COMPONENT_ID, ACTOR_TAG_COMPONENT_ID, TOMBSTONE_TAG_COMPONENT_ID,
-
-	PLAYER_CONTROLLER_COMPONENT_ID, PARTITION_COMPONENT_ID
-};
+extern const TArray<Worker_ComponentId> REQUIRED_COMPONENTS_FOR_NON_AUTH_SERVER_INTEREST;
 
 // A list of components servers require on entities they are authoritative over on top of the components already checked out by the interest
 // query.
-const TArray<Worker_ComponentId> REQUIRED_COMPONENTS_FOR_AUTH_SERVER_INTEREST =
-	TArray<Worker_ComponentId>{ // RPCs from clients
-								CLIENT_ENDPOINT_COMPONENT_ID,
-
-								// Player controller
-								PLAYER_CONTROLLER_COMPONENT_ID,
-
-								// Cross server endpoint
-								CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID, CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID,
-
-								// Actor tags
-								ACTOR_TAG_COMPONENT_ID, ACTOR_AUTH_TAG_COMPONENT_ID,
-
-								PARTITION_COMPONENT_ID
-	};
+extern const TArray<Worker_ComponentId> REQUIRED_COMPONENTS_FOR_AUTH_SERVER_INTEREST;
 
 inline bool IsEntityCompletenessComponent(Worker_ComponentId ComponentId)
 {
@@ -449,68 +363,13 @@ inline bool IsEntityCompletenessComponent(Worker_ComponentId ComponentId)
 }
 
 // TODO: These containers should be cleaned up when we move to reading component set data directly from schema bundle - UNR-4666
-const TArray<FString> ServerAuthorityWellKnownSchemaImports = {
-	"improbable/standard_library.schema",
-	"unreal/gdk/authority_intent.schema",
-	"unreal/gdk/debug_component.schema",
-	"unreal/gdk/debug_metrics.schema",
-	"unreal/gdk/net_owning_client_worker.schema",
-	"unreal/gdk/not_streamed.schema",
-	"unreal/gdk/query_tags.schema",
-	"unreal/gdk/relevant.schema",
-	"unreal/gdk/rpc_components.schema",
-	"unreal/gdk/spatial_debugging.schema",
-	"unreal/gdk/spawndata.schema",
-	"unreal/gdk/tombstone.schema",
-	"unreal/gdk/unreal_metadata.schema",
-	"unreal/generated/rpc_endpoints.schema",
-	"unreal/generated/NetCullDistance/ncdcomponents.schema",
-};
-
-const TMap<Worker_ComponentId, FString> ServerAuthorityWellKnownComponents = {
-	{ POSITION_COMPONENT_ID, "improbable.Position" },
-	{ INTEREST_COMPONENT_ID, "improbable.Interest" },
-	{ AUTHORITY_DELEGATION_COMPONENT_ID, "improbable.AuthorityDelegation" },
-	{ AUTHORITY_INTENT_COMPONENT_ID, "unreal.AuthorityIntent" },
-	{ GDK_DEBUG_COMPONENT_ID, "unreal.DebugComponent" },
-	{ DEBUG_METRICS_COMPONENT_ID, "unreal.DebugMetrics" },
-	{ NET_OWNING_CLIENT_WORKER_COMPONENT_ID, "unreal.NetOwningClientWorker" },
-	{ NOT_STREAMED_COMPONENT_ID, "unreal.NotStreamed" },
-	{ ALWAYS_RELEVANT_COMPONENT_ID, "unreal.AlwaysRelevant" },
-	{ DORMANT_COMPONENT_ID, "unreal.Dormant" },
-	{ VISIBLE_COMPONENT_ID, "unreal.Visible" },
-	{ SERVER_TO_SERVER_COMMAND_ENDPOINT_COMPONENT_ID, "unreal.UnrealServerToServerCommandEndpoint" },
-	{ SPATIAL_DEBUGGING_COMPONENT_ID, "unreal.SpatialDebugging" },
-	{ SPAWN_DATA_COMPONENT_ID, "unreal.SpawnData" },
-	{ TOMBSTONE_COMPONENT_ID, "unreal.Tombstone" },
-	{ UNREAL_METADATA_COMPONENT_ID, "unreal.UnrealMetadata" },
-	{ SERVER_ENDPOINT_COMPONENT_ID, "unreal.generated.UnrealServerEndpoint" },
-	{ MULTICAST_RPCS_COMPONENT_ID, "unreal.generated.UnrealMulticastRPCs" },
-	{ SERVER_ENDPOINT_COMPONENT_ID, "unreal.generated.UnrealServerEndpoint" },
-	{ CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID, "unreal.generated.UnrealCrossServerSenderRPCs" },
-	{ CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID, "unreal.generated.UnrealCrossServerReceiverACKRPCs" },
-};
-
-const TArray<FString> ClientAuthorityWellKnownSchemaImports = { "unreal/gdk/player_controller.schema", "unreal/gdk/rpc_components.schema",
-																"unreal/generated/rpc_endpoints.schema" };
-
-const TMap<Worker_ComponentId, FString> ClientAuthorityWellKnownComponents = {
-	{ PLAYER_CONTROLLER_COMPONENT_ID, "unreal.PlayerController" },
-	{ CLIENT_ENDPOINT_COMPONENT_ID, "unreal.generated.UnrealClientEndpoint" },
-};
-
-const TMap<Worker_ComponentId, FString> RoutingWorkerComponents = {
-	{ CROSSSERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID, "unreal.generated.UnrealCrossServerSenderACKRPCs" },
-	{ CROSSSERVER_RECEIVER_ENDPOINT_COMPONENT_ID, "unreal.generated.UnrealCrossServerReceiverRPCs" },
-};
-
-const TArray<FString> RoutingWorkerSchemaImports = { "unreal/gdk/rpc_components.schema", "unreal/generated/rpc_endpoints.schema" };
-
-const TArray<Worker_ComponentId> KnownEntityAuthorityComponents = { POSITION_COMPONENT_ID,		 METADATA_COMPONENT_ID,
-																	INTEREST_COMPONENT_ID,		 PLAYER_SPAWNER_COMPONENT_ID,
-																	DEPLOYMENT_MAP_COMPONENT_ID, STARTUP_ACTOR_MANAGER_COMPONENT_ID,
-																	GSM_SHUTDOWN_COMPONENT_ID,	 VIRTUAL_WORKER_TRANSLATION_COMPONENT_ID,
-																	SERVER_WORKER_COMPONENT_ID };
+extern const TArray<FString> ServerAuthorityWellKnownSchemaImports;
+extern const TMap<Worker_ComponentId, FString> ServerAuthorityWellKnownComponents;
+extern const TArray<FString> ClientAuthorityWellKnownSchemaImports;
+extern const TMap<Worker_ComponentId, FString> ClientAuthorityWellKnownComponents;
+extern const TMap<Worker_ComponentId, FString> RoutingWorkerComponents;
+extern const TArray<FString> RoutingWorkerSchemaImports;
+extern const TArray<Worker_ComponentId> KnownEntityAuthorityComponents;
 
 //
 // SPATIAL_SNAPSHOT_VERSION is the current version of supported snapshots.

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -2,6 +2,11 @@
 
 #include "SpatialGDKEditorModule.h"
 
+// clang-format off
+#include "SpatialConstants.h"
+#include "SpatialConstants.cxx"
+// clang-format on
+
 #include "Editor.h"
 #include "GeneralProjectSettings.h"
 #include "ISettingsContainer.h"

--- a/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/SpatialGDKEditorCommandletModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/SpatialGDKEditorCommandletModule.cpp
@@ -2,6 +2,11 @@
 
 #include "SpatialGDKEditorCommandletModule.h"
 
+// clang-format off
+#include "SpatialConstants.h"
+#include "SpatialConstants.cxx"
+// clang-format on
+
 #define LOCTEXT_NAMESPACE "FSpatialGDKEditorCommandletModule"
 
 DEFINE_LOG_CATEGORY(LogSpatialGDKEditorCommandlet);

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -2,6 +2,9 @@
 
 #include "SpatialGDKEditorToolbar.h"
 
+#include "SpatialConstants.cxx"
+#include "SpatialConstants.h"
+
 #include "AssetRegistryModule.h"
 #include "Async/Async.h"
 #include "Editor.h"

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialGDKFunctionalTestsModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialGDKFunctionalTestsModule.cpp
@@ -2,6 +2,11 @@
 
 #include "SpatialGDKFunctionalTestsModule.h"
 
+// clang-format off
+#include "SpatialConstants.h"
+#include "SpatialConstants.cxx"
+// clang-format on
+
 #include "IAutomationControllerModule.h"
 
 #include "LogSpatialFunctionalTest.h"

--- a/SpatialGDK/Source/SpatialGDKTests/Private/SpatialGDKTestsModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/Private/SpatialGDKTestsModule.cpp
@@ -2,6 +2,11 @@
 
 #include "SpatialGDKTestsModule.h"
 
+// clang-format off
+#include "SpatialConstants.h"
+#include "SpatialConstants.cxx"
+// clang-format on
+
 #include "SpatialGDKTestsPrivate.h"
 
 #define LOCTEXT_NAMESPACE "FSpatialGDKTestsModule"


### PR DESCRIPTION
#### Description
Complex types were instantiated in SpatialConstants.h, weighing on the compilation unecessarily.
They are changed to extern declaration and explicitely instantiated in the module files.
This shaves off 8 sec from the build (108 vs 117s) and 90 MB from the obj files (1.39 vs 1.48GB)