### PR TITLE
Explicitly include standard library schema

### DIFF
--- a/RequireSetup
+++ b/RequireSetup
@@ -1,4 +1,4 @@
 Increment the below number whenever it is required to run Setup.bat as part of a new commit.
 Our git hooks will detect this file has been updated and automatically run Setup.bat on pull.
 
-83
+84

--- a/SpatialGDK/Extras/schema/server_worker.schema
+++ b/SpatialGDK/Extras/schema/server_worker.schema
@@ -4,6 +4,7 @@ package unreal;
 import "unreal/gdk/core_types.schema";
 import "unreal/gdk/spawner.schema";
 import "unreal/generated/rpc_endpoints.schema";
+import "improbable/standard_library.schema";
 
 type ForwardSpawnPlayerRequest {
     SpawnPlayerRequest spawn_player_request = 1;


### PR DESCRIPTION
#### Description
`ServerWorkerAuthComponentSet` includes a few components from schema standard library, so we should explicitly include the standard library schema file.
This was causing the Mac CI to fail, and it's unclear why it wasn't causing any problems for the Windows builds.

#### Tests
Ran a Mac build that succeeded:
https://buildkite.com/improbable/unrealgdk-premerge/builds/23990#32bb6b09-3a31-4e57-8430-f13d077d06ca

#### Primary reviewers
@ImprobableNic @simonsarginson 
