### PR TITLE
unr-5322 view coordinator interface

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
@@ -98,16 +98,16 @@ void USpatialGameInstance::CreateNewSpatialConnectionManager()
 
 void USpatialGameInstance::DestroySpatialConnectionManager()
 {
-	if (SpatialConnectionManager != nullptr)
-	{
-		SpatialConnectionManager->DestroyConnection();
-		SpatialConnectionManager = nullptr;
-	}
-
 	if (GlobalStateManager != nullptr)
 	{
 		GlobalStateManager->ConditionalBeginDestroy();
 		GlobalStateManager = nullptr;
+	}
+
+	if (SpatialConnectionManager != nullptr)
+	{
+		SpatialConnectionManager->DestroyConnection();
+		SpatialConnectionManager = nullptr;
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
@@ -134,13 +134,13 @@ void USpatialWorkerConnection::FinishDestroy()
 const TArray<SpatialGDK::EntityDelta>& USpatialWorkerConnection::GetEntityDeltas()
 {
 	check(Coordinator.IsValid());
-	return Coordinator->GetViewDelta().GetEntityDeltas();
+	return Coordinator->GetEntityDeltas();
 }
 
 const TArray<Worker_Op>& USpatialWorkerConnection::GetWorkerMessages()
 {
 	check(Coordinator.IsValid());
-	return Coordinator->GetViewDelta().GetWorkerMessages();
+	return Coordinator->GetWorkerMessages();
 }
 
 void USpatialWorkerConnection::DestroyConnection()
@@ -350,6 +350,11 @@ void USpatialWorkerConnection::Flush()
 void USpatialWorkerConnection::SetStartupComplete()
 {
 	StartupComplete = true;
+}
+
+SpatialGDK::ISpatialOSWorker* USpatialWorkerConnection::GetSpatialWorkerInterface() const
+{
+	return Coordinator.Get();
 }
 
 void USpatialWorkerConnection::CreateServerWorkerEntity()

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/CrossServerRPCSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/CrossServerRPCSender.cpp
@@ -50,7 +50,7 @@ void CrossServerRPCSender::SendCommand(const FUnrealObjectRef InTargetObjectRef,
 	}
 	else
 	{
-		Coordinator->SendEntityCommandRequest(InTargetObjectRef.Entity, MoveTemp(CommandRequest), TOptional<uint32>(), SpanId);
+		Coordinator->SendEntityCommandRequest(InTargetObjectRef.Entity, MoveTemp(CommandRequest), NO_RETRIES, SpanId);
 	}
 
 #if !UE_BUILD_SHIPPING

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialWorkerConnection.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialWorkerConnection.h
@@ -113,6 +113,8 @@ public:
 
 	void SetStartupComplete();
 
+	SpatialGDK::ISpatialOSWorker* GetSpatialWorkerInterface() const;
+
 	DECLARE_MULTICAST_DELEGATE_OneParam(FOnEnqueueMessage, const SpatialGDK::FOutgoingMessage*);
 	FOnEnqueueMessage OnEnqueueMessage;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SpatialOSWorker.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SpatialOSWorker.h
@@ -1,0 +1,52 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+#include "Interop/Connection/SpatialGDKSpanId.h"
+#include "SpatialView/CommandRequest.h"
+#include "SpatialView/CommandResponse.h"
+#include "SpatialView/CommandRetryHandler.h"
+#include "SpatialView/ComponentData.h"
+#include "SpatialView/ComponentUpdate.h"
+#include "SpatialView/EntityQuery.h"
+#include "SpatialView/ViewDelta.h"
+
+namespace SpatialGDK
+{
+class SPATIALGDK_API ISpatialOSWorker
+{
+public:
+	virtual ~ISpatialOSWorker() = default;
+
+	virtual const TArray<EntityDelta>& GetEntityDeltas() const = 0;
+	virtual const TArray<Worker_Op>& GetWorkerMessages() const = 0;
+	virtual const EntityView& GetView() const = 0;
+
+	virtual const FString& GetWorkerId() const = 0;
+	virtual Worker_EntityId GetWorkerSystemEntityId() const = 0;
+
+	virtual const ComponentData* GetComponent(Worker_EntityId EntityId, Worker_ComponentId ComponentId) const = 0;
+
+	virtual void SendAddComponent(Worker_EntityId EntityId, ComponentData Data, const FSpatialGDKSpanId& SpanId = {}) = 0;
+	virtual void SendComponentUpdate(Worker_EntityId EntityId, ComponentUpdate Update, const FSpatialGDKSpanId& SpanId = {}) = 0;
+	virtual void SendRemoveComponent(Worker_EntityId EntityId, Worker_ComponentId ComponentId, const FSpatialGDKSpanId& SpanId = {}) = 0;
+
+	virtual Worker_RequestId SendEntityCommandRequest(Worker_EntityId EntityId, CommandRequest Request, FRetryData RetryData = NO_RETRIES,
+													  const FSpatialGDKSpanId& SpanId = {}) = 0;
+	virtual void SendEntityCommandResponse(Worker_RequestId RequestId, CommandResponse Response, const FSpatialGDKSpanId& SpanId = {}) = 0;
+	virtual void SendEntityCommandFailure(Worker_RequestId RequestId, FString Message, const FSpatialGDKSpanId& SpanId = {}) = 0;
+
+	virtual Worker_RequestId SendReserveEntityIdsRequest(uint32 NumberOfEntityIds, FRetryData RetryData = NO_RETRIES) = 0;
+	virtual Worker_RequestId SendCreateEntityRequest(TArray<ComponentData> EntityComponents, TOptional<Worker_EntityId> EntityId,
+													 FRetryData RetryData = NO_RETRIES, const FSpatialGDKSpanId& SpanId = {}) = 0;
+	virtual Worker_RequestId SendDeleteEntityRequest(Worker_EntityId EntityId, FRetryData RetryData = NO_RETRIES,
+													 const FSpatialGDKSpanId& SpanId = {}) = 0;
+	virtual Worker_RequestId SendEntityQueryRequest(EntityQuery Query, FRetryData RetryData = NO_RETRIES) = 0;
+
+	virtual void SendMetrics(SpatialMetrics Metrics) = 0;
+	virtual void SendLogMessage(Worker_LogLevel Level, const FName& LoggerName, FString Message) = 0;
+
+	virtual bool HasEntity(Worker_EntityId EntityId) const = 0;
+	virtual bool HasComponent(Worker_EntityId EntityId, Worker_ComponentId ComponentId) const = 0;
+	virtual bool HasAuthority(Worker_EntityId EntityId, Worker_ComponentSetId ComponentSetId) const = 0;
+};
+} // namespace SpatialGDK


### PR DESCRIPTION
#### Description
Create an interface wrapping the functionality of the ViewCoordinator to later be used in public interfaces.
Along with some minor change. Moved the order of functions around to be more sensible and removed the non-retry variants of the command senders as they aren't used and don't add extra functionality.
