### PR TITLE
Support separately enabling Event Tracing in Editor and non-Editor bu…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `StopInsights` command to `SpatialExecServerCmd`, which takes no additional parameters and disables any Insight capturing on the target worker
   - Example usage: "SpatialExecServerCmd local StopInsights
 - Renamed `StartInsights` command args - `trace` -> `channel` and `tracefile` -> `file`
+- Added bEventTracingEnabledWithEditor setting to separate out the ability to enable Event Tracing in Editor builds from non-Editor builds.
 
 ### Bug fixes:
 - An issue with `AActor::SetAutonomousProxy` has been fixed, where actors that were manually set as `AutonomousProxy` could get downgraded to `SimulatedProxy`. The functions `SetAutonomousProxyOnAuthority` and `IsAutonomousProxyOnAuthority` have been added to USpatialActorChannel, along with a change to `ActorSystem::HandleActorAuthority` which will upgrade an actor's role from `SimulatedProxy` to `AutonomousProxy` if the actor gains Authority when `IsAutonomousProxyOnAuthority` is true.

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialConnectionManager.cpp
@@ -621,7 +621,7 @@ void USpatialConnectionManager::OnConnectionFailure(uint8_t ConnectionStatusCode
 TSharedPtr<SpatialGDK::SpatialEventTracer> USpatialConnectionManager::CreateEventTracer(const FString& WorkerId)
 {
 	const USpatialGDKSettings* Settings = GetDefault<USpatialGDKSettings>();
-	if (Settings == nullptr || !Settings->bEventTracingEnabled)
+	if (Settings == nullptr || !Settings->GetEventTracingEnabled())
 	{
 		return nullptr;
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -186,6 +186,7 @@ USpatialGDKSettings::USpatialGDKSettings(const FObjectInitializer& ObjectInitial
 	, StartupLogRate(5.0f)
 	, ActorMigrationLogRate(5.0f)
 	, bEventTracingEnabled(false)
+	, bEventTracingEnabledWithEditor(false)
 	, EventTracingSamplingSettingsClass(UEventTracingSamplingSettings::StaticClass())
 	, EventTracingSingleLogMaxFileSizeBytes(DefaultEventTracingFileSize)
 	, bEnableEventTracingRotatingLogs(false)
@@ -218,7 +219,11 @@ void USpatialGDKSettings::PostInitProperties()
 							 TEXT("Prevent client cloud deployment auto connect"), bPreventClientCloudDeploymentAutoConnect);
 	CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideWorkerFlushAfterOutgoingNetworkOp"),
 							 TEXT("Flush worker ops after sending an outgoing network op."), bWorkerFlushAfterOutgoingNetworkOp);
+#if WITH_EDITOR
+	CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideEventTracingEnabled"), TEXT("Event tracing in-editor enabled"), bEventTracingEnabledWithEditor);
+#else
 	CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideEventTracingEnabled"), TEXT("Event tracing enabled"), bEventTracingEnabled);
+#endif
 	CheckCmdLineOverrideOptionalString(CommandLine, TEXT("OverrideMultiWorkerSettingsClass"), TEXT("Override MultiWorker Settings Class"),
 									   OverrideMultiWorkerSettingsClass);
 	CheckCmdLineOverrideOptionalStringWithCallback(
@@ -358,4 +363,12 @@ void USpatialGDKSettings::SetMultiWorkerEditorEnabled(bool bIsEnabled)
 }
 #endif // WITH_EDITOR
 
+bool USpatialGDKSettings::GetEventTracingEnabled() const
+{
+#if WITH_EDITOR
+	return bEventTracingEnabledWithEditor;
+#else
+	return bEventTracingEnabled;
+#endif
+}
 #undef LOCTEXT_NAMESPACE

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -156,6 +156,8 @@ USpatialGDKSettings::USpatialGDKSettings(const FObjectInitializer& ObjectInitial
 	, bUseFrameTimeAsLoad(false)
 	, bBatchSpatialPositionUpdates(false)
 	, MaxDynamicallyAttachedSubobjectsPerClass(3)
+	, bEventTracingEnabled(false)
+	, bEventTracingEnabledWithEditor(false)
 	, ServicesRegion(EServicesRegion::Default)
 	, WorkerLogLevel(ESettingsWorkerLogVerbosity::Warning) // Deprecated - UNR-4348
 	, LocalWorkerLogLevel(WorkerLogLevel)
@@ -185,8 +187,6 @@ USpatialGDKSettings::USpatialGDKSettings(const FObjectInitializer& ObjectInitial
 	, bEnableCrossLayerActorSpawning(true)
 	, StartupLogRate(5.0f)
 	, ActorMigrationLogRate(5.0f)
-	, bEventTracingEnabled(false)
-	, bEventTracingEnabledWithEditor(false)
 	, EventTracingSamplingSettingsClass(UEventTracingSamplingSettings::StaticClass())
 	, EventTracingSingleLogMaxFileSizeBytes(DefaultEventTracingFileSize)
 	, bEnableEventTracingRotatingLogs(false)
@@ -220,7 +220,8 @@ void USpatialGDKSettings::PostInitProperties()
 	CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideWorkerFlushAfterOutgoingNetworkOp"),
 							 TEXT("Flush worker ops after sending an outgoing network op."), bWorkerFlushAfterOutgoingNetworkOp);
 #if WITH_EDITOR
-	CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideEventTracingEnabled"), TEXT("Event tracing in-editor enabled"), bEventTracingEnabledWithEditor);
+	CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideEventTracingEnabled"), TEXT("Event tracing in-editor enabled"),
+							 bEventTracingEnabledWithEditor);
 #else
 	CheckCmdLineOverrideBool(CommandLine, TEXT("OverrideEventTracingEnabled"), TEXT("Event tracing enabled"), bEventTracingEnabled);
 #endif

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -456,9 +456,18 @@ public:
 
 	/*
 	 * -- EXPERIMENTAL --
+	 * Same as bEventTracingEnabled, but used if WITH_EDITOR is defined.
+	 */
+	UPROPERTY(EditAnywhere, Config, Category = "Event Tracing")
+	bool bEventTracingEnabledWithEditor;
+
+	bool GetEventTracingEnabled() const;
+
+	/*
+	 * -- EXPERIMENTAL --
 	 * Class containing various settings used to configure event trace sampling
 	 */
-	UPROPERTY(EditAnywhere, Config, Category = "Event Tracing", meta = (EditCondition = "bEventTracingEnabled"))
+	UPROPERTY(EditAnywhere, Config, Category = "Event Tracing", meta = (EditCondition = "bEventTracingEnabled || bEventTracingEnabledWithEditor"))
 	TSubclassOf<UEventTracingSamplingSettings> EventTracingSamplingSettingsClass;
 
 	UEventTracingSamplingSettings* GetEventTracingSamplingSettings() const;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -270,6 +270,21 @@ private:
 	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection")
 	bool bPreventClientCloudDeploymentAutoConnect;
 
+	/*
+	 * -- EXPERIMENTAL --
+	 * This will enable event tracing for the Unreal client/worker.
+	 */
+	UPROPERTY(EditAnywhere, Config, Category = "Event Tracing")
+	bool bEventTracingEnabled;
+
+	/*
+	 * -- EXPERIMENTAL --
+	 * Same as bEventTracingEnabled, but used if WITH_EDITOR is defined.
+	 */
+	UPROPERTY(EditAnywhere, Config, Category = "Event Tracing")
+	bool bEventTracingEnabledWithEditor;
+
+	friend class AEventTracingSettingsOverride;
 public:
 	bool GetPreventClientCloudDeploymentAutoConnect() const;
 
@@ -306,6 +321,8 @@ public:
 	void SetMultiWorkerEditorEnabled(const bool bIsEnabled);
 	FORCEINLINE bool IsMultiWorkerEditorEnabled() const { return bEnableMultiWorker; }
 #endif // WITH_EDITOR
+
+	bool GetEventTracingEnabled() const;
 
 private:
 #if WITH_EDITOR
@@ -449,25 +466,10 @@ public:
 
 	/*
 	 * -- EXPERIMENTAL --
-	 * This will enable event tracing for the Unreal client/worker.
-	 */
-	UPROPERTY(EditAnywhere, Config, Category = "Event Tracing")
-	bool bEventTracingEnabled;
-
-	/*
-	 * -- EXPERIMENTAL --
-	 * Same as bEventTracingEnabled, but used if WITH_EDITOR is defined.
-	 */
-	UPROPERTY(EditAnywhere, Config, Category = "Event Tracing")
-	bool bEventTracingEnabledWithEditor;
-
-	bool GetEventTracingEnabled() const;
-
-	/*
-	 * -- EXPERIMENTAL --
 	 * Class containing various settings used to configure event trace sampling
 	 */
-	UPROPERTY(EditAnywhere, Config, Category = "Event Tracing", meta = (EditCondition = "bEventTracingEnabled || bEventTracingEnabledWithEditor"))
+	UPROPERTY(EditAnywhere, Config, Category = "Event Tracing",
+			  meta = (EditCondition = "bEventTracingEnabled || bEventTracingEnabledWithEditor"))
 	TSubclassOf<UEventTracingSamplingSettings> EventTracingSamplingSettingsClass;
 
 	UEventTracingSamplingSettings* GetEventTracingSamplingSettings() const;

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKDefaultLaunchConfigGenerator.cpp
@@ -179,7 +179,7 @@ bool GenerateLaunchConfig(const FString& LaunchConfigPath, const FSpatialLaunchC
 		Writer->WriteValue(TEXT("max_concurrent_workers"), LaunchConfigDescription.MaxConcurrentWorkers);
 
 		// Event tracing
-		if (SpatialGDKSettings->bEventTracingEnabled)
+		if (SpatialGDKSettings->GetEventTracingEnabled())
 		{
 			Writer->WriteObjectStart(TEXT("event_tracing_configuration"));
 			Writer->WriteValue(TEXT("enabled"), true);

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/EventTracingTests/EventTracingSettingsOverride.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/EventTracingTests/EventTracingSettingsOverride.cpp
@@ -13,6 +13,9 @@
  *		[/Script/SpatialGDK.SpatialGDKSettings]
  *		bEventTracingEnabled=True
  *
+ *		[/Script/SpatialGDK.SpatialGDKSettings]
+ *		bEventTracingEnabledWithEditor=True
+ *
  *		[/Script/SpatialGDKEditor.SpatialGDKEditorSettings]
  *		SpatialOSCommandLineLaunchFlags="--event-tracing-enabled=true"
  *
@@ -41,8 +44,11 @@ void AEventTracingSettingsOverride::PrepareTest()
 	AddStep(
 		TEXT("Check SpatialGDKSettings override settings"), FWorkerDefinition::AllWorkers, nullptr,
 		[this]() {
-			bool bEventTracingEnabled = GetDefault<USpatialGDKSettings>()->bEventTracingEnabled;
+			const bool bEventTracingEnabled = GetDefault<USpatialGDKSettings>()->bEventTracingEnabled;
 			RequireTrue(bEventTracingEnabled, TEXT("Expected bEventTracingEnabled to be True"));
+
+			const bool bEventTracingEnabledWithEditor = GetDefault<USpatialGDKSettings>()->bEventTracingEnabledWithEditor;
+			RequireTrue(bEventTracingEnabledWithEditor, TEXT("Expected bEventTracingEnabledWithEditor to be True"));
 
 			FinishStep();
 		},
@@ -51,10 +57,10 @@ void AEventTracingSettingsOverride::PrepareTest()
 	AddStep(
 		TEXT("Check PIE override settings"), FWorkerDefinition::AllServers, nullptr,
 		[this]() {
-			int32 ExpectedNumberOfClients = 1;
-			int32 RequiredNumberOfClients = GetNumRequiredClients();
+			const int32 ExpectedNumberOfClients = 1;
+			const int32 RequiredNumberOfClients = GetNumRequiredClients();
 			RequireEqual_Int(RequiredNumberOfClients, ExpectedNumberOfClients, TEXT("Expected a certain number of required clients."));
-			int32 ActualNumberOfClients = GetNumberOfClientWorkers();
+			const int32 ActualNumberOfClients = GetNumberOfClientWorkers();
 			RequireEqual_Int(ActualNumberOfClients, ExpectedNumberOfClients, TEXT("Expected a certain number of actual clients."));
 
 			FinishStep();


### PR DESCRIPTION
#### Description
Support separate settings for enabling Event Tracing in Editor vs. non-Editor builds.  This allows us to turn on Event Tracing for our project's cloud-deployed builds without affecting everyone using the Editor.

#### Release note
Added.

#### Tests
Verified in our project that the settings work as expected.

STRONGLY SUGGESTED: How can this be verified by QA?
Try turning the setting on/off with Event Tracing setup (sampling settings, etc), and validate whether or not the output .etlog files are generated.

#### Documentation
Release note

#### Reminders (IMPORTANT)
If your change relies on a breaking engine change:
* Increment `SPATIAL_ENGINE_VERSION` in `Engine\Source\Runtime\Launch\Resources\SpatialVersion.h` (in the engine fork) as well as `SPATIAL_GDK_VERSION` in `SpatialGDK\Source\SpatialGDK\Public\Utils\EngineVersionCheck.h`. This helps others by providing a more helpful message during compilation to make sure the GDK and the Engine are up to date.

If your change updates `Setup.bat`, `Setup.sh`, core SDK version, any C# tools in `SpatialGDK\Build\Programs\Improbable.Unreal.Scripts`, or hand-written schema in `SpatialGDK\Extras\schema`:
* Increment the number in `RequireSetup`. This will automatically run `Setup.bat` or `Setup.sh` when the GDK is next pulled.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
