### PR TITLE
[UNR-5557] Initialize pointer in tracing callback

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverRPC.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverRPC.cpp
@@ -59,6 +59,7 @@ void FSpatialNetDriverRPC::OnRPCSent(SpatialGDK::SpatialEventTracer& EventTracer
 		UpdateToSend& Update = OutUpdates.AddDefaulted_GetRef();
 		Update.EntityId = EntityId;
 		Update.Update.component_id = ComponentId;
+		Update.Update.schema_type = nullptr;
 	}
 	OutUpdates.Last().Spans.Add(NewSpanId);
 }


### PR DESCRIPTION
#### Description
There was an additional path, when tracing was enabled, which pushed a new update item on the update queue. This path forgot to initialize the schema object to null.