### PR TITLE
[UNR-5812] Fix nightly test failures - UnresolvedRefTest in Native

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/StaticSubobjectsTest/StaticSubobjectsTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/StaticSubobjectsTest/StaticSubobjectsTest.cpp
@@ -200,7 +200,10 @@ void AStaticSubobjectsTest::PrepareTest()
 		FinishStep();
 	});
 
-	// Step 18 - Server Cleanup.
+	// Step 18 - In preparation for cleanup
+	MoveClientPawn(PawnSpawnLocation);
+
+	// Step 19 - Server Cleanup.
 	AddStep(TEXT("StaticSubobjectsTestServerCleanup"), FWorkerDefinition::Server(1), nullptr, [this]() {
 		// Possess the original pawn, so that the spawned character can get destroyed correctly
 		ASpatialFunctionalTestFlowController* ClientOneFlowController = GetFlowController(ESpatialFunctionalTestWorkerType::Client, 1);


### PR DESCRIPTION
#### Description
Fix the nightly tests by making the StaticSubobjectTest leave the pawn in a good location, so the UnresolvedReferenceTest can proceed smoothly. Interestingly, this only seems to be required in Native, as in Spatial the cleanup possession at the end of the StaticSubobjectTest seems to be sufficient.

#### Release note
N/A

#### Tests
Ran locally

#### Documentation
N/A

#### Primary reviewers
@MCArth-improbable 
