### PR TITLE
UNR-5530 Gameplay debugger interest setup

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/InterestFactory.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/InterestFactory.h
@@ -30,6 +30,7 @@
  * made by that server worker.
  */
 
+class AGameplayDebuggerCategoryReplicator;
 class UAbstractLBStrategy;
 class USpatialClassInfoManager;
 class USpatialPackageMapClient;
@@ -69,6 +70,11 @@ private:
 
 	// Defined Constraint AND Level Constraint
 	void AddClientPlayerControllerActorInterest(Interest& OutInterest, const AActor* InActor, const FClassInfo& InInfo) const;
+#if WITH_UNREAL_DEVELOPER_TOOLS || (!UE_BUILD_SHIPPING && !UE_BUILD_TEST)
+	// Entity ID query for the player controller responsible for the replicator
+	void AddServerGameplayDebuggerCategoryReplicatorActorInterest(Interest& OutInterest,
+																  const AGameplayDebuggerCategoryReplicator& Replicator) const;
+#endif
 	// The components clients need to see on entities they have authority over that they don't already see through authority.
 	void AddClientSelfInterest(Interest& OutInterest) const;
 	// The components servers need to see on entities they have authority over that they don't already see through authority.

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/InterestFactory.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/InterestFactory.h
@@ -70,7 +70,7 @@ private:
 
 	// Defined Constraint AND Level Constraint
 	void AddClientPlayerControllerActorInterest(Interest& OutInterest, const AActor* InActor, const FClassInfo& InInfo) const;
-#if WITH_UNREAL_DEVELOPER_TOOLS || (!UE_BUILD_SHIPPING && !UE_BUILD_TEST)
+#if WITH_GAMEPLAY_DEBUGGER
 	// Entity ID query for the player controller responsible for the replicator
 	void AddServerGameplayDebuggerCategoryReplicatorActorInterest(Interest& OutInterest,
 																  const AGameplayDebuggerCategoryReplicator& Replicator) const;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialActorUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialActorUtils.h
@@ -14,7 +14,7 @@
 #include "GameFramework/PlayerController.h"
 #include "Math/Vector.h"
 
-#if WITH_UNREAL_DEVELOPER_TOOLS || (!UE_BUILD_SHIPPING && !UE_BUILD_TEST)
+#if WITH_GAMEPLAY_DEBUGGER
 #include "GameplayDebuggerCategoryReplicator.h"
 #endif
 
@@ -108,7 +108,7 @@ inline FVector GetActorSpatialPosition(const AActor* InActor)
 inline bool DoesActorClassIgnoreVisibilityCheck(AActor* InActor)
 {
 	if (InActor->IsA(APlayerController::StaticClass()) || InActor->IsA(AGameModeBase::StaticClass())
-#if WITH_UNREAL_DEVELOPER_TOOLS || (!UE_BUILD_SHIPPING && !UE_BUILD_TEST)
+#if WITH_GAMEPLAY_DEBUGGER
 		|| InActor->IsA(AGameplayDebuggerCategoryReplicator::StaticClass())
 #endif
 	)


### PR DESCRIPTION
#### Description
This PR changes the `InterestFactory` to add an extra query to `GameplayDebuggerCategoryReplicator` actors ensuring that the auth server can see the owning `PlayerController`. Right now, this is a no-op change since the auth server for the player controller and the replicator are always the same one, so interest is maintained through authority. However, once we start decoupling them (see [design doc](https://brevi.link/multiworker-gameplay-debugger-design)) we have to ensure that whatever server gains authority over the replicator doesn't lose track of the owning player controller actor.

#### Release note
N/A, will follow as part of full feature release

#### Tests
Inspector shows the query being successfully added in the multi worker world composition gym:
![pcinterest](https://user-images.githubusercontent.com/21201120/121031323-25ef4800-c7a2-11eb-9d68-34394a751abe.png)
In this case, entity 3009 is the one representing the player controller.

#### Documentation
N/A, will follow as part of full feature release