### PR TITLE
[UNR-5141] Fix races in the DebugInterface test

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/DebugInterface/SpatialDebugInterfaceTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/DebugInterface/SpatialDebugInterfaceTest.cpp
@@ -410,7 +410,6 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 }
 
 USpatialDebugInterfaceMap::USpatialDebugInterfaceMap()
-	// disabled in CI due to a timeout flake: UNR-5141
 	: UGeneratedTestMap(EMapCategory::CI_PREMERGE_SPATIAL_ONLY, TEXT("SpatialDebugInterfaceMap"))
 {
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/DebugInterface/SpatialDebugInterfaceTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/DebugInterface/SpatialDebugInterfaceTest.cpp
@@ -138,7 +138,7 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 
 			FinishStep();
 		},
-		nullptr, 50.0f);
+		nullptr, 5.0f);
 
 	AddStep(
 		TEXT("Force actor delegation"), FWorkerDefinition::AllServers, nullptr, nullptr,
@@ -178,7 +178,7 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 				FinishStep();
 			}
 		},
-		50.0f);
+		5.0f);
 
 	AddStep(
 		TEXT("Create new actors"), FWorkerDefinition::AllServers, nullptr,
@@ -190,7 +190,7 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 			RegisterAutoDestroyActor(Actor);
 			FinishStep();
 		},
-		nullptr, 50.0f);
+		nullptr, 5.0f);
 
 	AddStep(
 		TEXT("Check new actors interest and delegation"), FWorkerDefinition::AllServers,
@@ -220,7 +220,7 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 				FinishStep();
 			}
 		},
-		50.0f);
+		5.0f);
 
 	AddStep(
 		TEXT("Remove extra interest"), FWorkerDefinition::AllServers, nullptr,
@@ -245,7 +245,7 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 		[this] {
 			FinishStep();
 		},
-		nullptr, 50.0f);
+		nullptr, 5.0f);
 
 	AddStep(
 		TEXT("Add extra interest again"), FWorkerDefinition::AllServers, nullptr,
@@ -257,7 +257,7 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 			AddInterestOnTag(GetTestTag());
 			FinishStep();
 		},
-		nullptr, 50.0f);
+		nullptr, 5.0f);
 
 	AddStep(
 		TEXT("Wait for extra interest to come back"), FWorkerDefinition::AllServers,
@@ -267,7 +267,7 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 		[this] {
 			FinishStep();
 		},
-		nullptr, 50.0f);
+		nullptr, 5.0f);
 
 	AddStep(
 		TEXT("Remove actor tags"), FWorkerDefinition::AllServers, nullptr,
@@ -289,7 +289,7 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 
 			FinishStep();
 		},
-		nullptr, 50.0f);
+		nullptr, 5.0f);
 
 	AddStep(
 		TEXT("Check state after tags removed"), FWorkerDefinition::AllServers,
@@ -317,7 +317,7 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 				FinishStep();
 			}
 		},
-		50.0f);
+		5.0f);
 
 	AddStep(
 		TEXT("Add tag and remove delegation"), FWorkerDefinition::AllServers, nullptr,
@@ -341,7 +341,7 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 			ClearTagDelegation(GetTestTag());
 			FinishStep();
 		},
-		nullptr, 50.0f);
+		nullptr, 5.0f);
 
 	AddStep(
 		TEXT("Check state after delegation removal"), FWorkerDefinition::AllServers,
@@ -367,7 +367,7 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 				FinishStep();
 			}
 		},
-		nullptr, 50.0f);
+		nullptr, 5.0f);
 
 	AddStep(
 		TEXT("Shutdown debugging"), FWorkerDefinition::AllServers, nullptr,
@@ -378,7 +378,7 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 				FinishStep();
 			}
 		},
-		nullptr, 50.0f);
+		nullptr, 5.0f);
 
 	AddStep(
 		TEXT("Check state after debug reset"), FWorkerDefinition::AllServers,
@@ -406,7 +406,7 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 				FinishStep();
 			}
 		},
-		50.0f);
+		5.0f);
 }
 
 USpatialDebugInterfaceMap::USpatialDebugInterfaceMap()

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/DebugInterface/SpatialDebugInterfaceTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/DebugInterface/SpatialDebugInterfaceTest.cpp
@@ -138,7 +138,7 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 
 			FinishStep();
 		},
