### PR TITLE
Fixed an issue with migration diagnostic logging failing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue with replicating references to stably named dynamically added subobjects of dynamic actors.
 - Fixed an issue during client logout where a client's corresponding Actors were not cleaned up correctly.
 - Reverted a fix relating to the `dbghelp` file that previously caused the Editor to crash when loading the Session Front End. Our fix is no longer necessary, as Epic have fixed the issue and we've adopted their fix.
+- Fixed an issue with migration diagnostic logging failing, when the actor did not have authority.
 
 ## [`0.12.0`] - 2021-02-01
 

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.cxx
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.cxx
@@ -233,6 +233,7 @@ const TMap<Worker_ComponentId, FString> ServerAuthorityWellKnownComponents = {
     { SERVER_ENDPOINT_COMPONENT_ID, "unreal.generated.UnrealServerEndpoint" },
     { CROSSSERVER_SENDER_ENDPOINT_COMPONENT_ID, "unreal.generated.UnrealCrossServerSenderRPCs" },
     { CROSSSERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID, "unreal.generated.UnrealCrossServerReceiverACKRPCs" },
+	{ MIGRATION_DIAGNOSTIC_COMPONENT_ID, "unreal.MigrationDiagnostic" },
 };
 
 const TArray<FString> ClientAuthorityWellKnownSchemaImports = { "unreal/gdk/player_controller.schema", "unreal/gdk/rpc_components.schema",


### PR DESCRIPTION
#### Description
Added the migration diagnostic component to the list of server authority well-known components.

#### Release note
- Fixed an issue with migration diagnostic logging failing, when the actor did not have authority.

#### Tests
To test this locally you can cause a migration failure, one way to do this in comment out the following code in the `ActorSystem` and then run the automated function test: `SpatialTestCharacterMigration`:
```
 // bReplicates is not replicated, but this actor is replicated. 
 /*if (!Actor->GetIsReplicated()) 
 { 
    Actor->SetReplicates(true); 
 }*/ 
```
The test should fail and you should see the following migration log:
`Prevented owning actor PlayerController_0 (11)'s hierarchy from migrating because of blocking actor Actor_2 (3016). Originating worker (2) does not have authority of blocking actor. Blocking actor replicates on originating worker but not on authoritative worker (1).  [C:\UESpatialGDK426\Engine\Source\Runtime\Core\Private\Logging\LogMacros.cpp(92)]`

#### Documentation
Release note.
