### PR TITLE
Downgrade aggressive GDK checks

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -1102,7 +1102,7 @@ void USpatialActorChannel::SetChannelActor(AActor* InActor, ESetChannelActorFlag
 
 	// Set up the shadow data for the handover properties. This is used later to compare the properties and send only changed ones.
 	if (!ensureAlwaysMsgf(!HandoverShadowDataMap.Contains(InActor),
-						  TEXT("HandoverShadowDataMap already contained Actor %s with id %lld, this shouldn't happen. Calling Empty()."),
+						  TEXT("HandoverShadowDataMap already contained Actor, will remove data. Actor: %s. Entity: %lld."),
 						  *InActor->GetName(), EntityId))
 	{
 		HandoverShadowDataMap.FindAndRemoveChecked(InActor);

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -852,7 +852,7 @@ void USpatialActorChannel::DynamicallyAttachSubobject(UObject* Object)
 		}
 	}
 
-	if (!ensureMsgf(Info != nullptr, TEXT("Subobject info was nullptr. Actor: %s"), *GetNameSafe(Object)))
+	if (!ensureAlwaysMsgf(Info != nullptr, TEXT("Subobject info was nullptr. Actor: %s"), *GetNameSafe(Object)))
 	{
 		return;
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -55,10 +55,19 @@ void UpdateChangelistHistory(TUniquePtr<FRepState>& RepState)
 {
 	FSendingRepState* SendingRepState = RepState->GetSendingRepState();
 
-	check(SendingRepState->HistoryEnd >= SendingRepState->HistoryStart);
+	if (!ensureAlwaysMsgf(SendingRepState->HistoryEnd >= SendingRepState->HistoryStart,
+						  TEXT("HistoryEnd buffer index should never be smaller than HistoryStart")))
+	{
+		return;
+	}
 
 	const int32 HistoryCount = SendingRepState->HistoryEnd - SendingRepState->HistoryStart;
-	check(HistoryCount < MaxSendingChangeHistory);
+
+	if (!ensureAlwaysMsgf(HistoryCount < MaxSendingChangeHistory,
+						  TEXT("Changelist history should always be smaller than the MaxSendingChangeHistory")))
+	{
+		return;
+	}
 
 	for (int32 i = SendingRepState->HistoryStart; i < SendingRepState->HistoryEnd; i++)
 	{
@@ -66,8 +75,7 @@ void UpdateChangelistHistory(TUniquePtr<FRepState>& RepState)
 
 		FRepChangedHistory& HistoryItem = SendingRepState->ChangeHistory[HistoryIndex];
 
-		// All active history items should contain a change list
-		check(HistoryItem.Changed.Num() > 0);
+		ensureAlwaysMsgf(HistoryItem.Changed.Num() > 0, TEXT("All active history items should contain a change list"));
 
 		HistoryItem.Changed.Empty();
 		HistoryItem.OutPacketIdRange = FPacketIdRange();
@@ -77,7 +85,10 @@ void UpdateChangelistHistory(TUniquePtr<FRepState>& RepState)
 	// Remove any tiling in the history markers to keep them from wrapping over time
 	const int32 NewHistoryCount = SendingRepState->HistoryEnd - SendingRepState->HistoryStart;
 
-	check(NewHistoryCount <= MaxSendingChangeHistory);
+	if (!ensureAlwaysMsgf(NewHistoryCount <= MaxSendingChangeHistory, TEXT("NewHistoryCount greater or equal to MaxSendingChangeHistory")))
+	{
+		return;
+	}
 
 	SendingRepState->HistoryStart = SendingRepState->HistoryStart % MaxSendingChangeHistory;
 	SendingRepState->HistoryEnd = SendingRepState->HistoryStart + NewHistoryCount;
@@ -345,7 +356,8 @@ int64 USpatialActorChannel::Close(EChannelCloseReason Reason)
 	}
 	else if (Reason == EChannelCloseReason::Relevancy)
 	{
-		check(IsAuthoritativeServer());
+		ensureAlwaysMsgf(IsAuthoritativeServer(),
+						 TEXT("Trying to close SpatialActorChannel because of Relevancy on a non-authoritative server"));
 		// Do nothing except close actor channel - this should only get processed on auth server
 	}
 	else
@@ -359,18 +371,12 @@ int64 USpatialActorChannel::Close(EChannelCloseReason Reason)
 	return Super::Close(Reason);
 }
 
-bool USpatialActorChannel::IsDynamicArrayHandle(UObject* Object, uint16 Handle)
-{
-	check(ObjectHasReplicator(Object));
-	FObjectReplicator& Replicator = FindOrCreateReplicator(Object).Get();
-	TSharedPtr<FRepLayout>& RepLayout = Replicator.RepLayout;
-	check(Handle - 1 < RepLayout->BaseHandleToCmdIndex.Num());
-	return RepLayout->Cmds[RepLayout->BaseHandleToCmdIndex[Handle - 1].CmdIndex].Type == ERepLayoutCmdType::DynamicArray;
-}
-
 void USpatialActorChannel::UpdateShadowData()
 {
-	check(Actor);
+	if (!ensureAlwaysMsgf(Actor != nullptr, TEXT("Called UpdateShadowData but Actor was nullptr")))
+	{
+		return;
+	}
 
 	// If this channel was responsible for creating the actor, we do not want to initialize our shadow data
 	// to the latest state since there could have been state that has changed between creation of the entity
@@ -846,7 +852,10 @@ void USpatialActorChannel::DynamicallyAttachSubobject(UObject* Object)
 		}
 	}
 
-	check(Info != nullptr);
+	if (!ensureMsgf(Info != nullptr, TEXT("Subobject info was nullptr. Actor: %s"), *GetNameSafe(Object)))
+	{
+		return;
+	}
 
 	NetDriver->ActorSystem->SendAddComponentForSubobject(this, Object, *Info, ReplicationBytesWritten);
 }
@@ -1092,7 +1101,12 @@ void USpatialActorChannel::SetChannelActor(AActor* InActor, ESetChannelActorFlag
 	}
 
 	// Set up the shadow data for the handover properties. This is used later to compare the properties and send only changed ones.
-	check(!HandoverShadowDataMap.Contains(InActor));
+	if (!ensureAlwaysMsgf(!HandoverShadowDataMap.Contains(InActor),
+						  TEXT("HandoverShadowDataMap already contained Actor %s with id %lld, this shouldn't happen. Calling Empty()."),
+						  *InActor->GetName(), EntityId))
+	{
+		HandoverShadowDataMap.FindAndRemoveChecked(InActor);
+	}
 
 	// Create the shadow map, and store a quick access pointer to it
 	const FClassInfo& Info = NetDriver->ClassInfoManager->GetOrCreateClassInfoByClass(InActor->GetClass());
@@ -1106,7 +1120,14 @@ void USpatialActorChannel::SetChannelActor(AActor* InActor, ESetChannelActorFlag
 	{
 		UObject* Subobject = SubobjectInfoPair.Key;
 
-		check(!HandoverShadowDataMap.Contains(Subobject));
+		if (!ensureAlwaysMsgf(
+				!HandoverShadowDataMap.Contains(Subobject),
+				TEXT("HandoverShadowDataMap already contained subobject %s of Actor %s with id %lld, this shouldn't happen. Calling "
+					 "Empty()."),
+				*Subobject->GetName(), *InActor->GetName(), EntityId))
+		{
+			HandoverShadowDataMap.FindAndRemoveChecked(Subobject);
+		}
 		InitializeHandoverShadowData(HandoverShadowDataMap.Add(Subobject, MakeShared<TArray<uint8>>()).Get(), Subobject);
 	}
 }
@@ -1286,7 +1307,12 @@ void USpatialActorChannel::ServerProcessOwnershipChange()
 	bool bUpdatedThisActor = false;
 
 	// Changing an Actor's owner can affect its NetConnection so we need to reevaluate this.
