### PR TITLE
[UNR-5324] SpatialTestLoadBalancingData is flaky

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestLoadBalancingData/SpatialTestLoadBalancingData.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestLoadBalancingData/SpatialTestLoadBalancingData.cpp
@@ -141,38 +141,34 @@ void ASpatialTestLoadBalancingData::PrepareTest()
 		FinishStep();
 	});
 
-	AddStep(
-		TEXT("Retrieve actors on all workers"), FWorkerDefinition::AllWorkers, nullptr, nullptr,
-		[this](float) {
-			TargetActor = GetWorldActor<ASpatialTestLoadBalancingDataActor>(GetWorld());
-			RequireTrue(TargetActor.IsValid(), TEXT("Received main actor"));
+	AddStep(TEXT("Retrieve actors on all workers"), FWorkerDefinition::AllWorkers, nullptr, nullptr, [this](float) {
+		TargetActor = GetWorldActor<ASpatialTestLoadBalancingDataActor>(GetWorld());
+		RequireTrue(TargetActor.IsValid(), TEXT("Received main actor"));
 
-			TargetOffloadedActor = GetWorldActor<ASpatialTestLoadBalancingDataOffloadedActor>(GetWorld());
-			RequireTrue(TargetOffloadedActor.IsValid(), TEXT("Received offloaded actor"));
+		TargetOffloadedActor = GetWorldActor<ASpatialTestLoadBalancingDataOffloadedActor>(GetWorld());
+		RequireTrue(TargetOffloadedActor.IsValid(), TEXT("Received offloaded actor"));
 
-			GetWorldActors<ASpatialTestLoadBalancingDataZonedActor, 2>(GetWorld(), TargetZonedActors);
-			RequireTrue(TargetZonedActors.Num() == 2, TEXT("Received zoned actors"));
+		GetWorldActors<ASpatialTestLoadBalancingDataZonedActor, 2>(GetWorld(), TargetZonedActors);
+		RequireTrue(TargetZonedActors.Num() == 2, TEXT("Received zoned actors"));
 
-			FinishStep();
-		});
+		FinishStep();
+	});
 
-	AddStep(
-		TEXT("Confirm LB group IDs on the server"), FWorkerDefinition::AllServers, nullptr, nullptr,
-		[this](float) {
-			// ServerWorkers should have interest in LoadBalancingData so it should be available
-			TOptional<SpatialGDK::ActorGroupMember> LoadBalancingData = GetActorGroupData(TargetActor.Get());
-			RequireTrue(LoadBalancingData.IsSet(), TEXT("Main actor entity has LoadBalancingData"));
+	AddStep(TEXT("Confirm LB group IDs on the server"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
+		// ServerWorkers should have interest in LoadBalancingData so it should be available
+		TOptional<SpatialGDK::ActorGroupMember> LoadBalancingData = GetActorGroupData(TargetActor.Get());
+		RequireTrue(LoadBalancingData.IsSet(), TEXT("Main actor entity has LoadBalancingData"));
 
-			TOptional<SpatialGDK::ActorGroupMember> OffloadedLoadBalancingData = GetActorGroupData(TargetOffloadedActor.Get());
-			RequireTrue(OffloadedLoadBalancingData.IsSet(), TEXT("Offloaded actor entity has LoadBalancingData"));
+		TOptional<SpatialGDK::ActorGroupMember> OffloadedLoadBalancingData = GetActorGroupData(TargetOffloadedActor.Get());
+		RequireTrue(OffloadedLoadBalancingData.IsSet(), TEXT("Offloaded actor entity has LoadBalancingData"));
 
-			const bool bIsValid = LoadBalancingData.IsSet() && OffloadedLoadBalancingData.IsSet()
-								  && LoadBalancingData->ActorGroupId != OffloadedLoadBalancingData->ActorGroupId;
+		const bool bIsValid = LoadBalancingData.IsSet() && OffloadedLoadBalancingData.IsSet()
+							  && LoadBalancingData->ActorGroupId != OffloadedLoadBalancingData->ActorGroupId;
 
-			RequireTrue(bIsValid, TEXT("Load balancing group ids are different for the main server and for the offloaded server"));
+		RequireTrue(bIsValid, TEXT("Load balancing group ids are different for the main server and for the offloaded server"));
 
-			FinishStep();
-		});
+		FinishStep();
+	});
 
 	AddStep(TEXT("Put zoned actors to a single ownership group"), ZonedServers[0], nullptr, [this]() {
 		AssertTrue(TargetZonedActors[0]->HasAuthority(), TEXT("Zoned actor 1 is owned by the zoned server 1"));
@@ -180,15 +176,13 @@ void ASpatialTestLoadBalancingData::PrepareTest()
 		FinishStep();
 	});
 
