### PR TITLE
Fixes UNR-5610 - UnrealGDK/Setup.sh throws `sed: can't read : No such file or directory`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a rare issue where one would see a change to the owner field but not the changes to owner-only fields.
 - Prevented a client crash that occurs if there is a mismatch between the client and server schema hash.
 - Fixed an issue for actors with bNetLoadOnClient. A dynamic subobject removed from such an actor while out of a client's view will now be properly removed on the client when the actor comes back into the client's view.
+- Fixed an issue that caused `UnrealGDK/Setup.sh` to report `sed: can't read : No such file or directory` when run on macOS.
 
 ### Internal:
 - Hide the Test MultiworkerSettings and GridStrategy classes from displaying in the editor. These are meant to only be used in Tests.

--- a/RequireSetup
+++ b/RequireSetup
@@ -1,4 +1,4 @@
-Increment the below number whenever it is required to run Setup.bat as part of a new commit.
+Increment the below number whenever it is required to run Setup.bat or Setup.sh as part of a new commit.
 Our git hooks will detect this file has been updated and automatically run Setup.bat on pull.
 
-87
+88

--- a/Setup.sh
+++ b/Setup.sh
@@ -42,7 +42,7 @@ if [[ -e .git/hooks ]]; then
     cp -R "$(pwd)/SpatialGDK/Extras/git/." "$(pwd)/.git/hooks"
 
     # We pass Setup.sh args, such as --mobile, to the post-merge hook to run Setup.sh with the same args in future.
-    sed -i "" -e "s/SETUP_ARGS/$*/g" .git/hooks/post-merge
+    sed -i -e "s/SETUP_ARGS/$*/g" .git/hooks/post-merge
 
     # This needs to be runnable.
     chmod +x .git/hooks/pre-commit


### PR DESCRIPTION
#### Description
* Fixes: [UNR-5610](https://improbableio.atlassian.net/browse/UNR-5610) - UnrealGDK/Setup.sh throws `sed: can't read : No such file or directory`
* This defect was discovered while I was working on: https://github.com/improbableio/UnrealEngine/pull/953

#### Release note
See CHANGELOG.

#### Tests
* Tested on macOS Big Sur
* Tested the full install path, the incremental install path, the CN & Mobile paths

#### Documentation
CHANGELOG entry will suffice.

#### I also did this
If your change updates `Setup.bat`, `Setup.sh`, core SDK version, any C# tools in `SpatialGDK\Build\Programs\Improbable.Unreal.Scripts`, or hand-written schema in `SpatialGDK\Extras\schema`:
* Increment the number in `RequireSetup`. This will automatically run `Setup.bat` or `Setup.sh` when the GDK is next pulled.

#### Primary reviewers
@MatthewSandfordImprobable 
