### PR TITLE
Change UGeneratedTestMap::AddActorToLevel to return a ref

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/TestMaps/GeneratedTestMap.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/TestMaps/GeneratedTestMap.cpp
@@ -87,17 +87,17 @@ void UGeneratedTestMap::GenerateBaseMap()
 
 	// Lights and fog are just for visual effects, strictly not needed for running tests, but it makes it a bit nicer to look at tests while
 	// they are running.
-	AExponentialHeightFog* Fog = AddActorToLevel<AExponentialHeightFog>(CurrentLevel, FTransform::Identity);
-	ASkyLight* SkyLight = AddActorToLevel<ASkyLight>(CurrentLevel, FTransform::Identity);
+	AExponentialHeightFog& Fog = AddActorToLevel<AExponentialHeightFog>(CurrentLevel, FTransform::Identity);
+	ASkyLight& SkyLight = AddActorToLevel<ASkyLight>(CurrentLevel, FTransform::Identity);
 
 	// On the other hand, the plane and the player start are needed for tests and they rely on various properties of them (plane catches
 	// things so they don't fall, player start controls not just the viewport, but is also used for certain tests to see how the spawned
 	// player behaves under LB conditions).
-	AStaticMeshActor* Plane = AddActorToLevel<AStaticMeshActor>(CurrentLevel, FTransform::Identity);
-	Plane->GetStaticMeshComponent()->SetStaticMesh(PlaneStaticMesh);
-	Plane->GetStaticMeshComponent()->SetMaterial(0, BasicShapeMaterial);
+	AStaticMeshActor& Plane = AddActorToLevel<AStaticMeshActor>(CurrentLevel, FTransform::Identity);
+	Plane.GetStaticMeshComponent()->SetStaticMesh(PlaneStaticMesh);
+	Plane.GetStaticMeshComponent()->SetMaterial(0, BasicShapeMaterial);
 	// Make the initial platform much much larger so things don't fall off for tests which use a large area (visibility test)
-	Plane->SetActorScale3D(FVector(10000, 10000, 1));
+	Plane.SetActorScale3D(FVector(10000, 10000, 1));
 
 	// Default player start location is chosen so that players spawn on server 1 by default.
 	// Individual test maps can change this if necessary.

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/TestMaps/SpatialAuthorityMap.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/TestMaps/SpatialAuthorityMap.cpp
@@ -22,18 +22,18 @@ void USpatialAuthorityMap::CreateCustomContentForMap()
 	FVector SpatialAuthorityTestActorPosition(-250, -250, 0);
 
 	// Add the tests
-	ASpatialAuthorityTest* AuthTestActor =
+	ASpatialAuthorityTest& AuthTestActor =
 		AddActorToLevel<ASpatialAuthorityTest>(CurrentLevel, FTransform(SpatialAuthorityTestActorPosition));
-	ASpatialAuthoritySettingsOverride* SettingsOverrideTest =
+	ASpatialAuthoritySettingsOverride& SettingsOverrideTest =
 		AddActorToLevel<ASpatialAuthoritySettingsOverride>(CurrentLevel, FTransform(SpatialAuthorityTestActorPosition));
 
 	// Add the helpers, as we need things placed in the level
-	AuthTestActor->LevelActor = AddActorToLevel<ASpatialAuthorityTestActor>(CurrentLevel, FTransform(SpatialAuthorityTestActorPosition));
-	AuthTestActor->LevelReplicatedActor =
-		AddActorToLevel<ASpatialAuthorityTestReplicatedActor>(CurrentLevel, FTransform(SpatialAuthorityTestActorPosition));
+	AuthTestActor.LevelActor = &AddActorToLevel<ASpatialAuthorityTestActor>(CurrentLevel, FTransform(SpatialAuthorityTestActorPosition));
+	AuthTestActor.LevelReplicatedActor =
+		&AddActorToLevel<ASpatialAuthorityTestReplicatedActor>(CurrentLevel, FTransform(SpatialAuthorityTestActorPosition));
 	// Says "on the border", but this map doesn't have multi-worker...?
-	AuthTestActor->LevelReplicatedActorOnBorder =
-		AddActorToLevel<ASpatialAuthorityTestReplicatedActor>(CurrentLevel, FTransform(FVector(0, 0, 0)));
+	AuthTestActor.LevelReplicatedActorOnBorder =
+		&AddActorToLevel<ASpatialAuthorityTestReplicatedActor>(CurrentLevel, FTransform(FVector(0, 0, 0)));
 
 	AWorldSettings* WorldSettings = World->GetWorldSettings();
 	WorldSettings->DefaultGameMode = ASpatialAuthorityTestGameMode::StaticClass();

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/TestMaps/SpatialComponentMap.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/TestMaps/SpatialComponentMap.cpp
@@ -23,14 +23,14 @@ void USpatialComponentMap::CreateCustomContentForMap()
 	FVector SpatialComponentTestActorPosition = FVector(-250, -250, 0);
 
 	// Add the tests
