### PR TITLE
[UNR-5415] Fix RPC parameter timeout around objects that can be locally loaded.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue with migration diagnostic logging failing, when the actor did not have authority.
 - Fixed an issue where during shutdown unregistering NetGUIDs could cause an asset load and program stall.
 - Fixed an issue where migration diagnostic tool would crash if the target actor's owner couldn't be found.
+- Fix RPC timeouts for parameters referencing assets that can be asynchronously loaded.
 
 ### Internal:
 - Reserved entity IDs previously expired after 3 minutes. Reserved Entity IDs now no longer expire, and persist until used.

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverRPC.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverRPC.cpp
@@ -405,7 +405,7 @@ bool FSpatialNetDriverRPC::ApplyRPC(Worker_EntityId EntityId, const FRPCPayload&
 
 	const USpatialGDKSettings* SpatialSettings = GetDefault<USpatialGDKSettings>();
 
-	TOptional<ERPCType> RPCType = SpatialConstants::RPCStringToType(MetaData.RPCName.ToString());
+	const TOptional<ERPCType> RPCType = SpatialConstants::RPCStringToType(MetaData.RPCName.ToString());
 
 	const float TimeQueued = (FPlatformTime::Cycles64() - MetaData.Timestamp) * FPlatformTime::GetSecondsPerCycle64();
 	const int32 UnresolvedRefCount = UnresolvedRefs.Num();
@@ -413,22 +413,20 @@ bool FSpatialNetDriverRPC::ApplyRPC(Worker_EntityId EntityId, const FRPCPayload&
 	const bool bIsReliableChannel = RPCType.Get(/*DefaultValue*/ ERPCType::Invalid) == ERPCType::ClientReliable
 									|| RPCType.Get(/*DefaultValue*/ ERPCType::Invalid) == ERPCType::ServerReliable;
 
-	bool bMissingServerObject = false;
-	for (const FUnrealObjectRef& MissingRef : UnresolvedRefs)
-	{
+	const bool bMissingServerObject = Algo::AnyOf(UnresolvedRefs, [&TargetObject, Function](const FUnrealObjectRef& MissingRef) {
 		if (MissingRef.bNoLoadOnClient)
 		{
-			bMissingServerObject = true;
+			return true;
 		}
 		else if (!ensureAlwaysMsgf(MissingRef.Path.IsSet(),
 								   TEXT("Received reference to dynamic object as loadable. Target : %s, Parameter Entity : %llu, RPC : %s"),
 								   *TargetObject->GetName(), MissingRef.Entity, *Function->GetName()))
 		{
 			// Validation code, to ensure that every loadable ref we receive has a name.
-			bMissingServerObject = true;
-			break;
+			return true;
 		}
-	}
+		return false;
+	});
 
 	const bool bCannotWaitLongerThanQueueTime = !bIsReliableChannel || bMissingServerObject;
 	const bool bQueueTimeExpired = TimeQueued > SpatialSettings->QueuedIncomingRPCWaitTime;

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverRPC.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverRPC.cpp
@@ -5,13 +5,14 @@
 #include "EngineClasses/SpatialNetDriver.h"
 #include "EngineClasses/SpatialPackageMapClient.h"
 #include "Interop/Connection/SpatialWorkerConnection.h"
+#include "Interop/RPCs/RPCQueues.h"
 #include "Interop/RPCs/RPC_RingBufferSerializer.h"
 #include "Interop/RPCs/RPC_RingBufferWithACK_Receiver.h"
 #include "Interop/RPCs/RPC_RingBufferWithACK_Sender.h"
 #include "Utils/RPCRingBuffer.h"
 #include "Utils/RepLayoutUtils.h"
 
-#include "Interop/RPCs/RPCQueues.h"
+#include "Algo/AnyOf.h"
 
 DEFINE_LOG_CATEGORY(LogSpatialNetDriverRPC);
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverRPC.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverRPC.cpp
@@ -387,15 +387,37 @@ bool FSpatialNetDriverRPC::ApplyRPC(Worker_EntityId EntityId, const FRPCPayload&
 
 	const USpatialGDKSettings* SpatialSettings = GetDefault<USpatialGDKSettings>();
 
+	TOptional<ERPCType> RPCType = SpatialConstants::RPCStringToType(MetaData.RPCName.ToString());
+
 	const float TimeQueued = (FPlatformTime::Cycles64() - MetaData.Timestamp) * FPlatformTime::GetSecondsPerCycle64();
 	const int32 UnresolvedRefCount = UnresolvedRefs.Num();
 
-	if (UnresolvedRefCount != 0 && TimeQueued < SpatialSettings->QueuedIncomingRPCWaitTime)
+	// Default to unreliable to allow the Queue to timeout.
+	bool bIsReliableChannel = RPCType.IsSet() ? RPCRingBufferUtils::ShouldQueueOverflowed(RPCType.GetValue()) : false;
+	bool bMissingServerObject = false;
+	for (const FUnrealObjectRef& MissingRef : UnresolvedRefs)
+	{
+		if (MissingRef.bNoLoadOnClient)
+		{
+			bMissingServerObject = true;
+		}
+		else if(!ensureAlwaysMsgf(MissingRef.Path.IsSet(), TEXT("Received reference to dynamic object as loadable. Target : %s, Parameter Entity : %llu, RPC : %s")
+			, *TargetObject->GetName(), MissingRef.Entity, *Function->GetName()))
+		{
+			// Validation code, to ensure that every loadable ref we receive has a name.
+			bMissingServerObject = true;
+			break;
+		}
+	}
+
+	const bool bCannotWaitLongerThanQueueTime = !bIsReliableChannel || bMissingServerObject;
+	const bool bQueueTimeExpired = TimeQueued > SpatialSettings->QueuedIncomingRPCWaitTime;
+	const bool bMustExecuteRPC = UnresolvedRefCount == 0 || (bCannotWaitLongerThanQueueTime && bQueueTimeExpired);
+
+	if (!bMustExecuteRPC)
 	{
 		return !RPCConsumed;
 	}
-
-	TOptional<ERPCType> RPCType = SpatialConstants::RPCStringToType(MetaData.RPCName.ToString());
 
 	if (UnresolvedRefCount > 0 && RPCType.IsSet() && !SpatialSettings->ShouldRPCTypeAllowUnresolvedParameters(RPCType.GetValue())
 		&& (Function->SpatialFunctionFlags & SPATIALFUNC_AllowUnresolvedParameters) == 0)

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -522,7 +522,7 @@ FNetworkGUID FSpatialNetGUIDCache::AssignNewEntityActorNetGUID(AActor* Actor, Wo
 
 			// Using StablyNamedRef for the outer since referencing ObjectRef in the map
 			// will have the EntityId
-			FUnrealObjectRef StablyNamedSubobjectRef(0, 0, Subobject->GetFName().ToString(), StablyNamedRef);
+			FUnrealObjectRef StablyNamedSubobjectRef(0, 0, Subobject->GetFName().ToString(), StablyNamedRef, CanClientLoadObject(Subobject, SubobjectNetGUID));
 
 			// This is the only extra object ref that has to be registered for the subobject.
 			UnrealObjectRefToNetGUID.Emplace(StablyNamedSubobjectRef, SubobjectNetGUID);
@@ -628,8 +628,9 @@ void FSpatialNetGUIDCache::RemoveEntityNetGUID(Worker_EntityId EntityId)
 
 				if (StablyNamedRefOption.IsSet())
 				{
+					// bNoLoadOnClient is set to a fixed value because it does not affect equality
 					UnrealObjectRefToNetGUID.Remove(
-						FUnrealObjectRef(0, 0, SubobjectInfoPair.Value->SubobjectName.ToString(), StablyNamedRefOption.GetValue()));
+						FUnrealObjectRef(0, 0, SubobjectInfoPair.Value->SubobjectName.ToString(), StablyNamedRefOption.GetValue(), /*bNoLoadOnClient*/ false));
 				}
 			}
 		}
@@ -704,8 +705,9 @@ void FSpatialNetGUIDCache::RemoveSubobjectNetGUID(const FUnrealObjectRef& Subobj
 
 			if (StablyNamedRefOption.IsSet())
 			{
+				// bNoLoadOnClient is set to a fixed value because it does not affect equality
 				UnrealObjectRefToNetGUID.Remove(
-					FUnrealObjectRef(0, 0, SubobjectInfoPtr->Get().SubobjectName.ToString(), StablyNamedRefOption.GetValue()));
+					FUnrealObjectRef(0, 0, SubobjectInfoPtr->Get().SubobjectName.ToString(), StablyNamedRefOption.GetValue(), /*bNoLoadOnClient*/ false));
 			}
 		}
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -522,7 +522,8 @@ FNetworkGUID FSpatialNetGUIDCache::AssignNewEntityActorNetGUID(AActor* Actor, Wo
 
 			// Using StablyNamedRef for the outer since referencing ObjectRef in the map
 			// will have the EntityId
-			FUnrealObjectRef StablyNamedSubobjectRef(0, 0, Subobject->GetFName().ToString(), StablyNamedRef, CanClientLoadObject(Subobject, SubobjectNetGUID));
+			FUnrealObjectRef StablyNamedSubobjectRef(0, 0, Subobject->GetFName().ToString(), StablyNamedRef,
+													 !CanClientLoadObject(Subobject, SubobjectNetGUID));
 
 			// This is the only extra object ref that has to be registered for the subobject.
 			UnrealObjectRefToNetGUID.Emplace(StablyNamedSubobjectRef, SubobjectNetGUID);
@@ -629,8 +630,8 @@ void FSpatialNetGUIDCache::RemoveEntityNetGUID(Worker_EntityId EntityId)
 				if (StablyNamedRefOption.IsSet())
 				{
 					// bNoLoadOnClient is set to a fixed value because it does not affect equality
-					UnrealObjectRefToNetGUID.Remove(
-						FUnrealObjectRef(0, 0, SubobjectInfoPair.Value->SubobjectName.ToString(), StablyNamedRefOption.GetValue(), /*bNoLoadOnClient*/ false));
+					UnrealObjectRefToNetGUID.Remove(FUnrealObjectRef(0, 0, SubobjectInfoPair.Value->SubobjectName.ToString(),
+																	 StablyNamedRefOption.GetValue(), /*bNoLoadOnClient*/ false));
 				}
 			}
 		}
