### PR TITLE
[UNR-5121] Placed single client cross server possession tests in same map

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
@@ -51,10 +51,11 @@ void ACrossServerMultiPossessionTest::PrepareTest()
 		{
 			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
 			{
-				ATestPossessionPlayerController* Controller = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
-				if (Controller != nullptr)
+				ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
+				if (PlayerController != nullptr)
 				{
-					Controller->RemotePossessOnClient(Pawn, false);
+					AddToOriginalPawns(PlayerController, PlayerController->GetPawn());
+					PlayerController->RemotePossessOnClient(Pawn, false);
 				}
 			}
 		}
@@ -77,6 +78,34 @@ void ACrossServerMultiPossessionTest::PrepareTest()
 					{
 						AssertTrue(PlayerController->HasMigrated(), TEXT("PlayerController should have migrated"), PlayerController);
 					}
+				}
+			}
+			FinishStep();
+		});
+
+	AddStep(TEXT("Clean up the test"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
+		for (const auto& OriginalPawnPair : OriginalPawns)
+		{
+			if (OriginalPawnPair.Controller.Get() != nullptr && OriginalPawnPair.Controller.Get()->HasAuthority())
+			{
+				OriginalPawnPair.Controller.Get()->UnPossess();
+				OriginalPawnPair.Controller.Get()->RemotePossessOnServer(OriginalPawnPair.Pawn.Get());
+			}
+		}
+		FinishStep();
+	});
+
+	AddStep(
+		TEXT("Wait for all controllers to migrate"), FWorkerDefinition::AllServers, nullptr, nullptr,
+		[this](float) {
+			for (const auto& OriginalPawnPair : OriginalPawns)
+			{
+				if (OriginalPawnPair.Controller.Get() != nullptr && OriginalPawnPair.Controller.Get()->HasAuthority())
+				{
+					RequireTrue(OriginalPawnPair.Pawn.Get()->HasAuthority(),
+								TEXT("We should have authority over both original pawn and player controller on their initial server"));
+					RequireTrue(OriginalPawnPair.Controller.Get()->GetPawn() == OriginalPawnPair.Pawn.Get(),
+								TEXT("The player controller should have possession over its original pawn"));
 				}
 			}
 			FinishStep();

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
@@ -44,7 +44,7 @@ void ACrossServerMultiPossessionTest::PrepareTest()
 {
 	ASpatialTestRemotePossession::PrepareTest();
 
-	AddStep(TEXT("Controller remote possess"), FWorkerDefinition::AllClients, nullptr, nullptr, [this](float DeltaTime) {
+	AddStep(TEXT("Controller remote possess"), FWorkerDefinition::AllClients, nullptr, nullptr, [this](float) {
 		ATestPossessionPawn* Pawn = GetPawn();
 		AssertIsValid(Pawn, TEXT("Test requires a Pawn"));
 		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
@@ -67,13 +67,13 @@ void ACrossServerMultiPossessionTest::PrepareTest()
 			return ATestPossessionPlayerController::OnPossessCalled == GetNumRequiredClients();
 		},
 		nullptr,
-		[this](float DeltaTime) {
+		[this](float) {
 			for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
 			{
 				if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
 				{
 					ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
-					if (PlayerController && PlayerController->HasAuthority())
+					if (PlayerController != nullptr && PlayerController->HasAuthority())
 					{
 						AssertTrue(PlayerController->HasMigrated(), TEXT("PlayerController should have migrated"), PlayerController);
 					}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
@@ -95,19 +95,17 @@ void ACrossServerMultiPossessionTest::PrepareTest()
 		FinishStep();
 	});
 
-	AddStep(
-		TEXT("Wait for all controllers to migrate"), FWorkerDefinition::AllServers, nullptr, nullptr,
-		[this](float) {
-			for (const auto& OriginalPawnPair : OriginalPawns)
+	AddStep(TEXT("Wait for all controllers to migrate"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
+		for (const auto& OriginalPawnPair : OriginalPawns)
+		{
+			if (OriginalPawnPair.Controller.Get() != nullptr && OriginalPawnPair.Controller.Get()->HasAuthority())
 			{
-				if (OriginalPawnPair.Controller.Get() != nullptr && OriginalPawnPair.Controller.Get()->HasAuthority())
-				{
-					RequireTrue(OriginalPawnPair.Pawn.Get()->HasAuthority(),
-								TEXT("We should have authority over both original pawn and player controller on their initial server"));
-					RequireTrue(OriginalPawnPair.Controller.Get()->GetPawn() == OriginalPawnPair.Pawn.Get(),
-								TEXT("The player controller should have possession over its original pawn"));
-				}
+				RequireTrue(OriginalPawnPair.Pawn.Get()->HasAuthority(),
+							TEXT("We should have authority over both original pawn and player controller on their initial server"));
+				RequireTrue(OriginalPawnPair.Controller.Get()->GetPawn() == OriginalPawnPair.Pawn.Get(),
+							TEXT("The player controller should have possession over its original pawn"));
 			}
-			FinishStep();
-		});
+		}
+		FinishStep();
+	});
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
@@ -54,7 +54,6 @@ void ACrossServerMultiPossessionTest::PrepareTest()
 				ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
 				if (PlayerController != nullptr)
 				{
-					AddToOriginalPawns(PlayerController, PlayerController->GetPawn());
 					PlayerController->RemotePossessOnClient(Pawn, false);
 				}
 			}
@@ -83,29 +82,5 @@ void ACrossServerMultiPossessionTest::PrepareTest()
 			FinishStep();
 		});
 
-	AddStep(TEXT("Clean up the test"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
-		for (const auto& OriginalPawnPair : OriginalPawns)
-		{
-			if (OriginalPawnPair.Controller.Get() != nullptr && OriginalPawnPair.Controller.Get()->HasAuthority())
-			{
-				OriginalPawnPair.Controller.Get()->UnPossess();
-				OriginalPawnPair.Controller.Get()->RemotePossessOnServer(OriginalPawnPair.Pawn.Get());
-			}
-		}
-		FinishStep();
-	});
-
-	AddStep(TEXT("Wait for all controllers to migrate"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
-		for (const auto& OriginalPawnPair : OriginalPawns)
-		{
-			if (OriginalPawnPair.Controller.Get() != nullptr && OriginalPawnPair.Controller.Get()->HasAuthority())
-			{
-				RequireTrue(OriginalPawnPair.Pawn.Get()->HasAuthority(),
-							TEXT("We should have authority over both original pawn and player controller on their initial server"));
-				RequireTrue(OriginalPawnPair.Controller.Get()->GetPawn() == OriginalPawnPair.Pawn.Get(),
-							TEXT("The player controller should have possession over its original pawn"));
-			}
-		}
-		FinishStep();
-	});
+	AddCleanupSteps();
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
@@ -40,7 +40,7 @@ void ACrossServerPossessionLockTest::PrepareTest()
 {
 	Super::PrepareTest();
 
-	AddStep(TEXT("Controller remote possess"), FWorkerDefinition::AllClients, nullptr, nullptr, [this](float DeltaTime) {
+	AddStep(TEXT("Controller remote possess"), FWorkerDefinition::AllClients, nullptr, nullptr, [this](float) {
 		ATestPossessionPawn* Pawn = GetPawn();
 		AssertIsValid(Pawn, TEXT("Test requires a Pawn"));
 		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
@@ -78,4 +78,7 @@ void ACrossServerPossessionLockTest::PrepareTest()
 		}
 		FinishStep();
 	});
+
+	AddCleanupSteps();
+
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
@@ -50,7 +50,6 @@ void ACrossServerPossessionLockTest::PrepareTest()
 				ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
 				if (PlayerController != nullptr)
 				{
-					AddToOriginalPawns(PlayerController, PlayerController->GetPawn());
 					PlayerController->RemotePossessOnClient(Pawn, true);
 				}
 			}
@@ -73,33 +72,8 @@ void ACrossServerPossessionLockTest::PrepareTest()
 			ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
 			if (PlayerController != nullptr)
 			{
+				PlayerController->RemovePossessionComponent();
 				PlayerController->UnlockAllTokens();
-			}
-		}
-		FinishStep();
-	});
-
-	AddStep(TEXT("Clean up the test"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
-		for (const auto& OriginalPawnPair : OriginalPawns)
-		{
-			if (OriginalPawnPair.Controller.Get() != nullptr && OriginalPawnPair.Controller.Get()->HasAuthority())
-			{
-				OriginalPawnPair.Controller.Get()->UnPossess();
-				OriginalPawnPair.Controller.Get()->RemotePossessOnServer(OriginalPawnPair.Pawn.Get());
-			}
-		}
-		FinishStep();
-	});
-
-	AddStep(TEXT("Wait for all controllers to migrate"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
-		for (const auto& OriginalPawnPair : OriginalPawns)
-		{
-			if (OriginalPawnPair.Controller.Get() != nullptr && OriginalPawnPair.Controller.Get()->HasAuthority())
-			{
-				RequireTrue(OriginalPawnPair.Pawn.Get()->HasAuthority(),
-							TEXT("We should have authority over both original pawn and player controller on their initial server"));
-				RequireTrue(OriginalPawnPair.Controller.Get()->GetPawn() == OriginalPawnPair.Pawn.Get(),
-							TEXT("The player controller should have possession over its original pawn"));
 			}
 		}
 		FinishStep();

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
@@ -47,10 +47,11 @@ void ACrossServerPossessionLockTest::PrepareTest()
 		{
 			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
 			{
-				ATestPossessionPlayerController* Controller = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
-				if (Controller != nullptr)
+				ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
+				if (PlayerController != nullptr)
 				{
-					Controller->RemotePossessOnClient(Pawn, true);
+					AddToOriginalPawns(PlayerController, PlayerController->GetPawn());
+					PlayerController->RemotePossessOnClient(Pawn, true);
 				}
 			}
 		}
@@ -65,4 +66,41 @@ void ACrossServerPossessionLockTest::PrepareTest()
 		AssertTrue(Pawn->GetController() == nullptr, TEXT("Pawn shouldn't have a controller"), Pawn);
 		FinishStep();
 	});
+
+	AddStep(TEXT("Release locks on the pawns and player controllers"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
+		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers()) {
+			ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
+			if (PlayerController != nullptr) {
+				PlayerController->UnlockAllTokens();
+			}
+		}
+		FinishStep();
+	});
+
+	AddStep(TEXT("Clean up the test"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
+		for (const auto& OriginalPawnPair : OriginalPawns)
+		{
+			if (OriginalPawnPair.Controller.Get() != nullptr && OriginalPawnPair.Controller.Get()->HasAuthority())
+			{
+				OriginalPawnPair.Controller.Get()->UnPossess();
+				OriginalPawnPair.Controller.Get()->RemotePossessOnServer(OriginalPawnPair.Pawn.Get());
+			}
+		}
+		FinishStep();
+	});
+
+	AddStep(TEXT("Wait for all controllers to migrate"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
+		for (const auto& OriginalPawnPair : OriginalPawns)
+		{
+			if (OriginalPawnPair.Controller.Get() != nullptr && OriginalPawnPair.Controller.Get()->HasAuthority())
+			{
+				RequireTrue(OriginalPawnPair.Pawn.Get()->HasAuthority(),
+							TEXT("We should have authority over both original pawn and player controller on their initial server"));
+				RequireTrue(OriginalPawnPair.Controller.Get()->GetPawn() == OriginalPawnPair.Pawn.Get(),
+							TEXT("The player controller should have possession over its original pawn"));
+			}
+		}
+		FinishStep();
+	});
+
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
@@ -79,6 +79,9 @@ void ACrossServerPossessionLockTest::PrepareTest()
 		FinishStep();
 	});
 