-	AddStep(
-		TEXT("Wait until actor set IDs are the same"), FWorkerDefinition::AllServers, nullptr, nullptr,
-		[this](float) {
-			RequireTrue(GetActorSetData(TargetZonedActors[0].Get())->ActorSetId == GetActorSetData(TargetZonedActors[1].Get())->ActorSetId,
-						TEXT("Actor set IDs are the same for the two zoned actors"));
-			const bool bShouldHaveAuthority = GetLocalWorkerId() == 4;
-			RequireTrue(TargetZonedActors[0]->HasAuthority() == bShouldHaveAuthority, TEXT("Authority was moved correctly"));
-			FinishStep();
-		});
+	AddStep(TEXT("Wait until actor set IDs are the same"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
+		RequireTrue(GetActorSetData(TargetZonedActors[0].Get())->ActorSetId == GetActorSetData(TargetZonedActors[1].Get())->ActorSetId,
+					TEXT("Actor set IDs are the same for the two zoned actors"));
+		const bool bShouldHaveAuthority = GetLocalWorkerId() == 4;
+		RequireTrue(TargetZonedActors[0]->HasAuthority() == bShouldHaveAuthority, TEXT("Authority was moved correctly"));
+		FinishStep();
+	});
 
 	AddStep(TEXT("Put main server actor and offloaded server actor into different ownership groups"), ZonedServers[1], nullptr, [this]() {
 		AssertTrue(TargetZonedActors[0]->HasAuthority(), TEXT("Zoned actor 1 is owned by the zoned server 2"));
@@ -196,14 +190,12 @@ void ASpatialTestLoadBalancingData::PrepareTest()
 		FinishStep();
 	});
 
-	AddStep(
-		TEXT("Wait until actor set IDs different again"), FWorkerDefinition::AllServers, nullptr, nullptr,
-		[this](float) {
-			RequireTrue(GetActorSetData(TargetZonedActors[0].Get())->ActorSetId != GetActorSetData(TargetZonedActors[1].Get())->ActorSetId,
-						TEXT("Actor set IDs are different for the two zoned actors"));
+	AddStep(TEXT("Wait until actor set IDs different again"), FWorkerDefinition::AllServers, nullptr, nullptr, [this](float) {
+		RequireTrue(GetActorSetData(TargetZonedActors[0].Get())->ActorSetId != GetActorSetData(TargetZonedActors[1].Get())->ActorSetId,
+					TEXT("Actor set IDs are different for the two zoned actors"));
 
-			FinishStep();
-		});
+		FinishStep();
+	});
 }
 
 template <typename TComponent>

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestLoadBalancingData/SpatialTestLoadBalancingData.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestLoadBalancingData/SpatialTestLoadBalancingData.cpp
@@ -9,6 +9,7 @@
 #include "SpatialCommonTypes.h"
 #include "SpatialView/EntityComponentTypes.h"
 #include "TestWorkerSettings.h"
+#include "Algo/AllOf.h"
 
 #include "Kismet/GameplayStatics.h"
 
@@ -87,9 +88,9 @@ void GetWorldActors(UWorld* World, TArray<U>& OutActors)
 		DiscoveredActors.Sort([](const AActor& Lhs, const AActor& Rhs) {
 			return Lhs.GetActorLocation().Y < Rhs.GetActorLocation().Y;
 		});