@@ -706,8 +707,8 @@ void FSpatialNetGUIDCache::RemoveSubobjectNetGUID(const FUnrealObjectRef& Subobj
 			if (StablyNamedRefOption.IsSet())
 			{
 				// bNoLoadOnClient is set to a fixed value because it does not affect equality
-				UnrealObjectRefToNetGUID.Remove(
-					FUnrealObjectRef(0, 0, SubobjectInfoPtr->Get().SubobjectName.ToString(), StablyNamedRefOption.GetValue(), /*bNoLoadOnClient*/ false));
+				UnrealObjectRefToNetGUID.Remove(FUnrealObjectRef(0, 0, SubobjectInfoPtr->Get().SubobjectName.ToString(),
+																 StablyNamedRefOption.GetValue(), /*bNoLoadOnClient*/ false));
 			}
 		}
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/SpatialRPCService.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/SpatialRPCService.cpp
@@ -8,11 +8,13 @@
 #include "EngineClasses/SpatialPackageMapClient.h"
 #include "Interop/Connection/SpatialEventTracer.h"
 #include "Interop/Connection/SpatialWorkerConnection.h"
-#include "Net/NetworkProfiler.h"
 #include "SpatialConstants.h"
 #include "Utils/ObjectAllocUtils.h"
 #include "Utils/RepLayoutUtils.h"
 #include "Utils/SpatialLatencyTracer.h"
