### PR TITLE
[UNR-5438] Change UNetDriver GetActorEntityId to not lazy construct

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -3113,22 +3113,14 @@ int64 USpatialNetDriver::GetClientID() const
 	return SpatialConstants::INVALID_ENTITY_ID;
 }
 
-int64 USpatialNetDriver::GetActorEntityId(AActor& Actor)
+int64 USpatialNetDriver::GetActorEntityId(const AActor& Actor) const
 {
 	if (PackageMap == nullptr)
 	{
 		return SpatialConstants::INVALID_ENTITY_ID;
 	}
 
-	int64 EntityId = PackageMap->GetEntityIdFromObject(&Actor);
-	if (EntityId == SpatialConstants::INVALID_ENTITY_ID)
-	{
-		if (IsServer() && Actor.GetIsReplicated() && (Actor.Role == ROLE_Authority))
-		{
-			EntityId = PackageMap->AllocateEntityIdAndResolveActor(&Actor);
-		}
-	}
-	return EntityId;
+	return PackageMap->GetEntityIdFromObject(&Actor);
 }
 
 bool USpatialNetDriver::HasTimedOut(const float Interval, uint64& TimeStamp)

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -266,7 +266,7 @@ public:
 
 	virtual int64 GetClientID() const override;
 
-	virtual int64 GetActorEntityId(AActor& Actor) override;
+	virtual int64 GetActorEntityId(const AActor& Actor) const override;
 
 	FShutdownEvent OnShutdown;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/EngineVersionCheck.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/EngineVersionCheck.h
@@ -7,7 +7,7 @@
 // GDK Version to be updated with SPATIAL_ENGINE_VERSION
 // when breaking changes are made to the engine that requires
 // changes to the GDK to remain compatible
-#define SPATIAL_GDK_VERSION 36
+#define SPATIAL_GDK_VERSION 37
 
 // Check if GDK is compatible with the current version of Unreal Engine
 // SPATIAL_ENGINE_VERSION is incremented in engine when breaking changes


### PR DESCRIPTION
#### Description
Changed GetActorEntityId() to not lazy construct an entityid, and the API to be const.

#### Tests
Manual.
