### PR TITLE
Feature/custom interest components

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/AbstractInterestComponent.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/AbstractInterestComponent.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "EngineClasses/Components/AbstractInterestComponent.h"
+
+#include "Engine/World.h"
+#include "EngineClasses/SpatialActorChannel.h"
+#include "EngineClasses/SpatialNetDriver.h"
+#include "GameFramework/Actor.h"
+#include "Utils/SpatialStatics.h"
+
+void UAbstractInterestComponent::NotifyChannelUpdateRequired()
+{
+	AActor* Owner = GetOwner();
+	check(Owner != nullptr && Owner->HasAuthority());
+	check(USpatialStatics::IsSpatialNetworkingEnabled());
+
+	UWorld* World = GetWorld();
+	check(World != nullptr);
+
+	USpatialNetDriver* SpatialNetDriver = Cast<USpatialNetDriver>(World->GetNetDriver());
+	check(SpatialNetDriver != nullptr);
+
+	USpatialActorChannel* Channel = SpatialNetDriver->GetOrCreateSpatialActorChannel(Owner);
+	check(Channel != nullptr);
+
+	Channel->SetIsInterestUpdateRequired(true);
+}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/ActorInterestComponent.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/ActorInterestComponent.cpp
@@ -9,11 +9,10 @@ UActorInterestComponent::UActorInterestComponent(const FObjectInitializer& Objec
 	: Super(ObjectInitializer)
 {
 	PrimaryComponentTick.bCanEverTick = false;
-	SetIsUpdateRequired(false);
 }
 
 void UActorInterestComponent::PopulateFrequencyToConstraintsMap(const USpatialClassInfoManager& ClassInfoManager,
-																SpatialGDK::FrequencyToConstraintsMap& OutFrequencyToQueryConstraints) const
+	SpatialGDK::FrequencyToConstraintsMap& OutFrequencyToQueryConstraints) const
 {
 	// Loop through the user specified queries to extract the constraints and frequencies.
 	// We don't construct the actual query at this point because the interest factory enforces the result types.

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/ActorInterestComponent.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/ActorInterestComponent.cpp
@@ -5,6 +5,13 @@
 #include "Interop/SpatialClassInfoManager.h"
 #include "Schema/Interest.h"
 
+UActorInterestComponent::UActorInterestComponent(const FObjectInitializer& ObjectInitializer)
+	: Super(ObjectInitializer)
+{
+	PrimaryComponentTick.bCanEverTick = false;
+	SetIsUpdateRequired(false);
+}
+
 void UActorInterestComponent::PopulateFrequencyToConstraintsMap(const USpatialClassInfoManager& ClassInfoManager,
 																SpatialGDK::FrequencyToConstraintsMap& OutFrequencyToQueryConstraints) const
 {

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/ActorInterestComponent.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/ActorInterestComponent.cpp
@@ -12,7 +12,7 @@ UActorInterestComponent::UActorInterestComponent(const FObjectInitializer& Objec
 }
 
 void UActorInterestComponent::PopulateFrequencyToConstraintsMap(const USpatialClassInfoManager& ClassInfoManager,
-	SpatialGDK::FrequencyToConstraintsMap& OutFrequencyToQueryConstraints) const
+																SpatialGDK::FrequencyToConstraintsMap& OutFrequencyToQueryConstraints) const
 {
 	// Loop through the user specified queries to extract the constraints and frequencies.
 	// We don't construct the actual query at this point because the interest factory enforces the result types.

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/ClosestNInterestComponent.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/ClosestNInterestComponent.cpp
@@ -1,0 +1,223 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "EngineClasses/Components/ClosestNInterestComponent.h"
+
+#include "Engine/World.h"
+#include "GameFramework/Actor.h"
+#include "GameFramework/PlayerController.h"
+#include "Interop/SpatialClassInfoManager.h"
+#include "Interop/SpatialInterestConstraints.h"
+#include "Kismet/GameplayStatics.h"
+#include "TimerManager.h"
+#include "Utils/SpatialStatics.h"
+
+DEFINE_LOG_CATEGORY(LogClosestNInterestComponent);
+
+bool UClosestNInterestComponent::bSoftTargetActorLimitExceededWarningShown = false;
+bool UClosestNInterestComponent::bSoftTargetEntityLimitExceededWarningShown = false;
+
+void UClosestNInterestComponent::BeginPlay()
+{
+	Super::BeginPlay();
+
+	const AActor* OwningActor = GetOwner();
+
+	if (OwningActor == nullptr)
+	{
+		UE_LOG(LogClosestNInterestComponent, Warning, TEXT("UClosestNInterestComponent::BeginPlay() has an invalid OwningActor!"));
+		return;
+	}
+
+	if (USpatialStatics::IsSpatialNetworkingEnabled() && OwningActor->HasAuthority())
+	{
+		checkf(!TargetActorClass->IsChildOf<APlayerController>(), TEXT("PlayerControllers are not supported as the TargetActorClass."));
+
+		MaxInterestRangeSqr = FMath::Pow(MaxInterestRange, 2.0f);
+		SoftMaxEntityCount = bIncludeHierarchy ? TargetActorMaxCount * SoftMaxAttachedActorsPerTargetActorCount : TargetActorMaxCount;
+
+		TargetActors.Reserve(SoftMaxTargetActorsOnServerCount);
+		TargetActorsSorted.Reserve(SoftMaxTargetActorsOnServerCount);
+		TargetEntityIds.Reserve(SoftMaxEntityCount);
+		PreviousTargetEntityIds.Reserve(SoftMaxEntityCount);
+
+		ConstraintList.AddZeroed_GetRef();
+
+		UpdateQuery();
+
+		// Schedule query to run at randomly offset start time for amortization
+		const float UpdateInterval = 1.0f / UnrealServerUpdateFrequency;
+
+		const UWorld* World = GetWorld();
+		check(World != nullptr);
+
+		World->GetTimerManager().SetTimer(UpdateQueryTimerHandle, this, &UClosestNInterestComponent::UpdateQuery, UpdateInterval, true, FMath::FRand() * UpdateInterval);
+	}
+}
+
+void UClosestNInterestComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+	const UWorld* World = GetWorld();
+	if (World != nullptr && UpdateQueryTimerHandle.IsValid())
+	{
+		World->GetTimerManager().ClearTimer(UpdateQueryTimerHandle);
+	}
+}
+
+void UClosestNInterestComponent::UpdateQuery()
+{
+	TRACE_CPUPROFILER_EVENT_SCOPE(UClosestNInterestComponent::UpdateQuery);
+	const AActor* OwningActor = GetOwner();
+	check(OwningActor != nullptr && OwningActor->HasAuthority());
+
+	FindTargetActors();
+	FindTargetEntityIds();
+	ConstructQuery();
+
+	if (TargetEntityIds != PreviousTargetEntityIds)
+	{
+		SetIsUpdateRequired(true);
+	}
+
+	PreviousTargetEntityIds.Reset();
+	PreviousTargetEntityIds.Append(TargetEntityIds);
+}
+
+void UClosestNInterestComponent::FindTargetActors()
+{
+	TRACE_CPUPROFILER_EVENT_SCOPE(UClosestNInterestComponent::FindTargetActors);
+	// If our owner is a PlayerController, we instead use it's Pawn for the distance calculations,
+	// since PlayerControllers aren't necessarily configured to move with their pawn (see bAttachToPawn).
+	AActor* LocationProvidingOwnerProxy = GetOwner();
+	if (const APlayerController* OwningActorAsPC = Cast<APlayerController>(LocationProvidingOwnerProxy))
+	{
+		LocationProvidingOwnerProxy = OwningActorAsPC->GetPawn();
+	}
+
+	if (LocationProvidingOwnerProxy == nullptr)
+	{
+		// This can happen transiently if the Component is bound to a PlayerController whose controlled pawn is not yet available.
+		return;
+	}
+
+	TargetActors.Reset();
+	{
+		TRACE_CPUPROFILER_EVENT_SCOPE(UClosestNInterestComponent::FindTargetActors_GetActors);
+		// TODO: Profile and eliminate this query if it's expensive / not-cached
+		UGameplayStatics::GetAllActorsOfClass(GetWorld(), TargetActorClass, TargetActors);
+	}
+
+	const int32 TargetActorCount = TargetActors.Num();
+
+	if (TargetActorCount > SoftMaxTargetActorsOnServerCount && !bSoftTargetActorLimitExceededWarningShown)
+	{
+		UE_LOG(LogClosestNInterestComponent, Warning,
+			TEXT("UClosestNInterestComponent::FindTargetActors() found more target actors (%d) than expected max (%d) and will perform dynamic allocations, consider increasing SoftMaxTargetActorsOnServerCount."),
+			TargetActorCount, SoftMaxTargetActorsOnServerCount);
+		bSoftTargetActorLimitExceededWarningShown = true;
+	}
+
+	int32 InRangeActorCount = 0;
+	{
+		TRACE_CPUPROFILER_EVENT_SCOPE(UClosestNInterestComponent::FindTargetActors_FindActorsInRange);
+		TargetActorsSorted.Reset(TargetActorCount);
+		TargetActorsSorted.AddUninitialized(TargetActorCount);
+
+		const FVector OwnerLocation = LocationProvidingOwnerProxy->GetActorLocation();
+
+		for (const auto Actor : TargetActors)
+		{
+			if (Actor != nullptr && !Actor->IsPendingKill() && Actor != LocationProvidingOwnerProxy)
+			{
+				const FVector ActorLocation = Actor->GetActorLocation();
+				const float DistanceBetweenActorsSqr = FVector::DistSquared(OwnerLocation, ActorLocation);
+
+				if (DistanceBetweenActorsSqr < MaxInterestRangeSqr)
+				{
+					FActorSortData& Data = TargetActorsSorted[InRangeActorCount++];
+					Data.Actor = Actor;
+					Data.DistanceSqr = DistanceBetweenActorsSqr;
+				}
+			}
+		}
+	}
+
+	{
+		TRACE_CPUPROFILER_EVENT_SCOPE(UClosestNInterestComponent::FindTargetActors_PurgeActors);
+		const int32 ActorsToPurgeCount = TargetActorCount - InRangeActorCount;
+
+		if (ActorsToPurgeCount > 0)
+		{
+			const bool bAllowShrinking = false;
+			TargetActorsSorted.RemoveAt(InRangeActorCount, ActorsToPurgeCount, bAllowShrinking);
+		}
+	}
+
+	{
+		TRACE_CPUPROFILER_EVENT_SCOPE(UClosestNInterestComponent::FindTargetActors_SortActors);
+		TargetActorsSorted.Sort([](const FActorSortData& LHS, const FActorSortData& RHS) { return LHS.DistanceSqr < RHS.DistanceSqr; });
+	}
+
+	{
+		TRACE_CPUPROFILER_EVENT_SCOPE(UClosestNInterestComponent::FindTargetActors_PurgeActors);
+		const int32 ActorsSortedCount = TargetActorsSorted.Num();
+		const int32 ActorsToKeepCount = FMath::Min<int32>(ActorsSortedCount, TargetActorMaxCount);
+		const int32 ActorsToPurgeCount = FMath::Max<int32>(ActorsSortedCount - TargetActorMaxCount, 0);
+
+		if (ActorsToPurgeCount > 0)
+		{
+			const bool bAllowShrinking = false;
+			TargetActorsSorted.RemoveAt(ActorsToKeepCount, ActorsToPurgeCount, bAllowShrinking);
+		}
+	}
+}
+
+void UClosestNInterestComponent::FindTargetEntityIds()
+{
+	TRACE_CPUPROFILER_EVENT_SCOPE(UClosestNInterestComponent::FindTargetEntityIds);
+	TargetEntityIds.Reset();
+
+	for (const auto& Data : TargetActorsSorted)
+	{
+		if (bIncludeHierarchy)
+		{
+			USpatialStatics::GetEntityIdsInHierarchy(Data.Actor, TargetEntityIds);
+		}
+		else
+		{
+			TargetEntityIds.Add(USpatialStatics::GetActorEntityId(Data.Actor));
+		}
+	}
+
+	TargetEntityIds.Sort();
+}
+
+void UClosestNInterestComponent::ConstructQuery()
+{
+	TRACE_CPUPROFILER_EVENT_SCOPE(UClosestNInterestComponent::ConstructDynamicQuery);
+	const int32 TargetEntityIdCount = TargetEntityIds.Num();
+	
+	if (TargetEntityIdCount > SoftMaxEntityCount && !bSoftTargetEntityLimitExceededWarningShown)
+	{
+		UE_LOG(LogClosestNInterestComponent, Warning,
+			TEXT("UClosestNInterestComponent::ConstructQuery() found more entities (%d) than estimated max (%d) and will perform dynamic allocations, consider increasing SoftMaxAttachedActorsPerTargetActorCount."),
+			TargetEntityIdCount, SoftMaxEntityCount);
+		bSoftTargetEntityLimitExceededWarningShown = true;
+	}
+
+	SpatialGDK::QueryConstraint& RootConstraint = ConstraintList[0];
+
+	RootConstraint.OrConstraint.Reset(TargetEntityIdCount);
+	RootConstraint.OrConstraint.AddZeroed(TargetEntityIdCount);
+
+	for (int i = 0; i < TargetEntityIdCount; ++i)
+	{
+		SpatialGDK::QueryConstraint& Constraint = RootConstraint.OrConstraint[i];
+		Constraint.EntityIdConstraint = TargetEntityIds[i];
+	}
+}
+
+void UClosestNInterestComponent::PopulateFrequencyToConstraintsMap(const USpatialClassInfoManager& ClassInfoManager,
+	SpatialGDK::FrequencyToConstraintsMap& OutFrequencyToQueryConstraints) const
+{
+	OutFrequencyToQueryConstraints.Add(RuntimeUpdateFrequency, ConstraintList);
+}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/ClosestNInterestComponent.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/ClosestNInterestComponent.cpp
@@ -57,6 +57,8 @@ void UClosestNInterestComponent::BeginPlay()
 
 void UClosestNInterestComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
 {
+	Super::EndPlay(EndPlayReason);
+
 	const UWorld* World = GetWorld();
 	if (World != nullptr && UpdateQueryTimerHandle.IsValid())
 	{
@@ -224,5 +226,6 @@ void UClosestNInterestComponent::ConstructQuery()
 void UClosestNInterestComponent::PopulateFrequencyToConstraintsMap(
 	const USpatialClassInfoManager& ClassInfoManager, SpatialGDK::FrequencyToConstraintsMap& OutFrequencyToQueryConstraints) const
 {
-	OutFrequencyToQueryConstraints.Add(RuntimeUpdateFrequency, ConstraintList);
+	TArray<SpatialGDK::QueryConstraint>& Constraints = OutFrequencyToQueryConstraints.FindOrAdd(RuntimeUpdateFrequency);
+	Constraints.Append(ConstraintList);
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/ClosestNInterestComponent.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/ClosestNInterestComponent.cpp
@@ -50,7 +50,8 @@ void UClosestNInterestComponent::BeginPlay()
 		const UWorld* World = GetWorld();
 		check(World != nullptr);
 
-		World->GetTimerManager().SetTimer(UpdateQueryTimerHandle, this, &UClosestNInterestComponent::UpdateQuery, UpdateInterval, true, FMath::FRand() * UpdateInterval);
+		World->GetTimerManager().SetTimer(UpdateQueryTimerHandle, this, &UClosestNInterestComponent::UpdateQuery, UpdateInterval, true,
+										  FMath::FRand() * UpdateInterval);
 	}
 }
 
@@ -111,8 +112,9 @@ void UClosestNInterestComponent::FindTargetActors()
 	if (TargetActorCount > SoftMaxTargetActorsOnServerCount && !bSoftTargetActorLimitExceededWarningShown)
 	{
 		UE_LOG(LogClosestNInterestComponent, Warning,
-			TEXT("UClosestNInterestComponent::FindTargetActors() found more target actors (%d) than expected max (%d) and will perform dynamic allocations, consider increasing SoftMaxTargetActorsOnServerCount."),
-			TargetActorCount, SoftMaxTargetActorsOnServerCount);
+			   TEXT("UClosestNInterestComponent::FindTargetActors() found more target actors (%d) than expected max (%d) and will perform "
+					"dynamic allocations, consider increasing SoftMaxTargetActorsOnServerCount."),
+			   TargetActorCount, SoftMaxTargetActorsOnServerCount);
 		bSoftTargetActorLimitExceededWarningShown = true;
 	}
 
@@ -154,7 +156,9 @@ void UClosestNInterestComponent::FindTargetActors()
 
 	{
 		TRACE_CPUPROFILER_EVENT_SCOPE(UClosestNInterestComponent::FindTargetActors_SortActors);
-		TargetActorsSorted.Sort([](const FActorSortData& LHS, const FActorSortData& RHS) { return LHS.DistanceSqr < RHS.DistanceSqr; });
+		TargetActorsSorted.Sort([](const FActorSortData& LHS, const FActorSortData& RHS) {
+			return LHS.DistanceSqr < RHS.DistanceSqr;
+		});
 	}
 
 	{
@@ -195,12 +199,13 @@ void UClosestNInterestComponent::ConstructQuery()
 {
 	TRACE_CPUPROFILER_EVENT_SCOPE(UClosestNInterestComponent::ConstructDynamicQuery);
 	const int32 TargetEntityIdCount = TargetEntityIds.Num();
-	
+
 	if (TargetEntityIdCount > SoftMaxEntityCount && !bSoftTargetEntityLimitExceededWarningShown)
 	{
 		UE_LOG(LogClosestNInterestComponent, Warning,
-			TEXT("UClosestNInterestComponent::ConstructQuery() found more entities (%d) than estimated max (%d) and will perform dynamic allocations, consider increasing SoftMaxAttachedActorsPerTargetActorCount."),
-			TargetEntityIdCount, SoftMaxEntityCount);
+			   TEXT("UClosestNInterestComponent::ConstructQuery() found more entities (%d) than estimated max (%d) and will perform "
+					"dynamic allocations, consider increasing SoftMaxAttachedActorsPerTargetActorCount."),
+			   TargetEntityIdCount, SoftMaxEntityCount);
 		bSoftTargetEntityLimitExceededWarningShown = true;
 	}
 
@@ -216,8 +221,8 @@ void UClosestNInterestComponent::ConstructQuery()
 	}
 }
 
