### PR TITLE
Demote Warning to Log

### DIFF
--- a/SpatialGDK/Source/SpatialGDKTests/Public/GDKAutomationTestBase.h
+++ b/SpatialGDK/Source/SpatialGDKTests/Public/GDKAutomationTestBase.h
@@ -52,8 +52,8 @@ protected:
 		FLocalDeploymentManager* LocalDeploymentManager = SpatialGDK::GetLocalDeploymentManager();
 		if (LocalDeploymentManager->IsLocalDeploymentRunning() || LocalDeploymentManager->IsDeploymentStarting())
 		{
-			UE_LOG(LogGDKTestBase, Warning, TEXT("Deployment found! (Was this left over from another test?)"))
-			UE_LOG(LogGDKTestBase, Warning, TEXT("Ending PIE session"))
+			UE_LOG(LogGDKTestBase, Log, TEXT("Deployment found! (Was this left over from another test?)"))
+			UE_LOG(LogGDKTestBase, Log, TEXT("Ending PIE session"))
 			GEditor->RequestEndPlayMap();
 			ADD_LATENT_AUTOMATION_COMMAND(FStopDeployment);
 			ADD_LATENT_AUTOMATION_COMMAND(FWaitForDeployment(this, EDeploymentState::IsNotRunning));


### PR DESCRIPTION
Context: After a functional test finishes we do not shut down the deployment. This saves us time in CI. This does mean that the next automated test will start with an already existing deployment running. This is where the warning came from. 

Potential fixes for this issue:
1. Demote warning to log
2. Shuffle all functional tests to the end of the test run.
3. Have a means of having a functional test shutdown the runtime when it finishes.

1. Seemed most appropriate as we 100% know this code path will be hit. 
2. Bad practice really...
3. Would require a sizable amount of work to ensure that deployments are not shutdown when a functional test finishes when the next test is another functional test and only in the case where the next test is an automated test.

What is most important here is that we get tests and CI passing. There is a small low priority question about the correctness of having a test "wait" for the previous test to fully finish. 

Have chatted to Miron and Ollie who are happy with this change. 