### PR TITLE
Fix asset load causing stall during shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue during client logout where a client's corresponding Actors were not cleaned up correctly.
 - Reverted a fix relating to the `dbghelp` file that previously caused the Editor to crash when loading the Session Front End. Our fix is no longer necessary, as Epic have fixed the issue and we've adopted their fix.
 - Fixed an issue with migration diagnostic logging failing, when the actor did not have authority.
+- Fixed an issue where during shutdown unregistering NetGUIDs could cause an asset load and program stall.
 
 ## [`0.12.0`] - 2021-02-01
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -603,7 +603,7 @@ void FSpatialNetGUIDCache::RemoveEntityNetGUID(Worker_EntityId EntityId)
 
 	// Due to UnrealMetadata::GetNativeEntityClass using LoadObject, if we are shutting down and garbage collecting,
 	// calling LoadObject will crash the editor. In this case, just return since everything will be cleaned up anyways.
-	if (IsInGameThread() && IsGarbageCollecting())
+	if (IsEngineExitRequested() || (IsInGameThread() && IsGarbageCollecting()))
 	{
 		return;
 	}
@@ -683,7 +683,7 @@ void FSpatialNetGUIDCache::RemoveSubobjectNetGUID(const FUnrealObjectRef& Subobj
 
 	// Due to UnrealMetadata::GetNativeEntityClass using LoadObject, if we are shutting down and garbage collecting,
 	// calling LoadObject will crash the editor. In this case, just return since everything will be cleaned up anyways.
-	if (IsInGameThread() && IsGarbageCollecting())
+	if (IsEngineExitRequested() || (IsInGameThread() && IsGarbageCollecting()))
 	{
 		return;
 	}


### PR DESCRIPTION
#### Description
https://improbableio.atlassian.net/browse/UNR-5425

IsGarbageCollecting() isn't sufficient in this instance, because the call originates from IncrementalPurgeGarbage(), not a garbage collect.

#### Release note
Bugfix: Fixed an issue where during shutdown unregistering NetGUIDs could cause an asset load and program stall.
