### PR TITLE
[UNR-5141] Fix the debug sub view not getting the locally authoritative components

### DIFF
--- a/RequireSetup
+++ b/RequireSetup
@@ -1,4 +1,4 @@
 Increment the below number whenever it is required to run Setup.bat as part of a new commit.
 Our git hooks will detect this file has been updated and automatically run Setup.bat on pull.
 
-84
+85

--- a/SpatialGDK/Extras/schema/debug_component.schema
+++ b/SpatialGDK/Extras/schema/debug_component.schema
@@ -6,3 +6,7 @@ component DebugComponent {
      option<uint32> worker_id_delegation = 1;
      string actor_tags = 2;
 }
+
+component DebugComponentTag {
+     id = 2011;
+}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -3012,17 +3012,18 @@ void USpatialNetDriver::TryFinishStartup()
 				if (WorldSettings && WorldSettings->bEnableDebugInterface)
 				{
 					auto DebugCompFilter = [this](const Worker_EntityId EntityId, const SpatialGDK::EntityViewElement& Element) {
-						if (Element.Components.ContainsByPredicate(
+						if (!Element.Components.ContainsByPredicate(
 								SpatialGDK::ComponentIdEquality{ SpatialConstants::GDK_DEBUG_COMPONENT_ID }))
 						{
-							return true;
+							return false;
 						}
 
-						return false;
+						return ActorFilter(EntityId, Element);
 					};
-					TArray<FDispatcherRefreshCallback> DebugCompRefresh = {
-						Connection->GetCoordinator().CreateComponentExistenceRefreshCallback(SpatialConstants::GDK_DEBUG_COMPONENT_ID)
-					};
+
+					TArray<FDispatcherRefreshCallback> DebugCompRefresh = ActorRefreshCallbacks;
+					DebugCompRefresh.Add(
+						Connection->GetCoordinator().CreateComponentExistenceRefreshCallback(SpatialConstants::GDK_DEBUG_COMPONENT_ID));
 
 					// Create the subview here rather than with the others as we only know if we need it or not at
 					// this point.

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -3011,10 +3011,23 @@ void USpatialNetDriver::TryFinishStartup()
 				ASpatialWorldSettings* WorldSettings = Cast<ASpatialWorldSettings>(GetWorld()->GetWorldSettings());
 				if (WorldSettings && WorldSettings->bEnableDebugInterface)
 				{
+					auto DebugCompFilter = [this](const Worker_EntityId EntityId, const SpatialGDK::EntityViewElement& Element) {
+						if (Element.Components.ContainsByPredicate(
+								SpatialGDK::ComponentIdEquality{ SpatialConstants::GDK_DEBUG_COMPONENT_ID }))
+						{
+							return true;
+						}
+
+						return false;
+					};
+					TArray<FDispatcherRefreshCallback> DebugCompRefresh = {
+						Connection->GetCoordinator().CreateComponentExistenceRefreshCallback(SpatialConstants::GDK_DEBUG_COMPONENT_ID)
+					};
+
 					// Create the subview here rather than with the others as we only know if we need it or not at
 					// this point.
 					const SpatialGDK::FSubView& DebugActorSubView = Connection->GetCoordinator().CreateSubView(
-						SpatialConstants::GDK_DEBUG_COMPONENT_ID, ActorFilter, ActorRefreshCallbacks);
+						SpatialConstants::GDK_DEBUG_TAG_COMPONENT_ID, DebugCompFilter, DebugCompRefresh);
 					USpatialNetDriverDebugContext::EnableDebugSpatialGDK(DebugActorSubView, this);
 				}
 #endif

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverDebugContext.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverDebugContext.cpp
@@ -439,6 +439,8 @@ void USpatialNetDriverDebugContext::TickServer()
 				{
 					FWorkerComponentData CompData = Data.Component.CreateDebugComponent();
 					NetDriver->Connection->SendAddComponent(Entity, &CompData);
+					NetDriver->Connection->GetCoordinator().RefreshEntityCompleteness(Entity);
+
 					Data.Entity = Entity;
 					Data.bAdded = true;
 				}

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -95,6 +95,7 @@ TArray<FWorkerComponentData> EntityFactory::CreateSkeletonEntityComponents(AActo
 	ComponentDatas.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::ACTOR_TAG_COMPONENT_ID));
 	ComponentDatas.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::LB_TAG_COMPONENT_ID));
 	ComponentDatas.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::ROUTINGWORKER_TAG_COMPONENT_ID));
