### PR TITLE
[UNR-5404] Fix error with flattened handover structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Granting an ability from an `FGameplayAbilitySpecDef` must now be done through the `FGameplayAbilitySpec::GiveAbilityFromSpecDef`/`GiveAbilityAndActivateOnceFromSpecDef` functions.
 - Removed `USpatialStaticComponentView`; similar functionality is now provided in `ViewCoordinator`.
 - We've removed `LaunchSpatial.bat` from the Example Project and Starter Template, having replaced it with an in-Editor workflow in order to maintain a native development experience.
+- Members of a struct marked with `UPROPERTY(Handover)` will now produce a compilation error. This has never been required to allow them to replicate, it is sufficient to mark the containing struct as `Handover`. This now mirrors native Unreal behaviour with struct members marked as `UPROPERTY(Replicated)`, which also produces a compilation error.
 
 ### Features:
 - Added a message box notification when game is closed due to missing generated schema.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Granting an ability from an `FGameplayAbilitySpecDef` must now be done through the `FGameplayAbilitySpec::GiveAbilityFromSpecDef`/`GiveAbilityAndActivateOnceFromSpecDef` functions.
 - Removed `USpatialStaticComponentView`; similar functionality is now provided in `ViewCoordinator`.
 - We've removed `LaunchSpatial.bat` from the Example Project and Starter Template, having replaced it with an in-Editor workflow in order to maintain a native development experience.
-- Members of a struct marked with `UPROPERTY(Handover)` will now produce a compilation error. This has never been required to allow them to replicate, it is sufficient to mark the containing struct as `Handover`. This now mirrors native Unreal behaviour with struct members marked as `UPROPERTY(Replicated)`, which also produces a compilation error.
+- Members of a struct marked with `UPROPERTY(Handover)` will now produce an Unreal Header Tool error. This has never been required to allow them to replicate, it is sufficient to mark the containing struct as `Handover`. This now mirrors native Unreal behaviour with struct members marked as `UPROPERTY(Replicated)`, which also produces an error.
 
 ### Features:
 - Added a message box notification when game is closed due to missing generated schema.

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/TypeStructure.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/TypeStructure.cpp
@@ -443,7 +443,7 @@ TSharedPtr<FUnrealType> CreateUnrealTypeInfo(UStruct* Type, uint32 ParentChecksu
 			PropertyInfo->HandoverData = MakeShared<FUnrealHandoverData>();
 			PropertyInfo->HandoverData->Handle = HandoverDataHandle++;
 		}
-		return true;
+		return false;
 	});
 
 	return TypeNode;

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/TypeStructure.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/TypeStructure.cpp
@@ -443,7 +443,7 @@ TSharedPtr<FUnrealType> CreateUnrealTypeInfo(UStruct* Type, uint32 ParentChecksu
 			PropertyInfo->HandoverData = MakeShared<FUnrealHandoverData>();
 			PropertyInfo->HandoverData->Handle = HandoverDataHandle++;
 		}