-	ASpatialComponentTest* CompTest = AddActorToLevel<ASpatialComponentTest>(CurrentLevel, FTransform(SpatialComponentTestActorPosition));
-	ASpatialComponentSettingsOverride* SettingsOverrideTest =
+	ASpatialComponentTest& CompTest = AddActorToLevel<ASpatialComponentTest>(CurrentLevel, FTransform(SpatialComponentTestActorPosition));
+	ASpatialComponentSettingsOverride& SettingsOverrideTest =
 		AddActorToLevel<ASpatialComponentSettingsOverride>(CurrentLevel, FTransform(SpatialComponentTestActorPosition));
 
 	// Add the helpers, as we need things placed in the level
-	CompTest->LevelActor = AddActorToLevel<ASpatialComponentTestActor>(CurrentLevel, FTransform(SpatialComponentTestActorPosition));
-	CompTest->LevelReplicatedActor =
-		AddActorToLevel<ASpatialComponentTestReplicatedActor>(CurrentLevel, FTransform(SpatialComponentTestActorPosition));
+	CompTest.LevelActor = &AddActorToLevel<ASpatialComponentTestActor>(CurrentLevel, FTransform(SpatialComponentTestActorPosition));
+	CompTest.LevelReplicatedActor =
+		&AddActorToLevel<ASpatialComponentTestReplicatedActor>(CurrentLevel, FTransform(SpatialComponentTestActorPosition));
 
 	// Quirk of the test. We need the player spawns on the same portion of the map as the test, so they are LBed together
 	AActor** PlayerStart = CurrentLevel->Actors.FindByPredicate([](AActor* Actor) {

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/TestMaps/GeneratedTestMap.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/TestMaps/GeneratedTestMap.h
@@ -46,9 +46,9 @@ protected:
 	// localized to the cpp file, so that the include does not leak into the header file. Thus modules relying on SpatialGDKFunctionalTests
 	// can define TestMaps without needing UnrealEd (most of the time).
 	template <class T>
-	T* AddActorToLevel(ULevel* Level, const FTransform& Transform)
+	T& AddActorToLevel(ULevel* Level, const FTransform& Transform)
 	{
-		return CastChecked<T>(AddActorToLevel(Level, T::StaticClass(), Transform));
+		return *CastChecked<T>(AddActorToLevel(Level, T::StaticClass(), Transform));
 	}
 
 	// Derived test maps can call this to set the string that will be printed into the .ini file to be used with this map to override

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestAttachedComponentReplication/SpatialTestAttachedComponentReplication.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestAttachedComponentReplication/SpatialTestAttachedComponentReplication.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright 1998-2019 Epic Games, Inc. All Rights Reserved.
+// Copyright 1998-2019 Epic Games, Inc. All Rights Reserved.
 
 #include "SpatialTestAttachedComponentReplication.h"
 
@@ -13,19 +13,19 @@ void USpatialTestAttachedComponentReplicationTestMap::CreateCustomContentForMap(
 
 	ULevel* TestLevel = World->GetCurrentLevel();
 
-	AActor* LevelActor = AddActorToLevel<ASpatialTestAttachedComponentReplicationActorForLevelPlacing>(TestLevel, FTransform::Identity);
+	AActor& LevelActor = AddActorToLevel<ASpatialTestAttachedComponentReplicationActorForLevelPlacing>(TestLevel, FTransform::Identity);
 
 	// Adding an instance component...
 	UActorComponent* InstanceComponent =
-		NewObject<USpatialTestAttachedComponentReplicationComponent>(LevelActor, TEXT("PlacedActorComponent"), RF_Transactional);
-	LevelActor->AddInstanceComponent(InstanceComponent);
+		NewObject<USpatialTestAttachedComponentReplicationComponent>(&LevelActor, TEXT("PlacedActorComponent"), RF_Transactional);
+	LevelActor.AddInstanceComponent(InstanceComponent);
 	InstanceComponent->OnComponentCreated();
 	InstanceComponent->RegisterComponent();
 
 	auto AddTest = [this, TestLevel](ESpatialTestAttachedComponentReplicationType TestType) {
-		ASpatialTestAttachedComponentReplication* Test =
+		ASpatialTestAttachedComponentReplication& Test =
 			AddActorToLevel<ASpatialTestAttachedComponentReplication>(TestLevel, FTransform::Identity);
-		Test->AssignedTestType = TestType;
+		Test.AssignedTestType = TestType;
 	};
 
 	AddTest(ESpatialTestAttachedComponentReplicationType::LevelPlaced);


### PR DESCRIPTION
#### Description
Minor change to UGeneratedTestMap::AddActorToLevel to return a ref since it does a CastChecked.

#### Tests
Ran the map generation command.