### PR TITLE
Additional facilities for getting LB data and cleanup of the systems using them

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LBDataStorage.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LBDataStorage.cpp
@@ -92,12 +92,7 @@ void FSpatialPositionStorage::OnComponentAdded(Worker_EntityId EntityId, Worker_
 	{
 		Schema_Object* PositionObject = Schema_GetComponentDataFields(Data);
 
-		Schema_Object* CoordsObject = Schema_GetObject(PositionObject, 1);
-		SpatialGDK::Coordinates Coords;
-		Coords.X = Schema_GetDouble(CoordsObject, 1);
-		Coords.Y = Schema_GetDouble(CoordsObject, 2);
-		Coords.Z = Schema_GetDouble(CoordsObject, 3);
-
+		SpatialGDK::Coordinates Coords = GetCoordinateFromSchema(PositionObject, 1);
 		FVector Position = SpatialGDK::Coordinates::ToFVector(Coords);
 
 		Modified.Add(EntityId);
@@ -117,11 +112,7 @@ void FSpatialPositionStorage::OnUpdate(Worker_EntityId EntityId, Worker_Componen
 	if (InComponentId == SpatialConstants::POSITION_COMPONENT_ID)
 	{
 		Schema_Object* PositionObject = Schema_GetComponentUpdateFields(Update);
-		Schema_Object* CoordsObject = Schema_GetObject(PositionObject, 1);
-		SpatialGDK::Coordinates Coords;
-		Coords.X = Schema_GetDouble(CoordsObject, 1);
-		Coords.Y = Schema_GetDouble(CoordsObject, 2);
-		Coords.Z = Schema_GetDouble(CoordsObject, 3);
+		SpatialGDK::Coordinates Coords = GetCoordinateFromSchema(PositionObject, 1);
 
 		FVector* Data = Positions.Find(EntityId);
 		if (!ensure(Data != nullptr))
@@ -132,36 +123,6 @@ void FSpatialPositionStorage::OnUpdate(Worker_EntityId EntityId, Worker_Componen
 
 		Modified.Add(EntityId);
 	}
-}
-
-FActorGroupStorage::FActorGroupStorage()
-{
-	Components.Add(SpatialConstants::ACTOR_GROUP_MEMBER_COMPONENT_ID);
-}
-
-void FActorGroupStorage::OnComponentAdded(Worker_EntityId EntityId, Worker_ComponentId ComponentId, Schema_ComponentData* Data)
-{
-	if (ensureAlways(SpatialConstants::ACTOR_GROUP_MEMBER_COMPONENT_ID == ComponentId))
-	{
-		Schema_Object* GroupObject = Schema_GetComponentDataFields(Data);
-		int32 GroupId = Schema_GetUint32(GroupObject, SpatialConstants::ACTOR_GROUP_MEMBER_COMPONENT_ACTOR_GROUP_ID);
-		Groups.Add(EntityId, GroupId);
-		Modified.Add(EntityId);
-	}
-}
-
-void FActorGroupStorage::OnRemoved(Worker_EntityId EntityId)
-{
-	Groups.Remove(EntityId);
-	Modified.Remove(EntityId);
-}
-
-void FActorGroupStorage::OnUpdate(Worker_EntityId EntityId, Worker_ComponentId InComponentId, Schema_ComponentUpdate* Update)
-{
-	Schema_Object* GroupObject = Schema_GetComponentUpdateFields(Update);
-	int32 GroupId = Schema_GetUint32(GroupObject, SpatialConstants::ACTOR_GROUP_MEMBER_COMPONENT_ACTOR_GROUP_ID);
-	Groups.Add(EntityId, GroupId);
-	Modified.Add(EntityId);
 }
 
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LBDataStorage.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LBDataStorage.cpp
@@ -4,31 +4,105 @@
 
 namespace SpatialGDK
 {
+void FLBDataCollection::Advance()
+{
+	for (const EntityDelta& Delta : SubView.GetViewDelta().EntityDeltas)
+	{
+		switch (Delta.Type)
+		{
+		case EntityDelta::UPDATE:
+		{
+			for (const auto& CompleteUpdate : Delta.ComponentsRefreshed)
+			{
+				for (auto& Storage : DataStorages)
+				{
+					if (Storage->GetComponentsToWatch().Contains(CompleteUpdate.ComponentId))
+					{
+						Storage->OnComponentRefreshed(Delta.EntityId, CompleteUpdate.ComponentId, CompleteUpdate.Data);
+					}
+				}
+			}
+			for (const auto& Update : Delta.ComponentUpdates)
+			{
+				for (auto& Storage : DataStorages)
+				{
+					if (Storage->GetComponentsToWatch().Contains(Update.ComponentId))
+					{
+						Storage->OnUpdate(Delta.EntityId, Update.ComponentId, Update.Update);
+					}
+				}
+			}
+		}
+		break;
+		case EntityDelta::ADD:
+		{
+			const SpatialGDK::EntityViewElement& Element = SubView.GetView().FindChecked(Delta.EntityId);
+			for (auto& Storage : DataStorages)
+			{
+				Storage->OnAdded(Delta.EntityId, Element);
+			}
+		}
+		break;
+		case EntityDelta::REMOVE:
+		{
+			for (auto& Storage : DataStorages)
+			{
+				Storage->OnRemoved(Delta.EntityId);
+			}
+		}
+		break;
+		case EntityDelta::TEMPORARILY_REMOVED:
+		{
+			for (auto& Storage : DataStorages)
+			{
+				Storage->OnRemoved(Delta.EntityId);
+			}
+			const SpatialGDK::EntityViewElement& Element = SubView.GetView().FindChecked(Delta.EntityId);
+			for (auto& Storage : DataStorages)
+			{
+				Storage->OnAdded(Delta.EntityId, Element);
+			}
+		}
+		break;
+		default:
+			break;
+		}
+	}
+}
+
+TSet<Worker_ComponentId> FLBDataCollection::GetComponentsToWatch() const
+{
+	TSet<Worker_ComponentId> Components;
+	for (auto Storage : DataStorages)
+	{
+		Components = Components.Union(Storage->GetComponentsToWatch());
+	}
+
+	return Components;
+}
+
 FSpatialPositionStorage::FSpatialPositionStorage()
 {
 	Components.Add(SpatialConstants::POSITION_COMPONENT_ID);
 }
 
-void FSpatialPositionStorage::OnAdded(Worker_EntityId EntityId, const SpatialGDK::EntityViewElement& Element)
+void FSpatialPositionStorage::OnComponentAdded(Worker_EntityId EntityId, Worker_ComponentId ComponentId, Schema_ComponentData* Data)
 {
-	for (const auto& Component : Element.Components)
+	if (ensureAlways(SpatialConstants::POSITION_COMPONENT_ID == ComponentId))
 	{
-		if (SpatialConstants::POSITION_COMPONENT_ID == Component.GetComponentId())
-		{
-			Schema_Object* PositionObject = Schema_GetComponentDataFields(Component.GetUnderlying());
+		Schema_Object* PositionObject = Schema_GetComponentDataFields(Data);
 
-			Schema_Object* CoordsObject = Schema_GetObject(PositionObject, 1);
-			SpatialGDK::Coordinates Coords;
-			Coords.X = Schema_GetDouble(CoordsObject, 1);
-			Coords.Y = Schema_GetDouble(CoordsObject, 2);
-			Coords.Z = Schema_GetDouble(CoordsObject, 3);
+		Schema_Object* CoordsObject = Schema_GetObject(PositionObject, 1);
+		SpatialGDK::Coordinates Coords;
+		Coords.X = Schema_GetDouble(CoordsObject, 1);
+		Coords.Y = Schema_GetDouble(CoordsObject, 2);
+		Coords.Z = Schema_GetDouble(CoordsObject, 3);
 
-			FVector Position = SpatialGDK::Coordinates::ToFVector(Coords);
+		FVector Position = SpatialGDK::Coordinates::ToFVector(Coords);
 
-			Modified.Add(EntityId);
+		Modified.Add(EntityId);
 
-			Positions.Add(EntityId, Position);
-		}
+		Positions.Add(EntityId, Position);
 	}
 }
 
@@ -65,17 +139,14 @@ FActorGroupStorage::FActorGroupStorage()
 	Components.Add(SpatialConstants::ACTOR_GROUP_MEMBER_COMPONENT_ID);
 }
 
-void FActorGroupStorage::OnAdded(Worker_EntityId EntityId, const SpatialGDK::EntityViewElement& Element)
+void FActorGroupStorage::OnComponentAdded(Worker_EntityId EntityId, Worker_ComponentId ComponentId, Schema_ComponentData* Data)
 {
-	for (const auto& Component : Element.Components)
+	if (ensureAlways(SpatialConstants::ACTOR_GROUP_MEMBER_COMPONENT_ID == ComponentId))
 	{
-		if (SpatialConstants::ACTOR_GROUP_MEMBER_COMPONENT_ID == Component.GetComponentId())
-		{
-			Schema_Object* GroupObject = Schema_GetComponentDataFields(Component.GetUnderlying());
-			int32 GroupId = Schema_GetUint32(GroupObject, SpatialConstants::ACTOR_GROUP_MEMBER_COMPONENT_ACTOR_GROUP_ID);
-			Groups.Add(EntityId, GroupId);
-			Modified.Add(EntityId);
-		}
+		Schema_Object* GroupObject = Schema_GetComponentDataFields(Data);
+		int32 GroupId = Schema_GetUint32(GroupObject, SpatialConstants::ACTOR_GROUP_MEMBER_COMPONENT_ACTOR_GROUP_ID);
+		Groups.Add(EntityId, GroupId);
+		Modified.Add(EntityId);
 	}
 }
 
@@ -90,42 +161,6 @@ void FActorGroupStorage::OnUpdate(Worker_EntityId EntityId, Worker_ComponentId I
 	Schema_Object* GroupObject = Schema_GetComponentUpdateFields(Update);
 	int32 GroupId = Schema_GetUint32(GroupObject, SpatialConstants::ACTOR_GROUP_MEMBER_COMPONENT_ACTOR_GROUP_ID);
 	Groups.Add(EntityId, GroupId);
-	Modified.Add(EntityId);
-}
-
-FDirectAssignmentStorage::FDirectAssignmentStorage()
-{
-	Components.Add(SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID);
-}
-
-void FDirectAssignmentStorage::OnAdded(Worker_EntityId EntityId, const SpatialGDK::EntityViewElement& Element)
-{
-	for (const auto& Component : Element.Components)
-	{
-		if (SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID == Component.GetComponentId())
-		{
-			AuthorityIntent NewIntent(Component.GetUnderlying());
-			Intents.Add(EntityId, NewIntent);
-			Modified.Add(EntityId);
-		}
-	}
-}
-
-void FDirectAssignmentStorage::OnRemoved(Worker_EntityId EntityId)
-{
-	Intents.Remove(EntityId);
-	Modified.Remove(EntityId);
-}
-
-void FDirectAssignmentStorage::OnUpdate(Worker_EntityId EntityId, Worker_ComponentId InComponentId, Schema_ComponentUpdate* Update)
-{
-	AuthorityIntent* Intent = Intents.Find(EntityId);
-	if (!ensure(Intent != nullptr))
-	{
-		return;
-	}
-
-	Intent->ApplyComponentUpdate(Update);
 	Modified.Add(EntityId);
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LegacyLoadBalancingStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LegacyLoadBalancingStrategy.cpp
@@ -243,7 +243,7 @@ void FLegacyLoadBalancing::CollectEntitiesToMigrate(FMigrationContext& Ctx)
 		}
 		else
 		{
-			const TMap<Worker_EntityId_Key, AuthorityIntent>& AssignmentMap = AssignmentStorage->GetAssignments();
+			const TMap<Worker_EntityId_Key, AuthorityIntent>& AssignmentMap = AssignmentStorage->GetObjects();
 			for (Worker_EntityId ToMigrate : Ctx.ModifiedEntities)
 			{
 				if (!ensureAlways(!Ctx.MigratingEntities.Contains(ToMigrate)))

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LegacyLoadBalancingStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LegacyLoadBalancingStrategy.cpp
@@ -208,8 +208,8 @@ void FLegacyLoadBalancing::CollectEntitiesToMigrate(FMigrationContext& Ctx)
 					continue;
 				}
 
-				int32 Group = GroupStorage->GetGroups().FindChecked(EntityId);
-				FLegacyLBContext::Layer& Layer = LBContext.Layers[Group];
+				const ActorGroupMember& Group = GroupStorage->GetObjects().FindChecked(EntityId);
+				FLegacyLBContext::Layer& Layer = LBContext.Layers[Group.ActorGroupId];
 
 				const FVector& Position = PositionStorage->GetPositions().FindChecked(EntityId);
 				const FVector2D Actor2DLocation(Position);

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/PartitionManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/PartitionManager.cpp
@@ -224,8 +224,8 @@ struct FPartitionManager::Impl
 		WorkersDispatcher.Advance();
 		SystemWorkersDispatcher.Advance();
 
-		TSet<Worker_EntityId> WorkersToInspect = WorkersData.GetModifiedEntities();
-		const TSet<Worker_EntityId>& SystemWorkerModified = SystemWorkersData.GetModifiedEntities();
+		TSet<Worker_EntityId_Key> WorkersToInspect = WorkersData.GetModifiedEntities();
+		const TSet<Worker_EntityId_Key>& SystemWorkerModified = SystemWorkersData.GetModifiedEntities();
 		if (SystemWorkerModified.Num() != 0)
 		{
 			for (const auto& Entry : WorkersData.GetObjects())

--- a/SpatialGDK/Source/SpatialGDK/Private/Schema/ActorOwnership.h
+++ b/SpatialGDK/Source/SpatialGDK/Private/Schema/ActorOwnership.h
@@ -16,7 +16,7 @@ namespace SpatialGDK
 // points to the PlayerController entity that owns a given actor.
 struct ActorOwnership
 {
-	static const Worker_ComponentId ComponentId = SpatialConstants::ACTOR_OWNERSHIP_COMPONENT_ID;
+	static constexpr Worker_ComponentId ComponentId = SpatialConstants::ACTOR_OWNERSHIP_COMPONENT_ID;
 
 	explicit ActorOwnership(Worker_EntityId InLeaderEntityId)
 		: OwnerActorEntityId(InLeaderEntityId)

--- a/SpatialGDK/Source/SpatialGDK/Private/Schema/StaticSymbols.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Schema/StaticSymbols.cpp
@@ -17,6 +17,8 @@
 #include "Schema/Tombstone.h"
 #include "Schema/UnrealMetadata.h"
 
+// Support older C++ standard by defining constexpr static members, this file should be removed once UE 4.25 is no longer supported.
+// Comment this section and build UE 4.25 on Linux if you wish to analyze the underlying issue.
 #if __cplusplus <= 201402L
 namespace SpatialGDK
 {

--- a/SpatialGDK/Source/SpatialGDK/Private/Schema/StaticSymbols.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Schema/StaticSymbols.cpp
@@ -1,0 +1,47 @@
+#include "Schema/ActorGroupMember.h"
+#include "Schema/ActorOwnership.h"
+#include "Schema/ActorSetMember.h"
+#include "Schema/AuthorityIntent.h"
+#include "Schema/DebugComponent.h"
+#include "Schema/GameplayDebuggerComponent.h"
+#include "Schema/Interest.h"
+#include "Schema/MigrationDiagnostic.h"
+#include "Schema/NetOwningClientWorker.h"
+#include "Schema/PlayerSpawner.h"
+#include "Schema/Restricted.h"
+#include "Schema/ServerWorker.h"
+#include "Schema/SnapshotVersionComponent.h"
+#include "Schema/SpatialDebugging.h"
+#include "Schema/SpawnData.h"
+#include "Schema/StandardLibrary.h"
+#include "Schema/Tombstone.h"
+#include "Schema/UnrealMetadata.h"
+
+#if __cplusplus <= 201402L
+namespace SpatialGDK
+{
+constexpr Worker_ComponentId ActorOwnership::ComponentId;
+constexpr Worker_ComponentId ActorGroupMember::ComponentId;
+constexpr Worker_ComponentId ActorSetMember::ComponentId;
+constexpr Worker_ComponentId DebugComponent::ComponentId;
+constexpr Worker_ComponentId AuthorityIntent::ComponentId;
+constexpr Worker_ComponentId AuthorityIntentACK::ComponentId;
+constexpr Worker_ComponentId GameplayDebuggerComponent::ComponentId;
+constexpr Worker_ComponentId Interest::ComponentId;
+constexpr Worker_ComponentId MigrationDiagnostic::ComponentId;
+constexpr Worker_ComponentId NetOwningClientWorker::ComponentId;
+constexpr Worker_ComponentId PlayerSpawner::ComponentId;
+constexpr Worker_ComponentId Partition::ComponentId;
+constexpr Worker_ComponentId ServerWorker::ComponentId;
+constexpr Worker_ComponentId SnapshotVersion::ComponentId;
+constexpr Worker_ComponentId SpatialDebugging::ComponentId;
+constexpr Worker_ComponentId SpawnData::ComponentId;
+constexpr Worker_ComponentId Metadata::ComponentId;
+constexpr Worker_ComponentId Position::ComponentId;
+constexpr Worker_ComponentId Persistence::ComponentId;
+constexpr Worker_ComponentId Worker::ComponentId;
+constexpr Worker_ComponentId AuthorityDelegation::ComponentId;
+constexpr Worker_ComponentId Tombstone::ComponentId;
+constexpr Worker_ComponentId UnrealMetadata::ComponentId;
+} // namespace SpatialGDK
+#endif

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialStrategySystem.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialStrategySystem.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 
+#include "LoadBalancing/LBDataStorage.h"
 #include "LoadBalancing/LoadBalancingTypes.h"
 #include "Schema/AuthorityIntent.h"
 #include "Schema/CrossServerEndpoint.h"
@@ -21,7 +22,6 @@ namespace SpatialGDK
 {
 class ISpatialOSWorker;
 class FLoadBalancingStrategy;
-class FLBDataStorage;
 class FPartitionManager;
 
 class FSpatialStrategySystem
@@ -41,19 +41,26 @@ private:
 
 	TUniquePtr<FPartitionManager> PartitionsMgr;
 
+	// +++ Components watched to implement the strategy +++
+	TLBDataStorage<AuthorityIntentACK> AuthACKView;
+	TLBDataStorage<NetOwningClientWorker> NetOwningClientView;
+	FLBDataCollection DataStorages;
+	FLBDataCollection UserDataStorages;
 	TSet<Worker_ComponentId> UpdatesToConsider;
-	TSet<Worker_EntityId_Key> MigratingEntities;
-	TSet<Worker_EntityId_Key> EntitiesACKMigration;
-	TSet<Worker_EntityId_Key> EntitiesClientChanged;
-	TMap<Worker_EntityId_Key, FPartitionHandle> PendingMigrations;
-	TArray<FLBDataStorage*> DataStorages;
+	// --- Components watched to implement the strategy ---
+
+	// +++ Components managed by the strategy worker +++
 	TMap<Worker_EntityId_Key, AuthorityIntentV2> AuthorityIntentView;
 	TMap<Worker_EntityId_Key, AuthorityDelegation> AuthorityDelegationView;
-	TMap<Worker_EntityId_Key, NetOwningClientWorker> NetOwningClientView;
+	// --- Components managed by the strategy worker ---
+
+	// +++ Migration data +++
 	TUniquePtr<FLoadBalancingStrategy> Strategy;
+	TSet<Worker_EntityId_Key> MigratingEntities;
+	TMap<Worker_EntityId_Key, FPartitionHandle> PendingMigrations;
+	// --- Migration data ---
 
 	void UpdateStrategySystemInterest(ISpatialOSWorker& Connection);
-
 	bool bStrategySystemInterestDirty = false;
 };
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LBDataStorage.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LBDataStorage.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "EngineClasses/SpatialNetDriver.h"
+#include "Schema/ActorGroupMember.h"
 #include "Schema/AuthorityIntent.h"
 #include "Utils/ComponentReader.h"
 
@@ -75,21 +76,6 @@ protected:
 	TMap<Worker_EntityId_Key, FVector> Positions;
 };
 
-class FActorGroupStorage : public FLBDataStorage
-{
-public:
-	FActorGroupStorage();
-
-	virtual void OnComponentAdded(Worker_EntityId EntityId, Worker_ComponentId ComponentId, Schema_ComponentData* Data) override;
-	virtual void OnRemoved(Worker_EntityId EntityId) override;
-	virtual void OnUpdate(Worker_EntityId EntityId, Worker_ComponentId InComponentId, Schema_ComponentUpdate* Update) override;
-
-	TMap<Worker_EntityId_Key, int32> const& GetGroups() const { return Groups; }
-
-protected:
-	TMap<Worker_EntityId_Key, int32> Groups;
-};
-
 template <typename T>
 class TLBDataStorage : public FLBDataStorage
 {
@@ -126,6 +112,10 @@ public:
 
 protected:
 	TMap<Worker_EntityId_Key, T> SchemaObjects;
+};
+
+class FActorGroupStorage : public TLBDataStorage<ActorGroupMember>
+{
 };
 
 class FDirectAssignmentStorage : public TLBDataStorage<AuthorityIntent>

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LBDataStorage.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LBDataStorage.h
@@ -108,7 +108,7 @@ public:
 		Modified.Add(EntityId);
 	}
 
-	TMap<Worker_EntityId_Key, T> const& GetObjects() const { return SchemaObjects; }
+	const TMap<Worker_EntityId_Key, T>& GetObjects() const { return SchemaObjects; }
 
 protected:
 	TMap<Worker_EntityId_Key, T> SchemaObjects;

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/ActorGroupMember.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/ActorGroupMember.h
@@ -16,7 +16,7 @@ using FActorLoadBalancingGroupId = uint32;
 // SpatialDebugger on clients but which would not normally be available to clients.
 struct SPATIALGDK_API ActorGroupMember
 {
-	static const Worker_ComponentId ComponentId = SpatialConstants::ACTOR_GROUP_MEMBER_COMPONENT_ID;
+	static constexpr Worker_ComponentId ComponentId = SpatialConstants::ACTOR_GROUP_MEMBER_COMPONENT_ID;
 
 	ActorGroupMember(FActorLoadBalancingGroupId InGroupId)
 		: ActorGroupId(InGroupId)

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/ActorGroupMember.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/ActorGroupMember.h
@@ -30,11 +30,15 @@ struct SPATIALGDK_API ActorGroupMember
 
 	ActorGroupMember(const ComponentData& Data) { ApplySchema(Data.GetFields()); }
 
+	ActorGroupMember(Schema_ComponentData* Data) { ApplySchema(Schema_GetComponentDataFields(Data)); }
+
 	ComponentData CreateComponentData() const { return CreateComponentDataHelper(*this); }
 
 	ComponentUpdate CreateComponentUpdate() const { return CreateComponentUpdateHelper(*this); }
 
 	void ApplyComponentUpdate(const ComponentUpdate& Update) { ApplySchema(Update.GetFields()); }
+
+	void ApplyComponentUpdate(Schema_ComponentUpdate* Update) { ApplySchema(Schema_GetComponentUpdateFields(Update)); }
 
 	void ApplySchema(Schema_Object* ComponentObject)
 	{

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/ActorSetMember.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/ActorSetMember.h
@@ -14,7 +14,7 @@ namespace SpatialGDK
 // SpatialDebugger on clients but which would not normally be available to clients.
 struct SPATIALGDK_API ActorSetMember
 {
-	static const Worker_ComponentId ComponentId = SpatialConstants::ACTOR_SET_MEMBER_COMPONENT_ID;
+	static constexpr Worker_ComponentId ComponentId = SpatialConstants::ACTOR_SET_MEMBER_COMPONENT_ID;
 
 	ActorSetMember(Worker_EntityId InLeaderEntityId)
 		: ActorSetId(InLeaderEntityId)

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/AuthorityIntent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/AuthorityIntent.h
@@ -16,7 +16,7 @@ namespace SpatialGDK
 // VirtualWorkerId set here doesn't match the worker's Id.
 struct AuthorityIntent : AbstractMutableComponent
 {
-	static const Worker_ComponentId ComponentId = SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID;
+	static constexpr Worker_ComponentId ComponentId = SpatialConstants::AUTHORITY_INTENT_COMPONENT_ID;
 
 	AuthorityIntent()
 		: VirtualWorkerId(SpatialConstants::AUTHORITY_INTENT_VIRTUAL_WORKER_ID)
@@ -79,7 +79,7 @@ struct AuthorityIntent : AbstractMutableComponent
 
 struct AuthorityIntentV2
 {
-	static const Worker_ComponentId ComponentId = SpatialConstants::AUTHORITY_INTENTV2_COMPONENT_ID;
+	static constexpr Worker_ComponentId ComponentId = SpatialConstants::AUTHORITY_INTENTV2_COMPONENT_ID;
 
 	AuthorityIntentV2() {}
 
@@ -142,7 +142,7 @@ struct AuthorityIntentV2
 
 struct AuthorityIntentACK
 {
-	static const Worker_ComponentId ComponentId = SpatialConstants::AUTHORITY_INTENT_ACK_COMPONENT_ID;
+	static constexpr Worker_ComponentId ComponentId = SpatialConstants::AUTHORITY_INTENT_ACK_COMPONENT_ID;
 
 	AuthorityIntentACK() {}
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/DebugComponent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/DebugComponent.h
@@ -14,7 +14,7 @@ namespace SpatialGDK
 {
 struct DebugComponent
 {
-	static const Worker_ComponentId ComponentId = SpatialConstants::GDK_DEBUG_COMPONENT_ID;
+	static constexpr Worker_ComponentId ComponentId = SpatialConstants::GDK_DEBUG_COMPONENT_ID;
 
 	DebugComponent() {}
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/GameplayDebuggerComponent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/GameplayDebuggerComponent.h
@@ -12,7 +12,7 @@ namespace SpatialGDK
 {
 struct GameplayDebuggerComponent
 {
-	static const Worker_ComponentId ComponentId = SpatialConstants::GDK_GAMEPLAY_DEBUGGER_COMPONENT_ID;
+	static constexpr Worker_ComponentId ComponentId = SpatialConstants::GDK_GAMEPLAY_DEBUGGER_COMPONENT_ID;
 
 	GameplayDebuggerComponent() {}
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/Interest.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/Interest.h
@@ -456,7 +456,7 @@ inline ComponentSetInterest GetComponentInterestFromSchema(Schema_Object* Object
 
 struct Interest : AbstractMutableComponent
 {
-	static const Worker_ComponentId ComponentId = SpatialConstants::INTEREST_COMPONENT_ID;
+	static constexpr Worker_ComponentId ComponentId = SpatialConstants::INTEREST_COMPONENT_ID;
 
 	Interest() = default;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/MigrationDiagnostic.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/MigrationDiagnostic.h
@@ -22,7 +22,7 @@ namespace SpatialGDK
 {
 struct MigrationDiagnostic : Component
 {
-	static const Worker_ComponentId ComponentId = SpatialConstants::MIGRATION_DIAGNOSTIC_COMPONENT_ID;
+	static constexpr Worker_ComponentId ComponentId = SpatialConstants::MIGRATION_DIAGNOSTIC_COMPONENT_ID;
 
 	MigrationDiagnostic() = default;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/NetOwningClientWorker.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/NetOwningClientWorker.h
@@ -15,7 +15,7 @@ namespace SpatialGDK
 {
 struct NetOwningClientWorker : AbstractMutableComponent
 {
-	static const Worker_ComponentId ComponentId = SpatialConstants::NET_OWNING_CLIENT_WORKER_COMPONENT_ID;
+	static constexpr Worker_ComponentId ComponentId = SpatialConstants::NET_OWNING_CLIENT_WORKER_COMPONENT_ID;
 
 	NetOwningClientWorker() = default;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/PlayerSpawner.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/PlayerSpawner.h
@@ -29,7 +29,7 @@ struct SpawnPlayerRequest
 
 struct PlayerSpawner : Component
 {
-	static const Worker_ComponentId ComponentId = SpatialConstants::PLAYER_SPAWNER_COMPONENT_ID;
+	static constexpr Worker_ComponentId ComponentId = SpatialConstants::PLAYER_SPAWNER_COMPONENT_ID;
 
 	PlayerSpawner() = default;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/Restricted.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/Restricted.h
@@ -13,7 +13,7 @@ namespace SpatialGDK
 {
 struct Partition : Component
 {
-	static const Worker_ComponentId ComponentId = SpatialConstants::PARTITION_COMPONENT_ID;
+	static constexpr Worker_ComponentId ComponentId = SpatialConstants::PARTITION_COMPONENT_ID;
 
 	Partition() = default;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/ServerWorker.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/ServerWorker.h
@@ -20,7 +20,7 @@ namespace SpatialGDK
 // worker names using the server worker entities.
 struct ServerWorker : Component
 {
-	static const Worker_ComponentId ComponentId = SpatialConstants::SERVER_WORKER_COMPONENT_ID;
+	static constexpr Worker_ComponentId ComponentId = SpatialConstants::SERVER_WORKER_COMPONENT_ID;
 
 	ServerWorker()
 		: WorkerName(SpatialConstants::INVALID_WORKER_NAME)

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/SnapshotVersionComponent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/SnapshotVersionComponent.h
@@ -9,7 +9,7 @@ namespace SpatialGDK
 {
 struct SnapshotVersion : AbstractMutableComponent
 {
-	static const Worker_ComponentId ComponentId = SpatialConstants::SNAPSHOT_VERSION_COMPONENT_ID;
+	static constexpr Worker_ComponentId ComponentId = SpatialConstants::SNAPSHOT_VERSION_COMPONENT_ID;
 
 	SnapshotVersion()
 		: Version(0)

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/SpatialDebugging.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/SpatialDebugging.h
@@ -14,7 +14,7 @@ namespace SpatialGDK
 // SpatialDebugger on clients but which would not normally be available to clients.
 struct SpatialDebugging : AbstractMutableComponent
 {
-	static const Worker_ComponentId ComponentId = SpatialConstants::SPATIAL_DEBUGGING_COMPONENT_ID;
+	static constexpr Worker_ComponentId ComponentId = SpatialConstants::SPATIAL_DEBUGGING_COMPONENT_ID;
 
 	SpatialDebugging()
 		: AuthoritativeVirtualWorkerId(SpatialConstants::INVALID_VIRTUAL_WORKER_ID)

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/SpawnData.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/SpawnData.h
@@ -16,7 +16,7 @@ namespace SpatialGDK
 {
 struct SpawnData : AbstractMutableComponent
 {
-	static const Worker_ComponentId ComponentId = SpatialConstants::SPAWN_DATA_COMPONENT_ID;
+	static constexpr Worker_ComponentId ComponentId = SpatialConstants::SPAWN_DATA_COMPONENT_ID;
 
 	SpawnData() = default;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/StandardLibrary.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/StandardLibrary.h
@@ -75,7 +75,7 @@ inline Coordinates GetCoordinateFromSchema(Schema_Object* Object, Schema_FieldId
 
 struct Metadata : AbstractMutableComponent
 {
-	static const Worker_ComponentId ComponentId = SpatialConstants::METADATA_COMPONENT_ID;
+	static constexpr Worker_ComponentId ComponentId = SpatialConstants::METADATA_COMPONENT_ID;
 
 	Metadata() = default;
 
@@ -108,7 +108,7 @@ struct Metadata : AbstractMutableComponent
 
 struct Position : AbstractMutableComponent
 {
-	static const Worker_ComponentId ComponentId = SpatialConstants::POSITION_COMPONENT_ID;
+	static constexpr Worker_ComponentId ComponentId = SpatialConstants::POSITION_COMPONENT_ID;
 
 	Position() = default;
 
@@ -162,7 +162,7 @@ struct Position : AbstractMutableComponent
 
 struct Persistence : AbstractMutableComponent
 {
-	static const Worker_ComponentId ComponentId = SpatialConstants::PERSISTENCE_COMPONENT_ID;
+	static constexpr Worker_ComponentId ComponentId = SpatialConstants::PERSISTENCE_COMPONENT_ID;
 
 	Persistence() = default;
 	Persistence(const Worker_ComponentData& Data) {}
@@ -204,7 +204,7 @@ struct Connection
 
 struct Worker : Component
 {
-	static const Worker_ComponentId ComponentId = SpatialConstants::WORKER_COMPONENT_ID;
+	static constexpr Worker_ComponentId ComponentId = SpatialConstants::WORKER_COMPONENT_ID;
 
 	Worker() = default;
 	Worker(const Worker_ComponentData& Data)
@@ -245,7 +245,7 @@ struct Worker : Component
 
 struct AuthorityDelegation : AbstractMutableComponent
 {
-	static const Worker_ComponentId ComponentId = SpatialConstants::AUTHORITY_DELEGATION_COMPONENT_ID;
+	static constexpr Worker_ComponentId ComponentId = SpatialConstants::AUTHORITY_DELEGATION_COMPONENT_ID;
 
 	AuthorityDelegation() = default;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/StandardLibrary.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/StandardLibrary.h
@@ -208,13 +208,22 @@ struct Worker : Component
 
 	Worker() = default;
 	Worker(const Worker_ComponentData& Data)
+		: Worker(Data.schema_type)
 	{
-		Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data.schema_type);
+	}
+
+	Worker(Schema_ComponentData* Data)
+	{
+		Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data);
 
 		WorkerId = GetStringFromSchema(ComponentObject, 1);
 		WorkerType = GetStringFromSchema(ComponentObject, 2);
 		Connection.ReadConnectionData(Schema_GetObject(ComponentObject, 3));
 	}
+
+	void ApplyComponentUpdate(const Worker_ComponentUpdate& Update) {}
+
+	void ApplyComponentUpdate(Schema_ComponentUpdate* Update) {}
 
 	FString WorkerId;
 	FString WorkerType;

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/Tombstone.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/Tombstone.h
@@ -12,7 +12,7 @@ namespace SpatialGDK
 {
 struct Tombstone : AbstractMutableComponent
 {
-	static const Worker_ComponentId ComponentId = SpatialConstants::TOMBSTONE_COMPONENT_ID;
+	static constexpr Worker_ComponentId ComponentId = SpatialConstants::TOMBSTONE_COMPONENT_ID;
 
 	Tombstone() = default;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealMetadata.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/UnrealMetadata.h
@@ -16,7 +16,7 @@ namespace SpatialGDK
 {
 struct UnrealMetadata : AbstractMutableComponent
 {
-	static const Worker_ComponentId ComponentId = SpatialConstants::UNREAL_METADATA_COMPONENT_ID;
+	static constexpr Worker_ComponentId ComponentId = SpatialConstants::UNREAL_METADATA_COMPONENT_ID;
 
 	UnrealMetadata() = default;
 


### PR DESCRIPTION
#### Description
Preparing some facilities in order to start working on a way to expose partition metadata to unreal server workers (to implement things like the test debug interface, amongst other things).
There was a lot of boilerplate code to extract data and updates from sub views, which could be united into a single utility class, and used everywhere we want to extract some collection of data.
This comes along with a template data storage which wraps the component classes we write for our custom components, in order to further reduce the amount of boilerplate code needed to pass component data around.

Read in commit order.

Had to fix an obscure linking error for Clang in C++14 (UE 4.25) : https://stackoverflow.com/questions/8016780/undefined-reference-to-static-constexpr-char