-		if(Algo::AllOf(DiscoveredActors, [](AActor* Actor) -> bool {
-			return Actor->IsActorReady();
-		}))
+		if (Algo::AllOf(DiscoveredActors, [](AActor* Actor) -> bool {
+				return Actor->IsActorReady();
+			}))
 		{
 			Algo::Transform(DiscoveredActors, OutActors, [](AActor* Actor) -> U {
 				return Cast<T>(Actor);

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestLoadBalancingData/SpatialTestLoadBalancingData.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestLoadBalancingData/SpatialTestLoadBalancingData.cpp
@@ -2,6 +2,7 @@
 
 #include "SpatialGDK/SpatialTestLoadBalancingData/SpatialTestLoadBalancingData.h"
 
+#include "Algo/AllOf.h"
 #include "EngineClasses/SpatialNetDriver.h"
 #include "EngineClasses/SpatialPackageMapClient.h"
 #include "EngineClasses/SpatialWorldSettings.h"
@@ -9,7 +10,6 @@
 #include "SpatialCommonTypes.h"
 #include "SpatialView/EntityComponentTypes.h"
 #include "TestWorkerSettings.h"
-#include "Algo/AllOf.h"
 
 #include "Kismet/GameplayStatics.h"
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestLoadBalancingData/SpatialTestLoadBalancingData.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestLoadBalancingData/SpatialTestLoadBalancingData.cpp
@@ -141,7 +141,6 @@ void ASpatialTestLoadBalancingData::PrepareTest()
 		FinishStep();
 	});
 
-	constexpr float ActorReceiptTimeout = 5.0f;
 	AddStep(
 		TEXT("Retrieve actors on all workers"), FWorkerDefinition::AllWorkers, nullptr, nullptr,
 		[this](float) {
@@ -155,10 +154,8 @@ void ASpatialTestLoadBalancingData::PrepareTest()
 			RequireTrue(TargetZonedActors.Num() == 2, TEXT("Received zoned actors"));
 
 			FinishStep();
-		},
-		ActorReceiptTimeout);
+		});
 
-	const float LoadBalancingDataReceiptTimeout = 5.0f;
 	AddStep(
 		TEXT("Confirm LB group IDs on the server"), FWorkerDefinition::AllServers, nullptr, nullptr,
 		[this](float) {
@@ -175,8 +172,7 @@ void ASpatialTestLoadBalancingData::PrepareTest()
 			RequireTrue(bIsValid, TEXT("Load balancing group ids are different for the main server and for the offloaded server"));
 
 			FinishStep();
-		},
-		LoadBalancingDataReceiptTimeout);
+		});
 
 	AddStep(TEXT("Put zoned actors to a single ownership group"), ZonedServers[0], nullptr, [this]() {
 		AssertTrue(TargetZonedActors[0]->HasAuthority(), TEXT("Zoned actor 1 is owned by the zoned server 1"));
@@ -192,8 +188,7 @@ void ASpatialTestLoadBalancingData::PrepareTest()
 			const bool bShouldHaveAuthority = GetLocalWorkerId() == 4;
 			RequireTrue(TargetZonedActors[0]->HasAuthority() == bShouldHaveAuthority, TEXT("Authority was moved correctly"));
 			FinishStep();
-		},
-		LoadBalancingDataReceiptTimeout);
+		});
 
 	AddStep(TEXT("Put main server actor and offloaded server actor into different ownership groups"), ZonedServers[1], nullptr, [this]() {
 		AssertTrue(TargetZonedActors[0]->HasAuthority(), TEXT("Zoned actor 1 is owned by the zoned server 2"));
@@ -208,8 +203,7 @@ void ASpatialTestLoadBalancingData::PrepareTest()
 						TEXT("Actor set IDs are different for the two zoned actors"));
 
 			FinishStep();
-		},
-		LoadBalancingDataReceiptTimeout);
+		});
 }
 
 template <typename TComponent>


### PR DESCRIPTION
#### Description
Increased timeouts in the timesteps by setting them to the default (20 seconds) and added an IsActorReady check to avoid potential nullptr on other servers.

#### Release note
Not required.

#### Tests
How did you test these changes prior to submitting this pull request?
Ran the test multiple times on CI and locally.

STRONGLY SUGGESTED: How can this be verified by QA?
Trigger multiple builds which run the functional tests on CI.
#### Documentation
Not required.
