### PR TITLE
[UNR-5632] Implement the test debug interface in the strategy worker

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -2305,15 +2305,6 @@ void USpatialNetDriver::TickDispatch(float DeltaTime)
 				PartitionSystemImpl->ProcessDeletionEvents();
 			}
 
-			if (ServerWorkerSystemImpl.IsValid())
-			{
-				for (auto& Update : ServerWorkerSystemImpl->PendingComponentUpdates)
-				{
-					Connection->GetCoordinator().SendComponentUpdate(WorkerEntityId, MoveTemp(Update));
-				}
-				ServerWorkerSystemImpl->PendingComponentUpdates.Empty();
-			}
-
 			if (RPCService.IsValid())
 			{
 				RPCService->AdvanceView();

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriver.cpp
@@ -2305,6 +2305,15 @@ void USpatialNetDriver::TickDispatch(float DeltaTime)
 				PartitionSystemImpl->ProcessDeletionEvents();
 			}
 
+			if (ServerWorkerSystemImpl.IsValid())
+			{
+				for (auto& Update : ServerWorkerSystemImpl->PendingComponentUpdates)
+				{
+					Connection->GetCoordinator().SendComponentUpdate(WorkerEntityId, MoveTemp(Update));
+				}
+				ServerWorkerSystemImpl->PendingComponentUpdates.Empty();
+			}
+
 			if (RPCService.IsValid())
 			{
 				RPCService->AdvanceView();

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverDebugContext.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverDebugContext.cpp
@@ -4,9 +4,11 @@
 
 #include "EngineClasses/SpatialNetDriver.h"
 #include "EngineClasses/SpatialPackageMapClient.h"
+#include "EngineClasses/SpatialServerWorkerSystem.h"
 #include "Interop/Connection/SpatialWorkerConnection.h"
 #include "Interop/SpatialSender.h"
 #include "LoadBalancing/DebugLBStrategy.h"
+#include "LoadBalancing/LegacyLoadbalancingComponents.h"
 #include "Utils/SpatialActorUtils.h"
 
 namespace
@@ -153,7 +155,7 @@ void USpatialNetDriverDebugContext::Reset()
 	SemanticDelegations.Empty();
 	CachedInterestSet.Empty();
 	ActorDebugInfo.Empty();
-
+	UpdateServerWorkerData();
 	NetDriver->Sender->UpdatePartitionEntityInterestAndPosition();
 }
 
@@ -307,6 +309,7 @@ void USpatialNetDriverDebugContext::AddInterestOnTag(FName Tag)
 				}
 			}
 		}
+		UpdateServerWorkerData();
 	}
 }
 
@@ -336,6 +339,7 @@ void USpatialNetDriverDebugContext::RemoveInterestOnTag(FName Tag)
 				}
 			}
 		}
+		UpdateServerWorkerData();
 	}
 }
 
@@ -349,14 +353,51 @@ void USpatialNetDriverDebugContext::KeepActorOnLocalWorker(AActor* Actor)
 	}
 }
 
+void USpatialNetDriverDebugContext::UpdateServerWorkerData()
+{
+	if (NetDriver->ServerWorkerSystemImpl)
+	{
+		UWorld* World = NetDriver->GetWorld();
+		if (World == nullptr)
+		{
+			return;
+		}
+
+		UGameInstance* GameInstance = World->GetGameInstance();
+		if (GameInstance == nullptr)
+		{
+			return;
+		}
+
+		USpatialServerWorkerSystem* ServerWorkerData = GameInstance->GetSubsystem<USpatialServerWorkerSystem>();
+		if (ensure(ServerWorkerData))
+		{
+			SpatialGDK::LegacyLB_CustomWorkerAssignments Assignments;
+			for (const auto& Delegation : SemanticDelegations)
+			{
+				Assignments.LabelToVirtualWorker.Add(Delegation.Key, Delegation.Value);
+			}
+			for (FName Label : SemanticInterest)
+			{
+				Assignments.AdditionalInterest.Add(Label);
+			}
+			TArray<SpatialGDK::ComponentUpdate> Updates;
+			Updates.Add(Assignments.CreateComponentUpdate());
+			ServerWorkerData->UpdateServerWorkerData(MoveTemp(Updates));
+		}
+	}
+}
+
 void USpatialNetDriverDebugContext::DelegateTagToWorker(FName Tag, uint32 WorkerId)
 {
 	SemanticDelegations.Add(Tag, WorkerId);
+	UpdateServerWorkerData();
 }
 
 void USpatialNetDriverDebugContext::RemoveTagDelegation(FName Tag)
 {
 	SemanticDelegations.Remove(Tag);
+	UpdateServerWorkerData();
 }
 
 TOptional<VirtualWorkerId> USpatialNetDriverDebugContext::GetActorHierarchyExplicitDelegation(const AActor* Actor)

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverDebugContext.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverDebugContext.cpp
@@ -378,10 +378,13 @@ void USpatialNetDriverDebugContext::UpdateServerWorkerData()
 		}
 
 		SpatialGDK::LegacyLB_CustomWorkerAssignments Assignments;