+
+#include "Algo/AnyOf.h"
+#include "Net/NetworkProfiler.h"
 
 DEFINE_LOG_CATEGORY(LogSpatialRPCService);
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/SpatialRPCService.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/SpatialRPCService.cpp
@@ -596,7 +596,7 @@ FRPCErrorInfo SpatialRPCService::ApplyRPCInternal(UObject* TargetObject, UFuncti
 	const float TimeQueued = (FDateTime::Now() - PendingRPCParams.Timestamp).GetTotalSeconds();
 	const int32 UnresolvedRefCount = UnresolvedRefs.Num();
 
-	bool bIsReliableChannel = RPCRingBufferUtils::ShouldQueueOverflowed(PendingRPCParams.Type);
+	const bool bIsReliableChannel = PendingRPCParams.Type == ERPCType::ClientReliable || PendingRPCParams.Type == ERPCType::ServerReliable;
 	bool bMissingServerObject = false;
 	for (const FUnrealObjectRef& MissingRef : UnresolvedRefs)
 	{
@@ -604,8 +604,9 @@ FRPCErrorInfo SpatialRPCService::ApplyRPCInternal(UObject* TargetObject, UFuncti
 		{
 			bMissingServerObject = true;
 		}
-		else if (!ensureAlwaysMsgf(MissingRef.Path.IsSet(), TEXT("Received reference to dynamic object as loadable. Target : %s, Parameter Entity : %llu, RPC : %s")
-		, *TargetObject->GetName(), MissingRef.Entity, *Function->GetName()))
+		else if (!ensureAlwaysMsgf(MissingRef.Path.IsSet(),
+								   TEXT("Received reference to dynamic object as loadable. Target : %s, Parameter Entity : %llu, RPC : %s"),
+								   *TargetObject->GetName(), MissingRef.Entity, *Function->GetName()))
 		{
 			// Validation code, to ensure that every loadable ref we receive has a name.
 			bMissingServerObject = true;

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -362,9 +362,11 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 	{
 		if (ComponentIds.Contains(ComponentData.component_id))
 		{
-			UE_LOG(LogEntityFactory, Error,
-				   TEXT("Constructed entity components for an Unreal actor channel contained a duplicate component. This is unexpected and "
-						"could cause problems later on."));
+			UE_LOG(
+				LogEntityFactory, Error,
+				TEXT("Constructed entity components for an Unreal actor channel contained a duplicate component %i. This is unexpected and "
+					 "could cause problems later on."),
+				ComponentData.component_id);
 		}
 		ComponentIds.Add(ComponentData.component_id);
 	}

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriverRPC.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriverRPC.h
@@ -160,13 +160,13 @@ protected:
 		TArray<FSpatialGDKSpanId> Spans;
 	};
 	StandardQueue::SentRPCCallback MakeRPCSentCallback();
-	SpatialGDK::RPCCallbacks::DataWritten MakeDataWriteCallback(TArray<FWorkerComponentData>& OutArray) const;
+	SpatialGDK::RPCCallbacks::UpdateWritten MakeDataWriteCallback(TArray<FWorkerComponentData>& OutArray) const;
 	SpatialGDK::RPCCallbacks::UpdateWritten MakeUpdateWriteCallback();
 
 	static void OnRPCSent(SpatialGDK::SpatialEventTracer& EventTracer, TArray<UpdateToSend>& OutUpdates, FName Name,
 						  Worker_EntityId EntityId, Worker_ComponentId ComponentId, uint64 RPCId, const FSpatialGDKSpanId& SpanId);
 	static void OnDataWritten(TArray<FWorkerComponentData>& OutArray, Worker_EntityId EntityId, Worker_ComponentId ComponentId,
-							  Schema_ComponentData* InData);
+							  Schema_ComponentUpdate* InData);
 	static void OnUpdateWritten(TArray<UpdateToSend>& OutUpdates, Worker_EntityId EntityId, Worker_ComponentId ComponentId,
 								Schema_ComponentUpdate* InUpdate);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealObjectRef.h
@@ -20,7 +20,7 @@ struct SPATIALGDK_API FUnrealObjectRef
 	{
 	}
 
-	FUnrealObjectRef(Worker_EntityId Entity, uint32 Offset, FString Path, FUnrealObjectRef Outer, bool bNoLoadOnClient = false)
+	FUnrealObjectRef(Worker_EntityId Entity, uint32 Offset, FString Path, FUnrealObjectRef Outer, bool bNoLoadOnClient)
 		: Entity(Entity)
 		, Offset(Offset)
 		, Path(Path)
@@ -78,7 +78,7 @@ struct SPATIALGDK_API FUnrealObjectRef
 	uint32 Offset;
 	SpatialGDK::TSchemaOption<FString> Path;
 	SpatialGDK::TSchemaOption<FUnrealObjectRef> Outer;
-	bool bNoLoadOnClient = false;
+	bool bNoLoadOnClient = true;
 	// If this field is set to true, we are saying that the Actor will exist at most once on the given worker.
 	// In addition, if we receive information for an Actor of this class over the network, then this data
 	// should be applied to the Actor we've already spawned (where another worker created the entity). This


### PR DESCRIPTION
#### Description
Contains the following modifications : 

1. Ensure FUnrealObjectRef::bNoLoadOnClient has a value that indicates if the referenced object can be resolved and loaded from a remote worker
2. Use FUnrealObjectRef::bNoLoadOnClient in the RPC application callbacks to know if we can wait longer than the RPC timeout. This is useful for objects asynchronously loaded.
3. A driveby fix, for a bug spotted while sending for a reliable and an unreliable RPC to a new actor in the new RPC service implementation. We did not merge data from different queues that targeted the same component. Now both Data and Updates are properly merged.

#### Tests
Added https://github.com/spatialos/UnrealGDKTestGyms/pull/366