### PR TITLE
Client crash schema hash mismatch 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the test settings overrides config filename in `Spatial World Settings` so that the file path is relative to the game directory.
 - Fix editor encountering exceptions when shutting down during a PIE session.
 - Fixed a rare issue where one would see a change to the owner field but not the changes to owner-only fields.
+- Prevented a client crash that occurs if there is a mismatch between the client and server schema hash.
 
 ### Internal:
 - Hide the Test MultiworkerSettings and GridStrategy classes from displaying in the editor. These are meant to only be used in Tests.

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -687,7 +687,8 @@ void USpatialNetDriver::ClientOnGSMQuerySuccess()
 					"version = '%llu'"),
 			   SnapshotVersion, SpatialConstants::SPATIAL_SNAPSHOT_VERSION);
 
-		NetworkFailureError = TEXT("Your snapshot version of the game does not match that of the server. Please try updating your game snapshot.");
+		NetworkFailureError =
+			TEXT("Your snapshot version of the game does not match that of the server. Please try updating your game snapshot.");
 
 		return;
 	}
@@ -702,7 +703,8 @@ void USpatialNetDriver::ClientOnGSMQuerySuccess()
 				   TEXT("Your client's schema does not match your deployment's schema. Client hash: '%u' Server hash: '%u'"),
 				   ClassInfoManager->SchemaDatabase->SchemaBundleHash, ServerHash);
 
-			NetworkFailureError = TEXT("Your version of the game does not match that of the server. Please try updating your game version.");
+			NetworkFailureError =
+				TEXT("Your version of the game does not match that of the server. Please try updating your game version.");
 			return;
 		}
 
@@ -2363,7 +2365,7 @@ void USpatialNetDriver::TickDispatch(float DeltaTime)
 	}
 
 	// Broadcast network failure if any network errors occurred
-	// NOTE: this should be performed at the end of this function to prevent network disconnection errors  
+	// NOTE: this should be performed at the end of this function to prevent network disconnection errors
 	if (!NetworkFailureError.IsEmpty())
 	{
 		if (USpatialGameInstance* GameInstance = GetGameInstance())

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -2365,7 +2365,7 @@ void USpatialNetDriver::TickDispatch(float DeltaTime)
 	}
 
 	// Broadcast network failure if any network errors occurred
-	// NOTE: this should be performed at the end of this function to prevent network disconnection errors
+	// NOTE: This should be performed at the end of this function to avoid shutting down the net driver while still running tick functions and indirectly destroying resources that those functions are still using.
 	if (!NetworkFailureError.IsEmpty())
 	{
 		if (USpatialGameInstance* GameInstance = GetGameInstance())

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -2368,7 +2368,8 @@ void USpatialNetDriver::TickDispatch(float DeltaTime)
 	}
 
 	// Broadcast network failure if any network errors occurred
-	// NOTE: This should be performed at the end of this function to avoid shutting down the net driver while still running tick functions and indirectly destroying resources that those functions are still using.
+	// NOTE: This should be performed at the end of this function to avoid shutting down the net driver while still running tick functions
+	// and indirectly destroying resources that those functions are still using.
 	if (PendingNetworkFailure)
 	{
 		if (USpatialGameInstance* GameInstance = GetGameInstance())

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -302,6 +302,7 @@ private:
 	bool bIsReadyToStart;
 	bool bMapLoaded;
 
+	FString NetworkFailureError;
 	FString SnapshotToLoad;
 
 	// Client variable which stores the SessionId given to us by the server in the URL options.

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+
+#include "Engine/EngineBaseTypes.h"
 #include "Interop/CrossServerRPCHandler.h"
 #include "Interop/Connection/ConnectionConfig.h"
 #include "Interop/CrossServerRPCSender.h"
@@ -304,7 +306,7 @@ private:
 
 	struct FPendingNetworkFailure
 	{
-		ENetworkFailure FailureType;
+		ENetworkFailure::Type FailureType;
 		FString Message;
 	};
 	TOptional<FPendingNetworkFailure> PendingNetworkFailure;

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -2,9 +2,8 @@
 
 #pragma once
 
-
-#include "Engine/EngineBaseTypes.h"
 #include "Interop/CrossServerRPCHandler.h"
+#include "Engine/EngineBaseTypes.h"
 #include "Interop/Connection/ConnectionConfig.h"
 #include "Interop/CrossServerRPCSender.h"
 #include "Interop/EntityQueryHandler.h"

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -302,7 +302,12 @@ private:
 	bool bIsReadyToStart;
 	bool bMapLoaded;
 
-	FString NetworkFailureError;
+	struct FPendingNetworkFailure
+	{
+		ENetworkFailure FailureType;
+		FString Message;
+	};
+	TOptional<FPendingNetworkFailure> PendingNetworkFailure;
 	FString SnapshotToLoad;
 
 	// Client variable which stores the SessionId given to us by the server in the URL options.


### PR DESCRIPTION
#### Description
Broadcast network failure if any network errors occurred at the end of the TickDispatch function.

#### Release note
Prevented client crash that occurs if there is a mismatch between the client and server schema hash.

#### Tests
Manual tests using the repro steps in the JIRA ticket.

#### Documentation
Release note.
