### PR TITLE
UNR-5837-Consolidate-Ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The GDK has been upgraded to use version 15.3.1 of SpatialOS.
 - Add the ability for tests to run without being placed within a standalone map. See `ANoneCrossServerPossessionTest` for an example of this.
 - Unreal Engine version 4.27.0 is supported!
+- Users can now change the `Server Port` under `Advanced Settings` in the `Play` dropdown menu and launch local deployments that use the new `Server Port` value
 
 ### Bug fixes:
 - Fix `A functional test is already running error` that would sometimes occur when re-running multi-server functional tests.

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -238,6 +238,8 @@ USpatialGDKSettings::USpatialGDKSettings(const FObjectInitializer& ObjectInitial
 {
 	DefaultReceptionistHost = SpatialConstants::LOCAL_HOST;
 	RPCRingBufferSizeOverrides.Add(ERPCType::ServerAlwaysWrite, 1);
+
+	GetDefault<ULevelEditorPlaySettings>()->GetServerPort(ReceptionistPort);
 }
 
 void USpatialGDKSettings::PostInitProperties()

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -235,11 +235,10 @@ USpatialGDKSettings::USpatialGDKSettings(const FObjectInitializer& ObjectInitial
 	, EventTracingRotatingLogsMaxFileCount(256)
 	, bEnableAlwaysWriteRPCs(false)
 	, bEnableInitialOnlyReplicationCondition(false)
+	, LevelEditorPlaySettings(GetDefault<ULevelEditorPlaySettings>())
 {
 	DefaultReceptionistHost = SpatialConstants::LOCAL_HOST;
 	RPCRingBufferSizeOverrides.Add(ERPCType::ServerAlwaysWrite, 1);
-
-	GetDefault<ULevelEditorPlaySettings>()->GetServerPort(ReceptionistPort);
 }
 
 void USpatialGDKSettings::PostInitProperties()
@@ -391,7 +390,15 @@ void USpatialGDKSettings::SetServicesRegion(EServicesRegion::Type NewRegion)
 bool USpatialGDKSettings::GetPreventClientCloudDeploymentAutoConnect() const
 {
 	return (IsRunningGame() || IsRunningClientOnly()) && bPreventClientCloudDeploymentAutoConnect;
-};
+}
+
+uint16_t USpatialGDKSettings::GetLevelSettingsServerPort() const
+{
+	uint16 LevelSettingsServerPort = 0;
+	LevelEditorPlaySettings->GetServerPort(LevelSettingsServerPort);
+
+	return LevelSettingsServerPort;
+}
 
 UEventTracingSamplingSettings* USpatialGDKSettings::GetEventTracingSamplingSettings() const
 {

--- a/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/SpatialGDKSettings.cpp
@@ -235,7 +235,6 @@ USpatialGDKSettings::USpatialGDKSettings(const FObjectInitializer& ObjectInitial
 	, EventTracingRotatingLogsMaxFileCount(256)
 	, bEnableAlwaysWriteRPCs(false)
 	, bEnableInitialOnlyReplicationCondition(false)
-	, LevelEditorPlaySettings(GetDefault<ULevelEditorPlaySettings>())
 {
 	DefaultReceptionistHost = SpatialConstants::LOCAL_HOST;
 	RPCRingBufferSizeOverrides.Add(ERPCType::ServerAlwaysWrite, 1);
@@ -392,12 +391,16 @@ bool USpatialGDKSettings::GetPreventClientCloudDeploymentAutoConnect() const
 	return (IsRunningGame() || IsRunningClientOnly()) && bPreventClientCloudDeploymentAutoConnect;
 }
 
-uint16_t USpatialGDKSettings::GetLevelSettingsServerPort() const
+uint16_t USpatialGDKSettings::GetDefaultPort() const
 {
+#if WITH_EDITOR
 	uint16 LevelSettingsServerPort = 0;
-	LevelEditorPlaySettings->GetServerPort(LevelSettingsServerPort);
+	GetDefault<ULevelEditorPlaySettings>()->GetServerPort(LevelSettingsServerPort);
 
 	return LevelSettingsServerPort;
+#else
+	return SpatialConstants::DEFAULT_PORT;
+#endif // WITH_EDITOR
 }
 
 UEventTracingSamplingSettings* USpatialGDKSettings::GetEventTracingSamplingSettings() const

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
@@ -248,7 +248,7 @@ public:
 	void LoadDefaults()
 	{
 		UseExternalIp = false;
-		ReceptionistPort = SpatialConstants::DEFAULT_PORT;
+		ReceptionistPort = GetDefault<USpatialGDKSettings>()->GetReceptionistPort();
 		SetReceptionistHost(GetDefault<USpatialGDKSettings>()->DefaultReceptionistHost);
 	}
 
@@ -324,5 +324,5 @@ private:
 
 	FString ReceptionistHost;
 
-	uint16 ReceptionistPort;
+	uint16_t ReceptionistPort;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
@@ -248,7 +248,7 @@ public:
 	void LoadDefaults()
 	{
 		UseExternalIp = false;
-		ReceptionistPort = GetDefault<USpatialGDKSettings>()->GetLevelSettingsServerPort();
+		ReceptionistPort = GetDefault<USpatialGDKSettings>()->GetDefaultPort();
 		SetReceptionistHost(GetDefault<USpatialGDKSettings>()->DefaultReceptionistHost);
 	}
 
@@ -320,7 +320,7 @@ private:
 		}
 	}
 
-	void SetReceptionistPort(const uint16 Port) { ReceptionistPort = Port; }
+	void SetReceptionistPort(const uint16_t Port) { ReceptionistPort = Port; }
 
 	FString ReceptionistHost;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/Connection/ConnectionConfig.h
@@ -248,7 +248,7 @@ public:
 	void LoadDefaults()
 	{
 		UseExternalIp = false;
-		ReceptionistPort = GetDefault<USpatialGDKSettings>()->GetReceptionistPort();
+		ReceptionistPort = GetDefault<USpatialGDKSettings>()->GetLevelSettingsServerPort();
 		SetReceptionistHost(GetDefault<USpatialGDKSettings>()->DefaultReceptionistHost);
 	}
 
@@ -309,7 +309,7 @@ public:
 
 	FString GetReceptionistHost() const { return ReceptionistHost; }
 
-	uint16 GetReceptionistPort() const { return ReceptionistPort; }
+	uint16_t GetReceptionistPort() const { return ReceptionistPort; }
 
 private:
 	void SetReceptionistHost(const FString& Host)

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -359,7 +359,6 @@ inline float GetCommandRetryWaitTimeSeconds(uint32 NumAttempts)
 }
 
 const FString LOCAL_HOST = TEXT("127.0.0.1");
