### PR TITLE
Client crash schema hash mismatch

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -440,10 +440,10 @@ void USpatialNetDriver::CreateAndInitializeCoreClasses()
 		PlayerSpawner = NewObject<USpatialPlayerSpawner>();
 		SnapshotManager = MakeUnique<SpatialSnapshotManager>();
 
-		MigrationDiagnosticsSystem = MakeUnique <SpatialGDK::MigrationDiagnosticsSystem>(*this);
+		MigrationDiagnosticsSystem = MakeUnique<SpatialGDK::MigrationDiagnosticsSystem>(*this);
 		DebugMetricsSystem = MakeUnique<SpatialGDK::DebugMetricsSystem>(*this);
 
-		QueryHandler = MakeUnique <SpatialGDK::EntityQueryHandler>();
+		QueryHandler = MakeUnique<SpatialGDK::EntityQueryHandler>();
 
 		if (SpatialSettings->bAsyncLoadNewClassesOnEntityCheckout)
 		{

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -222,8 +222,8 @@ public:
 	UAsyncPackageLoadFilter* AsyncPackageLoadFilter;
 
 	TUniquePtr<SpatialGDK::SpatialDebuggerSystem> SpatialDebuggerSystem;
-	TUniquePtr <SpatialGDK::MigrationDiagnosticsSystem> MigrationDiagnosticsSystem;
-	TUniquePtr <SpatialGDK::DebugMetricsSystem> DebugMetricsSystem;
+	TUniquePtr<SpatialGDK::MigrationDiagnosticsSystem> MigrationDiagnosticsSystem;
+	TUniquePtr<SpatialGDK::DebugMetricsSystem> DebugMetricsSystem;
 	TUniquePtr<SpatialGDK::ActorSystem> ActorSystem;
 	TUniquePtr<SpatialGDK::SpatialRPCService> RPCService;
 	TUniquePtr<FSpatialNetDriverRPC> RPCs;
@@ -289,7 +289,7 @@ private:
 	TUniquePtr<SpatialGDK::CrossServerRPCSender> CrossServerRPCSender;
 	TUniquePtr<SpatialGDK::CrossServerRPCHandler> CrossServerRPCHandler;
 
-	TUniquePtr <SpatialGDK::EntityQueryHandler> QueryHandler;
+	TUniquePtr<SpatialGDK::EntityQueryHandler> QueryHandler;
 
 	TMap<Worker_EntityId_Key, USpatialActorChannel*> EntityToActorChannel;
 	TSet<Worker_EntityId_Key> DormantEntities;

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -85,6 +85,8 @@ class InitialOnlyFilter;
 class CrossServerRPCSender;
 class CrossServerRPCHandler;
 class SpatialStrategySystem;
+class MigrationDiagnosticsSystem;
+class DebugMetricsSystem;
 } // namespace SpatialGDK
 
 UCLASS()
@@ -220,6 +222,8 @@ public:
 	UAsyncPackageLoadFilter* AsyncPackageLoadFilter;
 
 	TUniquePtr<SpatialGDK::SpatialDebuggerSystem> SpatialDebuggerSystem;
+	TUniquePtr <SpatialGDK::MigrationDiagnosticsSystem> MigrationDiagnosticsSystem;
+	TUniquePtr <SpatialGDK::DebugMetricsSystem> DebugMetricsSystem;
 	TUniquePtr<SpatialGDK::ActorSystem> ActorSystem;
 	TUniquePtr<SpatialGDK::SpatialRPCService> RPCService;
 	TUniquePtr<FSpatialNetDriverRPC> RPCs;
@@ -285,7 +289,7 @@ private:
 	TUniquePtr<SpatialGDK::CrossServerRPCSender> CrossServerRPCSender;
 	TUniquePtr<SpatialGDK::CrossServerRPCHandler> CrossServerRPCHandler;
 
-	SpatialGDK::EntityQueryHandler QueryHandler;
+	TUniquePtr <SpatialGDK::EntityQueryHandler> QueryHandler;
 
 	TMap<Worker_EntityId_Key, USpatialActorChannel*> EntityToActorChannel;
 	TSet<Worker_EntityId_Key> DormantEntities;


### PR DESCRIPTION
#### Description
Clean up SnapshotManager unique pointer in SpatialNetDriver::Shutdown and use additional unique pointers following the same pattern.

#### Release note
REQUIRED: Add a release note to the `##Unreleased` section of CHANGELOG.md. You can find guidance for writing useful release notes [here](../SpatialGDK/Extras/internal-documentation/how-to-write-good-release-notes.md). Documentation changes are exempt from this requirement.

#### Tests
How did you test these changes prior to submitting this pull request?
What automated tests are included in this PR?

STRONGLY SUGGESTED: How can this be verified by QA?

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

#### Reminders (IMPORTANT)
If your change relies on a breaking engine change:
* Increment `SPATIAL_ENGINE_VERSION` in `Engine\Source\Runtime\Launch\Resources\SpatialVersion.h` (in the engine fork) as well as `SPATIAL_GDK_VERSION` in `SpatialGDK\Source\SpatialGDK\Public\Utils\EngineVersionCheck.h`. This helps others by providing a more helpful message during compilation to make sure the GDK and the Engine are up to date.

If your change updates `Setup.bat`, `Setup.sh`, core SDK version, any C# tools in `SpatialGDK\Build\Programs\Improbable.Unreal.Scripts`, or hand-written schema in `SpatialGDK\Extras\schema`:
* Increment the number in `RequireSetup`. This will automatically run `Setup.bat` or `Setup.sh` when the GDK is next pulled.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