+		Assignments.LabelToVirtualWorker.Reserve(SemanticDelegations.Num());
 		for (const auto& Delegation : SemanticDelegations)
 		{
-			Assignments.LabelToVirtualWorker.Add(Delegation.Key, Delegation.Value);
+			Assignments.LabelToVirtualWorker.Emplace(Delegation.Key, Delegation.Value);
 		}
+
+		Assignments.AdditionalInterest.Reserve(SemanticInterest.Num());
 		for (const FName& Label : SemanticInterest)
 		{
 			Assignments.AdditionalInterest.Add(Label);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStrategySystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStrategySystem.cpp
@@ -25,7 +25,8 @@ FSpatialStrategySystem::FSpatialStrategySystem(TUniquePtr<FPartitionManager> InP
 	, ServerWorkerDataStorages(InServerWorkerView)
 	, Strategy(MoveTemp(InStrategy))
 {
-	Strategy->Init(UserDataStorages.DataStorages, ServerWorkerDataStorages.DataStorages);
+	FLoadBalancingSharedData SharedData(*PartitionsMgr, ActorSetSystem);
+	Strategy->Init(SharedData, UserDataStorages.DataStorages, ServerWorkerDataStorages.DataStorages);
 	DataStorages.DataStorages.Add(&AuthACKView);
 	DataStorages.DataStorages.Add(&NetOwningClientView);
 	DataStorages.DataStorages.Add(&SetMemberView);
@@ -109,7 +110,7 @@ void FSpatialStrategySystem::Flush(ISpatialOSWorker& Connection)
 	}
 
 	// Manage updates to partitions
-	Strategy->TickPartitions(*PartitionsMgr);
+	Strategy->TickPartitions();
 	PartitionsMgr->Flush(Connection);
 
 	// Iterator over the data storage to collect the entities which have been modified this frame.
@@ -124,6 +125,12 @@ void FSpatialStrategySystem::Flush(ISpatialOSWorker& Connection)
 		if (ActorSetSystem.GetSetLeader(*Iterator) != SpatialConstants::INVALID_ENTITY_ID)
 		{
 			Iterator.RemoveCurrent();
+			continue;
+		}
+		if (DataStorages.EntitiesRemoved.Contains(*Iterator))
+		{
+			Iterator.RemoveCurrent();
+			continue;
 		}
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/DebugLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/DebugLBStrategy.cpp
@@ -109,3 +109,20 @@ UAbstractLBStrategy* UDebugLBStrategy::GetLBStrategyForVisualRendering() const
 	check(WrappedStrategy);
 	return WrappedStrategy->GetLBStrategyForVisualRendering();
 }
+
+bool UDebugLBStrategy::IsStrategyWorkerAware() const
+{
+	return true;
+}
+
+void UDebugLBStrategy::GetLegacyLBInformation(FLegacyLBContext& Ctx) const
+{
+	check(WrappedStrategy);
+	return WrappedStrategy->GetLegacyLBInformation(Ctx);
+}
+
+TArray<SpatialGDK::ComponentData> UDebugLBStrategy::CreateStaticLoadBalancingData(const AActor& Actor) const
+{
+	check(WrappedStrategy);
+	return WrappedStrategy->CreateStaticLoadBalancingData(Actor);
+}

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
@@ -278,6 +278,10 @@ void UGridBasedLBStrategy::GetLegacyLBInformation(FLegacyLBContext& Ctx) const
 	{
 		Ctx.Layers.AddDefaulted();
 	}
+	if (WorkerCells.Num() > 0)
+	{
+		Ctx.Layers.Last().FirstWorkerId = VirtualWorkerIds[0];
+	}
 	for (int32 i = 0; i < WorkerCells.Num(); ++i)
 	{
 		FLegacyLBContext::Cell NewCell;

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/GridBasedLBStrategy.cpp
@@ -274,6 +274,11 @@ bool UGridBasedLBStrategy::IsStrategyWorkerAware() const
 
 void UGridBasedLBStrategy::GetLegacyLBInformation(FLegacyLBContext& Ctx) const
 {
+	if (!ensureAlwaysMsgf(VirtualWorkerIds.Num() == WorkerCells.Num(),
+						  TEXT("Found a mismatch between virtual worker count and worker cells count in load balancing strategy")))
+	{
+		return;
+	}
 	if (Ctx.Layers.Num() == 0)
 	{
 		Ctx.Layers.AddDefaulted();

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LBDataStorage.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LBDataStorage.cpp
@@ -30,11 +30,11 @@ void FLBDataCollection::Advance()
 				}
 			}
 
-			for (const auto& Added : Delta.ComponentsRemoved)
+			for (const auto& Removed : Delta.ComponentsRemoved)
 			{
 				for (auto& Storage : DataStorages)
 				{
-					if (Storage->GetComponentsToWatch().Contains(Added.ComponentId))
+					if (Storage->GetComponentsToWatch().Contains(Removed.ComponentId))
 					{
 						// The removal is not communicated though...
 						Storage->OnRemoved(Delta.EntityId);

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LBDataStorage.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LBDataStorage.cpp
@@ -36,7 +36,9 @@ void FLBDataCollection::Advance()
 				{
 					if (Storage->GetComponentsToWatch().Contains(Removed.ComponentId))
 					{
-						// The removal is not communicated though...
+						// As opposed to all the other operations, this particular one is not mirrored anywhere.
+						// It remains to be seen if this is going to be useful, or if dynamic components are not
+						// something we should use here.
 						Storage->OnRemoved(Delta.EntityId);
 					}
 				}

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LBDataStorage.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LBDataStorage.cpp
@@ -19,6 +19,28 @@ void FLBDataCollection::Advance()
 		{
 		case EntityDelta::UPDATE:
 		{
+			for (const auto& Added : Delta.ComponentsAdded)
+			{
+				for (auto& Storage : DataStorages)
+				{
+					if (Storage->GetComponentsToWatch().Contains(Added.ComponentId))
+					{
+						Storage->OnComponentAdded(Delta.EntityId, Added.ComponentId, Added.Data);
+					}
+				}
+			}
+
+			for (const auto& Added : Delta.ComponentsRemoved)
+			{
+				for (auto& Storage : DataStorages)
+				{
+					if (Storage->GetComponentsToWatch().Contains(Added.ComponentId))
+					{
+						// The removal is not communicated though...
+						Storage->OnRemoved(Delta.EntityId);
+					}
+				}
+			}
 			for (const auto& CompleteUpdate : Delta.ComponentsRefreshed)
 			{
 				for (auto& Storage : DataStorages)

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LegacyLoadBalancingStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LegacyLoadBalancingStrategy.cpp
@@ -5,6 +5,7 @@
 #include "EngineClasses/SpatialVirtualWorkerTranslator.h"
 #include "Interop/Connection/SpatialOSWorkerInterface.h"
 #include "LoadBalancing/AbstractLBStrategy.h"
+#include "LoadBalancing/ActorSetSystem.h"
 #include "LoadBalancing/LBDataStorage.h"
 #include "LoadBalancing/LegacyLoadBalancingCommon.h"
 #include "LoadBalancing/LegacyLoadbalancingComponents.h"
@@ -27,6 +28,10 @@ class FDebugComponentStorage : public TLBDataStorage<DebugComponent>
 {
 };
 
+class FCustomWorkerAssignmentStorage : public TLBDataStorage<LegacyLB_CustomWorkerAssignments>
+{
+};
+
 FLegacyLoadBalancing::FLegacyLoadBalancing(UAbstractLBStrategy& LegacyLBStrat, SpatialVirtualWorkerTranslator& InTranslator)
 	: Translator(InTranslator)
 {
@@ -43,6 +48,8 @@ FLegacyLoadBalancing::FLegacyLoadBalancing(UAbstractLBStrategy& LegacyLBStrat, S
 		PositionStorage = MakeUnique<FSpatialPositionStorage>();
 		GroupStorage = MakeUnique<FActorGroupStorage>();
 		DebugCompStorage = MakeUnique<FDebugComponentStorage>();
+
+		ServerWorkerCustomAssignment = MakeUnique<FCustomWorkerAssignmentStorage>();
 
 		LegacyLBStrat.GetLegacyLBInformation(LBContext);
 	}
@@ -109,8 +116,11 @@ void FLegacyLoadBalancing::Flush(ISpatialOSWorker& Connection)
 	}
 }
 
-void FLegacyLoadBalancing::Init(TArray<FLBDataStorage*>& OutLoadBalancingData, TArray<FLBDataStorage*>& OutServerWorkerData)
+void FLegacyLoadBalancing::Init(FLoadBalancingSharedData InSharedData, TArray<FLBDataStorage*>& OutLoadBalancingData,
+								TArray<FLBDataStorage*>& OutServerWorkerData)
 {
+	SharedData.Emplace(InSharedData);
+
 	if (PositionStorage)
 	{
 		OutLoadBalancingData.Add(PositionStorage.Get());
@@ -127,6 +137,11 @@ void FLegacyLoadBalancing::Init(TArray<FLBDataStorage*>& OutLoadBalancingData, T
 	{
 		OutLoadBalancingData.Add(DebugCompStorage.Get());
 	}
+
+	if (ServerWorkerCustomAssignment)
+	{
+		OutServerWorkerData.Add(ServerWorkerCustomAssignment.Get());
+	}
 }
 
 void FLegacyLoadBalancing::OnWorkersConnected(TArrayView<FLBWorkerHandle> InConnectedWorkers)
@@ -141,13 +156,76 @@ void FLegacyLoadBalancing::OnWorkersDisconnected(TArrayView<FLBWorkerHandle> Dis
 {
 	// Not handled
 }
-
-void FLegacyLoadBalancing::TickPartitions(FPartitionManager& PartitionMgr)
+void FLegacyLoadBalancing::TickPartitions()
 {
+	FPartitionManager& PartitionMgr = SharedData->PartitionManager;
+
 	if (bCreatedPartitions)
 	{
+		if (ServerWorkerCustomAssignment->GetModifiedEntities().Num() > 0 || DebugCompStorage->GetModifiedEntities().Num() > 0)
+		{
+			for (const auto& Layer : LBContext.Layers)
+			{
+				for (const auto& Cell : Layer.Cells)
+				{
+					uint32 WorkerIdx = Cell.WorkerId - 1;
+					FPartitionHandle WorkerPartition = Partitions[WorkerIdx];
+					FLBWorkerHandle WorkerHandle = VirtualWorkerIdToHandle[WorkerIdx];
+					Worker_EntityId ServerWorkerEntity = PartitionMgr.GetServerWorkerEntityIdForWorker(WorkerHandle);
+
+					const LegacyLB_CustomWorkerAssignments* DebugWorkerInfo =
+						ServerWorkerCustomAssignment->GetObjects().Find(ServerWorkerEntity);
+					TSet<Worker_EntityId> AdditionalEntities;
+					if (DebugWorkerInfo)
+					{
+						for (const auto& DebugEntry : DebugCompStorage->GetObjects())
+						{
+							for (FName Label : DebugEntry.Value.ActorTags)
+							{
+								if (DebugWorkerInfo->AdditionalInterest.Contains(Label))
+								{
+									AdditionalEntities.Add(DebugEntry.Key);
+									break;
+								}
+							}
+						}
+					}
+
+					FVector2D CellCenter = Cell.Region.GetCenter();
+					const FVector Center3D{ CellCenter.X, CellCenter.Y, 0.0f };
+
+					const FVector2D EdgeLengths2D = Cell.Region.GetSize();
+					check(EdgeLengths2D.X > 0.0f && EdgeLengths2D.Y > 0.0f);
+					const FVector EdgeLengths3D{ EdgeLengths2D.X + Cell.Border, EdgeLengths2D.Y + Cell.Border, FLT_MAX };
+
+					SpatialGDK::QueryConstraint Constraint;
+					Constraint.BoxConstraint = SpatialGDK::BoxConstraint{ SpatialGDK::Coordinates::FromFVector(Center3D),
+																		  SpatialGDK::EdgeLength::FromFVector(EdgeLengths3D) };
+
+					if (AdditionalEntities.Num() > 0)
+					{
+						SpatialGDK::QueryConstraint EntitiesConstraint;
+						for (Worker_EntityId Entity : AdditionalEntities)
+						{
+							SpatialGDK::QueryConstraint EntityQuery;
+							EntityQuery.EntityIdConstraint = Entity;
+							EntitiesConstraint.OrConstraint.Add(EntityQuery);
+						}
+						SpatialGDK::QueryConstraint CompleteConstraint;
+						CompleteConstraint.OrConstraint.Add(Constraint);
+						CompleteConstraint.OrConstraint.Add(EntitiesConstraint);
+						PartitionMgr.SetPartitionInterest(WorkerPartition, CompleteConstraint);
+					}
+					else
+					{
+						PartitionMgr.SetPartitionInterest(WorkerPartition, Constraint);
+					}
+				}
+			}
+		}
 		return;
 	}
+
 	if (ConnectedWorkers.Num() == ExpectedWorkers && bTranslatorIsReady)
 	{
 		TMap<Worker_EntityId_Key, FLBWorkerHandle> WorkersMap;
@@ -165,6 +243,7 @@ void FLegacyLoadBalancing::TickPartitions(FPartitionManager& PartitionMgr)
 		if (!bDirectAssignment)
 		{
 			Partitions.SetNum(ExpectedWorkers);
+
 			for (const auto& Layer : LBContext.Layers)
 			{
 				for (const auto& Cell : Layer.Cells)
@@ -238,6 +317,101 @@ void FLegacyLoadBalancing::TickPartitions(FPartitionManager& PartitionMgr)
 	}
 }
 
+TOptional<uint32> FLegacyLoadBalancing::EvaluateDebugComponent(Worker_EntityId EntityId)
+{
+	auto AssignmentData = ServerWorkerCustomAssignment->GetObjects().Find(WorkerForCustomAssignment);
+	if (!AssignmentData)
+	{
+		return {};
+	}
+
+	if (const DebugComponent* DbgComp = DebugCompStorage->GetObjects().Find(EntityId))
+	{
+		if (DbgComp->DelegatedWorkerId.IsSet())
+		{
+			if (!ensure(int32(DbgComp->DelegatedWorkerId.GetValue() - 1) < Partitions.Num()))
+			{
+				return {};
+			}
+			return DbgComp->DelegatedWorkerId.GetValue();
+		}
+
+		FPartitionHandle CandidatePartition;
+		uint32 CandidateWorker;
+		for (auto Tag : DbgComp->ActorTags)
+		{
+			if (const uint32* WorkerId = AssignmentData->LabelToVirtualWorker.Find(Tag))
+			{
+				if (!ensure(int32(*WorkerId - 1) < Partitions.Num()))
+				{
+					continue;
+				}
+				FPartitionHandle CurPartition = Partitions[*WorkerId - 1];
+				ensure(!CandidatePartition.IsValid() || CurPartition == CandidatePartition);
+				CandidatePartition = CurPartition;
+				CandidateWorker = *WorkerId;
+			}
+		}
+		if (CandidatePartition.IsValid())
+		{
+			return CandidateWorker;
+		}
+	}
+	return {};
+}
+
+TOptional<TPair<Worker_EntityId, uint32>> FLegacyLoadBalancing::EvaluateDebugComponentWithSet(Worker_EntityId EntityId)
+{
+	Worker_EntityId SetLeader = SharedData->ActorSets.GetSetLeader(EntityId);
+	if (SetLeader != SpatialConstants::INVALID_ENTITY_ID)
+	{
+		TOptional<uint32> CandidateWorker = EvaluateDebugComponent(SetLeader);
+		const TSet<Worker_EntityId_Key>* ActorSet = SharedData->ActorSets.GetSet(SetLeader);
+
+		if (ensure(ActorSet != nullptr))
+		{
+			for (auto SetMember : *ActorSet)
+			{
+				TOptional<uint32> Worker = EvaluateDebugComponent(SetMember);
+				if (Worker)
+				{
+					ensure(!CandidateWorker || Worker.GetValue() == CandidateWorker.GetValue());
+					CandidateWorker = Worker;
+				}
+			}
+		}
+
+		if (CandidateWorker)
+		{
+			return MakeTuple(SetLeader, CandidateWorker.GetValue());
+		}
+	}
+	else
+	{
+		TOptional<uint32> Worker = EvaluateDebugComponent(EntityId);
+		if (Worker)
+		{
+			return MakeTuple(EntityId, Worker.GetValue());
+		}
+	}
+	return {};
+}
+
+void FLegacyLoadBalancing::EvaluateDebugComponent(Worker_EntityId EntityId, FMigrationContext& Ctx)
+{
+	auto NewAssignment = EvaluateDebugComponentWithSet(EntityId);
+	if (NewAssignment)
+	{
+		ToRefresh.Remove(NewAssignment->Key);
+		int32& CurAssignment = Assignment.FindOrAdd(EntityId, -1);
+		if (CurAssignment != NewAssignment->Value - 1)
+		{
+			CurAssignment = NewAssignment->Value - 1;
+			Ctx.EntitiesToMigrate.Add(EntityId, Partitions[CurAssignment]);
+		}
+	}
+}
+
 void FLegacyLoadBalancing::CollectEntitiesToMigrate(FMigrationContext& Ctx)
 {
 	if (bCreatedPartitions)
@@ -246,6 +420,28 @@ void FLegacyLoadBalancing::CollectEntitiesToMigrate(FMigrationContext& Ctx)
 		{
 			TSet<Worker_EntityId_Key> NotChecked;
 			ToRefresh = ToRefresh.Union(Ctx.ModifiedEntities);
+			ToRefresh = ToRefresh.Difference(Ctx.DeletedEntities);
+
+			if (ServerWorkerCustomAssignment->GetModifiedEntities().Contains(WorkerForCustomAssignment))
+			{
+				for (const auto& Entry : DebugCompStorage->GetObjects())
+				{
+					EvaluateDebugComponent(Entry.Key, Ctx);
+				}
+			}
+			else if (DebugCompStorage->GetObjects().Num() > 0)
+			{
+				for (const auto& Entity : DebugCompStorage->GetModifiedEntities())
+				{
+					EvaluateDebugComponent(Entity, Ctx);
+				}
+				TSet<Worker_EntityId_Key> ToRefreshCopy = ToRefresh;
+				for (const auto& Entity : ToRefreshCopy)
+				{
+					EvaluateDebugComponent(Entity, Ctx);
+				}
+			}
+
 			for (Worker_EntityId EntityId : ToRefresh)
 			{
 				if (Ctx.MigratingEntities.Contains(EntityId))
@@ -262,9 +458,10 @@ void FLegacyLoadBalancing::CollectEntitiesToMigrate(FMigrationContext& Ctx)
 
 				int32& CurAssignment = Assignment.FindOrAdd(EntityId, -1);
 
-				if (CurAssignment >= 0 && CurAssignment < Layer.Cells.Num())
+				if (CurAssignment >= 0 && CurAssignment < Partitions.Num())
 				{
-					if (Layer.Cells[CurAssignment].Region.IsInside(Actor2DLocation))
+					int32 LayerIndex = CurAssignment + 1 - Layer.FirstWorkerId;
+					if (ensureAlways(LayerIndex < Layer.Cells.Num()) && Layer.Cells[LayerIndex].Region.IsInside(Actor2DLocation))
 					{
 						continue;
 					}

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LegacyLoadBalancingStrategy.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LegacyLoadBalancingStrategy.cpp
@@ -175,7 +175,7 @@ void FLegacyLoadBalancing::TickPartitions()
 
 					const LegacyLB_CustomWorkerAssignments* DebugWorkerInfo =
 						ServerWorkerCustomAssignment->GetObjects().Find(ServerWorkerEntity);
-					TSet<Worker_EntityId> AdditionalEntities;
+					TSet<Worker_EntityId_Key> AdditionalEntities;
 					if (DebugWorkerInfo)
 					{
 						for (const auto& DebugEntry : DebugCompStorage->GetObjects())

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LegacyServerWorkerSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/LegacyServerWorkerSystem.cpp
@@ -6,7 +6,7 @@ ULegacyServerWorkerSystem::ULegacyServerWorkerSystem() = default;
 TArray<SpatialGDK::ComponentData> ULegacyServerWorkerSystem::GetServerWorkerInitialData()
 {
 	TArray<SpatialGDK::ComponentData> Data;
-	// Will be used to add test debug data in the next PR.
-	// Data.Add(SpatialGDK::LegacyLB_CustomWorkerAssignments().CreateComponentData());
+	Data.Add(SpatialGDK::LegacyLB_CustomWorkerAssignments().CreateComponentData());
+
 	return Data;
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/PartitionManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/PartitionManager.cpp
@@ -327,6 +327,18 @@ struct FPartitionManager::Impl
 					}
 				}
 			}
+
+			if (PartitionState.bInterestDirty)
+			{
+				if (Connection.GetView().Find(PartitionState.Id))
+				{
+					Worker_ComponentUpdate WorkerUpdate =
+						InterestF->CreatePartitionInterest(PartitionState.LBConstraint, true).CreateInterestUpdate();
+					ComponentUpdate Update(OwningComponentUpdatePtr(WorkerUpdate.schema_type), WorkerUpdate.component_id);
+					Connection.SendComponentUpdate(PartitionState.Id, MoveTemp(Update));
+					PartitionState.bInterestDirty = false;
+				}
+			}
 		}
 	}
 
@@ -353,7 +365,7 @@ struct FPartitionManager::Impl
 		Components.Add(Persistence().CreateComponentData());
 		Components.Add(Metadata(PartitionName).CreateComponentData());
 
-		Components.Add(InterestF->CreatePartitionInterest(LBConstraint, false).CreateComponentData());
+		Components.Add(InterestF->CreatePartitionInterest(LBConstraint, true).CreateComponentData());
 
 		Components.Add(AuthorityDelegation(DelegationMap).CreateComponentData());
 		Components.Add(ComponentFactory::CreateEmptyComponentData(SpatialConstants::PARTITION_SHADOW_COMPONENT_ID));

--- a/SpatialGDK/Source/SpatialGDK/Private/Schema/StaticSymbols.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Schema/StaticSymbols.cpp
@@ -50,5 +50,6 @@ constexpr Worker_ComponentId UnrealMetadata::ComponentId;
 constexpr Worker_ComponentId LegacyLB_GridCell::ComponentId;
 constexpr Worker_ComponentId LegacyLB_Layer::ComponentId;
 constexpr Worker_ComponentId LegacyLB_VirtualWorkerAssignment::ComponentId;
+constexpr Worker_ComponentId LegacyLB_CustomWorkerAssignments::ComponentId;
 } // namespace SpatialGDK
 #endif

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriverDebugContext.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriverDebugContext.h
@@ -91,6 +91,7 @@ protected:
 	void OnComponentChange(Worker_EntityId EntityId, const SpatialGDK::ComponentChange& Change);
 	void ApplyComponentUpdate(Worker_EntityId EntityId, Schema_ComponentUpdate* Update);
 	void AuthorityLost(Worker_EntityId EntityId);
+	void UpdateServerWorkerData();
 
 	struct DebugComponentAuthData
 	{

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/AbstractLBStrategy.h
@@ -31,6 +31,7 @@ struct FLegacyLBContext
 	struct Layer
 	{
 		FName Name;
+		VirtualWorkerId FirstWorkerId;
 		TArray<Cell> Cells;
 	};
 

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/DebugLBStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/DebugLBStrategy.h
@@ -56,6 +56,10 @@ public:
 
 	UAbstractLBStrategy* GetWrappedStrategy() const { return WrappedStrategy; }
 
+	virtual bool IsStrategyWorkerAware() const override;
+	virtual void GetLegacyLBInformation(FLegacyLBContext& Ctx) const override;
+	virtual TArray<SpatialGDK::ComponentData> CreateStaticLoadBalancingData(const AActor& Actor) const override;
+
 private:
 	UPROPERTY()
 	UAbstractLBStrategy* WrappedStrategy = nullptr;

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LegacyLoadbalancingComponents.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LegacyLoadbalancingComponents.h
@@ -8,6 +8,13 @@ namespace SpatialGDK
 {
 struct LegacyLB_GridCell
 {
+	// Schema in <TestGym>/Game/Content/Spatial/PartitionMetadata/LegacyMetadata.schema
+	// component GridCell{
+	// 	 id = 1901;
+	// 	 improbable.Coordinates center = 1;
+	// 	 improbable.EdgeLength edge_length = 2;
+	// }
+
 	static constexpr Worker_ComponentId ComponentId = 1901;
 
 	LegacyLB_GridCell() {}
@@ -69,6 +76,12 @@ struct LegacyLB_GridCell
 
 struct LegacyLB_Layer
 {
+	// Schema in <TestGym>/Game/Content/Spatial/PartitionMetadata/LegacyMetadata.schema
+	// component Layer{
+	//  id = 1902;
+	//  uint32 layer = 1;
+	// }
+
 	static constexpr Worker_ComponentId ComponentId = 1902;
 
 	LegacyLB_Layer() {}
@@ -127,6 +140,12 @@ struct LegacyLB_Layer
 
 struct LegacyLB_VirtualWorkerAssignment
 {
+	// Schema in <TestGym>/Game/Content/Spatial/PartitionMetadata/LegacyMetadata.schema
+	// component VirtualWorkerAssignment{
+	//  id = 1903;
+	//  uint32 virtual_worker_id = 1;
+	// }
+
 	static constexpr Worker_ComponentId ComponentId = 1903;
 
 	LegacyLB_VirtualWorkerAssignment() {}
@@ -185,6 +204,14 @@ struct LegacyLB_VirtualWorkerAssignment
 
 struct LegacyLB_CustomWorkerAssignments
 {
+	// Schema in <TestGym>/Game/Content/Spatial/ServerWorkerMetadata/TestAuthorityAssignment.schema
+	// component CustomWorkerAssignments {
+	//   id = 1904;
+	//   list<uint32> virtual_worker_id = 1;
+	//   list<string> actor_label = 2;
+	//   list<string> interest_label = 3;
+    // }
+
 	static constexpr Worker_ComponentId ComponentId = 1904;
 
 	LegacyLB_CustomWorkerAssignments() = default;

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LegacyLoadbalancingComponents.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LegacyLoadbalancingComponents.h
@@ -8,7 +8,7 @@ namespace SpatialGDK
 {
 struct LegacyLB_GridCell
 {
-	static constexpr Worker_ComponentId ComponentId = 190502;
+	static constexpr Worker_ComponentId ComponentId = 1901;
 
 	LegacyLB_GridCell() {}
 
@@ -69,7 +69,7 @@ struct LegacyLB_GridCell
 
 struct LegacyLB_Layer
 {
-	static constexpr Worker_ComponentId ComponentId = 190501;
+	static constexpr Worker_ComponentId ComponentId = 1902;
 
 	LegacyLB_Layer() {}
 
@@ -127,7 +127,7 @@ struct LegacyLB_Layer
 
 struct LegacyLB_VirtualWorkerAssignment
 {
-	static constexpr Worker_ComponentId ComponentId = 190500;
+	static constexpr Worker_ComponentId ComponentId = 1903;
 
 	LegacyLB_VirtualWorkerAssignment() {}
 
@@ -185,7 +185,7 @@ struct LegacyLB_VirtualWorkerAssignment
 
 struct LegacyLB_CustomWorkerAssignments
 {
-	static constexpr Worker_ComponentId ComponentId = 180500;
+	static constexpr Worker_ComponentId ComponentId = 1904;
 
 	LegacyLB_CustomWorkerAssignments() = default;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LegacyLoadbalancingComponents.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LegacyLoadbalancingComponents.h
@@ -187,14 +187,14 @@ struct LegacyLB_CustomWorkerAssignments
 {
 	static constexpr Worker_ComponentId ComponentId = 180500;
 
-	LegacyLB_CustomWorkerAssignments() {}
+	LegacyLB_CustomWorkerAssignments() = default;
 
-	LegacyLB_CustomWorkerAssignments(const ComponentData& Data)
+	explicit LegacyLB_CustomWorkerAssignments(const ComponentData& Data)
 		: LegacyLB_CustomWorkerAssignments(Data.GetUnderlying())
 	{
 	}
 
-	LegacyLB_CustomWorkerAssignments(Schema_ComponentData* Data)
+	explicit LegacyLB_CustomWorkerAssignments(Schema_ComponentData* Data)
 	{
 		Schema_Object* ComponentObject = Schema_GetComponentDataFields(Data);
 		ReadFromObject(ComponentObject);

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LoadBalancingStrategy.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LoadBalancingStrategy.h
@@ -17,14 +17,17 @@ class SPATIALGDK_API FLoadBalancingStrategy
 public:
 	virtual ~FLoadBalancingStrategy() = default;
 
-	virtual void Init(TArray<FLBDataStorage*>& OutLoadBalancingData, TArray<FLBDataStorage*>& OutServerWorkerData) {}
+	virtual void Init(FLoadBalancingSharedData InSharedData, TArray<FLBDataStorage*>& OutLoadBalancingData,
+					  TArray<FLBDataStorage*>& OutServerWorkerData)
+	{
+	}
 
 	virtual void Advance(ISpatialOSWorker& Connection) {}
 	virtual void Flush(ISpatialOSWorker& Connection) {}
 
 	virtual void OnWorkersConnected(TArrayView<FLBWorkerHandle> ConnectedWorkers) {}
 	virtual void OnWorkersDisconnected(TArrayView<FLBWorkerHandle> DisconnectedWorkers) {}
-	virtual void TickPartitions(FPartitionManager& Partitions) {}
+	virtual void TickPartitions() {}
 	virtual void CollectEntitiesToMigrate(FMigrationContext& Ctx) {}
 };
 

--- a/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LoadBalancingTypes.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/LoadBalancing/LoadBalancingTypes.h
@@ -25,6 +25,28 @@ struct FPartitionDesc : TSharedFromThis<FPartitionDesc>
 };
 using FPartitionHandle = TSharedPtr<FPartitionDesc>;
 
+class FActorSetSystem;
+class FPartitionManager;
+
+// Some abstractions from SpatialOS and Unreal that are expected to be available to all load balancing systems.
+struct FLoadBalancingSharedData
+{
+	FLoadBalancingSharedData(FPartitionManager& InPartitionManager, FActorSetSystem& InActorSets)
+		: PartitionManager(InPartitionManager)
+		, ActorSets(InActorSets)
+	{
+	}
+
+	FLoadBalancingSharedData(const FLoadBalancingSharedData& Other)
+		: PartitionManager(Other.PartitionManager)
+		, ActorSets(Other.ActorSets)
+	{
+	}
+
+	FPartitionManager& PartitionManager;
+	FActorSetSystem& ActorSets;
+};
+
 struct FMigrationContext
 {
 	FMigrationContext(const TSet<Worker_EntityId_Key>& InMigratingEntities, const TSet<Worker_EntityId_Key>& InModifiedEntities,
@@ -34,7 +56,6 @@ struct FMigrationContext
 		, DeletedEntities(InDeletedEntities)
 	{
 	}
-
 	const TSet<Worker_EntityId_Key>& MigratingEntities;
 	const TSet<Worker_EntityId_Key>& ModifiedEntities;
 	const TSet<Worker_EntityId_Key>& DeletedEntities;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SchemaOption.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SchemaOption.h
@@ -35,6 +35,10 @@ public:
 			{
 				Value = MakeUnique<T>(*InValue);
 			}
+			else
+			{
+				Value.Reset();
+			}
 		}
 
 		return *this;


### PR DESCRIPTION
#### Description
Implements the test debug strategy in the centralized load balancer.
This requires data to be published in the various server workers, and interpreted on the centralized load balancer, to manipulate interest and authority accordingly.

#### Tests
TestDebugInterface and SpatialTestPlayerControllerHandover use this feature.