-void UClosestNInterestComponent::PopulateFrequencyToConstraintsMap(const USpatialClassInfoManager& ClassInfoManager,
-	SpatialGDK::FrequencyToConstraintsMap& OutFrequencyToQueryConstraints) const
+void UClosestNInterestComponent::PopulateFrequencyToConstraintsMap(
+	const USpatialClassInfoManager& ClassInfoManager, SpatialGDK::FrequencyToConstraintsMap& OutFrequencyToQueryConstraints) const
 {
 	OutFrequencyToQueryConstraints.Add(RuntimeUpdateFrequency, ConstraintList);
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/ClosestNInterestComponent.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/Components/ClosestNInterestComponent.cpp
@@ -78,7 +78,7 @@ void UClosestNInterestComponent::UpdateQuery()
 
 	if (TargetEntityIds != PreviousTargetEntityIds)
 	{
-		SetIsUpdateRequired(true);
+		NotifyChannelUpdateRequired();
 	}
 
 	PreviousTargetEntityIds.Reset();

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -686,30 +686,10 @@ int64 USpatialActorChannel::ReplicateActor()
 			NetDriver->ActorSystem->UpdateInterestComponent(Actor);
 			SetNeedOwnerInterestUpdate(false);
 		}
-		else
+		else if (IsInterestUpdateRequired())
 		{
-			TArray<UActorComponent*> InterestProvidingComponents = Actor->GetComponentsByInterface(USpatialInterestProvider::StaticClass());
-
-			// Here we send at most 1 update regardless of the # of InterestProviders that have an update ready.
-			// The InterestFactory will gather updates from all InterestProviders on the Actor.
-			// TODO: Remove the need to check each provider here.
-			bool bInterestUpdated = false;
-			for (const auto InterestProvidingComponent : InterestProvidingComponents)
-			{
-				ISpatialInterestProvider* InterestProvider = Cast<ISpatialInterestProvider>(InterestProvidingComponent);
-				check(InterestProvider != nullptr);
-
-				if (InterestProvider->IsUpdateRequired())
-				{
-					if (!bInterestUpdated)
-					{
-						NetDriver->ActorSystem->UpdateInterestComponent(Actor);
-						bInterestUpdated = true;
-					}
-
-					InterestProvider->SetIsUpdateRequired(false);
-				}
-			}
+			NetDriver->ActorSystem->UpdateInterestComponent(Actor);
+			SetIsInterestUpdateRequired(false);
 		}
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetConnection.cpp
@@ -98,10 +98,13 @@ void USpatialNetConnection::UpdateLevelVisibility(const struct FUpdateLevelVisib
 	UNetConnection::UpdateLevelVisibility(LevelVisibility);
 #endif
 
-	// We want to update our interest as fast as possible
-	// So we send an Interest update immediately.
-	SpatialGDK::ActorSystem* ActorSystem = Cast<USpatialNetDriver>(Driver)->ActorSystem.Get();
-	ActorSystem->UpdateInterestComponent(Cast<AActor>(PlayerController));
+	USpatialNetDriver* SpatialNetDriver = Cast<USpatialNetDriver>(Driver);
+	check(SpatialNetDriver != nullptr);
+
+	USpatialActorChannel* Channel = SpatialNetDriver->GetOrCreateSpatialActorChannel(PlayerController);
+	check(Channel != nullptr);
+
+	Channel->SetIsInterestUpdateRequired(true);
 }
 
 void USpatialNetConnection::FlushDormancy(AActor* Actor)

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -530,11 +530,15 @@ void InterestFactory::GetActorUserDefinedQueryConstraints(const AActor* InActor,
 
 	if (InterestProvidingComponents.Num() == 1)
 	{
-		Cast<ISpatialInterestProvider>(InterestProvidingComponents[0])->PopulateFrequencyToConstraintsMap(*ClassInfoManager, OutFrequencyToConstraints);
+		Cast<ISpatialInterestProvider>(InterestProvidingComponents[0])
+			->PopulateFrequencyToConstraintsMap(*ClassInfoManager, OutFrequencyToConstraints);
 	}
 	else if (InterestProvidingComponents.Num() > 1)
 	{
-		UE_LOG(LogInterestFactory, Error, TEXT("USpatialActorChannel::ReplicateActor(): Actor %s has more than 1 component that implements ISpatialInterestProvider, this is not supported!"), *GetNameSafe(InActor));
+		UE_LOG(LogInterestFactory, Error,
+			   TEXT("USpatialActorChannel::ReplicateActor(): Actor %s has more than 1 component that implements ISpatialInterestProvider, "
+					"this is not supported!"),
+			   *GetNameSafe(InActor));
 		checkNoEntry()
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialStatics.cpp
@@ -374,6 +374,21 @@ FName USpatialStatics::GetLayerName(const UObject* WorldContextObject)
 	return LBStrategy->GetLocalLayerName();
 }
 
+void USpatialStatics::GetEntityIdsInHierarchy(const AActor* RootActor, TArray<int64>& OutEntityIds)
+{
+	const int64 EntityId = USpatialStatics::GetActorEntityId(RootActor);
+
+	if (EntityId != SpatialConstants::INVALID_ENTITY_ID)
+	{
+		OutEntityIds.Add(EntityId);
+	}
+
+	for (const auto& Child : RootActor->Children)
+	{
+		GetEntityIdsInHierarchy(Child, OutEntityIds);
+	}
+}
+
 int64 USpatialStatics::GetMaxDynamicallyAttachedSubobjectsPerClass()
 {
 	return GetDefault<USpatialGDKSettings>()->MaxDynamicallyAttachedSubobjectsPerClass;

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/AbstractInterestComponent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/AbstractInterestComponent.h
@@ -12,6 +12,8 @@ class SPATIALGDK_API UAbstractInterestComponent : public UActorComponent, public
 	GENERATED_BODY()
 
 public:
+	UAbstractInterestComponent(const FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer) { bIsUpdateRequired = false; }
+
 	virtual void SetIsUpdateRequired(const bool bUpdateRequired) override { bIsUpdateRequired = bUpdateRequired; }
 	virtual bool IsUpdateRequired() const override { return bIsUpdateRequired; }
 
@@ -20,7 +22,7 @@ public:
 public:
 	/**
 	 * Whether to use NetCullDistanceSquared to generate constraints relative to the Actor that this component is attached to.
-	 */
+	*/
 	UPROPERTY(BlueprintReadOnly, EditDefaultsOnly, Category = "Interest")
 	bool bUseNetCullDistanceSquaredForCheckoutRadius = true;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/AbstractInterestComponent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/AbstractInterestComponent.h
@@ -11,16 +11,6 @@ class SPATIALGDK_API UAbstractInterestComponent : public UActorComponent, public
 {
 	GENERATED_BODY()
 
-public:
-	UAbstractInterestComponent(const FObjectInitializer& ObjectInitializer)
-		: Super(ObjectInitializer)
-	{
-		bIsUpdateRequired = false;
-	}
-
-	virtual void SetIsUpdateRequired(const bool bUpdateRequired) override { bIsUpdateRequired = bUpdateRequired; }
-	virtual bool IsUpdateRequired() const override { return bIsUpdateRequired; }
-
-private:
-	bool bIsUpdateRequired;
+protected:
+	void NotifyChannelUpdateRequired();
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/AbstractInterestComponent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/AbstractInterestComponent.h
@@ -20,7 +20,7 @@ public:
 public:
 	/**
 	 * Whether to use NetCullDistanceSquared to generate constraints relative to the Actor that this component is attached to.
-	*/
+	 */
 	UPROPERTY(BlueprintReadOnly, EditDefaultsOnly, Category = "Interest")
 	bool bUseNetCullDistanceSquaredForCheckoutRadius = true;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/AbstractInterestComponent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/AbstractInterestComponent.h
@@ -1,0 +1,29 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "Components/ActorComponent.h"
+#include "Interfaces/ISpatialInterestProvider.h"
+#include "AbstractInterestComponent.generated.h"
+
+UCLASS(ClassGroup = (SpatialGDK), abstract, NotSpatialType)
+class SPATIALGDK_API UAbstractInterestComponent : public UActorComponent, public ISpatialInterestProvider
+{
+	GENERATED_BODY()
+
+public:
+	virtual void SetIsUpdateRequired(const bool bUpdateRequired) override { bIsUpdateRequired = bUpdateRequired; }
+	virtual bool IsUpdateRequired() const override { return bIsUpdateRequired; }
+
+	virtual bool GetUseNetCullDistanceSquaredForCheckoutRadius() const override { return bUseNetCullDistanceSquaredForCheckoutRadius; }
+
+public:
+	/**
+	 * Whether to use NetCullDistanceSquared to generate constraints relative to the Actor that this component is attached to.
+	*/
+	UPROPERTY(BlueprintReadOnly, EditDefaultsOnly, Category = "Interest")
+	bool bUseNetCullDistanceSquaredForCheckoutRadius = true;
+
+private:
+	bool bIsUpdateRequired;
+};

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/AbstractInterestComponent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/AbstractInterestComponent.h
@@ -12,7 +12,11 @@ class SPATIALGDK_API UAbstractInterestComponent : public UActorComponent, public
 	GENERATED_BODY()
 
 public:
-	UAbstractInterestComponent(const FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer) { bIsUpdateRequired = false; }
+	UAbstractInterestComponent(const FObjectInitializer& ObjectInitializer)
+		: Super(ObjectInitializer)
+	{
+		bIsUpdateRequired = false;
+	}
 
 	virtual void SetIsUpdateRequired(const bool bUpdateRequired) override { bIsUpdateRequired = bUpdateRequired; }
 	virtual bool IsUpdateRequired() const override { return bIsUpdateRequired; }
@@ -22,7 +26,7 @@ public:
 public:
 	/**
 	 * Whether to use NetCullDistanceSquared to generate constraints relative to the Actor that this component is attached to.
-	*/
+	 */
 	UPROPERTY(BlueprintReadOnly, EditDefaultsOnly, Category = "Interest")
 	bool bUseNetCullDistanceSquaredForCheckoutRadius = true;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/AbstractInterestComponent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/AbstractInterestComponent.h
@@ -21,15 +21,6 @@ public:
 	virtual void SetIsUpdateRequired(const bool bUpdateRequired) override { bIsUpdateRequired = bUpdateRequired; }
 	virtual bool IsUpdateRequired() const override { return bIsUpdateRequired; }
 
-	virtual bool GetUseNetCullDistanceSquaredForCheckoutRadius() const override { return bUseNetCullDistanceSquaredForCheckoutRadius; }
-
-public:
-	/**
-	 * Whether to use NetCullDistanceSquared to generate constraints relative to the Actor that this component is attached to.
-	 */
-	UPROPERTY(BlueprintReadOnly, EditDefaultsOnly, Category = "Interest")
-	bool bUseNetCullDistanceSquaredForCheckoutRadius = true;
-
 private:
 	bool bIsUpdateRequired;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/ActorInterestComponent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/ActorInterestComponent.h
@@ -4,6 +4,7 @@
 
 #include "Components/ActorComponent.h"
 #include "CoreMinimal.h"
+#include "EngineClasses/Components/AbstractInterestComponent.h"
 #include "Interop/SpatialInterestConstraints.h"
 #include "Schema/Interest.h"
 
@@ -15,23 +16,15 @@ class USpatialClassInfoManager;
  * Creates a set of SpatialOS Queries for describing interest that this actor has in other entities.
  */
 UCLASS(ClassGroup = (SpatialGDK), NotSpatialType, Meta = (BlueprintSpawnableComponent))
-class SPATIALGDK_API UActorInterestComponent final : public UActorComponent
+class SPATIALGDK_API UActorInterestComponent final : public UAbstractInterestComponent
 {
 	GENERATED_BODY()
 
 public:
-	UActorInterestComponent() = default;
-	~UActorInterestComponent() = default;
+	UActorInterestComponent(const FObjectInitializer& ObjectInitializer = FObjectInitializer::Get());
 
-	void PopulateFrequencyToConstraintsMap(const USpatialClassInfoManager& ClassInfoManager,
-										   SpatialGDK::FrequencyToConstraintsMap& OutFrequencyToQueryConstraints) const;
-
-	/**
-	 * Whether to use NetCullDistanceSquared to generate constraints relative to the Actor that this component is attached to.
-	 */
-	UPROPERTY(BlueprintReadOnly, EditDefaultsOnly, Category = "Interest")
-	bool bUseNetCullDistanceSquaredForCheckoutRadius = true;
-
+	virtual void PopulateFrequencyToConstraintsMap(const USpatialClassInfoManager& ClassInfoManager,
+										   SpatialGDK::FrequencyToConstraintsMap& OutFrequencyToQueryConstraints) const override;
 	/**
 	 * The Queries associated with this component.
 	 */

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/ActorInterestComponent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/ActorInterestComponent.h
@@ -24,7 +24,7 @@ public:
 	UActorInterestComponent(const FObjectInitializer& ObjectInitializer = FObjectInitializer::Get());
 
 	virtual void PopulateFrequencyToConstraintsMap(const USpatialClassInfoManager& ClassInfoManager,
-										   SpatialGDK::FrequencyToConstraintsMap& OutFrequencyToQueryConstraints) const override;
+												   SpatialGDK::FrequencyToConstraintsMap& OutFrequencyToQueryConstraints) const override;
 	/**
 	 * The Queries associated with this component.
 	 */

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/ClosestNInterestComponent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/ClosestNInterestComponent.h
@@ -1,0 +1,82 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+#include "EngineClasses/Components/AbstractInterestComponent.h"
+#include "Schema/Interest.h"
+#include "ClosestNInterestComponent.generated.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogClosestNInterestComponent, Log, All);
+
+UCLASS(ClassGroup = (SpatialGDK), NotSpatialType, Meta = (BlueprintSpawnableComponent))
+class SPATIALGDK_API UClosestNInterestComponent : public UAbstractInterestComponent
+{
+	GENERATED_BODY()
+
+public:
+
+	virtual void BeginPlay() override;
+	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
+	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category = "Interest", meta = (ToolTip = "Target class to express Interest in."))
+	TSubclassOf<AActor> TargetActorClass;
+
+	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category = "Interest", meta = (ToolTip = "Express Interest in at most this many target actors, regardless of how many are on the UnrealServer."))
+	int32 TargetActorMaxCount = 20;
+
+	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category = "Interest", meta = (ToolTip = "Frequency UnrealServer should recalculate Interest queries and send them to SpatialOS Runtime (Hz)."))
+	float UnrealServerUpdateFrequency = 0.2f;
+
+	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category = "Interest", meta = (ToolTip = "Frequency SpatialOS Runtime should run the query and send the result to the client (Hz)."))
+	float RuntimeUpdateFrequency = 1.0f;
+
+	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category = "Interest", meta = (ToolTip = "Maximum range that a target actor can be away from the owning client's PlayerController or currently possessed Pawn and still be considered for Interest (cm)."))
+	float MaxInterestRange = 15000.0f;
+	float MaxInterestRangeSqr;
+
+	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category = "Interest", meta = (ToolTip = "For each target actor we will express Interest in, also express interest in it's attachment hierarchy."))
+	bool bIncludeHierarchy = false;
+
+	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category = "Advanced", meta = (ToolTip = "Reduce dynamic memory allocations from this component by setting this to the max expected # of target actors on the UnrealServer."))
+	int32 SoftMaxTargetActorsOnServerCount = 16;
+
+	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category = "Advanced", meta = (EditCondition="bIncludeHierarchy", ToolTip = "Reduce dynamic memory allocations from this component by setting this to the max expected # of replicating attached actors in the target actor's hierarchy on the UnrealServer."))
+	int32 SoftMaxAttachedActorsPerTargetActorCount = 24;
+
+	// ISpatialInterestProvider
+	virtual void PopulateFrequencyToConstraintsMap(const USpatialClassInfoManager& ClassInfoManager,
+		SpatialGDK::FrequencyToConstraintsMap& OutFrequencyToQueryConstraints) const override;
+
+private:
+
+	void UpdateQuery();
+
+	void FindTargetActors();
+	void FindTargetEntityIds();
+
+	void ConstructQuery();
+
+	FTimerHandle UpdateQueryTimerHandle;
+	TArray<SpatialGDK::QueryConstraint> ConstraintList;
+
+	TArray<AActor*> TargetActors;
+
+	struct FActorSortData
+	{
+		AActor* Actor;
+		float DistanceSqr;
+	};
+
+	TArray<FActorSortData> TargetActorsSorted;
+
+	TArray<int64> TargetEntityIds;
+	TArray<int64> PreviousTargetEntityIds;
+
+	// Constants per runtime invocation, need to be calculated at runtime from parameters set on the component
+	int32 SoftMaxEntityCount = 0; 
+
+	static bool bSoftTargetActorLimitExceededWarningShown;
+	static bool bSoftTargetEntityLimitExceededWarningShown;
+};

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/ClosestNInterestComponent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/ClosestNInterestComponent.h
@@ -16,41 +16,50 @@ class SPATIALGDK_API UClosestNInterestComponent : public UAbstractInterestCompon
 	GENERATED_BODY()
 
 public:
