### PR TITLE
Small tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Static subobjects on bNetLoadOnClient actors are now removed on clients in a manner matching native unreal's behavior. This change affects subobjects removed by the server while the actor is not in the client's interest.
 - Fixed an issue where multicast rpcs could be overwritten and then dropped on authority flicker.
 - Fixed issue using the runtime snapshot endpoint with a local deployment, using `localhost:5006/snapshot` works again and creates a snapshot.
+- Dormant actors will now always have their channels closed correctly when entering dormancy.
 
 ### Internal:
 - Hide the Test MultiworkerSettings and GridStrategy classes from displaying in the editor. These are meant to only be used in Tests.

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -1089,22 +1089,22 @@ void USpatialActorChannel::UpdateSpatialPosition()
 		return;
 	}
 
-	LastPositionSinceUpdate = NewSpatialActorPosition;
-	TimeWhenPositionLastUpdated = NetDriver->GetElapsedTime();
-
-	SendPositionUpdate(Actor, EntityId, LastPositionSinceUpdate);
+	SendPositionUpdate(Actor, EntityId, NewSpatialActorPosition);
 
 	if (APlayerController* PlayerController = Cast<APlayerController>(Actor))
 	{
 		if (APawn* Pawn = PlayerController->GetPawn())
 		{
-			SendPositionUpdate(Pawn, NetDriver->PackageMap->GetEntityIdFromObject(Pawn), LastPositionSinceUpdate);
+			SendPositionUpdate(Pawn, NetDriver->PackageMap->GetEntityIdFromObject(Pawn), NewSpatialActorPosition);
 		}
 	}
 }
 
 void USpatialActorChannel::SendPositionUpdate(AActor* InActor, Worker_EntityId InEntityId, const FVector& NewPosition)
 {
+	LastPositionSinceUpdate = NewPosition;
+	TimeWhenPositionLastUpdated = NetDriver->GetElapsedTime();
+
 	if (InEntityId != SpatialConstants::INVALID_ENTITY_ID && NetDriver->HasServerAuthority(InEntityId))
 	{
 		FWorkerComponentUpdate Update = SpatialGDK::Position::CreatePositionUpdate(SpatialGDK::Coordinates::FromFVector(NewPosition));

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -1083,12 +1083,13 @@ void USpatialActorChannel::UpdateSpatialPosition()
 		}
 	}
 
-	if (!SatisfiesSpatialPositionUpdateRequirements())
+	FVector NewSpatialActorPosition;
+	if (!SatisfiesSpatialPositionUpdateRequirements(NewSpatialActorPosition))
 	{
 		return;
 	}
 
-	LastPositionSinceUpdate = SpatialGDK::GetActorSpatialPosition(Actor);
+	LastPositionSinceUpdate = NewSpatialActorPosition;
 	TimeWhenPositionLastUpdated = NetDriver->GetElapsedTime();
 
 	SendPositionUpdate(Actor, EntityId, LastPositionSinceUpdate);
@@ -1281,11 +1282,11 @@ void USpatialActorChannel::ResetShadowData(FRepLayout& RepLayout, FRepStateStati
 	}
 }
 
