### PR TITLE
Fix settings override path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue where migration diagnostic tool would crash if the target actor's owner couldn't be found.
 - Fixed an issue where during shutdown unregistering NetGUIDs could cause an asset load and program stall.
 - Fix RPC timeouts for parameters referencing assets that can be asynchronously loaded.
+- Fixed the test settings overrides config filename in the `World Settings` so that the file path is relative to the game directory.
 
 ### Internal:
 - Hide the Test MultiworkerSettings and GridStrategy classes from displaying in the editor. These are meant to only be used in Tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue where migration diagnostic tool would crash if the target actor's owner couldn't be found.
 - Fixed an issue where during shutdown unregistering NetGUIDs could cause an asset load and program stall.
 - Fix RPC timeouts for parameters referencing assets that can be asynchronously loaded.
-- Fixed the test settings overrides config filename in the `World Settings` so that the file path is relative to the game directory.
+- Fixed the test settings overrides config filename in `Spatial World Settings` so that the file path is relative to the game directory.
 
 ### Internal:
 - Hide the Test MultiworkerSettings and GridStrategy classes from displaying in the editor. These are meant to only be used in Tests.

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialWorldSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialWorldSettings.h
@@ -25,7 +25,7 @@ public:
 	TSubclassOf<USpatialMultiWorkerSettings> GetMultiWorkerSettingsClass(bool bForceNonEditorSettings = false);
 
 #if WITH_EDITORONLY_DATA
-	UPROPERTY(EditAnywhere, Category = "Testing", Meta = (FilePathFilter = "ini"))
+	UPROPERTY(EditAnywhere, Category = "Testing", Meta = (FilePathFilter = "ini", RelativeToGameDir))
 	FFilePath SettingsOverride;
 
 	UPROPERTY(EditAnywhere, Category = "Testing")

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialTestSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialTestSettings.cpp
@@ -57,7 +57,7 @@ void FSpatialTestSettings::Override(const FString& MapName)
 		}
 		else if (!SpatialWorldSettings->SettingsOverride.FilePath.IsEmpty())
 		{
-			UE_LOG(LogSpatialTestSettings, Error, TEXT("Could not find setting override file %s."), *GroupOverridesFilename);
+			UE_LOG(LogSpatialTestSettings, Error, TEXT("Could not find settings override file %s."), *GroupOverridesFilename);
 		}
 	}
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialTestSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialTestSettings.cpp
@@ -49,11 +49,15 @@ void FSpatialTestSettings::Override(const FString& MapName)
 
 	if (ASpatialWorldSettings* SpatialWorldSettings = Cast<ASpatialWorldSettings>(World->GetWorldSettings()))
 	{
-		FString GroupOverridesFilename = FPaths::ConvertRelativePathToFull(SpatialWorldSettings->SettingsOverride.FilePath);
+		FString GroupOverridesFilename = FPaths::ProjectDir() + SpatialWorldSettings->SettingsOverride.FilePath;
 		if (FPaths::FileExists(GroupOverridesFilename))
 		{
 			// Override the settings from the group specific config file, if it exists
 			Load(GroupOverridesFilename);
+		}
+		else if (!SpatialWorldSettings->SettingsOverride.FilePath.IsEmpty())
+		{
+			UE_LOG(LogSpatialTestSettings, Error, TEXT("Could not find setting override file %s."), *GroupOverridesFilename);
 		}
 	}
 


### PR DESCRIPTION
#### Description
Made the settings override the file path relative to the game directory.
Added an error message if a file is specified but cannot be found.

#### Release note
- Fixed the test settings overrides config filename in the `World Settings` so that the file path is relative to the game directory.

#### Tests
Run automated functional tests locally.

#### Documentation
Release note
