### PR TITLE
Move SendComponentUpdates early out to avoid memory leak

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
@@ -1929,7 +1929,7 @@ void ActorSystem::SendComponentUpdates(UObject* Object, const FClassInfo& Info, 
 
 	// It's not clear if this is ever valid for authority to not be true anymore (since component sets), but still possible if we attempt
 	// to process updates whilst an entity creation is in progress, or after the entity has been deleted or removed from view. So in the
-	// meantime we've kept the checking and queuing of updates, along with an error message.
+	// meantime we've kept the checking with an error message.
 	if (!NetDriver->HasServerAuthority(EntityId))
 	{
 		UE_LOG(LogActorSystem, Error, TEXT("Trying to send component update but don't have authority! entity: %lld"), EntityId);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
@@ -1927,6 +1927,15 @@ void ActorSystem::SendComponentUpdates(UObject* Object, const FClassInfo& Info, 
 	SCOPE_CYCLE_COUNTER(STAT_ActorSystemSendComponentUpdates);
 	const Worker_EntityId EntityId = Channel->GetEntityId();
 
+	// It's not clear if this is ever valid for authority to not be true anymore (since component sets), but still possible if we attempt
+	// to process updates whilst an entity creation is in progress, or after the entity has been deleted or removed from view. So in the
+	// meantime we've kept the checking and queuing of updates, along with an error message.
+	if (!NetDriver->HasServerAuthority(EntityId))
+	{
+		UE_LOG(LogActorSystem, Error, TEXT("Trying to send component update but don't have authority! entity: %lld"), EntityId);
+		return;
+	}
+
 	UE_LOG(LogActorSystem, Verbose, TEXT("Sending component update (object: %s, entity: %lld)"), *Object->GetName(), EntityId);
 
 	USpatialLatencyTracer* Tracer = USpatialLatencyTracer::GetTracer(Object);
@@ -1959,15 +1968,6 @@ void ActorSystem::SendComponentUpdates(UObject* Object, const FClassInfo& Info, 
 
 			PropertySpans.Push(PropertySpan);
 		}
-	}
-
-	// It's not clear if this is ever valid for authority to not be true anymore (since component sets), but still possible if we attempt
-	// to process updates whilst an entity creation is in progress, or after the entity has been deleted or removed from view. So in the
-	// meantime we've kept the checking and queuing of updates, along with an error message.
-	if (!NetDriver->HasServerAuthority(EntityId))
-	{
-		UE_LOG(LogActorSystem, Error, TEXT("Trying to send component update but don't have authority! entity: %lld"), EntityId);
-		return;
 	}
 
 	for (int i = 0; i < ComponentUpdates.Num(); i++)


### PR DESCRIPTION
#### Description
Returning after allocating `FWorkerComponentUpdate`s leaks memory due to that type not owning the underlying `Worker_ComponentUpdate` allocation.
From what I can see there's no reason to do the authority check that late in the function, so I moved it up. This also means we don't send traces for replicating data we then don't send.

Another way to fix this is to just remove the authority check altogether, though it's not clear if we are now guaranteed to not hit this check.

#### Release note
TODO. Is this worth a changelog note?

#### Tests
N/A
