### PR TITLE
[UNR-4714] Fix level reload crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue where authority was not correctly delegated to sublevel world settings prior to BeginPlay being issued. This resulted in duplicate world settings entities being created.
 - Fixed an issue in the SpatialTestCharacterMovement test where trigger boxes sometimes wouldn't trigger.
 - Fixed an issue where dynamic components without handover or owneronly data weren't created on receiving workers.
-- Downgraded a check to an error in SpatialSender::SendAuthorityIntentUpdate with sending the same intent twice. 
+- Downgraded a check to an error in SpatialSender::SendAuthorityIntentUpdate with sending the same intent twice.
+- Fixed a client crash that sometimes occurred when quickly unloading and reloading sublevels.
 
 ## [`0.12.0`] - 2021-02-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue where authority was not correctly delegated to sublevel world settings prior to BeginPlay being issued. This resulted in duplicate world settings entities being created.
 - Fixed an issue in the SpatialTestCharacterMovement test where trigger boxes sometimes wouldn't trigger.
 - Fixed an issue where dynamic components without handover or owneronly data weren't created on receiving workers.
-- Downgraded a check to an error in SpatialSender::SendAuthorityIntentUpdate with sending the same intent twice.
+- Downgraded a check to an error in SpatialSender::SendAuthorityIntentUpdate when sending the same intent twice.
 - Fixed a client crash that sometimes occurred when quickly unloading and reloading sublevels.
 
 ## [`0.12.0`] - 2021-02-01

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -283,8 +283,20 @@ void USpatialActorChannel::RetireEntityIfAuthoritative()
 	}
 }
 
