### PR TITLE
Feature/worker health prototype

### DIFF
--- a/SpatialGDK/Extras/schema/server_worker.schema
+++ b/SpatialGDK/Extras/schema/server_worker.schema
@@ -21,16 +21,19 @@ component ServerWorker {
     string worker_name = 1;
     bool ready_to_begin_play = 2;
     EntityId server_system_entity_id = 3;
+    bool healthy = 4;
+    int32 healthy_as_of = 5;
+    uint32 virtual_worker_id = 6;
     command ForwardSpawnPlayerResponse forward_spawn_player(ForwardSpawnPlayerRequest);
 }
 
 component_set ServerWorkerAuthComponentSet {
   id = 9908;
   components = [
-	improbable.Position,
-	improbable.Metadata,
-	improbable.Interest,
-	unreal.ServerWorker,
-	unreal.generated.UnrealCrossServerSenderRPCs
+    improbable.Position,
+    improbable.Metadata,
+    improbable.Interest,
+    unreal.ServerWorker,
+    unreal.generated.UnrealCrossServerSenderRPCs
   ];
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -1309,3 +1309,19 @@ void FObjectReferencesMapDeleter::operator()(FObjectReferencesMap* Ptr) const
 {
 	delete Ptr;
 }
+
+// NotifyMigrationFailed finds a safe position for the actor and broadcasts that to who ever is listening.
+void USpatialActorChannel::NotifyMigrationFailed()
+{
+	FVector2D SafePosition;
+	if(NetDriver->LoadBalanceStrategy->GetSafePositionForActor(*Actor, SafePosition))
+	{
+		OnActorMigrationFailed.Broadcast(SafePosition);
+	}
+	else
+	{
+		UE_LOG(LogSpatialActorChannel, Error,
+			TEXT("Actor has transitioned to a bad worker, we need to rescue them: %s"), *Actor->GetName());
+	}
+}
+

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialLoadBalancingHandler.cpp
@@ -122,15 +122,13 @@ FSpatialLoadBalancingHandler::EvaluateActorResult FSpatialLoadBalancingHandler::
 
 				if (NewAuthVirtualWorkerId == SpatialConstants::INVALID_VIRTUAL_WORKER_ID)
 				{
-					UE_LOG(LogSpatialLoadBalancingHandler, Error,
-						   TEXT("Load Balancing Strategy returned invalid virtual worker for actor %s"), *Actor->GetName());
-				}
-				else if (!bShouldHaveAuthority && NewAuthVirtualWorkerId == NetDriver->LoadBalanceStrategy->GetLocalVirtualWorkerId())
-				{
-					UE_LOG(LogSpatialLoadBalancingHandler, Error,
-						   TEXT("ShouldHaveAuthority returned false for actor %s, but WhoShouldHaveAuthority returned this worker's id. "
-								"Actor will not be migrated."),
-						   *Actor->GetName());
+					if (USpatialActorChannel* Channel = NetDriver->GetOrCreateSpatialActorChannel(NetOwner))
+					{
+						Channel->NotifyMigrationFailed();
+					}
+
+					//UE_LOG(LogSpatialLoadBalancingHandler, Error,
+					//	   TEXT("Load Balancing Strategy returned invalid virtual worker for actor %s"), *Actor->GetName());
 				}
 				else
 				{

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -271,6 +271,11 @@ public:
 
 	bool NeedOwnerInterestUpdate() const { return bNeedOwnerInterestUpdate; }
 
+	DECLARE_MULTICAST_DELEGATE_OneParam(FOnActorMigrationFailed, const FVector2D&);
+	FOnActorMigrationFailed OnActorMigrationFailed;
+	void NotifyMigrationFailed();
+
+
 protected:
 	// Begin UChannel interface
 	virtual bool CleanUp(const bool bForDestroy, EChannelCloseReason CloseReason) override;

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialWorkerConnection.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialWorkerConnection.h
@@ -9,6 +9,7 @@
 
 #include "SpatialCommonTypes.h"
 #include "SpatialConstants.h"
+#include "Schema/ServerWorker.h"
 #include "SpatialView/EntityView.h"
 #include "SpatialView/OpList/ExtractedOpList.h"
 #include "SpatialView/OpList/OpList.h"
@@ -27,6 +28,7 @@ public:
 	ServerWorkerEntityCreator(USpatialNetDriver& InNetDriver, USpatialWorkerConnection& InConnection);
 	void CreateWorkerEntity();
 	void ProcessOps(const TArray<Worker_Op>& Ops);
+	bool Tick(const float Delta);
 
 private:
 	void OnEntityCreated(const Worker_CreateEntityResponseOp& Op);
@@ -42,6 +44,8 @@ private:
 
 	CreateEntityHandler CreateEntityHandler;
 	ClaimPartitionHandler ClaimPartitionHandler;
+	float TimeSinceLastUpdate;
+	TMap<Worker_EntityId_Key, ServerWorker> ServerWorkers;
 };
 } // namespace SpatialGDK
 
