### PR TITLE
Fix graceful shutdown spam crashing the editor

### DIFF
--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -240,7 +240,7 @@ FLocalDeploymentManager::ERuntimeStartResponse FLocalDeploymentManager::StartLoc
 	RuntimeStartTime = FDateTime::Now();
 	bRedeployRequired = false;
 
-	if (bLocalDeploymentRunning)
+	if (bLocalDeploymentRunning || bStartingDeployment)
 	{
 		UE_LOG(LogSpatialDeploymentManager, Verbose, TEXT("Tried to start a local deployment but one is already running."));
 		if (CallBack)
@@ -358,7 +358,10 @@ FLocalDeploymentManager::ERuntimeStartResponse FLocalDeploymentManager::StartLoc
 bool FLocalDeploymentManager::SetupRuntimeFileLogger(const FString& RuntimeLogDir)
 {
 	// Ensure any old log file is cleaned up.
-	RuntimeLogFileHandle.Reset();
+	if (RuntimeLogFileHandle)
+	{
+		RuntimeLogFileHandle.Reset();
+	}
 
 	FString RuntimeLogFilePath = FPaths::Combine(RuntimeLogDir, TEXT("runtime.log"));
 	IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
@@ -449,6 +452,12 @@ bool FLocalDeploymentManager::StartLocalDeploymentShutDown()
 		return false;
 	}
 
+	if (bStoppingDeployment)
+	{
+		UE_LOG(LogSpatialDeploymentManager, Verbose, TEXT("Tried to stop local deployment but stopping process is already in progress."));
+		return false;
+	}
+
 	bStoppingDeployment = true;
 	return true;
 }
@@ -475,7 +484,10 @@ bool FLocalDeploymentManager::WaitForRuntimeProcessToShutDown()
 void FLocalDeploymentManager::FinishLocalDeploymentShutDown()
 {
 	// Kill the log file handle.
-	RuntimeLogFileHandle.Reset();
+	if (RuntimeLogFileHandle)
+	{
+		RuntimeLogFileHandle.Reset();
+	}
 
 	bLocalDeploymentRunning = false;
 	bStoppingDeployment = false;

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -358,10 +358,7 @@ FLocalDeploymentManager::ERuntimeStartResponse FLocalDeploymentManager::StartLoc
 bool FLocalDeploymentManager::SetupRuntimeFileLogger(const FString& RuntimeLogDir)
 {
 	// Ensure any old log file is cleaned up.
-	if (RuntimeLogFileHandle)
-	{
-		RuntimeLogFileHandle.Reset();
-	}
+	RuntimeLogFileHandle.Reset();
 
 	FString RuntimeLogFilePath = FPaths::Combine(RuntimeLogDir, TEXT("runtime.log"));
 	IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
@@ -484,10 +481,7 @@ bool FLocalDeploymentManager::WaitForRuntimeProcessToShutDown()
 void FLocalDeploymentManager::FinishLocalDeploymentShutDown()
 {
 	// Kill the log file handle.
-	if (RuntimeLogFileHandle)
-	{
-		RuntimeLogFileHandle.Reset();
-	}
+	RuntimeLogFileHandle.Reset();
 
 	bLocalDeploymentRunning = false;
 	bStoppingDeployment = false;

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKServices/LocalDeploymentManager/LocalDeploymentManagerUtilities.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKServices/LocalDeploymentManager/LocalDeploymentManagerUtilities.cpp
@@ -88,7 +88,8 @@ bool FStartDeployment::Update()
 				return;
 			}
 
-			if (LocalDeploymentManager->IsLocalDeploymentRunning())
+			if (LocalDeploymentManager->IsLocalDeploymentRunning() || LocalDeploymentManager->IsDeploymentStarting()
+				|| LocalDeploymentManager->IsDeploymentStopping())
 			{
 				return;
 			}


### PR DESCRIPTION
#### Description
Prevent async calls from being able to spam the deployment manager and crash the editor.

#### Tests
Repro steps in https://improbableio.atlassian.net/browse/UNR-5390 no longer crash the editor when Graceful Runtime Shutdown is enabled

#### Primary reviewers
@MatthewSandfordImprobable  @improbable-danny 