+void USpatialActorChannel::ValidateChannelNotBroken()
+{
+	// In native Unreal, channels can be broken in certain circumstances (e.g. when unloading streaming levels or failing to process a
+	// bunch). This shouldn't happen in Spatial and would likely lead to unexpected behavior.
+	if (Broken)
+	{
+		UE_LOG(LogSpatialActorChannel, Error, TEXT("Channel broken when cleaning up/closing channel. Entity id: %lld"), EntityId);
+	}
+}
+
 bool USpatialActorChannel::CleanUp(const bool bForDestroy, EChannelCloseReason CloseReason)
 {
+	ValidateChannelNotBroken();
+
 	if (NetDriver != nullptr)
 	{
 #if WITH_EDITOR
@@ -322,6 +334,8 @@ bool USpatialActorChannel::CleanUp(const bool bForDestroy, EChannelCloseReason C
 
 int64 USpatialActorChannel::Close(EChannelCloseReason Reason)
 {
+	ValidateChannelNotBroken();
+
 	if (Reason == EChannelCloseReason::Dormancy)
 	{
 		// Closed for dormancy reasons, ensure we update the component state of this entity.

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -289,7 +289,8 @@ void USpatialActorChannel::ValidateChannelNotBroken()
 	// bunch). This shouldn't happen in Spatial and would likely lead to unexpected behavior.
 	if (Broken)
 	{
-		UE_LOG(LogSpatialActorChannel, Error, TEXT("Channel broken when cleaning up/closing channel. Entity id: %lld"), EntityId);
+		UE_LOG(LogSpatialActorChannel, Error, TEXT("Channel broken when cleaning up/closing channel. Entity id: %lld, actor: %s"), EntityId,
+			   *GetNameSafe(Actor));
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -4,6 +4,7 @@
 
 #include "Engine/ActorChannel.h"
 #include "Engine/Engine.h"
+#include "Engine/LevelScriptActor.h"
 #include "Engine/LocalPlayer.h"
 #include "Engine/NetworkObjectList.h"
 #include "EngineGlobals.h"
@@ -1253,6 +1254,48 @@ void USpatialNetDriver::OnOwnerUpdated(AActor* Actor, AActor* OldOwner)
 	Channel->MarkInterestDirty();
 
 	OwnershipChangedEntities.Add(EntityId);
+}
+
+void USpatialNetDriver::NotifyActorLevelUnloaded(AActor* Actor)
+{
+	// Intentionally does not call Super::NotifyActorLevelUnloaded.
+	// The native UNetDriver breaks the channel on the client because it can't properly close it
+	// until the server does, but we can clean it up because we don't send data through the channels.
+	// Cleaning it up also removes the references to the entity and channel from our maps.
+
+	NotifyActorDestroyed(Actor, true);
+
+	if (ServerConnection != nullptr)
+	{
+		UActorChannel* Channel = ServerConnection->FindActorChannelRef(Actor);
+		if (Channel != nullptr)
+		{
+			Channel->ConditionalCleanUp(false, EChannelCloseReason::LevelUnloaded);
+		}
+	}
+}
+
+void USpatialNetDriver::NotifyStreamingLevelUnload(class ULevel* Level)
+{
+	// Native Unreal has a very specific bit of code in NotifyStreamingLevelUnload
+	// that will break the channel of the level script actor when garbage collecting
+	// a streaming level. Normally, the level script actor would be handled together
+	// with other actors and go through NotifyActorLevelUnloaded, but just in case
+	// that doesn't happen for whatever reason, we clean up the channel here before
+	// calling Super:: so we don't end up with a broken channel.
+	if (ServerConnection != nullptr)
+	{
+		if (Level->LevelScriptActor != nullptr)
+		{
+			UActorChannel* Channel = ServerConnection->FindActorChannelRef(Level->LevelScriptActor);
+			if (Channel != nullptr)
+			{
+				Channel->ConditionalCleanUp(false, EChannelCloseReason::LevelUnloaded);
+			}
+		}
+	}
+
+	Super::NotifyStreamingLevelUnload(Level);
 }
 
 void USpatialNetDriver::ProcessOwnershipChanges()

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
@@ -481,6 +481,17 @@ void ActorSystem::ComponentAdded(const Worker_EntityId EntityId, const Worker_Co
 	}
 
 	USpatialActorChannel* Channel = NetDriver->GetActorChannelByEntityId(EntityId);
+	if (!NetDriver->IsServer() && Channel == nullptr)
+	{
+		// Try to restore the channel if this is a stably named actor. This can happen if a sublevel
+		// gets reloaded quickly and results in the entity components getting refreshed instead of
+		// the entity getting removed and added again.
+		if (AActor* StablyNamedActor = TryGetActor(ActorDataStore[EntityId].Metadata))
+		{
+			Channel = TryRestoreActorChannelForStablyNamedActor(StablyNamedActor, EntityId);
+		}
+	}
+
 	if (Channel == nullptr)
 	{
 		UE_LOG(LogActorSystem, Error,
@@ -489,6 +500,7 @@ void ActorSystem::ComponentAdded(const Worker_EntityId EntityId, const Worker_Co
 			   EntityId, ComponentId);
 		return;
 	}
+
 	if (Channel->bCreatedEntity)
 	{
 		// Allows servers to change state if they are going to be authoritative, without us overwriting it with old data.
@@ -1250,44 +1262,23 @@ void ActorSystem::ReceiveActor(Worker_EntityId EntityId)
 		return;
 	}
 
-	UNetConnection* Connection = NetDriver->GetSpatialOSNetConnection();
-
-	if (Connection == nullptr)
-	{
-		UE_LOG(LogActorSystem, Error,
-			   TEXT("Unable to find SpatialOSNetConnection! Has this worker been disconnected from SpatialOS due to a timeout?"));
-		return;
-	}
-
 	if (!NetDriver->PackageMap->ResolveEntityActor(EntityActor, EntityId))
 	{
 		UE_LOG(LogActorSystem, Warning,
-			   TEXT("Failed to resolve entity actor when receiving entity %lld. The actor (%s) will not be spawned."), EntityId,
-			   *EntityActor->GetName());
+			   TEXT("Failed to resolve entity actor when receiving entity. Actor will not be spawned. Entity: %lld, actor: %s"), EntityId,
+			   *EntityActor->GetPathName());
 		EntityActor->Destroy(true);
 		return;
 	}
 
-	// Set up actor channel.
-	USpatialActorChannel* Channel = NetDriver->GetActorChannelByEntityId(EntityId);
-	if (Channel == nullptr)
-	{
-		Channel = Cast<USpatialActorChannel>(Connection->CreateChannelByName(
-			NAME_Actor, NetDriver->IsServer() ? EChannelCreateFlags::OpenedLocally : EChannelCreateFlags::None));
-	}
-
+	USpatialActorChannel* Channel = SetUpActorChannel(EntityActor, EntityId);
 	if (Channel == nullptr)
 	{
 		UE_LOG(LogActorSystem, Warning,
-			   TEXT("Failed to create an actor channel when receiving entity %lld. The actor (%s) will not be spawned."), EntityId,
-			   *EntityActor->GetName());
+			   TEXT("Failed to create an actor channel when receiving entity. Actor will not be spawned. Entity: %lld, actor: %s"),
+			   EntityId, *EntityActor->GetPathName());
 		EntityActor->Destroy(true);
 		return;
-	}
-
-	if (Channel->Actor == nullptr)
-	{
-		Channel->SetChannelActor(EntityActor, ESetChannelActorFlags::None);
 	}
 
 	TArray<ObjectPtrRefPair> ObjectsToResolvePendingOpsFor;
@@ -1557,6 +1548,54 @@ void ActorSystem::ApplyComponentDataOnActorCreation(const Worker_EntityId Entity
 		UE_LOG(LogActorSystem, Warning, TEXT("Actor subobject got invalidated after applying component data! Subobject: %s"),
 			   *TargetObjectPath);
 	}
+}
+
+USpatialActorChannel* ActorSystem::SetUpActorChannel(AActor* Actor, const Worker_EntityId EntityId)
+{
+	UNetConnection* Connection = NetDriver->GetSpatialOSNetConnection();
+
+	if (Connection == nullptr)
+	{
+		UE_LOG(LogActorSystem, Error,
+			   TEXT("Unable to find SpatialOSNetConnection! Has this worker been disconnected from SpatialOS due to a timeout?"));
+		return nullptr;
+	}
+
+	// Set up actor channel.
+	USpatialActorChannel* Channel = NetDriver->GetActorChannelByEntityId(EntityId);
+	if (Channel == nullptr)
+	{
+		Channel = Cast<USpatialActorChannel>(Connection->CreateChannelByName(
+			NAME_Actor, NetDriver->IsServer() ? EChannelCreateFlags::OpenedLocally : EChannelCreateFlags::None));
+	}
+
+	if (Channel != nullptr && Channel->Actor == nullptr)
+	{
+		Channel->SetChannelActor(Actor, ESetChannelActorFlags::None);
+	}
+
+	return Channel;
+}
+
+USpatialActorChannel* ActorSystem::TryRestoreActorChannelForStablyNamedActor(AActor* StablyNamedActor, const Worker_EntityId EntityId)
+{
+	if (!NetDriver->PackageMap->ResolveEntityActor(StablyNamedActor, EntityId))
+	{
+		UE_LOG(LogActorSystem, Warning,
+			   TEXT("Failed to restore actor channel for stably named actor: failed to resolve actor. Entity: %lld, actor: %s"), EntityId,
+			   *StablyNamedActor->GetPathName());
+		return nullptr;
+	}
+
+	USpatialActorChannel* Channel = SetUpActorChannel(StablyNamedActor, EntityId);
+	if (Channel == nullptr)
+	{
+		UE_LOG(LogActorSystem, Warning,
+			   TEXT("Failed to restore actor channel for stably named actor: failed to create channel. Entity: %lld, actor: %s"), EntityId,
+			   *StablyNamedActor->GetPathName());
+	}
+
+	return Channel;
 }
 
 void ActorSystem::RemoveActor(const Worker_EntityId EntityId)

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -298,6 +298,8 @@ private:
 
 	bool SatisfiesSpatialPositionUpdateRequirements();
 
+	void ValidateChannelNotBroken();
+
 public:
 	// If this actor channel is responsible for creating a new entity, this will be set to true once the entity creation request is issued.
 	bool bCreatedEntity;

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -117,6 +117,9 @@ public:
 	virtual void NotifyActorFullyDormantForConnection(AActor* Actor, UNetConnection* NetConnection) override;
 	virtual void OnOwnerUpdated(AActor* Actor, AActor* OldOwner) override;
 
+	virtual void NotifyActorLevelUnloaded(AActor* Actor) override;
+	virtual void NotifyStreamingLevelUnload(class ULevel* Level) override;
+
 	virtual void PushCrossServerRPCSender(AActor* Sender) override;
 	virtual void PopCrossServerRPCSender(AActor* Sender) override;
 	// End UNetDriver interface.
@@ -289,7 +292,7 @@ private:
 	bool bMapLoaded;
 
 	FString SnapshotToLoad;
-	
+
 	// Client variable which stores the SessionId given to us by the server in the URL options.
 	// Used to compare against the GSM SessionId to ensure the the server is ready to spawn players.
 	int32 SessionId;

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/ActorSystem.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/ActorSystem.h
@@ -144,6 +144,9 @@ private:
 	void ApplyComponentDataOnActorCreation(Worker_EntityId EntityId, Worker_ComponentId ComponentId, Schema_ComponentData* Data,
 										   USpatialActorChannel& Channel, TArray<ObjectPtrRefPair>& OutObjectsToResolve);
 
+	USpatialActorChannel* SetUpActorChannel(AActor* Actor, Worker_EntityId EntityId);
+	USpatialActorChannel* TryRestoreActorChannelForStablyNamedActor(AActor* StablyNamedActor, Worker_EntityId EntityId);
+
 	// Entity remove
 	void DestroyActor(AActor* Actor, Worker_EntityId EntityId);
 	static FString GetObjectNameFromRepState(const FSpatialObjectRepState& RepState);


### PR DESCRIPTION
#### Description
Previously, when a sublevel got unloaded, the actor channels for its actors would be broken by native Unreal. This PR overrides the level unload callbacks on `SpatialNetDriver` so we clean up the channels instead of breaking them and adds an error log to `SpatialActorChannel` to flag if an actor channel gets broken in the future (e.g. if the related code changes in a future engine version).
Additionally, after cleaning up the channel, there was a case where if the sublevel gets unloaded and reloaded fast enough so the temporary loss of interest results in components being refreshed instead of remove and add entity, the newly loaded stably named actors wouldn't have actor channels to process the component refresh. This PR also restores the actor channels for those actors in that situation.

#### Release note
- Fixed a client crash that sometimes occurred when quickly unloading and reloading sublevels.

#### Tests
Couldn't automate this due to framework limitations (added a [task](https://improbableio.atlassian.net/browse/UNR-5193) to investigate extending the testing framework)

Tested these changes manually using these branches:
GDK: https://github.com/spatialos/UnrealGDK/tree/test/repro-UNR-4714
TestGyms: https://github.com/spatialos/UnrealGDKTestGyms/tree/test/repro-UNR-4714

#### Primary reviewers
@m-samiec @samiwh 
