### PR TITLE
UNR-5551 - Use GetSpatialWorkerId in Tracelib Enabled Code

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialGameInstance.cpp
@@ -246,7 +246,7 @@ void USpatialGameInstance::HandleOnConnected(USpatialNetDriver& NetDriver)
 	UE_LOG(LogSpatialGameInstance, Log, TEXT("Successfully connected to SpatialOS"));
 	SetSpatialWorkerId(SpatialConnectionManager->GetWorkerConnection()->GetWorkerId());
 #if TRACE_LIB_ACTIVE
-	SpatialLatencyTracer->SetWorkerId(SpatialWorkerId);
+	SpatialLatencyTracer->SetWorkerId(GetSpatialWorkerId());
 
 	USpatialWorkerConnection* WorkerConnection = SpatialConnectionManager->GetWorkerConnection();
 	WorkerConnection->OnEnqueueMessage.AddUObject(SpatialLatencyTracer, &USpatialLatencyTracer::OnEnqueueMessage);


### PR DESCRIPTION
#### Description
Switch from calling member directly to using GetSpatialWorkerId()

#### Tests
Built this locally with tracelibs enable but nothing significant past that.

STRONGLY SUGGESTED: How can this be verified by QA?
Build it with tracelibs enabled, run an NFR scenario.
Fixed NFR Run: https://buildkite.com/improbable/unrealgdk-nfr/builds/5033

#### Reminders (IMPORTANT)
This is a fix for something which broke the nightly NFRs. Thanks to Jane for pinpointing this issue.
Broken nightly nfr: https://buildkite.com/improbable/unrealgdk-nfr/builds/5029#1c865c46-ed92-41f3-ac10-31f07e8bb55d

#### Primary reviewers
@martin-improbable @m-samiec @Jane-XuJingyi 