-
 	virtual void BeginPlay() override;
 	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
 	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category = "Interest", meta = (ToolTip = "Target class to express Interest in."))
 	TSubclassOf<AActor> TargetActorClass;
 
-	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category = "Interest", meta = (ToolTip = "Express Interest in at most this many target actors, regardless of how many are on the UnrealServer."))
+	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category = "Interest",
+			  meta = (ToolTip = "Express Interest in at most this many target actors, regardless of how many are on the UnrealServer."))
 	int32 TargetActorMaxCount = 20;
 
-	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category = "Interest", meta = (ToolTip = "Frequency UnrealServer should recalculate Interest queries and send them to SpatialOS Runtime (Hz)."))
+	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category = "Interest",
+			  meta = (ToolTip = "Frequency UnrealServer should recalculate Interest queries and send them to SpatialOS Runtime (Hz)."))
 	float UnrealServerUpdateFrequency = 0.2f;
 
-	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category = "Interest", meta = (ToolTip = "Frequency SpatialOS Runtime should run the query and send the result to the client (Hz)."))
+	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category = "Interest",
+			  meta = (ToolTip = "Frequency SpatialOS Runtime should run the query and send the result to the client (Hz)."))
 	float RuntimeUpdateFrequency = 1.0f;
 
-	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category = "Interest", meta = (ToolTip = "Maximum range that a target actor can be away from the owning client's PlayerController or currently possessed Pawn and still be considered for Interest (cm)."))
+	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category = "Interest",
+			  meta = (ToolTip = "Maximum range that a target actor can be away from the owning client's PlayerController or currently "
+								"possessed Pawn and still be considered for Interest (cm)."))
 	float MaxInterestRange = 15000.0f;
 	float MaxInterestRangeSqr;
 
