### PR TITLE
[UNR-5632] Add ServerWorker System

### DIFF
--- a/SpatialGDK/Extras/schema/server_worker.schema
+++ b/SpatialGDK/Extras/schema/server_worker.schema
@@ -26,13 +26,3 @@ component ServerWorker {
     command Void exec_server_command(ExecServerCommandPayload);
 }
 
-component_set ServerWorkerAuthComponentSet {
-  id = 9908;
-  components = [
-    improbable.Position,
-    improbable.Metadata,
-    improbable.Interest,
-    unreal.ServerWorker,
-    unreal.generated.UnrealCrossServerSenderRPCs
-  ];
-}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -28,6 +28,7 @@
 #include "EngineClasses/SpatialPartitionSystem.h"
 #include "EngineClasses/SpatialPendingNetGame.h"
 #include "EngineClasses/SpatialReplicationGraph.h"
+#include "EngineClasses/SpatialServerWorkerSystem.h"
 #include "EngineClasses/SpatialShadowActor.h"
 #include "EngineClasses/SpatialWorldSettings.h"
 #include "Interop/ActorSubviews.h"
@@ -53,6 +54,7 @@
 #include "Interop/SpatialReceiver.h"
 #include "Interop/SpatialRoutingSystem.h"
 #include "Interop/SpatialSender.h"
+#include "Interop/SpatialServerWorkerSystemImpl.h"
 #include "Interop/SpatialSnapshotManager.h"
 #include "Interop/SpatialStrategySystem.h"
 #include "Interop/SpatialWorkerFlags.h"
@@ -499,6 +501,13 @@ void USpatialNetDriver::CreateAndInitializeCoreClasses()
 				PartitionSystemImpl = MakeUnique<SpatialGDK::FPartitionSystemImpl>(PartitionsSubView);
 				PartitionSystemImpl->PartitionData.DataStorages = Partitions->GetData();
 				Partitions->SetImpl(*PartitionSystemImpl);
+			}
+
+			USpatialServerWorkerSystem* ServerWorkerData = GameInstance->GetSubsystem<USpatialServerWorkerSystem>();
+			if (ServerWorkerData)
+			{
+				ServerWorkerSystemImpl = MakeUnique<SpatialGDK::FServerWorkerSystemImpl>();
+				ServerWorkerData->SetImpl(*ServerWorkerSystemImpl);
 			}
 		}
 
@@ -2599,6 +2608,11 @@ void USpatialNetDriver::TickFlush(float DeltaTime)
 			{
 				ActorSystem->ProcessPositionUpdates();
 			}
+
+			if (ServerWorkerSystemImpl.IsValid())
+			{
+				ServerWorkerSystemImpl->Flush(WorkerEntityId, Connection->GetCoordinator());
+			}
 		}
 #endif // WITH_SERVER_CODE
 	}
@@ -3267,16 +3281,20 @@ void USpatialNetDriver::TryFinishStartup()
 				Connection->GetCoordinator().CreateSubView(SpatialConstants::STRATEGYWORKER_TAG_COMPONENT_ID,
 														   SpatialGDK::FSubView::NoFilter, SpatialGDK::FSubView::NoDispatcherCallbacks);
 
-			auto PartitionMgr =
-				MakeUnique<SpatialGDK::FPartitionManager>(Connection->GetWorkerSystemEntityId(), Connection->GetCoordinator(),
-														  MakeUnique<SpatialGDK::InterestFactory>(ClassInfoManager));
+			SpatialGDK::FSubView& ServerWorkerView = Connection->GetCoordinator().CreateSubView(
+				SpatialConstants::SERVER_WORKER_COMPONENT_ID, SpatialGDK::FSubView::NoFilter, SpatialGDK::FSubView::NoDispatcherCallbacks);
+
+			auto PartitionMgr = MakeUnique<SpatialGDK::FPartitionManager>(ServerWorkerView, Connection->GetWorkerSystemEntityId(),
+																		  Connection->GetCoordinator(),
+																		  MakeUnique<SpatialGDK::InterestFactory>(ClassInfoManager));
 
 			PartitionMgr->Init(Connection->GetCoordinator());
 
 			TUniquePtr<SpatialGDK::FLoadBalancingStrategy> Strategy =
 				MakeUnique<SpatialGDK::FLegacyLoadBalancing>(*LoadBalanceStrategy, *VirtualWorkerTranslator);
 
