### PR TITLE
[UNR-5780] Handle races on interest for routing worker

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/CrossServerRPCService.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/CrossServerRPCService.cpp
@@ -420,7 +420,7 @@ void CrossServerRPCService::UpdateSentRPCsACKs(Worker_EntityId SenderId, const C
 					const RPCPayload& SenderPayload = SlotData.GetValue();
 					const PendingRPCPayload PendingPayload(SenderPayload, {});
 
-					PushCrossServerRPC(TargetEntityId, Sender, PendingPayload, true); // mk = is true correct?
+					PushCrossServerRPC(TargetEntityId, Sender, PendingPayload, true);
 				}
 
 				SenderState.Alloc.FreeSlot(SentRPC->SourceSlot);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/CrossServerRPCService.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/CrossServerRPCService.cpp
@@ -400,7 +400,7 @@ void CrossServerRPCService::UpdateSentRPCsACKs(Worker_EntityId SenderId, const C
 			CrossServer::SentRPCEntry* SentRPC = SenderState.Mailbox.Find(RPCKey);
 			if (SentRPC != nullptr)
 			{
-				// If the ACK result is 'TargetUnknown' then resend the RPC immediately only 
+				// If the ACK result is 'TargetUnknown' then resend the RPC immediately only
 				// as a temporary measure to bypass race conditions. But only if the receiver
 				// is known the exist. There is deliberately no time-out handling at present.
 				if (ACK.Result == static_cast<uint64>(CrossServer::Result::TargetUnknown))
@@ -435,7 +435,8 @@ void CrossServerRPCService::UpdateSentRPCsACKs(Worker_EntityId SenderId, const C
 						else
 						{
 							UE_LOG(LogCrossServerRPCService, Error,
-								   TEXT("Attempting to resend RPC but the receiver has been deleted, the RPC will therefore be dropped. Receiver: %llu, Sender: %llu"),
+								   TEXT("Attempting to resend RPC but the receiver has been deleted, the RPC will therefore be dropped. "
+										"Receiver: %llu, Sender: %llu"),
 								   TargetEntityId, SenderId);
 						}
 					}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/SpatialRPCService.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/RPCs/SpatialRPCService.cpp
@@ -40,11 +40,11 @@ SpatialRPCService::SpatialRPCService(const FSubView& InActorAuthSubView, const F
 	if (NetDriver != nullptr && NetDriver->IsServer()
 		&& Settings->CrossServerRPCImplementation == ECrossServerRPCImplementation::RoutingWorker)
 	{
-		CrossServerRPCs.Emplace(CrossServerRPCService(
-			ActorCanExtractRPCDelegate::CreateRaw(this, &SpatialRPCService::ActorCanExtractRPC),
-			ExtractRPCDelegate::CreateRaw(this, &SpatialRPCService::ProcessOrQueueIncomingRPC),
-			DoesEntityIdHaveValidObjectDelegate::CreateRaw(this, &SpatialRPCService::DoesEntityIdHaveValidObject),
-			InActorAuthSubView, InWorkerEntitySubView, RPCStore));
+		CrossServerRPCs.Emplace(
+			CrossServerRPCService(ActorCanExtractRPCDelegate::CreateRaw(this, &SpatialRPCService::ActorCanExtractRPC),
+								  ExtractRPCDelegate::CreateRaw(this, &SpatialRPCService::ProcessOrQueueIncomingRPC),
+								  DoesEntityIdHaveValidObjectDelegate::CreateRaw(this, &SpatialRPCService::DoesEntityIdHaveValidObject),
+								  InActorAuthSubView, InWorkerEntitySubView, RPCStore));
 	}
 	IncomingRPCs.BindProcessingFunction(FProcessRPCDelegate::CreateRaw(this, &SpatialRPCService::ApplyRPC));
 	OutgoingRPCs.BindProcessingFunction(FProcessRPCDelegate::CreateRaw(this, &SpatialRPCService::SendRPC));

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialRoutingSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialRoutingSystem.cpp
@@ -135,7 +135,7 @@ void SpatialRoutingSystem::OnSenderChanged(Worker_EntityId SenderId, RoutingComp
 		if (Slots.ACKSlot < 0)
 		{
 			// This is a race we could solve with either blank entities, or timeout
-			UE_LOG(LogSpatialRoutingSystem, Error, TEXT("Receiver missing from view. RPC will be dropped. Receiver: %llu, Sender: %llu"),
+			UE_LOG(LogSpatialRoutingSystem, Verbose, TEXT("Receiver missing from view. RPC will be resent until Receiver appears. Receiver: %llu, Sender: %llu"),
 				   RPC.Value, SenderId);
 			Slots.CounterpartEntity = RPC.Value;
 			WriteACKToSender(RPC.Key, Components, CrossServer::Result::TargetUnknown);

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialRoutingSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialRoutingSystem.cpp
@@ -134,9 +134,9 @@ void SpatialRoutingSystem::OnSenderChanged(Worker_EntityId SenderId, RoutingComp
 		auto& Slots = Components.SenderACKState.RPCSlots.FindOrAdd(RPC.Key);
 		if (Slots.ACKSlot < 0)
 		{
-			// This is a race we could solve with either blank entities, or timeout
-			UE_LOG(LogSpatialRoutingSystem, Verbose, TEXT("Receiver missing from view. RPC will be resent until Receiver appears. Receiver: %llu, Sender: %llu"),
-				   RPC.Value, SenderId);
+			UE_LOG(LogSpatialRoutingSystem, Verbose,
+				   TEXT("Receiver missing from view. RPC will be resent until Receiver appears. Receiver: %llu, Sender: %llu"), RPC.Value,
+				   SenderId);
 			Slots.CounterpartEntity = RPC.Value;
 			WriteACKToSender(RPC.Key, Components, CrossServer::Result::TargetUnknown);
 		}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialRoutingSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialRoutingSystem.cpp
@@ -135,7 +135,7 @@ void SpatialRoutingSystem::OnSenderChanged(Worker_EntityId SenderId, RoutingComp
 		if (Slots.ACKSlot < 0)
 		{
 			UE_LOG(LogSpatialRoutingSystem, Verbose,
-				   TEXT("Receiver missing from view. RPC will be resent until Receiver appears. Receiver: %llu, Sender: %llu"), RPC.Value,
+				   TEXT("Receiver missing from view. RPC will be resent if receiver not deleted. Receiver: %llu, Sender: %llu"), RPC.Value,
 				   SenderId);
 			Slots.CounterpartEntity = RPC.Value;
 			WriteACKToSender(RPC.Key, Components, CrossServer::Result::TargetUnknown);

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/TestRoutingWorker.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/TestRoutingWorker.cpp
@@ -560,8 +560,13 @@ ROUTING_SERVICE_TEST(TestRoutingWorker_WhiteBox_SendOneMessage)
 		RPCServiceBackptr->WriteCrossServerACKFor(Target.Entity, Sender);
 	};
 
+	auto DoesEntityIdHaveValidObjectCallback = [this](Worker_EntityId EntityId) {
+		return true;
+	};
+
 	SpatialGDK::FRPCStore RPCStore;
 	SpatialGDK::CrossServerRPCService RPCService(TestFixture.CanExtractDelegate, ExtractRPCDelegate::CreateLambda(ExtractRPCCallback),
+												 DoesEntityIdHaveValidObjectDelegate::CreateLambda(DoesEntityIdHaveValidObjectCallback),
 												 TestFixture.ServerWorker.SubView, TestFixture.ServerWorker.DummyRoutingWorkerSubView,
 												 RPCStore);
 
@@ -660,8 +665,13 @@ ROUTING_SERVICE_TEST(TestRoutingWorker_BlackBox_SendSeveralMessagesToSeveralEnti
 		RPCServiceBackptr->WriteCrossServerACKFor(Target.Entity, Sender);
 	};
 
+	auto DoesEntityIdHaveValidObjectCallback = [this](Worker_EntityId EntityId) {
+		return true;
+	};
+
 	SpatialGDK::FRPCStore RPCStore;
 	SpatialGDK::CrossServerRPCService RPCService(TestFixture.CanExtractDelegate, ExtractRPCDelegate::CreateLambda(ExtractRPCCallback),
+												 DoesEntityIdHaveValidObjectDelegate::CreateLambda(DoesEntityIdHaveValidObjectCallback),
 												 TestFixture.ServerWorker.SubView, TestFixture.ServerWorker.DummyRoutingWorkerSubView,
 												 RPCStore);
 	RPCServiceBackptr = &RPCService;
@@ -737,8 +747,13 @@ ROUTING_SERVICE_TEST(TestRoutingWorker_BlackBox_SendOneMessageBetweenDeletedEnti
 		RPCServiceBackptr->WriteCrossServerACKFor(Target.Entity, Sender);
 	};
 
+	auto DoesEntityIdHaveValidObjectCallback = [this](Worker_EntityId EntityId) {
+		return false;
+	};
+
 	SpatialGDK::FRPCStore RPCStore;
 	SpatialGDK::CrossServerRPCService RPCService(TestFixture.CanExtractDelegate, ExtractRPCDelegate::CreateLambda(ExtractRPCCallback),
+												 DoesEntityIdHaveValidObjectDelegate::CreateLambda(DoesEntityIdHaveValidObjectCallback),
 												 TestFixture.ServerWorker.SubView, TestFixture.ServerWorker.DummyRoutingWorkerSubView,
 												 RPCStore);
 
@@ -757,7 +772,7 @@ ROUTING_SERVICE_TEST(TestRoutingWorker_BlackBox_SendOneMessageBetweenDeletedEnti
 
 			if (ToRemove == 100)
 			{
-				AddExpectedError(TEXT("Receiver missing from view. RPC will be dropped"));
+				AddExpectedError(TEXT("Attempting to resend RPC but the receiver has been deleted, the RPC will therefore be dropped"));
 			}
 
 			PendingRPCPayload DummyPayload(RPCPayload(0, 0, {}, TArray<uint8>()), {});
@@ -829,8 +844,13 @@ ROUTING_SERVICE_TEST(TestRoutingWorker_BlackBox_SendMoreMessagesThanRingBufferCa
 		RPCServiceBackptr->WriteCrossServerACKFor(Target.Entity, Sender);
 	};
 
+	auto DoesEntityIdHaveValidObjectCallback = [this](Worker_EntityId EntityId) {
+		return true;
+	};
+
 	SpatialGDK::FRPCStore RPCStore;
 	SpatialGDK::CrossServerRPCService RPCService(TestFixture.CanExtractDelegate, ExtractRPCDelegate::CreateLambda(ExtractRPCCallback),
+												 DoesEntityIdHaveValidObjectDelegate::CreateLambda(DoesEntityIdHaveValidObjectCallback),
 												 TestFixture.ServerWorker.SubView, TestFixture.ServerWorker.DummyRoutingWorkerSubView,
 												 RPCStore);
 
@@ -916,8 +936,14 @@ ROUTING_SERVICE_TEST(TestRoutingWorker_WhiteBox_SendMessagePriorToReceiverCreati
 		RPCServiceBackptr->WriteCrossServerACKFor(Target.Entity, Sender);
 	};
 
+	auto DoesEntityIdHaveValidObjectCallback = [this](Worker_EntityId EntityId) {
+		// Pretend the receiver exists for the purposes of resending RPCs
+		return true;
+	};
+
 	SpatialGDK::FRPCStore RPCStore;
 	SpatialGDK::CrossServerRPCService RPCService(TestFixture.CanExtractDelegate, ExtractRPCDelegate::CreateLambda(ExtractRPCCallback),
+												 DoesEntityIdHaveValidObjectDelegate::CreateLambda(DoesEntityIdHaveValidObjectCallback),
 												 TestFixture.ServerWorker.SubView, TestFixture.ServerWorker.DummyRoutingWorkerSubView,
 												 RPCStore);
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Tests/TestRoutingWorker.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Tests/TestRoutingWorker.cpp
@@ -930,7 +930,7 @@ ROUTING_SERVICE_TEST(TestRoutingWorker_WhiteBox_SendMessagePriorToReceiverCreati
 
 	// Expect 'Receiver' to not exist in view (yet)
 	{
-		const SpatialGDK::EntityViewElement* ViewElement =  TestFixture.ServerWorker.Coordinator.GetView().Find(ReceiverEntityId);
+		const SpatialGDK::EntityViewElement* ViewElement = TestFixture.ServerWorker.Coordinator.GetView().Find(ReceiverEntityId);
 		TestNull(TEXT("BeforeReceiverExists: Receiver does not exist in view"), ViewElement);
 	}
 
@@ -950,7 +950,8 @@ ROUTING_SERVICE_TEST(TestRoutingWorker_WhiteBox_SendMessagePriorToReceiverCreati
 			TestTrue(TEXT("BeforeReceiverExists: SenderACKs written"), SenderComps.SenderACK->ACKArray[0].IsSet());
 			if (SenderComps.SenderACK->ACKArray[0].IsSet())
 			{
-				TestTrue(TEXT("BeforeReceiverExists: SenderACKs written as TargetUnknown"), SenderComps.SenderACK->ACKArray[0]->Result == static_cast<uint64>(SpatialGDK::CrossServer::Result::TargetUnknown));
+				TestTrue(TEXT("BeforeReceiverExists: SenderACKs written as TargetUnknown"),
+						 SenderComps.SenderACK->ACKArray[0]->Result == static_cast<uint64>(SpatialGDK::CrossServer::Result::TargetUnknown));
 			}
 		}
 	}

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/CrossServerRPCService.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/CrossServerRPCService.h
@@ -38,7 +38,8 @@ class SPATIALGDK_API CrossServerRPCService
 {
 public:
 	CrossServerRPCService(const ActorCanExtractRPCDelegate InCanExtractRPCDelegate, const ExtractRPCDelegate InExtractRPCCallback,
-						  const FSubView& InActorSubView, const FSubView& InWorkerEntitySubView, FRPCStore& InRPCStore);
+						  const DoesEntityIdHaveValidObjectDelegate InDoesEntityIdHaveValidObjectDelegate, const FSubView& InActorSubView,
+						  const FSubView& InWorkerEntitySubView, FRPCStore& InRPCStore);
 
 	void AdvanceView();
 	void ProcessChanges();
@@ -77,6 +78,7 @@ private:
 
 	ActorCanExtractRPCDelegate CanExtractRPCDelegate;
 	ExtractRPCDelegate ExtractRPCCallback;
+	DoesEntityIdHaveValidObjectDelegate DoesEntityIdHaveValidObjectCallback;
 	const FSubView& ActorSubView;
 	const FSubView& WorkerEntitySubView;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCStore.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/RPCStore.h
@@ -10,6 +10,7 @@
 DECLARE_DELEGATE_RetVal_OneParam(bool, ActorCanExtractRPCDelegate, Worker_EntityId);
 DECLARE_DELEGATE_FourParams(ExtractRPCDelegate, const FUnrealObjectRef&, const SpatialGDK::RPCSender&, SpatialGDK::RPCPayload,
 							TOptional<uint64>);
+DECLARE_DELEGATE_RetVal_OneParam(bool, DoesEntityIdHaveValidObjectDelegate, Worker_EntityId);
 
 namespace SpatialGDK
 {

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/SpatialRPCService.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/RPCs/SpatialRPCService.h
@@ -81,6 +81,7 @@ private:
 	FSpatialNetBitWriter PackRPCDataToSpatialNetBitWriter(UFunction* Function, void* Parameters) const;
 
 	bool ActorCanExtractRPC(Worker_EntityId) const;
+	bool DoesEntityIdHaveValidObject(const Worker_EntityId EntityId) const;
 
 	USpatialNetDriver* NetDriver;
 	USpatialLatencyTracer* SpatialLatencyTracer;


### PR DESCRIPTION
#### Description
When encountering race conditions around entity interest when sending/receiving RPCs, RPCs that fail to send due to 'TargetUnknown' are immediately resent. 

Alternative solutions like 'blank entities' might be considered in the future.

#### Tests
Automated test.