-	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category = "Interest", meta = (ToolTip = "For each target actor we will express Interest in, also express interest in it's attachment hierarchy."))
+	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category = "Interest",
+			  meta = (ToolTip = "For each target actor we will express Interest in, also express interest in it's attachment hierarchy."))
 	bool bIncludeHierarchy = false;
 
-	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category = "Advanced", meta = (ToolTip = "Reduce dynamic memory allocations from this component by setting this to the max expected # of target actors on the UnrealServer."))
+	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category = "Advanced",
+			  meta = (ToolTip = "Reduce dynamic memory allocations from this component by setting this to the max expected # of target "
+								"actors on the UnrealServer."))
 	int32 SoftMaxTargetActorsOnServerCount = 16;
 
-	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category = "Advanced", meta = (EditCondition="bIncludeHierarchy", ToolTip = "Reduce dynamic memory allocations from this component by setting this to the max expected # of replicating attached actors in the target actor's hierarchy on the UnrealServer."))
+	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category = "Advanced",
+			  meta = (EditCondition = "bIncludeHierarchy",
+					  ToolTip = "Reduce dynamic memory allocations from this component by setting this to the max expected # of "
+								"replicating attached actors in the target actor's hierarchy on the UnrealServer."))
 	int32 SoftMaxAttachedActorsPerTargetActorCount = 24;
 
 	// ISpatialInterestProvider
 	virtual void PopulateFrequencyToConstraintsMap(const USpatialClassInfoManager& ClassInfoManager,
-		SpatialGDK::FrequencyToConstraintsMap& OutFrequencyToQueryConstraints) const override;
+												   SpatialGDK::FrequencyToConstraintsMap& OutFrequencyToQueryConstraints) const override;
 
 private:
-
 	void UpdateQuery();
 
 	void FindTargetActors();
@@ -75,7 +84,7 @@ private:
 	TArray<int64> PreviousTargetEntityIds;
 
 	// Constants per runtime invocation, need to be calculated at runtime from parameters set on the component
-	int32 SoftMaxEntityCount = 0; 
+	int32 SoftMaxEntityCount = 0;
 
 	static bool bSoftTargetActorLimitExceededWarningShown;
 	static bool bSoftTargetEntityLimitExceededWarningShown;

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/ClosestNInterestComponent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/ClosestNInterestComponent.h
@@ -35,8 +35,7 @@ public:
 	float RuntimeUpdateFrequency = 1.0f;
 
 	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category = "Interest",
-			  meta = (ToolTip = "Maximum range that a target actor can be away from the owning client's PlayerController or currently "
-								"possessed Pawn and still be considered for Interest (cm)."))
+			  meta = (ToolTip = "Maximum range that a target actor can be away from the owning client's PlayerController or currently possessed Pawn and still be considered for Interest (cm)."))
 	float MaxInterestRange = 15000.0f;
 	float MaxInterestRangeSqr;
 
@@ -45,14 +44,12 @@ public:
 	bool bIncludeHierarchy = false;
 
 	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category = "Advanced",