-const uint16 DEFAULT_PORT = 7777;
 
 const float ENTITY_QUERY_RETRY_WAIT_SECONDS = 3.0f;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -339,6 +339,7 @@ extern const FString SpatialSessionIdURLOption;
 extern const FString LOCATOR_HOST;
 extern const FString LOCATOR_HOST_CN;
 const uint16 LOCATOR_PORT = 443;
+const uint16_t DEFAULT_PORT = 7777;
 
 extern const FString CONSOLE_HOST;
 extern const FString CONSOLE_HOST_CN;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -361,8 +361,6 @@ inline float GetCommandRetryWaitTimeSeconds(uint32 NumAttempts)
 const FString LOCAL_HOST = TEXT("127.0.0.1");
 const uint16 DEFAULT_PORT = 7777;
 
-const uint16 DEFAULT_SERVER_RECEPTIONIST_PROXY_PORT = 7777;
-
 const float ENTITY_QUERY_RETRY_WAIT_SECONDS = 3.0f;
 
 const Worker_ComponentId MIN_EXTERNAL_SCHEMA_ID = 1000;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -323,7 +323,9 @@ private:
 public:
 	bool GetPreventClientCloudDeploymentAutoConnect() const;
 
-	uint16_t GetLevelSettingsServerPort() const;
+
+	uint16_t GetDefaultPort() const;
+
 
 	UPROPERTY(EditAnywhere, Config, Category = "Region settings",
 			  meta = (ConfigRestartRequired = true, DisplayName = "Region where services are located"))
@@ -377,7 +379,6 @@ private:
 
 	void UpdateServicesRegionFile();
 #endif
-	const ULevelEditorPlaySettings* LevelEditorPlaySettings;
 
 public:
 	/**

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -320,8 +320,13 @@ private:
 
 	friend class AEventTracingSettingsOverride;
 
+	/** Port used as default ReceptionistPort for any new Spatial connection. */
+	uint16_t ReceptionistPort;
+
 public:
 	bool GetPreventClientCloudDeploymentAutoConnect() const;
+
+	FORCEINLINE uint16_t GetReceptionistPort() const { return ReceptionistPort; }
 
 	UPROPERTY(EditAnywhere, Config, Category = "Region settings",
 			  meta = (ConfigRestartRequired = true, DisplayName = "Region where services are located"))

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialGDKSettings.h
@@ -320,13 +320,10 @@ private:
 
 	friend class AEventTracingSettingsOverride;
 
-	/** Port used as default ReceptionistPort for any new Spatial connection. */
-	uint16_t ReceptionistPort;
-
 public:
 	bool GetPreventClientCloudDeploymentAutoConnect() const;
 
-	FORCEINLINE uint16_t GetReceptionistPort() const { return ReceptionistPort; }
+	uint16_t GetLevelSettingsServerPort() const;
 
 	UPROPERTY(EditAnywhere, Config, Category = "Region settings",
 			  meta = (ConfigRestartRequired = true, DisplayName = "Region where services are located"))
@@ -380,6 +377,7 @@ private:
 
 	void UpdateServicesRegionFile();
 #endif
