### PR TITLE
[UNR-5840] Fix flakiness of SpatialTestCharacterMigration

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestCharacterMigration/SpatialTestCharacterMigration.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestCharacterMigration/SpatialTestCharacterMigration.cpp
@@ -41,8 +41,8 @@ ASpatialTestCharacterMigration::ASpatialTestCharacterMigration()
 	Description = TEXT("Test Character Migration");
 	TimeLimit = 300;
 
-	PositionOnServerOne = FVector(-250.0f, 0.0f, 40.0f);
-	PositionOnServerTwo = FVector(250.0f, 0.0f, 40.0f);
+	PositionOnServerOne = FVector(-200.0f, 0.0f, 40.0f);
+	PositionOnServerTwo = FVector(200.0f, 0.0f, 40.0f);
 }
 
 void ASpatialTestCharacterMigration::PrepareTest()
@@ -108,16 +108,18 @@ void ASpatialTestCharacterMigration::PrepareTest()
 				{
 					const VirtualWorkerId VirtualWorker = SpatialNetDriver->LoadBalanceStrategy->WhoShouldHaveAuthority(*Character);
 					RequireEqual_Int(VirtualWorker, ExpectedVirtualWorker,
-									 FString::Printf(TEXT("%s on %s crossed boundary"), *Character->GetName(), *WorkerId));
+									 FString::Printf(TEXT("TestMovementCharacter %lld on %s crossed boundary"),
+													 SpatialNetDriver->GetActorEntityId(*Character), *WorkerId));
 				}
 			}
 
 			if (bShouldRunRequires)
 			{
 				const bool bReachDestination =
-					GetTargetDistanceOnLine(StartPos, EndPos, Character->GetActorLocation()) > -20.0f; // 20cm overlap
+					GetTargetDistanceOnLine(StartPos, EndPos, Character->GetActorLocation()) > -40.0f; // 40cm overlap
 				RequireEqual_Bool(bReachDestination, true,
-								  FString::Printf(TEXT("%s on %s reached destination"), *Character->GetName(), *WorkerId));
+								  FString::Printf(TEXT("TestMovementCharacter %lld on %s reached destination"),
+												  SpatialNetDriver->GetActorEntityId(*Character), *WorkerId));
 			}
 
 			Count++;


### PR DESCRIPTION
#### Description
The test was flaky because sometimes the deletion would be so slow on a no-interest map that the old actors would still be on the old server while the new server already gained authority over them.

Fixed by just distinguishing characters by entity id rather than their Unreal name.

#### Release note
N/A

#### Tests
Ran 200 times in CI, no failures.

#### Documentation
N/A

#### Primary reviewers
@m-samiec 