+	//Wait for playercontroller to get unlocked before trying to migrate it back in the cleanup steps
+	AddWaitStep(FWorkerDefinition::AllServers);
+
 	AddCleanupSteps();
 
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
@@ -68,9 +68,11 @@ void ACrossServerPossessionLockTest::PrepareTest()
 	});
 
 	AddStep(TEXT("Release locks on the pawns and player controllers"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
-		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers()) {
+		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
+		{
 			ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
-			if (PlayerController != nullptr) {
+			if (PlayerController != nullptr)
+			{
 				PlayerController->UnlockAllTokens();
 			}
 		}
@@ -102,5 +104,4 @@ void ACrossServerPossessionLockTest::PrepareTest()
 		}
 		FinishStep();
 	});
-
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.h
@@ -7,12 +7,11 @@
 #include "TestPossessionPlayerController.h"
 #include "CrossServerPossessionLockTest.generated.h"
 
-
 UCLASS()
 class SPATIALGDKFUNCTIONALTESTS_API ACrossServerPossessionLockTest : public ASpatialTestRemotePossession
 {
 	GENERATED_BODY()
-	
+
 public:
 	ACrossServerPossessionLockTest();
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.h
@@ -4,12 +4,15 @@
 
 #include "CoreMinimal.h"
 #include "SpatialTestRemotePossession.h"
+#include "TestPossessionPlayerController.h"
 #include "CrossServerPossessionLockTest.generated.h"
+
 
 UCLASS()
 class SPATIALGDKFUNCTIONALTESTS_API ACrossServerPossessionLockTest : public ASpatialTestRemotePossession
 {
 	GENERATED_BODY()
+	
 public:
 	ACrossServerPossessionLockTest();
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionMap.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionMap.cpp
@@ -31,39 +31,9 @@ void UCrossServerPossessionMap::CreateCustomContentForMap()
 {
 	ULevel* CurrentLevel = World->GetCurrentLevel();
 
-	// Add the test
+	// Add the tests
 	AddActorToLevel<ACrossServerPossessionTest>(CurrentLevel, FTransform::Identity);
-
-	CrossServerPossessionMapPrivate::SetupWorldSettings(*World);
-}
-
-UCrossServerPossessionLockMap::UCrossServerPossessionLockMap()
-	: UGeneratedTestMap(EMapCategory::CI_NIGHTLY_SPATIAL_ONLY, TEXT("CrossServerPossessionLockMap"))
-{
-	SetNumberOfClients(1);
-}
-
-void UCrossServerPossessionLockMap::CreateCustomContentForMap()
-{
-	ULevel* CurrentLevel = World->GetCurrentLevel();
-
-	// Add the test
 	AddActorToLevel<ACrossServerPossessionLockTest>(CurrentLevel, FTransform::Identity);
-
-	CrossServerPossessionMapPrivate::SetupWorldSettings(*World);
-}
-
-UNoneCrossServerPossessionMap::UNoneCrossServerPossessionMap()
-	: UGeneratedTestMap(EMapCategory::CI_NIGHTLY_SPATIAL_ONLY, TEXT("NoneCrossServerPossessionMap"))
-{
-	SetNumberOfClients(1);
-}
-
-void UNoneCrossServerPossessionMap::CreateCustomContentForMap()
-{
-	ULevel* CurrentLevel = World->GetCurrentLevel();
-
-	// Add the test
 	AddActorToLevel<ANoneCrossServerPossessionTest>(CurrentLevel, FTransform::Identity);
 
 	CrossServerPossessionMapPrivate::SetupWorldSettings(*World);

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionMap.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionMap.h
@@ -24,30 +24,6 @@ protected:
 };
 
 UCLASS()
-class SPATIALGDKFUNCTIONALTESTS_API UCrossServerPossessionLockMap : public UGeneratedTestMap
-{
-	GENERATED_BODY()
-
-public:
-	UCrossServerPossessionLockMap();
-
-protected:
-	virtual void CreateCustomContentForMap() override;
-};
-
-UCLASS()
-class SPATIALGDKFUNCTIONALTESTS_API UNoneCrossServerPossessionMap : public UGeneratedTestMap
-{
-	GENERATED_BODY()
-
-public:
-	UNoneCrossServerPossessionMap();
-
-protected:
-	virtual void CreateCustomContentForMap() override;
-};
-
-UCLASS()
 class SPATIALGDKFUNCTIONALTESTS_API UCrossServerMultiPossessionMap : public UGeneratedTestMap
 {
 	GENERATED_BODY()

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
@@ -54,7 +54,7 @@ void ACrossServerPossessionTest::PrepareTest()
 					{
 						AssertTrue(PlayerController->HasAuthority(), TEXT("PlayerController should HasAuthority"), PlayerController);
 						AssertFalse(Pawn->HasAuthority(), TEXT("Pawn shouldn't HasAuthority"), Pawn);
-						//RequireFalse(Pawn->HasAuthority(), TEXT("Pawn shouldn't HasAuthority"));
+						// RequireFalse(Pawn->HasAuthority(), TEXT("Pawn shouldn't HasAuthority"));
 						if (!(Pawn->HasAuthority()))
 						{
 							AddToOriginalPawns(PlayerController, PlayerController->GetPawn());
@@ -88,6 +88,7 @@ void ACrossServerPossessionTest::PrepareTest()
 			}
 			FinishStep();
 		});
+
 	AddStep(TEXT("Clean up the test"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
 		for (const auto& OriginalPawnPair : OriginalPawns)
 		{
@@ -99,16 +100,20 @@ void ACrossServerPossessionTest::PrepareTest()
 		}
 		FinishStep();
 	});
-	AddStep(TEXT("Wait for all controllers to migrate"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
-		for (const auto& OriginalPawnPair : OriginalPawns)
-		{
-			if (OriginalPawnPair.Controller.Get() != nullptr && OriginalPawnPair.Controller.Get()->HasAuthority())
+
+	AddStep(
+		TEXT("Wait for all controllers to migrate"), FWorkerDefinition::AllServers, nullptr, nullptr,
+		[this](float) {
+			for (const auto& OriginalPawnPair : OriginalPawns)
 			{
-				RequireTrue(OriginalPawnPair.Pawn.Get()->HasAuthority(),  TEXT("We should have authority over both original pawn and player controller on their initial server"));
-				RequireTrue(OriginalPawnPair.Controller.Get()->GetPawn() == OriginalPawnPair.Pawn.Get(),
-							TEXT("The player controller should have possession over its original pawn"));
+				if (OriginalPawnPair.Controller.Get() != nullptr && OriginalPawnPair.Controller.Get()->HasAuthority())
+				{
+					RequireTrue(OriginalPawnPair.Pawn.Get()->HasAuthority(),
+								TEXT("We should have authority over both original pawn and player controller on their initial server"));
+					RequireTrue(OriginalPawnPair.Controller.Get()->GetPawn() == OriginalPawnPair.Pawn.Get(),
+								TEXT("The player controller should have possession over its original pawn"));
+				}
 			}
-		}
-		FinishStep();
-	}, 10000.0);
+			FinishStep();
+		});
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
@@ -101,19 +101,17 @@ void ACrossServerPossessionTest::PrepareTest()
 		FinishStep();
 	});
 