-	check(NetDriver->HasServerAuthority(EntityId));
+	if (!ensureAlwaysMsgf(NetDriver->HasServerAuthority(EntityId),
+						  TEXT("Trying to process ownership change on non-auth server. Entity: %lld"), EntityId))
+	{
+		return;
+	}
+
 	TOptional<SpatialGDK::NetOwningClientWorker> CurrentNetOwningClientData =
 		SpatialGDK::DeserializeComponent<SpatialGDK::NetOwningClientWorker>(NetDriver->Connection->GetCoordinator(), EntityId);
 	const Worker_PartitionId CurrentClientPartitionId = CurrentNetOwningClientData->ClientPartitionId.IsSet()

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
@@ -79,8 +79,8 @@ void USpatialNetConnection::LowLevelSend(void* Data, int32 CountBits, FOutPacket
 
 bool USpatialNetConnection::ClientHasInitializedLevelFor(const AActor* TestActor) const
 {
-	check(Driver->IsServer());
-	return true;
+	return ensureAlwaysMsgf(Driver->IsServer(), TEXT("ClientHasInitializedLevelFor should only be called on servers. Actor %s"),
+							*GetNameSafe(TestActor));
 	// Intentionally does not call Super::
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
@@ -79,8 +79,9 @@ void USpatialNetConnection::LowLevelSend(void* Data, int32 CountBits, FOutPacket
 
 bool USpatialNetConnection::ClientHasInitializedLevelFor(const AActor* TestActor) const
 {
-	return ensureAlwaysMsgf(Driver->IsServer(), TEXT("ClientHasInitializedLevelFor should only be called on servers. Actor %s"),
-							*GetNameSafe(TestActor));
+	ensureAlwaysMsgf(Driver->IsServer(), TEXT("ClientHasInitializedLevelFor should only be called on servers. Actor %s"),
+					 *GetNameSafe(TestActor));
+	return true;
 	// Intentionally does not call Super::
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -3232,7 +3232,7 @@ void USpatialNetDriver::TryFinishStartup()
 // This should only be called once on each client, in the SpatialMetricsDisplay constructor after the class is replicated to each client.
 void USpatialNetDriver::SetSpatialMetricsDisplay(ASpatialMetricsDisplay* InSpatialMetricsDisplay)
 {
-	if (!ensure(!IsServer(), TEXT("SetSpatialMetricsDisplay should only be called on the client")))
+	if (!ensureAlwaysMsgf(!IsServer(), TEXT("SetSpatialMetricsDisplay should only be called on the client")))
 	{
 		return;
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -2901,7 +2901,7 @@ TMap<Worker_EntityId_Key, USpatialActorChannel*>& USpatialNetDriver::GetEntityTo
 
 USpatialActorChannel* USpatialNetDriver::GetOrCreateSpatialActorChannel(UObject* TargetObject)
 {
-	if (!ensureAlwaysMsgf(TargetObject, TEXT("TargetObject was nullptr when trying to get or create Actor channel")))
+	if (!ensureAlwaysMsgf(TargetObject != nullptr, TEXT("TargetObject was nullptr when trying to get or create Actor channel")))
 	{
 		return nullptr;
 	}
@@ -2915,7 +2915,7 @@ USpatialActorChannel* USpatialNetDriver::GetOrCreateSpatialActorChannel(UObject*
 			TargetActor = Cast<AActor>(TargetObject->GetOuter());
 		}
 
-		if (!ensureAlwaysMsgf(TargetObject, TEXT("Failed to find outer Actor when getting Actor channel for object: %s"),
+		if (!ensureAlwaysMsgf(TargetObject != nullptr, TEXT("Failed to find outer Actor when getting Actor channel for object: %s"),
 							  *GetNameSafe(TargetObject)))
 		{
 			return nullptr;

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -3075,13 +3075,10 @@ bool USpatialNetDriver::IsDormantEntity(Worker_EntityId EntityId) const
 USpatialActorChannel* USpatialNetDriver::CreateSpatialActorChannel(AActor* Actor)
 {
 	// This should only be called from GetOrCreateSpatialActorChannel, otherwise we could end up clobbering an existing channel.
-
 	if (!ensureAlwaysMsgf(Actor != nullptr, TEXT("Tried to call CreateSpatialActorChannel for a nullptr Actor")))
 	{
 		return nullptr;
 	}
-
-	check(PackageMap != nullptr);
 
 	const Worker_EntityId EntityId = PackageMap->GetEntityIdFromObject(Actor);
 	ensureAlwaysMsgf(GetActorChannelByEntityId(EntityId) == nullptr,

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverDebugContext.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverDebugContext.cpp
@@ -185,7 +185,7 @@ void USpatialNetDriverDebugContext::AddActorTag(AActor* Actor, FName Tag)
 {
 	if (Actor->HasAuthority())
 	{
-		DebugComponentAuthData Comp = GetAuthDebugComponent(Actor);
+		DebugComponentAuthData& Comp = GetAuthDebugComponent(Actor);
 		Comp.Component.ActorTags.Add(Tag);
 		if (SemanticInterest.Contains(Tag) && Comp.Entity != SpatialConstants::INVALID_ENTITY_ID)
 		{

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverDebugContext.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverDebugContext.cpp
@@ -239,7 +239,12 @@ void USpatialNetDriverDebugContext::RemoveComponent(Worker_EntityId EntityId)
 void USpatialNetDriverDebugContext::ApplyComponentUpdate(Worker_EntityId Entity, Schema_ComponentUpdate* Update)
 {
 	SpatialGDK::DebugComponent* DbgComp = DebugComponents.Find(Entity);
-	check(DbgComp);
+
+	if (!ensureAlwaysMsgf(DbgComp != nullptr, TEXT("Failed to ApplyComponentUpdate for debug context because component data wasn't found")))
+	{
+		return;
+	}
+
 	DbgComp->ApplyComponentUpdate(Update);
 
 	if (IsSetIntersectionEmpty(SemanticInterest, DbgComp->ActorTags))

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverDebugContext.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverDebugContext.cpp
@@ -159,7 +159,12 @@ void USpatialNetDriverDebugContext::Reset()
 
 USpatialNetDriverDebugContext::DebugComponentAuthData& USpatialNetDriverDebugContext::GetAuthDebugComponent(AActor* Actor)
 {
-	check(Actor && Actor->HasAuthority());
+	if (!ensureAlwaysMsgf(Actor && Actor->HasAuthority(), TEXT("Called GetAuthDebugComponent without authority for Actor: %s"),
+						  *GetNameSafe(Actor)))
+	{
+		return;
+	}
+
 	SpatialGDK::DebugComponent* DbgComp = nullptr;
 
 	Worker_EntityId Entity = NetDriver->PackageMap->GetEntityIdFromObject(Actor);
@@ -213,7 +218,10 @@ void USpatialNetDriverDebugContext::AddComponent(Worker_EntityId EntityId)
 	const SpatialGDK::ComponentData* Data = Element.Components.FindByPredicate([](const SpatialGDK::ComponentData& Component) {
 		return Component.GetComponentId() == SpatialConstants::GDK_DEBUG_COMPONENT_ID;
 	});
-	check(Data != nullptr);
+	if (!ensureAlwaysMsgf(Data != nullptr, TEXT("Failed to access Debug component data for entity %lld"), EntityId))
+	{
+		return;
+	}
 	SpatialGDK::DebugComponent& DbgComp = DebugComponents.Add(EntityId, SpatialGDK::DebugComponent(Data->GetUnderlying()));
 
 	if (!IsSetIntersectionEmpty(SemanticInterest, DbgComp.ActorTags))

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverDebugContext.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverDebugContext.cpp
@@ -157,7 +157,7 @@ void USpatialNetDriverDebugContext::Reset()
 	NetDriver->Sender->UpdatePartitionEntityInterestAndPosition();
 }
 
-void USpatialNetDriverDebugContext::GetAuthDebugComponent(AActor* Actor, DebugComponentAuthData& Comp)
+void USpatialNetDriverDebugContext::GetAuthDebugComponent(AActor* Actor, DebugComponentAuthData& OutComp)
 {
 	if (!ensureAlwaysMsgf(Actor && Actor->HasAuthority(), TEXT("Called GetAuthDebugComponent without authority for Actor: %s"),
 						  *GetNameSafe(Actor)))
@@ -173,13 +173,13 @@ void USpatialNetDriverDebugContext::GetAuthDebugComponent(AActor* Actor, DebugCo
 		DbgComp = DebugComponents.Find(Entity);
 	}
 
-	Comp = ActorDebugInfo.FindOrAdd(Actor);
-	if (DbgComp && Comp.Entity == SpatialConstants::INVALID_ENTITY_ID)
+	OutComp = ActorDebugInfo.FindOrAdd(Actor);
+	if (DbgComp && OutComp.Entity == SpatialConstants::INVALID_ENTITY_ID)
 	{
-		Comp.Component = *DbgComp;
-		Comp.bAdded = true;
+		OutComp.Component = *DbgComp;
+		OutComp.bAdded = true;
 	}
-	Comp.Entity = Entity;
+	OutComp.Entity = Entity;
 }
 
 void USpatialNetDriverDebugContext::AddActorTag(AActor* Actor, FName Tag)

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverDebugContext.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverDebugContext.cpp
@@ -157,7 +157,7 @@ void USpatialNetDriverDebugContext::Reset()
 	NetDriver->Sender->UpdatePartitionEntityInterestAndPosition();
 }
 
-USpatialNetDriverDebugContext::DebugComponentAuthData& USpatialNetDriverDebugContext::GetAuthDebugComponent(AActor* Actor)
+void USpatialNetDriverDebugContext::GetAuthDebugComponent(AActor* Actor, DebugComponentAuthData& Comp)
 {
 	if (!ensureAlwaysMsgf(Actor && Actor->HasAuthority(), TEXT("Called GetAuthDebugComponent without authority for Actor: %s"),
 						  *GetNameSafe(Actor)))
@@ -173,22 +173,21 @@ USpatialNetDriverDebugContext::DebugComponentAuthData& USpatialNetDriverDebugCon
 		DbgComp = DebugComponents.Find(Entity);
 	}
 
-	DebugComponentAuthData& Comp = ActorDebugInfo.FindOrAdd(Actor);
+	Comp = ActorDebugInfo.FindOrAdd(Actor);
 	if (DbgComp && Comp.Entity == SpatialConstants::INVALID_ENTITY_ID)
 	{
 		Comp.Component = *DbgComp;
 		Comp.bAdded = true;
 	}
 	Comp.Entity = Entity;
-
-	return Comp;
 }
 
 void USpatialNetDriverDebugContext::AddActorTag(AActor* Actor, FName Tag)
 {
 	if (Actor->HasAuthority())
 	{
-		DebugComponentAuthData& Comp = GetAuthDebugComponent(Actor);
+		DebugComponentAuthData Comp{};
+		GetAuthDebugComponent(Actor, Comp);
 		Comp.Component.ActorTags.Add(Tag);
 		if (SemanticInterest.Contains(Tag) && Comp.Entity != SpatialConstants::INVALID_ENTITY_ID)
 		{
@@ -202,7 +201,8 @@ void USpatialNetDriverDebugContext::RemoveActorTag(AActor* Actor, FName Tag)
 {
 	if (Actor->HasAuthority())
 	{
-		DebugComponentAuthData& Comp = GetAuthDebugComponent(Actor);
+		DebugComponentAuthData Comp{};
+		GetAuthDebugComponent(Actor, Comp);
 		Comp.Component.ActorTags.Remove(Tag);
 		if (IsSetIntersectionEmpty(SemanticInterest, Comp.Component.ActorTags) && Comp.Entity != SpatialConstants::INVALID_ENTITY_ID)
 		{
@@ -346,7 +346,8 @@ void USpatialNetDriverDebugContext::KeepActorOnLocalWorker(AActor* Actor)
 {
 	if (Actor->HasAuthority())
 	{
-		DebugComponentAuthData& Comp = GetAuthDebugComponent(Actor);
+		DebugComponentAuthData Comp{};
+		GetAuthDebugComponent(Actor, Comp);
 		Comp.Component.DelegatedWorkerId = DebugStrategy->GetLocalVirtualWorkerId();
 		Comp.bDirty = true;
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -465,7 +465,10 @@ static FSubobjectToOffsetMap CreateOffsetMapFromActor(USpatialPackageMapClient* 
 
 FNetworkGUID FSpatialNetGUIDCache::AssignNewEntityActorNetGUID(AActor* Actor, Worker_EntityId EntityId)
 {
-	check(EntityId > 0);
+	if (!ensureAlwaysMsgf(EntityId > 0, TEXT("Tried to assign net guid for invalid entity ID. Actor: %s"), *GetNameSafe(Actor)))
+	{
+		return FNetworkGUID();
+	}
 
 	USpatialNetDriver* SpatialNetDriver = Cast<USpatialNetDriver>(Driver);
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslationManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslationManager.cpp
@@ -40,8 +40,13 @@ void SpatialVirtualWorkerTranslationManager::SetNumberOfVirtualWorkers(const uin
 
 void SpatialVirtualWorkerTranslationManager::AuthorityChanged(const Worker_ComponentSetAuthorityChangeOp& AuthOp)
 {
-	check(AuthOp.component_set_id == SpatialConstants::GDK_KNOWN_ENTITY_AUTH_COMPONENT_SET_ID
-		  || AuthOp.component_set_id == SpatialConstants::SERVER_WORKER_ENTITY_AUTH_COMPONENT_SET_ID);
+	if (!ensureAlwaysMsgf(AuthOp.component_set_id == SpatialConstants::GDK_KNOWN_ENTITY_AUTH_COMPONENT_SET_ID
+							  || AuthOp.component_set_id == SpatialConstants::SERVER_WORKER_ENTITY_AUTH_COMPONENT_SET_ID,
+						  TEXT("Translation managed handled unexpected component set auth op. Entity: %lld. Set: %u"), AuthOp.entity_id,
+						  AuthOp.component_set_id))
+	{
+		return
+	}
 
 	const bool bAuthoritative = AuthOp.authority == WORKER_AUTHORITY_AUTHORITATIVE;
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslationManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialVirtualWorkerTranslationManager.cpp
@@ -45,7 +45,7 @@ void SpatialVirtualWorkerTranslationManager::AuthorityChanged(const Worker_Compo
 						  TEXT("Translation managed handled unexpected component set auth op. Entity: %lld. Set: %u"), AuthOp.entity_id,
 						  AuthOp.component_set_id))
 	{
-		return
+		return;
 	}
 
 	const bool bAuthoritative = AuthOp.authority == WORKER_AUTHORITY_AUTHORITATIVE;

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSetWriter.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSetWriter.cpp
@@ -10,10 +10,20 @@ namespace SpatialGDK
 ActorSetMember GetActorSetData(const USpatialPackageMapClient& PackageMap, const AActor& Actor)
 {
 	const AActor* LeaderActor = GetReplicatedHierarchyRoot(&Actor);
-	check(IsValid(LeaderActor));
+
+	if (!ensureAlwaysMsgf(IsValid(LeaderActor), TEXT("Failed to get replicated hierarchy root when getting Actor set data for Actor: %s"),
+						  *GetNameSafe(&Actor)))
+	{
+		return ActorSetMember();
+	}
 
 	const Worker_EntityId LeaderEntityId = PackageMap.GetEntityIdFromObject(LeaderActor);
-	check(LeaderEntityId != SpatialConstants::INVALID_ENTITY_ID);
+
+	if (!ensureAlwaysMsgf(LeaderEntityId != SpatialConstants::INVALID_ENTITY_ID,
+						  TEXT("Failed to get entity Id from package map for Actor: %s"), *GetNameSafe(LeaderActor)))
+	{
+		return ActorSetMember();
+	}
 
 	return ActorSetMember(LeaderEntityId);
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
@@ -2397,7 +2397,11 @@ void ActorSystem::DeleteEntityComponentData(TArray<FWorkerComponentData>& Entity
 
 void ActorSystem::AddTombstoneToEntity(Worker_EntityId EntityId) const
 {
-	check(ActorSubView->HasAuthority(EntityId, SpatialConstants::SERVER_AUTH_COMPONENT_SET_ID));
+	if (!ensureAlwaysMsgf(ActorSubView->HasAuthority(EntityId, SpatialConstants::SERVER_AUTH_COMPONENT_SET_ID),
+						  TEXT("Trying to add tombstone to entity from non-auth server")))
+	{
+		return;
+	}
 
 	FWorkerComponentData TombstoneData = Tombstone().CreateComponentData();
 	NetDriver->Connection->SendAddComponent(EntityId, &TombstoneData);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
@@ -2398,7 +2398,7 @@ void ActorSystem::DeleteEntityComponentData(TArray<FWorkerComponentData>& Entity
 void ActorSystem::AddTombstoneToEntity(Worker_EntityId EntityId) const
 {
 	if (!ensureAlwaysMsgf(ActorSubView->HasAuthority(EntityId, SpatialConstants::SERVER_AUTH_COMPONENT_SET_ID),
-						  TEXT("Trying to add tombstone to entity from non-auth server")))
+						  TEXT("Trying to add tombstone to entity without authority")))
 	{
 		return;
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
@@ -645,7 +645,11 @@ void USpatialClassInfoManager::QuitGame()
 
 Worker_ComponentId USpatialClassInfoManager::ComputeActorInterestComponentId(const AActor* Actor) const
 {
-	check(Actor);
+	if (!ensureAlwaysMsgf(Actor != nullptr, TEXT("Trying to compute Actor interest component ID for nullptr Actor")))
+	{
+		return SpatialConstants::INVALID_COMPONENT_ID;
+	}
+
 	const AActor* ActorForRelevancy = Actor;
 	// bAlwaysRelevant takes precedence over bNetUseOwnerRelevancy - see AActor::IsNetRelevantFor
 	while (!ActorForRelevancy->bAlwaysRelevant && ActorForRelevancy->bNetUseOwnerRelevancy && ActorForRelevancy->GetOwner() != nullptr)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
@@ -334,7 +334,7 @@ void USpatialClassInfoManager::FinishConstructingSubobjectClassInfo(const FStrin
 		if (!ensureAlwaysMsgf(Offset != SpatialConstants::INVALID_COMPONENT_ID,
 							  TEXT("Failed to get dynamic subobject data offset when constructing subobject. Is Schema up to date?")))
 		{
-			return;
+			continue;
 		}
 
 		ForAllSchemaComponentTypes([&](ESchemaComponentType Type) {

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
@@ -332,7 +332,7 @@ void USpatialClassInfoManager::FinishConstructingSubobjectClassInfo(const FStrin
 
 		int32 Offset = DynamicSubobjectData.SchemaComponents[SCHEMA_Data];
 		if (!ensureAlwaysMsgf(Offset != SpatialConstants::INVALID_COMPONENT_ID,
-							  TEXT("Failed to get dynamic subobject data offset when constructing subobject")))
+							  TEXT("Failed to get dynamic subobject data offset when constructing subobject. Is Schema up to date?")))
 		{
 			return;
 		}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialClassInfoManager.cpp
@@ -331,7 +331,11 @@ void USpatialClassInfoManager::FinishConstructingSubobjectClassInfo(const FStrin
 		SpecificDynamicSubobjectInfo->bDynamicSubobject = true;
 
 		int32 Offset = DynamicSubobjectData.SchemaComponents[SCHEMA_Data];
-		check(Offset != SpatialConstants::INVALID_COMPONENT_ID);
+		if (!ensureAlwaysMsgf(Offset != SpatialConstants::INVALID_COMPONENT_ID,
+							  TEXT("Failed to get dynamic subobject data offset when constructing subobject")))
+		{
+			return;
+		}
 
 		ForAllSchemaComponentTypes([&](ESchemaComponentType Type) {
 			Worker_ComponentId ComponentId = DynamicSubobjectData.SchemaComponents[Type];

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialSender.cpp
@@ -102,7 +102,7 @@ void USpatialSender::SendAuthorityIntentUpdate(const AActor& InActor, VirtualWor
 
 	if (!ensureAlwaysMsgf(EntityId != SpatialConstants::INVALID_ENTITY_ID,
 						  TEXT("Couldn't find entity ID from package map when sending auth intent update. Actor: %s"),
-						  *GetNameSafe(&Actor)))
+						  *GetNameSafe(&InActor)))
 	{
 		return;
 	}
@@ -112,7 +112,7 @@ void USpatialSender::SendAuthorityIntentUpdate(const AActor& InActor, VirtualWor
 
 	if (!ensureAlwaysMsgf(AuthorityIntentComponent.IsSet(),
 						  TEXT("Failed to get currnet AuthorityIntent data from view coordinator when sending update. Actor: %s"),
-						  *GetNameSafe(&Actor)))
+						  *GetNameSafe(&InActor)))
 	{
 		return;
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
@@ -118,7 +118,12 @@ VirtualWorkerId UGridBasedLBStrategy::WhoShouldHaveAuthority(const AActor& Actor
 
 	const FVector2D Actor2DLocation = GetActorLoadBalancingPosition(Actor);
 
-	check(VirtualWorkerIds.Num() == WorkerCells.Num());
+	if (!ensureAlwaysMsgf(VirtualWorkerIds.Num() == WorkerCells.Num(),
+						  TEXT("Found a mismatch between virtual worker count and worker cells count in load balancing strategy")))
+	{
+		return SpatialConstants::INVALID_VIRTUAL_WORKER_ID;
+	}
+
 	for (int i = 0; i < WorkerCells.Num(); i++)
 	{
 		if (IsInside(WorkerCells[i], Actor2DLocation))
@@ -170,8 +175,17 @@ FVector2D UGridBasedLBStrategy::GetActorLoadBalancingPosition(const AActor& Acto
 
 FVector UGridBasedLBStrategy::GetWorkerEntityPosition() const
 {
-	check(IsReady());
-	check(bIsStrategyUsedOnLocalWorker);
+	if (!ensureAlwaysMsgf(IsReady(), TEXT("Called GetWorkerEntityPosition before load balancing strategy is ready")))
+	{
+		return FVector();
+	}
+
+	if (!ensureAlwaysMsgf(bIsStrategyUsedOnLocalWorker,
+						  TEXT("Called GetWorkerEntityPosition on load balancing stratey that isn't in use by the local worker")))
+	{
+		return FVector();
+	}
+
 	const FVector2D Centre = WorkerCells[LocalCellId].GetCenter();
 	return FVector{ Centre.X, Centre.Y, 0.f };
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
@@ -183,13 +183,13 @@ FVector UGridBasedLBStrategy::GetWorkerEntityPosition() const
 {
 	if (!ensureAlwaysMsgf(IsReady(), TEXT("Called GetWorkerEntityPosition before load balancing strategy is ready")))
 	{
-		return FVector();
+		return FVector::ZeroVector;
 	}
 
 	if (!ensureAlwaysMsgf(bIsStrategyUsedOnLocalWorker,
 						  TEXT("Called GetWorkerEntityPosition on load balancing stratey that isn't in use by the local worker")))
 	{
-		return FVector();
+		return FVector::ZeroVector;
 	}
 
 	const FVector2D Centre = WorkerCells[LocalCellId].GetCenter();

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
@@ -159,7 +159,13 @@ SpatialGDK::QueryConstraint UGridBasedLBStrategy::GetWorkerInterestQueryConstrai
 	const FVector Center3D{ Center2D.X, Center2D.Y, 0.0f };
 
 	const FVector2D EdgeLengths2D = Interest2D.GetSize();
-	check(EdgeLengths2D.X > 0.0f && EdgeLengths2D.Y > 0.0f);
+
+	if (!ensureAlwaysMsgf(EdgeLengths2D.X > 0.0f && EdgeLengths2D.Y > 0.0f,
+						  TEXT("Failed to create worker interest constraint. Grid cell area was 0")))
+	{
+		return SpatialGDK::QueryConstraint();
+	}
+
 	const FVector EdgeLengths3D{ EdgeLengths2D.X, EdgeLengths2D.Y, FLT_MAX };
 
 	SpatialGDK::QueryConstraint Constraint;

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
@@ -300,7 +300,7 @@ UAbstractLBStrategy* ULayeredLBStrategy::GetLBStrategyForLayer(FName Layer) cons
 #ifndef WITH_EDITOR
 	if (!ensureAlwaysMsgf(IsReady(), TEXT("Called GetLBStrategyForLayer before load balancing strategy was ready")))
 	{
-		return __nullptr;
+		return nullptr;
 	}
 #endif
 

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
@@ -194,13 +194,13 @@ FVector ULayeredLBStrategy::GetWorkerEntityPosition() const
 {
 	if (!ensureAlwaysMsgf(IsReady(), TEXT("Called GetWorkerEntityPosition before load balancing strategy was ready")))
 	{
-		return FVector();
+		return FVector::ZeroVector;
 	}
 
 	if (!VirtualWorkerIdToLayerName.Contains(LocalVirtualWorkerId))
 	{
 		UE_LOG(LogLayeredLBStrategy, Error, TEXT("LayeredLBStrategy doesn't have a LBStrategy for worker %d."), LocalVirtualWorkerId);
-		return FVector{ 0.f, 0.f, 0.f };
+		return FVector::ZeroVector;
 	}
 
 	const FName& LayerName = VirtualWorkerIdToLayerName[LocalVirtualWorkerId];
@@ -208,7 +208,7 @@ FVector ULayeredLBStrategy::GetWorkerEntityPosition() const
 	if (!ensureAlwaysMsgf(LayerNameToLBStrategy.Contains(LayerName),
 						  TEXT("Called GetWorkerEntityPosition but couldn't find layer %s in local map"), *LayerName.ToString()))
 	{
-		return FVector();
+		return FVector::ZeroVector;
 	}
 
 	return LayerNameToLBStrategy[LayerName]->GetWorkerEntityPosition();

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LayeredLBStrategy.cpp
@@ -204,7 +204,13 @@ FVector ULayeredLBStrategy::GetWorkerEntityPosition() const
 	}
 
 	const FName& LayerName = VirtualWorkerIdToLayerName[LocalVirtualWorkerId];
-	check(LayerNameToLBStrategy.Contains(LayerName));
+
+	if (!ensureAlwaysMsgf(LayerNameToLBStrategy.Contains(LayerName),
+						  TEXT("Called GetWorkerEntityPosition but couldn't find layer %s in local map"), *LayerName.ToString()))
+	{
+		return FVector();
+	}
+
 	return LayerNameToLBStrategy[LayerName]->GetWorkerEntityPosition();
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/OwnershipLockingPolicy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/OwnershipLockingPolicy.cpp
@@ -181,7 +181,7 @@ bool UOwnershipLockingPolicy::ReleaseLockFromDelegate(AActor* ActorToRelease, co
 
 void UOwnershipLockingPolicy::OnOwnerUpdated(const AActor* Actor, const AActor* OldOwner)
 {
-	if (!ensureAlwaysMsgf(Actor != nullptr, TEXT("Load balancing strategy description should be more than 1 character in length")))
+	if (!ensureAlwaysMsgf(Actor != nullptr, TEXT("Attempted to call owner update locking policy callback for nullptr Actor")))
 	{
 		return;
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/OwnershipLockingPolicy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/OwnershipLockingPolicy.cpp
@@ -72,7 +72,7 @@ bool UOwnershipLockingPolicy::ReleaseLock(const ActorLockToken Token)
 	if (!ensureAlwaysMsgf(ActorToLockingState.Contains(Actor),
 						  TEXT("Tried to release lock on Actor which wasn't present in locking state map. Actor: %s"), *GetNameSafe(Actor)))
 	{
-		return nullptr;
+		return false;
 	}
 
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/SpatialMultiWorkerSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/SpatialMultiWorkerSettings.cpp
@@ -40,7 +40,11 @@ void UAbstractSpatialMultiWorkerSettings::PostEditChangeProperty(struct FPropert
 void UAbstractSpatialMultiWorkerSettings::EditorRefreshSpatialDebugger() const
 {
 	const UWorld* World = GEditor->GetEditorWorldContext().World();
-	check(World != nullptr);
+
+	if (!ensureAlwaysMsgf(World != nullptr, TEXT("Tried to refresh editor spatial debugger but failed to access World from GEditor")))
+	{
+		return;
+	}
 
 	const TSubclassOf<UAbstractSpatialMultiWorkerSettings> VisibleMultiWorkerSettingsClass =
 		USpatialStatics::GetSpatialMultiWorkerClass(World);
@@ -58,8 +62,11 @@ uint32 UAbstractSpatialMultiWorkerSettings::GetMinimumRequiredWorkerCount() cons
 
 	for (const FLayerInfo& LayerInfo : WorkerLayers)
 	{
-		check(*LayerInfo.LoadBalanceStrategy != nullptr);
-		WorkerCount += GetDefault<UAbstractLBStrategy>(*LayerInfo.LoadBalanceStrategy)->GetMinimumRequiredWorkers();
+		if (ensureAlwaysMsgf(*LayerInfo.LoadBalanceStrategy != nullptr,
+							 TEXT("Failed to get minimum worker count for multiserver settings because strategy on a layer was invalid")))
+		{
+			WorkerCount += GetDefault<UAbstractLBStrategy>(*LayerInfo.LoadBalanceStrategy)->GetMinimumRequiredWorkers();
+		}
 	}
 
 	return WorkerCount;

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -124,7 +124,11 @@ void EntityFactory::WriteLBComponents(TArray<FWorkerComponentData>& ComponentDat
 #if !UE_BUILD_SHIPPING
 	if (NetDriver->SpatialDebugger != nullptr)
 	{
-		check(NetDriver->VirtualWorkerTranslator != nullptr);
+		if (!ensureAlwaysMsgf(NetDriver->VirtualWorkerTranslator != nullptr,
+							  TEXT("Failed to add debugging utilities. Translator was invalid")))
+		{
+			return;
+		}
 
 		const PhysicalWorkerName* PhysicalWorkerName =
 			NetDriver->VirtualWorkerTranslator->GetPhysicalWorkerForVirtualWorker(IntendedVirtualWorkerId);
@@ -374,7 +378,10 @@ TArray<FWorkerComponentData> EntityFactory::CreateEntityComponents(USpatialActor
 
 TArray<FWorkerComponentData> EntityFactory::CreateTombstoneEntityComponents(AActor* Actor) const
 {
-	check(Actor->IsNetStartupActor());
+	if (!ensureAlwaysMsgf(Actor->IsNetStartupActor(), TEXT("Tried to create tombstone entity components for non-net-startup Actor")))
+	{
+		return TArray<FWorkerComponentData>{};
+	}
 
 	const UClass* Class = Actor->GetClass();
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityFactory.cpp
@@ -124,23 +124,21 @@ void EntityFactory::WriteLBComponents(TArray<FWorkerComponentData>& ComponentDat
 #if !UE_BUILD_SHIPPING
 	if (NetDriver->SpatialDebugger != nullptr)
 	{
-		if (!ensureAlwaysMsgf(NetDriver->VirtualWorkerTranslator != nullptr,
-							  TEXT("Failed to add debugging utilities. Translator was invalid")))
+		if (ensureAlwaysMsgf(NetDriver->VirtualWorkerTranslator != nullptr,
+							 TEXT("Failed to add debugging utilities. Translator was invalid")))
 		{
-			return;
+			const PhysicalWorkerName* PhysicalWorkerName =
+				NetDriver->VirtualWorkerTranslator->GetPhysicalWorkerForVirtualWorker(IntendedVirtualWorkerId);
+			const FColor InvalidServerTintColor = NetDriver->SpatialDebugger->InvalidServerTintColor;
+			const FColor IntentColor =
+				PhysicalWorkerName != nullptr ? SpatialGDK::GetColorForWorkerName(*PhysicalWorkerName) : InvalidServerTintColor;
+
+			const bool bIsLocked = NetDriver->LockingPolicy->IsLocked(Actor);
+
+			SpatialDebugging DebuggingInfo(SpatialConstants::INVALID_VIRTUAL_WORKER_ID, InvalidServerTintColor, IntendedVirtualWorkerId,
+										   IntentColor, bIsLocked);
+			ComponentDatas.Add(DebuggingInfo.CreateComponentData());
 		}
-
-		const PhysicalWorkerName* PhysicalWorkerName =
-			NetDriver->VirtualWorkerTranslator->GetPhysicalWorkerForVirtualWorker(IntendedVirtualWorkerId);
-		FColor InvalidServerTintColor = NetDriver->SpatialDebugger->InvalidServerTintColor;
-		FColor IntentColor =
-			PhysicalWorkerName != nullptr ? SpatialGDK::GetColorForWorkerName(*PhysicalWorkerName) : InvalidServerTintColor;
-
-		const bool bIsLocked = NetDriver->LockingPolicy->IsLocked(Actor);
-
-		SpatialDebugging DebuggingInfo(SpatialConstants::INVALID_VIRTUAL_WORKER_ID, InvalidServerTintColor, IntendedVirtualWorkerId,
-									   IntentColor, bIsLocked);
-		ComponentDatas.Add(DebuggingInfo.CreateComponentData());
 	}
 #endif // !UE_BUILD_SHIPPING
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityPool.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/EntityPool.cpp
@@ -24,7 +24,7 @@ void UEntityPool::ReserveEntityIDs(uint32 EntitiesToReserve)
 {
 	UE_LOG(LogSpatialEntityPool, Verbose, TEXT("Sending bulk entity ID Reservation Request for %d IDs"), EntitiesToReserve);
 
-	if (ensureAlwaysMsgf(!bIsAwaitingResponse, TEXT("Trying to reserve Entity IDs while another reserve request is in flight")))
+	if (!ensureAlwaysMsgf(!bIsAwaitingResponse, TEXT("Trying to reserve Entity IDs while another reserve request is in flight")))
 	{
 		return;
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/Interest/NetCullDistanceInterest.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/Interest/NetCullDistanceInterest.cpp
@@ -249,7 +249,11 @@ TMap<UClass*, float> NetCullDistanceInterest::GetActorTypeToRadius()
 	// Can't do inline removal since the sorted order is only guaranteed when the map isn't changed.
 	for (const auto& ActorInterestDistance : DiscoveredInterestDistancesSquared)
 	{
-		check(ActorInterestDistance.Key);
+		if (!ensureAlwaysMsgf(ActorInterestDistance.Key != nullptr,
+							  TEXT("Failed to add an ActorInterestDistance setting because the relevant UCLass was nullptr")))
+		{
+			continue;
+		}
 
 		// Spatial distance works in meters, whereas unreal distance works in cm^2. Here we do the dimensionally strange conversion between
 		// the two.
@@ -327,7 +331,12 @@ float NetCullDistanceInterest::NetCullDistanceSquaredToSpatialDistance(float Net
 void NetCullDistanceInterest::AddTypeHierarchyToConstraint(const UClass& BaseType, QueryConstraint& OutConstraint,
 														   USpatialClassInfoManager* ClassInfoManager)
 {
-	check(ClassInfoManager);
+	if (!ensureAlwaysMsgf(ClassInfoManager != nullptr,
+						  TEXT("Failed to add type hierarchy constraint to interset because the ClassInfoManager was nullptr")))
+	{
+		return;
+	}
+
 	TArray<Worker_ComponentId> ComponentIds = ClassInfoManager->GetComponentIdsForClassHierarchy(BaseType);
 	for (Worker_ComponentId ComponentId : ComponentIds)
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -485,12 +485,6 @@ FrequencyToConstraintsMap InterestFactory::GetUserDefinedFrequencyToConstraintsM
 void InterestFactory::GetActorUserDefinedQueryConstraints(const AActor* InActor, FrequencyToConstraintsMap& OutFrequencyToConstraints,
 														  bool bRecurseChildren) const
 {
-	if (!ensureAlwaysMsgf(ClassInfoManager != nullptr,
-						  TEXT("Failed to get Actor user defined query constraints. ClassInfoManager was undefined")))
-	{
-		return;
-	}
-
 	if (InActor == nullptr)
 	{
 		return;

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -485,7 +485,11 @@ FrequencyToConstraintsMap InterestFactory::GetUserDefinedFrequencyToConstraintsM
 void InterestFactory::GetActorUserDefinedQueryConstraints(const AActor* InActor, FrequencyToConstraintsMap& OutFrequencyToConstraints,
 														  bool bRecurseChildren) const
 {
-	check(ClassInfoManager);
+	if (!ensureAlwaysMsgf(ClassInfoManager != nullptr,
+						  TEXT("Failed to get Actor user defined query constraints. ClassInfoManager was undefined")))
+	{
+		return;
+	}
 
 	if (InActor == nullptr)
 	{
@@ -582,7 +586,6 @@ bool InterestFactory::ShouldAddNetCullDistanceInterest(const AActor* InActor) co
 	if (ActorInterestComponents.Num() == 1)
 	{
 		const UActorInterestComponent* ActorInterest = ActorInterestComponents[0];
-		check(ActorInterest);
 		if (!ActorInterest->bUseNetCullDistanceSquaredForCheckoutRadius)
 		{
 			return false;
@@ -669,9 +672,20 @@ QueryConstraint InterestFactory::CreateLevelConstraints(const AActor* InActor) c
 	LevelConstraint.OrConstraint.Add(DefaultConstraint);
 
 	UNetConnection* Connection = InActor->GetNetConnection();
-	check(Connection);
+	if (!ensureAlwaysMsgf(Connection != nullptr,
+						  TEXT("Failed to create interest level constraints. Couldn't access net connection for Actor %s"),
+						  *GetNameSafe(Actor)))
+	{
+		return QueryConstraint{};
+	}
+
 	APlayerController* PlayerController = Connection->GetPlayerController(nullptr);
-	check(PlayerController);
+	if (!ensureAlwaysMsgf(PlayerController != nullptr,
+						  TEXT("Failed to create interest level constraints. Couldn't find player controller for Actor %s"),
+						  *GetNameSafe(Actor)))
+	{
+		return QueryConstraint{};
+	}
 
 	const TSet<FName>& LoadedLevels = PlayerController->NetConnection->ClientVisibleLevelNames;
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -29,6 +29,7 @@ InterestFactory::InterestFactory(USpatialClassInfoManager* InClassInfoManager, U
 	: ClassInfoManager(InClassInfoManager)
 	, PackageMap(InPackageMap)
 {
+	check(ClassInfoManager != nullptr);
 	CreateAndCacheInterestState();
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -668,7 +668,7 @@ QueryConstraint InterestFactory::CreateLevelConstraints(const AActor* InActor) c
 	UNetConnection* Connection = InActor->GetNetConnection();
 	if (!ensureAlwaysMsgf(Connection != nullptr,
 						  TEXT("Failed to create interest level constraints. Couldn't access net connection for Actor %s"),
-						  *GetNameSafe(Actor)))
+						  *GetNameSafe(InActor)))
 	{
 		return QueryConstraint{};
 	}
@@ -676,7 +676,7 @@ QueryConstraint InterestFactory::CreateLevelConstraints(const AActor* InActor) c
 	APlayerController* PlayerController = Connection->GetPlayerController(nullptr);
 	if (!ensureAlwaysMsgf(PlayerController != nullptr,
 						  TEXT("Failed to create interest level constraints. Couldn't find player controller for Actor %s"),
-						  *GetNameSafe(Actor)))
+						  *GetNameSafe(InActor)))
 	{
 		return QueryConstraint{};
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCContainer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/RPCContainer.cpp
@@ -74,7 +74,10 @@ void LogRPCError(const FRPCErrorInfo& ErrorInfo, ERPCQueueType QueueType, const 
 		*ERPCResultToString(ErrorInfo.ErrorCode));
 
 	const USpatialGDKSettings* SpatialGDKSettings = GetDefault<USpatialGDKSettings>();
-	check(SpatialGDKSettings != nullptr);
+	if (!ensureAlwaysMsgf(SpatialGDKSettings != nullptr, TEXT("Failed to log RPC error. Couldn't access GDK settings")))
+	{
+		return;
+	}
 
 	if (TimeDiff.GetTotalSeconds() > SpatialGDKSettings->GetSecondsBeforeWarning(ErrorInfo.ErrorCode))
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
@@ -80,7 +80,10 @@ void ASpatialDebugger::BeginPlay()
 {
 	Super::BeginPlay();
 
-	check(NetDriver != nullptr);
+	if (!ensureAlwaysMsgf(NetDriver != nullptr, TEXT("Failed to call BeginPlay on SpatialDebugger. NetDriver was nullptr")))
+	{
+		return;
+	}
 
 	NetDriver->RegisterSpatialDebugger(this);
 
@@ -92,7 +95,10 @@ void ASpatialDebugger::BeginPlay()
 		{
 			AActor* PresentActor = PresentActorPair.Value.Get();
 
-			check(IsValid(PresentActor));
+			if (!ensureAlwaysMsgf(IsValid(PresentActor), TEXT("Actor was invalid when iterating through debugger system")))
+			{
+				continue;
+			}
 
 			OnEntityAdded(PresentActor);
 		}
@@ -120,7 +126,10 @@ void ASpatialDebugger::Tick(float DeltaSeconds)
 {
 	Super::Tick(DeltaSeconds);
 
-	check(NetDriver != nullptr);
+	if (!ensureAlwaysMsgf(NetDriver != nullptr, TEXT("Failed to call SpatialDebugger::Tick. NetDriver was nullptr")))
+	{
+		return;
+	}
 
 	if (!NetDriver->IsServer())
 	{
@@ -219,7 +228,12 @@ void ASpatialDebugger::CreateWorkerRegions()
 	}
 	SpawnParams.bHideFromSceneOutliner = true;
 #endif
-	check(World != nullptr);
+
+	if (!ensureAlwaysMsgf(World != nullptr, TEXT("Failed to call SpatialDebugger::CreateWorkerRegions. World was nullptr")))
+	{
+		return;
+	}
+
 	SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
 	for (const FWorkerRegionInfo& WorkerRegionData : WorkerRegions)
 	{
@@ -265,7 +279,11 @@ void ASpatialDebugger::Destroyed()
 
 void ASpatialDebugger::LoadIcons()
 {
-	check(NetDriver != nullptr && !NetDriver->IsServer());
+	if (!ensureAlwaysMsgf(NetDriver != nullptr && !NetDriver->IsServer(),
+						  TEXT("Failed to call SpatialDebugger::LoadIcons. NetDriver was nullptr OR running on server")))
+	{
+		return;
+	}
 
 	UTexture2D* DefaultTexture = LoadObject<UTexture2D>(nullptr, TEXT("/Engine/EngineResources/DefaultTexture.DefaultTexture"));
 
@@ -432,7 +450,11 @@ void ASpatialDebugger::DrawTag(UCanvas* Canvas, const FVector2D& ScreenLocation,
 {
 	SCOPE_CYCLE_COUNTER(STAT_DrawTag);
 
-	check(NetDriver != nullptr && !NetDriver->IsServer());
+	if (!ensureAlwaysMsgf(NetDriver != nullptr && !NetDriver->IsServer(),
+						  TEXT("Failed to call SpatialDebugger::DrawTag. NetDriver was nullptr OR running on server")))
+	{
+		return;
+	}
 
 	const TOptional<SpatialDebugging> DebuggingInfo = GetDebuggerSystem()->GetDebuggingData(EntityId);
 
@@ -572,7 +594,11 @@ void ASpatialDebugger::DrawDebug(UCanvas* Canvas, APlayerController* /* Controll
 {
 	SCOPE_CYCLE_COUNTER(STAT_DrawDebug);
 
-	check(NetDriver != nullptr && !NetDriver->IsServer());
+	if (!ensureAlwaysMsgf(NetDriver != nullptr && !NetDriver->IsServer(),
+						  TEXT("Failed to call SpatialDebugger::DrawDebug. NetDriver was nullptr OR running on server")))
+	{
+		return;
+	}
 
 #if WITH_EDITOR
 	// Prevent one client's data rendering in another client's view in PIE when using UDebugDrawService.  Lifted from EQSRenderingComponent.
@@ -862,7 +888,11 @@ void ASpatialDebugger::DrawDebugLocalPlayer(UCanvas* Canvas)
 
 void ASpatialDebugger::SpatialToggleDebugger()
 {
-	check(NetDriver != nullptr && !NetDriver->IsServer());
+	if (!ensureAlwaysMsgf(NetDriver != nullptr && !NetDriver->IsServer(),
+						  TEXT("Failed to call SpatialDebugger::SpatialToggleDebugger. NetDriver was nullptr OR running on server")))
+	{
+		return;
+	}
 
 	if (DrawDebugDelegateHandle.IsValid())
 	{
@@ -926,7 +956,11 @@ void ASpatialDebugger::EditorInitialiseWorkerRegions()
 	WorkerRegions.Empty();
 
 	const UWorld* World = GEditor->GetEditorWorldContext().World();
-	check(World != nullptr);
+
+	if (!ensureAlwaysMsgf(World != nullptr, TEXT("Failed to EditorInitialiseWorkerRegions. Couldn't access World from GEditor")))
+	{
+		return;
+	}
 
 	const UAbstractSpatialMultiWorkerSettings* MultiWorkerSettings =
 		USpatialStatics::GetSpatialMultiWorkerClass(World)->GetDefaultObject<UAbstractSpatialMultiWorkerSettings>();
@@ -978,6 +1012,9 @@ void ASpatialDebugger::PostEditChangeProperty(FPropertyChangedEvent& PropertyCha
 
 SpatialDebuggerSystem* ASpatialDebugger::GetDebuggerSystem() const
 {
-	check(NetDriver->SpatialDebuggerSystem.IsValid());
+	if (!ensureAlwaysMsgf(NetDriver->SpatialDebuggerSystem.IsValid(), TEXT("Failed to access invalid debugger system")))
+	{
+		return nullptr;
+	}
 	return NetDriver->SpatialDebuggerSystem.Get();
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetricsDisplay.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialMetricsDisplay.cpp
@@ -162,7 +162,10 @@ void ASpatialMetricsDisplay::DrawDebug(class UCanvas* Canvas, APlayerController*
 void ASpatialMetricsDisplay::SpatialToggleStatDisplay()
 {
 #if !UE_BUILD_SHIPPING
-	check(GetNetMode() == NM_Client);
+	if (!ensureAlwaysMsgf(GetNetMode() == NM_Client, TEXT("Tried to toggle metrics stat display from a server")))
+	{
+		return;
+	}
 
 	if (DrawDebugDelegateHandle.IsValid())
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
@@ -395,12 +395,15 @@ void USpatialStatics::SpatialDebuggerSetOnConfigUIClosedCallback(const UObject* 
 
 void USpatialStatics::SpatialSwitchHasAuthority(const AActor* Target, ESpatialHasAuthority& Authority)
 {
-	if (!ensureAlwaysMsgf(IsValid(Target) && Target->IsA(AActor::StaticClass()), TEXT("Called SpatialSwitchHasAuthority for an invalid or non-Actor target: %s", *GetNameSafe(Target)))
+	if (!ensureAlwaysMsgf(IsValid(Target) && Target->IsA(AActor::StaticClass()),
+						  TEXT("Called SpatialSwitchHasAuthority for an invalid or non-Actor target: %s"), *GetNameSafe(Target)))
 	{
 		return;
 	}
 
-	if (!ensureAlwaysMsgf(Target->GetNetDriver() != nullptr, TEXT("Called SpatialSwitchHasAuthority for %s but couldn't access NetDriver through Actor."), *GetNameSafe(Target)))
+	if (!ensureAlwaysMsgf(Target->GetNetDriver() != nullptr,
+						  TEXT("Called SpatialSwitchHasAuthority for %s but couldn't access NetDriver through Actor."),
+						  *GetNameSafe(Target)))
 	{
 		return;
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
@@ -346,7 +346,11 @@ FName USpatialStatics::GetLayerName(const UObject* WorldContextObject)
 	}
 
 	const ULayeredLBStrategy* LBStrategy = Cast<ULayeredLBStrategy>(SpatialNetDriver->LoadBalanceStrategy);
-	check(LBStrategy != nullptr);
+	if (!ensureAlwaysMsgf(LBStrategy != nullptr, TEXT("Failed calling GetLayerName because load balancing strategy was nullptr")))
+	{
+		return FName();
+	}
+
 	return LBStrategy->GetLocalLayerName();
 }
 
@@ -391,14 +395,20 @@ void USpatialStatics::SpatialDebuggerSetOnConfigUIClosedCallback(const UObject* 
 
 void USpatialStatics::SpatialSwitchHasAuthority(const AActor* Target, ESpatialHasAuthority& Authority)
 {
+	if (!ensureAlwaysMsgf(IsValid(Target) && Target->IsA(AActor::StaticClass()), TEXT("Called SpatialSwitchHasAuthority for an invalid or non-Actor target: %s", *GetNameSafe(Target)))
+	{
+		return;
+	}
+
+	if (!ensureAlwaysMsgf(Target->GetNetDriver() != nullptr, TEXT("Called SpatialSwitchHasAuthority for %s but couldn't access NetDriver through Actor."), *GetNameSafe(Target)))
+	{
+		return;
+	}
+
 	// A static UFunction does not have the Target parameter, here it is recreated by adding our own Target parameter
 	// that is defaulted to self and hidden so that the user does not need to set it
-	check(IsValid(Target));
-	check(Target->IsA(AActor::StaticClass()));
-	check(Target->GetNetDriver() != nullptr);
-
-	const bool bHasAuthority = Target->HasAuthority();
 	const bool bIsServer = Target->GetNetDriver()->IsServer();
+	const bool bHasAuthority = Target->HasAuthority();
 
 	if (bHasAuthority && bIsServer)
 	{

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -248,10 +248,6 @@ public:
 	FRepChangeState CreateInitialRepChangeState(TWeakObjectPtr<UObject> Object);
 	FHandoverChangeState CreateInitialHandoverChangeState(const FClassInfo& ClassInfo);
 
-	// For an object that is replicated by this channel (i.e. this channel's actor or its component), find out whether a given handle is an
-	// array.
-	bool IsDynamicArrayHandle(UObject* Object, uint16 Handle);
-
 	FObjectReplicator* PreReceiveSpatialUpdate(UObject* TargetObject);
 	void PostReceiveSpatialUpdate(UObject* TargetObject, const TArray<GDK_PROPERTY(Property) *>& RepNotifies,
 								  const TMap<GDK_PROPERTY(Property) *, FSpatialGDKSpanId>& PropertySpanIds);

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriverDebugContext.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriverDebugContext.h
@@ -100,7 +100,7 @@ protected:
 		bool bDirty = false;
 	};
 
-	void GetAuthDebugComponent(AActor* Actor, DebugComponentAuthData& OutComp);
+	DebugComponentAuthData& GetAuthDebugComponent(AActor* Actor);
 
 	TOptional<VirtualWorkerId> GetActorExplicitDelegation(const AActor* Actor);
 	TOptional<VirtualWorkerId> GetActorHierarchyExplicitDelegation_Traverse(const AActor* Actor);

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriverDebugContext.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriverDebugContext.h
@@ -100,7 +100,7 @@ protected:
 		bool bDirty = false;
 	};
 
-	DebugComponentAuthData& GetAuthDebugComponent(AActor* Actor);
+	void GetAuthDebugComponent(AActor* Actor, DebugComponentAuthData& Comp);
 
 	TOptional<VirtualWorkerId> GetActorExplicitDelegation(const AActor* Actor);
 	TOptional<VirtualWorkerId> GetActorHierarchyExplicitDelegation_Traverse(const AActor* Actor);

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriverDebugContext.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriverDebugContext.h
@@ -100,7 +100,7 @@ protected:
 		bool bDirty = false;
 	};
 
-	void GetAuthDebugComponent(AActor* Actor, DebugComponentAuthData& Comp);
+	void GetAuthDebugComponent(AActor* Actor, DebugComponentAuthData& OutComp);
 
 	TOptional<VirtualWorkerId> GetActorExplicitDelegation(const AActor* Actor);
 	TOptional<VirtualWorkerId> GetActorHierarchyExplicitDelegation_Traverse(const AActor* Actor);

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/CreateEntityHandler.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/CreateEntityHandler.h
@@ -21,7 +21,10 @@ class CreateEntityHandler
 public:
 	void AddRequest(Worker_RequestId RequestId, CreateEntityDelegate&& Handler)
 	{
-		check(Handler.IsBound());
+		if (!ensureAlwaysMsgf(Handler.IsBound(), TEXT("Failed to add create entity requested handler. Handler delegate was unbound")))
+		{
+			return;
+		}
 		Handlers.Emplace(RequestId, MoveTemp(Handler));
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCTypes.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCTypes.h
@@ -321,7 +321,7 @@ protected:
 		const uint32 WrittenRPCsReported = this->Sender.Write(Ctx, EntityId, Queue.RPCs, WrittenCallback);
 
 		// Basic check that the written callback was called for every individual RPC.
-		check(WrittenRPCs == WrittenRPCsReported);
+		ensureAlwaysMsgf(WrittenRPCs == WrittenRPCsReported, TEXT("Failed to add callbacks for every written RPC"));
 
 		if (WrittenRPCs == QueuedRPCs)
 		{

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/MigrationDiagnostic.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/MigrationDiagnostic.h
@@ -41,13 +41,16 @@ struct MigrationDiagnostic : Component
 	static Worker_CommandResponse CreateMigrationDiagnosticResponse(USpatialNetDriver* NetDriver, Worker_EntityId EntityId,
 																	AActor* BlockingActor)
 	{
-		check(NetDriver != nullptr);
-		check(NetDriver->Connection != nullptr);
-		check(NetDriver->LockingPolicy != nullptr);
-		check(NetDriver->VirtualWorkerTranslator != nullptr);
-		check(NetDriver->PackageMap != nullptr);
-
 		Worker_CommandResponse CommandResponse = {};
+
+		if (!ensureAlwaysMsgf(
+				NetDriver != nullptr && NetDriver->Connection != nullptr && NetDriver->LockingPolicy != nullptr
+					&& NetDriver->VirtualWorkerTranslator != nullptr && NetDriver->PackageMap != nullptr,
+				TEXT("Failed to create migration disagnostic response. Some core class was undefined. EntityId: %lld. Actor: %s"), EntityId,
+				*GetNameSafe(BlockingActor)))
+		{
+			return CommandResponse;
+		}
 
 		CommandResponse.component_id = SpatialConstants::MIGRATION_DIAGNOSTIC_COMPONENT_ID;
 		CommandResponse.command_index = SpatialConstants::MIGRATION_DIAGNOSTIC_COMMAND_ID;
@@ -84,9 +87,12 @@ struct MigrationDiagnostic : Component
 	// worker over the actor that is blocking the migration and log the results.
 	static FString CreateMigrationDiagnosticLog(USpatialNetDriver* NetDriver, Schema_Object* ResponseObject, AActor* BlockingActor)
 	{
-		check(NetDriver != nullptr);
-		check(NetDriver->Connection != nullptr);
-		check(NetDriver->LockingPolicy != nullptr);
+		if (!ensureAlwaysMsgf(NetDriver != nullptr && NetDriver->Connection != nullptr && NetDriver->LockingPolicy != nullptr,
+							  TEXT("Failed to create migration disagnostic log. Some core class was undefined. Actor: %s"),
+							  *GetNameSafe(BlockingActor)))
+		{
+			return FString();
+		}
 
 		if (ResponseObject == nullptr)
 		{

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialActorUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialActorUtils.h
@@ -22,7 +22,10 @@ namespace SpatialGDK
 {
 inline AActor* GetTopmostReplicatedOwner(const AActor* Actor)
 {
-	check(Actor != nullptr);
+	if (!ensureAlwaysMsgf(Actor != nullptr), TEXT("Called GetTopmostReplicatedOwner for nullptr Actor"))
+	{
+		return nullptr;
+	}
 
 	AActor* Owner = Actor->GetOwner();
 	if (Owner == nullptr || Owner->IsPendingKillPending() || !Owner->GetIsReplicated())

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialActorUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialActorUtils.h
@@ -22,7 +22,7 @@ namespace SpatialGDK
 {
 inline AActor* GetTopmostReplicatedOwner(const AActor* Actor)
 {
-	if (!ensureAlwaysMsgf(Actor != nullptr), TEXT("Called GetTopmostReplicatedOwner for nullptr Actor"))
+	if (!ensureAlwaysMsgf(Actor != nullptr, TEXT("Called GetTopmostReplicatedOwner for nullptr Actor")))
 	{
 		return nullptr;
 	}


### PR DESCRIPTION
#### Description
Use ensures over checks because middleware shouldn't be crashing any games. 

High-level tenets:
* General rule of thumb: use ensures over checks
* Checks in any debugging / utility / logging code should be removed
* Checks in code that's part of a direct user API (highly susceptible to bad input) should be removed
* Checks in places where state means a client is wrecked but the server could remain healthy should be removed
* Checks can still exist in fundamental locations, e.g. trying to initialize core load balancing classes but NetDriver is undefined