-			  meta = (ToolTip = "Reduce dynamic memory allocations from this component by setting this to the max expected # of target "
-								"actors on the UnrealServer."))
+			  meta = (ToolTip = "Reduce dynamic memory allocations from this component by setting this to the max expected # of target actors on the UnrealServer."))
 	int32 SoftMaxTargetActorsOnServerCount = 16;
 
 	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category = "Advanced",
 			  meta = (EditCondition = "bIncludeHierarchy",
-					  ToolTip = "Reduce dynamic memory allocations from this component by setting this to the max expected # of "
-								"replicating attached actors in the target actor's hierarchy on the UnrealServer."))
+					  ToolTip = "Reduce dynamic memory allocations from this component by setting this to the max expected # of replicating attached actors in the target actor's hierarchy on the UnrealServer."))
 	int32 SoftMaxAttachedActorsPerTargetActorCount = 24;
 
 	// ISpatialInterestProvider

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/InterestSettingsComponent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/InterestSettingsComponent.h
@@ -1,0 +1,18 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "InterestSettingsComponent.generated.h"
+
+UCLASS(ClassGroup = (SpatialGDK), NotSpatialType, Meta = (BlueprintSpawnableComponent))
+class SPATIALGDK_API UInterestSettingsComponent : public UActorComponent
+{
+	GENERATED_BODY()
+
+public:
+
+	UPROPERTY(BlueprintReadOnly, EditDefaultsOnly, Category = "Whether or not to use NCD queries when calculating interest for our owner.")
+	bool bUseNetCullDistanceSquaredForCheckoutRadius = true;
+};

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/InterestSettingsComponent.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/Components/InterestSettingsComponent.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
-#include "CoreMinimal.h"
 #include "Components/ActorComponent.h"
