### PR TITLE
Unr 4922/update delete dynamic entities flag usage

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -84,13 +84,12 @@ FRuntimeVariantVersion& USpatialGDKEditorSettings::GetRuntimeVariantVersion(ESpa
 #if WITH_EDITOR
 bool USpatialGDKEditorSettings::CanEditChange(const FProperty* InProperty) const
 {
-	const bool ParentVal =
-		Super::CanEditChange(InProperty);
+	const bool bParentVal = Super::CanEditChange(InProperty);
 	if (InProperty->GetFName() == GET_MEMBER_NAME_CHECKED(USpatialGDKEditorSettings, bDeleteDynamicEntities))
 	{
-		return ParentVal && AutoStopLocalDeployment != EAutoStopLocalDeploymentMode::OnEndPIE;
+		return bParentVal && AutoStopLocalDeployment != EAutoStopLocalDeploymentMode::OnEndPIE;
 	}
-	return ParentVal;
+	return bParentVal;
 }
 #endif
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -39,7 +39,6 @@ const FString& FRuntimeVariantVersion::GetVersionForCloud() const
 
 USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
-	, bDeleteDynamicEntities(true)
 	, bGenerateDefaultLaunchConfig(true)
 	, StandardRuntimeVersion(SpatialGDKServicesConstants::SpatialOSRuntimePinnedStandardVersion)
 	, bShutdownRuntimeGracefullyOnPIEExit(true)
@@ -49,6 +48,7 @@ USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& O
 	, bAutoStartLocalDeployment(true)
 	, bSpatialDebuggerEditorEnabled(false)
 	, AutoStopLocalDeployment(EAutoStopLocalDeploymentMode::OnEndPIE)
+	, bDeleteDynamicEntities(false)
 	, bStopPIEOnTestingCompleted(true)
 	, CookAndGeneratePlatform("")
 	, CookAndGenerateAdditionalArguments("-cookall -unversioned")
@@ -80,6 +80,19 @@ FRuntimeVariantVersion& USpatialGDKEditorSettings::GetRuntimeVariantVersion(ESpa
 {
 	return StandardRuntimeVersion;
 }
+
+#if WITH_EDITOR
+bool USpatialGDKEditorSettings::CanEditChange(const FProperty* InProperty) const
+{
+	const bool ParentVal =
+		Super::CanEditChange(InProperty);
+	if (InProperty->GetFName() == GET_MEMBER_NAME_CHECKED(USpatialGDKEditorSettings, bDeleteDynamicEntities))
+	{
+		return ParentVal && AutoStopLocalDeployment != EAutoStopLocalDeploymentMode::OnEndPIE;
+	}
+	return ParentVal;
+}
+#endif
 
 void USpatialGDKEditorSettings::PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent)
 {

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -276,10 +276,6 @@ public:
 	virtual void PostInitProperties() override;
 
 public:
-	/** Select to delete all a server-worker instance’s dynamically-spawned entities when the server-worker instance shuts down. If NOT
-	 * selected, a new server-worker instance has all of these entities from the former server-worker instance’s session. */
-	UPROPERTY(EditAnywhere, config, Category = "Play in editor settings", meta = (DisplayName = "Delete dynamically spawned entities"))
-	bool bDeleteDynamicEntities;
 
 	/** Select the check box for the GDK to auto-generate a launch configuration file for your game when you launch a deployment session. If
 	 * NOT selected, you must specify a launch configuration `.json` file. */
@@ -344,11 +340,18 @@ public:
 	/** Allows the local SpatialOS deployment to be automatically stopped. */
 	UPROPERTY(EditAnywhere, config, Category = "Launch", meta = (DisplayName = "Auto-stop local deployment"))
 	EAutoStopLocalDeploymentMode AutoStopLocalDeployment;
+	/** Select to delete all a server-worker instance’s dynamically-spawned entities when the server-worker instance shuts down. If NOT
+	 * selected, a new server-worker instance has all of these entities from the former server-worker instance’s session. */
+	UPROPERTY(EditAnywhere, config, Category = "Launch", meta = (DisplayName = "Delete dynamically spawned entities"))
+	bool bDeleteDynamicEntities;
 
 	/** Stop play in editor when Automation Manager finishes running Tests. If false, the native Unreal Engine behaviour maintains of
 	 * leaving the last map PIE running. */
 	UPROPERTY(EditAnywhere, config, Category = "Launch", meta = (DisplayName = "Stop play in editor on Testing completed"))
 	bool bStopPIEOnTestingCompleted;
+	#if WITH_EDITOR
+	virtual bool CanEditChange(const FProperty* InProperty) const override;
+	#endif
 
 private:
 	/** Name of your SpatialOS snapshot file that will be generated. */

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -276,7 +276,6 @@ public:
 	virtual void PostInitProperties() override;
 
 public:
-
 	/** Select the check box for the GDK to auto-generate a launch configuration file for your game when you launch a deployment session. If
 	 * NOT selected, you must specify a launch configuration `.json` file. */
 	UPROPERTY(EditAnywhere, config, Category = "Launch", meta = (DisplayName = "Auto-generate launch configuration file"))
@@ -349,9 +348,9 @@ public:
 	 * leaving the last map PIE running. */
 	UPROPERTY(EditAnywhere, config, Category = "Launch", meta = (DisplayName = "Stop play in editor on Testing completed"))
 	bool bStopPIEOnTestingCompleted;
-	#if WITH_EDITOR
+#if WITH_EDITOR
 	virtual bool CanEditChange(const FProperty* InProperty) const override;
-	#endif
+#endif
 
 private:
 	/** Name of your SpatialOS snapshot file that will be generated. */


### PR DESCRIPTION
Made "delete dynamic entities" flag a child of "auto stop deployment" flag so as to disable the ability to toggle it when auto stop is set to OnEndPIE.