### PR TITLE
Fix bad tombstone creations

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1068,28 +1068,50 @@ void USpatialNetDriver::NotifyActorDestroyed(AActor* ThisActor, bool IsSeamlessT
 		// Check if this is a dormant entity, and if so retire the entity
 		if (PackageMap != nullptr && World != nullptr)
 		{
-			const Worker_EntityId EntityId = PackageMap->GetEntityIdFromObject(ThisActor);
-
-			// If the actor is an initially dormant startup actor that has not been replicated.
-			if (EntityId == SpatialConstants::INVALID_ENTITY_ID && ThisActor->IsNetStartupActor() && ThisActor->GetIsReplicated()
-				&& ThisActor->HasAuthority())
+			if (!World->bBegunPlay)
 			{
-				UE_LOG(LogSpatialOSNetDriver, Log,
-					   TEXT("Creating a tombstone entity for initially dormant statup actor. "
-							"Actor: %s."),
-					   *ThisActor->GetName());
-				ActorSystem->CreateTombstoneEntity(ThisActor);
-			}
-			else if (IsDormantEntity(EntityId) && ThisActor->HasAuthority())
-			{
-				// Deliberately don't unregister the dormant entity, but let it get cleaned up in the entity remove op process
-				if (!HasServerAuthority(EntityId))
+				// When running in PIE, Blueprint loaded levels can be duplicated and immediately unloaded.
+				// This causes each actor in the level to be destroyed, which we catch here and attempt to create a tombstone for.
+				// This is incorrect behaviour, as the level was never actually part of the scene, just an artifact from the
+				// world duplication process. So ignore this destroy call if the world hasn't begun play, and it was duplicated from PIE.
+				if (ThisActor->GetLevel() != nullptr && ThisActor->GetLevel()->bWasDuplicatedForPIE)
 				{
-					UE_LOG(LogSpatialOSNetDriver, Warning,
-						   TEXT("Retiring dormant entity that we don't have spatial authority over [%lld][%s]"), EntityId,
+					UE_LOG(LogSpatialOSNetDriver, Verbose,
+						   TEXT("USpatialNetDriver::NotifyActorDestroyed ignore because world hasn't begun play. Actor: %s."),
 						   *ThisActor->GetName());
 				}
-				ActorSystem->RetireEntity(EntityId, ThisActor->IsNetStartupActor());
+				else
+				{
+					UE_LOG(LogSpatialOSNetDriver, Error,
+						   TEXT("USpatialNetDriver::NotifyActorDestroyed ignore because world hasn't begun play. Actor: %s."),
+						   *ThisActor->GetName());
+				}
+			}
+			else
+			{
+				const Worker_EntityId EntityId = PackageMap->GetEntityIdFromObject(ThisActor);
+
+				// If the actor is an initially dormant startup actor that has not been replicated.
+				if (EntityId == SpatialConstants::INVALID_ENTITY_ID && ThisActor->IsNetStartupActor() && ThisActor->GetIsReplicated()
+					&& ThisActor->HasAuthority())
+				{
+					UE_LOG(LogSpatialOSNetDriver, Log,
+						   TEXT("Creating a tombstone entity for initially dormant statup actor. "
+								"Actor: %s."),
+						   *ThisActor->GetName());
+					ActorSystem->CreateTombstoneEntity(ThisActor);
+				}
+				else if (IsDormantEntity(EntityId) && ThisActor->HasAuthority())
+				{
+					// Deliberately don't unregister the dormant entity, but let it get cleaned up in the entity remove op process
+					if (!HasServerAuthority(EntityId))
+					{
+						UE_LOG(LogSpatialOSNetDriver, Warning,
+							   TEXT("Retiring dormant entity that we don't have spatial authority over [%lld][%s]"), EntityId,
+							   *ThisActor->GetName());
+					}
+					ActorSystem->RetireEntity(EntityId, ThisActor->IsNetStartupActor());
+				}
 			}
 		}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1070,20 +1070,21 @@ void USpatialNetDriver::NotifyActorDestroyed(AActor* ThisActor, bool IsSeamlessT
 		{
 			if (!World->bBegunPlay)
 			{
-				// When running in PIE, Blueprint loaded levels can be duplicated and immediately unloaded.
-				// This causes each actor in the level to be destroyed, which we catch here and attempt to create a tombstone for.
-				// This is incorrect behaviour, as the level was never actually part of the scene, just an artifact from the
-				// world duplication process. So ignore this destroy call if the world hasn't begun play, and it was duplicated from PIE.
+				// When running in PIE, Blueprint loaded sub-levels can be duplicated and immediately unloaded.
+				// This causes each actor in the level to be destroyed, which we process here and if the actor is replicated etc., attempt
+				// to create a tombstone for. This would be incorrect behaviour, as the level and actors were never intentionally loaded,
+				// but are present just as an effect of the world duplication process.
+				// So we ignore this destroy call if the world hasn't begun play, and it was duplicated from PIE.
 				if (ThisActor->GetLevel() != nullptr && ThisActor->GetLevel()->bWasDuplicatedForPIE)
 				{
 					UE_LOG(LogSpatialOSNetDriver, Verbose,
-						   TEXT("USpatialNetDriver::NotifyActorDestroyed ignore because world hasn't begun play. Actor: %s."),
+						   TEXT("USpatialNetDriver::NotifyActorDestroyed ignored as level was duplicated for PIE. Actor: %s."),
 						   *ThisActor->GetName());
 				}
 				else
 				{
 					UE_LOG(LogSpatialOSNetDriver, Error,
-						   TEXT("USpatialNetDriver::NotifyActorDestroyed ignore because world hasn't begun play. Actor: %s."),
+						   TEXT("USpatialNetDriver::NotifyActorDestroyed ignored because world hasn't begun play. Actor: %s."),
 						   *ThisActor->GetName());
 				}
 			}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
@@ -1754,9 +1754,9 @@ void ActorSystem::CreateTombstoneEntity(AActor* Actor)
 
 	if (EntityId == SpatialConstants::INVALID_ENTITY_ID)
 	{
-		// This shouldn't happen, but as a precaution error and return instead of attempting to create an entity with ID 0.
+		// This shouldn't happen, but as a precaution, error and return instead of attempting to create an entity with ID 0.
 		UE_LOG(LogActorSystem, Error, TEXT("Failed to tombstone actor, no entity ids available. Actor: %s."), *Actor->GetName());
-		return false;
+		return;
 	}
 
 	EntityFactory DataFactory(NetDriver, NetDriver->PackageMap, NetDriver->ClassInfoManager, NetDriver->GetRPCService());

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
@@ -1752,6 +1752,13 @@ void ActorSystem::CreateTombstoneEntity(AActor* Actor)
 
 	const Worker_EntityId EntityId = NetDriver->PackageMap->AllocateEntityIdAndResolveActor(Actor);
 
+	if (EntityId == SpatialConstants::INVALID_ENTITY_ID)
+	{
+		// This shouldn't happen, but as a precaution error and return instead of attempting to create an entity with ID 0.
+		UE_LOG(LogActorSystem, Error, TEXT("Failed to tombstone actor, no entity ids available. Actor: %s."), *Actor->GetName());
+		return false;
+	}
+
 	EntityFactory DataFactory(NetDriver, NetDriver->PackageMap, NetDriver->ClassInfoManager, NetDriver->GetRPCService());
 	TArray<FWorkerComponentData> Components = DataFactory.CreateTombstoneEntityComponents(Actor);
 


### PR DESCRIPTION
#### Description
Fix issue where  on startup blueprint streamed levels would immediately trigger an unload and an attempted tombstone creation before entity pool was complete. 
The fix was to check the world was in a correct state before allowing tombstone to be created for it. Additionally added a check that we don't attempt to create tombstones with INVALID_ENTITY_ID which was breaking connection to runtime.
