### PR TITLE
Prevent functional tests from crashing if they aren't set to replicated

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
@@ -451,7 +451,6 @@ void ASpatialFunctionalTest::RegisterFlowController(ASpatialFunctionalTestFlowCo
 
 ASpatialFunctionalTestFlowController* ASpatialFunctionalTest::GetLocalFlowController()
 {
-	ensureMsgf(LocalFlowController, TEXT("GetLocalFlowController being called without it being set, shouldn't happen"));
 	return LocalFlowController;
 }
 
@@ -678,8 +677,7 @@ void ASpatialFunctionalTest::OnReplicated_CurrentStepIndex()
 	{
 		RequireHandler.LogAndClearStepRequires();
 		// if we ever started in first place
-		ASpatialFunctionalTestFlowController* AuxLocalFlowController = GetLocalFlowController();
-		if (AuxLocalFlowController != nullptr)
+		if (ASpatialFunctionalTestFlowController* AuxLocalFlowController = GetLocalFlowController())
 		{
 			AuxLocalFlowController->OnTestFinished();
 			if (AuxLocalFlowController->WorkerDefinition.Type == ESpatialFunctionalTestWorkerType::Server)

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestRequireHandler.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestRequireHandler.cpp
@@ -351,6 +351,14 @@ bool SpatialFunctionalTestRequireHandler::GenericRequire(const FString& Msg, boo
 
 void SpatialFunctionalTestRequireHandler::LogAndClearStepRequires()
 {
+	if (Requires.Num() == 0)
+	{
+		FString Msg = FString::Printf(TEXT("[Failed] Test not started"));
+		UE_VLOG(nullptr, LogSpatialGDKFunctionalTests, Error, TEXT("%s"), *Msg);
+		UE_LOG(LogSpatialGDKFunctionalTests, Error, TEXT("%s"), *Msg);
+		return;
+	}
+
 	// Since it's a TMap, we need to order them for better readability.
 	TArray<FSpatialFunctionalTestRequire> RequiresOrdered;
 	RequiresOrdered.Reserve(Requires.Num());


### PR DESCRIPTION
#### Description
Knock on from testing - https://github.com/improbableio/UnrealEngine/pull/870
This change prevents the testing framework from crashing if a SpatialFunctionalTest is set to `bReplicates=false`.
This is actually invalid behaviour, and the test will timeout, but we shouldn't be crashing.

#### Release note
Transient change - no release note