-bool USpatialActorChannel::SatisfiesSpatialPositionUpdateRequirements()
+bool USpatialActorChannel::SatisfiesSpatialPositionUpdateRequirements(FVector& OutNewSpatialPosition)
 {
 	// Check that the Actor satisfies both lower thresholds OR either of the maximum thresholds
-	FVector ActorSpatialPosition = SpatialGDK::GetActorSpatialPosition(Actor);
-	const float DistanceTravelledSinceLastUpdateSquared = FVector::DistSquared(ActorSpatialPosition, LastPositionSinceUpdate);
+	OutNewSpatialPosition = SpatialGDK::GetActorSpatialPosition(Actor);
+	const float DistanceTravelledSinceLastUpdateSquared = FVector::DistSquared(OutNewSpatialPosition, LastPositionSinceUpdate);
 
 	// If the Actor did not travel at all, then we consider its position to be up to date and we early out.
 	if (FMath::IsNearlyZero(DistanceTravelledSinceLastUpdateSquared))

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/Interest/NetCullDistanceInterest.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/Interest/NetCullDistanceInterest.cpp
@@ -79,7 +79,15 @@ FrequencyConstraints NetCullDistanceInterest::CreateNetCullDistanceConstraint(US
 
 	for (const auto& DistanceComponentPair : NetCullDistancesToComponentIds)
 	{
-		const float MaxCheckoutRadiusMeters = NetCullDistanceInterest::NetCullDistanceSquaredToSpatialDistance(DistanceComponentPair.Key);
+		const float NetCullDistanceSquared = DistanceComponentPair.Key;
+
+		if (NetCullDistanceSquared <= 0.f)
+		{
+			// Ignore NCDs that have been setup with invalid distances
+			continue;
+		}
+
+		const float MaxCheckoutRadiusMeters = NetCullDistanceInterest::NetCullDistanceSquaredToSpatialDistance(NetCullDistanceSquared);
 
 		QueryConstraint ComponentConstraint;
 		ComponentConstraint.ComponentConstraint = DistanceComponentPair.Value;
@@ -106,7 +114,15 @@ FrequencyConstraints NetCullDistanceInterest::CreateNetCullDistanceConstraintWit
 
 	for (const auto& DistanceComponentPair : NetCullDistancesToComponentIds)
 	{
-		const float MaxCheckoutRadiusMeters = NetCullDistanceInterest::NetCullDistanceSquaredToSpatialDistance(DistanceComponentPair.Key);
+		const float NetCullDistanceSquared = DistanceComponentPair.Key;
+
+		if (NetCullDistanceSquared <= 0.f)
+		{
+			// Ignore NCDs that have been setup with invalid distances
+			continue;
+		}
+
+		const float MaxCheckoutRadiusMeters = NetCullDistanceInterest::NetCullDistanceSquaredToSpatialDistance(NetCullDistanceSquared);
 
 		QueryConstraint ComponentConstraint;
 		ComponentConstraint.ComponentConstraint = DistanceComponentPair.Value;

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -276,6 +276,8 @@ public:
 
 	bool NeedOwnerInterestUpdate() const { return bNeedOwnerInterestUpdate; }
 
+	const FVector& GetLastUpdatedSpatialPosition() const {	return LastPositionSinceUpdate; }
+
 protected:
 	// Begin UChannel interface
 	virtual bool CleanUp(const bool bForDestroy, EChannelCloseReason CloseReason) override;

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -120,7 +120,7 @@ public:
 
 	void UpdateRefToRepStateMap(FObjectToRepStateMap& ReplicatorMap);
 	bool MoveMappedObjectToUnmapped(const FUnrealObjectRef& ObjRef);
-	bool HasUnresolved() const { return UnresolvedRefs.Num() == 0; }
+	bool HasUnresolved() const { return UnresolvedRefs.Num() != 0; }
 
 	const FChannelObjectPair& GetChannelObjectPair() const { return ThisObj; }
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -292,7 +292,7 @@ private:
 
 	void UpdateVisibleComponent(AActor* Actor);
 
-	bool SatisfiesSpatialPositionUpdateRequirements();
+	bool SatisfiesSpatialPositionUpdateRequirements(FVector& OutNewSpatialPosition);
 
 	void ValidateChannelNotBroken();
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -276,7 +276,7 @@ public:
 
 	bool NeedOwnerInterestUpdate() const { return bNeedOwnerInterestUpdate; }
 
-	const FVector& GetLastUpdatedSpatialPosition() const {	return LastPositionSinceUpdate; }
+	const FVector& GetLastUpdatedSpatialPosition() const { return LastPositionSinceUpdate; }
 
 protected:
 	// Begin UChannel interface


### PR DESCRIPTION
#### Description
Small usability tweaks based on NFR work.
1. Expose last updated spatial actor position
2. Call GetSpatialActorPosition only once in a standard update
3. Don't create interest queries with invalid distance constraints