### PR TITLE
Disable TestDebugInterface because of flakyness.

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/DebugInterface/SpatialDebugInterfaceTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/DebugInterface/SpatialDebugInterfaceTest.cpp
@@ -437,7 +437,7 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 }
 
 USpatialDebugInterfaceMap::USpatialDebugInterfaceMap()
-	: UGeneratedTestMap(EMapCategory::CI_PREMERGE_SPATIAL_ONLY, TEXT("SpatialDebugInterfaceMap"))
+	: UGeneratedTestMap(EMapCategory::NO_CI, TEXT("SpatialDebugInterfaceMap"))
 {
 }
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/DebugInterface/SpatialDebugInterfaceTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/DebugInterface/SpatialDebugInterfaceTest.cpp
@@ -437,6 +437,7 @@ void ASpatialDebugInterfaceTest::PrepareTest()
 }
 
 USpatialDebugInterfaceMap::USpatialDebugInterfaceMap()
+	// TODO: make EMapCategory::CI_PREMERGE_SPATIAL_ONLY when fixed UNR-5141
 	: UGeneratedTestMap(EMapCategory::NO_CI, TEXT("SpatialDebugInterfaceMap"))
 {
 }


### PR DESCRIPTION
#### Description
Disable the DebugInterface test until either we get time to debug it, or we decide what to do with flaky tests.