-			StrategySystem = MakeUnique<SpatialGDK::FSpatialStrategySystem>(MoveTemp(PartitionMgr), LBView, MoveTemp(Strategy));
+			StrategySystem =
+				MakeUnique<SpatialGDK::FSpatialStrategySystem>(MoveTemp(PartitionMgr), LBView, ServerWorkerView, MoveTemp(Strategy));
 
 			bIsReadyToStart = true;
 			Connection->SetStartupComplete();

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialServerWorkerSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialServerWorkerSystem.cpp
@@ -1,0 +1,70 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "EngineClasses/SpatialServerWorkerSystem.h"
+#include "EngineClasses/SpatialGameInstance.h"
+#include "Interop/SpatialServerWorkerSystemImpl.h"
+#include "SpatialGDKSettings.h"
+
+DEFINE_LOG_CATEGORY(LogSpatialServerWorkerSystem);
+
+DEFINE_VTABLE_PTR_HELPER_CTOR(USpatialServerWorkerSystem);
+USpatialServerWorkerSystem::USpatialServerWorkerSystem() = default;
+USpatialServerWorkerSystem::~USpatialServerWorkerSystem() = default;
+
+bool USpatialServerWorkerSystem::ShouldCreateSubsystem(UObject* Outer) const
+{
+	USpatialGameInstance* GameInstance = Cast<USpatialGameInstance>(Outer);
+	if (!ensure(GameInstance != nullptr))
+	{
+		return false;
+	}
+
+	if (GameInstance->GetSpatialWorkerType() != SpatialConstants::DefaultServerWorkerType)
+	{
+		return false;
+	}
+
+	const USpatialGDKSettings* Settings = GetDefault<USpatialGDKSettings>();
+	if (Settings->ServerWorkerSystemClass.Get() == GetClass())
+	{
+		return true;
+	}
+
+	return false;
+}
+
+TArray<SpatialGDK::ComponentData> USpatialServerWorkerSystem::GetServerWorkerData()
+{
+	return TArray<SpatialGDK::ComponentData>();
+}
+
+void USpatialServerWorkerSystem::UpdateServerWorkerData(TArray<SpatialGDK::ComponentUpdate> Updates)
+{
+	if (Impl == nullptr)
+	{
+		return;
+	}
+
+	for (auto& Update : Updates)
+	{
+		if (!Impl->ServerWorkerComponents.Contains(Update.GetComponentId()))
+		{
+			UE_LOG(LogSpatialServerWorkerSystem, Error,
+				   TEXT("Cannot update component not initially present on the server worker entity, ComponentId : %i"),
+				   Update.GetComponentId());
+			continue;
+		}
+		SpatialGDK::ComponentUpdate* ExistingUpdate =
+			Impl->PendingComponentUpdates.FindByPredicate([&Update](const SpatialGDK::ComponentUpdate& PendingUpdate) {
+				return PendingUpdate.GetComponentId() == Update.GetComponentId();
+			});
+		if (ExistingUpdate != nullptr)
+		{
+			ExistingUpdate->Merge(MoveTemp(Update));
+		}
+		else
+		{
+			Impl->PendingComponentUpdates.Add(MoveTemp(Update));
+		}
+	}
+}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialServerWorkerSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialServerWorkerSystem.cpp
@@ -33,11 +33,6 @@ bool USpatialServerWorkerSystem::ShouldCreateSubsystem(UObject* Outer) const
 	return false;
 }
 
-TArray<SpatialGDK::ComponentData> USpatialServerWorkerSystem::GetServerWorkerInitialData()
-{
-	return TArray<SpatialGDK::ComponentData>();
-}
-
 void USpatialServerWorkerSystem::UpdateServerWorkerData(TArray<SpatialGDK::ComponentUpdate> Updates)
 {
 	if (Impl == nullptr)

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialServerWorkerSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialServerWorkerSystem.cpp
@@ -33,7 +33,7 @@ bool USpatialServerWorkerSystem::ShouldCreateSubsystem(UObject* Outer) const
 	return false;
 }
 
-TArray<SpatialGDK::ComponentData> USpatialServerWorkerSystem::GetServerWorkerData()
+TArray<SpatialGDK::ComponentData> USpatialServerWorkerSystem::GetServerWorkerInitialData()
 {
 	return TArray<SpatialGDK::ComponentData>();
 }
@@ -67,4 +67,10 @@ void USpatialServerWorkerSystem::UpdateServerWorkerData(TArray<SpatialGDK::Compo
 			Impl->PendingComponentUpdates.Add(MoveTemp(Update));
 		}
 	}
+}
+
+void USpatialServerWorkerSystem::SetImpl(SpatialGDK::FServerWorkerSystemImpl& InImpl)
+{
+	Impl = &InImpl;
+	Impl->InitialData = GetServerWorkerInitialData();
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
@@ -95,16 +95,11 @@ void ServerWorkerEntityCreator::CreateWorkerEntity()
 
 	if (NetDriver.ServerWorkerSystemImpl)
 	{
-		UGameInstance* GameInstance = NetDriver.GetWorld()->GetGameInstance();
-		USpatialServerWorkerSystem* ServerWorkerData = GameInstance->GetSubsystem<USpatialServerWorkerSystem>();
-		if (ensure(ServerWorkerData))
+		TArray<ComponentData> DataArray = MoveTemp(NetDriver.ServerWorkerSystemImpl->InitialData);
+		for (auto& Data : DataArray)
 		{
-			TArray<ComponentData> DataArray = ServerWorkerData->GetServerWorkerData();
-			for (auto& Data : DataArray)
-			{
-				NetDriver.ServerWorkerSystemImpl->ServerWorkerComponents.Add(Data.GetComponentId());
-				ComponentDatas.Add(MoveTemp(Data));
-			}
+			NetDriver.ServerWorkerSystemImpl->ServerWorkerComponents.Add(Data.GetComponentId());
+			ComponentDatas.Add(MoveTemp(Data));
 		}
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/Connection/SpatialWorkerConnection.cpp
@@ -87,6 +87,12 @@ void ServerWorkerEntityCreator::CreateWorkerEntity()
 	// GDK known entities completeness tags.
 	Components.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::GDK_KNOWN_ENTITY_TAG_COMPONENT_ID));
 
