### PR TITLE
UNR-5318 Fix (Invalid schema state if schema fails to generate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **注意**：自虚幻引擎开发套件 v0.10.0 版本起，其日志提供中英文两个版本。每个日志的中文版本都置于英文版本之后。
 
 ## [`x.y.z`] - Unreleased
+- Added a "Clean and Generate Schema" option to the Schema menu, which lets you delete the SchemaDatabase.uasset, all generated schema files, and run a Full Scan in one click.
+- Added a pop-up message when schema generation fails, which suggests running a Clean and Generate to fix a bad schema state.
+- Fixed a bug that left the SchemaDatabase.uasset file locked after a failed schema generation.
+
 ### Breaking changes:
 - Removed support for UE 4.24.
 - `MaxRPCRingBufferSize` setting has been removed. This was previously used to specify the RPC ring buffer size when generating schema. Now, `DefaultRPCRingBufferSize` is used, and can be overridden per RPC type using `RPCRingBufferSizeOverrides`.

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -1266,8 +1266,6 @@ bool LoadGeneratorStateFromSchemaDatabase(const FString& FileName)
 		return false;
 	}
 
-	bool bResetSchema = false;
-
 	FFileStatData StatData = FPlatformFileManager::Get().GetPlatformFile().GetStatData(*RelativeFileName);
 	if (StatData.bIsValid)
 	{

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
@@ -232,9 +232,18 @@ void FSpatialGDKEditor::GenerateSchema(ESchemaGenerationMethod Method, TFunction
 		else
 		{
 			UE_LOG(LogSpatialGDKEditor, Error, TEXT("Schema generation failed. View earlier log messages for errors."));
+
+			// Make sure SchemaDatabase is not loaded (unlocks the file after any failed schema gen operations)
+			if (UPackage* LoadedDatabase = FindPackage(nullptr, *FPaths::Combine(TEXT("/Game/"), *SpatialConstants::SCHEMA_DATABASE_FILE_PATH)))
+			{
+				TArray<UPackage*> ToUnload;
+				ToUnload.Add(LoadedDatabase);
+				UPackageTools::UnloadPackages(ToUnload);
+			}
 		}
 
 		ResultCallback(bResult);
+
 		return;
 	}
 }

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
@@ -146,7 +146,7 @@ void FSpatialGDKEditor::GenerateSchema(ESchemaGenerationMethod Method, TFunction
 		}
 
 		// Make sure SchemaDatabase is not loaded.
