### PR TITLE
[UNR-5579] Re-fix too many spatial flow controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue that caused `UnrealGDK/Setup.sh` to report `sed: can't read : No such file or directory` when run on macOS.
 - Static subobjects on bNetLoadOnClient actors are now removed on clients in a manner matching native unreal's behavior. This change affects subobjects removed by the server while the actor is not in the client's interest.
 - Fixed an issue where multicast rpcs could be overwritten and then dropped on authority flicker.
+- Fixed an issue with registering spatial flow controllers in the Spatial Testing Framework.
 
 ### Internal:
 - Hide the Test MultiworkerSettings and GridStrategy classes from displaying in the editor. These are meant to only be used in Tests.

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTest.cpp
@@ -427,13 +427,9 @@ void ASpatialFunctionalTest::RegisterFlowController(ASpatialFunctionalTestFlowCo
 {
 	if (FlowController->IsLocalController())
 	{
-		if (LocalFlowController != nullptr)
-		{
-			checkf(LocalFlowController == FlowController,
-				   TEXT("OwningTest already had different LocalFlowController, this shouldn't happen"));
-			return;
-		}
+		checkf(LocalFlowController == nullptr, TEXT("OwningTest already had a LocalFlowController, this shouldn't happen"));
 		LocalFlowController = FlowController;
+		LocalFlowController->TrySetReadyToRunTest();
 	}
 
 	if (!HasAuthority())
@@ -447,7 +443,7 @@ void ASpatialFunctionalTest::RegisterFlowController(ASpatialFunctionalTestFlowCo
 		// Since Clients can spawn on any worker we need to centralize the assignment of their ids to the Test Authority.
 		FlowControllerSpawner.AssignClientFlowControllerId(FlowController);
 	}
-
+	checkf(!FlowControllers.Contains(FlowController), TEXT("Auth test already registered this flow controller, this shouldn't happen"));
 	FlowControllers.Add(FlowController);
 }
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestFlowControllerSpawner.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/SpatialFunctionalTestFlowControllerSpawner.cpp
@@ -48,6 +48,8 @@ ASpatialFunctionalTestFlowController* SpatialFunctionalTestFlowControllerSpawner
 	ServerFlowController->FinishSpawning(FTransform(), true);
 	// TODO: Replace locking with custom LB strategy - UNR-3393
 	LockFlowControllerDelegations(ServerFlowController);
+	// register the auth flow controller
+	ServerFlowController->RegisterFlowController();
 
 	return ServerFlowController;
 }
@@ -64,6 +66,8 @@ ASpatialFunctionalTestFlowController* SpatialFunctionalTestFlowControllerSpawner
 						   INVALID_FLOW_CONTROLLER_ID }; // by default have invalid id, Test Authority will set it to ensure uniqueness
 
 	FlowController->FinishSpawning(OwningTest->GetActorTransform(), true);
+	// register the auth flow controller
+	FlowController->RegisterFlowController();
 
 	return FlowController;
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTestFlowController.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Public/SpatialFunctionalTestFlowController.h
@@ -24,8 +24,6 @@ public:
 
 	void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
 
-	virtual void BeginPlay() override;
-
 	virtual void OnAuthorityGained() override;
 
 	virtual void Tick(float DeltaSeconds) override;
@@ -79,14 +77,15 @@ public:
 	bool HasAckFinishedTest() const { return bHasAckFinishedTest; }
 
 	UFUNCTION()
+	void RegisterFlowController();
+	UFUNCTION()
+	void TrySetReadyToRunTest();
+	UFUNCTION()
 	void DeregisterFlowController();
 
 private:
 	// Current Step being executed
 	SpatialFunctionalTestStep CurrentStep;
-
-	UPROPERTY(ReplicatedUsing = OnReadyToRegisterWithTest)
-	uint8 bReadyToRegisterWithTest : 1;
 
 	UPROPERTY(Replicated)
 	bool bIsReadyToRunTest;
@@ -95,12 +94,7 @@ private:
 	bool bHasAckFinishedTest;
 
 	UFUNCTION()
-	void OnReadyToRegisterWithTest();
-
-	UFUNCTION()
 	void OnRep_OwningTest();
-
-	void TryRegisterFlowControllerWithOwningTest();
 
 	UFUNCTION(Server, Reliable)
 	void ServerSetReadyToRunTest(bool bIsReady);


### PR DESCRIPTION
Re-revert for the original fix now that https://github.com/improbableio/UnrealEngine/commit/67b19471da6744c16ea8a3e9aba5ba3144637d89 (and the 4.25 version) are in.
Original: https://github.com/spatialos/UnrealGDK/pull/3175/