### PR TITLE
[UNR-5762] Avoid a crash in the routing worker in case of interest races on the receiver

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialRoutingSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialRoutingSystem.cpp
@@ -84,7 +84,8 @@ void SpatialRoutingSystem::OnSenderChanged(Worker_EntityId SenderId, RoutingComp
 					if (Slots != nullptr)
 					{
 						UE_LOG(LogSpatialRoutingSystem, Verbose,
-							   TEXT("RPC %llu,%llu already acked on %llu, probably from missing receiver"), Receiver, RPCId, SenderId);
+							   TEXT("RPC already acked, probably from missing receiver, Receiver: %llu, RPCId: %llu, Sender: %llu"),
+							   Receiver, RPCId, SenderId);
 					}
 					else
 					{
@@ -134,7 +135,7 @@ void SpatialRoutingSystem::OnSenderChanged(Worker_EntityId SenderId, RoutingComp
 		if (Slots.ACKSlot < 0)
 		{
 			// This is a race we could solve with either blank entities, or timeout
-			UE_LOG(LogSpatialRoutingSystem, Error, TEXT("Receiver %llu missing from view for RPC from Sender %llu. RPC will be dropped."),
+			UE_LOG(LogSpatialRoutingSystem, Error, TEXT("Receiver missing from view. RPC will be dropped. Receiver: %llu, Sender: %llu"),
 				   RPC.Value, SenderId);
 			Slots.CounterpartEntity = RPC.Value;
 			WriteACKToSender(RPC.Key, Components, CrossServer::Result::TargetUnknown);
@@ -196,12 +197,12 @@ void SpatialRoutingSystem::TransferRPCsToReceiver(Worker_EntityId ReceiverId, Ro
 				// Sender disappeared before we could deliver the RPC.
 				// This should eventually become impossible by tombstoning actors instead of erasing their entities.
 				UE_LOG(LogSpatialRoutingSystem, Error,
-					   TEXT("Sender %llu disappeared before delivery to receiver %llu, RPC will be dropped"), SenderId, ReceiverId);
+					   TEXT("Sender disappeared before delivery, RPC will be dropped. Sender: %llu, Receiver: %llu"), SenderId, ReceiverId);
 				continue;
 			}
 
 			CrossServer::RPCSlots* ExistingSlot = SenderComps->SenderACKState.RPCSlots.Find(RPCToSend);
-			if (!ensureAlwaysMsgf(ExistingSlot == nullptr, TEXT("Sender %llu has already been sent a missing receiver ACK for %llu"),
+			if (!ensureAlwaysMsgf(ExistingSlot == nullptr, TEXT("Sender has already been sent an ACK. Sender: %llu, Receiver: %llu"),
 								  SenderId, ReceiverId))
 			{
 				// Sender was already sent ACK for this one, probably for a missing receiver

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialRoutingSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialRoutingSystem.cpp
@@ -80,13 +80,22 @@ void SpatialRoutingSystem::OnSenderChanged(Worker_EntityId SenderId, RoutingComp
 			{
 				if (ReceiverComps->ReceiverState.Mailbox.Find(RPCKey) == nullptr)
 				{
-					CrossServer::SentRPCEntry Entry;
-					Entry.Target = RPCTarget(Counterpart.GetValue());
-					Entry.SourceSlot = SlotIdx;
+					CrossServer::RPCSlots* Slots = Components.SenderACKState.RPCSlots.Find(RPCKey);
+					if (Slots != nullptr)
+					{
+						UE_LOG(LogSpatialRoutingSystem, Verbose,
+							   TEXT("RPC %llu,%llu already acked on %llu, probably from missing receiver"), Receiver, RPCId, SenderId);
+					}
+					else
+					{
+						CrossServer::SentRPCEntry Entry;
+						Entry.Target = RPCTarget(Counterpart.GetValue());
+						Entry.SourceSlot = SlotIdx;
 
-					ReceiverComps->ReceiverState.Mailbox.Add(RPCKey, Entry);
-					ReceiverComps->ReceiverSchedule.Add(RPCKey);
-					ReceiversToInspect.Add(Receiver);
+						ReceiverComps->ReceiverState.Mailbox.Add(RPCKey, Entry);
+						ReceiverComps->ReceiverSchedule.Add(RPCKey);
+						ReceiversToInspect.Add(Receiver);
+					}
 				}
 			}
 			else
@@ -101,16 +110,20 @@ void SpatialRoutingSystem::OnSenderChanged(Worker_EntityId SenderId, RoutingComp
 		const CrossServer::RPCSlots& Slots = SlotToClear.Value;
 		{
 			EntityComponentId SenderPair(SenderId, SpatialConstants::CROSS_SERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID);
-			Components.SenderACKState.ACKAlloc.FreeSlot(Slots.ACKSlot);
+			if (ensureAlways(Slots.ACKSlot >= 0))
+			{
+				Components.SenderACKState.ACKAlloc.FreeSlot(Slots.ACKSlot);
+			}
 
 			GetOrCreateComponentUpdate(SenderPair);
 		}
-
-		if (RoutingComponents* ReceiverComps = RoutingWorkerView.Find(Slots.CounterpartEntity))
+		if (Slots.ACKResult == CrossServer::Result::Success)
 		{
-			ClearReceiverSlot(Slots.CounterpartEntity, SlotToClear.Key, *ReceiverComps);
+			if (RoutingComponents* ReceiverComps = RoutingWorkerView.Find(Slots.CounterpartEntity))
+			{
+				ClearReceiverSlot(Slots.CounterpartEntity, SlotToClear.Key, *ReceiverComps);
+			}
 		}
-
 		Components.SenderACKState.RPCSlots.Remove(SlotToClear.Key);
 	}
 
@@ -120,6 +133,9 @@ void SpatialRoutingSystem::OnSenderChanged(Worker_EntityId SenderId, RoutingComp
 		auto& Slots = Components.SenderACKState.RPCSlots.FindOrAdd(RPC.Key);
 		if (Slots.ACKSlot < 0)
 		{
+			// This is a race we could solve with either blank entities, or timeout
+			UE_LOG(LogSpatialRoutingSystem, Error, TEXT("Receiver %llu missing from view for RPC from Sender %llu. RPC will be dropped."),
+				   RPC.Value, SenderId);
 			Slots.CounterpartEntity = RPC.Value;
 			WriteACKToSender(RPC.Key, Components, CrossServer::Result::TargetUnknown);
 		}
@@ -129,11 +145,17 @@ void SpatialRoutingSystem::OnSenderChanged(Worker_EntityId SenderId, RoutingComp
 void SpatialRoutingSystem::ClearReceiverSlot(Worker_EntityId Receiver, CrossServer::RPCKey RPCKey, RoutingComponents& ReceiverComponents)
 {
 	CrossServer::SentRPCEntry* SentRPC = ReceiverComponents.ReceiverState.Mailbox.Find(RPCKey);
-	check(SentRPC != nullptr);
+	if (!ensureAlways(SentRPC != nullptr))
+	{
+		return;
+	}
 
 	EntityComponentId ReceiverPair(Receiver, SpatialConstants::CROSS_SERVER_RECEIVER_ENDPOINT_COMPONENT_ID);
 
-	check(SentRPC->DestinationSlot.IsSet());
+	if (!ensureAlways(SentRPC->DestinationSlot.IsSet()))
+	{
+		return;
+	}
 	uint32 SlotIdx = SentRPC->DestinationSlot.GetValue();
 
 	ReceiverComponents.ReceiverState.Mailbox.Remove(RPCKey);
@@ -155,6 +177,7 @@ void SpatialRoutingSystem::TransferRPCsToReceiver(Worker_EntityId ReceiverId, Ro
 			TOptional<uint32> FreeSlot = ReceiverComps->ReceiverState.Alloc.PeekFreeSlot();
 			if (!FreeSlot)
 			{
+				UE_LOG(LogSpatialRoutingSystem, Verbose, TEXT("Receiver %llu out of slots"), ReceiverId);
 				return;
 			}
 			CrossServer::RPCKey RPCToSend = ReceiverComps->ReceiverSchedule.Extract();
@@ -172,6 +195,17 @@ void SpatialRoutingSystem::TransferRPCsToReceiver(Worker_EntityId ReceiverId, Ro
 				ReceiverComps->ReceiverState.Mailbox.Remove(RPCToSend);
 				// Sender disappeared before we could deliver the RPC.
 				// This should eventually become impossible by tombstoning actors instead of erasing their entities.
+				UE_LOG(LogSpatialRoutingSystem, Error,
+					   TEXT("Sender %llu disappeared before delivery to receiver %llu, RPC will be dropped"), SenderId, ReceiverId);
+				continue;
+			}
+
+			CrossServer::RPCSlots* ExistingSlot = SenderComps->SenderACKState.RPCSlots.Find(RPCToSend);
+			if (!ensureAlwaysMsgf(ExistingSlot == nullptr, TEXT("Sender %llu has already been sent a missing receiver ACK for %llu"),
+								  SenderId, ReceiverId))
+			{
+				// Sender was already sent ACK for this one, probably for a missing receiver
+				ReceiverComps->ReceiverState.Mailbox.Remove(RPCToSend);
 				continue;
 			}
 
@@ -209,6 +243,7 @@ void SpatialRoutingSystem::WriteACKToSender(CrossServer::RPCKey RPCKey, RoutingC
 		if (TOptional<uint32_t> ReservedSlot = SenderComponents.SenderACKState.ACKAlloc.ReserveSlot())
 		{
 			Slots->ACKSlot = ReservedSlot.GetValue();
+			Slots->ACKResult = Result;
 			EntityComponentId SenderPair(RPCKey.Get<0>(), SpatialConstants::CROSS_SERVER_SENDER_ACK_ENDPOINT_COMPONENT_ID);
 			Schema_ComponentUpdate* Update = GetOrCreateComponentUpdate(SenderPair);
 			Schema_Object* UpdateObject = Schema_GetComponentUpdateFields(Update);
@@ -353,7 +388,10 @@ void SpatialRoutingSystem::Advance(SpatialOSWorkerInterface* Connection)
 						if (Slot.IsSet())
 						{
 							const TOptional<CrossServerRPCInfo>& SenderBackRef = TempView.ReliableRPCBuffer.Counterpart[SlotIdx];
-							check(SenderBackRef.IsSet());
+							if (!ensureAlways(SenderBackRef.IsSet()))
+							{
+								continue;
+							}
 
 							CrossServer::RPCKey RPCKey(SenderBackRef->Entity, SenderBackRef->RPCId);
 							CrossServer::SentRPCEntry NewEntry;
@@ -383,6 +421,11 @@ void SpatialRoutingSystem::Advance(SpatialOSWorkerInterface* Connection)
 		case EntityDelta::REMOVE:
 		case EntityDelta::TEMPORARILY_REMOVED:
 		{
+			if (Delta.Type == EntityDelta::TEMPORARILY_REMOVED)
+			{
+				UE_LOG(LogSpatialRoutingSystem, Warning, TEXT("Unexpected refresh for %llu"), Delta.EntityId);
+			}
+
 			ReceiversToInspect.Remove(Delta.EntityId);
 			PendingComponentUpdatesToSend.Remove(
 				EntityComponentId(Delta.EntityId, SpatialConstants::CROSS_SERVER_RECEIVER_ENDPOINT_COMPONENT_ID));

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/TestRoutingWorker.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/TestRoutingWorker.cpp
@@ -747,6 +747,11 @@ ROUTING_SERVICE_TEST(TestRoutingWorker_BlackBox_SendOneMessageBetweenDeletedEnti
 			Worker_EntityId ToRemove = (Attempt % 2) == 0 ? Sender : Receiver;
 			Worker_EntityId ToCheck = (Attempt % 2) == 1 ? Sender : Receiver;
 
+			if (ToRemove == 100)
+			{
+				AddExpectedError(TEXT("Receiver missing from view. RPC will be dropped"));
+			}
+
 			PendingRPCPayload DummyPayload(RPCPayload(0, 0, {}, TArray<uint8>()), {});
 			RPCService.PushCrossServerRPC(Receiver, RPCSender(Sender, 0), DummyPayload, false);
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/CrossServerUtils.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/CrossServerUtils.h
@@ -16,6 +16,7 @@ enum class Result
 	Success,
 	TargetDestroyed,
 	TargetUnknown,
+	Undefined
 };
 
 inline void WritePayloadAndCounterpart(Schema_Object* EndpointObject, const RPCPayload& Payload, const CrossServerRPCInfo& Info,
@@ -148,6 +149,7 @@ struct RPCSlots
 	Worker_EntityId CounterpartEntity;
 	int32 CounterpartSlot = -1;
 	int32 ACKSlot = -1;
+	Result ACKResult = Result::Undefined;
 };
 
 using ReadRPCMap = TMap<CrossServer::RPCKey, RPCSlots>;


### PR DESCRIPTION
#### Description
The routing worker had a couple of edge cases that were not handled when a receiver was missing, or arrived too late into the view.

#### Tests
Ran SpatialEntityInteractionTest, and checked that the crash did not appear (test could fail for other reasons though, see https://improbableio.atlassian.net/browse/UNR-5780)