### PR TITLE
Spatialguidmap has an objectref->netguid mapping that should have been deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Internal:
 - Modified startup flow to only create ActorSystem, RPCService and some others after startup has otherwise finished; removed initial op reordering.
 - Unused worker types will no longer generate worker configuration files.
+- Fixed an issue that could cause SpatialNetGuidCache and native's NetGuidCache to become out of sync.
 
 ## [`0.14.0-rc`] - Unreleased
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -1009,7 +1009,7 @@ FObjectReplicator* USpatialActorChannel::PreReceiveSpatialUpdate(UObject* Target
 {
 	// If there is no NetGUID for this object, we will crash in FObjectReplicator::StartReplicating, so we verify this here.
 	FNetworkGUID ObjectNetGUID = Connection->Driver->GuidCache->GetOrAssignNetGUID(TargetObject);
-	NetDriver->PackageMap->SlowCheckMapsConsistency(TargetObject, TEXT("PreReceiveSpatialUpdate"));
+	NetDriver->PackageMap->SlowCheckMapsConsistency(TargetObject);
 
 	if (ObjectNetGUID.IsDefault() || !ObjectNetGUID.IsValid())
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -1009,6 +1009,8 @@ FObjectReplicator* USpatialActorChannel::PreReceiveSpatialUpdate(UObject* Target
 {
 	// If there is no NetGUID for this object, we will crash in FObjectReplicator::StartReplicating, so we verify this here.
 	FNetworkGUID ObjectNetGUID = Connection->Driver->GuidCache->GetOrAssignNetGUID(TargetObject);
+	NetDriver->PackageMap->SlowCheckMapsConsistency(TargetObject, TEXT("PreReceiveSpatialUpdate"));
+
 	if (ObjectNetGUID.IsDefault() || !ObjectNetGUID.IsValid())
 	{
 		// SpatialReceiver tried to resolve this object in the PackageMap, but it didn't propagate to GuidCache.

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -181,6 +181,24 @@ void USpatialPackageMapClient::ResolveSubobject(UObject* Object, const FUnrealOb
 	{
 		SpatialGuidCache->AssignNewSubobjectNetGUID(Object, ObjectRef);
 	}
+	else
+	{
+		// TODO UNR-5785 - Remove this once fixed, as really SpatialGuidCache and Native's GuidCache should be in sync
+		FNetworkGUID ObjectNetGUID = GetNetGUIDFromObject(Object);
+		if (!ObjectNetGUID.IsValid())
+		{
+			UE_LOG(LogSpatialPackageMap, Log, TEXT("SpatialGuidCache has a NetGUID mapping which native's GuidCache does not have for object: %s with NetGUID: %u. Removing existing mapping from SpatialGuidCache and recreating."),
+				*Object->GetName(), NetGUID.Value);
+			RemoveSubobject(ObjectRef);
+			SpatialGuidCache->AssignNewSubobjectNetGUID(Object, ObjectRef);
+		}
+		else if (ObjectNetGUID != NetGUID)
+		{
+			UE_LOG(LogSpatialPackageMap, Warning,
+				TEXT("ResolveSubobject has NetGuid mismatch between SpatialGuidCache and GuidCache for object: %s with NetGUID: %u and ObjectNetGUID: %u"),
+				*Object->GetName(), NetGUID.Value, ObjectNetGUID.Value);
+		}
+	}
 }
 
 void USpatialPackageMapClient::RemoveEntityActor(Worker_EntityId EntityId)

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -194,13 +194,6 @@ void USpatialPackageMapClient::ResolveSubobject(UObject* Object, const FUnrealOb
 			RemoveSubobject(ObjectRef);
 			SpatialGuidCache->AssignNewSubobjectNetGUID(Object, ObjectRef);
 		}
-		else if (ObjectNetGUID != NetGUID)
-		{
-			UE_LOG(LogSpatialPackageMap, Warning,
-				   TEXT("ResolveSubobject has NetGuid mismatch between SpatialGuidCache and GuidCache for object: %s with NetGUID: %u and "
-						"ObjectNetGUID: %u"),
-				   *Object->GetName(), NetGUID.Value, ObjectNetGUID.Value);
-		}
 	}
 
 	SlowCheckMapsConsistency(Object, TEXT("ResolveSubobject"));

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -894,7 +894,7 @@ void FSpatialNetGUIDCache::SlowCheckMapsConsistency(const UObject* Object) const
 		ensureAlwaysMsgf(ObjectNetGUID.IsValid(), TEXT("Object is valid but has an invalid ObjectNetGUID. Object: %s, ObjectNetGUID: %u"),
 						 *Object->GetName(), ObjectNetGUID.Value);
 		ensureAlwaysMsgf(ObjectRefNetGUID.IsValid(),
-						 TEXT("Object is valid but has an ivalid ObjRefNetGUID. Object: %s, ObjectRefNetGUID: %u"), *Object->GetName(),
+						 TEXT("Object is valid but has an invalid ObjRefNetGUID. Object: %s, ObjectRefNetGUID: %u"), *Object->GetName(),
 						 ObjectRefNetGUID.Value);
 		ensureAlwaysMsgf(
 			ObjectRef.Entity != SpatialConstants::INVALID_ENTITY_ID || ObjectRef.Path.IsSet(),

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -873,21 +873,33 @@ void FSpatialNetGUIDCache::SlowCheckMapsConsistency(const UObject* Object, const
 	const FUnrealObjectRef ObjectRef = GetUnrealObjectRefFromNetGUID(ObjectNetGUID);
 	const FNetworkGUID ObjectRefNetGUID = UnrealObjectRefToNetGUID.FindRef(ObjectRef);
 
-	ensureAlwaysMsgf(ObjectNetGUID == ObjectRefNetGUID, TEXT("NetGUID inconsistency between SpatialNetGuidCache and native's NetGuidCache. Object: %s, ObjectNetGUID: %u, "
-					"ObjectRefNetGUID: %u"), *GetNameSafe(Object), ObjectNetGUID.Value, ObjectRefNetGUID.Value);
+	ensureAlwaysMsgf(ObjectNetGUID == ObjectRefNetGUID,
+					 TEXT("NetGUID inconsistency between SpatialNetGuidCache and native's NetGuidCache. Object: %s, ObjectNetGUID: %u, "
+						  "ObjectRefNetGUID: %u"),
+					 *GetNameSafe(Object), ObjectNetGUID.Value, ObjectRefNetGUID.Value);
 
 	if (!IsValid(Object))
 	{
-		ensureAlwaysMsgf(!ObjectNetGUID.IsValid(), TEXT("Object is not valid but has a valid ObjectNetGUID. Object: %s, ObjectNetGUID: %u"), *GetNameSafe(Object), ObjectNetGUID.Value);
-		ensureAlwaysMsgf(!ObjectRefNetGUID.IsValid(), TEXT("Object is not valid but has a valid ObjectRefNetGUID. Object: %s, ObjectRefNetGUID: %u"), *GetNameSafe(Object), ObjectRefNetGUID.Value);
-		ensureAlwaysMsgf(ObjectRef.Entity == SpatialConstants::INVALID_ENTITY_ID, TEXT("Object is not valid but has a valid ObjectRef Entity ID. Object: %s, EntityId: %lld, Offset: %u"), *GetNameSafe(Object), ObjectRef.Entity, ObjectRef.Offset);
+		ensureAlwaysMsgf(!ObjectNetGUID.IsValid(), TEXT("Object is not valid but has a valid ObjectNetGUID. Object: %s, ObjectNetGUID: %u"),
+						 *GetNameSafe(Object), ObjectNetGUID.Value);
+		ensureAlwaysMsgf(!ObjectRefNetGUID.IsValid(),
+						 TEXT("Object is not valid but has a valid ObjectRefNetGUID. Object: %s, ObjectRefNetGUID: %u"),
+						 *GetNameSafe(Object), ObjectRefNetGUID.Value);
+		ensureAlwaysMsgf(ObjectRef.Entity == SpatialConstants::INVALID_ENTITY_ID,
+						 TEXT("Object is not valid but has a valid ObjectRef Entity ID. Object: %s, EntityId: %lld, Offset: %u"),
+						 *GetNameSafe(Object), ObjectRef.Entity, ObjectRef.Offset);
 	}
 	else
 	{
-		ensureAlwaysMsgf(ObjectNetGUID.IsValid(), TEXT("Object is valid but has an invalid ObjectNetGUID. Object: %s, ObjectNetGUID: %u"), *Object->GetName(), ObjectNetGUID.Value);
-		ensureAlwaysMsgf(ObjectRefNetGUID.IsValid(), TEXT("Object is valid but has an ivalid ObjRefNetGUID. Object: %s, ObjectRefNetGUID: %u"), *Object->GetName(), ObjectRefNetGUID.Value);
-		ensureAlwaysMsgf(ObjectRef.Entity != SpatialConstants::INVALID_ENTITY_ID || ObjectRef.Path.IsSet(), TEXT("Object is valid but has an ObjectRef with an invalid Entity ID and no set Path. Object: %s, EntityId: %lld, offset: %u"), *Object->GetName(),
-				ObjectRef.Entity, ObjectRef.Offset);
+		ensureAlwaysMsgf(ObjectNetGUID.IsValid(), TEXT("Object is valid but has an invalid ObjectNetGUID. Object: %s, ObjectNetGUID: %u"),
+						 *Object->GetName(), ObjectNetGUID.Value);
+		ensureAlwaysMsgf(ObjectRefNetGUID.IsValid(),
+						 TEXT("Object is valid but has an ivalid ObjRefNetGUID. Object: %s, ObjectRefNetGUID: %u"), *Object->GetName(),
+						 ObjectRefNetGUID.Value);
+		ensureAlwaysMsgf(
+			ObjectRef.Entity != SpatialConstants::INVALID_ENTITY_ID || ObjectRef.Path.IsSet(),
+			TEXT("Object is valid but has an ObjectRef with an invalid Entity ID and no set Path. Object: %s, EntityId: %lld, offset: %u"),
+			*Object->GetName(), ObjectRef.Entity, ObjectRef.Offset);
 	}
 #endif
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -184,7 +184,7 @@ void USpatialPackageMapClient::ResolveSubobject(UObject* Object, const FUnrealOb
 	else
 	{
 		// TODO UNR-5785 - Remove this once fixed, as really SpatialGuidCache and Native's GuidCache should be in sync
-		FNetworkGUID ObjectNetGUID = GetNetGUIDFromObject(Object);
+		const FNetworkGUID ObjectNetGUID = GetNetGUIDFromObject(Object);
 		if (!ObjectNetGUID.IsValid())
 		{
 			UE_LOG(LogSpatialPackageMap, Log,

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -187,16 +187,19 @@ void USpatialPackageMapClient::ResolveSubobject(UObject* Object, const FUnrealOb
 		FNetworkGUID ObjectNetGUID = GetNetGUIDFromObject(Object);
 		if (!ObjectNetGUID.IsValid())
 		{
-			UE_LOG(LogSpatialPackageMap, Log, TEXT("SpatialGuidCache has a NetGUID mapping which native's GuidCache does not have for object: %s with NetGUID: %u. Removing existing mapping from SpatialGuidCache and recreating."),
-				*Object->GetName(), NetGUID.Value);
+			UE_LOG(LogSpatialPackageMap, Log,
+				   TEXT("SpatialGuidCache has a NetGUID mapping which native's GuidCache does not have for object: %s with NetGUID: %u. "
+						"Removing existing mapping from SpatialGuidCache and recreating."),
+				   *Object->GetName(), NetGUID.Value);
 			RemoveSubobject(ObjectRef);
 			SpatialGuidCache->AssignNewSubobjectNetGUID(Object, ObjectRef);
 		}
 		else if (ObjectNetGUID != NetGUID)
 		{
 			UE_LOG(LogSpatialPackageMap, Warning,
-				TEXT("ResolveSubobject has NetGuid mismatch between SpatialGuidCache and GuidCache for object: %s with NetGUID: %u and ObjectNetGUID: %u"),
-				*Object->GetName(), NetGUID.Value, ObjectNetGUID.Value);
+				   TEXT("ResolveSubobject has NetGuid mismatch between SpatialGuidCache and GuidCache for object: %s with NetGUID: %u and "
+						"ObjectNetGUID: %u"),
+				   *Object->GetName(), NetGUID.Value, ObjectNetGUID.Value);
 		}
 	}
 }
@@ -643,8 +646,7 @@ void FSpatialNetGUIDCache::RemoveSubobjectNetGUID(const FUnrealObjectRef& Subobj
 
 	if (UnrealMetadata->NativeClass.IsStale())
 	{
-		UE_LOG(LogSpatialPackageMap, Log, TEXT("Attempting to remove stale subobject from package map - %s"),
-			   *UnrealMetadata->ClassPath);
+		UE_LOG(LogSpatialPackageMap, Log, TEXT("Attempting to remove stale subobject from package map - %s"), *UnrealMetadata->ClassPath);
 	}
 	else
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -871,59 +871,23 @@ void FSpatialNetGUIDCache::SlowCheckMapsConsistency(const UObject* Object, const
 #if DO_GUARD_SLOW
 	const FNetworkGUID ObjectNetGUID = GetNetGUID(Object);
 	const FUnrealObjectRef ObjectRef = GetUnrealObjectRefFromNetGUID(ObjectNetGUID);
-	const FNetworkGUID ObjRefNetGUID = UnrealObjectRefToNetGUID.FindRef(ObjectRef);
-	;
+	const FNetworkGUID ObjectRefNetGUID = UnrealObjectRefToNetGUID.FindRef(ObjectRef);
 
-	if (ObjectNetGUID != ObjRefNetGUID)
-	{
-		UE_LOG(LogSpatialPackageMap, Error,
-			   TEXT("NetGUID inconsistency between SpatialNetGuidCache and native's NetGuidCache. Object: %s, ObjectNetGUID: %u, "
-					"ObjRefNetGUID: %u"),
-			   *GetNameSafe(Object), ObjectNetGUID.Value, ObjRefNetGUID.Value);
-	}
+	ensureAlwaysMsgf(ObjectNetGUID == ObjectRefNetGUID, TEXT("NetGUID inconsistency between SpatialNetGuidCache and native's NetGuidCache. Object: %s, ObjectNetGUID: %u, "
+					"ObjectRefNetGUID: %u"), *GetNameSafe(Object), ObjectNetGUID.Value, ObjectRefNetGUID.Value);
 
 	if (!IsValid(Object))
 	{
-		if (ObjectNetGUID.IsValid())
-		{
-			UE_LOG(LogSpatialPackageMap, Error,
-				   TEXT("Object is not valid but has a valid ObjectNetGUID. Object: %s, ObjectNetGUID: %u, check callsite: %s"),
-				   *GetNameSafe(Object), ObjectNetGUID.Value, *CheckCallsite);
-		}
-		if (ObjRefNetGUID.IsValid())
-		{
-			UE_LOG(LogSpatialPackageMap, Error,
-				   TEXT("Object is not valid but has a valid ObjRefNetGUID. Object: %s, ObjectNetGUID: %u, check callsite: %s"),
-				   *GetNameSafe(Object), ObjRefNetGUID.Value, *CheckCallsite);
-		}
-		if (ObjectRef.Entity != SpatialConstants::INVALID_ENTITY_ID)
-		{
-			UE_LOG(
-				LogSpatialPackageMap, Error,
-				TEXT("Object is not valid but has a valid ObjectRef Entity ID. Object: %s, EntityId: %lld, Offset: %u, check callsite: %s"),
-				*GetNameSafe(Object), ObjectRef.Entity, ObjectRef.Offset, *CheckCallsite);
-		}
+		ensureAlwaysMsgf(!ObjectNetGUID.IsValid(), TEXT("Object is not valid but has a valid ObjectNetGUID. Object: %s, ObjectNetGUID: %u"), *GetNameSafe(Object), ObjectNetGUID.Value);
+		ensureAlwaysMsgf(!ObjectRefNetGUID.IsValid(), TEXT("Object is not valid but has a valid ObjectRefNetGUID. Object: %s, ObjectRefNetGUID: %u"), *GetNameSafe(Object), ObjectRefNetGUID.Value);
+		ensureAlwaysMsgf(ObjectRef.Entity == SpatialConstants::INVALID_ENTITY_ID, TEXT("Object is not valid but has a valid ObjectRef Entity ID. Object: %s, EntityId: %lld, Offset: %u"), *GetNameSafe(Object), ObjectRef.Entity, ObjectRef.Offset);
 	}
 	else
 	{
-		if (!ObjectNetGUID.IsValid())
-		{
-			UE_LOG(LogSpatialPackageMap, Error,
-				   TEXT("Object is valid but has an invalid ObjectNetGUID. Object: %s, ObjectNetGUID: %u, check callsite: %s"),
-				   *GetNameSafe(Object), ObjectNetGUID.Value, *CheckCallsite);
-		}
-		if (!ObjRefNetGUID.IsValid())
-		{
-			UE_LOG(LogSpatialPackageMap, Error,
-				   TEXT("Object is valid but has an ivalid ObjRefNetGUID. Object: %s, ObjectNetGUID: %u, check callsite: %s"),
-				   *GetNameSafe(Object), ObjRefNetGUID.Value, *CheckCallsite);
-		}
-		if (ObjectRef.Entity == SpatialConstants::INVALID_ENTITY_ID && !ObjectRef.Path.IsSet())
-		{
-			UE_LOG(LogSpatialPackageMap, Error,
-				   TEXT("Object is valid but has an invalid ObjectRef Entity ID. Object: %s, check callsite: %s"), *GetNameSafe(Object),
-				   ObjectRef.Entity, ObjectRef.Offset, *CheckCallsite);
-		}
+		ensureAlwaysMsgf(ObjectNetGUID.IsValid(), TEXT("Object is valid but has an invalid ObjectNetGUID. Object: %s, ObjectNetGUID: %u"), *Object->GetName(), ObjectNetGUID.Value);
+		ensureAlwaysMsgf(ObjectRefNetGUID.IsValid(), TEXT("Object is valid but has an ivalid ObjRefNetGUID. Object: %s, ObjectRefNetGUID: %u"), *Object->GetName(), ObjectRefNetGUID.Value);
+		ensureAlwaysMsgf(ObjectRef.Entity != SpatialConstants::INVALID_ENTITY_ID || ObjectRef.Path.IsSet(), TEXT("Object is valid but has an ObjectRef with an invalid Entity ID and no set Path. Object: %s, EntityId: %lld, offset: %u"), *Object->GetName(),
+				ObjectRef.Entity, ObjectRef.Offset);
 	}
 #endif
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -196,7 +196,7 @@ void USpatialPackageMapClient::ResolveSubobject(UObject* Object, const FUnrealOb
 		}
 	}
 
-	SlowCheckMapsConsistency(Object, TEXT("ResolveSubobject"));
+	SlowCheckMapsConsistency(Object);
 }
 
 void USpatialPackageMapClient::RemoveEntityActor(Worker_EntityId EntityId)
@@ -402,11 +402,11 @@ Worker_EntityId USpatialPackageMapClient::AllocateNewEntityId() const
 	return EntityPool->GetNextEntityId();
 }
 
-void USpatialPackageMapClient::SlowCheckMapsConsistency(const UObject* Object, const FString& CallSite) const
+void USpatialPackageMapClient::SlowCheckMapsConsistency(const UObject* Object) const
 {
 #if DO_GUARD_SLOW
 	FSpatialNetGUIDCache* SpatialGuidCache = static_cast<FSpatialNetGUIDCache*>(GuidCache.Get());
-	SpatialGuidCache->SlowCheckMapsConsistency(Object, CallSite);
+	SpatialGuidCache->SlowCheckMapsConsistency(Object);
 #endif
 }
 
@@ -446,14 +446,14 @@ FNetworkGUID FSpatialNetGUIDCache::AssignNewEntityActorNetGUID(AActor* Actor, Wo
 		StablyNamedRef = NetGUIDToUnrealObjectRef[NetGUID];
 		NetGUIDToUnrealObjectRef.Emplace(NetGUID, EntityObjectRef);
 
-		SlowCheckMapsConsistency(Actor, TEXT("AssignNewEntityActorNetGUID_StablyNamedActor"));
+		SlowCheckMapsConsistency(Actor);
 	}
 	else
 	{
 		NetGUID = GetOrAssignNetGUID_SpatialGDK(Actor);
 		RegisterObjectRef(NetGUID, EntityObjectRef);
 
-		SlowCheckMapsConsistency(Actor, TEXT("AssignNewEntityActorNetGUID_NonStablyNamedActor"));
+		SlowCheckMapsConsistency(Actor);
 	}
 
 	UE_LOG(LogSpatialPackageMap, Verbose, TEXT("Registered new object ref for actor: %s. NetGUID: %s, entity ID: %lld"), *Actor->GetName(),
@@ -501,7 +501,7 @@ FNetworkGUID FSpatialNetGUIDCache::AssignNewEntityActorNetGUID(AActor* Actor, Wo
 			   TEXT("Registered new object ref for subobject %s inside actor %s. NetGUID: %s, object ref: %s"), *Subobject->GetName(),
 			   *Actor->GetName(), *SubobjectNetGUID.ToString(), *EntityIdSubobjectRef.ToString());
 
-		SlowCheckMapsConsistency(Subobject, TEXT("AssignNewEntityActorNetGUID_Subobject"));
+		SlowCheckMapsConsistency(Subobject);
 	}
 
 	return NetGUID;
@@ -512,7 +512,7 @@ void FSpatialNetGUIDCache::AssignNewSubobjectNetGUID(UObject* Subobject, const F
 	FNetworkGUID SubobjectNetGUID = GetOrAssignNetGUID_SpatialGDK(Subobject);
 	RegisterObjectRef(SubobjectNetGUID, SubobjectRef);
 
-	SlowCheckMapsConsistency(Subobject, TEXT("AssignNewSubobjectNetGUID"));
+	SlowCheckMapsConsistency(Subobject);
 }
 
 // Recursively assign netguids to the outer chain of a UObject. Then associate them with their Spatial representation (FUnrealObjectRef)
@@ -551,7 +551,7 @@ FNetworkGUID FSpatialNetGUIDCache::AssignNewStablyNamedObjectNetGUID(UObject* Ob
 		(OuterGUID.IsValid() && !OuterGUID.IsDefault()) ? GetUnrealObjectRefFromNetGUID(OuterGUID) : FUnrealObjectRef(), bNoLoadOnClient);
 	RegisterObjectRef(NetGUID, StablyNamedObjRef);
 
-	SlowCheckMapsConsistency(Object, TEXT("AssignNewStablyNamedObjectNetGUID"));
+	SlowCheckMapsConsistency(Object);
 
 	return NetGUID;
 }
@@ -866,7 +866,7 @@ void FSpatialNetGUIDCache::RegisterObjectRef(FNetworkGUID NetGUID, const FUnreal
 	UnrealObjectRefToNetGUID.Emplace(RemappedObjectRef, NetGUID);
 }
 
-void FSpatialNetGUIDCache::SlowCheckMapsConsistency(const UObject* Object, const FString& CheckCallsite) const
+void FSpatialNetGUIDCache::SlowCheckMapsConsistency(const UObject* Object) const
 {
 #if DO_GUARD_SLOW
 	const FNetworkGUID ObjectNetGUID = GetNetGUID(Object);

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -202,7 +202,7 @@ void USpatialPackageMapClient::ResolveSubobject(UObject* Object, const FUnrealOb
 				   *Object->GetName(), NetGUID.Value, ObjectNetGUID.Value);
 		}
 	}
-	
+
 	SlowCheckMapsConsistency(Object, TEXT("ResolveSubobject"));
 }
 
@@ -878,42 +878,58 @@ void FSpatialNetGUIDCache::SlowCheckMapsConsistency(const UObject* Object, const
 #if DO_GUARD_SLOW
 	const FNetworkGUID ObjectNetGUID = GetNetGUID(Object);
 	const FUnrealObjectRef ObjectRef = GetUnrealObjectRefFromNetGUID(ObjectNetGUID);
-	const FNetworkGUID ObjRefNetGUID = UnrealObjectRefToNetGUID.FindRef(ObjectRef);;
+	const FNetworkGUID ObjRefNetGUID = UnrealObjectRefToNetGUID.FindRef(ObjectRef);
+	;
 
 	if (ObjectNetGUID != ObjRefNetGUID)
 	{
-		UE_LOG(LogSpatialPackageMap, Error, TEXT("NetGUID inconsistency between SpatialNetGuidCache and native's NetGuidCache. Object: %s, ObjectNetGUID: %u, ObjRefNetGUID: %u"),
-			*GetNameSafe(Object), ObjectNetGUID.Value, ObjRefNetGUID.Value);
+		UE_LOG(LogSpatialPackageMap, Error,
+			   TEXT("NetGUID inconsistency between SpatialNetGuidCache and native's NetGuidCache. Object: %s, ObjectNetGUID: %u, "
+					"ObjRefNetGUID: %u"),
+			   *GetNameSafe(Object), ObjectNetGUID.Value, ObjRefNetGUID.Value);
 	}
 
 	if (!IsValid(Object))
 	{
 		if (ObjectNetGUID.IsValid())
 		{
-			UE_LOG(LogSpatialPackageMap, Error, TEXT("Object is not valid but has a valid ObjectNetGUID. Object: %s, ObjectNetGUID: %u, check callsite: %s"), *GetNameSafe(Object), ObjectNetGUID.Value, *CheckCallsite);
+			UE_LOG(LogSpatialPackageMap, Error,
+				   TEXT("Object is not valid but has a valid ObjectNetGUID. Object: %s, ObjectNetGUID: %u, check callsite: %s"),
+				   *GetNameSafe(Object), ObjectNetGUID.Value, *CheckCallsite);
 		}
 		if (ObjRefNetGUID.IsValid())
 		{
-			UE_LOG(LogSpatialPackageMap, Error, TEXT("Object is not valid but has a valid ObjRefNetGUID. Object: %s, ObjectNetGUID: %u, check callsite: %s"), *GetNameSafe(Object), ObjRefNetGUID.Value, *CheckCallsite);
+			UE_LOG(LogSpatialPackageMap, Error,
+				   TEXT("Object is not valid but has a valid ObjRefNetGUID. Object: %s, ObjectNetGUID: %u, check callsite: %s"),
+				   *GetNameSafe(Object), ObjRefNetGUID.Value, *CheckCallsite);
 		}
 		if (ObjectRef.Entity != SpatialConstants::INVALID_ENTITY_ID)
 		{
-			UE_LOG(LogSpatialPackageMap, Error, TEXT("Object is not valid but has a valid ObjectRef Entity ID. Object: %s, EntityId: %lld, Offset: %u, check callsite: %s"), *GetNameSafe(Object), ObjectRef.Entity, ObjectRef.Offset, *CheckCallsite);
+			UE_LOG(
+				LogSpatialPackageMap, Error,
+				TEXT("Object is not valid but has a valid ObjectRef Entity ID. Object: %s, EntityId: %lld, Offset: %u, check callsite: %s"),
+				*GetNameSafe(Object), ObjectRef.Entity, ObjectRef.Offset, *CheckCallsite);
 		}
 	}
 	else
 	{
 		if (!ObjectNetGUID.IsValid())
 		{
-			UE_LOG(LogSpatialPackageMap, Error, TEXT("Object is valid but has an invalid ObjectNetGUID. Object: %s, ObjectNetGUID: %u, check callsite: %s"), *GetNameSafe(Object), ObjectNetGUID.Value, *CheckCallsite);
+			UE_LOG(LogSpatialPackageMap, Error,
+				   TEXT("Object is valid but has an invalid ObjectNetGUID. Object: %s, ObjectNetGUID: %u, check callsite: %s"),
+				   *GetNameSafe(Object), ObjectNetGUID.Value, *CheckCallsite);
 		}
 		if (!ObjRefNetGUID.IsValid())
 		{
-			UE_LOG(LogSpatialPackageMap, Error, TEXT("Object is valid but has an ivalid ObjRefNetGUID. Object: %s, ObjectNetGUID: %u, check callsite: %s"), *GetNameSafe(Object), ObjRefNetGUID.Value, *CheckCallsite);
+			UE_LOG(LogSpatialPackageMap, Error,
+				   TEXT("Object is valid but has an ivalid ObjRefNetGUID. Object: %s, ObjectNetGUID: %u, check callsite: %s"),
+				   *GetNameSafe(Object), ObjRefNetGUID.Value, *CheckCallsite);
 		}
 		if (ObjectRef.Entity == SpatialConstants::INVALID_ENTITY_ID && !ObjectRef.Path.IsSet())
 		{
-			UE_LOG(LogSpatialPackageMap, Error, TEXT("Object is valid but has an invalid ObjectRef Entity ID. Object: %s, check callsite: %s"), *GetNameSafe(Object), ObjectRef.Entity, ObjectRef.Offset, *CheckCallsite);
+			UE_LOG(LogSpatialPackageMap, Error,
+				   TEXT("Object is valid but has an invalid ObjectRef Entity ID. Object: %s, check callsite: %s"), *GetNameSafe(Object),
+				   ObjectRef.Entity, ObjectRef.Offset, *CheckCallsite);
 		}
 	}
 #endif

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialPackageMapClient.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialPackageMapClient.h
@@ -72,6 +72,7 @@ public:
 	TSet<FNetworkGUID> PendingReferences;
 
 	Worker_EntityId AllocateNewEntityId() const;
+	void SlowCheckMapsConsistency(const UObject* Object, const FString& CallSite) const;
 
 private:
 	UPROPERTY()
@@ -105,6 +106,8 @@ public:
 	// This function is ONLY used in SpatialPackageMapClient::UnregisterActorObjectRefOnly
 	// to undo the unintended registering of objects when looking them up with static paths.
 	void UnregisterActorObjectRefOnly(const FUnrealObjectRef& ObjectRef);
+
+	void SlowCheckMapsConsistency(const UObject* Object, const FString& CheckCallsite) const;
 
 private:
 	FNetworkGUID GetNetGUIDFromUnrealObjectRefInternal(const FUnrealObjectRef& ObjectRef);

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialPackageMapClient.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialPackageMapClient.h
@@ -72,7 +72,7 @@ public:
 	TSet<FNetworkGUID> PendingReferences;
 
 	Worker_EntityId AllocateNewEntityId() const;
-	void SlowCheckMapsConsistency(const UObject* Object, const FString& CallSite) const;
+	void SlowCheckMapsConsistency(const UObject* Object) const;
 
 private:
 	UPROPERTY()
@@ -107,7 +107,7 @@ public:
 	// to undo the unintended registering of objects when looking them up with static paths.
 	void UnregisterActorObjectRefOnly(const FUnrealObjectRef& ObjectRef);
 
-	void SlowCheckMapsConsistency(const UObject* Object, const FString& CheckCallsite) const;
+	void SlowCheckMapsConsistency(const UObject* Object) const;
 
 private:
 	FNetworkGUID GetNetGUIDFromUnrealObjectRefInternal(const FUnrealObjectRef& ObjectRef);


### PR DESCRIPTION
#### Description
Running the GDK I encounter a dynamic subobject (AutoDestroyActor component) that already has a netguid->objectref/objectref->netguid mapping in spatialguidmap when running resolvesubobject while the object itself does not have a netguid/does not exist within the standard guidmap.

Related is https://improbableio.atlassian.net/browse/UNR-5785 (see for repro steps)

#### Documentation
`- Fixed an issue that could cause SpatialNetGuidCache and native's NetGuidCache to become out of sync.`