@@ -121,6 +125,7 @@ public:
 
 	SpatialGDK::SpatialEventTracer* GetEventTracer() const { return EventTracer; }
 
+	bool bHealthy = true;
 private:
 	TOptional<SpatialGDK::ServerWorkerEntityCreator> WorkerEntityCreator;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLBStrategy.h
@@ -52,6 +52,20 @@ public:
 	virtual SpatialGDK::FActorLoadBalancingGroupId GetActorGroupId(const AActor& Actor) const
 		PURE_VIRTUAL(UAbstractLBStrategy::GetActorGroupId, return 0;);
 
+
+	virtual void SetLocalVirtualWorkerHealth(VirtualWorkerId WorkerId, bool Healthy) {};
+
+	/**
+	 * GetSafeActorPosition returns a safe position to teleport the player to assuming there are areas in the load balancer
+	 * that are not safe for the actor to be in.  This allows for a worker to crash, and we redirect actors to a safe location.
+	 *
+	 * The position is a 2D position, you will need to trace down to find the correct height in world.
+	 *
+	 * Returns false if there is no safe position.
+	 */
+	virtual bool GetSafePositionForActor(const AActor& Actor, FVector2D& SafePosition) const { return false; }
+
+
 	/**
 	 * Get a logical worker entity position for this strategy. For example, the centre of a grid square in a grid-based strategy.
 	 * Optional- otherwise returns the origin.

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/GridBasedLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/GridBasedLBStrategy.h
@@ -48,6 +48,10 @@ public:
 	virtual VirtualWorkerId WhoShouldHaveAuthority(const AActor& Actor) const override;
 	virtual SpatialGDK::FActorLoadBalancingGroupId GetActorGroupId(const AActor& Actor) const override;
 
+	virtual void SetLocalVirtualWorkerHealth(const VirtualWorkerId WorkerId, const bool Healthy) override;
+	virtual bool GetSafePositionForActor(const AActor& Actor, FVector2D& SafePosition) const override;
+
+
 	virtual SpatialGDK::QueryConstraint GetWorkerInterestQueryConstraint(const VirtualWorkerId VirtualWorker) const override;
 
 	virtual bool RequiresHandoverData() const override { return Rows * Cols > 1; }
@@ -83,6 +87,9 @@ protected:
 
 private:
 	TArray<VirtualWorkerId> VirtualWorkerIds;
+
+	TArray<bool> VirtualWorkerHealth;
+
 
 	TArray<FBox2D> WorkerCells;
 	uint32 LocalCellId;

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LayeredLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LayeredLBStrategy.h
@@ -47,6 +47,10 @@ public:
 	virtual VirtualWorkerId WhoShouldHaveAuthority(const AActor& Actor) const override;
 	virtual SpatialGDK::FActorLoadBalancingGroupId GetActorGroupId(const AActor& Actor) const override;
 
+	virtual void SetLocalVirtualWorkerHealth(VirtualWorkerId WorkerId, bool Healthy) override;
+	virtual bool GetSafePositionForActor(const AActor& Actor, FVector2D& SafePosition) const override;
+
+
 	virtual SpatialGDK::QueryConstraint GetWorkerInterestQueryConstraint(const VirtualWorkerId VirtualWorker) const override;
 
 	virtual bool RequiresHandoverData() const override;

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/ServerWorker.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/ServerWorker.h
@@ -9,6 +9,7 @@
 #include "Utils/SchemaUtils.h"
 
 #include "Containers/UnrealString.h"
+#include "Logging/LogMacros.h"
 
 #include <WorkerSDK/improbable/c_schema.h>
 #include <WorkerSDK/improbable/c_worker.h>
@@ -26,14 +27,20 @@ struct ServerWorker : Component
 		: WorkerName(SpatialConstants::INVALID_WORKER_NAME)
 		, bReadyToBeginPlay(false)
 		, SystemEntityId(SpatialConstants::INVALID_ENTITY_ID)
+		, bHealthy(false)
+		, HealthyAsOf(0)
+		, VirtualWorkerId(0)
 	{
 	}
 
-	ServerWorker(const PhysicalWorkerName& InWorkerName, const bool bInReadyToBeginPlay, const Worker_EntityId InSystemEntityId)
+	ServerWorker(const PhysicalWorkerName& InWorkerName, const bool bInReadyToBeginPlay, const Worker_EntityId InSystemEntityId, const bool bInHealthy, const int32 InHealthyAsOf, const uint32 InVirtualWorkerId)
 	{
 		WorkerName = InWorkerName;
 		bReadyToBeginPlay = bInReadyToBeginPlay;
 		SystemEntityId = InSystemEntityId;
+		bHealthy = bInHealthy;
+		HealthyAsOf = InHealthyAsOf;
+		VirtualWorkerId = InVirtualWorkerId;
 	}
 
 	ServerWorker(const Worker_ComponentData& Data)
@@ -43,6 +50,9 @@ struct ServerWorker : Component
 		WorkerName = GetStringFromSchema(ComponentObject, SpatialConstants::SERVER_WORKER_NAME_ID);
 		bReadyToBeginPlay = GetBoolFromSchema(ComponentObject, SpatialConstants::SERVER_WORKER_READY_TO_BEGIN_PLAY_ID);
 		SystemEntityId = Schema_GetEntityId(ComponentObject, SpatialConstants::SERVER_WORKER_SYSTEM_ENTITY_ID);
+		bHealthy = GetBoolFromSchema(ComponentObject, SpatialConstants::SERVER_WORKER_HEALTHY_ID);
+		HealthyAsOf = Schema_GetInt32(ComponentObject, SpatialConstants::SERVER_WORKER_HEALTHY_AS_OF_ID);
+		VirtualWorkerId = Schema_GetUint32(ComponentObject, SpatialConstants::SERVER_WORKER_VIRTUAL_WORKER_ID);
 	}
 
 	Worker_ComponentData CreateServerWorkerData()
@@ -55,6 +65,9 @@ struct ServerWorker : Component
 		AddStringToSchema(ComponentObject, SpatialConstants::SERVER_WORKER_NAME_ID, WorkerName);
 		Schema_AddBool(ComponentObject, SpatialConstants::SERVER_WORKER_READY_TO_BEGIN_PLAY_ID, bReadyToBeginPlay);
 		Schema_AddEntityId(ComponentObject, SpatialConstants::SERVER_WORKER_SYSTEM_ENTITY_ID, SystemEntityId);
+		Schema_AddBool(ComponentObject, SpatialConstants::SERVER_WORKER_HEALTHY_ID, bHealthy);
+		Schema_AddInt32(ComponentObject, SpatialConstants::SERVER_WORKER_HEALTHY_AS_OF_ID, HealthyAsOf);
+		Schema_AddUint32(ComponentObject, SpatialConstants::SERVER_WORKER_VIRTUAL_WORKER_ID, VirtualWorkerId);
 
 		return Data;
 	}
@@ -69,6 +82,9 @@ struct ServerWorker : Component
 		AddStringToSchema(ComponentObject, SpatialConstants::SERVER_WORKER_NAME_ID, WorkerName);
 		Schema_AddBool(ComponentObject, SpatialConstants::SERVER_WORKER_READY_TO_BEGIN_PLAY_ID, bReadyToBeginPlay);
 		Schema_AddEntityId(ComponentObject, SpatialConstants::SERVER_WORKER_SYSTEM_ENTITY_ID, SystemEntityId);
+		Schema_AddBool(ComponentObject, SpatialConstants::SERVER_WORKER_HEALTHY_ID, bHealthy);
+		Schema_AddInt32(ComponentObject, SpatialConstants::SERVER_WORKER_HEALTHY_AS_OF_ID, HealthyAsOf);
+		Schema_AddUint32(ComponentObject, SpatialConstants::SERVER_WORKER_VIRTUAL_WORKER_ID, VirtualWorkerId);
 
 		return Update;
 	}
@@ -80,6 +96,9 @@ struct ServerWorker : Component
 		WorkerName = GetStringFromSchema(ComponentObject, SpatialConstants::SERVER_WORKER_NAME_ID);
 		bReadyToBeginPlay = GetBoolFromSchema(ComponentObject, SpatialConstants::SERVER_WORKER_READY_TO_BEGIN_PLAY_ID);
 		SystemEntityId = Schema_GetEntityId(ComponentObject, SpatialConstants::SERVER_WORKER_SYSTEM_ENTITY_ID);
+		bHealthy = GetBoolFromSchema(ComponentObject, SpatialConstants::SERVER_WORKER_HEALTHY_ID);
+		HealthyAsOf = Schema_GetInt32(ComponentObject, SpatialConstants::SERVER_WORKER_HEALTHY_AS_OF_ID);
+		VirtualWorkerId = Schema_GetUint32(ComponentObject, SpatialConstants::SERVER_WORKER_VIRTUAL_WORKER_ID);
 	}
 
 	static Worker_CommandRequest CreateForwardPlayerSpawnRequest(Schema_CommandRequest* SchemaCommandRequest)
@@ -121,6 +140,9 @@ struct ServerWorker : Component
 	PhysicalWorkerName WorkerName;
 	bool bReadyToBeginPlay;
 	Worker_EntityId SystemEntityId;
+	bool bHealthy;
+	int32 HealthyAsOf;
+	uint32 VirtualWorkerId;
 };
 
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.cxx
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.cxx
@@ -179,6 +179,8 @@ const TArray<Worker_ComponentId> REQUIRED_COMPONENTS_FOR_NON_AUTH_SERVER_INTERES
     ACTOR_OWNER_ONLY_DATA_TAG_COMPONENT_ID,
 
     ACTOR_OWNERSHIP_COMPONENT_ID,
+    // ServerWorker component lets us see if other workers are healthy.
+    SERVER_WORKER_COMPONENT_ID
 };
 
 const TArray<Worker_ComponentId> REQUIRED_COMPONENTS_FOR_AUTH_SERVER_INTEREST =
@@ -207,6 +209,7 @@ const TArray<FString> ServerAuthorityWellKnownSchemaImports = {
     "unreal/gdk/query_tags.schema",
     "unreal/gdk/relevant.schema",
     "unreal/gdk/rpc_components.schema",
+    "unreal/gdk/server_worker.schema",
     "unreal/gdk/spatial_debugging.schema",
     "unreal/gdk/spawndata.schema",
     "unreal/gdk/tombstone.schema",
@@ -244,6 +247,7 @@ const TMap<Worker_ComponentId, FString> ServerAuthorityWellKnownComponents = {
     { CROSS_SERVER_RECEIVER_ACK_ENDPOINT_COMPONENT_ID, "unreal.generated.UnrealCrossServerReceiverACKRPCs" },
 	{ MIGRATION_DIAGNOSTIC_COMPONENT_ID, "unreal.MigrationDiagnostic" },
 	{ ACTOR_OWNERSHIP_COMPONENT_ID, "unreal.ActorOwnership" },
+    { SERVER_WORKER_COMPONENT_ID, "unreal.ServerWorker"},
 };
 
 const TArray<FString> ClientAuthorityWellKnownSchemaImports = { "unreal/gdk/player_controller.schema", "unreal/gdk/rpc_components.schema",

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -236,6 +236,9 @@ const Schema_FieldId SPATIAL_DEBUGGING_IS_LOCKED = 5;
 const Schema_FieldId SERVER_WORKER_NAME_ID = 1;
 const Schema_FieldId SERVER_WORKER_READY_TO_BEGIN_PLAY_ID = 2;
 const Schema_FieldId SERVER_WORKER_SYSTEM_ENTITY_ID = 3;
+const Schema_FieldId SERVER_WORKER_HEALTHY_ID = 4;
+const Schema_FieldId SERVER_WORKER_HEALTHY_AS_OF_ID = 5;
+const Schema_FieldId SERVER_WORKER_VIRTUAL_WORKER_ID = 6;
 const Schema_FieldId SERVER_WORKER_FORWARD_SPAWN_REQUEST_COMMAND_ID = 1;
 
 // SpawnPlayerRequest type IDs.


### PR DESCRIPTION
This is a FYI/initial feedback type PR, and not something I'm looking to actively merge to the GDK.

On our project we want to handle several cases where too many players may end up on a worker, or other reasons that a worker may become unavailable(Like a worker has crashed).

1st: I adjust the load balancer to have a delegate it can fire that indicates that an actor migration has failed.  We then provide a safe space where the actor can be teleported to.  It's not the GDK's responsibility to move the actor to the safe space, but it's up to the game to decide what to do with that data.  We're only able to provide a 2d coord and need to find a safe space on terrain, etc to successfully teleport the player to a safe space.

2nd: I store Healthy/HealthyAsOf, and the virtual worker assigned to that server worker.  This can be used to detect a worker that has crashed(stale HealthyAsOf value), or a worker that has decided to mark itself as unhealthy(Healthy set to false).  This is to mitigate too many players on a worker, or if a worker just needs a break for a little while.

Almost all of this code is foreign to me, so I'm guessing I've put things in the wrong places, or done things generally the wrong way, so any better ways of accomplishing the same would be appreciated.