### PR TITLE
UNR-5896 - Test Timeouts

### DIFF
--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -1295,23 +1295,28 @@ void ResetUsedNames()
 	}
 }
 
-bool RunSchemaCompiler(FString& SchemaBundleJsonOutput, FString SchemaInputDir, FString BuildDir)
+bool RunSchemaCompiler(FString& SchemaBundleJsonOutput, FString SchemaInputDir, FString BuildDir, FString CompiledSchemaDir)
 {
 	FString PluginDir = FSpatialGDKServicesModule::GetSpatialGDKPluginDirectory();
 
 	// Get the schema_compiler path and arguments
 	FString SchemaCompilerExe = FPaths::Combine(PluginDir, TEXT("SpatialGDK/Binaries/ThirdParty/Improbable/Programs/schema_compiler.exe"));
 
-	if (SchemaInputDir == "")
+	if (SchemaInputDir.IsEmpty())
 	{
 		SchemaInputDir = FPaths::Combine(SpatialGDKServicesConstants::SpatialOSDirectory, TEXT("schema"));
 	}
 
-	if (BuildDir == "")
+	if (BuildDir.IsEmpty())
 	{
 		BuildDir = FPaths::Combine(SpatialGDKServicesConstants::SpatialOSDirectory, TEXT("build"));
 	}
-	FString CompiledSchemaDir = FPaths::Combine(BuildDir, TEXT("assembly/schema"));
+
+	if (CompiledSchemaDir.IsEmpty())
+	{
+		CompiledSchemaDir = FPaths::Combine(BuildDir, TEXT("assembly/schema"));
+	}
+
 	FString CoreSDKSchemaDir = FPaths::Combine(BuildDir, TEXT("dependencies/schema/standard_library"));
 
 	FString CompiledSchemaASTDir = FPaths::Combine(CompiledSchemaDir, TEXT("ast"));
@@ -1456,8 +1461,13 @@ bool CreateCustomAuthoritySet(FString SchemaInputPath, FString SchemaOutputPath,
 			return true;
 		});
 
+		// Put the generated schema binary for our custom schema in the Intermediate folder.
+		// This is so it doesn't stomp the users (or tests) proper schema binary used by the runtime.
+		FString SchemaCompilerIntermediateDir = FPaths::Combine(FPaths::ProjectIntermediateDir(), TEXT("Improbable"), TEXT("schema"));
+		Filesystem.CreateDirectoryTree(*SchemaCompilerIntermediateDir);
+
 		FString SchemaJsonPath;
-		if (!RunSchemaCompiler(SchemaJsonPath, SchemaInputPath))
+		if (!RunSchemaCompiler(SchemaJsonPath, SchemaInputPath, "" /*BuildDir*/, SchemaCompilerIntermediateDir))
 		{
 			UE_LOG(LogSpatialGDKSchemaGenerator, Error, TEXT("Failed to parse %s meta data schema files"), *SetDesc.ComponentSetName);
 			return false;

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSchemaGenerator.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSchemaGenerator.h
@@ -63,7 +63,7 @@ SPATIALGDKEDITOR_API bool RefreshSchemaFiles(const FString& SchemaOutputPath, co
 
 SPATIALGDKEDITOR_API void CopyWellKnownSchemaFiles(const FString& GDKSchemaCopyDir, const FString& CoreSDKSchemaCopyDir);
 
-SPATIALGDKEDITOR_API bool RunSchemaCompiler(FString& SchemaJsonPath, FString SchemaInputDir = "", FString BuildDir = "");
+SPATIALGDKEDITOR_API bool RunSchemaCompiler(FString& SchemaJsonPath, FString SchemaInputDir = "", FString BuildDir = "", FString CompiledSchemaDir = "");
 
 SPATIALGDKEDITOR_API bool ExtractInformationFromSchemaJson(const FString& SchemaJsonPath, TMap<uint32, FComponentIDs>& OutComponentSetMap,
 														   TMap<uint32, uint32>& OutComponentIdToFieldIdsIndex,


### PR DESCRIPTION
#### Description
Our tests were timing out on when running nightlies.
This was because the nightly tests run as follows:
- Fast Tests
- Slow Tests (inc schema gen tests)
- RepGraph Tests <--- Tests fail and timeout

The Slow Tests with schema gen tests were wrecking the compiled schema binary (schema.sb) which was used in following runs. This is due to https://github.com/spatialos/UnrealGDK/commit/d767ba0e2a5170f52eb071ef62756bc029a91148 
What's happening is the new additional run of `SchemaCompiler` as part of the final test in `CreateServerWorkerAuthoritySet` https://github.com/spatialos/UnrealGDK/commit/2c6620cde8db612fa4e5dc2ec7063283e1b241b4 
causes the schema binary used by the runtime to get nuked. This causes the next test which uses the runtime to enter a bad state and thus timeout. 

This only started manifesting when https://github.com/spatialos/UnrealGDKTestGyms/commit/75ce1d432fe66398acdc2387d606c364bf747dc7 was merged as the code will not run the schema compiler unless some custom schema is present in `Game/Content/Spatial`, hence why this started happening at a strange time and was hard to debug.

The fix is to simply allow the schema compiler to output to a custom directory, for the usage of `CreateServerWorkerAuthoritySet`. 


#### Tests
Nightlies work again

#### Primary reviewers
@ImprobableNic @samiwh @mironec 