-	AddStep(
-		TEXT("Wait for all controllers to migrate"), FWorkerDefinition::AllServers, nullptr, nullptr,
-		[this](float) {
-			for (const auto& OriginalPawnPair : OriginalPawns)
+	AddStep(TEXT("Wait for all controllers to migrate"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
+		for (const auto& OriginalPawnPair : OriginalPawns)
+		{
+			if (OriginalPawnPair.Controller.Get() != nullptr && OriginalPawnPair.Controller.Get()->HasAuthority())
 			{
-				if (OriginalPawnPair.Controller.Get() != nullptr && OriginalPawnPair.Controller.Get()->HasAuthority())
-				{
-					RequireTrue(OriginalPawnPair.Pawn.Get()->HasAuthority(),
-								TEXT("We should have authority over both original pawn and player controller on their initial server"));
-					RequireTrue(OriginalPawnPair.Controller.Get()->GetPawn() == OriginalPawnPair.Pawn.Get(),
-								TEXT("The player controller should have possession over its original pawn"));
-				}
+				RequireTrue(OriginalPawnPair.Pawn.Get()->HasAuthority(),
+							TEXT("We should have authority over both original pawn and player controller on their initial server"));
+				RequireTrue(OriginalPawnPair.Controller.Get()->GetPawn() == OriginalPawnPair.Pawn.Get(),
+							TEXT("The player controller should have possession over its original pawn"));
 			}
-			FinishStep();
-		});
+		}
+		FinishStep();
+	});
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
@@ -17,7 +17,6 @@
  * Recommend to use 2*2 load balancing grid because the position is written in the code
  * The client workers begin with a player controller and their default pawns, which they initially possess.
  * The flow is as follows:
