### PR TITLE
UNR-5752: Fixed an error caused by destroying an actor between entity creation and confirmation thereof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes:
 - Fix `A functional test is already running error` that would sometimes occur when re-running multi-server functional tests.
+- Fixed an issue around actors being destroyed between entity creation and receiving a confirmation thereof.
+
 ### Internal:
 - Modified startup flow to only create ActorSystem, RPCService and some others after startup has otherwise finished; removed initial op reordering.
 - Unused worker types will no longer generate worker configuration files.

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
@@ -177,6 +177,17 @@ void ActorSystem::ProcessAdds(const FEntitySubViewUpdate& SubViewUpdate)
 		{
 			const Worker_EntityId EntityId = Delta.EntityId;
 
+			if (SubViewUpdate.SubViewType == ENetRole::ROLE_Authority)
+			{
+				// Check if this entity is EntitiesToRetireOnAuthorityGain first,
+				// to avoid creating an actor that might've been deleted before.
+				if (HasEntityBeenRequestedForDelete(EntityId))
+				{
+					HandleEntityDeletedAuthority(EntityId);
+					continue;
+				}
+			}
+
 			if (!PresentEntities.Contains(Delta.EntityId))
 			{
 				// Create new actor for the entity.
@@ -385,15 +396,6 @@ void ActorSystem::AuthorityGained(Worker_EntityId EntityId, Worker_ComponentSetI
 	if (ComponentSetId != SpatialConstants::SERVER_AUTH_COMPONENT_SET_ID
 		&& ComponentSetId != SpatialConstants::CLIENT_AUTH_COMPONENT_SET_ID)
 	{
-		return;
-	}
-
-	if (HasEntityBeenRequestedForDelete(EntityId))
-	{
-		if (ComponentSetId == SpatialConstants::SERVER_AUTH_COMPONENT_SET_ID)
-		{
-			HandleEntityDeletedAuthority(EntityId);
-		}
 		return;
 	}
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/TestMaps/Spatial2WorkerMap.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/Private/TestMaps/Spatial2WorkerMap.cpp
@@ -5,6 +5,7 @@
 #include "SpatialGDKFunctionalTests/SpatialGDK/CrossServerAndClientOrchestrationTest/CrossServerAndClientOrchestrationTest.h"
 #include "SpatialGDKFunctionalTests/SpatialGDK/RegisterAutoDestroyActorsTest/RegisterAutoDestroyActorsTest.h"
 #include "SpatialGDKFunctionalTests/SpatialGDK/RelevancyTest/RelevancyTest.h"
+#include "SpatialGDKFunctionalTests/SpatialGDK/SpatialActorResolutionTest/SpatialActorResolutionTest.h"
 #include "SpatialGDKFunctionalTests/SpatialGDK/SpatialTestMultiServerUnrealComponents/SpatialTestMultiServerUnrealComponents.h"
 #include "SpatialGDKFunctionalTests/SpatialGDK/SpatialTestReplicationConditions/SpatialTestReplicationConditions.h"
 #include "TestWorkerSettings.h"
@@ -32,6 +33,8 @@ void USpatial2WorkerMap::CreateCustomContentForMap()
 	// Test actor is placed in Server 1 load balancing area to ensure Server 1 becomes authoritative.
 	AddActorToLevel<ASpatialTestMultiServerUnrealComponents>(CurrentLevel, Server1Pos);
 	AddActorToLevel<ASpatialTestReplicationConditions>(CurrentLevel, Server1Pos);
+
+	AddActorToLevel<ASpatialActorResolutionTest>(CurrentLevel, FTransform::Identity);
 
 	ASpatialWorldSettings* WorldSettings = CastChecked<ASpatialWorldSettings>(World->GetWorldSettings());
 	WorldSettings->SetMultiWorkerSettingsClass(UTest1x2FullInterestWorkerSettings::StaticClass());

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialActorResolutionTest/SpatialActorResolutionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialActorResolutionTest/SpatialActorResolutionTest.cpp
@@ -15,8 +15,11 @@ void ASelfDestroyingActor::PreReplication(IRepChangedPropertyTracker& ChangedPro
 	TSharedPtr<FDelegateHandle> DelegateHandle = MakeShared<FDelegateHandle>();
 
 	// OnEndFrame decouples us from tick rates and gives no opportunity for the NetDriver to tick in-between.
-	*DelegateHandle = FCoreDelegates::OnEndFrame.AddLambda([this, DelegateHandle]() {
-		Destroy();
+	*DelegateHandle = FCoreDelegates::OnEndFrame.AddLambda([WeakThis = MakeWeakObjectPtr(this), DelegateHandle]() {
+		if (WeakThis.IsValid())
+		{
+			WeakThis->Destroy();
+		}
 		FCoreDelegates::OnEndFrame.Remove(*DelegateHandle);
 	});
 

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialActorResolutionTest/SpatialActorResolutionTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialActorResolutionTest/SpatialActorResolutionTest.cpp
@@ -1,0 +1,59 @@
+﻿#include "SpatialActorResolutionTest.h"
+
+#include "Engine/World.h"
+#include "Misc/CoreDelegates.h"
+
+#include "SpatialFunctionalTestStep.h"
+
+ASelfDestroyingActor::ASelfDestroyingActor()
+{
+	bReplicates = true;
+}
+
+void ASelfDestroyingActor::PreReplication(IRepChangedPropertyTracker& ChangedPropertyTracker)
+{
+	TSharedPtr<FDelegateHandle> DelegateHandle = MakeShared<FDelegateHandle>();
+
+	// OnEndFrame decouples us from tick rates and gives no opportunity for the NetDriver to tick in-between.
+	*DelegateHandle = FCoreDelegates::OnEndFrame.AddLambda([this, DelegateHandle]() {
+		Destroy();
+		FCoreDelegates::OnEndFrame.Remove(*DelegateHandle);
+	});
+
+	return Super::PreReplication(ChangedPropertyTracker);
+}
+
+ASpatialActorResolutionTest::ASpatialActorResolutionTest()
+{
+	Author = TEXT("Dmitrii <dmitriikozlov@improbable.io>");
+}
+
+/*
+ * This test creates an actor that destroys itself after replicating for the first time, then
+ * waits to check if there are any errors. Created to validate UNR-5752.
+ */
+void ASpatialActorResolutionTest::PrepareTest()
+{
+	Super::PrepareTest();
+
+	AddStep(TEXT("Spawn the self-destroying actor and save its EntityID"), FWorkerDefinition::Server(1), nullptr, [this]() {
+		TestActor = GetWorld()->SpawnActor<ASelfDestroyingActor>();
+		FinishStep();
+	});
+
+	AddStep(TEXT("Wait until the test actor is destroyed"), FWorkerDefinition::Server(1), nullptr, nullptr, [this](float) {
+		RequireTrue(TestActor.IsStale(), TEXT("The actor became invalid"));
+		FinishStep();
+	});
+
+	AddStep(
+		TEXT("Wait for a predetermined timeout to see there's no errors"), FWorkerDefinition::Server(1), nullptr,
+		[this]() {
+			TimeElapsed = 0.0f;
+		},
+		[this](float DeltaTime) {
+			TimeElapsed += DeltaTime;
+			RequireCompare_Float(TimeElapsed, EComparisonMethod::Greater_Than, 1.0f, TEXT("Waited for required time"));
+			FinishStep();
+		});
+}

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialActorResolutionTest/SpatialActorResolutionTest.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialActorResolutionTest/SpatialActorResolutionTest.h
@@ -1,0 +1,34 @@
+﻿#pragma once
+
+#include "GameFramework/Actor.h"
+
+#include "SpatialCommonTypes.h"
+#include "SpatialFunctionalTest.h"
+
+#include "SpatialActorResolutionTest.generated.h"
+
+UCLASS()
+class ASelfDestroyingActor : public AActor
+{
+	GENERATED_BODY()
+
+public:
+	ASelfDestroyingActor();
+
+	virtual void PreReplication(IRepChangedPropertyTracker& ChangedPropertyTracker) override;
+};
+
+UCLASS()
+class ASpatialActorResolutionTest : public ASpatialFunctionalTest
+{
+	GENERATED_BODY()
+public:
+	ASpatialActorResolutionTest();
+
+	virtual void PrepareTest() override;
+
+	UPROPERTY(Transient)
+	TWeakObjectPtr<ASelfDestroyingActor> TestActor;
+
+	float TimeElapsed;
+};


### PR DESCRIPTION
#### Description
Reapplied a part of the fix introduced in UNR-4849 and added a functional test covering this functionality.

The flow of the bug is:

1. Create a replicated actor
2. This actor is replicated for the first time and has an entity created for it
3. The actor is destroyed before we've received the entity from the Runtime; we save this entity ID as EntityToRetireOnAuthorityGain.
4. We receive the entity and try to create it.

The fix is first checking for the entity to be an EntityToRetireOnAuthorityGain, and not creating an actor for it in such a case.

#### Release note
Added a release note.

#### Tests
I've added a new functional test and ran the existing test suite.

#### Documentation
Release note.