### PR TITLE
Revert CompleteEntity recalculation

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
@@ -243,7 +243,10 @@ ActorSystem::ActorSystem(const FSubView& InActorSubView, const FSubView& InAutho
 #if DO_CHECK
 static void ValidateNoSubviewIntersections(const FSubView& Lhs, const FSubView& Rhs, const FString& SubviewDescription)
 {
-	for (const Worker_EntityId Overlapping : Lhs.GetCompleteEntities().Intersect(Rhs.GetCompleteEntities()))
+	TSet<Worker_EntityId_Key> LhsEntities, RhsEntities;
+	Algo::Copy(Lhs.GetCompleteEntities(), LhsEntities);
+	Algo::Copy(Rhs.GetCompleteEntities(), RhsEntities);
+	for (const Worker_EntityId Overlapping : LhsEntities.Intersect(RhsEntities))
 	{
 		UE_LOG(LogActorSystem, Warning, TEXT("Entity %lld is doubly complete on %s"), Overlapping, *SubviewDescription);
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
@@ -55,7 +55,7 @@ const FSubViewDelta& FSubView::GetViewDelta() const
 	return SubViewDelta;
 }
 
-TArray<Worker_EntityId> FSubView::GetCompleteEntities() const
+const TArray<Worker_EntityId>& FSubView::GetCompleteEntities() const
 {
 	return CompleteEntities;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
@@ -55,9 +55,9 @@ const FSubViewDelta& FSubView::GetViewDelta() const
 	return SubViewDelta;
 }
 
-TSet<Worker_EntityId_Key> FSubView::GetCompleteEntities() const
+TArray<Worker_EntityId> FSubView::GetCompleteEntities() const
 {
-	return TSet<Worker_EntityId_Key>( CompleteEntities );
+	return CompleteEntities;
 }
 
 void FSubView::Refresh()

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialView/SubView.cpp
@@ -57,16 +57,7 @@ const FSubViewDelta& FSubView::GetViewDelta() const
 
 TSet<Worker_EntityId_Key> FSubView::GetCompleteEntities() const
 {
-	TSet<Worker_EntityId_Key> CompleteEntitiesSet;
-
-	Algo::Copy(CompleteEntities, CompleteEntitiesSet);
-	Algo::Copy(NewlyCompleteEntities, CompleteEntitiesSet);
-
-	TSet<Worker_EntityId_Key> IncompleteEntitiesSet;
-
-	Algo::Copy(NewlyIncompleteEntities, IncompleteEntitiesSet);
-
-	return CompleteEntitiesSet.Difference(IncompleteEntitiesSet);
+	return TSet<Worker_EntityId_Key>( CompleteEntities );
 }
 
 void FSubView::Refresh()
@@ -98,7 +89,7 @@ bool FSubView::HasEntity(const Worker_EntityId EntityId) const
 
 bool FSubView::IsEntityComplete(const Worker_EntityId EntityId) const
 {
-	return GetCompleteEntities().Contains(EntityId);
+	return CompleteEntities.Contains(EntityId);
 }
 
 bool FSubView::HasComponent(const Worker_EntityId EntityId, const Worker_ComponentId ComponentId) const

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -40,7 +40,7 @@ public:
 
 	void Advance(const ViewDelta& Delta);
 	const FSubViewDelta& GetViewDelta() const;
-	TSet<Worker_EntityId_Key> GetCompleteEntities() const;
+	TArray<Worker_EntityId> GetCompleteEntities() const;
 	void Refresh();
 	void RefreshEntity(const Worker_EntityId EntityId);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialView/SubView.h
@@ -40,7 +40,7 @@ public:
 
 	void Advance(const ViewDelta& Delta);
 	const FSubViewDelta& GetViewDelta() const;
-	TArray<Worker_EntityId> GetCompleteEntities() const;
+	const TArray<Worker_EntityId>& GetCompleteEntities() const;
 	void Refresh();
 	void RefreshEntity(const Worker_EntityId EntityId);
 


### PR DESCRIPTION
#### Description
As part of https://github.com/spatialos/UnrealGDK/pull/3030/files `GetCompleteEntities` was refactored to provide any entity state that was is the process of being complete this frame (between dispatcher invoke and subview advance). In practice this isn't needed, and is a huge performance hit, so reverting to using the CompleteEntities array instead.

#### Primary reviewers
@improbable-dmitrii 