+	const ULevelEditorPlaySettings* LevelEditorPlaySettings;
 
 public:
 	/**

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -114,7 +114,7 @@ bool FSpatialGDKEditorModule::TryStartLocalReceptionistProxyServer() const
 		const USpatialGDKEditorSettings* EditorSettings = GetDefault<USpatialGDKEditorSettings>();
 		bool bSuccess = LocalReceptionistProxyServerManager->TryStartReceptionistProxyServer(
 			GetDefault<USpatialGDKSettings>()->IsRunningInChina(), EditorSettings->GetPrimaryDeploymentName(),
-			EditorSettings->ListeningAddress, EditorSettings->LocalReceptionistPort);
+			EditorSettings->ListeningAddress, EditorSettings->GetLevelSettingsServerPort());
 
 		if (bSuccess)
 		{

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorModule.cpp
@@ -114,7 +114,7 @@ bool FSpatialGDKEditorModule::TryStartLocalReceptionistProxyServer() const
 		const USpatialGDKEditorSettings* EditorSettings = GetDefault<USpatialGDKEditorSettings>();
 		bool bSuccess = LocalReceptionistProxyServerManager->TryStartReceptionistProxyServer(
 			GetDefault<USpatialGDKSettings>()->IsRunningInChina(), EditorSettings->GetPrimaryDeploymentName(),
-			EditorSettings->ListeningAddress, EditorSettings->GetLevelSettingsServerPort());
+			EditorSettings->ListeningAddress, EditorSettings->GetDefaultPort());
 
 		if (bSuccess)
 		{

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -74,7 +74,7 @@ USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& O
 	// Force update users settings in-case they have a bad server worker name saved.
 	LaunchConfigDesc.ServerWorkerConfiguration.WorkerTypeName = SpatialConstants::DefaultServerWorkerType;
 
-	GetMutableDefault<ULevelEditorPlaySettings>()->GetServerPort(LocalReceptionistPort);
+	GetDefault<ULevelEditorPlaySettings>()->GetServerPort(LocalReceptionistPort);
 	RuntimeGRPCPort = LocalReceptionistPort;
 }
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -188,12 +188,16 @@ bool USpatialGDKEditorSettings::IsDeploymentNameValid(const FString& Name)
 	return RegMatcher.FindNext();
 }
 
-uint16_t USpatialGDKEditorSettings::GetLevelSettingsServerPort() const
+uint16_t USpatialGDKEditorSettings::GetDefaultPort() const
 {
+#if WITH_EDITOR
 	uint16_t LevelSettingsServerPort = 0;
 	LevelEditorPlaySettings->GetServerPort(LevelSettingsServerPort);
 
 	return LevelSettingsServerPort;
+#else
+	return SpatialConstants::DEFAULT_PORT;
+#endif // WITH_EDITOR
 }
 
 bool USpatialGDKEditorSettings::IsRegionCodeValid(const ERegionCode::Type RegionCode)

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -64,6 +64,7 @@ USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& O
 	, bPackageMobileCommandLineArgs(true)
 	, bStartPIEClientsWithLocalLaunchOnDevice(false)
 	, SpatialOSNetFlowType(ESpatialOSNetFlow::LocalDeployment)
+	, LevelEditorPlaySettings(GetDefault<ULevelEditorPlaySettings>())
 {
 	SpatialOSLaunchConfig.FilePath = GetSpatialOSLaunchConfig();
 	SpatialOSSnapshotToSave = GetSpatialOSSnapshotToSave();
@@ -73,9 +74,6 @@ USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& O
 	// TODO: UNR-4472 - Remove this WorkerTypeName renaming when refactoring FLaunchConfigDescription.
 	// Force update users settings in-case they have a bad server worker name saved.
 	LaunchConfigDesc.ServerWorkerConfiguration.WorkerTypeName = SpatialConstants::DefaultServerWorkerType;
-
-	GetDefault<ULevelEditorPlaySettings>()->GetServerPort(LocalReceptionistPort);
-	RuntimeGRPCPort = LocalReceptionistPort;
 }
 
 FRuntimeVariantVersion& USpatialGDKEditorSettings::GetRuntimeVariantVersion(ESpatialOSRuntimeVariant::Type Variant)
@@ -188,6 +186,14 @@ bool USpatialGDKEditorSettings::IsDeploymentNameValid(const FString& Name)
 	FRegexMatcher RegMatcher(DeploymentPatternRegex, Name);
 
 	return RegMatcher.FindNext();
+}
+
+uint16_t USpatialGDKEditorSettings::GetLevelSettingsServerPort() const
+{
+	uint16_t LevelSettingsServerPort = 0;
+	LevelEditorPlaySettings->GetServerPort(LevelSettingsServerPort);
+
+	return LevelSettingsServerPort;
 }
 
 bool USpatialGDKEditorSettings::IsRegionCodeValid(const ERegionCode::Type RegionCode)

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -75,6 +75,7 @@ USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& O
 	LaunchConfigDesc.ServerWorkerConfiguration.WorkerTypeName = SpatialConstants::DefaultServerWorkerType;
 
 	GetMutableDefault<ULevelEditorPlaySettings>()->GetServerPort(LocalReceptionistPort);
+	RuntimeGRPCPort = LocalReceptionistPort;
 }
 
 FRuntimeVariantVersion& USpatialGDKEditorSettings::GetRuntimeVariantVersion(ESpatialOSRuntimeVariant::Type Variant)

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SpatialGDKEditorSettings.cpp
@@ -59,7 +59,6 @@ USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& O
 	, bBuildAndUploadAssembly(true)
 	, AssemblyBuildConfiguration(TEXT("Development"))
 	, bConnectServerToCloud(false)
-	, LocalReceptionistPort(SpatialConstants::DEFAULT_SERVER_RECEPTIONIST_PROXY_PORT)
 	, ListeningAddress(SpatialConstants::LOCAL_HOST)
 	, SimulatedPlayerDeploymentRegionCode(ERegionCode::US)
 	, bPackageMobileCommandLineArgs(true)
@@ -74,6 +73,8 @@ USpatialGDKEditorSettings::USpatialGDKEditorSettings(const FObjectInitializer& O
 	// TODO: UNR-4472 - Remove this WorkerTypeName renaming when refactoring FLaunchConfigDescription.
 	// Force update users settings in-case they have a bad server worker name saved.
 	LaunchConfigDesc.ServerWorkerConfiguration.WorkerTypeName = SpatialConstants::DefaultServerWorkerType;
+
+	GetMutableDefault<ULevelEditorPlaySettings>()->GetServerPort(LocalReceptionistPort);
 }
 
 FRuntimeVariantVersion& USpatialGDKEditorSettings::GetRuntimeVariantVersion(ESpatialOSRuntimeVariant::Type Variant)

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -683,7 +683,7 @@ public:
 	static bool IsDeploymentNameValid(const FString& Name);
 	static void TrimTMap(TMap<FString, FString>& Map);
 
-	uint16_t GetLevelSettingsServerPort() const;
+	uint16_t GetDefaultPort() const;
 
 private:
 	const ULevelEditorPlaySettings* LevelEditorPlaySettings;

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -311,7 +311,6 @@ public:
 	UPROPERTY(EditAnywhere, config, Category = "Inspector", meta = (EditCondition = "!bUseGDKPinnedInspectorVersion"))
 	FString InspectorVersionOverride;
 
-	FORCEINLINE uint16_t GetRuntimeGRPCPort() const { return RuntimeGRPCPort; }
 
 	/** Returns the version information for the currently set inspector*/
 	const FString& GetInspectorVersion() const
@@ -328,8 +327,6 @@ private:
 	UPROPERTY(EditAnywhere, config, Category = "Launch",
 			  meta = (EditCondition = "!bGenerateDefaultLaunchConfig", DisplayName = "Launch configuration file path"))
 	FFilePath SpatialOSLaunchConfig;
-
-	uint16_t RuntimeGRPCPort;
 
 public:
 	/** Specify on which IP address the local runtime should be reachable. If empty, the local runtime will not be exposed. Changes are
@@ -458,11 +455,6 @@ public:
 			  meta = (DisplayName = "Connect local server worker to the cloud deployment"))
 	bool bConnectServerToCloud;
 
-	/** Port on which the receptionist proxy will be available. */
-	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection",
-			  meta = (EditCondition = "bConnectServerToCloud", DisplayName = "Local Receptionist Port"))
-	uint16 LocalReceptionistPort;
-
 	/** Network address to bind the receptionist proxy to. */
 	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection",
 			  meta = (EditCondition = "bConnectServerToCloud", DisplayName = "Listening Address"))
@@ -517,6 +509,7 @@ public:
 	UPROPERTY(EditAnywhere, config, Category = "Mobile",
 			  meta = (DisplayName = "Start PIE Clients when launching on a device with local deployment flow"))
 	bool bStartPIEClientsWithLocalLaunchOnDevice;
+
 
 public:
 	/** If you have selected **Auto-generate launch configuration file**, you can change the default options in the file from the drop-down
@@ -689,4 +682,9 @@ public:
 	static bool IsAssemblyNameValid(const FString& Name);
 	static bool IsDeploymentNameValid(const FString& Name);
 	static void TrimTMap(TMap<FString, FString>& Map);
+
+	uint16_t GetLevelSettingsServerPort() const;
+
+private:
+	const ULevelEditorPlaySettings* LevelEditorPlaySettings;
 };

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -457,7 +457,7 @@ public:
 	/** Port on which the receptionist proxy will be available. */
 	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection",
 			  meta = (EditCondition = "bConnectServerToCloud", DisplayName = "Local Receptionist Port"))