-		return false;
+		return true;
 	});
 
 	return TypeNode;

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/TestMaps/SpatialComponentMap.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/TestMaps/SpatialComponentMap.cpp
@@ -13,6 +13,7 @@
 USpatialComponentMap::USpatialComponentMap()
 	: UGeneratedTestMap(EMapCategory::CI_PREMERGE, TEXT("SpatialComponentMap"))
 {
+	SetNumberOfClients(2);
 }
 
 void USpatialComponentMap::CreateCustomContentForMap()

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestHandoverReplication/SpatialTestHandoverActorComponentReplication.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestHandoverReplication/SpatialTestHandoverActorComponentReplication.cpp
@@ -36,21 +36,39 @@ void AHandoverReplicationTestCube::SetTestValues(int UpdatedTestPropertyValue)
 {
 	HandoverTestProperty = UpdatedTestPropertyValue;
 	ReplicatedTestProperty = UpdatedTestPropertyValue;
+	HandoverTestStruct.FirstProperty = UpdatedTestPropertyValue;
+	HandoverTestStruct.SecondProperty = UpdatedTestPropertyValue * 2; // Just to get something different
+
 	HandoverComponent->HandoverTestProperty = UpdatedTestPropertyValue;
 	HandoverComponent->ReplicatedTestProperty = UpdatedTestPropertyValue;
+	HandoverComponent->HandoverTestStruct.FirstProperty = UpdatedTestPropertyValue;
+	HandoverComponent->HandoverTestStruct.SecondProperty = UpdatedTestPropertyValue * 2; // Just to get something different
 }
 
 void AHandoverReplicationTestCube::RequireTestValues(ASpatialTestHandoverActorComponentReplication* FunctionalTest, int RequiredValue,
 													 const FString& Postfix) const
 {
+	// Handover cube (this actor)
 	FunctionalTest->RequireEqual_Int(HandoverTestProperty, RequiredValue,
 									 FString::Printf(TEXT("Handover Cube = %d: %s"), RequiredValue, *Postfix));
 	FunctionalTest->RequireEqual_Int(ReplicatedTestProperty, RequiredValue,
 									 FString::Printf(TEXT("Replicated Cube = %d: %s"), RequiredValue, *Postfix));
+	FunctionalTest->RequireEqual_Int(HandoverTestStruct.FirstProperty, RequiredValue,
+									 FString::Printf(TEXT("Handover Cube Struct First = %d: %s"), RequiredValue, *Postfix));
+	FunctionalTest->RequireEqual_Int(HandoverTestStruct.SecondProperty,
+									 RequiredValue * 2, // Just to get something different and to match the SetTestValues
+									 FString::Printf(TEXT("Handover Cube Struct Second = %d: %s"), RequiredValue, *Postfix));
+
+	// Handover Component
 	FunctionalTest->RequireEqual_Int(HandoverComponent->HandoverTestProperty, RequiredValue,
 									 FString::Printf(TEXT("Handover Component = %d: %s"), RequiredValue, *Postfix));
 	FunctionalTest->RequireEqual_Int(HandoverComponent->ReplicatedTestProperty, RequiredValue,
 									 FString::Printf(TEXT("Replicated Component = %d: %s"), RequiredValue, *Postfix));
+	FunctionalTest->RequireEqual_Int(HandoverComponent->HandoverTestStruct.FirstProperty, RequiredValue,
+									 FString::Printf(TEXT("Handover Component Struct First = %d: %s"), RequiredValue, *Postfix));
+	FunctionalTest->RequireEqual_Int(HandoverComponent->HandoverTestStruct.SecondProperty,
+									 RequiredValue * 2, // Just to get something different and to match the SetTestValues
+									 FString::Printf(TEXT("Handover Component Struct Second = %d: %s"), RequiredValue, *Postfix));
 }
 
 void AHandoverReplicationTestCube::OnAuthorityGained()

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestHandoverReplication/SpatialTestHandoverActorComponentReplication.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestHandoverReplication/SpatialTestHandoverActorComponentReplication.cpp
@@ -37,12 +37,16 @@ void AHandoverReplicationTestCube::SetTestValues(int UpdatedTestPropertyValue)
 	HandoverTestProperty = UpdatedTestPropertyValue;
 	ReplicatedTestProperty = UpdatedTestPropertyValue;
 	HandoverTestStruct.FirstProperty = UpdatedTestPropertyValue;
-	HandoverTestStruct.SecondProperty = UpdatedTestPropertyValue * 2; // Just to get something different
+	HandoverTestStruct.SecondProperty = UpdatedTestPropertyValue;
+	HandoverTestStruct.InnerStruct.FirstProperty = UpdatedTestPropertyValue;
+	HandoverTestStruct.InnerStruct.SecondProperty = UpdatedTestPropertyValue;
 
 	HandoverComponent->HandoverTestProperty = UpdatedTestPropertyValue;
 	HandoverComponent->ReplicatedTestProperty = UpdatedTestPropertyValue;
 	HandoverComponent->HandoverTestStruct.FirstProperty = UpdatedTestPropertyValue;