+#include "CoreMinimal.h"
 #include "InterestSettingsComponent.generated.h"
 
 UCLASS(ClassGroup = (SpatialGDK), NotSpatialType, Meta = (BlueprintSpawnableComponent))
@@ -12,7 +12,6 @@ class SPATIALGDK_API UInterestSettingsComponent : public UActorComponent
 	GENERATED_BODY()
 
 public:
-
 	UPROPERTY(BlueprintReadOnly, EditDefaultsOnly, Category = "Whether or not to use NCD queries when calculating interest for our owner.")
 	bool bUseNetCullDistanceSquaredForCheckoutRadius = true;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialActorChannel.h
@@ -278,6 +278,9 @@ public:
 
 	bool NeedOwnerInterestUpdate() const { return bNeedOwnerInterestUpdate; }
 
+	inline void SetIsInterestUpdateRequired(const bool bUpdateRequired) { bIsInterestUpdateRequired = bUpdateRequired; }
+	inline bool IsInterestUpdateRequired() const { return bIsInterestUpdateRequired; }
+
 	const FVector& GetLastUpdatedSpatialPosition() const { return LastPositionSinceUpdate; }
 
 protected:
@@ -356,6 +359,7 @@ private:
 	// In case the actor's owner did not have an entity ID when trying to set interest to it
 	// We set this flag in order to try to add interest as soon as possible.
 	bool bNeedOwnerInterestUpdate;
