### PR TITLE
Move tear off channels after rep notifies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue that could cause SpatialNetGuidCache and native's NetGuidCache to become out of sync.
 - Add helpers to the test framework - `SpawnActor`, `RequireValid`, `GetFlowPlayerController`, `RequireEqual_Enum`, and `RequireNotEqual_Enum`.
 - Refactored startup to be all in a couple classes, `FSpatialServerStartupHandler` and `FSpatialClientStartupHandler`.
+- Newly torn off channels are now conditionally closed after all updates in a given tick have been applied.
 
 ## [`0.14.0-rc`] - Unreleased
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
@@ -1904,6 +1904,7 @@ void ActorSystem::CleanUpTornOffChannels()
 			Channel->ConditionalCleanUp(false, EChannelCloseReason::TearOff);
 		}
 	}
+	EntityChannelsToSetTornOff.Empty();
 }
 
 void ActorSystem::RemoveActor(const Worker_EntityId EntityId)

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
@@ -338,6 +338,10 @@ void ActorSystem::Advance()
 	// authoritative you are supposed to be the only server that can update properties.
 	InvokeRepNotifies();
 
+	// And finally send clean up for channels that we got a tear off update for.
+	// We don't do this earlier as Rep Notifies require the actor channel.
+	CleanUpTornOffChannels();
+
 	// No need to ProcessAuthorityGains on SimulatedSubView as we won't have gained authority on Entities in that SubView.
 	ProcessAuthorityGains(EntityAuthSubView);
 	ProcessAuthorityGains(EntityOwnershipSubView);
@@ -973,10 +977,10 @@ void ActorSystem::ApplyComponentData(USpatialActorChannel& Channel, UObject& Tar
 		ComponentReader Reader(NetDriver, RepStateHelper.GetRefMap(), NetDriver->Connection->GetEventTracer());
 		bool bOutReferencesChanged = false;
 
-		FObjectRepNotifies& ObjectRepNotifiesOut = GetObjectRepNotifies(TargetObject);
 		const bool bSuccessfullyPreNetReceived = InvokePreNetReceive(TargetObject);
 		if (bSuccessfullyPreNetReceived)
 		{
+			FObjectRepNotifies& ObjectRepNotifiesOut = GetObjectRepNotifies(TargetObject);
 			Reader.ApplyComponentData(ComponentId, Data, TargetObject, Channel, ObjectRepNotifiesOut, bOutReferencesChanged);
 		}
 		else
@@ -1305,11 +1309,11 @@ void ActorSystem::ApplyComponentUpdate(const Worker_ComponentId ComponentId, Sch
 
 	ComponentReader Reader(NetDriver, RepStateHelper.GetRefMap(), NetDriver->Connection->GetEventTracer());
 	bool bOutReferencesChanged = false;
-	FObjectRepNotifies& ObjectRepNotifiesOut = GetObjectRepNotifies(TargetObject);
 
 	const bool bSuccessfullyPreNetReceived = InvokePreNetReceive(TargetObject);
 	if (bSuccessfullyPreNetReceived)
 	{
+		FObjectRepNotifies& ObjectRepNotifiesOut = GetObjectRepNotifies(TargetObject);
 		Reader.ApplyComponentUpdate(ComponentId, ComponentUpdate, TargetObject, Channel, ObjectRepNotifiesOut, bOutReferencesChanged);
 	}
 	else
@@ -1330,7 +1334,7 @@ void ActorSystem::ApplyComponentUpdate(const Worker_ComponentId ComponentId, Sch
 		// Check if bTearOff has been set to true
 		if (GetBoolFromSchema(ComponentObject, SpatialConstants::ACTOR_TEAROFF_ID))
 		{
-			Channel.ConditionalCleanUp(false, EChannelCloseReason::TearOff);
+			EntityChannelsToSetTornOff.Add(Channel.GetEntityId());
 		}
 	}
 }
@@ -1887,6 +1891,17 @@ void ActorSystem::RemoveRepNotifiesWithUnresolvedObjs(UObject& Object, const USp
 		{
 			FObjectReplicator& Replicator = ReplicatorRef->Get();
 			Channel.RemoveRepNotifiesWithUnresolvedObjs(RepNotifies, *Replicator.RepLayout, ObjectRepState->ReferenceMap, &Object);
+		}
+	}
+}
+
+void ActorSystem::CleanUpTornOffChannels()
+{
+	for (const Worker_EntityId EntityId : EntityChannelsToSetTornOff)
+	{
+		if (USpatialActorChannel* Channel = NetDriver->GetActorChannelByEntityId(EntityId))
+		{
+			Channel->ConditionalCleanUp(false, EChannelCloseReason::TearOff);
 		}
 	}
 }

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/ActorSystem.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/ActorSystem.h
@@ -140,6 +140,7 @@ private:
 	void TryInvokeRepNotifiesForObject(FWeakObjectPtr& Object, FObjectRepNotifies& ObjectRepNotifies) const;
 	static void RemoveRepNotifiesWithUnresolvedObjs(UObject& Object, const USpatialActorChannel& Channel,
 													TArray<GDK_PROPERTY(Property) *>& RepNotifies);
+	void CleanUpTornOffChannels();
 
 	// Authority
 	bool HasEntityBeenRequestedForDelete(Worker_EntityId EntityId) const;
@@ -217,6 +218,9 @@ private:
 	// RepNotifies are stored here then sent after all updates we have are applied
 	FObjectToRepNotifies ActorRepNotifiesToSend;
 	FObjectToRepNotifies SubobjectRepNotifiesToSend;
+
+	// Channels are set as torn off after we have sent all our other user callbacks, such as rep notifies.
+	TArray<Worker_EntityId> EntityChannelsToSetTornOff;
 
 	// Deserialized state store for Actor relevant components.
 	TMap<Worker_EntityId_Key, ActorData> ActorDataStore;


### PR DESCRIPTION
#### Description
In this PR I have moved the tearing off of channels that have been newly marked as tear off (and we noticed after  an applycomponentupdate), to after rep notifies.

Why:

The TearOff test started failing after https://github.com/spatialos/UnrealGDK/pull/3268/files was merged, due to the `Failed to invoke rep notifies for an object as its entity id was invalid` warning.

However, that PR did not actually break tearoff. The reason it surfaced there was because I removed the early out clause for repnotifies.

```
void ActorSystem::TryInvokeRepNotifiesForObject(FWeakObjectPtr& WeakObjectPtr, FObjectRepNotifies& ObjectRepNotifies) const
{
	if (ObjectRepNotifies.RepNotifies.Num() == 0)
	{
		return;
	}
```

The change that broke this was the change that moved repnotifies for all entities till after all updates had been applied.

This changed the ordering of closing channels for tear off from after rep notifies had been applied, to before rep notifies were applied. Since applying rep notifies (with current implementation) requires a channel, this broke sending rep notifies.

#### Release note
`- Newly torn off channels are now conditionally closed after all updates in a given tick have been applied.`

#### Tests
Ran SpatialTestTearOff