-	HandoverComponent->HandoverTestStruct.SecondProperty = UpdatedTestPropertyValue * 2; // Just to get something different
+	HandoverComponent->HandoverTestStruct.SecondProperty = UpdatedTestPropertyValue;
+	HandoverComponent->HandoverTestStruct.InnerStruct.FirstProperty = UpdatedTestPropertyValue;
+	HandoverComponent->HandoverTestStruct.InnerStruct.SecondProperty = UpdatedTestPropertyValue;
 }
 
 void AHandoverReplicationTestCube::RequireTestValues(ASpatialTestHandoverActorComponentReplication* FunctionalTest, int RequiredValue,
@@ -55,9 +59,12 @@ void AHandoverReplicationTestCube::RequireTestValues(ASpatialTestHandoverActorCo
 									 FString::Printf(TEXT("Replicated Cube = %d: %s"), RequiredValue, *Postfix));
 	FunctionalTest->RequireEqual_Int(HandoverTestStruct.FirstProperty, RequiredValue,
 									 FString::Printf(TEXT("Handover Cube Struct First = %d: %s"), RequiredValue, *Postfix));
-	FunctionalTest->RequireEqual_Int(HandoverTestStruct.SecondProperty,
-									 RequiredValue * 2, // Just to get something different and to match the SetTestValues
+	FunctionalTest->RequireEqual_Int(HandoverTestStruct.SecondProperty, RequiredValue,
 									 FString::Printf(TEXT("Handover Cube Struct Second = %d: %s"), RequiredValue, *Postfix));
+	FunctionalTest->RequireEqual_Int(HandoverTestStruct.InnerStruct.FirstProperty, RequiredValue,
+									 FString::Printf(TEXT("Handover Cube Struct Inner First = %d: %s"), RequiredValue, *Postfix));
+	FunctionalTest->RequireEqual_Int(HandoverTestStruct.InnerStruct.SecondProperty, RequiredValue,
+									 FString::Printf(TEXT("Handover Cube Struct Inner Second = %d: %s"), RequiredValue, *Postfix));
 
 	// Handover Component
 	FunctionalTest->RequireEqual_Int(HandoverComponent->HandoverTestProperty, RequiredValue,
@@ -66,9 +73,12 @@ void AHandoverReplicationTestCube::RequireTestValues(ASpatialTestHandoverActorCo
 									 FString::Printf(TEXT("Replicated Component = %d: %s"), RequiredValue, *Postfix));
 	FunctionalTest->RequireEqual_Int(HandoverComponent->HandoverTestStruct.FirstProperty, RequiredValue,
 									 FString::Printf(TEXT("Handover Component Struct First = %d: %s"), RequiredValue, *Postfix));
-	FunctionalTest->RequireEqual_Int(HandoverComponent->HandoverTestStruct.SecondProperty,
-									 RequiredValue * 2, // Just to get something different and to match the SetTestValues
+	FunctionalTest->RequireEqual_Int(HandoverComponent->HandoverTestStruct.SecondProperty, RequiredValue,
 									 FString::Printf(TEXT("Handover Component Struct Second = %d: %s"), RequiredValue, *Postfix));
+	FunctionalTest->RequireEqual_Int(HandoverComponent->HandoverTestStruct.InnerStruct.FirstProperty, RequiredValue,
+									 FString::Printf(TEXT("Handover Component Struct Inner First = %d: %s"), RequiredValue, *Postfix));
+	FunctionalTest->RequireEqual_Int(HandoverComponent->HandoverTestStruct.InnerStruct.SecondProperty, RequiredValue,
+									 FString::Printf(TEXT("Handover Component Struct Inner Second = %d: %s"), RequiredValue, *Postfix));
 }
 
 void AHandoverReplicationTestCube::OnAuthorityGained()

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestHandoverReplication/SpatialTestHandoverActorComponentReplication.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestHandoverReplication/SpatialTestHandoverActorComponentReplication.h
@@ -25,11 +25,9 @@ struct FHandoverReplicationTestStructInner
 {
 	GENERATED_BODY()
 
-	UPROPERTY(Handover)
+	UPROPERTY()
 	int FirstProperty;
 
-	// Both the handover marked one and this one should get replicated if the parent property is marked handover.
-	// This is here as a regression test for UNR-5404.
 	UPROPERTY()
 	int SecondProperty;
 };
@@ -39,11 +37,9 @@ struct FHandoverReplicationTestStruct
 {
 	GENERATED_BODY()
 
-	UPROPERTY(Handover)
+	UPROPERTY()
 	int FirstProperty;
 
-	// Both the handover marked one and this one should get replicated if the parent property is marked handover.
-	// This is here as a regression test for UNR-5404.
 	UPROPERTY()
 	int SecondProperty;
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestHandoverReplication/SpatialTestHandoverActorComponentReplication.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestHandoverReplication/SpatialTestHandoverActorComponentReplication.h
@@ -21,6 +21,20 @@ enum class EHandoverReplicationTestStage
 };
 
 USTRUCT()
+struct FHandoverReplicationTestStructInner
+{
+	GENERATED_BODY()
+
+	UPROPERTY(Handover)
+	int FirstProperty;
+
+	// Both the handover marked one and this one should get replicated if the parent property is marked handover.
+	// This is here as a regression test for UNR-5404.
+	UPROPERTY()
+	int SecondProperty;
+};
+
+USTRUCT()
 struct FHandoverReplicationTestStruct
 {
 	GENERATED_BODY()
@@ -32,6 +46,9 @@ struct FHandoverReplicationTestStruct
 	// This is here as a regression test for UNR-5404.
 	UPROPERTY()
 	int SecondProperty;
+
+	UPROPERTY()
+	FHandoverReplicationTestStructInner InnerStruct;
 };
 
 namespace HandoverReplicationTestValues

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestHandoverReplication/SpatialTestHandoverActorComponentReplication.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestHandoverReplication/SpatialTestHandoverActorComponentReplication.h
@@ -20,6 +20,20 @@ enum class EHandoverReplicationTestStage
 	Final,
 };
 
+USTRUCT()
+struct FHandoverReplicationTestStruct
+{
+	GENERATED_BODY()
+
+	UPROPERTY(Handover)
+	int FirstProperty;
+
+	// Both the handover marked one and this one should get replicated if the parent property is marked handover.
+	// This is here as a regression test for UNR-5404.
+	UPROPERTY()
+	int SecondProperty;
+};
+
 namespace HandoverReplicationTestValues
 {
 // This value has to be zero as handover shadow state is zero-initialized
@@ -47,6 +61,9 @@ public:
 	UPROPERTY(Handover)
 	int HandoverTestProperty = HandoverReplicationTestValues::BasicTestPropertyValue;
 
+	UPROPERTY(Handover)
+	FHandoverReplicationTestStruct HandoverTestStruct;
+
 	UPROPERTY(Replicated)
 	int ReplicatedTestProperty = HandoverReplicationTestValues::BasicTestPropertyValue;
 };
@@ -71,6 +88,9 @@ public:
 
 	UPROPERTY(Handover)
 	int HandoverTestProperty = HandoverReplicationTestValues::BasicTestPropertyValue;
+
+	UPROPERTY(Handover)
+	FHandoverReplicationTestStruct HandoverTestStruct;
 
 	UPROPERTY(Replicated)
 	int ReplicatedTestProperty = HandoverReplicationTestValues::BasicTestPropertyValue;


### PR DESCRIPTION
#### Description
Previously if a handover struct had handover member variables in it, schema would be generated for the inner members, even though they would not be used during runtime, as we don't support flattening handover structs. This produced errors as a result of UNR-3128.

Fix here is to not generate the schema for these inner members. The proper long term fix is to support flattened handover structs.

#### Release note
Probably not required?

#### Tests
Modified a test to also check for this.

#### Documentation
N/A

#### Primary reviewers
@m-samiec @improbable-dmitrii 