+	bool bIsInterestUpdateRequired = false;
 
 	// Track whether an Actor should have its Role upgrade to AutonomousProxy when it gains authority
 	uint8 bIsAutonomousProxyOnAuthority : 1;

--- a/SpatialGDK/Source/SpatialGDK/Public/Interfaces/ISpatialInterestProvider.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interfaces/ISpatialInterestProvider.h
@@ -21,7 +21,4 @@ public:
 	virtual void PopulateFrequencyToConstraintsMap(const USpatialClassInfoManager& ClassInfoManager,
 												   SpatialGDK::FrequencyToConstraintsMap& OutFrequencyToQueryConstraints) const
 		PURE_VIRTUAL(, );
-
-	virtual void SetIsUpdateRequired(const bool bUpdateRequired) PURE_VIRTUAL(, );
-	virtual bool IsUpdateRequired() const PURE_VIRTUAL(ISpatialInterestProvider::IsUpdateRequired, return false;);
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/Interfaces/ISpatialInterestProvider.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interfaces/ISpatialInterestProvider.h
@@ -1,0 +1,29 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "UObject/Interface.h"
+#include "Interop/SpatialClassInfoManager.h"
+#include "Schema/Interest.h"
+#include "ISpatialInterestProvider.generated.h"
+
+UINTERFACE()
+class SPATIALGDK_API USpatialInterestProvider : public UInterface
+{
+	GENERATED_BODY()
+};
+
+class SPATIALGDK_API ISpatialInterestProvider
+{
+	GENERATED_BODY()
+
+public:
+
+	virtual void PopulateFrequencyToConstraintsMap(const USpatialClassInfoManager& ClassInfoManager,
+		SpatialGDK::FrequencyToConstraintsMap& OutFrequencyToQueryConstraints) const PURE_VIRTUAL(, );
+
+	virtual void SetIsUpdateRequired(const bool bUpdateRequired) PURE_VIRTUAL(, );
+	virtual bool IsUpdateRequired() const PURE_VIRTUAL(ISpatialInterestProvider::IsUpdateRequired, return false;);
+
+	virtual bool GetUseNetCullDistanceSquaredForCheckoutRadius() const PURE_VIRTUAL(ISpatialInterestProvider::GetUseNetCullDistanceSquaredForCheckoutRadius, return false;);
+};

--- a/SpatialGDK/Source/SpatialGDK/Public/Interfaces/ISpatialInterestProvider.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interfaces/ISpatialInterestProvider.h
@@ -24,7 +24,4 @@ public:
 
 	virtual void SetIsUpdateRequired(const bool bUpdateRequired) PURE_VIRTUAL(, );
 	virtual bool IsUpdateRequired() const PURE_VIRTUAL(ISpatialInterestProvider::IsUpdateRequired, return false;);
-
-	virtual bool GetUseNetCullDistanceSquaredForCheckoutRadius() const
-		PURE_VIRTUAL(ISpatialInterestProvider::GetUseNetCullDistanceSquaredForCheckoutRadius, return false;);
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/Interfaces/ISpatialInterestProvider.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interfaces/ISpatialInterestProvider.h
@@ -2,9 +2,9 @@
 
 #pragma once
 
-#include "UObject/Interface.h"
 #include "Interop/SpatialClassInfoManager.h"
 #include "Schema/Interest.h"
+#include "UObject/Interface.h"
 #include "ISpatialInterestProvider.generated.h"
 
 UINTERFACE()
@@ -18,12 +18,13 @@ class SPATIALGDK_API ISpatialInterestProvider
 	GENERATED_BODY()
 
 public:
-
 	virtual void PopulateFrequencyToConstraintsMap(const USpatialClassInfoManager& ClassInfoManager,
-		SpatialGDK::FrequencyToConstraintsMap& OutFrequencyToQueryConstraints) const PURE_VIRTUAL(, );
+												   SpatialGDK::FrequencyToConstraintsMap& OutFrequencyToQueryConstraints) const
+		PURE_VIRTUAL(, );
 
 	virtual void SetIsUpdateRequired(const bool bUpdateRequired) PURE_VIRTUAL(, );
 	virtual bool IsUpdateRequired() const PURE_VIRTUAL(ISpatialInterestProvider::IsUpdateRequired, return false;);
 
-	virtual bool GetUseNetCullDistanceSquaredForCheckoutRadius() const PURE_VIRTUAL(ISpatialInterestProvider::GetUseNetCullDistanceSquaredForCheckoutRadius, return false;);
+	virtual bool GetUseNetCullDistanceSquaredForCheckoutRadius() const
+		PURE_VIRTUAL(ISpatialInterestProvider::GetUseNetCullDistanceSquaredForCheckoutRadius, return false;);
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialStatics.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SpatialStatics.h
@@ -183,6 +183,8 @@ public:
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "SpatialOS", meta = (WorldContext = "WorldContextObject"))
 	static FName GetLayerName(const UObject* WorldContextObject);
 
+	static void GetEntityIdsInHierarchy(const AActor* RootActor, TArray<int64>& OutEntityIds);
+
 	/**
 	 * Returns the Max Dynamically Attached Subobjects Per Class as per Spatial GDK settings
 	 */


### PR DESCRIPTION
Draft PR for Custom Interest Components.  This allows game teams to write custom components that can run on the server and determine custom interest for a given client.  A sample ClosestNInterestComponent is included.  This helps address potential overload conditions on clients when radius-based QBI is used.

Also has a fix for 200ms hitches as players join servers (optimization to USpatialNetConnection::UpdateLevelVisibility).