### PR TITLE
Introduce a staging property for the worker connection 

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
@@ -435,7 +435,8 @@ void USpatialConnectionManager::FinishConnecting(Worker_ConnectionFuture* Connec
 {
 	TWeakObjectPtr<USpatialConnectionManager> WeakSpatialConnectionManager(this);
 
-	// A pending connection is used to avoid creating objects in the task graph as it can be called during GC (via UMaterialInstace::Destroy -> FlushRenderingCommands) and trigger an error.
+	// A pending connection is used to avoid creating objects in the task graph as it can be called during GC (via UMaterialInstace::Destroy
+	// -> FlushRenderingCommands) and trigger an error.
 	PendingWorkerConnection = NewObject<USpatialWorkerConnection>(this);
 	AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [ConnectionFuture, WeakSpatialConnectionManager,
 															 EventTracing = MoveTemp(NewEventTracer)]() mutable {

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
@@ -435,7 +435,7 @@ void USpatialConnectionManager::FinishConnecting(Worker_ConnectionFuture* Connec
 {
 	TWeakObjectPtr<USpatialConnectionManager> WeakSpatialConnectionManager(this);
 
-	// Create a pending object because GameThread async tasks can be called via a GC callstack.
+	// A pending connection is used to avoid creating objects in the task graph as it can be called during GC (via UMaterialInstace::Destroy -> FlushRenderingCommands) and trigger an error.
 	PendingWorkerConnection = NewObject<USpatialWorkerConnection>(this);
 	AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [ConnectionFuture, WeakSpatialConnectionManager,
 															 EventTracing = MoveTemp(NewEventTracer)]() mutable {

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
@@ -436,7 +436,7 @@ void USpatialConnectionManager::FinishConnecting(Worker_ConnectionFuture* Connec
 	TWeakObjectPtr<USpatialConnectionManager> WeakSpatialConnectionManager(this);
 
 	// A pending connection is used to avoid creating objects in the task graph as it can be called during GC (via UMaterialInstace::Destroy
-	// -> FlushRenderingCommands) and trigger an error.
+	// -> FlushRenderingCommands) and trigger an error. UNR-5421
 	PendingWorkerConnection = NewObject<USpatialWorkerConnection>(this);
 	AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [ConnectionFuture, WeakSpatialConnectionManager,
 															 EventTracing = MoveTemp(NewEventTracer)]() mutable {

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialConnectionManager.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialConnectionManager.h
@@ -91,6 +91,7 @@ private:
 	UPROPERTY()
 	USpatialWorkerConnection* WorkerConnection;
 
+	/* A temporary used to create a worker connection UObject outside of the task graph system (UNR-5421). */
 	UPROPERTY()
 	USpatialWorkerConnection* PendingWorkerConnection;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialConnectionManager.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialConnectionManager.h
@@ -91,6 +91,9 @@ private:
 	UPROPERTY()
 	USpatialWorkerConnection* WorkerConnection;
 
+	UPROPERTY()
+	USpatialWorkerConnection* PendingWorkerConnection;
+
 	Worker_Locator* WorkerLocator;
 
 	bool bIsConnected;


### PR DESCRIPTION
#### Description
Seems that this task can be called during a GC stack (inadvertently I expect) via UMaterialInstance::Destroy -> FlushRenderingCommands. 