### PR TITLE
[UNR-5121] Cross server possession tests can't be placed in the same map

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
@@ -44,17 +44,17 @@ void ACrossServerMultiPossessionTest::PrepareTest()
 {
 	ASpatialTestRemotePossession::PrepareTest();
 
-	AddStep(TEXT("Controller remote possess"), FWorkerDefinition::AllClients, nullptr, nullptr, [this](float DeltaTime) {
+	AddStep(TEXT("Controller remote possess"), FWorkerDefinition::AllClients, nullptr, nullptr, [this](float) {
 		ATestPossessionPawn* Pawn = GetPawn();
 		AssertIsValid(Pawn, TEXT("Test requires a Pawn"));
 		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
 		{
 			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
 			{
-				ATestPossessionPlayerController* Controller = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
-				if (Controller != nullptr)
+				ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
+				if (PlayerController != nullptr)
 				{
-					Controller->RemotePossessOnClient(Pawn, false);
+					PlayerController->RemotePossessOnClient(Pawn, false);
 				}
 			}
 		}
@@ -67,13 +67,13 @@ void ACrossServerMultiPossessionTest::PrepareTest()
 			return ATestPossessionPlayerController::OnPossessCalled == GetNumRequiredClients();
 		},
 		nullptr,
-		[this](float DeltaTime) {
+		[this](float) {
 			for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
 			{
 				if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
 				{
 					ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
-					if (PlayerController && PlayerController->HasAuthority())
+					if (PlayerController != nullptr && PlayerController->HasAuthority())
 					{
 						AssertTrue(PlayerController->HasMigrated(), TEXT("PlayerController should have migrated"), PlayerController);
 					}
@@ -81,4 +81,6 @@ void ACrossServerMultiPossessionTest::PrepareTest()
 			}
 			FinishStep();
 		});
+
+	AddCleanupSteps();
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
@@ -51,7 +51,6 @@ void ACrossServerMultiPossessionTest::PrepareTest()
 		{
 			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
 			{
-				
 				if (ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner()))
 				{
 					PlayerController->RemotePossessOnClient(Pawn, false);

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerMultiPossessionTest.cpp
@@ -44,15 +44,15 @@ void ACrossServerMultiPossessionTest::PrepareTest()
 {
 	ASpatialTestRemotePossession::PrepareTest();
 
-	AddStep(TEXT("Controller remote possess"), FWorkerDefinition::AllClients, nullptr, nullptr, [this](float) {
+	AddStep(TEXT("Controller remote possess"), FWorkerDefinition::AllClients, nullptr, /*StartEvent*/ [this]() {
 		ATestPossessionPawn* Pawn = GetPawn();
 		AssertIsValid(Pawn, TEXT("Test requires a Pawn"));
 		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
 		{
 			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
 			{
-				ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
-				if (PlayerController != nullptr)
+				
+				if (ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner()))
 				{
 					PlayerController->RemotePossessOnClient(Pawn, false);
 				}
@@ -66,8 +66,8 @@ void ACrossServerMultiPossessionTest::PrepareTest()
 		[this]() -> bool {
 			return ATestPossessionPlayerController::OnPossessCalled == GetNumRequiredClients();
 		},
-		nullptr,
-		[this](float) {
+		/*StartEvent*/
+		[this]() {
 			for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
 			{
 				if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
@@ -6,7 +6,6 @@
 #include "Net/UnrealNetwork.h"
 #include "SpatialFunctionalTestFlowController.h"
 #include "SpatialGDKFunctionalTests/SpatialGDK/TestActors/TestPossessionPawn.h"
-#include "TestPossessionPlayerController.h"
 
 /**
  * This test tests 1 locked Controller remote possess over 1 pawn.
@@ -49,7 +48,10 @@ void ACrossServerPossessionLockTest::PrepareTest()
 			{
 				if (ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner()))
 				{
-					PlayerController->RemotePossessOnClient(Pawn, true);
+					if (PlayerController->HasAuthority())
+					{
+						PlayerController->RemotePossessOnClient(Pawn, true);
+					}
 				}
 			}
 		}
@@ -65,7 +67,7 @@ void ACrossServerPossessionLockTest::PrepareTest()
 		FinishStep();
 	});
 
-	AddStep(TEXT("Release locks on the pawns and player controllers"), FWorkerDefinition::AllServers, nullptr, [this]() {
+	AddStep(TEXT("Release locks on the player controllers"), FWorkerDefinition::AllServers, nullptr, [this]() {
 		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
 		{
 			if (ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner()))

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.cpp
@@ -40,15 +40,14 @@ void ACrossServerPossessionLockTest::PrepareTest()
 {
 	Super::PrepareTest();
 
-	AddStep(TEXT("Controller remote possess"), FWorkerDefinition::AllClients, nullptr, nullptr, [this](float) {
+	AddStep(TEXT("Controller remote possess"), FWorkerDefinition::AllClients, nullptr, /*StartEvent*/ [this]() {
 		ATestPossessionPawn* Pawn = GetPawn();
 		AssertIsValid(Pawn, TEXT("Test requires a Pawn"));
 		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
 		{
 			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
 			{
-				ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
-				if (PlayerController != nullptr)
+				if (ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner()))
 				{
 					PlayerController->RemotePossessOnClient(Pawn, true);
 				}
@@ -59,18 +58,17 @@ void ACrossServerPossessionLockTest::PrepareTest()
 
 	AddWaitStep(FWorkerDefinition::AllServers);
 
-	AddStep(TEXT("Check test result"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
+	AddStep(TEXT("Check test result"), FWorkerDefinition::AllServers, nullptr, /*StartEvent*/ [this]() {
 		ATestPossessionPawn* Pawn = GetPawn();
 		AssertIsValid(Pawn, TEXT("Test requires a Pawn"));
 		AssertTrue(Pawn->GetController() == nullptr, TEXT("Pawn shouldn't have a controller"), Pawn);
 		FinishStep();
 	});
 
-	AddStep(TEXT("Release locks on the pawns and player controllers"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
+	AddStep(TEXT("Release locks on the pawns and player controllers"), FWorkerDefinition::AllServers, nullptr, [this]() {
 		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
 		{
-			ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
-			if (PlayerController != nullptr)
+			if (ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner()))
 			{
 				PlayerController->RemovePossessionComponent();
 				PlayerController->UnlockAllTokens();

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.h
@@ -4,7 +4,6 @@
 
 #include "CoreMinimal.h"
 #include "SpatialTestRemotePossession.h"
-#include "TestPossessionPlayerController.h"
 #include "CrossServerPossessionLockTest.generated.h"
 
 UCLASS()

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionLockTest.h
@@ -4,12 +4,14 @@
 
 #include "CoreMinimal.h"
 #include "SpatialTestRemotePossession.h"
+#include "TestPossessionPlayerController.h"
 #include "CrossServerPossessionLockTest.generated.h"
 
 UCLASS()
 class SPATIALGDKFUNCTIONALTESTS_API ACrossServerPossessionLockTest : public ASpatialTestRemotePossession
 {
 	GENERATED_BODY()
+
 public:
 	ACrossServerPossessionLockTest();
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionMap.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionMap.cpp
@@ -31,39 +31,9 @@ void UCrossServerPossessionMap::CreateCustomContentForMap()
 {
 	ULevel* CurrentLevel = World->GetCurrentLevel();
 
-	// Add the test
+	// Add the tests
 	AddActorToLevel<ACrossServerPossessionTest>(CurrentLevel, FTransform::Identity);
-
-	CrossServerPossessionMapPrivate::SetupWorldSettings(*World);
-}
-
-UCrossServerPossessionLockMap::UCrossServerPossessionLockMap()
-	: UGeneratedTestMap(EMapCategory::CI_NIGHTLY_SPATIAL_ONLY, TEXT("CrossServerPossessionLockMap"))
-{
-	SetNumberOfClients(1);
-}
-
-void UCrossServerPossessionLockMap::CreateCustomContentForMap()
-{
-	ULevel* CurrentLevel = World->GetCurrentLevel();
-
-	// Add the test
 	AddActorToLevel<ACrossServerPossessionLockTest>(CurrentLevel, FTransform::Identity);
-
-	CrossServerPossessionMapPrivate::SetupWorldSettings(*World);
-}
-
-UNoneCrossServerPossessionMap::UNoneCrossServerPossessionMap()
-	: UGeneratedTestMap(EMapCategory::CI_NIGHTLY_SPATIAL_ONLY, TEXT("NoneCrossServerPossessionMap"))
-{
-	SetNumberOfClients(1);
-}
-
-void UNoneCrossServerPossessionMap::CreateCustomContentForMap()
-{
-	ULevel* CurrentLevel = World->GetCurrentLevel();
-
-	// Add the test
 	AddActorToLevel<ANoneCrossServerPossessionTest>(CurrentLevel, FTransform::Identity);
 
 	CrossServerPossessionMapPrivate::SetupWorldSettings(*World);

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionMap.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionMap.h
@@ -24,30 +24,6 @@ protected:
 };
 
 UCLASS()
-class SPATIALGDKFUNCTIONALTESTS_API UCrossServerPossessionLockMap : public UGeneratedTestMap
-{
-	GENERATED_BODY()
-
-public:
-	UCrossServerPossessionLockMap();
-
-protected:
-	virtual void CreateCustomContentForMap() override;
-};
-
-UCLASS()
-class SPATIALGDKFUNCTIONALTESTS_API UNoneCrossServerPossessionMap : public UGeneratedTestMap
-{
-	GENERATED_BODY()
-
-public:
-	UNoneCrossServerPossessionMap();
-
-protected:
-	virtual void CreateCustomContentForMap() override;
-};
-
-UCLASS()
 class SPATIALGDKFUNCTIONALTESTS_API UCrossServerMultiPossessionMap : public UGeneratedTestMap
 {
 	GENERATED_BODY()

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
@@ -40,8 +40,7 @@ void ACrossServerPossessionTest::PrepareTest()
 {
 	Super::PrepareTest();
 
-	AddStep(
-		TEXT("Cross-Server Possession"), FWorkerDefinition::AllServers, nullptr, /*StartEvent*/ [this](float DeltaTime) {
+	AddStep(TEXT("Cross-Server Possession"), FWorkerDefinition::AllServers, nullptr, /*StartEvent*/ [this](float DeltaTime) {
 		ATestPossessionPawn* Pawn = GetPawn();
 		AssertIsValid(Pawn, TEXT("Test requires a Pawn"));
 		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
@@ -63,8 +62,7 @@ void ACrossServerPossessionTest::PrepareTest()
 		FinishStep();
 	});
 
-
-	//The pawn is expected to be spawned on server 4 and thus the player controller is expected to migrate to server 4 to possess it
+	// The pawn is expected to be spawned on server 4 and thus the player controller is expected to migrate to server 4 to possess it
 	AddStep(
 		TEXT("Check test result"), FWorkerDefinition::Server(4),
 		[this]() -> bool {

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/CrossServerPossessionTest.cpp
@@ -40,7 +40,7 @@ void ACrossServerPossessionTest::PrepareTest()
 {
 	Super::PrepareTest();
 
-	AddStep(TEXT("Cross-Server Possession"), FWorkerDefinition::AllServers, nullptr, /*StartEvent*/ [this](float DeltaTime) {
+	AddStep(TEXT("Cross-Server Possession"), FWorkerDefinition::AllServers, nullptr, /*StartEvent*/ [this]() {
 		ATestPossessionPawn* Pawn = GetPawn();
 		AssertIsValid(Pawn, TEXT("Test requires a Pawn"));
 		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/NoneCrossServerPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/NoneCrossServerPossessionTest.cpp
@@ -49,7 +49,7 @@ void ANoneCrossServerPossessionTest::PrepareTest()
 			if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
 			{
 				ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
-				if (PlayerController && PlayerController->HasAuthority())
+				if (PlayerController != nullptr && PlayerController->HasAuthority())
 				{
 					AssertTrue(PlayerController->HasAuthority(), TEXT("PlayerController should HasAuthority"), PlayerController);
 					AssertTrue(Pawn->HasAuthority(), TEXT("Pawn should HasAuthority"), Pawn);
@@ -73,7 +73,7 @@ void ANoneCrossServerPossessionTest::PrepareTest()
 				if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)
 				{
 					ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
-					if (PlayerController && PlayerController->HasAuthority())
+					if (PlayerController != nullptr && PlayerController->HasAuthority())
 					{
 						AssertFalse(PlayerController->HasMigrated(), TEXT("PlayerController shouldn't have migrated"), PlayerController);
 					}
@@ -81,4 +81,6 @@ void ANoneCrossServerPossessionTest::PrepareTest()
 			}
 			FinishStep();
 		});
+
+	AddCleanupSteps();
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/NoneCrossServerPossessionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/NoneCrossServerPossessionTest.cpp
@@ -41,7 +41,7 @@ void ANoneCrossServerPossessionTest::PrepareTest()
 {
 	Super::PrepareTest();
 
-	AddStep(TEXT("Possession"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
+	AddStep(TEXT("Possession"), FWorkerDefinition::AllServers, nullptr, /*StartEvent*/ [this]() {
 		ATestPossessionPawn* Pawn = GetPawn();
 		AssertIsValid(Pawn, TEXT("Test requires a Pawn"));
 		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
@@ -66,8 +66,8 @@ void ANoneCrossServerPossessionTest::PrepareTest()
 		[this]() -> bool {
 			return ATestPossessionPlayerController::OnPossessCalled == 1;
 		},
-		nullptr,
-		[this](float) {
+		/*StartEvent*/
+		[this]() {
 			for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
 			{
 				if (FlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Client)

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.cpp
@@ -3,6 +3,7 @@
 #include "SpatialTestRemotePossession.h"
 
 #include "Kismet/GameplayStatics.h"
+#include "SpatialFunctionalTestFlowController.h"
 #include "SpatialGDKFunctionalTests/SpatialGDK/TestActors/TestPossessionPawn.h"
 #include "TestPossessionPlayerController.h"
 
@@ -31,23 +32,82 @@ void ASpatialTestRemotePossession::PrepareTest()
 		FinishStep();
 	});
 
-	AddStep(TEXT("Create Pawn"), FWorkerDefinition::Server(1), nullptr, nullptr, [this](float DeltaTime) {
+	AddStep(TEXT("Create Pawn"), FWorkerDefinition::Server(1), nullptr, [this]() {
 		ATestPossessionPawn* Pawn =
 			GetWorld()->SpawnActor<ATestPossessionPawn>(LocationOfPawn, FRotator::ZeroRotator, FActorSpawnParameters());
 		RegisterAutoDestroyActor(Pawn);
 		FinishStep();
 	});
 
+	AddStep(TEXT("Clear Original Pawn Array"), FWorkerDefinition::AllServers, nullptr, [this]() {
+		OriginalPawns.Empty();
+		FinishStep();
+	});
+
 	// Ensure that all Controllers are located on the right Worker
 	AddWaitStep(FWorkerDefinition::AllServers);
 
+	AddStep(TEXT("Save Original Pawns"), FWorkerDefinition::AllServers, nullptr, [this]() {
+		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
+		{
+			ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
+			if (PlayerController != nullptr && PlayerController->HasAuthority() && PlayerController->GetPawn()->HasAuthority())
+			{
+				AddToOriginalPawns(PlayerController, PlayerController->GetPawn());
+				UE_LOG(LogTemp, Log, TEXT("Adding original pawn %s to array"), *PlayerController->GetPawn()->GetName());
+			}
+		}
+		FinishStep();
+	});
+
 	ATestPossessionPlayerController::ResetCalledCounter();
+}
+
+void ASpatialTestRemotePossession::AddCleanupSteps()
+{
+	AddStep(TEXT("Clean up the test"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
+		for (const auto& OriginalPawnPair : OriginalPawns)
+		{
+			if (OriginalPawnPair.Controller != nullptr && OriginalPawnPair.Controller->HasAuthority())
+			{
+				OriginalPawnPair.Controller->UnPossess();
+				OriginalPawnPair.Controller->RemotePossessOnServer(OriginalPawnPair.Pawn);
+				AssertIsValid(OriginalPawnPair.Pawn, TEXT("Original pawn shouldn't be null"));
+			}
+		}
+		FinishStep();
+	});
+
+	AddStep(TEXT("Wait for all controllers to migrate back"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
+		for (const auto& OriginalPawnPair : OriginalPawns)
+		{
+			if (AssertIsValid(OriginalPawnPair.Controller, TEXT("We should be able to see all player controllers from any server")))
+			// if (OriginalPawnPair.Controller)
+			{
+				RequireTrue(OriginalPawnPair.Controller->GetPawn() == OriginalPawnPair.Pawn,
+							FString::Printf(TEXT("The player controller should have possession over its original pawn %s"),
+											*OriginalPawnPair.Pawn->GetName()));
+				if (OriginalPawnPair.Controller->GetPawn() == OriginalPawnPair.Pawn && OriginalPawnPair.Controller->HasAuthority())
+					UE_LOG(LogTemp, Log, TEXT("Controller %s is back on its original server %s"), *OriginalPawnPair.Controller->GetName(),
+						   *GetLocalFlowController()->GetDisplayName());
+			}
+		}
+		FinishStep();
+	});
 }
 
 bool ASpatialTestRemotePossession::IsReadyForPossess()
 {
 	ATestPossessionPawn* Pawn = GetPawn();
 	return Pawn->Controller != nullptr;
+}
+
+void ASpatialTestRemotePossession::AddToOriginalPawns_Implementation(ATestPossessionPlayerController* Controller, APawn* Pawn)
+{
+	FControllerPawnPair OriginalPair;
+	OriginalPair.Controller = Controller;
+	OriginalPair.Pawn = Pawn;
+	OriginalPawns.Add(OriginalPair);
 }
 
 void ASpatialTestRemotePossession::AddWaitStep(const FWorkerDefinition& Worker)

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.cpp
@@ -51,10 +51,12 @@ void ASpatialTestRemotePossession::PrepareTest()
 		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
 		{
 			ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
-			if (PlayerController != nullptr && PlayerController->HasAuthority() && PlayerController->GetPawn() != nullptr
-				&& PlayerController->GetPawn()->HasAuthority())
+			if (PlayerController != nullptr && PlayerController->HasAuthority())
 			{
-				AddToOriginalPawns(PlayerController, PlayerController->GetPawn());
+				if (PlayerController->GetPawn() != nullptr && PlayerController->GetPawn()->HasAuthority())
+				{
+					AddToOriginalPawns(PlayerController, PlayerController->GetPawn());
+				}
 			}
 		}
 		FinishStep();

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.cpp
@@ -51,7 +51,8 @@ void ASpatialTestRemotePossession::PrepareTest()
 		for (ASpatialFunctionalTestFlowController* FlowController : GetFlowControllers())
 		{
 			ATestPossessionPlayerController* PlayerController = Cast<ATestPossessionPlayerController>(FlowController->GetOwner());
-			if (PlayerController != nullptr && PlayerController->HasAuthority() && PlayerController->GetPawn() != nullptr &&PlayerController->GetPawn()->HasAuthority())
+			if (PlayerController != nullptr && PlayerController->HasAuthority() && PlayerController->GetPawn() != nullptr
+				&& PlayerController->GetPawn()->HasAuthority())
 			{
 				AddToOriginalPawns(PlayerController, PlayerController->GetPawn());
 			}
@@ -78,17 +79,18 @@ void ASpatialTestRemotePossession::AddCleanupSteps()
 
 	AddStep(TEXT("Wait for all controllers to migrate back"), FWorkerDefinition::AllServers, nullptr, nullptr,
 			/*TickEvent*/ [this](float DeltaTime) {
-		for (const auto& OriginalPawnPair : OriginalPawns)
-		{
-			if (AssertIsValid(OriginalPawnPair.PlayerController, TEXT("We should be able to see all player controllers from any server")))
-			{
-				RequireTrue(OriginalPawnPair.PlayerController->GetPawn() == OriginalPawnPair.Pawn,
-							FString::Printf(TEXT("The player controller should have possession over its original pawn %s"),
-											*OriginalPawnPair.Pawn->GetName()));					
-			}
-		}
-		FinishStep();
-	});
+				for (const auto& OriginalPawnPair : OriginalPawns)
+				{
+					if (AssertIsValid(OriginalPawnPair.PlayerController,
+									  TEXT("We should be able to see all player controllers from any server")))
+					{
+						RequireTrue(OriginalPawnPair.PlayerController->GetPawn() == OriginalPawnPair.Pawn,
+									FString::Printf(TEXT("The player controller should have possession over its original pawn %s"),
+													*OriginalPawnPair.Pawn->GetName()));
+					}
+				}
+				FinishStep();
+			});
 }
 
 bool ASpatialTestRemotePossession::IsReadyForPossess()

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.h
@@ -4,9 +4,22 @@
 
 #include "CoreMinimal.h"
 #include "SpatialFunctionalTest.h"
+#include "TestPossessionPlayerController.h"
 #include "SpatialTestRemotePossession.generated.h"
 
 class ATestPossessionPawn;
+
+USTRUCT()
+struct FControllerPawnPair
+{
+	GENERATED_BODY()
+
+	UPROPERTY()
+	ATestPossessionPlayerController* Controller;
+
+	UPROPERTY()
+	APawn* Pawn;
+};
 
 UCLASS()
 class SPATIALGDKFUNCTIONALTESTS_API ASpatialTestRemotePossession : public ASpatialFunctionalTest
@@ -27,4 +40,13 @@ protected:
 	FVector LocationOfPawn;
 	float WaitTime;
 	const static float MaxWaitTime;
+
+	void AddCleanupSteps();
+
+	UFUNCTION(CrossServer, Reliable)
+	void AddToOriginalPawns(ATestPossessionPlayerController* Controller, APawn* Pawn);
+
+	// To save original Pawns and possess them back at the end
+	UPROPERTY(Handover, Transient)
+	TArray<FControllerPawnPair> OriginalPawns;
 };

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/SpatialTestRemotePossession.h
@@ -15,7 +15,7 @@ struct FControllerPawnPair
 	GENERATED_BODY()
 
 	UPROPERTY()
-	ATestPossessionPlayerController* Controller;
+	ATestPossessionPlayerController* PlayerController;
 
 	UPROPERTY()
 	APawn* Pawn;
@@ -44,7 +44,7 @@ protected:
 	void AddCleanupSteps();
 
 	UFUNCTION(CrossServer, Reliable)
-	void AddToOriginalPawns(ATestPossessionPlayerController* Controller, APawn* Pawn);
+	void AddToOriginalPawns(ATestPossessionPlayerController* PlayerController, APawn* Pawn);
 
 	// To save original Pawns and possess them back at the end
 	UPROPERTY(Handover, Transient)

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.cpp
@@ -49,7 +49,8 @@ void ATestPossessionPlayerController::RemotePossessOnClient_Implementation(APawn
 	if (bLockBefore)
 	{
 		USpatialNetDriver* NetDriver = Cast<USpatialNetDriver>(GetNetDriver());
-		if (NetDriver != nullptr && NetDriver->LockingPolicy)
+		check(NetDriver != nullptr);
+		if (NetDriver->LockingPolicy)
 		{
 			Tokens.Add(NetDriver->LockingPolicy->AcquireLock(this, TEXT("TestLock")));
 		}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
@@ -7,6 +7,14 @@
 #include "SpatialCommonTypes.h"
 #include "TestPossessionPlayerController.generated.h"
 
+USTRUCT()
+struct FActorLockToken
+{
+	GENERATED_BODY()
+
+	ActorLockToken Token;
+};
+
 DECLARE_LOG_CATEGORY_EXTERN(LogTestPossessionPlayerController, Log, All);
 
 UCLASS()
@@ -23,10 +31,14 @@ public:
 
 	void RemotePossessOnServer(APawn* InPawn);
 
+	void RemovePossessionComponent();
+
 	UFUNCTION(Server, Reliable)
 	void RemotePossessOnClient(APawn* InPawn, bool bLockBefore);
 
 	bool HasMigrated() const { return BeforePossessionWorkerId != AfterPossessionWorkerId; }
+
+	void UnlockAllTokens();
 
 	static void ResetCalledCounter();
 
@@ -35,6 +47,11 @@ public:
 private:
 	VirtualWorkerId GetCurrentWorkerId();
 
-	VirtualWorkerId BeforePossessionWorkerId;
-	VirtualWorkerId AfterPossessionWorkerId;
+	UPROPERTY(Handover)
+	uint32 BeforePossessionWorkerId;
+
+	UPROPERTY(Handover)
+	uint32 AfterPossessionWorkerId;
+
+	TArray<ActorLockToken> Tokens;
 };

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPossession/TestPossessionPlayerController.h
@@ -7,14 +7,6 @@
 #include "SpatialCommonTypes.h"
 #include "TestPossessionPlayerController.generated.h"
 
-USTRUCT()
-struct FActorLockToken
-{
-	GENERATED_BODY()
-
-	ActorLockToken Token;
-};
-
 DECLARE_LOG_CATEGORY_EXTERN(LogTestPossessionPlayerController, Log, All);
 
 UCLASS()


### PR DESCRIPTION
#### Description
Added cleanup steps for the tests so that the map is reverted to its original state at the end of each test. In all cases this involved restoring possession of the original pawns to the player controllers. For the lock test needed to add support to release locks from netdriver.
Some refactoring was done as there's shared code between the tests and they share a parent class. 
Some fixes were applied to the tests themselves as some didn't achieve their intended functionality.

#### Tests
How did you test these changes prior to submitting this pull request?
Ran the tests in CI and on multiple machines multiple times through the Session Frontend.
What automated tests are included in this PR?
All Cross-Server Possession Tests.
STRONGLY SUGGESTED: How can this be verified by QA?
Starting the tests through the Session Frontend by going to Window > Generate test maps, then through Session Frontend select all the tests in CrossServerPossessionMap and start them with 1 run multiple times. (This might flake due to "A functional test is already running" error if tried with multiple runs, which is a known bug found at https://improbableio.atlassian.net/browse/UNR-5171)
#### Primary reviewers
@improbable-valentyn 
I suggest going through each commit separately