### PR TITLE
Remove UnrealGDK slack notify as this is now in UnrealGDKBuild

### DIFF
--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -65,12 +65,3 @@ steps:
       env:
         NIGHTLY_BUILD: "${NIGHTLY_BUILD:-false}"
         GDK_BRANCH: "${BUILDKITE_BRANCH}"
-
-# Notify unreal-gdk-builds if there was a failure
-notify:
-  - slack: 
-      channels: 
-        - "#unreal-gdk-builds"
-      message: "<!subteam^SDB5161M5> Build failure! Please triage and post ticket." # SDB5161M5 is @support-unreal
-    if: build.env("BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG") != "unrealgdktestgyms-premerge" && (build.state == "failed" || build.state == "canceled") && build.branch == "master"
-    


### PR DESCRIPTION
#### Description
Remove UnrealGDK slack notify as this is now in UnrealGDKBuild

#### Primary reviewers
@mironec @simonsarginson 
