### PR TITLE
Bugfix/unr 5454 trace span duplication

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
@@ -1936,8 +1936,7 @@ void ActorSystem::SendComponentUpdates(UObject* Object, const FClassInfo& Info, 
 
 	UE_LOG(LogActorSystem, Verbose, TEXT("Sending component update (object: %s, entity: %lld)"), *Object->GetName(), EntityId);
 
-	USpatialLatencyTracer* Tracer = USpatialLatencyTracer::GetTracer(Object);
-	ComponentFactory UpdateFactory(Channel->GetInterestDirty(), NetDriver, Tracer);
+	ComponentFactory UpdateFactory(Channel->GetInterestDirty(), NetDriver);
 
 	TArray<FWorkerComponentUpdate> ComponentUpdates =
 		UpdateFactory.CreateComponentUpdates(Object, Info, EntityId, RepChanges, HandoverChanges, OutBytesWritten);
@@ -2057,7 +2056,7 @@ void ActorSystem::SendAddComponentForSubobject(USpatialActorChannel* Channel, UO
 	FRepChangeState SubobjectRepChanges = Channel->CreateInitialRepChangeState(Subobject);
 	FHandoverChangeState SubobjectHandoverChanges = Channel->CreateInitialHandoverChangeState(SubobjectInfo);
 
-	ComponentFactory DataFactory(false, NetDriver, USpatialLatencyTracer::GetTracer(Subobject));
+	ComponentFactory DataFactory(false, NetDriver);
 
 	TArray<FWorkerComponentData> SubobjectDatas =
 		DataFactory.CreateComponentDatas(Subobject, SubobjectInfo, SubobjectRepChanges, SubobjectHandoverChanges, OutBytesWritten);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/SpatialRPCService.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/SpatialRPCService.cpp
@@ -6,6 +6,7 @@
 #include "EngineClasses/SpatialNetBitReader.h"
 #include "EngineClasses/SpatialNetConnection.h"
 #include "EngineClasses/SpatialPackageMapClient.h"
+#include "Interop/Connection/SpatialEventTracer.h"
 #include "Interop/Connection/SpatialWorkerConnection.h"
 #include "Net/NetworkProfiler.h"
 #include "SpatialConstants.h"

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialPlayerSpawner.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialPlayerSpawner.cpp
@@ -4,6 +4,7 @@
 
 #include "EngineClasses/SpatialNetDriver.h"
 #include "EngineClasses/SpatialVirtualWorkerTranslator.h"
+#include "Interop/Connection/SpatialEventTracer.h"
 #include "Interop/Connection/SpatialWorkerConnection.h"
 #include "Interop/SpatialReceiver.h"
 #include "LoadBalancing/AbstractLBStrategy.h"

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
@@ -39,14 +39,14 @@ TraceKey* GetTraceKeyFromComponentObject(T& Obj)
 } // namespace
 namespace SpatialGDK
 {
-ComponentFactory::ComponentFactory(bool bInterestDirty, USpatialNetDriver* InNetDriver, USpatialLatencyTracer* InLatencyTracer)
+ComponentFactory::ComponentFactory(bool bInterestDirty, USpatialNetDriver* InNetDriver)
 	: NetDriver(InNetDriver)
 	, PackageMap(InNetDriver->PackageMap)
 	, ClassInfoManager(InNetDriver->ClassInfoManager)
 	, bInterestHasChanged(bInterestDirty)
 	, bInitialOnlyDataWritten(false)
 	, bInitialOnlyReplicationEnabled(GetDefault<USpatialGDKSettings>()->bEnableInitialOnlyReplicationCondition)
-	, LatencyTracer(InLatencyTracer)
+	, LatencyTracer(USpatialLatencyTracer::GetTracer(InNetDriver))
 {
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -245,9 +245,7 @@ void EntityFactory::WriteUnrealComponents(TArray<FWorkerComponentData>& Componen
 		ComponentDatas.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::PLAYER_CONTROLLER_COMPONENT_ID));
 	}
 
-	USpatialLatencyTracer* Tracer = USpatialLatencyTracer::GetTracer(Actor);
-
-	ComponentFactory DataFactory(false, NetDriver, Tracer);
+	ComponentFactory DataFactory(false, NetDriver);
 
 	FRepChangeState InitialRepChanges = Channel->CreateInitialRepChangeState(Actor);
 	FHandoverChangeState InitialHandoverChanges = Channel->CreateInitialHandoverChangeState(Info);

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/OutgoingMessages.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/OutgoingMessages.h
@@ -10,7 +10,6 @@
 #include "Templates/UniquePtr.h"
 #include "Templates/UnrealTemplate.h"
 #include "UObject/NameTypes.h"
-#include "Utils/SpatialLatencyTracer.h"
 
 #include <string>
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/SpatialRPCService.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/SpatialRPCService.h
@@ -24,7 +24,6 @@ struct RPCRingBuffer;
 
 namespace SpatialGDK
 {
-
 class SpatialEventTracer;
 
 class SPATIALGDK_API SpatialRPCService

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/SpatialRPCService.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/SpatialRPCService.h
@@ -7,7 +7,6 @@
 #include "ClientServerRPCService.h"
 #include "CrossServerRPCService.h"
 #include "EngineClasses/SpatialNetBitWriter.h"
-#include "Interop/Connection/SpatialEventTracer.h"
 #include "Interop/Connection/SpatialGDKSpanId.h"
 #include "Interop/SpatialClassInfoManager.h"
 #include "MulticastRPCService.h"
@@ -25,6 +24,9 @@ struct RPCRingBuffer;
 
 namespace SpatialGDK
 {
+
+class SpatialEventTracer;
+
 class SPATIALGDK_API SpatialRPCService
 {
 public:

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/CommandRetryHandler.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/CommandRetryHandler.h
@@ -1,9 +1,10 @@
-﻿// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
 #pragma once
 
 #include "SpatialView/OpList/OpList.h"
 #include "SpatialView/WorkerView.h"
+#include "SpatialConstants.h"
 
 #include "Containers/Array.h"
 #include "Containers/Map.h"

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/CommandRetryHandler.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/CommandRetryHandler.h
@@ -2,9 +2,9 @@
 
 #pragma once
 
+#include "SpatialConstants.h"
 #include "SpatialView/OpList/OpList.h"
 #include "SpatialView/WorkerView.h"
-#include "SpatialConstants.h"
 
 #include "Containers/Array.h"
 #include "Containers/Map.h"

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/ComponentFactory.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/ComponentFactory.h
@@ -27,7 +27,7 @@ namespace SpatialGDK
 class SPATIALGDK_API ComponentFactory
 {
 public:
-	ComponentFactory(bool bInterestDirty, USpatialNetDriver* InNetDriver, USpatialLatencyTracer* LatencyTracer);
+	ComponentFactory(bool bInterestDirty, USpatialNetDriver* InNetDriver);
 
 	TArray<FWorkerComponentData> CreateComponentDatas(UObject* Object, const FClassInfo& Info, const FRepChangeState& RepChangeState,
 													  const FHandoverChangeState& HandoverChangeState, uint32& OutBytesWritten);

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracer.h
@@ -12,6 +12,8 @@
 
 #if TRACE_LIB_ACTIVE
 
+// As a result of using both the old and new trace.h, there's now a shadow warning for TraceSpan. Worker
+// will fix in the interim, but as a stop gap lets just ignore the warning - UNR-5460.
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wshadow"
@@ -23,7 +25,7 @@
 #pragma clang diagnostic pop
 #endif
 
-#endif
+#endif // TRACE_LIB_ACTIVE
 
 #include "SpatialLatencyTracer.generated.h"
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialLatencyTracer.h
@@ -11,7 +11,18 @@
 #include "Utils/GDKPropertyMacros.h"
 
 #if TRACE_LIB_ACTIVE
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow"
+#endif
+
 #include <WorkerSDK/improbable/legacy/trace.h>
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
 #endif
 
 #include "SpatialLatencyTracer.generated.h"


### PR DESCRIPTION
#### Description
NFRs currently failing to build on linux due to shadow definition warning.
Temporarily removed shadow warnings when building legacy tracer.
Also some driveby include dependency cleanup.

Will run a NFR latency pass before merging - https://buildkite.com/improbable/product-research-benchmarks-run/builds/23094#b7bc6cff-9382-4ddd-a105-0ef1f9427b30

#### Primary reviewers
@improbable-danny 