-	int32 LocalReceptionistPort;
+	uint16 LocalReceptionistPort;
 
 	/** Network address to bind the receptionist proxy to. */
 	UPROPERTY(EditAnywhere, config, Category = "Cloud Connection",

--- a/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Public/SpatialGDKEditorSettings.h
@@ -311,6 +311,8 @@ public:
 	UPROPERTY(EditAnywhere, config, Category = "Inspector", meta = (EditCondition = "!bUseGDKPinnedInspectorVersion"))
 	FString InspectorVersionOverride;
 
+	FORCEINLINE uint16_t GetRuntimeGRPCPort() const { return RuntimeGRPCPort; }
+
 	/** Returns the version information for the currently set inspector*/
 	const FString& GetInspectorVersion() const
 	{
@@ -326,6 +328,8 @@ private:
 	UPROPERTY(EditAnywhere, config, Category = "Launch",
 			  meta = (EditCondition = "!bGenerateDefaultLaunchConfig", DisplayName = "Launch configuration file path"))
 	FFilePath SpatialOSLaunchConfig;
+
+	uint16_t RuntimeGRPCPort;
 
 public:
 	/** Specify on which IP address the local runtime should be reachable. If empty, the local runtime will not be exposed. Changes are

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -141,7 +141,7 @@ void FSpatialGDKEditorToolbarModule::StartupModule()
 	});
 
 	LocalDeploymentManager->Init();
-	LocalReceptionistProxyServerManager->Init(GetDefault<USpatialGDKEditorSettings>()->LocalReceptionistPort);
+	LocalReceptionistProxyServerManager->Init(GetDefault<USpatialGDKEditorSettings>()->GetLevelSettingsServerPort());
 
 	SpatialGDKEditorInstance = FModuleManager::GetModuleChecked<FSpatialGDKEditorModule>("SpatialGDKEditor").GetSpatialGDKEditorInstance();
 
@@ -944,7 +944,7 @@ void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment(FString ForceSnaps
 	const FString SnapshotName = ForceSnapshot.IsEmpty() ? SpatialGDKEditorSettings->GetSpatialOSSnapshotToLoad() : ForceSnapshot;
 	const FString SnapshotPath = FPaths::Combine(SpatialGDKServicesConstants::SpatialOSSnapshotFolderPath, SnapshotName);
 	const FString RuntimeVersion = SpatialGDKEditorSettings->GetSelectedRuntimeVariantVersion().GetVersionForLocal();
-	const uint16_t RuntimeGRPCPort = SpatialGDKEditorSettings->GetRuntimeGRPCPort();
+	const uint16_t RuntimeGRPCPort = SpatialGDKEditorSettings->GetLevelSettingsServerPort();
 
 	AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [this, LaunchConfig, LaunchFlags, SnapshotPath, RuntimeVersion,
 															 RuntimeGRPCPort] {
@@ -1027,7 +1027,7 @@ void FSpatialGDKEditorToolbarModule::StartInspectorProcess(TFunction<void()> OnR
 {
 	const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>();
 	const FString InspectorVersion = SpatialGDKEditorSettings->GetInspectorVersion();
-	const uint16_t RuntimeGRPCPort = SpatialGDKEditorSettings->GetRuntimeGRPCPort();
+	const uint16_t RuntimeGRPCPort = SpatialGDKEditorSettings->GetLevelSettingsServerPort();
 
 	AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [this, InspectorVersion, OnReady, RuntimeGRPCPort] {
 		if (InspectorProcess && InspectorProcess->Update())

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Private/SpatialGDKEditorToolbar.cpp
@@ -142,7 +142,7 @@ void FSpatialGDKEditorToolbarModule::StartupModule()
 	});
 
 	LocalDeploymentManager->Init();
-	LocalReceptionistProxyServerManager->Init(GetDefault<USpatialGDKEditorSettings>()->GetLevelSettingsServerPort());
+	LocalReceptionistProxyServerManager->Init(GetDefault<USpatialGDKEditorSettings>()->GetDefaultPort());
 
 	SpatialGDKEditorInstance = FModuleManager::GetModuleChecked<FSpatialGDKEditorModule>("SpatialGDKEditor").GetSpatialGDKEditorInstance();
 
@@ -945,7 +945,7 @@ void FSpatialGDKEditorToolbarModule::VerifyAndStartDeployment(FString ForceSnaps
 	const FString SnapshotName = ForceSnapshot.IsEmpty() ? SpatialGDKEditorSettings->GetSpatialOSSnapshotToLoad() : ForceSnapshot;
 	const FString SnapshotPath = FPaths::Combine(SpatialGDKServicesConstants::SpatialOSSnapshotFolderPath, SnapshotName);
 	const FString RuntimeVersion = SpatialGDKEditorSettings->GetSelectedRuntimeVariantVersion().GetVersionForLocal();
-	const uint16_t RuntimeGRPCPort = SpatialGDKEditorSettings->GetLevelSettingsServerPort();
+	const uint16_t RuntimeGRPCPort = SpatialGDKEditorSettings->GetDefaultPort();
 
 	AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [this, LaunchConfig, LaunchFlags, SnapshotPath, RuntimeVersion,
 															 RuntimeGRPCPort] {
@@ -1028,7 +1028,7 @@ void FSpatialGDKEditorToolbarModule::StartInspectorProcess(TFunction<void()> OnR
 {
 	const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>();
 	const FString InspectorVersion = SpatialGDKEditorSettings->GetInspectorVersion();
-	const uint16_t RuntimeGRPCPort = SpatialGDKEditorSettings->GetLevelSettingsServerPort();
+	const uint16_t RuntimeGRPCPort = SpatialGDKEditorSettings->GetDefaultPort();
 	// If the Runtime port has changed, the previous Inspector process should be killed 
 	bool bShouldKillInspectorProcess = RuntimeGRPCPort != PreviousRuntimeGRPCPort && PreviousRuntimeGRPCPort != 0;
 	PreviousRuntimeGRPCPort = RuntimeGRPCPort;

--- a/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
+++ b/SpatialGDK/Source/SpatialGDKEditorToolbar/Public/SpatialGDKEditorToolbar.h
@@ -206,4 +206,6 @@ private:
 	TWeakObjectPtr<ASpatialDebugger> SpatialDebugger;
 
 	TOptional<FMonitoredProcess> InspectorProcess = {};
+
+	uint16_t PreviousRuntimeGRPCPort;
 };

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -184,7 +184,6 @@ bool FLocalDeploymentManager::LocalDeploymentPreRunChecks()
 
 	// Check for the known runtime ports which could be blocked by other processes.
 
-	// Pass the RuntimeGRPCPort to this function
 	TArray<uint16_t> RequiredRuntimePorts = { RequiredRuntimePort, WorkerPort, HTTPPort, SpatialGDKServicesConstants::RuntimeGRPCPort };
 
 	for (uint16_t RuntimePort : RequiredRuntimePorts)
@@ -213,7 +212,6 @@ void FLocalDeploymentManager::TryStartLocalDeployment(const FString& LaunchConfi
 													  const FString& SnapshotName, const FString& RuntimeIPToExpose,
 													  const LocalDeploymentCallback& CallBack)
 {
-
 	int NumRetries = RuntimeStartRetries;
 	while (NumRetries > 0)
 	{
@@ -293,11 +291,12 @@ FLocalDeploymentManager::ERuntimeStartResponse FLocalDeploymentManager::StartLoc
 	// --worker-external-host 127.0.0.1 --snapshots-directory=spatial/snapshots/<timestamp>
 	// --schema-bundle=spatial/build/assembly/schema/schema.sb
 	// --event - tracing - logs - directory = `<Project > / spatial / localdeployment / <timestamp> / `
-	FString RuntimeArgs = FString::Printf(
-		TEXT("--config=\"%s\" --snapshot=\"%s\" --worker-port %s --http-port=%s --grpc-port=%s "
-			 "--snapshots-directory=\"%s\" --schema-bundle=\"%s\" --event-tracing-logs-directory=\"%s\" %s"),
-		*LaunchConfig, *SnapshotName, *FString::FromInt(WorkerPort), *FString::FromInt(HTTPPort),
-		*FString::FromInt(SpatialGDKServicesConstants::RuntimeGRPCPort), *CurrentSnapshotPath, *SchemaBundle, *EventTracingPath, *LaunchArgs);
+	FString RuntimeArgs =
+		FString::Printf(TEXT("--config=\"%s\" --snapshot=\"%s\" --worker-port %s --http-port=%s --grpc-port=%s "
+							 "--snapshots-directory=\"%s\" --schema-bundle=\"%s\" --event-tracing-logs-directory=\"%s\" %s"),
+						*LaunchConfig, *SnapshotName, *FString::FromInt(WorkerPort), *FString::FromInt(HTTPPort),
+						*FString::FromInt(SpatialGDKServicesConstants::RuntimeGRPCPort), *CurrentSnapshotPath, *SchemaBundle,
+						*EventTracingPath, *LaunchArgs);
 
 	if (!RuntimeIPToExpose.IsEmpty())
 	{

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalDeploymentManager.cpp
@@ -118,7 +118,7 @@ void FLocalDeploymentManager::WorkerBuildConfigAsync()
 	});
 }
 
-bool FLocalDeploymentManager::CheckIfPortIsBound(int32 Port)
+bool FLocalDeploymentManager::CheckIfPortIsBound(uint16_t Port)
 {
 	ISocketSubsystem* SocketSubsystem = ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM);
 	bool bCanBindToPort = false;
@@ -163,7 +163,7 @@ bool FLocalDeploymentManager::CheckIfPortIsBound(int32 Port)
 	return !bCanBindToPort;
 }
 
-bool FLocalDeploymentManager::KillProcessBlockingPort(int32 Port)
+bool FLocalDeploymentManager::KillProcessBlockingPort(uint16_t Port)
 {
 	FString PID;
 	FString State;
@@ -183,9 +183,11 @@ bool FLocalDeploymentManager::LocalDeploymentPreRunChecks()
 	bool bSuccess = true;
 
 	// Check for the known runtime ports which could be blocked by other processes.
-	TArray<int32> RequiredRuntimePorts = { RequiredRuntimePort, WorkerPort, HTTPPort, SpatialGDKServicesConstants::RuntimeGRPCPort };
 
-	for (int32 RuntimePort : RequiredRuntimePorts)
+	// Pass the RuntimeGRPCPort to this function
+	TArray<uint16_t> RequiredRuntimePorts = { RequiredRuntimePort, WorkerPort, HTTPPort, SpatialGDKServicesConstants::RuntimeGRPCPort };
+
+	for (uint16_t RuntimePort : RequiredRuntimePorts)
 	{
 		if (CheckIfPortIsBound(RuntimePort))
 		{
@@ -211,6 +213,7 @@ void FLocalDeploymentManager::TryStartLocalDeployment(const FString& LaunchConfi
 													  const FString& SnapshotName, const FString& RuntimeIPToExpose,
 													  const LocalDeploymentCallback& CallBack)
 {
+
 	int NumRetries = RuntimeStartRetries;
 	while (NumRetries > 0)
 	{

--- a/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/LocalReceptionistProxyServerManager.cpp
@@ -24,7 +24,7 @@ FLocalReceptionistProxyServerManager::FLocalReceptionistProxyServerManager()
 {
 }
 
-bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound(int32 Port, FString& OutPID, FString& OutLogMsg)
+bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound(uint16_t Port, FString& OutPID, FString& OutLogMsg)
 {
 	FString State;
 	FString ProcessName;
@@ -39,7 +39,7 @@ bool FLocalReceptionistProxyServerManager::CheckIfPortIsBound(int32 Port, FStrin
 	return false;
 }
 
-bool FLocalReceptionistProxyServerManager::LocalReceptionistProxyServerPreRunChecks(int32 ReceptionistPort)
+bool FLocalReceptionistProxyServerManager::LocalReceptionistProxyServerPreRunChecks(uint16_t ReceptionistPort)
 {
 	FString OutLogMessage;
 	FString PID;
@@ -77,7 +77,7 @@ bool FLocalReceptionistProxyServerManager::LocalReceptionistProxyServerPreRunChe
 	return false;
 }
 
-void FLocalReceptionistProxyServerManager::Init(int32 Port)
+void FLocalReceptionistProxyServerManager::Init(uint16_t Port)
 {
 	if (!IsRunningCommandlet())
 	{
@@ -169,7 +169,7 @@ void FLocalReceptionistProxyServerManager::DeletePIDFile()
 }
 
 bool FLocalReceptionistProxyServerManager::TryStartReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName,
-																		   const FString& ListeningAddress, const int32 ReceptionistPort)
+																		   const FString& ListeningAddress, const uint16_t ReceptionistPort)
 {
 	FString StartResult;
 	int32 ExitCode;

--- a/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
+++ b/SpatialGDK/Source/SpatialGDKServices/Private/SpatialCommandUtils.cpp
@@ -246,10 +246,10 @@ bool SpatialCommandUtils::HasDevLoginTag(const FString& DeploymentName, bool bIs
 }
 
 FProcHandle SpatialCommandUtils::StartLocalReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName,
-																   const FString& ListeningAddress, const int32 Port, FString& OutResult,
+																   const FString& ListeningAddress, const uint16_t Port, FString& OutResult,
 																   int32& OutExitCode)
 {
-	FString Command = FString::Printf(TEXT("cloud connect external %s --listening_address %s --local_receptionist_port %i"),
+	FString Command = FString::Printf(TEXT("cloud connect external %s --listening_address %s --local_receptionist_port %u"),
 									  *CloudDeploymentName, *ListeningAddress, Port);
 
 	if (bIsRunningInChina)
@@ -413,7 +413,7 @@ void SpatialCommandUtils::TryGracefullyKillWindows(const FString& ProcName)
 }
 #endif
 
-bool SpatialCommandUtils::GetProcessInfoFromPort(int32 Port, FString& OutPid, FString& OutState, FString& OutProcessName)
+bool SpatialCommandUtils::GetProcessInfoFromPort(uint16_t Port, FString& OutPid, FString& OutState, FString& OutProcessName)
 {
 #if PLATFORM_WINDOWS
 	const FString Command = FString::Printf(TEXT("netstat"));
@@ -422,7 +422,7 @@ bool SpatialCommandUtils::GetProcessInfoFromPort(int32 Port, FString& OutPid, FS
 #elif PLATFORM_MAC
 	const FString Command = FPaths::Combine(SpatialGDKServicesConstants::LsofCmdFilePath, TEXT("lsof"));
 	// -i:Port list the processes that are running on Port
-	const FString Args = FString::Printf(TEXT("-i:%i"), Port);
+	const FString Args = FString::Printf(TEXT("-i:%u"), Port);
 #endif
 
 	FString Result;
@@ -435,7 +435,7 @@ bool SpatialCommandUtils::GetProcessInfoFromPort(int32 Port, FString& OutPid, FS
 	{
 #if PLATFORM_WINDOWS
 		// Get the line of the netstat output that contains the port we're looking for.
-		FRegexPattern PidMatcherPattern(FString::Printf(TEXT("(.*?:%i.)(.*)( [0-9]+)"), Port));
+		FRegexPattern PidMatcherPattern(FString::Printf(TEXT("(.*?:%u.)(.*)( [0-9]+)"), Port));
 #elif PLATFORM_MAC
 		// Get the line that contains the name, pid and state of the process.
 		FRegexPattern PidMatcherPattern(TEXT("(\\S+)( *\\d+).*(\\(\\S+\\))"));
@@ -459,7 +459,7 @@ bool SpatialCommandUtils::GetProcessInfoFromPort(int32 Port, FString& OutPid, FS
 		}
 
 #if PLATFORM_WINDOWS
-		UE_LOG(LogSpatialCommandUtils, Log, TEXT("The required port %i is not blocked!"), Port);
+		UE_LOG(LogSpatialCommandUtils, Log, TEXT("The required port %u is not blocked!"), Port);
 		return false;
 #endif
 	}
@@ -467,7 +467,7 @@ bool SpatialCommandUtils::GetProcessInfoFromPort(int32 Port, FString& OutPid, FS
 #if PLATFORM_MAC
 	if (bSuccess && ExitCode == 1 && StdErr.IsEmpty())
 	{
-		UE_LOG(LogSpatialCommandUtils, Log, TEXT("The required port %i is not blocked!"), Port);
+		UE_LOG(LogSpatialCommandUtils, Log, TEXT("The required port %u is not blocked!"), Port);
 		return false;
 	}
 #endif

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalDeploymentManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalDeploymentManager.h
@@ -25,8 +25,8 @@ public:
 
 	void SPATIALGDKSERVICES_API Init();
 
-	bool CheckIfPortIsBound(int32 Port);
-	bool KillProcessBlockingPort(int32 Port);
+	bool CheckIfPortIsBound(uint16_t Port);
+	bool KillProcessBlockingPort(uint16_t Port);
 	bool LocalDeploymentPreRunChecks();
 
 	using LocalDeploymentCallback = TFunction<void(bool)>;
@@ -92,9 +92,9 @@ private:
 	TUniquePtr<IFileHandle> RuntimeLogFileHandle;
 	FDateTime RuntimeStartTime;
 
-	static const int32 RequiredRuntimePort = 5301;
-	static const int32 WorkerPort = 8018;
-	static const int32 HTTPPort = 5006;
+	static const uint16_t RequiredRuntimePort = 5301;
+	static const uint16_t WorkerPort = 8018;
+	static const uint16_t HTTPPort = 5006;
 
 	static constexpr double RuntimeTimeout = 10.0;
 	static constexpr int32 RuntimeStartRetries = 3;

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalDeploymentManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalDeploymentManager.h
@@ -27,13 +27,13 @@ public:
 
 	bool CheckIfPortIsBound(uint16_t Port);
 	bool KillProcessBlockingPort(uint16_t Port);
-	bool LocalDeploymentPreRunChecks();
+	bool LocalDeploymentPreRunChecks(const uint16_t& RuntimeGRPCPort);
 
 	using LocalDeploymentCallback = TFunction<void(bool)>;
 
 	void SPATIALGDKSERVICES_API TryStartLocalDeployment(const FString& LaunchConfig, const FString& RuntimeVersion,
 														const FString& LaunchArgs, const FString& SnapshotName,
-														const FString& RuntimeIPToExpose, const LocalDeploymentCallback& CallBack);
+														const FString& RuntimeIPToExpose, const uint16_t& RuntimeGRPCPort, const LocalDeploymentCallback& CallBack);
 
 	bool SPATIALGDKSERVICES_API TryStopLocalDeployment();
 	bool SPATIALGDKSERVICES_API TryStopLocalDeploymentGracefully();
@@ -81,7 +81,7 @@ private:
 	};
 
 	ERuntimeStartResponse StartLocalDeployment(const FString& LaunchConfig, const FString& RuntimeVersion, const FString& LaunchArgs,
-											   const FString& SnapshotName, const FString& RuntimeIPToExpose,
+											   const FString& SnapshotName, const FString& RuntimeIPToExpose, const uint16_t& RuntimeGRPCPort,
 											   const LocalDeploymentCallback& CallBack);
 
 	FCriticalSection StoppingDeployment;

--- a/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/LocalReceptionistProxyServerManager.h
@@ -11,12 +11,12 @@ class FLocalReceptionistProxyServerManager
 public:
 	FLocalReceptionistProxyServerManager();
 
-	bool CheckIfPortIsBound(int32 Port, FString& OutPID, FString& OutLogMessages);
-	bool LocalReceptionistProxyServerPreRunChecks(int32 ReceptionistPort);
+	bool CheckIfPortIsBound(uint16_t Port, FString& OutPID, FString& OutLogMessages);
+	bool LocalReceptionistProxyServerPreRunChecks(uint16_t ReceptionistPort);
 
-	void SPATIALGDKSERVICES_API Init(int32 ReceptionistPort);
+	void SPATIALGDKSERVICES_API Init(uint16_t ReceptionistPort);
 	bool SPATIALGDKSERVICES_API TryStartReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName,
-																const FString& ListeningAddress, int32 ReceptionistPort);
+																const FString& ListeningAddress, uint16_t ReceptionistPort);
 	bool SPATIALGDKSERVICES_API TryStopReceptionistProxyServer();
 
 private:
@@ -27,7 +27,7 @@ private:
 
 	FProcHandle ProxyServerProcHandle;
 	FString RunningCloudDeploymentName;
-	int32 RunningProxyReceptionistPort;
+	uint16_t RunningProxyReceptionistPort;
 	FString RunningProxyListeningAddress;
 
 	bool bProxyIsRunning = false;

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialCommandUtils.h
@@ -19,10 +19,10 @@ public:
 	SPATIALGDKSERVICES_API static bool HasDevLoginTag(const FString& DeploymentName, bool bIsRunningInChina, FText& OutErrorMessage);
 	SPATIALGDKSERVICES_API static FProcHandle StartLocalReceptionistProxyServer(bool bIsRunningInChina, const FString& CloudDeploymentName,
 																				const FString& ListeningAddress,
-																				const int32 ReceptionistPort, FString& OutResult,
+																				const uint16_t ReceptionistPort, FString& OutResult,
 																				int32& OutExitCode);
 	SPATIALGDKSERVICES_API static void StopLocalReceptionistProxyServer(FProcHandle& ProcessHandle);
-	SPATIALGDKSERVICES_API static bool GetProcessInfoFromPort(int32 Port, FString& OutPid, FString& OutState, FString& OutProcessName);
+	SPATIALGDKSERVICES_API static bool GetProcessInfoFromPort(uint16_t Port, FString& OutPid, FString& OutState, FString& OutProcessName);
 	SPATIALGDKSERVICES_API static bool GetProcessName(const FString& PID, FString& OutProcessName);
 	SPATIALGDKSERVICES_API static bool TryKillProcessWithPID(const FString& PID);
 	SPATIALGDKSERVICES_API static void TryKillProcessWithName(const FString& ProcessName);

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesConstants.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesConstants.h
@@ -54,10 +54,8 @@ static const FString GetInspectorExecutablePath(const FString& InspectorVersion)
 
 const FString SpatialOSRuntimePinnedStandardVersion = TEXT("15.3.0");
 
-const uint16_t RuntimeGRPCPort = 7777;
 const uint16_t RuntimeHTTPPort = 5006;
 
-const FString InspectorGRPCAddress = FString::Printf(TEXT("localhost:%s"), *FString::FromInt(RuntimeGRPCPort));
 const FString InspectorHTTPAddress = FString::Printf(TEXT("localhost:%s"), *FString::FromInt(RuntimeHTTPPort));
 const FString InspectorV2URL = TEXT("http://localhost:33333/inspector-v2");
 const FString InspectorPinnedVersion = TEXT("15.1.0");

--- a/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesConstants.h
+++ b/SpatialGDK/Source/SpatialGDKServices/Public/SpatialGDKServicesConstants.h
@@ -54,8 +54,8 @@ static const FString GetInspectorExecutablePath(const FString& InspectorVersion)
 
 const FString SpatialOSRuntimePinnedStandardVersion = TEXT("15.3.0");
 
-const int32 RuntimeGRPCPort = 7777;
-const int32 RuntimeHTTPPort = 5006;
+const uint16_t RuntimeGRPCPort = 7777;
+const uint16_t RuntimeHTTPPort = 5006;
 
 const FString InspectorGRPCAddress = FString::Printf(TEXT("localhost:%s"), *FString::FromInt(RuntimeGRPCPort));
 const FString InspectorHTTPAddress = FString::Printf(TEXT("localhost:%s"), *FString::FromInt(RuntimeHTTPPort));

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/Connection/SpatialConnectionManagerTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/Connection/SpatialConnectionManagerTest.cpp
@@ -3,6 +3,7 @@
 #include "CoreMinimal.h"
 #include "Interop/Connection/SpatialConnectionManager.h"
 #include "SpatialGDKTests/Public/GDKAutomationTestBase.h"
+#include "SpatialGDKSettings.h"
 
 #define CONNECTIONMANAGER_TEST(TestName) GDK_AUTOMATION_TEST(Core, SpatialConnectionManager, TestName)
 
@@ -224,7 +225,7 @@ CONNECTIONMANAGER_TEST(SetupFromURL_Receptionist_ExternalBridgeNoHost)
 	// THEN
 	TestEqual("UseExternalIp", Manager->ReceptionistConfig.UseExternalIp, true);
 	TestEqual("ReceptionistHost", Manager->ReceptionistConfig.GetReceptionistHost(), "127.0.0.1");
-	TestEqual("ReceptionistPort", Manager->ReceptionistConfig.GetReceptionistPort(), SpatialConstants::DEFAULT_PORT);
+	TestEqual("ReceptionistPort", Manager->ReceptionistConfig.GetReceptionistPort(), GetDefault<USpatialGDKSettings>()->GetReceptionistPort());
 	TestEqual("WorkerType", Manager->ReceptionistConfig.WorkerType, "SomeWorkerType");
 
 	return true;

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/Connection/SpatialConnectionManagerTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/Connection/SpatialConnectionManagerTest.cpp
@@ -225,7 +225,7 @@ CONNECTIONMANAGER_TEST(SetupFromURL_Receptionist_ExternalBridgeNoHost)
 	// THEN
 	TestEqual("UseExternalIp", Manager->ReceptionistConfig.UseExternalIp, true);
 	TestEqual("ReceptionistHost", Manager->ReceptionistConfig.GetReceptionistHost(), "127.0.0.1");
-	TestEqual("ReceptionistPort", Manager->ReceptionistConfig.GetReceptionistPort(), GetDefault<USpatialGDKSettings>()->GetReceptionistPort());
+	TestEqual("ReceptionistPort", Manager->ReceptionistConfig.GetReceptionistPort(), GetDefault<USpatialGDKSettings>()->GetLevelSettingsServerPort());
 	TestEqual("WorkerType", Manager->ReceptionistConfig.WorkerType, "SomeWorkerType");
 
 	return true;

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/Connection/SpatialConnectionManagerTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDK/Interop/Connection/SpatialConnectionManagerTest.cpp
@@ -225,7 +225,7 @@ CONNECTIONMANAGER_TEST(SetupFromURL_Receptionist_ExternalBridgeNoHost)
 	// THEN
 	TestEqual("UseExternalIp", Manager->ReceptionistConfig.UseExternalIp, true);
 	TestEqual("ReceptionistHost", Manager->ReceptionistConfig.GetReceptionistHost(), "127.0.0.1");
-	TestEqual("ReceptionistPort", Manager->ReceptionistConfig.GetReceptionistPort(), GetDefault<USpatialGDKSettings>()->GetLevelSettingsServerPort());
+	TestEqual("ReceptionistPort", Manager->ReceptionistConfig.GetReceptionistPort(), GetDefault<USpatialGDKSettings>()->GetDefaultPort());
 	TestEqual("WorkerType", Manager->ReceptionistConfig.WorkerType, "SomeWorkerType");
 
 	return true;

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKServices/LocalDeploymentManager/LocalDeploymentManagerUtilities.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKServices/LocalDeploymentManager/LocalDeploymentManagerUtilities.cpp
@@ -82,7 +82,7 @@ bool FStartDeployment::Update()
 		const FString LaunchFlags = SpatialGDKEditorSettings->GetSpatialOSCommandLineLaunchFlags();
 		const FString SnapshotName = SpatialGDKEditorSettings->GetSpatialOSSnapshotToLoadPath();
 		const FString RuntimeVersion = SpatialGDKEditorSettings->GetSelectedRuntimeVariantVersion().GetVersionForLocal();
-		const uint16_t RuntimeGRPCPort = SpatialGDKEditorSettings->GetRuntimeGRPCPort();
+		const uint16_t RuntimeGRPCPort = SpatialGDKEditorSettings->GetLevelSettingsServerPort();
 
 		AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [LocalDeploymentManager, LaunchConfig, LaunchFlags, SnapshotName,
 																 RuntimeVersion, RuntimeGRPCPort] {

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKServices/LocalDeploymentManager/LocalDeploymentManagerUtilities.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKServices/LocalDeploymentManager/LocalDeploymentManagerUtilities.cpp
@@ -82,7 +82,7 @@ bool FStartDeployment::Update()
 		const FString LaunchFlags = SpatialGDKEditorSettings->GetSpatialOSCommandLineLaunchFlags();
 		const FString SnapshotName = SpatialGDKEditorSettings->GetSpatialOSSnapshotToLoadPath();
 		const FString RuntimeVersion = SpatialGDKEditorSettings->GetSelectedRuntimeVariantVersion().GetVersionForLocal();
-		const uint16_t RuntimeGRPCPort = SpatialGDKEditorSettings->GetLevelSettingsServerPort();
+		const uint16_t RuntimeGRPCPort = SpatialGDKEditorSettings->GetDefaultPort();
 
 		AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [LocalDeploymentManager, LaunchConfig, LaunchFlags, SnapshotName,
 																 RuntimeVersion, RuntimeGRPCPort] {

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKServices/LocalDeploymentManager/LocalDeploymentManagerUtilities.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKServices/LocalDeploymentManager/LocalDeploymentManagerUtilities.cpp
@@ -74,17 +74,18 @@ bool DeleteWorkerJson()
 
 bool FStartDeployment::Update()
 {
-	if (const USpatialGDKEditorSettings* SpatialGDKSettings = GetDefault<USpatialGDKEditorSettings>())
+	if (const USpatialGDKEditorSettings* SpatialGDKEditorSettings = GetDefault<USpatialGDKEditorSettings>())
 	{
 		FLocalDeploymentManager* LocalDeploymentManager = SpatialGDK::GetLocalDeploymentManager();
 		const FString LaunchConfig =
 			FPaths::Combine(FPaths::ConvertRelativePathToFull(FPaths::ProjectIntermediateDir()), AutomationLaunchConfig);
-		const FString LaunchFlags = SpatialGDKSettings->GetSpatialOSCommandLineLaunchFlags();
-		const FString SnapshotName = SpatialGDKSettings->GetSpatialOSSnapshotToLoadPath();
-		const FString RuntimeVersion = SpatialGDKSettings->GetSelectedRuntimeVariantVersion().GetVersionForLocal();
+		const FString LaunchFlags = SpatialGDKEditorSettings->GetSpatialOSCommandLineLaunchFlags();
+		const FString SnapshotName = SpatialGDKEditorSettings->GetSpatialOSSnapshotToLoadPath();
+		const FString RuntimeVersion = SpatialGDKEditorSettings->GetSelectedRuntimeVariantVersion().GetVersionForLocal();
+		const uint16_t RuntimeGRPCPort = SpatialGDKEditorSettings->GetRuntimeGRPCPort();
 
 		AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, [LocalDeploymentManager, LaunchConfig, LaunchFlags, SnapshotName,
-																 RuntimeVersion] {
+																 RuntimeVersion, RuntimeGRPCPort] {
 			if (!GenerateWorkerJson())
 			{
 				return;
@@ -112,7 +113,7 @@ bool FStartDeployment::Update()
 				return;
 			}
 
-			LocalDeploymentManager->TryStartLocalDeployment(LaunchConfig, RuntimeVersion, LaunchFlags, SnapshotName, TEXT(""), nullptr);
+			LocalDeploymentManager->TryStartLocalDeployment(LaunchConfig, RuntimeVersion, LaunchFlags, SnapshotName, TEXT(""), RuntimeGRPCPort, nullptr);
 		});
 	}
 


### PR DESCRIPTION
#### Description
This PR removes our constraint of always using 7777 as the `ServerPort `under `Advanced Settings` in the `Play `button dropdown, by making several previously constants get the value stored in `ServerPort` whenever necessary.  

It also includes a code clean-up, that ensures that `uint16_t `is used consistently by variables that are storing Port numbers.

#### Tests

Testing of these changes implied manually changing the `ServerPort `from the `Advanced Settings` under `Play`, hitting `Play`, ensuring that the deployment starts correctly, and that the `Inspector `correctly connects as well. 


Testing also included starting a cloud deployment and ensuring that connections can be successfully established for multiple clients. 

The` Functional Tests` and `Spatial Tests` from the `Test Gyms` were also ran.

STRONGLY SUGGESTED: How can this be verified by QA?
QA can verify this by using the ExampleProject, running a deployment, then stopping it and changing the `Server Port` from the `Advanced Settings` under `Play`, hitting `Play `and ensuring the deployment starts correctly and that the `Inspector `also runs smoothly.

#### Documentation

This PR includes a release note. 

#### Primary reviewers
@joshuahuburn 
