### PR TITLE
[UNR-5524] make ending deployment during PIE thread safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue where migration diagnostic tool would crash if the target actor's owner couldn't be found.
 - Fixed an issue where during shutdown unregistering NetGUIDs could cause an asset load and program stall.
 - Fix RPC timeouts for parameters referencing assets that can be asynchronously loaded.
+- Fix editor encountering exceptions when shutting down during a PIE session.
 
 ### Internal:
 - Hide the Test MultiworkerSettings and GridStrategy classes from displaying in the editor. These are meant to only be used in Tests.

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -46,7 +46,6 @@ FLocalDeploymentManager::~FLocalDeploymentManager()
 	// The idea behind this lock is to try and make the thread calling the destructor wait for the thread that is cleaning up processes
 	// if something tries to run on this object after the destructor then we're ruined anyway
 	FScopeLock StoppingDeploymentScoped(&StoppingDeployment);
-	RuntimeProcess->Stop();
 }
 
 void FLocalDeploymentManager::PreInit(bool bChinaEnabled)

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -412,7 +412,6 @@ bool FLocalDeploymentManager::TryStopLocalDeploymentGracefully()
 		return TryStopLocalDeployment();
 	}
 
-
 	FScopeLock StoppingDeploymentScoped(&StoppingDeployment);
 	if (!StartLocalDeploymentShutDown())
 	{

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -37,6 +37,7 @@ FLocalDeploymentManager::FLocalDeploymentManager()
 	: bLocalDeploymentRunning(false)
 	, bStartingDeployment(false)
 	, bStoppingDeployment(false)
+	, bTestRunnning(false)
 {
 }
 
@@ -45,6 +46,7 @@ FLocalDeploymentManager::~FLocalDeploymentManager()
 	// The idea behind this lock is to try and make the thread calling the destructor wait for the thread that is cleaning up processes
 	// if something tries to run on this object after the destructor then we're ruined anyway
 	FScopeLock StoppingDeploymentScoped(&StoppingDeployment);
+	RuntimeProcess->Stop();
 }
 
 void FLocalDeploymentManager::PreInit(bool bChinaEnabled)

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
 #include "LocalDeploymentManager.h"
 
 #include "AssetRegistryModule.h"

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalDeploymentManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalDeploymentManager.h
@@ -15,7 +15,7 @@ DECLARE_LOG_CATEGORY_EXTERN(LogSpatialDeploymentManager, Log, All);
 
 class FJsonObject;
 
-class FLocalDeploymentManager
+class FLocalDeploymentManager final
 {
 public:
 	FLocalDeploymentManager();

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalDeploymentManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalDeploymentManager.h
@@ -19,6 +19,7 @@ class FLocalDeploymentManager
 {
 public:
 	FLocalDeploymentManager();
+	~FLocalDeploymentManager();
 
 	void SPATIALGDKSERVICES_API PreInit(bool bChinaEnabled);
 
@@ -80,6 +81,8 @@ private:
 	ERuntimeStartResponse StartLocalDeployment(const FString& LaunchConfig, const FString& RuntimeVersion, const FString& LaunchArgs,
 											   const FString& SnapshotName, const FString& RuntimeIPToExpose,
 											   const LocalDeploymentCallback& CallBack);
+
+	FCriticalSection StoppingDeployment;
 
 	TFuture<bool> AttemptSpatialAuthResult;
 


### PR DESCRIPTION
#### Description
before, multiple threads could attempt to shut down the runtime at the same time. Sometimes the runtime took a long time to shut down, and unreal's main thread called the destructor of `LocalDeploymentManager` while that other thread was still running on the shutdown runtime method/s.

This fixes that

#### Release note
`Fix editor encountering exceptions when shutting down during a PIE session.`

#### Tests
How did you test these changes prior to submitting this pull request?
I saw I could follow repro steps and it no longer crashed

What automated tests are included in this PR?
none

STRONGLY SUGGESTED: How can this be verified by QA?
see linked ticket for repro steps

#### Documentation
release note

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@joshuahuburn 