### PR TITLE
Added missing 'ActorReady' check to SpatialCleanupConnectionTest

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialCleanupConnectionTest/SpatialCleanupConnectionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialCleanupConnectionTest/SpatialCleanupConnectionTest.cpp
@@ -63,6 +63,15 @@ void ASpatialCleanupConnectionTest::PrepareTest()
 	});
 
 	AddStep(
+		TEXT("Wait for actor to be ready"), FWorkerDefinition::Server(1),
+		[this]() -> bool {
+			return SpawnedPawn->IsActorReady();
+		},
+		[this]() {
+			FinishStep();
+		});
+
+	AddStep(
 		TEXT("Post spawn check connections on server 2"), FWorkerDefinition::Server(2), nullptr, nullptr,
 		[this](float delta) {
 			USpatialNetDriver* Driver = Cast<USpatialNetDriver>(GetNetDriver());


### PR DESCRIPTION
#### Description
Added missing 'ActorReady' verification step, to ensure actor is ready before later steps are executed.
