### PR TITLE
[UNR-5233] Stopped callbacks marked as "pending remove" from being invoked

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/CallbacksTest.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/SpatialView/CallbacksTest.cpp
@@ -139,7 +139,7 @@ CALLBACKS_TEST(GIVEN_Callbacks_With_Callback_WHEN_Callback_Adds_Other_Callback_T
 	return true;
 }
 
-CALLBACKS_TEST(GIVEN_Callbacks_With_Two_Callback_WHEN_Callback_Removes_Other_Callback_THEN_Calls_Both_Callbacks)
+CALLBACKS_TEST(GIVEN_Callbacks_With_Two_Callback_WHEN_First_Callback_Removes_Second_Callback_THEN_Second_Callback_Is_Not_Called)
 {
 	// GIVEN
 	SpatialGDK::CallbackId Id = 2;
@@ -159,12 +159,12 @@ CALLBACKS_TEST(GIVEN_Callbacks_With_Two_Callback_WHEN_Callback_Removes_Other_Cal
 	Callbacks.Invoke(1);
 
 	// THEN
-	TestEqual("Both callbacks were invoked", InvokeCount, 2);
+	TestEqual("Only first callback was invoked", InvokeCount, 1);
 
-	// sanity check: Only one callback invoked on second invocation
+	// sanity check: Only one callback invoked on second invocation also
 	InvokeCount = 0;
 	Callbacks.Invoke(1);
-	TestEqual("Only one callback invoked", InvokeCount, 1);
+	TestEqual("Still only one callback invoked on second invoke", InvokeCount, 1);
 
 	return true;
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/Callbacks.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/Callbacks.h
@@ -58,6 +58,11 @@ public:
 		bCurrentlyInvokingCallbacks = true;
 		for (const CallbackAndId& Callback : Callbacks)
 		{
+			if (CallbacksToRemove.Contains(Callback.Id))
+			{
+				continue;
+			}
+
 			Callback.Callback(Value);
 		}
 		bCurrentlyInvokingCallbacks = false;


### PR DESCRIPTION
#### Description
Stopped callbacks marked as "pending remove" from being invoked.

#### Tests
Fixed associated automated test to verify this behaviour.