-		nullptr, 5.0f);
+		nullptr, 50.0f);
 
 	AddStep(
 		TEXT("Force actor delegation"), FWorkerDefinition::AllServers, nullptr, nullptr,
@@ -175,16 +175,22 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 
 			if (DelegationStep >= Workers.Num() * 2)
 			{
-				UWorld* World = GetWorld();
-
-				AReplicatedTestActorBase* Actor = World->SpawnActor<AReplicatedTestActorBase>(WorkerEntityPosition, FRotator());
-				AddDebugTag(Actor, GetTestTag());
-				RegisterAutoDestroyActor(Actor);
-
 				FinishStep();
 			}
 		},
-		5.0f);
+		50.0f);
+
+	AddStep(
+		TEXT("Create new actors"), FWorkerDefinition::AllServers, nullptr,
+		[this] {
+			UWorld* World = GetWorld();
+
+			AReplicatedTestActorBase* Actor = World->SpawnActor<AReplicatedTestActorBase>(WorkerEntityPosition, FRotator());
+			AddDebugTag(Actor, GetTestTag());
+			RegisterAutoDestroyActor(Actor);
+			FinishStep();
+		},
+		nullptr, 50.0f);
 
 	AddStep(
 		TEXT("Check new actors interest and delegation"), FWorkerDefinition::AllServers,
@@ -214,7 +220,7 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 				FinishStep();
 			}
 		},
-		5.0f);
+		50.0f);
 
 	AddStep(
 		TEXT("Remove extra interest"), FWorkerDefinition::AllServers, nullptr,
@@ -239,7 +245,7 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 		[this] {
 			FinishStep();
 		},
-		nullptr, 5.0f);
+		nullptr, 50.0f);
 
 	AddStep(
 		TEXT("Add extra interest again"), FWorkerDefinition::AllServers, nullptr,
@@ -251,13 +257,20 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 			AddInterestOnTag(GetTestTag());
 			FinishStep();
 		},
-		nullptr, 5.0f);
+		nullptr, 50.0f);
 
 	AddStep(
-		TEXT("Remove actor tags"), FWorkerDefinition::AllServers,
+		TEXT("Wait for extra interest to come back"), FWorkerDefinition::AllServers,
 		[this] {
 			return WaitToSeeActors(AReplicatedTestActorBase::StaticClass(), Workers.Num() * 2);
 		},
+		[this] {
+			FinishStep();
+		},
+		nullptr, 50.0f);
+
+	AddStep(
+		TEXT("Remove actor tags"), FWorkerDefinition::AllServers, nullptr,
 		[this] {
 			if (!bIsOnDefaultLayer)
 			{
@@ -276,7 +289,7 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 
 			FinishStep();
 		},
-		nullptr, 5.0f);
+		nullptr, 50.0f);
 
 	AddStep(
 		TEXT("Check state after tags removed"), FWorkerDefinition::AllServers,
@@ -304,7 +317,7 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 				FinishStep();
 			}
 		},
-		5.0f);
+		50.0f);
 
 	AddStep(
 		TEXT("Add tag and remove delegation"), FWorkerDefinition::AllServers, nullptr,
@@ -328,7 +341,7 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 			ClearTagDelegation(GetTestTag());
 			FinishStep();
 		},
-		nullptr, 5.0f);
+		nullptr, 50.0f);
 
 	AddStep(
 		TEXT("Check state after delegation removal"), FWorkerDefinition::AllServers,
@@ -354,7 +367,7 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 				FinishStep();
 			}
 		},
-		nullptr, 5.0f);
+		nullptr, 50.0f);
 
 	AddStep(
 		TEXT("Shutdown debugging"), FWorkerDefinition::AllServers, nullptr,
@@ -365,7 +378,7 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 				FinishStep();
 			}
 		},
-		nullptr, 5.0f);
+		nullptr, 50.0f);
 
 	AddStep(
 		TEXT("Check state after debug reset"), FWorkerDefinition::AllServers,
@@ -393,12 +406,12 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 				FinishStep();
 			}
 		},
-		5.0f);
+		50.0f);
 }
 
 USpatialDebugInterfaceMap::USpatialDebugInterfaceMap()
 	// disabled in CI due to a timeout flake: UNR-5141
-	: UGeneratedTestMap(EMapCategory::NO_CI, TEXT("SpatialDebugInterfaceMap"))
+	: UGeneratedTestMap(EMapCategory::CI_PREMERGE_SPATIAL_ONLY, TEXT("SpatialDebugInterfaceMap"))
 {
 }
 


### PR DESCRIPTION
#### Description
The DebugInterface test had steps which mixed observing changes to actors with changes to the same actors. If workers do not go through these in lock-steps, it could cause some workers to get stuck in a future step.
Fixing it requires separating the steps that poll for changes from the steps that modify the world.

#### Tests
The test will be added back into the CI