### PR TITLE
Fix RPC queue moving incorrect number of items

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/RPCs/RPCRingBufferTest.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/RPCs/RPCRingBufferTest.cpp
@@ -282,16 +282,18 @@ RPCRINGBUFFER_TEST(TestRingBufferPartialExtractionAndOverflow)
 		Fixture.ServerQueue.Push(EntityForTest, Payload(RpcId++));
 	}
 	TestFalse(TEXT("Queue did not overflow 2"), bQueueOverflowed);
+
+	NumRPCToExtract += BufferSize;
 	Fixture.ServerQueue.FlushAll(WritingCtx);
 	Fixture.ClientWorker.OnUpdate(BufferUpdateReadingCtx);
 	Fixture.ClientWorker.ExtractReceivedRPCs(CanExtractCallback, ExtractCallback);
-	TestEqual(TEXT("Partial extraction step 3 (1.5 buffer size)"), Extracted, BufferSize / 2);
+	TestEqual(TEXT("Partial extraction step 3 (2 buffer size)"), Extracted, BufferSize);
 	Extracted = 0;
 
 	Fixture.ClientWorker.FlushUpdates(WritingCtx);
 	Fixture.ServerWorker.OnUpdate(ACKUpdateReadingCtx);
-	// Write 4 additional RPC, 2 will overflow
-	for (uint32 i = 0; i < BufferSize; ++i)
+	// Write 6 additional RPC, 2 will overflow
+	for (uint32 i = 0; i < BufferSize * 1.5; ++i)
 	{
 		Fixture.ServerQueue.Push(EntityForTest, Payload(RpcId++));
 	}
@@ -299,10 +301,9 @@ RPCRINGBUFFER_TEST(TestRingBufferPartialExtractionAndOverflow)
 	TestTrue(TEXT("Queue did overflow"), bQueueOverflowed);
 	bQueueOverflowed = false;
 
-	NumRPCToExtract += BufferSize;
 	Fixture.ClientWorker.OnUpdate(BufferUpdateReadingCtx);
 	Fixture.ClientWorker.ExtractReceivedRPCs(CanExtractCallback, ExtractCallback);
-	TestEqual(TEXT("Full extraction step 4 (2.5 buffer size)"), Extracted, BufferSize);
+	TestEqual(TEXT("Full extraction step 4 (3 buffer size)"), Extracted, BufferSize);
 	Extracted = 0;
 
 	Fixture.ClientWorker.FlushUpdates(WritingCtx);
@@ -313,7 +314,7 @@ RPCRINGBUFFER_TEST(TestRingBufferPartialExtractionAndOverflow)
 
 	Fixture.ClientWorker.OnUpdate(BufferUpdateReadingCtx);
 	Fixture.ClientWorker.ExtractReceivedRPCs(CanExtractCallback, ExtractCallback);
-	TestEqual(TEXT("Full extraction step 5 (3 buffer size)"), Extracted, BufferSize / 2);
+	TestEqual(TEXT("Full extraction step 5 (3.5 buffer size)"), Extracted, BufferSize / 2);
 	Extracted = 0;
 
 	return true;

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCTypes.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCTypes.h
@@ -331,13 +331,14 @@ protected:
 		}
 		else
 		{
-			for (uint32 i = 0; i < WrittenRPCs; ++i)
+			const int32 RemainingRPCs = QueuedRPCs - WrittenRPCs;
+			for (int32 i = 0; i < RemainingRPCs; ++i)
 			{
 				Queue.RPCs[i] = MoveTemp(Queue.RPCs[i + WrittenRPCs]);
 				Queue.AddData[i] = MoveTemp(Queue.AddData[i + WrittenRPCs]);
 			}
-			Queue.RPCs.SetNum(QueuedRPCs - WrittenRPCs);
-			Queue.AddData.SetNum(QueuedRPCs - WrittenRPCs);
+			Queue.RPCs.SetNum(RemainingRPCs);
+			Queue.AddData.SetNum(RemainingRPCs);
 		}
 
 		return false;


### PR DESCRIPTION
#### Description
The RPC queue was looping over the incorrect number of items to move, which caused Array out of bounds, and Memory stomp issues.