+	TArray<ComponentData> ComponentDatas;
+	for (FWorkerComponentData& Component : Components)
+	{
+		ComponentDatas.Emplace(ToComponentData(Component));
+	}
+
 	if (NetDriver.ServerWorkerSystemImpl)
 	{
 		UGameInstance* GameInstance = NetDriver.GetWorld()->GetGameInstance();
@@ -94,29 +100,12 @@ void ServerWorkerEntityCreator::CreateWorkerEntity()
 		if (ensure(ServerWorkerData))
 		{
 			TArray<ComponentData> DataArray = ServerWorkerData->GetServerWorkerData();
-			for (auto& Update : NetDriver.ServerWorkerSystemImpl->PendingComponentUpdates)
-			{
-				if (ComponentData* ExistingData = DataArray.FindByPredicate(ComponentIdEquality()))
-				{
-					ExistingData->ApplyUpdate(MoveTemp(Update));
-				}
-			}
-			NetDriver.ServerWorkerSystemImpl->PendingComponentUpdates.Empty();
 			for (auto& Data : DataArray)
 			{
 				NetDriver.ServerWorkerSystemImpl->ServerWorkerComponents.Add(Data.GetComponentId());
-				FWorkerComponentData WorkerComponentData = {};
-				WorkerComponentData.component_id = Data.GetComponentId();
-				WorkerComponentData.schema_type = Schema_CopyComponentData(Data.GetUnderlying());
-				Components.Add(WorkerComponentData);
+				ComponentDatas.Add(MoveTemp(Data));
 			}
 		}
-	}
-	
-	TArray<ComponentData> ComponentDatas;
-	for (FWorkerComponentData& Component : Components)
-	{
-		ComponentDatas.Emplace(ToComponentData(Component));
 	}
 
 	const Worker_RequestId CreateEntityRequestId =

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialServerWorkerSystemImpl.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialServerWorkerSystemImpl.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#include "Interop/SpatialServerWorkerSystemImpl.h"
+#include "SpatialConstants.h"
+
+namespace SpatialGDK
+{
+void FServerWorkerSystemImpl::Flush(Worker_EntityId ServerWorkerEntityId, ISpatialOSWorker& Connection)
+{
+	for (auto& Update : PendingComponentUpdates)
+	{
+		Connection.SendComponentUpdate(ServerWorkerEntityId, MoveTemp(Update));
+	}
+	PendingComponentUpdates.Empty();
+}
+} // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialServerWorkerSystemImpl.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialServerWorkerSystemImpl.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
 #include "Interop/SpatialServerWorkerSystemImpl.h"
