### PR TITLE
Update SpatialSwitchHasAuthority to check NetDriver via World

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [`x.y.z`] - Unreleased
 
 ### Breaking changes:
+- SpatialSwitchHasAuthority now respects World's version of IsServer which assumes server status when NetDriver is null.
 
 ### Features:
--Gameplay Debugger now supports multi-worker environments.
+- Gameplay Debugger now supports multi-worker environments.
 
 ### Bug fixes:
 - Fix `A functional test is already running error` that would sometimes occur when re-running multi-server functional tests.

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
@@ -407,16 +407,9 @@ void USpatialStatics::SpatialSwitchHasAuthority(const AActor* Target, ESpatialHa
 		return;
 	}
 
-	if (!ensureAlwaysMsgf(Target->GetNetDriver() != nullptr,
-						  TEXT("Called SpatialSwitchHasAuthority for %s but couldn't access NetDriver through Actor."),
-						  *GetNameSafe(Target)))
-	{
-		return;
-	}
-
 	// A static UFunction does not have the Target parameter, here it is recreated by adding our own Target parameter
 	// that is defaulted to self and hidden so that the user does not need to set it
-	const bool bIsServer = Target->GetNetDriver()->IsServer();
+	const bool bIsServer = Target->GetWorld() ? Target->GetWorld()->IsServer() : false;
 	const bool bHasAuthority = Target->HasAuthority();
 
 	if (bHasAuthority && bIsServer)


### PR DESCRIPTION
#### Release note
SpatialSwitchHasAuthority now respects World's version of IsServer which assumes server status when NetDriver is null.
