### PR TITLE
Revert "Fix spatial flow controller registration" 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue for actors with bNetLoadOnClient. A dynamic subobject removed from such an actor while out of a client's view will now be properly removed on the client when the actor comes back into the client's view.
 - Fixed an issue that caused `UnrealGDK/Setup.sh` to report `sed: can't read : No such file or directory` when run on macOS.
 - Fixed an issue where multicast rpcs could be overwritten and then dropped on authority flicker.
-- Fixed an issue with registering spatial flow controllers in the Spatial Testing Framework.
 
 ### Internal:
 - Hide the Test MultiworkerSettings and GridStrategy classes from displaying in the editor. These are meant to only be used in Tests.

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
@@ -425,9 +425,13 @@ void ASpatialFunctionalTest::RegisterFlowController(ASpatialFunctionalTestFlowCo
 {
 	if (FlowController->IsLocalController())
 	{
-		checkf(LocalFlowController == nullptr, TEXT("OwningTest already had a LocalFlowController, this shouldn't happen"));
+		if (LocalFlowController != nullptr)
+		{
+			checkf(LocalFlowController == FlowController,
+				   TEXT("OwningTest already had different LocalFlowController, this shouldn't happen"));
+			return;
+		}
 		LocalFlowController = FlowController;
-		LocalFlowController->TrySetReadyToRunTest();
 	}
 
 	if (!HasAuthority())
@@ -441,7 +445,7 @@ void ASpatialFunctionalTest::RegisterFlowController(ASpatialFunctionalTestFlowCo
 		// Since Clients can spawn on any worker we need to centralize the assignment of their ids to the Test Authority.
 		FlowControllerSpawner.AssignClientFlowControllerId(FlowController);
 	}
-	checkf(!FlowControllers.Contains(FlowController), TEXT("Auth test already registered this flow controller, this shouldn't happen"));
+
 	FlowControllers.Add(FlowController);
 }
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestFlowController.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestFlowController.cpp
@@ -30,6 +30,7 @@ ASpatialFunctionalTestFlowController::ASpatialFunctionalTestFlowController(const
 #endif
 	OwningTest = nullptr;
 	bHasAckFinishedTest = true;
+	bReadyToRegisterWithTest = false;
 	bIsReadyToRunTest = false;
 }
 
@@ -37,10 +38,29 @@ void ASpatialFunctionalTestFlowController::GetLifetimeReplicatedProps(TArray<FLi
 {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 
+	DOREPLIFETIME(ASpatialFunctionalTestFlowController, bReadyToRegisterWithTest);
 	DOREPLIFETIME(ASpatialFunctionalTestFlowController, bIsReadyToRunTest);
 	DOREPLIFETIME(ASpatialFunctionalTestFlowController, bHasAckFinishedTest);
 	DOREPLIFETIME(ASpatialFunctionalTestFlowController, OwningTest);
 	DOREPLIFETIME(ASpatialFunctionalTestFlowController, WorkerDefinition);
+}
+
+void ASpatialFunctionalTestFlowController::BeginPlay()
+{
+	Super::BeginPlay();
+
+	if (HasAuthority())
+	{
+		// Super hack
+		FTimerHandle Handle;
+		GetWorldTimerManager().SetTimer(
+			Handle,
+			[this]() {
+				bReadyToRegisterWithTest = true;
+				OnReadyToRegisterWithTest();
+			},
+			1.0f, false);
+	}
 }
 
 void ASpatialFunctionalTestFlowController::OnAuthorityGained() {}
@@ -65,32 +85,28 @@ void ASpatialFunctionalTestFlowController::CrossServerSetWorkerId_Implementation
 	WorkerDefinition.Id = NewWorkerId;
 }
 
+void ASpatialFunctionalTestFlowController::OnReadyToRegisterWithTest()
+{
+	TryRegisterFlowControllerWithOwningTest();
+}
+
 void ASpatialFunctionalTestFlowController::OnRep_OwningTest()
 {
-	// Register replicated flow controllers
-	RegisterFlowController();
+	TryRegisterFlowControllerWithOwningTest();
 }
 
-void ASpatialFunctionalTestFlowController::RegisterFlowController()
+void ASpatialFunctionalTestFlowController::TryRegisterFlowControllerWithOwningTest()
 {
-	OwningTest->RegisterFlowController(this);
-}
-
-void ASpatialFunctionalTestFlowController::TrySetReadyToRunTest()
-{
-	if (IsLocalController())
+	if (!bReadyToRegisterWithTest || OwningTest == nullptr)
 	{
-		if (HasActorBegunPlay() && IsActorReady() && OwningTest->HasActorBegunPlay() && OwningTest->IsActorReady()
-			&& OwningTest->HasPreparedTest())
-		{
-			SetReadyToRunTest(true);
-		}
-		else
-		{
-			GetWorld()->GetTimerManager().SetTimerForNextTick([this]() {
-				TrySetReadyToRunTest();
-			});
-		}
+		return;
+	}
+
+	OwningTest->RegisterFlowController(this);
+
+	if (OwningTest->HasPreparedTest())
+	{
+		SetReadyToRunTest(true);
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestFlowControllerSpawner.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestFlowControllerSpawner.cpp
@@ -48,8 +48,6 @@ ASpatialFunctionalTestFlowController* SpatialFunctionalTestFlowControllerSpawner
 	ServerFlowController->FinishSpawning(FTransform(), true);
 	// TODO: Replace locking with custom LB strategy - UNR-3393
 	LockFlowControllerDelegations(ServerFlowController);
-	// register the auth flow controller
-	ServerFlowController->RegisterFlowController();
 
 	return ServerFlowController;
 }
@@ -66,8 +64,6 @@ ASpatialFunctionalTestFlowController* SpatialFunctionalTestFlowControllerSpawner
 						   INVALID_FLOW_CONTROLLER_ID }; // by default have invalid id, Test Authority will set it to ensure uniqueness
 
 	FlowController->FinishSpawning(OwningTest->GetActorTransform(), true);
-	// register the auth flow controller
-	FlowController->RegisterFlowController();
 
 	return FlowController;
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTestFlowController.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTestFlowController.h
@@ -24,6 +24,8 @@ public:
 
 	void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
 
+	virtual void BeginPlay() override;
+
 	virtual void OnAuthorityGained() override;
 
 	virtual void Tick(float DeltaSeconds) override;
@@ -77,15 +79,14 @@ public:
 	bool HasAckFinishedTest() const { return bHasAckFinishedTest; }
 
 	UFUNCTION()
-	void RegisterFlowController();
-	UFUNCTION()
-	void TrySetReadyToRunTest();
-	UFUNCTION()
 	void DeregisterFlowController();
 
 private:
 	// Current Step being executed
 	SpatialFunctionalTestStep CurrentStep;
+
+	UPROPERTY(ReplicatedUsing = OnReadyToRegisterWithTest)
+	uint8 bReadyToRegisterWithTest : 1;
 
 	UPROPERTY(Replicated)
 	bool bIsReadyToRunTest;
@@ -94,7 +95,12 @@ private:
 	bool bHasAckFinishedTest;
 
 	UFUNCTION()
+	void OnReadyToRegisterWithTest();
+
+	UFUNCTION()
 	void OnRep_OwningTest();
+
+	void TryRegisterFlowControllerWithOwningTest();
 
 	UFUNCTION(Server, Reliable)
 	void ServerSetReadyToRunTest(bool bIsReady);


### PR DESCRIPTION
Reverted https://github.com/spatialos/UnrealGDK/pull/3175 . This caused native tests to fail as the number of registered clients was wrong.