### PR TITLE
[UNR-5849] Make subobject test about actor component, instead of a spawned actor.

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPropertyReplication/ReplicatedTestActorSubobject.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPropertyReplication/ReplicatedTestActorSubobject.cpp
@@ -3,23 +3,33 @@
 #include "ReplicatedTestActorSubobject.h"
 #include "Net/UnrealNetwork.h"
 
+UReplicatedSubobject::UReplicatedSubobject()
+{
+	SetIsReplicatedByDefault(true);
+	TestReplicatedProperty = 0;
+}
+
+void UReplicatedSubobject::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+
+	DOREPLIFETIME(UReplicatedSubobject, TestReplicatedProperty);
+}
+
 AReplicatedTestActorSubobject::AReplicatedTestActorSubobject()
 {
-	ReplicatedSubActor = nullptr;
+	bReplicates = true;
+	ReplicatedSubobject = CreateDefaultSubobject<UReplicatedSubobject>("Subobject");
+}
+
+void AReplicatedTestActorSubobject::OnAuthorityGained()
+{
+	Super::OnAuthorityGained();
 }
 
 void AReplicatedTestActorSubobject::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
 {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 
-	DOREPLIFETIME(AReplicatedTestActorSubobject, ReplicatedSubActor);
-}
-
-void AReplicatedTestActorSubobject::OnAuthorityGained()
-{
-	Super::OnAuthorityGained();
-
-	// Spawn sub-actor
-	ReplicatedSubActor = GetWorld()->SpawnActor<AReplicatedTestActor>(FVector::ZeroVector, FRotator::ZeroRotator, FActorSpawnParameters());
-	ReplicatedSubActor->AttachToActor(this, FAttachmentTransformRules::KeepRelativeTransform);
+	DOREPLIFETIME(AReplicatedTestActorSubobject, ReplicatedSubobject);
 }

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPropertyReplication/ReplicatedTestActorSubobject.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPropertyReplication/ReplicatedTestActorSubobject.h
@@ -10,6 +10,19 @@
 class AReplicatedTestActor;
 
 UCLASS()
+class UReplicatedSubobject : public UActorComponent
+{
+	GENERATED_BODY()
+public:
+	UReplicatedSubobject();
+
+	void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
+
+	UPROPERTY(Replicated)
+	int TestReplicatedProperty;
+};
+
+UCLASS()
 class AReplicatedTestActorSubobject : public AReplicatedTestActorBase
 {
 	GENERATED_BODY()
@@ -17,11 +30,11 @@ class AReplicatedTestActorSubobject : public AReplicatedTestActorBase
 public:
 	AReplicatedTestActorSubobject();
 
-	void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
-
 	void OnAuthorityGained() override;
+
+	void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
 
 	// Subobjects
 	UPROPERTY(Replicated)
-	AReplicatedTestActor* ReplicatedSubActor;
+	UReplicatedSubobject* ReplicatedSubobject;
 };

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPropertyReplication/SpatialTestPropertyReplicationSubobject.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestPropertyReplication/SpatialTestPropertyReplicationSubobject.cpp
@@ -93,7 +93,7 @@ void ASpatialTestPropertyReplicationSubobject::PrepareTest()
 							 TEXT("The ReplicatedIntProperty on subobject should equal 999."));
 			FinishStep();
 		},
-		500.0f);
+		5.0f);
 
 	// This step generates an expected error for the replicated subobject
 	AddStep(


### PR DESCRIPTION
#### Description
The subobject test was actually testing another actor, which is redundant, and introduced races in the way it was setup.
Since we actually want to test subobjects, changed the test to be about actor components instead, since this is something we will be interested in eventually.