-		if (UPackage* LoadedDatabase = FindPackage(nullptr, *FPaths::Combine(TEXT("/Game/"), *SpatialConstants::SCHEMA_DATABASE_FILE_PATH)))
+		if (UPackage* LoadedDatabase = FindPackage(nullptr, *SpatialConstants::SCHEMA_DATABASE_ASSET_PATH))
 		{
 			TArray<UPackage*> ToUnload;
 			ToUnload.Add(LoadedDatabase);
@@ -234,8 +234,7 @@ void FSpatialGDKEditor::GenerateSchema(ESchemaGenerationMethod Method, TFunction
 			UE_LOG(LogSpatialGDKEditor, Error, TEXT("Schema generation failed. View earlier log messages for errors."));
 
 			// Make sure SchemaDatabase is not loaded (unlocks the file after any failed schema gen operations)
-			if (UPackage* LoadedDatabase =
-					FindPackage(nullptr, *SpatialConstants::SCHEMA_DATABASE_ASSET_PATH))
+			if (UPackage* LoadedDatabase = FindPackage(nullptr, *SpatialConstants::SCHEMA_DATABASE_ASSET_PATH))
 			{
 				TArray<UPackage*> ToUnload;
 				ToUnload.Add(LoadedDatabase);

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
@@ -235,7 +235,7 @@ void FSpatialGDKEditor::GenerateSchema(ESchemaGenerationMethod Method, TFunction
 
 			// Make sure SchemaDatabase is not loaded (unlocks the file after any failed schema gen operations)
 			if (UPackage* LoadedDatabase =
-					FindPackage(nullptr, *FPaths::Combine(TEXT("/Game/"), *SpatialConstants::SCHEMA_DATABASE_FILE_PATH)))
+					FindPackage(nullptr, *SpatialConstants::SCHEMA_DATABASE_ASSET_PATH))
 			{
 				TArray<UPackage*> ToUnload;
 				ToUnload.Add(LoadedDatabase);

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditor.cpp
@@ -234,7 +234,8 @@ void FSpatialGDKEditor::GenerateSchema(ESchemaGenerationMethod Method, TFunction
 			UE_LOG(LogSpatialGDKEditor, Error, TEXT("Schema generation failed. View earlier log messages for errors."));
 
 			// Make sure SchemaDatabase is not loaded (unlocks the file after any failed schema gen operations)
-			if (UPackage* LoadedDatabase = FindPackage(nullptr, *FPaths::Combine(TEXT("/Game/"), *SpatialConstants::SCHEMA_DATABASE_FILE_PATH)))
+			if (UPackage* LoadedDatabase =
+					FindPackage(nullptr, *FPaths::Combine(TEXT("/Game/"), *SpatialConstants::SCHEMA_DATABASE_FILE_PATH)))
 			{
 				TArray<UPackage*> ToUnload;
 				ToUnload.Add(LoadedDatabase);

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -248,6 +248,10 @@ void FSpatialGDKEditorToolbarModule::MapActions(TSharedPtr<class FUICommandList>
 	InPluginCommands->MapAction(FSpatialGDKEditorToolbarCommands::Get().DeleteSchemaDatabase,
 								FExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::DeleteSchemaDatabaseButtonClicked));
 
+	InPluginCommands->MapAction(FSpatialGDKEditorToolbarCommands::Get().CleanGenerateSchema,
+								FExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::CleanSchemaGenerateButtonClicked),
+								FCanExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::CanExecuteSchemaGenerator));
+
 	InPluginCommands->MapAction(FSpatialGDKEditorToolbarCommands::Get().CreateSpatialGDKSnapshot,
 								FExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::CreateSnapshotButtonClicked),
 								FCanExecuteAction::CreateRaw(this, &FSpatialGDKEditorToolbarModule::CanExecuteSnapshotGenerator));
@@ -403,6 +407,7 @@ TSharedRef<SWidget> FSpatialGDKEditorToolbarModule::CreateGenerateSchemaMenuCont
 	{
 		MenuBuilder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().CreateSpatialGDKSchemaFull);
 		MenuBuilder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().DeleteSchemaDatabase);
+		MenuBuilder.AddMenuEntry(FSpatialGDKEditorToolbarCommands::Get().CleanGenerateSchema);
 	}
 	MenuBuilder.EndSection();
 
@@ -559,15 +564,49 @@ void FSpatialGDKEditorToolbarModule::DeleteSchemaDatabaseButtonClicked()
 							 LOCTEXT("DeleteSchemaDatabase_Prompt", "Are you sure you want to delete the schema database?"))
 		== EAppReturnType::Yes)
 	{
-		OnShowTaskStartNotification(TEXT("Deleting schema database"));
-		if (SpatialGDKEditor::Schema::DeleteSchemaDatabase(SpatialConstants::SCHEMA_DATABASE_FILE_PATH))
-		{
-			OnShowSuccessNotification(TEXT("Schema database deleted"));
-		}
-		else
-		{
-			OnShowFailedNotification(TEXT("Failed to delete schema database"));
-		}
+		DeleteSchemaDatabase();
+	}
+}
+
+bool FSpatialGDKEditorToolbarModule::DeleteSchemaDatabase()
+{
+	OnShowTaskStartNotification(TEXT("Deleting schema database"));
+	bool bResult = SpatialGDKEditor::Schema::DeleteSchemaDatabase(SpatialConstants::SCHEMA_DATABASE_FILE_PATH);
+
+	if (bResult)
+	{
+		OnShowSuccessNotification(TEXT("Schema database deleted"));
+	}
+	else
+	{
+		OnShowFailedNotification(TEXT("Failed to delete schema database"));
+	}
+
+	return bResult;
+}
+
+void FSpatialGDKEditorToolbarModule::CleanSchemaGenerateButtonClicked()
+{
+	if (FMessageDialog::Open(
+		EAppMsgType::YesNo,
+		LOCTEXT("DeleteSchemaDatabase_Prompt",
+			"Are you sure you want to delete the schema database, delete all generated schema, and regenerate schema?"))
+		== EAppReturnType::Yes)
+	{
+		CleanSchemaGenerate();
+	}
+}
+
+void FSpatialGDKEditorToolbarModule::CleanSchemaGenerate()
+{
+	if (DeleteSchemaDatabase())
+	{
+		SpatialGDKEditor::Schema::ResetSchemaGeneratorStateAndCleanupFolders();
+		GenerateSchema(true);
+	}
+	else
+	{
+		UE_LOG(LogSpatialGDKEditorToolbar, Error, TEXT("Failed to delete Schema Database; schema will not be cleaned and regenerated."));
 	}
 }
 
