### PR TITLE
Fix ASpatialTestReplicationConditions COND_Custom test

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestReplicationConditions/SpatialTestReplicationConditions.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestReplicationConditions/SpatialTestReplicationConditions.cpp
@@ -561,7 +561,7 @@ void ASpatialTestReplicationConditions::ProcessCommonActorProperties(bool bWrite
 void ASpatialTestReplicationConditions::ProcessCustomActorProperties(ATestReplicationConditionsActor_Custom* Actor, const bool bWrite,
 																	 const bool bCustomEnabled)
 {
-	auto WrappedAction = [&](int32& Source, const bool bEnabled, const int32 Expected, FString const AdditionalText = TEXT("")) {
+	auto WrappedAction = [&](int32& Source, const bool bEnabled, const int32 Expected, const FString AdditionalText = TEXT("")) {
 		bool CondIgnore[COND_Max]{};
 		CondIgnore[COND_Custom] = !bEnabled;
 		Action(Source, Expected, COND_Custom, bWrite, CondIgnore, AdditionalText);

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestReplicationConditions/SpatialTestReplicationConditions.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestReplicationConditions/SpatialTestReplicationConditions.cpp
@@ -481,8 +481,8 @@ FString CondAsString(ELifetimeCondition Condition)
 	return ConditionName.ToString();
 }
 
-FString StaticCompText = TEXT(" on static component");
-FString DynamicCompText = TEXT(" on dynamic component");
+static FString StaticCompText = TEXT(" on static component");
+static FString DynamicCompText = TEXT(" on dynamic component");
 
 // This function encapsulates the logic for both writing to, and reading from (and asserting) the properties of TestActor_Common.
 // When bWrite is true, the Action lambda just writes the expected property values to the Actor.
@@ -559,16 +559,17 @@ void ASpatialTestReplicationConditions::ProcessCommonActorProperties(bool bWrite
 }
 
 void ASpatialTestReplicationConditions::ProcessCustomActorProperties(ATestReplicationConditionsActor_Custom* Actor, bool bWrite,
-																	 bool bCustomEnabled)
+																	 const bool bCustomEnabled)
 {
-	auto WrappedAction = [&](int32& Source, int32 Expected, FString AdditionalText = TEXT("")) {
+	auto WrappedAction = [&](int32& Source, const bool bEnabled, const int32 Expected, FString const AdditionalText = TEXT("")) {
 		bool CondIgnore[COND_Max]{};
+		CondIgnore[COND_Custom] = !bEnabled;
 		Action(Source, Expected, COND_Custom, bWrite, CondIgnore, AdditionalText);
 	};
 
-	WrappedAction(Actor->CondCustom_Var, bCustomEnabled ? 1010 : 2010);
-	WrappedAction(Actor->StaticComponent->CondCustom_Var, bCustomEnabled ? 1020 : 2020, StaticCompText);
-	WrappedAction(Actor->DynamicComponent->CondCustom_Var, bCustomEnabled ? 1030 : 2030, DynamicCompText);
+	WrappedAction(Actor->CondCustom_Var, bCustomEnabled, bCustomEnabled ? 1010 : 2010);
+	WrappedAction(Actor->StaticComponent->CondCustom_Var, bCustomEnabled, bCustomEnabled ? 1020 : 2020, StaticCompText);
+	WrappedAction(Actor->DynamicComponent->CondCustom_Var, bCustomEnabled, bCustomEnabled ? 1030 : 2030, DynamicCompText);
 }
 
 void ASpatialTestReplicationConditions::ProcessAutonomousOnlyActorProperties(bool bWrite, bool bAutonomousExpected, bool bSimulatedExpected)

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestReplicationConditions/SpatialTestReplicationConditions.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestReplicationConditions/SpatialTestReplicationConditions.cpp
@@ -558,7 +558,7 @@ void ASpatialTestReplicationConditions::ProcessCommonActorProperties(bool bWrite
 	WrappedAction(TestActor_Common->DynamicComponent->CondServerOnly_Var, 550, COND_ServerOnly, DynamicCompText);
 }
 
-void ASpatialTestReplicationConditions::ProcessCustomActorProperties(ATestReplicationConditionsActor_Custom* Actor, bool bWrite,
+void ASpatialTestReplicationConditions::ProcessCustomActorProperties(ATestReplicationConditionsActor_Custom* Actor, const bool bWrite,
 																	 const bool bCustomEnabled)
 {
 	auto WrappedAction = [&](int32& Source, const bool bEnabled, const int32 Expected, FString const AdditionalText = TEXT("")) {


### PR DESCRIPTION
This fixes a bug you can only trigger manually by running the SpatialTestReplicationConditions test manually in the session frontend with spatial turned off (it does not run in CI because its in the spatial only folder).
