### PR TITLE
Fix a race condition in PartiallyStablePathTest

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/PartiallyStablePathTest/PartiallyStablePathTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/PartiallyStablePathTest/PartiallyStablePathTest.cpp
@@ -88,8 +88,8 @@ void APartiallyStablePathTest::PrepareTest()
 		nullptr, 5.0f);
 
 	AddStep(
-		TEXT("Server receives the Server RPC"), FWorkerDefinition::Server(1), nullptr,
-		[this]() {
+		TEXT("Server receives the Server RPC"), FWorkerDefinition::Server(1), nullptr, nullptr,
+		[this](float DeltaTime) {
 			RequireTrue(Pawn->bServerRPCCalled, TEXT("Server RPC was called"));
 			if (Pawn->bServerRPCCalled)
 			{
@@ -98,7 +98,7 @@ void APartiallyStablePathTest::PrepareTest()
 
 			FinishStep();
 		},
-		nullptr, 5.0f);
+		5.0f);
 
 	AddStep(
 		TEXT("Reset the pawn"), FWorkerDefinition::Server(1), nullptr,


### PR DESCRIPTION
#### Description
The test step to receive the server RPC was supposed to be on the tick event. If it's on the start event, there's a chance it would start before the RPC is received, and then it wouldn't call the event again and the step would time out.

#### Primary reviewers
@m-samiec 