### PR TITLE
Tombstone logging for destroyed actors before BeginPlay triggering errors during map load

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1070,18 +1070,14 @@ void USpatialNetDriver::NotifyActorDestroyed(AActor* ThisActor, bool IsSeamlessT
 		{
 			if (!World->bBegunPlay)
 			{
-				// PackageMap != nullptr implies the spatial connection is connected, however World::BeginPlay may not have been called yet which
-				// means we are still in a UEngine::LoadMap call. During the load process, actors are created and destroyed in the following
-				// scenarios:
+				// PackageMap != nullptr implies the spatial connection is connected, however World::BeginPlay may not have been called yet
+				// which means we are still in a UEngine::LoadMap call. During the initial load process, actors are created and destroyed in the
+				// following scenarios:
 				// - When running in PIE, Blueprint loaded sub-levels can be duplicated and immediately unloaded.
 				// - ChildActorComponent::OnRegister
-				// If an actor is destroyed as part of these processes, we process here and if the actor is replicated etc., attempt
-				// to create a tombstone for. This would be incorrect behavior, as the level and actors were never intentionally loaded,
-				// but are present just as an effect of the map load process.
-				// So we ignore this destroy call if the world hasn't begun play.
 				UE_LOG(LogSpatialOSNetDriver, Verbose,
-						TEXT("USpatialNetDriver::NotifyActorDestroyed ignored because world hasn't begun play. Actor: %s."),
-						*ThisActor->GetName());
+					   TEXT("USpatialNetDriver::NotifyActorDestroyed ignored because world hasn't begun play. Actor: %s."),
+					   *ThisActor->GetName());
 			}
 			else
 			{

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1071,8 +1071,8 @@ void USpatialNetDriver::NotifyActorDestroyed(AActor* ThisActor, bool IsSeamlessT
 			if (!World->bBegunPlay)
 			{
 				// PackageMap != nullptr implies the spatial connection is connected, however World::BeginPlay may not have been called yet
-				// which means we are still in a UEngine::LoadMap call. During the initial load process, actors are created and destroyed in the
-				// following scenarios:
+				// which means we are still in a UEngine::LoadMap call. During the initial load process, actors are created and destroyed in
+				// the following scenarios:
 				// - When running in PIE, Blueprint loaded sub-levels can be duplicated and immediately unloaded.
 				// - ChildActorComponent::OnRegister
 				UE_LOG(LogSpatialOSNetDriver, Verbose,

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1068,27 +1068,14 @@ void USpatialNetDriver::NotifyActorDestroyed(AActor* ThisActor, bool IsSeamlessT
 		// Check if this is a dormant entity, and if so retire the entity
 		if (PackageMap != nullptr && World != nullptr)
 		{
-			if (!World->bBegunPlay)
-			{
-				// When running in PIE, Blueprint loaded sub-levels can be duplicated and immediately unloaded.
-				// This causes each actor in the level to be destroyed, which we process here and if the actor is replicated etc., attempt
-				// to create a tombstone for. This would be incorrect behaviour, as the level and actors were never intentionally loaded,
-				// but are present just as an effect of the world duplication process.
-				// So we ignore this destroy call if the world hasn't begun play, and it was duplicated from PIE.
-				if (ThisActor->GetLevel() != nullptr && ThisActor->GetLevel()->bWasDuplicatedForPIE)
-				{
-					UE_LOG(LogSpatialOSNetDriver, Verbose,
-						   TEXT("USpatialNetDriver::NotifyActorDestroyed ignored as level was duplicated for PIE. Actor: %s."),
-						   *ThisActor->GetName());
-				}
-				else
-				{
-					UE_LOG(LogSpatialOSNetDriver, Error,
-						   TEXT("USpatialNetDriver::NotifyActorDestroyed ignored because world hasn't begun play. Actor: %s."),
-						   *ThisActor->GetName());
-				}
-			}
-			else
+			// PackageMap != nullptr implies the spatial connection is connected, however World::BeginPlay has not been called yet which means we are still in a UEngine::LoadMap call. During the load process, actors are created and destroyed in the following scenarios:
+			// - When running in PIE, Blueprint loaded sub-levels can be duplicated and immediately unloaded.
+			// - ChildActorComponent::OnRegister
+			// If an actor is destroyed as part of these processes, we process here and if the actor is replicated etc., attempt
+			// to create a tombstone for. This would be incorrect behavior, as the level and actors were never intentionally loaded,
+			// but are present just as an effect of the map load process.
+			// So we ignore this destroy call if the world hasn't begun play.
+			if (World->bBegunPlay)
 			{
 				const Worker_EntityId EntityId = PackageMap->GetEntityIdFromObject(ThisActor);
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -1068,7 +1068,9 @@ void USpatialNetDriver::NotifyActorDestroyed(AActor* ThisActor, bool IsSeamlessT
 		// Check if this is a dormant entity, and if so retire the entity
 		if (PackageMap != nullptr && World != nullptr)
 		{
-			// PackageMap != nullptr implies the spatial connection is connected, however World::BeginPlay has not been called yet which means we are still in a UEngine::LoadMap call. During the load process, actors are created and destroyed in the following scenarios:
+			// PackageMap != nullptr implies the spatial connection is connected, however World::BeginPlay may not been called yet which
+			// means we are still in a UEngine::LoadMap call. During the load process, actors are created and destroyed in the following
+			// scenarios:
 			// - When running in PIE, Blueprint loaded sub-levels can be duplicated and immediately unloaded.
 			// - ChildActorComponent::OnRegister
 			// If an actor is destroyed as part of these processes, we process here and if the actor is replicated etc., attempt


### PR DESCRIPTION
#### Description
It seemed that this code was only triggered by blueprint-referenced sublevels but it seems that as part of LoadMap that this can actually happen in at least one other scenario (ChildActorComponent::OnRegister). It seems the best course of action is to ignore all actor deletion prior to World::BeginPlay, as all other Actor::BeginPlay are triggered after this point. 

The reason we didn't see this before is because there is a race around PackageMap, if the Spatial connection isn't fully connected yet (which is the case usually in PIE) then this code is not hit at all due to the PackageMap != null condition. 

See 

 	UE4Editor-Engine-Win64-Debug.dll!AActor::BeginPlay Line 3702
 	UE4Editor-Engine-Win64-Debug.dll!AStaticMeshActor::BeginPlay Line 58
 	UE4Editor-Engine-Win64-Debug.dll!AActor::DispatchBeginPlay) Line 3677
 	UE4Editor-Engine-Win64-Debug.dll!AWorldSettings::NotifyBeginPlay Line 259
 	UE4Editor-Engine-Win64-Debug.dll!AGameStateBase::HandleBeginPlay Line 205
 	UE4Editor-Engine-Win64-Debug.dll!AGameModeBase::StartPlay Line 204
	UE4Editor-Engine-Win64-Debug.dll!UWorld::BeginPlay Line 4347
 	UE4Editor-Engine-Win64-Debug.dll!UEngine::LoadMap Line 13136

This was added in a previous PR [here](https://github.com/spatialos/UnrealGDK/pull/3077/files)
#### Primary reviewers
@mironec 