-#include "SpatialConstants.h"
 
 namespace SpatialGDK
 {

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialServerWorkerSystemImpl.h
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialServerWorkerSystemImpl.h
@@ -15,6 +15,7 @@ public:
 	void Flush(Worker_EntityId ServerWorkerEntityId, ISpatialOSWorker& Connection);
 
 	TSet<Worker_ComponentId> ServerWorkerComponents;
+	TArray<SpatialGDK::ComponentData> InitialData;
 	TArray<SpatialGDK::ComponentUpdate> PendingComponentUpdates;
 };
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialServerWorkerSystemImpl.h
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialServerWorkerSystemImpl.h
@@ -1,0 +1,20 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "EngineClasses/SpatialServerWorkerSystem.h"
+#include "LoadBalancing/LBDataStorage.h"
+
+namespace SpatialGDK
+{
+class ISpatialOSWorker;
+
+class FServerWorkerSystemImpl
+{
+public:
+	void Flush(Worker_EntityId ServerWorkerEntityId, ISpatialOSWorker& Connection);
+
+	TSet<Worker_ComponentId> ServerWorkerComponents;
+	TArray<SpatialGDK::ComponentUpdate> PendingComponentUpdates;
+};
+} // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/ActorSetSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/ActorSetSystem.cpp
@@ -6,6 +6,9 @@ namespace SpatialGDK
 {
 void FActorSetSystem::Update(TLBDataStorage<ActorSetMember>& Data, TSet<Worker_EntityId_Key>& DeletedEntities)
 {
+	EntitiesToEvaluate.Empty();
+	EntitiesToAttach.Empty();
+
 	for (Worker_EntityId Modified : Data.GetModifiedEntities())
 	{
 		const ActorSetMember* Membership = Data.GetObjects().Find(Modified);

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LBDataStorage.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LBDataStorage.cpp
@@ -6,6 +6,13 @@ namespace SpatialGDK
 {
 void FLBDataCollection::Advance()
 {
+	EntitiesAdded.Empty();
+	EntitiesRemoved.Empty();
+	for (auto& Storage : DataStorages)
+	{
+		Storage->ClearModified();
+	}
+
 	for (const EntityDelta& Delta : SubView.GetViewDelta().EntityDeltas)
 	{
 		switch (Delta.Type)

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LegacyServerWorkerSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LegacyServerWorkerSystem.cpp
@@ -1,0 +1,12 @@
+#include "LoadBalancing/LegacyServerWorkerSystem.h"
+#include "LoadBalancing/LegacyLoadbalancingComponents.h"
+
+ULegacyServerWorkerSystem::ULegacyServerWorkerSystem() = default;
+
+TArray<SpatialGDK::ComponentData> ULegacyServerWorkerSystem::GetServerWorkerData()
+{
+	TArray<SpatialGDK::ComponentData> Data;
+	// Will be used to add test debug data in the next PR.
+	// Data.Add(SpatialGDK::LegacyLB_CustomWorkerAssignments().CreateComponentData());
+	return Data;
+}

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LegacyServerWorkerSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LegacyServerWorkerSystem.cpp
@@ -3,7 +3,7 @@
 
 ULegacyServerWorkerSystem::ULegacyServerWorkerSystem() = default;
 
-TArray<SpatialGDK::ComponentData> ULegacyServerWorkerSystem::GetServerWorkerData()
+TArray<SpatialGDK::ComponentData> ULegacyServerWorkerSystem::GetServerWorkerInitialData()
 {
 	TArray<SpatialGDK::ComponentData> Data;
 	// Will be used to add test debug data in the next PR.

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/PartitionManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/PartitionManager.cpp
@@ -69,9 +69,8 @@ CommandRequest CreateClaimPartitionRequest(Worker_PartitionId Partition)
 
 struct FPartitionManager::Impl
 {
-	Impl(ViewCoordinator& Coordinator, TUniquePtr<InterestFactory>&& InInterestF)
-		: WorkerView(Coordinator.CreateSubView(SpatialConstants::SERVER_WORKER_COMPONENT_ID, SpatialGDK::FSubView::NoFilter,
-											   SpatialGDK::FSubView::NoDispatcherCallbacks))
+	Impl(const FSubView& InServerWorkerView, ViewCoordinator& Coordinator, TUniquePtr<InterestFactory>&& InInterestF)
+		: WorkerView(InServerWorkerView)
 		, SystemWorkerView(Coordinator.CreateSubView(SpatialConstants::WORKER_COMPONENT_ID, SpatialGDK::FSubView::NoFilter,
 													 SpatialGDK::FSubView::NoDispatcherCallbacks))
 		, PartitionView(Coordinator.CreateSubView(SpatialConstants::PARTITION_ACK_COMPONENT_ID, SpatialGDK::FSubView::NoFilter,
@@ -408,9 +407,9 @@ struct FPartitionManager::Impl
 
 FPartitionManager::~FPartitionManager() = default;
 
-FPartitionManager::FPartitionManager(Worker_EntityId InStrategyWorkerEntityId, ViewCoordinator& Coordinator,
-									 TUniquePtr<InterestFactory>&& InterestF)
-	: m_Impl(MakeUnique<Impl>(Coordinator, MoveTemp(InterestF)))
+FPartitionManager::FPartitionManager(const FSubView& InServerWorkerView, Worker_EntityId InStrategyWorkerEntityId,
+									 ViewCoordinator& Coordinator, TUniquePtr<InterestFactory>&& InterestF)
+	: m_Impl(MakeUnique<Impl>(InServerWorkerView, Coordinator, MoveTemp(InterestF)))
 {
 	m_Impl->StrategyWorkerEntityId = InStrategyWorkerEntityId;
 }
@@ -547,6 +546,19 @@ Worker_EntityId FPartitionManager::GetServerWorkerEntityIdForWorker(FLBWorkerHan
 	}
 
 	return Worker->State->ServerWorkerId;
+}
+
+FLBWorkerHandle FPartitionManager::GetWorkerForServerWorkerEntity(Worker_EntityId EntityId)
+{
+	for (const auto& Worker : m_Impl->ConnectedWorkers)
+	{
+		if (Worker->State->ServerWorkerId == EntityId)
+		{
+			return Worker;
+		}
+	}
+
+	return FLBWorkerHandle();
 }
 
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriver.h
@@ -96,6 +96,7 @@ class FSkeletonEntityCreationStartupStep;
 class FSpatialServerStartupHandler;
 class FSpatialClientStartupHandler;
 class FPartitionSystemImpl;
+class FServerWorkerSystemImpl;
 } // namespace SpatialGDK
 
 UCLASS()
@@ -244,6 +245,7 @@ public:
 	TUniquePtr<SpatialGDK::SpatialRoutingSystem> RoutingSystem;
 	TUniquePtr<SpatialGDK::FSpatialStrategySystem> StrategySystem;
 	TUniquePtr<SpatialGDK::FPartitionSystemImpl> PartitionSystemImpl;
+	TUniquePtr<SpatialGDK::FServerWorkerSystemImpl> ServerWorkerSystemImpl;
 	TUniquePtr<SpatialGDK::SpatialLoadBalanceEnforcer> LoadBalanceEnforcer;
 	TUniquePtr<SpatialGDK::FSpatialHandoverManager> HandoverManager;
 	TUniquePtr<SpatialGDK::UnrealServerInterestFactory> InterestFactory;

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialServerWorkerSystem.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialServerWorkerSystem.h
@@ -35,6 +35,8 @@ public:
 	void ClearImpl() { Impl = nullptr; }
 
 private:
-	virtual TArray<SpatialGDK::ComponentData> GetServerWorkerInitialData();
-	SpatialGDK::FServerWorkerSystemImpl* Impl = nullptr;
+	virtual TArray<SpatialGDK::ComponentData> GetServerWorkerInitialData()
+		PURE_VIRTUAL(GetServerWorkerData, return TArray<SpatialGDK::ComponentData>();)
+
+			SpatialGDK::FServerWorkerSystemImpl* Impl = nullptr;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialServerWorkerSystem.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialServerWorkerSystem.h
@@ -29,13 +29,12 @@ public:
 
 	virtual bool ShouldCreateSubsystem(UObject* Outer) const override;
 
-	virtual TArray<SpatialGDK::ComponentData> GetServerWorkerData();
-
 	void UpdateServerWorkerData(TArray<SpatialGDK::ComponentUpdate> Updates);
 
-	void SetImpl(SpatialGDK::FServerWorkerSystemImpl& InImpl) { Impl = &InImpl; }
+	void SetImpl(SpatialGDK::FServerWorkerSystemImpl& InImpl);
 	void ClearImpl() { Impl = nullptr; }
 
 private:
+	virtual TArray<SpatialGDK::ComponentData> GetServerWorkerInitialData();
 	SpatialGDK::FServerWorkerSystemImpl* Impl = nullptr;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialServerWorkerSystem.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialServerWorkerSystem.h
@@ -1,0 +1,41 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "SpatialCommonTypes.h"
+#include "SpatialView/ComponentData.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+
+#include "SpatialServerWorkerSystem.generated.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogSpatialServerWorkerSystem, Log, All);
+
+namespace SpatialGDK
+{
+class FServerWorkerSystemImpl;
+} // namespace SpatialGDK
+
+class USpatialNetDriver;
+
+UCLASS(Abstract)
+class SPATIALGDK_API USpatialServerWorkerSystem : public UGameInstanceSubsystem
+{
+	GENERATED_BODY()
+
+public:
+	USpatialServerWorkerSystem();
+	USpatialServerWorkerSystem(FVTableHelper&);
+	~USpatialServerWorkerSystem();
+
+	virtual bool ShouldCreateSubsystem(UObject* Outer) const override;
+
+	virtual TArray<SpatialGDK::ComponentData> GetServerWorkerData();
+
+	void UpdateServerWorkerData(TArray<SpatialGDK::ComponentUpdate> Updates);
+
+	void SetImpl(SpatialGDK::FServerWorkerSystemImpl& InImpl) { Impl = &InImpl; }
+	void ClearImpl() { Impl = nullptr; }
+
+private:
+	SpatialGDK::FServerWorkerSystemImpl* Impl = nullptr;
+};

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialStrategySystem.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialStrategySystem.h
@@ -29,7 +29,7 @@ class FPartitionManager;
 class FSpatialStrategySystem
 {
 public:
-	FSpatialStrategySystem(TUniquePtr<FPartitionManager> InPartitionMgr, const FSubView& InLBView,
+	FSpatialStrategySystem(TUniquePtr<FPartitionManager> InPartitionMgr, const FSubView& InLBView, const FSubView& InServerWorkerView,
 						   TUniquePtr<FLoadBalancingStrategy> Strategy);
 
 	~FSpatialStrategySystem();
@@ -39,8 +39,6 @@ public:
 	void Destroy(ISpatialOSWorker& Connection);
 
 private:
-	void ClearUserStorages();
-
 	const FSubView& LBView;
 
 	TUniquePtr<FPartitionManager> PartitionsMgr;
@@ -52,6 +50,7 @@ private:
 	FActorSetSystem ActorSetSystem;
 	FLBDataCollection DataStorages;
 	FLBDataCollection UserDataStorages;
+	FLBDataCollection ServerWorkerDataStorages;
 	TSet<Worker_ComponentId> UpdatesToConsider;
 	// --- Components watched to implement the strategy ---
 

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/ActorSetSystem.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/ActorSetSystem.h
@@ -22,11 +22,6 @@ public:
 
 	const TSet<Worker_EntityId_Key>& GetEntitiesToEvaluate() const { return EntitiesToEvaluate; }
 	const TSet<Worker_EntityId_Key>& GetEntitiesToAttach() const { return EntitiesToAttach; }
-	void Clear()
-	{
-		EntitiesToEvaluate.Empty();
-		EntitiesToAttach.Empty();
-	}
 
 protected:
 	TMap<Worker_EntityId_Key, TSet<Worker_EntityId_Key>> ActorSets;

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LBDataStorage.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LBDataStorage.h
@@ -116,12 +116,4 @@ protected:
 	TMap<Worker_EntityId_Key, T> SchemaObjects;
 };
 
-class FActorGroupStorage : public TLBDataStorage<ActorGroupMember>
-{
-};
-
-class FDirectAssignmentStorage : public TLBDataStorage<AuthorityIntent>
-{
-};
-
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LegacyLoadBalancingStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LegacyLoadBalancingStrategy.h
@@ -60,7 +60,7 @@ protected:
 	TMap<Worker_EntityId_Key, int32> Assignment;
 	bool bDirectAssignment = false;
 
-	Worker_EntityId WorkerForCustomAssignment = 0;
+	Worker_EntityId WorkerForCustomAssignment = SpatialConstants::INVALID_ENTITY_ID;
 	// --- Load Balancing ---
 };
 

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LegacyLoadBalancingStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LegacyLoadBalancingStrategy.h
@@ -13,7 +13,8 @@ namespace SpatialGDK
 class FSpatialPositionStorage;
 class FActorGroupStorage;
 class FDirectAssignmentStorage;
-class FLoadBalancingCalculator;
+class FDebugComponentStorage;
+class FCustomWorkerAssignmentStorage;
 
 class FLegacyLoadBalancing : public FLoadBalancingStrategy
 {
@@ -21,7 +22,7 @@ public:
 	FLegacyLoadBalancing(UAbstractLBStrategy& LegacyLBStrat, SpatialVirtualWorkerTranslator& InTranslator);
 	~FLegacyLoadBalancing();
 
-	virtual void Init(TArray<FLBDataStorage*>& OutLoadBalancingData) override;
+	virtual void Init(TArray<FLBDataStorage*>& OutLoadBalancingData, TArray<FLBDataStorage*>& OutServerWorkerData) override;
 
 	virtual void Advance(ISpatialOSWorker& Connection) override;
 	virtual void Flush(ISpatialOSWorker& Connection) override;
@@ -38,6 +39,7 @@ protected:
 	TUniquePtr<FSpatialPositionStorage> PositionStorage;
 	TUniquePtr<FActorGroupStorage> GroupStorage;
 	TUniquePtr<FDirectAssignmentStorage> AssignmentStorage;
+	TUniquePtr<FDebugComponentStorage> DebugCompStorage;
 	// --- Data Storage ---
 
 	// +++ Partition Assignment +++
@@ -57,6 +59,8 @@ protected:
 	TSet<Worker_EntityId_Key> ToRefresh;
 	TMap<Worker_EntityId_Key, int32> Assignment;
 	bool bDirectAssignment = false;
+
+	Worker_EntityId WorkerForCustomAssignment = 0;
 	// --- Load Balancing ---
 };
 

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LegacyServerWorkerSystem.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LegacyServerWorkerSystem.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "EngineClasses/SpatialServerWorkerSystem.h"
+#include "LoadBalancing/LegacyLoadbalancingComponents.h"
+#include "LegacyServerWorkerSystem.generated.h"
+
+UCLASS()
+class ULegacyServerWorkerSystem : public USpatialServerWorkerSystem
+{
+	GENERATED_BODY()
+public:
+	ULegacyServerWorkerSystem();
+
+	TArray<SpatialGDK::ComponentData> GetServerWorkerData() override;
+};

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LegacyServerWorkerSystem.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LegacyServerWorkerSystem.h
@@ -11,5 +11,6 @@ class ULegacyServerWorkerSystem : public USpatialServerWorkerSystem
 public:
 	ULegacyServerWorkerSystem();
 
-	TArray<SpatialGDK::ComponentData> GetServerWorkerData() override;
+private:
+	TArray<SpatialGDK::ComponentData> GetServerWorkerInitialData() override;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LoadBalancingStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LoadBalancingStrategy.h
@@ -17,7 +17,7 @@ class SPATIALGDK_API FLoadBalancingStrategy
 public:
 	virtual ~FLoadBalancingStrategy() = default;
 
-	virtual void Init(TArray<FLBDataStorage*>& OutLoadBalancingData) {}
+	virtual void Init(TArray<FLBDataStorage*>& OutLoadBalancingData, TArray<FLBDataStorage*>& OutServerWorkerData) {}
 
 	virtual void Advance(ISpatialOSWorker& Connection) {}
 	virtual void Flush(ISpatialOSWorker& Connection) {}

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/PartitionManager.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/PartitionManager.h
@@ -19,7 +19,8 @@ class ViewCoordinator;
 class FPartitionManager
 {
 public:
-	FPartitionManager(Worker_EntityId InStrategyWorkerEntityId, ViewCoordinator& Coordinator, TUniquePtr<InterestFactory>&& InterestF);
+	FPartitionManager(const FSubView& InServerWorkerView, Worker_EntityId InStrategyWorkerEntityId, ViewCoordinator& Coordinator,
+					  TUniquePtr<InterestFactory>&& InterestF);
 	~FPartitionManager();
 
 	void Init(ISpatialOSWorker& Connection);
@@ -40,6 +41,7 @@ public:
 	TArray<FLBWorkerHandle> GetDisconnectedWorkers();
 
 	Worker_EntityId GetServerWorkerEntityIdForWorker(FLBWorkerHandle);
+	FLBWorkerHandle GetWorkerForServerWorkerEntity(Worker_EntityId);
 
 private:
 	struct Impl;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -6,7 +6,6 @@
 #include "Engine/EngineTypes.h"
 #include "Misc/Paths.h"
 
-#include "EngineClasses/SpatialPartitionSystem.h"
 #include "Utils/GDKPropertyMacros.h"
 #include "Utils/RPCContainer.h"
 
@@ -15,6 +14,8 @@
 DECLARE_LOG_CATEGORY_EXTERN(LogSpatialGDKSettings, Log, All);
 
 class ASpatialDebugger;
+class USpatialPartitionSystem;
+class USpatialServerWorkerSystem;
 
 /**
  * Enum that maps Unreal's log verbosity to allow use in settings.
@@ -357,6 +358,9 @@ public:
 
 	UPROPERTY(EditAnywhere, Config, Category = "Load Balancing", meta = (DisplayName = "EXPERIMENTAL PartitionSystem to use"))
 	TSubclassOf<USpatialPartitionSystem> PartitionSystemClass;
+
+	UPROPERTY(EditAnywhere, Config, Category = "Load Balancing", meta = (DisplayName = "EXPERIMENTAL ServerWorkerSystem to use"))
+	TSubclassOf<USpatialServerWorkerSystem> ServerWorkerSystemClass;
 
 #if WITH_EDITOR
 	void SetMultiWorkerEditorEnabled(const bool bIsEnabled);

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -1393,7 +1393,19 @@ bool RunSchemaCompiler(FString& SchemaBundleJsonOutput, FString SchemaInputDir, 
 	}
 }
 
-bool CreatePartitionAuthoritySet(FString SchemaInputPath, FString SchemaOutputPath)
+struct CustomComponentSetDesc
+{
+	FString ComponentSetName;
+	Worker_ComponentSetId ComponentSetId;
+
+	FString CustomSchemaFolder;
+	FString SchemaFileName;
+
+	TArray<FString> InitialComponentSetContent;
+	TArray<FString> AdditionalSetInclude;
+};
+
+bool CreateCustomAuthoritySet(FString SchemaInputPath, FString SchemaOutputPath, const CustomComponentSetDesc& SetDesc)
 {
 	if (SchemaOutputPath.IsEmpty())
 	{
@@ -1401,23 +1413,22 @@ bool CreatePartitionAuthoritySet(FString SchemaInputPath, FString SchemaOutputPa
 	}
 
 	FString IntermediateDir = GenerateIntermediateDirectory();
-	const FString PartitionDataFolderName(TEXT("PartitionMetadata"));
 
 	if (SchemaInputPath.IsEmpty())
 	{
 		FString ContentDir = FPaths::ProjectContentDir();
-		SchemaInputPath = FPaths::Combine(ContentDir, TEXT("Spatial"), PartitionDataFolderName);
+		SchemaInputPath = FPaths::Combine(ContentDir, TEXT("Spatial"), SetDesc.CustomSchemaFolder);
 	}
 
 	IPlatformFile& Filesystem = IPlatformFile::GetPlatformPhysical();
 
-	FString DestinationSchemaDir = FPaths::Combine(SchemaOutputPath, PartitionDataFolderName);
+	FString DestinationSchemaDir = FPaths::Combine(SchemaOutputPath, SetDesc.CustomSchemaFolder);
 	if (FPaths::DirectoryExists(DestinationSchemaDir))
 	{
 		if (!Filesystem.DeleteDirectoryRecursively(*DestinationSchemaDir))
 		{
 			// clang-format off
-			UE_LOG(LogSpatialGDKSchemaGenerator, Error, TEXT("Could not delete pre-existing partition metadata schema directory '%s'! Please make sure the directory is writeable."), *DestinationSchemaDir);
+			UE_LOG(LogSpatialGDKSchemaGenerator, Error, TEXT("Could not delete pre-existing %s metadata schema directory '%s'! Please make sure the directory is writeable."), *SetDesc.ComponentSetName, *DestinationSchemaDir);
 			// clang-format on
 			return false;
 		}
@@ -1443,7 +1454,7 @@ bool CreatePartitionAuthoritySet(FString SchemaInputPath, FString SchemaOutputPa
 		FString SchemaJsonPath;
 		if (!RunSchemaCompiler(SchemaJsonPath, SchemaInputPath))
 		{
-			UE_LOG(LogSpatialGDKSchemaGenerator, Error, TEXT("Failed to parse partition meta data schema files"));
+			UE_LOG(LogSpatialGDKSchemaGenerator, Error, TEXT("Failed to parse %s meta data schema files"), *SetDesc.ComponentSetName);
 			return false;
 		}
 
@@ -1459,7 +1470,7 @@ bool CreatePartitionAuthoritySet(FString SchemaInputPath, FString SchemaOutputPa
 		if (!Filesystem.CreateDirectoryTree(*DestinationSchemaDir))
 		{
 			// clang-format off
-			UE_LOG(LogSpatialGDKSchemaGenerator, Error, TEXT("Could not create partition metadata schema directory '%s'! Please make sure the parent directory is writeable."), *DestinationSchemaDir);
+			UE_LOG(LogSpatialGDKSchemaGenerator, Error, TEXT("Could not create %s metadata schema directory '%s'! Please make sure the parent directory is writeable."), *SetDesc.ComponentSetName, *DestinationSchemaDir);
 			// clang-format on
 			return false;
 		}
@@ -1479,25 +1490,29 @@ bool CreatePartitionAuthoritySet(FString SchemaInputPath, FString SchemaOutputPa
 	Writer.PrintNewLine();
 
 	// Write all import statements.
-	Writer.Printf("import \"{0}\";", TEXT("improbable/standard_library.schema"));
+	for (const auto& File : SetDesc.AdditionalSetInclude)
+	{
+		Writer.Printf("import \"{0}\";", *File);
+	}
 	for (const auto& File : SchemaFiles)
 	{
-		FString ImportPath = FPaths::Combine(TEXT("unreal"), TEXT("generated"), PartitionDataFolderName, FPaths::GetCleanFilename(File));
+		FString ImportPath = FPaths::Combine(TEXT("unreal"), TEXT("generated"), SetDesc.CustomSchemaFolder, FPaths::GetCleanFilename(File));
 		Writer.Printf("import \"{0}\";", *ImportPath);
 	}
 
 	Writer.PrintNewLine();
-	Writer.Printf("component_set {0} {", TEXT("PartitionMetadataAuth")).Indent();
-	Writer.Printf("id = {0};", SpatialConstants::PARTITION_METADATA_AUTH_COMPONENT_SET_ID);
+	Writer.Printf("component_set {0} {", SetDesc.ComponentSetName).Indent();
+	Writer.Printf("id = {0};", SetDesc.ComponentSetId);
 	Writer.Printf("components = [").Indent();
 
 	// Write all import components.
-	Writer.Printf("improbable.Position,");
-	Writer.Printf("improbable.Interest,");
-	Writer.Printf("improbable.AuthorityDelegation,");
-	for (const auto& MetadataComponentId : Components)
+	for (const auto& Component : SetDesc.InitialComponentSetContent)
 	{
-		Writer.Printf("{0},", MetadataComponentId.Name);
+		Writer.Printf("{0},", Component);
+	}
+	for (const auto& MetadataComponent : Components)
+	{
+		Writer.Printf("{0},", MetadataComponent.Name);
 	}
 
 	Writer.RemoveTrailingComma();
@@ -1505,9 +1520,46 @@ bool CreatePartitionAuthoritySet(FString SchemaInputPath, FString SchemaOutputPa
 	Writer.Outdent().Print("];");
 	Writer.Outdent().Print("}");
 
-	Writer.WriteToFile(FPaths::Combine(*SchemaOutputPath, TEXT("ComponentSets/PartitionAuthoritativeComponentSet.schema")));
+	Writer.WriteToFile(FPaths::Combine(*SchemaOutputPath, *FString::Printf(TEXT("ComponentSets/%s.schema"), *SetDesc.SchemaFileName)));
 
 	return true;
+}
+
+bool CreatePartitionAuthoritySet(FString SchemaInputPath, FString SchemaOutputPath)
+{
+	CustomComponentSetDesc Desc;
+	Desc.ComponentSetName = TEXT("PartitionMetadataAuth");
+	Desc.ComponentSetId = SpatialConstants::PARTITION_METADATA_AUTH_COMPONENT_SET_ID;
+	Desc.CustomSchemaFolder = TEXT("PartitionMetadata");
+	Desc.SchemaFileName = TEXT("PartitionAuthoritativeComponentSet");
+	Desc.InitialComponentSetContent.Add(TEXT("improbable.Position"));
+	Desc.InitialComponentSetContent.Add(TEXT("improbable.Interest"));
+	Desc.InitialComponentSetContent.Add(TEXT("improbable.AuthorityDelegation"));
+
+	Desc.AdditionalSetInclude.Add(TEXT("improbable/standard_library.schema"));
+
+	return CreateCustomAuthoritySet(SchemaInputPath, SchemaOutputPath, Desc);
+}
+
+bool CreateServerWorkerAuthoritySet(FString SchemaInputPath, FString SchemaOutputPath)
+{
+	CustomComponentSetDesc Desc;
+	Desc.ComponentSetName = TEXT("ServerWorkerAuthComponentSet");
+	Desc.ComponentSetId = SpatialConstants::SERVER_WORKER_ENTITY_AUTH_COMPONENT_SET_ID;
+	Desc.CustomSchemaFolder = TEXT("ServerWorkerMetadata");
+	Desc.SchemaFileName = TEXT("ServerWorkerAuthorityComponentSet");
+	Desc.InitialComponentSetContent.Add(TEXT("improbable.Position"));
+	Desc.InitialComponentSetContent.Add(TEXT("improbable.Interest"));
+	Desc.InitialComponentSetContent.Add(TEXT("improbable.AuthorityDelegation"));
+	Desc.InitialComponentSetContent.Add(TEXT("improbable.Metadata"));
+	Desc.InitialComponentSetContent.Add(TEXT("unreal.ServerWorker"));
+	Desc.InitialComponentSetContent.Add(TEXT("unreal.generated.UnrealCrossServerSenderRPCs"));
+
+	Desc.AdditionalSetInclude.Add(TEXT("unreal/generated/rpc_endpoints.schema"));
+	Desc.AdditionalSetInclude.Add(TEXT("unreal/gdk/server_worker.schema"));
+	Desc.AdditionalSetInclude.Add(TEXT("improbable/standard_library.schema"));
+
+	return CreateCustomAuthoritySet(SchemaInputPath, SchemaOutputPath, Desc);
 }
 
 bool ExtractInformationFromSchemaJson(const FString& SchemaJsonPath, TMap<uint32, FComponentIDs>& OutComponentSetMap,
@@ -1523,6 +1575,11 @@ bool SpatialGDKGenerateSchema()
 	SchemaGeneratedClasses.Empty();
 
 	if (!CreatePartitionAuthoritySet())
+	{
+		return false;
+	}
+
+	if (!CreateServerWorkerAuthoritySet())
 	{
 		return false;
 	}

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSchemaGenerator.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSchemaGenerator.h
@@ -81,6 +81,7 @@ SPATIALGDKEDITOR_API void WriteComponentSetBySchemaType(const USchemaDatabase* S
 														const FString& SchemaOutputPath);
 
 SPATIALGDKEDITOR_API bool CreatePartitionAuthoritySet(FString SchemaInputPath = FString(), FString SchemaOutputPath = FString());
+SPATIALGDKEDITOR_API bool CreateServerWorkerAuthoritySet(FString SchemaInputPath = FString(), FString SchemaOutputPath = FString());
 
 } // namespace Schema
 } // namespace SpatialGDKEditor

--- a/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/CookAndGenerateSchemaCommandlet.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorCommandlet/Private/Commandlets/CookAndGenerateSchemaCommandlet.cpp
@@ -121,6 +121,11 @@ int32 UCookAndGenerateSchemaCommandlet::Main(const FString& CmdLineParams)
 		return 0;
 	}
 
+	if (!CreateServerWorkerAuthoritySet())
+	{
+		return 0;
+	}
+
 	// Sort classes here so that batching does not have an effect on ordering.
 	ReferencedClasses.Sort([](const FSoftClassPath& A, const FSoftClassPath& B) {
 		return FNameLexicalLess()(A.GetAssetPathName(), B.GetAssetPathName());

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
@@ -1106,6 +1106,7 @@ SCHEMA_GENERATOR_TEST(GIVEN_actor_class_WHEN_generating_schema_THEN_expected_com
 	SpatialGDKEditor::Schema::CopyWellKnownSchemaFiles(GDKSchemaCopyDir, CoreSDKSchemaCopyDir);
 	SpatialGDKEditor::Schema::GenerateSchemaForRPCEndpoints(SchemaGenerationFolder);
 	SpatialGDKEditor::Schema::GenerateSchemaForNCDs(SchemaGenerationFolder);
+	SpatialGDKEditor::Schema::CreateServerWorkerAuthoritySet(FString(), SchemaGenerationFolder);
 
 	// Run the schema compiler
 	FString SchemaJsonPath;


### PR DESCRIPTION
#### Description
Add server a serverworker subsystem which allows per-worker information to be published to the centralized load balancer.

Also contains a couple of driveby, to clear the modified entities at the beginning of each advance/update steps, instead of doing it explicitely.