### PR TITLE
Warn when ref to nonreplicated object changed by network

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
@@ -501,7 +501,6 @@ void ComponentReader::ApplyProperty(Schema_Object* Object, Schema_FieldId FieldI
 			}
 			if (!bUnresolved)
 			{
-				// IMP-CHANGE
 				UObject* OldObject = ObjectProperty->GetObjectPropertyValue(Data);
 				if (AActor* OldActor = Cast<AActor>(OldObject))
 				{
@@ -515,7 +514,6 @@ void ComponentReader::ApplyProperty(Schema_Object* Object, Schema_FieldId FieldI
 							ObjectValue ? *ObjectValue->GetName() : TEXT("null"));
 					}
 				}
-				// IMP-END
 
 				ObjectProperty->SetObjectPropertyValue(Data, ObjectValue);
 				if (ObjectValue != nullptr)

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentReader.cpp
@@ -501,6 +501,22 @@ void ComponentReader::ApplyProperty(Schema_Object* Object, Schema_FieldId FieldI
 			}
 			if (!bUnresolved)
 			{
+				// IMP-CHANGE
+				UObject* OldObject = ObjectProperty->GetObjectPropertyValue(Data);
+				if (AActor* OldActor = Cast<AActor>(OldObject))
+				{
+					if (!OldActor->GetIsReplicated() && OldObject != ObjectValue)
+					{
+						UE_LOG(LogSpatialComponentReader, Warning,
+							TEXT("ComponentReader::ApplyProperty: Reference to non replicated object has been changed due to an update received from"
+								" Runtime. Field: %d, Property name: %s, Old reference value: %s New reference value: %s"),
+							FieldId, Property ? *Property->GetFullName() : TEXT("null"),
+							OldObject ? *OldObject->GetName() : TEXT("null"),
+							ObjectValue ? *ObjectValue->GetName() : TEXT("null"));
+					}
+				}
+				// IMP-END
+
 				ObjectProperty->SetObjectPropertyValue(Data, ObjectValue);
 				if (ObjectValue != nullptr)
 				{


### PR DESCRIPTION
#### Description
Warn whenever a reference to a non replicated object gets changed due to a Runtime update.

A typical case is to have a a non replicated AI Controller referenced by a replicated Pawn::Controller property. The Controller property gets nulled when the pawn crosses a boundary, meaning the local AI Controller never gets cleaned up.

Currently seeing this warning print on clients in legit cases where owner is removed. Needs further consideration before potentially being merged but something like this is definitely useful to prevent leaks.

#### Release note
TBD

#### Tests
Only tested in 0.13.0

STRONGLY SUGGESTED: How can this be verified by QA?

#### Primary reviewers
@ImprobableNic @samiwh 