- *	Recommend to use ControllerPossessPawnGym.umap in UnrealGDKTestGyms project which ready for tests.
  *  - Setup:
  *    - Specify `GameMode Override` as ACrossServerPossessionGameMode
  *    - Specify `Multi Worker Settings Class` as Zoning 2x2(e.g. BP_Possession_Settings_Zoning2_2 of UnrealGDKTestGyms)
@@ -41,25 +40,33 @@ void ACrossServerPossessionTest::PrepareTest()
 {
 	Super::PrepareTest();
 
-	AddStep(TEXT("Cross-Server Possession"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
-		ATestPossessionPawn* Pawn = GetPawn();
-		AssertIsValid(Pawn, TEXT("Test requires a Pawn"));
-		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
-		{
-			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
+	AddStep(
+		TEXT("Cross-Server Possession"), FWorkerDefinition::AllServers, nullptr, nullptr,
+		[this](float) {
+			ATestPossessionPawn* Pawn = GetPawn();
+			// AssertIsValid(Pawn, TEXT("Test requires a Pawn"));
+			for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
 			{
-				ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
-				if (PlayerController && PlayerController->HasAuthority())
+				if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
 				{
-					AssertTrue(PlayerController->HasAuthority(), TEXT("PlayerController should HasAuthority"), PlayerController);
-					AssertFalse(Pawn->HasAuthority(), TEXT("Pawn shouldn't HasAuthority"), Pawn);
-					PlayerController->UnPossess();
-					PlayerController->RemotePossessOnServer(Pawn);
+					ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
+					if (PlayerController && PlayerController->HasAuthority())
+					{
+						AssertTrue(PlayerController->HasAuthority(), TEXT("PlayerController should HasAuthority"), PlayerController);
+						AssertFalse(Pawn->HasAuthority(), TEXT("Pawn shouldn't HasAuthority"), Pawn);
+						//RequireFalse(Pawn->HasAuthority(), TEXT("Pawn shouldn't HasAuthority"));
+						if (!(Pawn->HasAuthority()))
+						{
+							AddToOriginalPawns(PlayerController, PlayerController->GetPawn());
+							PlayerController->UnPossess();
+							PlayerController->RemotePossessOnServer(Pawn);
+						}
+					}
 				}
 			}
-		}
-		FinishStep();
-	});
+			FinishStep();
+		},
+		10000.0);
 
 	AddStep(
 		TEXT("Check test result"), FWorkerDefinition::Server(1),
@@ -67,7 +74,7 @@ void ACrossServerPossessionTest::PrepareTest()
 			return ATestPossessionPlayerController::OnPossessCalled == 1;
 		},
 		nullptr,
-		[this](float) {
+		[this](float DeltaTime) {
 			for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
 			{
 				if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
@@ -81,4 +88,27 @@ void ACrossServerPossessionTest::PrepareTest()
 			}
 			FinishStep();
 		});
+	AddStep(TEXT("Clean up the test"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
+		for (const auto& OriginalPawnPair : OriginalPawns)
+		{
+			if (OriginalPawnPair.Controller.Get() != nullptr && OriginalPawnPair.Controller.Get()->HasAuthority())
+			{
+				OriginalPawnPair.Controller.Get()->UnPossess();
+				OriginalPawnPair.Controller.Get()->RemotePossessOnServer(OriginalPawnPair.Pawn.Get());
+			}
+		}
+		FinishStep();
+	});
+	AddStep(TEXT("Wait for all controllers to migrate"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
+		for (const auto& OriginalPawnPair : OriginalPawns)
+		{
+			if (OriginalPawnPair.Controller.Get() != nullptr && OriginalPawnPair.Controller.Get()->HasAuthority())
+			{
+				RequireTrue(OriginalPawnPair.Pawn.Get()->HasAuthority(),  TEXT("We should have authority over both original pawn and player controller on their initial server"));
+				RequireTrue(OriginalPawnPair.Controller.Get()->GetPawn() == OriginalPawnPair.Pawn.Get(),
+							TEXT("The player controller should have possession over its original pawn"));
+			}
+		}
+		FinishStep();
+	}, 10000.0);
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
@@ -40,32 +40,28 @@ void ACrossServerPossessionTest::PrepareTest()
 {
 	Super::PrepareTest();
 
-	AddStep(
-		TEXT("Cross-Server Possession"), FWorkerDefinition::AllServers, nullptr, nullptr,
-		[this](float) {
-			ATestPossessionPawn* Pawn = GetPawn();
-			AssertIsValid(Pawn, TEXT("Test requires a Pawn"));
-			for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
+	AddStep(TEXT("Cross-Server Possession"), FWorkerDefinition::AllServers, nullptr, [this]() {
+		ATestPossessionPawn* Pawn = GetPawn();
+		AssertIsValid(Pawn, TEXT("Test requires a Pawn"));
+		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
+		{
+			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
 			{
-				if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
+				ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
+				if (PlayerController && PlayerController->HasAuthority())
 				{
-					ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
-					if (PlayerController && PlayerController->HasAuthority())
+					AssertTrue(PlayerController->HasAuthority(), TEXT("PlayerController should HasAuthority"), PlayerController);
+					AssertFalse(Pawn->HasAuthority(), TEXT("Pawn shouldn't HasAuthority"), Pawn);
+					if (!(Pawn->HasAuthority()))
 					{
-						AssertTrue(PlayerController->HasAuthority(), TEXT("PlayerController should HasAuthority"), PlayerController);
-						AssertFalse(Pawn->HasAuthority(), TEXT("Pawn shouldn't HasAuthority"), Pawn);
-						// RequireFalse(Pawn->HasAuthority(), TEXT("Pawn shouldn't HasAuthority"));
-						if (!(Pawn->HasAuthority()))
-						{
-							PlayerController->UnPossess();
-							PlayerController->RemotePossessOnServer(Pawn);
-						}
+						PlayerController->UnPossess();
+						PlayerController->RemotePossessOnServer(Pawn);
 					}
 				}
 			}
-			FinishStep();
-		},
-		10000.0);
+		}
+		FinishStep();
+	});
 
 	AddStep(
 		TEXT("Check test result"), FWorkerDefinition::Server(4),

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
@@ -79,7 +79,7 @@ void ACrossServerPossessionTest::PrepareTest()
 				if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
 				{
 					ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
-					if (PlayerController)
+					if (PlayerController != nullptr)
 					{
 						AssertTrue(PlayerController->HasAuthority(), TEXT("The PlayerController should be on server 4"));
 						AssertTrue(PlayerController->HasMigrated(), TEXT("PlayerController should have migrated"), PlayerController);

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
@@ -40,7 +40,7 @@ void ACrossServerPossessionTest::PrepareTest()
 {
 	Super::PrepareTest();
 
-	AddStep(TEXT("Cross-Server Possession"), FWorkerDefinition::AllServers, nullptr, [this]() {
+	AddStep(TEXT("Cross-Server Possession"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
 		ATestPossessionPawn* Pawn = GetPawn();
 		AssertIsValid(Pawn, TEXT("Test requires a Pawn"));
 		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
@@ -69,7 +69,7 @@ void ACrossServerPossessionTest::PrepareTest()
 			return ATestPossessionPlayerController::OnPossessCalled == 1;
 		},
 		nullptr,
-		[this](float DeltaTime) {
+		[this](float) {
 			for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
 			{
 				if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.h
@@ -6,7 +6,6 @@
 #include "SpatialTestRemotePossession.h"
 #include "CrossServerPossessionTest.generated.h"
 
-
 UCLASS()
 class SPATIALGDKFUNCTIONALTESTS_API ACrossServerPossessionTest : public ASpatialTestRemotePossession
 {
@@ -16,5 +15,4 @@ public:
 	ACrossServerPossessionTest();
 
 	virtual void PrepareTest() override;
-
 };

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.h
@@ -6,6 +6,7 @@
 #include "SpatialTestRemotePossession.h"
 #include "CrossServerPossessionTest.generated.h"
 
+
 UCLASS()
 class SPATIALGDKFUNCTIONALTESTS_API ACrossServerPossessionTest : public ASpatialTestRemotePossession
 {
@@ -15,4 +16,5 @@ public:
 	ACrossServerPossessionTest();
 
 	virtual void PrepareTest() override;
+
 };

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/NoneCrossServerPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/NoneCrossServerPossessionTest.cpp
@@ -53,7 +53,6 @@ void ANoneCrossServerPossessionTest::PrepareTest()
 				{
 					AssertTrue(PlayerController->HasAuthority(), TEXT("PlayerController should HasAuthority"), PlayerController);
 					AssertTrue(Pawn->HasAuthority(), TEXT("Pawn should HasAuthority"), Pawn);
-					AddToOriginalPawns(PlayerController, PlayerController->GetPawn());
 					PlayerController->UnPossess();
 					PlayerController->RemotePossessOnServer(Pawn);
 				}
@@ -83,29 +82,5 @@ void ANoneCrossServerPossessionTest::PrepareTest()
 			FinishStep();
 		});
 
-	AddStep(TEXT("Clean up the test"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
-		for (const auto& OriginalPawnPair : OriginalPawns)
-		{
-			if (OriginalPawnPair.Controller.Get() != nullptr && OriginalPawnPair.Controller.Get()->HasAuthority())
-			{
-				OriginalPawnPair.Controller.Get()->UnPossess();
-				OriginalPawnPair.Controller.Get()->RemotePossessOnServer(OriginalPawnPair.Pawn.Get());
-			}
-		}
-		FinishStep();
-	});
-
-	AddStep(TEXT("Wait for all controllers to migrate"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
-		for (const auto& OriginalPawnPair : OriginalPawns)
-		{
-			if (OriginalPawnPair.Controller.Get() != nullptr && OriginalPawnPair.Controller.Get()->HasAuthority())
-			{
-				RequireTrue(OriginalPawnPair.Pawn.Get()->HasAuthority(),
-							TEXT("We should have authority over both original pawn and player controller on their initial server"));
-				RequireTrue(OriginalPawnPair.Controller.Get()->GetPawn() == OriginalPawnPair.Pawn.Get(),
-							TEXT("The player controller should have possession over its original pawn"));
-			}
-		}
-		FinishStep();
-	});
+	AddCleanupSteps();
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/NoneCrossServerPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/NoneCrossServerPossessionTest.cpp
@@ -49,7 +49,7 @@ void ANoneCrossServerPossessionTest::PrepareTest()
 			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
 			{
 				ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
-				if (PlayerController && PlayerController->HasAuthority())
+				if (PlayerController != nullptr && PlayerController->HasAuthority())
 				{
 					AssertTrue(PlayerController->HasAuthority(), TEXT("PlayerController should HasAuthority"), PlayerController);
 					AssertTrue(Pawn->HasAuthority(), TEXT("Pawn should HasAuthority"), Pawn);
@@ -73,7 +73,7 @@ void ANoneCrossServerPossessionTest::PrepareTest()
 				if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
 				{
 					ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
-					if (PlayerController && PlayerController->HasAuthority())
+					if (PlayerController != nullptr && PlayerController->HasAuthority())
 					{
 						AssertFalse(PlayerController->HasMigrated(), TEXT("PlayerController shouldn't have migrated"), PlayerController);
 					}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.cpp
@@ -32,7 +32,7 @@ void ASpatialTestRemotePossession::PrepareTest()
 		FinishStep();
 	});
 
-	AddStep(TEXT("Create Pawn"), FWorkerDefinition::Server(1), nullptr, nullptr, [this](float DeltaTime) {
+	AddStep(TEXT("Create Pawn"), FWorkerDefinition::Server(1), nullptr, [this]() {
 		ATestPossessionPawn* Pawn =
 			GetWorld()->SpawnActor<ATestPossessionPawn>(LocationOfPawn, FRotator::ZeroRotator, FActorSpawnParameters());
 		RegisterAutoDestroyActor(Pawn);
@@ -63,7 +63,8 @@ void ASpatialTestRemotePossession::PrepareTest()
 	ATestPossessionPlayerController::ResetCalledCounter();
 }
 
-void ASpatialTestRemotePossession::AddCleanupSteps() {
+void ASpatialTestRemotePossession::AddCleanupSteps()
+{
 	AddStep(TEXT("Clean up the test"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
 		for (const auto& OriginalPawnPair : OriginalPawns)
 		{
@@ -80,14 +81,15 @@ void ASpatialTestRemotePossession::AddCleanupSteps() {
 	AddStep(TEXT("Wait for all controllers to migrate back"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
 		for (const auto& OriginalPawnPair : OriginalPawns)
 		{
-			//if(AssertIsValid(OriginalPawnPair.Controller,TEXT("We should be able to see all player controllers from any server")))
-			if (OriginalPawnPair.Controller)
+			if (AssertIsValid(OriginalPawnPair.Controller, TEXT("We should be able to see all player controllers from any server")))
+			// if (OriginalPawnPair.Controller)
 			{
 				RequireTrue(OriginalPawnPair.Controller->GetPawn() == OriginalPawnPair.Pawn,
 							FString::Printf(TEXT("The player controller should have possession over its original pawn %s"),
 											*OriginalPawnPair.Pawn->GetName()));
 				if (OriginalPawnPair.Controller->GetPawn() == OriginalPawnPair.Pawn && OriginalPawnPair.Controller->HasAuthority())
-					UE_LOG(LogTemp, Log, TEXT("Controller %s is back on its original server %s"), *OriginalPawnPair.Controller->GetName(), *GetLocalFlowController()->GetDisplayName());
+					UE_LOG(LogTemp, Log, TEXT("Controller %s is back on its original server %s"), *OriginalPawnPair.Controller->GetName(),
+						   *GetLocalFlowController()->GetDisplayName());
 			}
 		}
 		FinishStep();
@@ -119,4 +121,3 @@ void ASpatialTestRemotePossession::AddWaitStep(const FWorkerDefinition& Worker)
 		WaitTime += DeltaTime;
 	});
 }
-

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.cpp
@@ -50,6 +50,14 @@ bool ASpatialTestRemotePossession::IsReadyForPossess()
 	return Pawn->Controller != nullptr;
 }
 
+void ASpatialTestRemotePossession::AddToOriginalPawns_Implementation(ATestPossessionPlayerController* Controller, APawn* Pawn)
+{
+	FControllerPawnPair OriginalPair;
+	OriginalPair.Controller = MakeWeakObjectPtr(Controller);
+	OriginalPair.Pawn = MakeWeakObjectPtr(Pawn);
+	OriginalPawns.Add(OriginalPair);
+}
+
 void ASpatialTestRemotePossession::AddWaitStep(const FWorkerDefinition& Worker)
 {
 	AddStep(TEXT("Wait"), Worker, nullptr, nullptr, [this](float DeltaTime) {

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.h
@@ -14,8 +14,11 @@ struct FControllerPawnPair
 {
 	GENERATED_BODY()
 
-	TWeakObjectPtr<ATestPossessionPlayerController> Controller;
-	TWeakObjectPtr<APawn> Pawn;
+	UPROPERTY()
+	ATestPossessionPlayerController* Controller;
+
+	UPROPERTY()
+	APawn* Pawn;
 };
 
 UCLASS()
@@ -37,6 +40,8 @@ protected:
 	FVector LocationOfPawn;
 	float WaitTime;
 	const static float MaxWaitTime;
+
+	void AddCleanupSteps();
 
 	UFUNCTION(CrossServer, Reliable)
 	void AddToOriginalPawns(ATestPossessionPlayerController* Controller, APawn* Pawn);

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.h
@@ -4,9 +4,19 @@
 
 #include "CoreMinimal.h"
 #include "SpatialFunctionalTest.h"
+#include "TestPossessionPlayerController.h"
 #include "SpatialTestRemotePossession.generated.h"
 
 class ATestPossessionPawn;
+
+USTRUCT()
+struct FControllerPawnPair
+{
+	GENERATED_BODY()
+
+	TWeakObjectPtr<ATestPossessionPlayerController> Controller;
+	TWeakObjectPtr<APawn> Pawn;
+};
 
 UCLASS()
 class SPATIALGDKFUNCTIONALTESTS_API ASpatialTestRemotePossession : public ASpatialFunctionalTest
@@ -27,4 +37,11 @@ protected:
 	FVector LocationOfPawn;
 	float WaitTime;
 	const static float MaxWaitTime;
+
+	UFUNCTION(CrossServer, Reliable)
+	void AddToOriginalPawns(ATestPossessionPlayerController* Controller, APawn* Pawn);
+
+	// To save original Pawns and possess them back at the end
+	UPROPERTY(Handover, Transient)
+	TArray<FControllerPawnPair> OriginalPawns;
 };

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
@@ -77,7 +77,6 @@ void ATestPossessionPlayerController::UnlockAllTokens()
 			NetDriver->LockingPolicy->ReleaseLock(Token);
 		}
 	}
-	
 }
 
 void ATestPossessionPlayerController::ResetCalledCounter()

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
@@ -87,6 +87,7 @@ void ATestPossessionPlayerController::UnlockAllTokens()
 			NetDriver->LockingPolicy->ReleaseLock(Token);
 		}
 	}
+	Tokens.Empty();
 }
 
 void ATestPossessionPlayerController::ResetCalledCounter()

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
@@ -51,7 +51,7 @@ void ATestPossessionPlayerController::RemotePossessOnClient_Implementation(APawn
 		USpatialNetDriver* NetDriver = Cast<USpatialNetDriver>(GetNetDriver());
 		if (NetDriver != nullptr && NetDriver->LockingPolicy)
 		{
-			NetDriver->LockingPolicy->AcquireLock(this, TEXT("TestLock"));
+			Tokens.Add(NetDriver->LockingPolicy->AcquireLock(this, TEXT("TestLock")));
 		}
 	}
 	UnPossess();
@@ -65,6 +65,19 @@ void ATestPossessionPlayerController::RemotePossessOnServer(APawn* InPawn)
 	Component->Target = InPawn;
 	Component->RegisterComponent();
 	BeforePossessionWorkerId = GetCurrentWorkerId();
+}
+
+void ATestPossessionPlayerController::UnlockAllTokens()
+{
+	USpatialNetDriver* NetDriver = Cast<USpatialNetDriver>(GetNetDriver());
+	if (NetDriver != nullptr && NetDriver->LockingPolicy)
+	{
+		for (ActorLockToken Token : Tokens)
+		{
+			NetDriver->LockingPolicy->ReleaseLock(Token);
+		}
+	}
+	
 }
 
 void ATestPossessionPlayerController::ResetCalledCounter()

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
@@ -60,6 +60,8 @@ void ATestPossessionPlayerController::RemotePossessOnClient_Implementation(APawn
 
 void ATestPossessionPlayerController::RemotePossessOnServer(APawn* InPawn)
 {
+	check(HasAuthority());
+
 	URemotePossessionComponent* Component =
 		NewObject<URemotePossessionComponent>(this, URemotePossessionComponent::StaticClass(), TEXT("CrossServer Possession"));
 	Component->Target = InPawn;

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
@@ -67,6 +67,16 @@ void ATestPossessionPlayerController::RemotePossessOnServer(APawn* InPawn)
 	BeforePossessionWorkerId = GetCurrentWorkerId();
 }
 
+void ATestPossessionPlayerController::RemovePossessionComponent()
+{
+	URemotePossessionComponent* Component =
+		Cast<URemotePossessionComponent>(GetComponentByClass(URemotePossessionComponent::StaticClass()));
+	if (Component != nullptr)
+	{
+		Component->DestroyComponent();
+	}
+}
+
 void ATestPossessionPlayerController::UnlockAllTokens()
 {
 	USpatialNetDriver* NetDriver = Cast<USpatialNetDriver>(GetNetDriver());

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
@@ -7,6 +7,14 @@
 #include "SpatialCommonTypes.h"
 #include "TestPossessionPlayerController.generated.h"
 
+USTRUCT()
+struct FActorLockToken
+{
+	GENERATED_BODY()
+
+	ActorLockToken Token;
+};
+
 DECLARE_LOG_CATEGORY_EXTERN(LogTestPossessionPlayerController, Log, All);
 
 UCLASS()
@@ -28,6 +36,8 @@ public:
 
 	bool HasMigrated() const { return BeforePossessionWorkerId != AfterPossessionWorkerId; }
 
+	void UnlockAllTokens();
+
 	static void ResetCalledCounter();
 
 	static int32 OnPossessCalled;
@@ -37,4 +47,5 @@ private:
 
 	VirtualWorkerId BeforePossessionWorkerId;
 	VirtualWorkerId AfterPossessionWorkerId;
+	TArray<ActorLockToken> Tokens;
 };

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
@@ -47,7 +47,11 @@ public:
 private:
 	VirtualWorkerId GetCurrentWorkerId();
 
-	VirtualWorkerId BeforePossessionWorkerId;
-	VirtualWorkerId AfterPossessionWorkerId;
+	UPROPERTY(Handover)
+	uint32 BeforePossessionWorkerId;
+
+	UPROPERTY(Handover)
+	uint32 AfterPossessionWorkerId;
+
 	TArray<ActorLockToken> Tokens;
 };

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
@@ -31,6 +31,8 @@ public:
 
 	void RemotePossessOnServer(APawn* InPawn);
 
+	void RemovePossessionComponent();
+
 	UFUNCTION(Server, Reliable)
 	void RemotePossessOnClient(APawn* InPawn, bool bLockBefore);
 


### PR DESCRIPTION
#### Description
Added cleanup steps for the tests so that the map is reverted to its original state at the end of each test. In all cases this involved restoring possession of the original pawns to the player controllers. In some cases there
Some refactoring was done as there's shared code between the tests and they share a parent class. 
Some fixes were applied to the tests themselves as some didn't achieve their intended functionality.

#### Tests
How did you test these changes prior to submitting this pull request?
Ran the tests in CI and on multiple machines multiple times through the Session Frontend.
What automated tests are included in this PR?
All Cross-Server Possession Tests.
STRONGLY SUGGESTED: How can this be verified by QA?
Starting the tests through the Session Frontend by going to Window > Generate test maps, then through Session Frontend select all the tests in CrossServerPossessionMap and start them with 1 run multiple times. (This might flake due to "A functional test is already running" error if tried with multiple runs, which is a known bug found at https://improbableio.atlassian.net/browse/UNR-5171)
#### Primary reviewers
@mironec @improbable-valentyn 