+	ComponentDatas.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::GDK_DEBUG_TAG_COMPONENT_ID));
 
 	return ComponentDatas;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -171,7 +171,7 @@ Interest InterestFactory::CreatePartitionInterest(const UAbstractLBStrategy* LBS
 	if (bDebug)
 	{
 		PartitionQuery = Query();
-		PartitionQuery.ResultComponentIds = { SpatialConstants::GDK_DEBUG_COMPONENT_ID };
+		PartitionQuery.ResultComponentIds = { SpatialConstants::GDK_DEBUG_TAG_COMPONENT_ID, SpatialConstants::GDK_DEBUG_COMPONENT_ID };
 		PartitionQuery.Constraint.ComponentConstraint = SpatialConstants::GDK_DEBUG_COMPONENT_ID;
 		AddComponentQueryPairToInterestComponent(PartitionInterest, SpatialConstants::GDK_KNOWN_ENTITY_AUTH_COMPONENT_SET_ID,
 												 PartitionQuery);

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -171,8 +171,14 @@ Interest InterestFactory::CreatePartitionInterest(const UAbstractLBStrategy* LBS
 	if (bDebug)
 	{
 		PartitionQuery = Query();
-		PartitionQuery.ResultComponentIds = { SpatialConstants::GDK_DEBUG_TAG_COMPONENT_ID, SpatialConstants::GDK_DEBUG_COMPONENT_ID };
+		PartitionQuery.ResultComponentIds = { SpatialConstants::GDK_DEBUG_COMPONENT_ID };
 		PartitionQuery.Constraint.ComponentConstraint = SpatialConstants::GDK_DEBUG_COMPONENT_ID;
+		AddComponentQueryPairToInterestComponent(PartitionInterest, SpatialConstants::GDK_KNOWN_ENTITY_AUTH_COMPONENT_SET_ID,
+												 PartitionQuery);
+
+		PartitionQuery = Query();
+		PartitionQuery.ResultComponentIds = { SpatialConstants::GDK_DEBUG_TAG_COMPONENT_ID };
+		PartitionQuery.Constraint.ComponentConstraint = SpatialConstants::GDK_DEBUG_TAG_COMPONENT_ID;
 		AddComponentQueryPairToInterestComponent(PartitionInterest, SpatialConstants::GDK_KNOWN_ENTITY_AUTH_COMPONENT_SET_ID,
 												 PartitionQuery);
 	}

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -150,8 +150,9 @@ const Worker_ComponentId LB_TAG_COMPONENT_ID = 2005;
 const Worker_ComponentId GDK_KNOWN_ENTITY_TAG_COMPONENT_ID = 2007;
 const Worker_ComponentId ROUTINGWORKER_TAG_COMPONENT_ID = 2009;
 const Worker_ComponentId STRATEGYWORKER_TAG_COMPONENT_ID = 2010;
+const Worker_ComponentId GDK_DEBUG_TAG_COMPONENT_ID = 2011;
 // Add component ids above here, this should always be last and be equal to the previous component id
-const Worker_ComponentId LAST_EC_COMPONENT_ID = 2010;
+const Worker_ComponentId LAST_EC_COMPONENT_ID = 2011;
 
 const Schema_FieldId DEPLOYMENT_MAP_MAP_URL_ID = 1;
 const Schema_FieldId DEPLOYMENT_MAP_ACCEPTING_PLAYERS_ID = 2;

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/DebugInterface/SpatialDebugInterfaceTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/DebugInterface/SpatialDebugInterfaceTest.cpp
@@ -13,9 +13,10 @@
 
 /**
  * Test for coverage of the USpatialGDKDebugInterface.
- * The debug interface allows you to manipulate interest and load balancing by tagging actors and declaring interest and delegation over these tags
- * The goal is to have an easier time writing load balancing test to not have to derive an additional load balancing strategy for each new test.
- * 
+ * The debug interface allows you to manipulate interest and load balancing by tagging actors and declaring interest and delegation over
+ * these tags The goal is to have an easier time writing load balancing test to not have to derive an additional load balancing strategy for
+ * each new test.
+ *
  * The test walks through a couple of situations that one can setup through the debug interface :
  * - Add interest over all actors having some tags
  * - Delegate tags to specific workers, forcing load balancing
@@ -24,7 +25,7 @@
  * - Remove tags from actors and see interest and load-balancing revert to their default.
  * - Add tags again and clear delegation
  * - Clear all debug information
- * 
+ *
  * Most of these tests are performed in a two-step way, that is setting some debug behaviour and waiting for it to happen on the next step
  * Delegation commands expect consensus between workers to behave properly, so separating change steps from observation steps helps avoiding
  * races that could happen around interest or load balancing.
@@ -319,7 +320,6 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 			}
 
 			bool bExpectedResult = true;
-			bool bIsAtWorkerPos = true;
 			uint32 NumAuth = 0;
 
 			TArray<AActor*> TestActors;
@@ -328,13 +328,11 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 			{
 				bExpectedResult &= Actor->HasAuthority();
 				NumAuth += Actor->HasAuthority() ? 1 : 0;
-				bIsAtWorkerPos &= Actor->GetActorLocation() == WorkerEntityPosition;
 			}
 
 			if (bExpectedResult)
 			{
-				check(bIsAtWorkerPos);
-				check(NumAuth == 2);
+				AssertTrue(NumAuth == 2, TEXT("We see the expected number of authoritative actors"));
 
 				FinishStep();
 			}
@@ -362,7 +360,7 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 				}
 			}
 
-			check(NumUpdated == 2);
+			AssertTrue(NumUpdated == 2, TEXT("We updated the expected number of authoritative actors"));
 
 			ClearTagDelegation(GetTestTag());
 			FinishStep();

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/DebugInterface/SpatialDebugInterfaceTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/DebugInterface/SpatialDebugInterfaceTest.cpp
@@ -304,16 +304,23 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 			}
 
 			bool bExpectedResult = true;
+			bool bIsAtWorkerPos = true;
+			uint32 NumAuth = 0;
 
 			TArray<AActor*> TestActors;
 			UGameplayStatics::GetAllActorsOfClass(GetWorld(), AReplicatedTestActorBase::StaticClass(), TestActors);
 			for (AActor* Actor : TestActors)
 			{
 				bExpectedResult &= Actor->HasAuthority();
+				NumAuth += Actor->HasAuthority() ? 1 : 0;
+				bIsAtWorkerPos &= Actor->GetActorLocation() == WorkerEntityPosition;
 			}
 
 			if (bExpectedResult)
 			{
+				check(bIsAtWorkerPos);
+				check(NumAuth == 2);
+
 				FinishStep();
 			}
 		},
@@ -326,7 +333,8 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 			{
 				FinishStep();
 			}
-			bool bExpectedResult = true;
+
+			uint32 NumUpdated = 0;
 
 			TArray<AActor*> TestActors;
 			UGameplayStatics::GetAllActorsOfClass(GetWorld(), AReplicatedTestActorBase::StaticClass(), TestActors);
@@ -335,8 +343,11 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 				if (Actor->HasAuthority())
 				{
 					AddDebugTag(Actor, GetTestTag());
+					NumUpdated++;
 				}
 			}
+
+			check(NumUpdated == 2);
 
 			ClearTagDelegation(GetTestTag());
 			FinishStep();

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/DebugInterface/SpatialDebugInterfaceTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/DebugInterface/SpatialDebugInterfaceTest.cpp
@@ -11,9 +11,24 @@
 
 #include "Kismet/GameplayStatics.h"
 
-/*
-	Test for coverage of the USpatialGDKDebugInterface.
-*/
+/**
+ * Test for coverage of the USpatialGDKDebugInterface.
+ * The debug interface allows you to manipulate interest and load balancing by tagging actors and declaring interest and delegation over these tags
+ * The goal is to have an easier time writing load balancing test to not have to derive an additional load balancing strategy for each new test.
+ * 
+ * The test walks through a couple of situations that one can setup through the debug interface :
+ * - Add interest over all actors having some tags
+ * - Delegate tags to specific workers, forcing load balancing
+ * - Create new actors with the tag and check that extra interest and delegation is properly applied
+ * - Remove extra interest
+ * - Remove tags from actors and see interest and load-balancing revert to their default.
+ * - Add tags again and clear delegation
+ * - Clear all debug information
+ * 
+ * Most of these tests are performed in a two-step way, that is setting some debug behaviour and waiting for it to happen on the next step
+ * Delegation commands expect consensus between workers to behave properly, so separating change steps from observation steps helps avoiding
+ * races that could happen around interest or load balancing.
+ */
 
 ASpatialDebugInterfaceTest::ASpatialDebugInterfaceTest()
 	: Super()


### PR DESCRIPTION
#### Description
SpatialSubView have a blind spot regarding completeness depending on dynamically added components used as tags.
Since loopback is disabled, component addition won't make it into the view delta, and the view on the authoritative worker won't be updated once it adds the tag.
The debug system has a requirement on receiving authority loss events to properly choose which data to use for load-balancing decisions.
This PR changes how the debug view works by adding a static tag, and a filter on the actual debug component. The query for the debug components still looks for the dynamic components in order to not have every single incomplete actor being tagged in the subview.

#### Tests
Ran the SpatialDebugInterfaceTest with random delays in steps to help trigger the races.