### PR TITLE
Spatial actor channel stored last updated position correctly

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -288,9 +288,9 @@ private:
 
 	void RetireEntityIfAuthoritative();
 
-	void SendPositionUpdate(AActor* InActor, Worker_EntityId InEntityId, const FVector& NewPosition);
+	void SendPositionUpdate(const FVector& NewPosition);
 
-	void UpdateVisibleComponent(AActor* Actor);
+	void UpdateVisibleComponent();
 
 	bool SatisfiesSpatialPositionUpdateRequirements(FVector& OutNewSpatialPosition);
 


### PR DESCRIPTION
Spatial actor channel now stores last updated position and time correctly per actor. Also refactored some of the functionality to prevent confusing usage.