### PR TITLE
Fixing ET Settings Warnings

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialEventTracer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialEventTracer.cpp
@@ -10,7 +10,6 @@ DEFINE_LOG_CATEGORY(LogSpatialEventTracer);
 
 namespace SpatialGDK
 {
-
 void SpatialEventTracer::TraceCallback(void* UserData, const Trace_Item* Item)
 {
 	SpatialEventTracer* EventTracer = static_cast<SpatialEventTracer*>(UserData);
@@ -26,7 +25,7 @@ void SpatialEventTracer::TraceCallback(void* UserData, const Trace_Item* Item)
 	const bool bTrackFileSize = EventTracer->MaxFileSize != 0;
 	if (!bTrackFileSize || (EventTracer->BytesWrittenToStream + ItemSize <= EventTracer->MaxFileSize))
 	{
-		if (bTrackFileSize) 
+		if (bTrackFileSize)
 		{
 			EventTracer->BytesWrittenToStream += ItemSize;
 		}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialEventTracer.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialEventTracer.cpp
@@ -10,24 +10,6 @@ DEFINE_LOG_CATEGORY(LogSpatialEventTracer);
 
 namespace SpatialGDK
 {
-TraceQueryPtr ParseOrDefault(const FString& Str, const TCHAR* FilterForLog)
-{
-	TraceQueryPtr Ptr;
-	if (Str.Len() > 0)
-	{
-		Ptr.Reset(Trace_ParseSimpleQuery(TCHAR_TO_ANSI(*Str)));
-		UE_LOG(LogSpatialEventTracer, Log, TEXT("Applied %s query: %s"), FilterForLog, *Str);
-	}
-
-	if (!Ptr.IsValid())
-	{
-		UE_LOG(LogSpatialEventTracer, Warning, TEXT("The specified query \"%s\" is invalid; defaulting to \"false\" query. %s"),
-			   FilterForLog, Trace_GetLastError());
-		Ptr.Reset(Trace_ParseSimpleQuery("false"));
-	}
-
-	return Ptr;
-}
 
 void SpatialEventTracer::TraceCallback(void* UserData, const Trace_Item* Item)
 {
@@ -130,8 +112,8 @@ SpatialEventTracer::SpatialEventTracer(const FString& WorkerId)
 	Parameters.span_sampling_parameters.probabilistic_parameters.probabilities = SpanSamplingProbabilities.GetData();
 
 	// Filters
-	TraceQueryPtr PreFilter = ParseOrDefault(SamplingSettings->GDKEventPreFilter, TEXT("pre-filter"));
-	TraceQueryPtr PostFilter = ParseOrDefault(SamplingSettings->GDKEventPostFilter, TEXT("post-filter"));
+	UEventTracingSamplingSettings::TraceQueryPtr PreFilter = SamplingSettings->GetGDKEventPreFilter();
+	UEventTracingSamplingSettings::TraceQueryPtr PostFilter = SamplingSettings->GetGDKEventPostFilter();
 
 	checkf(PreFilter.Get() != nullptr, TEXT("Pre-filter is invalid."));
 	checkf(PostFilter.Get() != nullptr, TEXT("Post-filter is invalid."));

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -98,6 +98,17 @@ void CheckCmdLineOverrideOptionalStringWithCallback(const TCHAR* CommandLine, co
 
 } // namespace
 
+FString UEventTracingSamplingSettings::DefaultFilter = "false";
+
+UEventTracingSamplingSettings::UEventTracingSamplingSettings()
+	: SamplingProbability(1.0)
+	, GDKEventPreFilter(DefaultFilter)
+	, GDKEventPostFilter(DefaultFilter)
+	, RuntimeEventPreFilter(DefaultFilter)
+	, RuntimeEventPostFilter(DefaultFilter)
+{
+}
+
 UEventTracingSamplingSettings::TraceQueryPtr UEventTracingSamplingSettings::ParseOrDefault(const FString& Str, const TCHAR* FilterForLog)
 {
 	TraceQueryPtr Ptr;
@@ -118,7 +129,12 @@ UEventTracingSamplingSettings::TraceQueryPtr UEventTracingSamplingSettings::Pars
 
 bool UEventTracingSamplingSettings::IsFilterValid(const FString& Str)
 {
-	return !Str.IsEmpty() && TraceQueryPtr(Trace_ParseSimpleQuery(TCHAR_TO_ANSI(*Str))).Get() == nullptr;
+	return !Str.IsEmpty() && TraceQueryPtr(Trace_ParseSimpleQuery(TCHAR_TO_ANSI(*Str))).Get() != nullptr;
+}
+
+const FString& UEventTracingSamplingSettings::GetFilterString(const FString& Filter)
+{
+	return IsFilterValid(Filter) ? Filter : DefaultFilter;
 }
 
 #if WITH_EDITOR

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -98,34 +98,58 @@ void CheckCmdLineOverrideOptionalStringWithCallback(const TCHAR* CommandLine, co
 
 } // namespace
 
+UEventTracingSamplingSettings::TraceQueryPtr UEventTracingSamplingSettings::ParseOrDefault(const FString& Str, const TCHAR* FilterForLog)
+{
+	TraceQueryPtr Ptr;
+	if (!Str.IsEmpty())
+	{
+		Ptr.Reset(Trace_ParseSimpleQuery(TCHAR_TO_ANSI(*Str)));
+	}
+
+	if (!Ptr.IsValid())
+	{
+		UE_LOG(LogSpatialGDKSettings, Warning, TEXT("The specified query \"%s\" is invalid; defaulting to \"false\" query. %s"),
+			FilterForLog, Trace_GetLastError());
+		Ptr.Reset(Trace_ParseSimpleQuery("false"));
+	}
+
+	return Ptr;
+}
+
+bool UEventTracingSamplingSettings::IsFilterValid(const FString& Str)
+{
+	return !Str.IsEmpty() && TraceQueryPtr(Trace_ParseSimpleQuery(TCHAR_TO_ANSI(*Str))).Get() == nullptr;
+}
+
 #if WITH_EDITOR
 void UEventTracingSamplingSettings::PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent)
 {
-	auto CheckQueryValid = [](const char* QueryStr) {
-		if (strlen(QueryStr) > 0 && SpatialGDK::TraceQueryPtr(Trace_ParseSimpleQuery(QueryStr)).Get() == nullptr)
+	auto CheckQueryValid = [](const FString& QueryStr) {
+		if (!IsFilterValid(QueryStr))
 		{
 			FMessageDialog::Open(EAppMsgType::Ok,
 								 FText::Format(LOCTEXT("EventTracingSamplingSetting_QueryInvalid", "The query entered is not valid. {0}"),
 											   FText::FromString(ANSI_TO_TCHAR(Trace_GetLastError()))));
 		}
 	};
+
 	Super::PostEditChangeProperty(PropertyChangedEvent);
 	const FName Name = (PropertyChangedEvent.MemberProperty != nullptr) ? PropertyChangedEvent.MemberProperty->GetFName() : NAME_None;
 	if (Name == GET_MEMBER_NAME_CHECKED(UEventTracingSamplingSettings, GDKEventPreFilter))
 	{
-		CheckQueryValid(TCHAR_TO_ANSI(*GDKEventPreFilter));
+		CheckQueryValid(GDKEventPreFilter);
 	}
 	else if (Name == GET_MEMBER_NAME_CHECKED(UEventTracingSamplingSettings, RuntimeEventPreFilter))
 	{
-		CheckQueryValid(TCHAR_TO_ANSI(*RuntimeEventPreFilter));
+		CheckQueryValid(RuntimeEventPreFilter);
 	}
 	else if (Name == GET_MEMBER_NAME_CHECKED(UEventTracingSamplingSettings, GDKEventPostFilter))
 	{
-		CheckQueryValid(TCHAR_TO_ANSI(*GDKEventPostFilter));
+		CheckQueryValid(GDKEventPostFilter);
 	}
 	else if (Name == GET_MEMBER_NAME_CHECKED(UEventTracingSamplingSettings, RuntimeEventPostFilter))
 	{
-		CheckQueryValid(TCHAR_TO_ANSI(*RuntimeEventPostFilter));
+		CheckQueryValid(RuntimeEventPostFilter);
 	}
 }
 #endif

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -109,7 +109,7 @@ UEventTracingSamplingSettings::TraceQueryPtr UEventTracingSamplingSettings::Pars
 	if (!Ptr.IsValid())
 	{
 		UE_LOG(LogSpatialGDKSettings, Warning, TEXT("The specified query \"%s\" is invalid; defaulting to \"false\" query. %s"),
-			FilterForLog, Trace_GetLastError());
+			   FilterForLog, Trace_GetLastError());
 		Ptr.Reset(Trace_ParseSimpleQuery("false"));
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialEventTracer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialEventTracer.h
@@ -16,17 +16,6 @@ DECLARE_LOG_CATEGORY_EXTERN(LogSpatialEventTracer, Log, All);
 
 namespace SpatialGDK
 {
-struct TraceQueryDeleter
-{
-	void operator()(Trace_Query* Query) const
-	{
-		if (Query != nullptr)
-		{
-			Trace_Query_Destroy(Query);
-		}
-	}
-};
-typedef TUniquePtr<Trace_Query, TraceQueryDeleter> TraceQueryPtr;
 
 // SpatialEventTracer wraps Trace_EventTracer related functionality
 class SPATIALGDK_API SpatialEventTracer

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialEventTracer.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/SpatialEventTracer.h
@@ -16,7 +16,6 @@ DECLARE_LOG_CATEGORY_EXTERN(LogSpatialEventTracer, Log, All);
 
 namespace SpatialGDK
 {
-
 // SpatialEventTracer wraps Trace_EventTracer related functionality
 class SPATIALGDK_API SpatialEventTracer
 {

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -83,30 +83,32 @@ public:
 
 	using TraceQueryPtr = TUniquePtr<Trace_Query, TraceQueryDeleter>;
 
+	UEventTracingSamplingSettings();
+
 	UPROPERTY(EditAnywhere, Category = "Event Tracing", meta = (ClampMin = 0.0f, ClampMax = 1.0f))
-	double SamplingProbability = 1.0f;
+	double SamplingProbability;
 
 	UPROPERTY(EditAnywhere, Category = "Event Tracing")
 	TMap<FName, double> EventSamplingModeOverrides;
 
 	UPROPERTY(EditAnywhere, Category = "Event Tracing")
-	FString GDKEventPreFilter = "false";
+	FString GDKEventPreFilter;
 
 	UPROPERTY(EditAnywhere, Category = "Event Tracing")
-	FString GDKEventPostFilter = "false";
+	FString GDKEventPostFilter;
 
 	/* The runtime filter which is used for local/cloud editor workflows (generated configs). */
 	UPROPERTY(EditAnywhere, Category = "Event Tracing")
-	FString RuntimeEventPreFilter = "false";
+	FString RuntimeEventPreFilter;
 
 	/* The runtime filter which is used for local/cloud editor workflows (generated configs). */
 	UPROPERTY(EditAnywhere, Category = "Event Tracing")
-	FString RuntimeEventPostFilter = "false";
+	FString RuntimeEventPostFilter;
 
-	FString GetGDKEventPreFilterString() const { return IsFilterValid(GDKEventPreFilter) ? GDKEventPreFilter : "false"; }
-	FString GetGDKEventPostFilterString() const { return IsFilterValid(GDKEventPostFilter) ? GDKEventPostFilter : "false"; }
-	FString GetRuntimeEventPreFilterString() const { return IsFilterValid(RuntimeEventPreFilter) ? RuntimeEventPreFilter : "false"; }
-	FString GetRuntimeEventPostFilterString() const { return IsFilterValid(RuntimeEventPostFilter) ? RuntimeEventPostFilter : "false"; }
+	const FString& GetGDKEventPreFilterString() const { return GetFilterString(GDKEventPreFilter); }
+	const FString& GetGDKEventPostFilterString() const { return GetFilterString(GDKEventPostFilter); }
+	const FString& GetRuntimeEventPreFilterString() const { return GetFilterString(RuntimeEventPreFilter); }
+	const FString& GetRuntimeEventPostFilterString() const { return GetFilterString(RuntimeEventPostFilter); }
 
 	TraceQueryPtr GetGDKEventPreFilter() const { return ParseOrDefault(GDKEventPreFilter, TEXT("gdk-pre-filter")); }
 	TraceQueryPtr GetGDKEventPostFilter() const { return ParseOrDefault(GDKEventPostFilter, TEXT("gdk-post-filter")); }
@@ -117,8 +119,12 @@ public:
 	virtual void PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent) override;
 #endif
 private:
+
+	static FString DefaultFilter;
+
 	static bool IsFilterValid(const FString& Str);
 	static TraceQueryPtr ParseOrDefault(const FString& Str, const TCHAR* FilterForLog);
+	static const FString& GetFilterString(const FString& Filter);
 };
 
 UCLASS(config = SpatialGDKSettings, defaultconfig)

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -70,7 +70,6 @@ class SPATIALGDK_API UEventTracingSamplingSettings : public UObject
 {
 	GENERATED_BODY()
 public:
-
 	struct TraceQueryDeleter
 	{
 		void operator()(Trace_Query* Query) const
@@ -105,7 +104,7 @@ public:
 	FString RuntimeEventPostFilter = "false";
 
 	FString GetGDKEventPreFilterString() const { return IsFilterValid(GDKEventPreFilter) ? GDKEventPreFilter : "false"; }
-	FString GetGDKEventPostFilterString() const { return IsFilterValid(GDKEventPostFilter) ? GDKEventPostFilter : "false";}
+	FString GetGDKEventPostFilterString() const { return IsFilterValid(GDKEventPostFilter) ? GDKEventPostFilter : "false"; }
 	FString GetRuntimeEventPreFilterString() const { return IsFilterValid(RuntimeEventPreFilter) ? RuntimeEventPreFilter : "false"; }
 	FString GetRuntimeEventPostFilterString() const { return IsFilterValid(RuntimeEventPostFilter) ? RuntimeEventPostFilter : "false"; }
 

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -119,7 +119,6 @@ public:
 	virtual void PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent) override;
 #endif
 private:
-
 	static FString DefaultFilter;
 
 	static bool IsFilterValid(const FString& Str);

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
@@ -201,10 +201,8 @@ bool GenerateLaunchConfig(const FString& LaunchConfigPath, const FSpatialLaunchC
 			Writer->WriteObjectStart(TEXT("event_filter_configuration"));
 
 			UEventTracingSamplingSettings* SamplingSettings = SpatialGDKSettings->GetEventTracingSamplingSettings();
-			Writer->WriteValue(TEXT("event_pre_filter"),
-							   SamplingSettings->RuntimeEventPreFilter.Len() ? *SamplingSettings->RuntimeEventPreFilter : TEXT("false"));
-			Writer->WriteValue(TEXT("event_post_filter"),
-							   SamplingSettings->RuntimeEventPostFilter.Len() ? SamplingSettings->RuntimeEventPostFilter : TEXT("false"));
+			Writer->WriteValue(TEXT("event_pre_filter"), *SamplingSettings->GetRuntimeEventPreFilterString());
+			Writer->WriteValue(TEXT("event_post_filter"), *SamplingSettings->GetRuntimeEventPostFilterString());
 
 			Writer->WriteObjectEnd(); // event_filter_configuration end
 			Writer->WriteObjectEnd(); // event_tracing_configuration end


### PR DESCRIPTION
Warnings were being fired when a "None" ET sampling settings object was being used when ET was enabled. This was due to us not being able to parse a valid filter on the sampling settings.

To get around this filters now default to "false" so that None and new ET sampling settings assets are valid by default. 

Additionally moved a bit of the logic into the settings to allow the settings to always return valid filters in whatever form they are needed. 