@@ -579,6 +618,24 @@ void FSpatialGDKEditorToolbarModule::SchemaGenerateButtonClicked()
 void FSpatialGDKEditorToolbarModule::SchemaGenerateFullButtonClicked()
 {
 	GenerateSchema(true);
+}
+
+void FSpatialGDKEditorToolbarModule::HandleGenerateSchemaFailure()
+{
+	// Run the dialogue on a background task -- this allows the editor UI to update and display Schema Gen errors in the log
+	AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [this] {
+		if (FMessageDialog::Open(EAppMsgType::YesNo,
+			LOCTEXT("DeleteAndRegenerateSchemaDatabase_Prompt",
+				"Schema generation failed. Common schema generation issues can be solved by deleting all schema "
+				"and generating again. Would you like to clean and retry now?"))
+			== EAppReturnType::Yes)
+		{
+			// GameThread is required for building schema
+			AsyncTask(ENamedThreads::GameThread, [this] {
+				CleanSchemaGenerate();
+			});
+		}
+	});
 }
 
 void FSpatialGDKEditorToolbarModule::OnShowSingleFailureNotification(const FString& NotificationText)
@@ -1284,6 +1341,8 @@ void FSpatialGDKEditorToolbarModule::GenerateSchema(bool bFullScan)
 		else
 		{
 			OnShowFailedNotification(OnTaskFailMessage);
+
+			HandleGenerateSchemaFailure();
 		}
 	});
 	;

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -588,9 +588,9 @@ bool FSpatialGDKEditorToolbarModule::DeleteSchemaDatabase()
 void FSpatialGDKEditorToolbarModule::CleanSchemaGenerateButtonClicked()
 {
 	if (FMessageDialog::Open(
-		EAppMsgType::YesNo,
-		LOCTEXT("DeleteSchemaDatabase_Prompt",
-			"Are you sure you want to delete the schema database, delete all generated schema, and regenerate schema?"))
+			EAppMsgType::YesNo,
+			LOCTEXT("DeleteSchemaDatabase_Prompt",
+					"Are you sure you want to delete the schema database, delete all generated schema, and regenerate schema?"))
 		== EAppReturnType::Yes)
 	{
 		CleanSchemaGenerate();
@@ -625,9 +625,9 @@ void FSpatialGDKEditorToolbarModule::HandleGenerateSchemaFailure()
 	// Run the dialogue on a background task -- this allows the editor UI to update and display Schema Gen errors in the log
 	AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [this] {
 		if (FMessageDialog::Open(EAppMsgType::YesNo,
-			LOCTEXT("DeleteAndRegenerateSchemaDatabase_Prompt",
-				"Schema generation failed. Common schema generation issues can be solved by deleting all schema "
-				"and generating again. Would you like to clean and retry now?"))
+								 LOCTEXT("DeleteAndRegenerateSchemaDatabase_Prompt",
+										 "Schema generation failed. Common schema generation issues can be solved by deleting all schema "
+										 "and generating again. Would you like to clean and retry now?"))
 			== EAppReturnType::Yes)
 		{
 			// GameThread is required for building schema

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarCommands.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbarCommands.cpp
@@ -10,8 +10,11 @@ void FSpatialGDKEditorToolbarCommands::RegisterCommands()
 			   EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(CreateSpatialGDKSchemaFull, "Schema (Full Scan)", "Creates SpatialOS Unreal GDK schema for all assets.",
 			   EUserInterfaceActionType::Button, FInputGesture());
-	UI_COMMAND(DeleteSchemaDatabase, "Delete schema database", "Deletes the schema database file", EUserInterfaceActionType::Button,
+	UI_COMMAND(DeleteSchemaDatabase, "Delete Schema Database", "Deletes the schema database file", EUserInterfaceActionType::Button,
 			   FInputGesture());
+	UI_COMMAND(CleanGenerateSchema, "Clean and Generate Schema",
+			   "Deletes the schema database file and all generated schema files, and then runs Schema Full Scan",
+			   EUserInterfaceActionType::Button, FInputGesture());
 	UI_COMMAND(CreateSpatialGDKSnapshot, "Snapshot", "Creates SpatialOS Unreal GDK snapshot.", EUserInterfaceActionType::Button,
 			   FInputGesture());
 	UI_COMMAND(StartNative, "Start Deployment", "Use native Unreal networking", EUserInterfaceActionType::Button, FInputGesture());

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -120,7 +120,11 @@ private:
 	void CreateSnapshotButtonClicked();
 	void SchemaGenerateButtonClicked();
 	void SchemaGenerateFullButtonClicked();
+	void CleanSchemaGenerateButtonClicked();
+	void CleanSchemaGenerate();
 	void DeleteSchemaDatabaseButtonClicked();
+	bool DeleteSchemaDatabase();
+	void HandleGenerateSchemaFailure();
 	void OnPropertyChanged(UObject* ObjectBeingModified, FPropertyChangedEvent& PropertyChangedEvent);
 
 	void ShowCloudDeploymentDialog();

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbarCommands.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbarCommands.h
@@ -22,6 +22,7 @@ public:
 	TSharedPtr<FUICommandInfo> CreateSpatialGDKSchema;
 	TSharedPtr<FUICommandInfo> CreateSpatialGDKSchemaFull;
 	TSharedPtr<FUICommandInfo> DeleteSchemaDatabase;
+	TSharedPtr<FUICommandInfo> CleanGenerateSchema;
 	TSharedPtr<FUICommandInfo> CreateSpatialGDKSnapshot;
 	TSharedPtr<FUICommandInfo> StartNative;
 	TSharedPtr<FUICommandInfo> StartLocalSpatialDeployment;


### PR DESCRIPTION
#### Description
This change
- Fixes the bug, where if a schema gen failed, the SchemaDatabase.uasset would stay in a locked state and couldn't be deleted (see note below).
- Adds a menu option for cleaning and regenerating schema (ie, deletes the schema database, the schema generated folder, and runs a full scan).
- Adds a pop-up menu prompt that comes up when schema generation fails, asking the user if they would like to clean and regenerate schema (This is meant to help unblock the average user who doesn't think about schema, since most issues can be fixed with a clean and regen -- this prompt would likely have saved some hours of dev time based on what I saw on Scavengers)

Note: I'm not super sure about the fix to unlock the SchemaDatabase.uasset. What I saw happening was that schema generation begins (and SchemaDatabase.uasset becomes locked), and then either...
a) it completes successfully, and the "save" operation overwrites SchemaDatabase.uasset and unlocks it, or
b) schema gen fails for some reason, there is no save operation, so the file stays locked.
I'm trying to unlock it using UPackageTools::UnloadPackages, which DOES unlock it if it is locked, but weirdly, seems to LOCK the file if it is already unlocked. I'm not sure what's going on, but if I run this code only in the schema gen fail state, the bug is solved without knock-on effects. Happy to change if someone knows a better way. 

#### Release note
REQUIRED: Add a release note to the `##Unreleased` section of CHANGELOG.md. You can find guidance for writing useful release notes [here](../SpatialGDK/Extras/internal-documentation/how-to-write-good-release-notes.md). Documentation changes are exempt from this requirement.
- Added a "Clean and Generate Schema" option to the Schema menu, which lets you delete the SchemaDatabase.uasset, all generated schema files, and run a Full Scan in one click.
- Added a pop-up message when schema generation fails, which suggests running a Clean and Generate to fix a bad schema state.
- Fixed a bug that left the SchemaDatabase.uasset file locked after a failed schema generation.

#### Tests
How did you test these changes prior to submitting this pull request?
- Locally ran the editor, generating schema in states that are successful or fail and verifying the file is locked/unlocked using LockHunter
- See UNR-5318 for repro steps
What automated tests are included in this PR? None

STRONGLY SUGGESTED: How can this be verified by QA? 
Follow repro steps in the comments of UNR-5318 and verify that SchemDatabase can be deleted after failed and successful schema generation. Verify that the new menu option for Clean and Generate Schema deletes everything and runs af ull scan.

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

#### Reminders (IMPORTANT)
If your change relies on a breaking engine change:
* Increment `SPATIAL_ENGINE_VERSION` in `Engine\Source\Runtime\Launch\Resources\SpatialVersion.h` (in the engine fork) as well as `SPATIAL_GDK_VERSION` in `SpatialGDK\Source\SpatialGDK\Public\Utils\EngineVersionCheck.h`. This helps others by providing a more helpful message during compilation to make sure the GDK and the Engine are up to date.

If your change updates `Setup.bat`, `Setup.sh`, core SDK version, any C# tools in `SpatialGDK\Build\Programs\Improbable.Unreal.Scripts`, or hand-written schema in `SpatialGDK\Extras\schema`:
* Increment the number in `RequireSetup`. This will automatically run `Setup.bat` or `Setup.sh` when the GDK is next pulled.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
