### PR TITLE
Fix labels and messages. Make new ci required.

### DIFF
--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -25,10 +25,11 @@ steps:
   # New build pipeline
   # Trigger a 4.26 build
   - trigger: "unrealgdkbuild-ci"
-    label: "gdk-ci-426 ${BUILDKITE_MESSAGE}"
+    label: "gdk-ci-4.26"
     async: false
     build:
       branch: *ci_version
+      message: "gdk-4.26 ${BUILDKITE_MESSAGE}"
       env: 
         BUILD_TYPE: "GDK"
         GDK_BRANCH: "${BUILDKITE_BRANCH}"
@@ -43,10 +44,11 @@ steps:
 
   # Trigger a 4.25 build
   - trigger: "unrealgdkbuild-ci"
-    label: "gdk-ci-425 ${BUILDKITE_MESSAGE}"
+    label: "gdk-ci-4.25"
     async: false
     build:
       branch: *ci_version
+      message: "gdk-4.25 ${BUILDKITE_MESSAGE}"
       env: 
         BUILD_TYPE: "GDK" # GDK or ENGINE
         GDK_BRANCH: "${BUILDKITE_BRANCH}"


### PR DESCRIPTION
#### Description
Labels are used to identify which builds are required by GH. By generating unique labels for each branch we were spamming our GH UI with new builds to watch and also made it impossible to make the old-ci non-required without removing it. This fixes that.

#### Primary reviewers
@mironec @simonsarginson 
