### PR TITLE
[UNR-5046] Duplicate authority intent update bugfix

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
@@ -79,9 +79,10 @@ FSpatialLoadBalancingHandler::EvaluateActorResult FSpatialLoadBalancingHandler::
 		}
 
 		const bool bNetOwnerHasAuth = NetOwner->HasAuthority();
+		const bool bShouldHaveAuthority = NetDriver->LoadBalanceStrategy->ShouldHaveAuthority(*NetOwner);
 
 		// Load balance if we are not supposed to be on this worker, or if we are separated from our owner.
-		if ((!NetDriver->LoadBalanceStrategy->ShouldHaveAuthority(*NetOwner) || !bNetOwnerHasAuth)
+		if ((bShouldHaveAuthority || !bNetOwnerHasAuth)
 			&& !NetDriver->LockingPolicy->IsLocked(Actor))
 		{
 			uint64 HierarchyAuthorityReceivedTimestamp = GetLatestAuthorityChangeFromHierarchy(NetOwner);
@@ -124,6 +125,10 @@ FSpatialLoadBalancingHandler::EvaluateActorResult FSpatialLoadBalancingHandler::
 				{
 					UE_LOG(LogSpatialLoadBalancingHandler, Error,
 						   TEXT("Load Balancing Strategy returned invalid virtual worker for actor %s"), *Actor->GetName());
+				}
+				else if(bShouldHaveAuthority && NewAuthVirtualWorkerId == NetDriver->LoadBalanceStrategy->GetLocalVirtualWorkerId())
+				{
+					UE_LOG(LogSpatialLoadBalancingHandler, Error, TEXT("ShouldHaveAuthority returned false for actor %s, but WhoShouldHaveAuthority returned this worker's id. Actor will not be migrated."), *Actor->GetName());
 				}
 				else
 				{

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
@@ -82,8 +82,7 @@ FSpatialLoadBalancingHandler::EvaluateActorResult FSpatialLoadBalancingHandler::
 		const bool bShouldHaveAuthority = NetDriver->LoadBalanceStrategy->ShouldHaveAuthority(*NetOwner);
 
 		// Load balance if we are not supposed to be on this worker, or if we are separated from our owner.
-		if ((bShouldHaveAuthority || !bNetOwnerHasAuth)
-			&& !NetDriver->LockingPolicy->IsLocked(Actor))
+		if ((bShouldHaveAuthority || !bNetOwnerHasAuth) && !NetDriver->LockingPolicy->IsLocked(Actor))
 		{
 			uint64 HierarchyAuthorityReceivedTimestamp = GetLatestAuthorityChangeFromHierarchy(NetOwner);
 
@@ -126,9 +125,12 @@ FSpatialLoadBalancingHandler::EvaluateActorResult FSpatialLoadBalancingHandler::
 					UE_LOG(LogSpatialLoadBalancingHandler, Error,
 						   TEXT("Load Balancing Strategy returned invalid virtual worker for actor %s"), *Actor->GetName());
 				}
-				else if(bShouldHaveAuthority && NewAuthVirtualWorkerId == NetDriver->LoadBalanceStrategy->GetLocalVirtualWorkerId())
+				else if (!bShouldHaveAuthority && NewAuthVirtualWorkerId == NetDriver->LoadBalanceStrategy->GetLocalVirtualWorkerId())
 				{
-					UE_LOG(LogSpatialLoadBalancingHandler, Error, TEXT("ShouldHaveAuthority returned false for actor %s, but WhoShouldHaveAuthority returned this worker's id. Actor will not be migrated."), *Actor->GetName());
+					UE_LOG(LogSpatialLoadBalancingHandler, Error,
+						   TEXT("ShouldHaveAuthority returned false for actor %s, but WhoShouldHaveAuthority returned this worker's id. "
+								"Actor will not be migrated."),
+						   *Actor->GetName());
 				}
 				else
 				{

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
@@ -82,7 +82,7 @@ FSpatialLoadBalancingHandler::EvaluateActorResult FSpatialLoadBalancingHandler::
 		const bool bShouldHaveAuthority = NetDriver->LoadBalanceStrategy->ShouldHaveAuthority(*NetOwner);
 
 		// Load balance if we are not supposed to be on this worker, or if we are separated from our owner.
-		if ((bShouldHaveAuthority || !bNetOwnerHasAuth) && !NetDriver->LockingPolicy->IsLocked(Actor))
+		if ((!bShouldHaveAuthority || !bNetOwnerHasAuth) && !NetDriver->LockingPolicy->IsLocked(Actor))
 		{
 			uint64 HierarchyAuthorityReceivedTimestamp = GetLatestAuthorityChangeFromHierarchy(NetOwner);
 


### PR DESCRIPTION
#### Description
If ShouldHaveAuthority(MyActor) returns false on a worker, but WhoShouldHaveAuthority(MyActor) returns that worker's virtual worker id, then the GDK will log `Attempted to update AuthorityIntent twice to the same value.` The worker will treat that actor as if it has lost authority, but the actor will never be migrated, resulting in a bad state where no worker thinks it is auth over the actor.

This situation doesn't occur (to my knowledge) in GDK load balancing strategies, but can occur in bad custom load balancing strategies, and has proven difficult to track down in the past.

#### Tests
Tested in game code base.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
