### PR TITLE
InfluxDB MetricsExport ActorComponent

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/MetricsExport.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/MetricsExport.cpp
@@ -1,0 +1,125 @@
+#include "Utils/MetricsExport.h"
+#include <chrono>
+#include "EngineClasses/SpatialNetDriver.h"
+#include "HttpModule.h"
+#include "Interfaces/IHttpRequest.h"
+#include "Interop/Connection/SpatialWorkerConnection.h"
+#include "Runtime/Online/HTTP/Public/Http.h"
+UMetricsExport::UMetricsExport(const FObjectInitializer& ObjectInitializer)
+    : Super(ObjectInitializer)
+{
+    PrimaryComponentTick.bCanEverTick = true;
+    PrimaryComponentTick.bStartWithTickEnabled = true;
+    LastUpdateSendTime = FDateTime::Now().ToUnixTimestamp();
+    FString InfluxUrlOverride;
+    if (FParse::Value(FCommandLine::Get(), TEXT("influxUrl"), InfluxUrlOverride))
+    {
+        InfluxUrl = InfluxUrlOverride;
+    }
+    else
+    {
+        InfluxUrl = FString::Printf(TEXT("http://%s:%s/write?db=%s"), *InfluxHost, *InfluxPort, *InfluxDbName);
+    }
+    FString InfluxTokenFromCli;
+    if (FParse::Value(FCommandLine::Get(), TEXT("influxToken"), InfluxTokenFromCli))
+    {
+        InfluxToken = InfluxTokenFromCli;
+    }
+    FString ProjectNameFromCli;
+    if (FParse::Value(FCommandLine::Get(), TEXT("appName"), ProjectNameFromCli))
+    {
+        ProjectName = ProjectNameFromCli;
+    }
+    else
+    {
+        ProjectName = TEXT("local_project");
+    }
+    FString DeploymentNameFromCli;
+    if (FParse::Value(FCommandLine::Get(), TEXT("deploymentName"), DeploymentNameFromCli))
+    {
+        DeploymentName = DeploymentNameFromCli;
+    }
+    else
+    {
+        DeploymentName = TEXT("local_dpl");
+    }
+}
+void UMetricsExport::BeginPlay()
+{
+    Super::BeginPlay();
+    USpatialNetDriver* NetDriver = Cast<USpatialNetDriver>(GetWorld()->GetNetDriver());
+    if (NetDriver == nullptr)
+    {
+        return;
+    }
+    WorkerType = NetDriver->IsServer() ? TEXT("Server") : TEXT("Client");
+    WorkerId = NetDriver->Connection->GetWorkerId();
+    MetricsPrefix = FString::Printf(TEXT("worker_data,worker=%s,project=%s,deployment=%s,type=%s"), *WorkerId, *ProjectName,
+                                    *DeploymentName, *WorkerType);
+}
+void UMetricsExport::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
+{
+    Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
+    FramesSinceLastFpsWrite++;
+    const int64 Now = FDateTime::Now().ToUnixTimestamp();
+    const int64 TimeSinceLastUpdate = Now - LastUpdateSendTime;
+    if (TimeSinceLastUpdate > InfluxMetricsSendGapSecs)
+    {
+        const uint32 Fps = FramesSinceLastFpsWrite / (Now - LastUpdateSendTime);
+        PushMetric(TEXT("fps"), Fps, {});
+        FlushMetrics();
+        LastUpdateSendTime = Now;
+        FramesSinceLastFpsWrite = 0;
+    }
+}
+void UMetricsExport::PushMetric(const FString& Field, float Value, const TMap<FString, FString>& Tags)
+{
+    MetricsToFlush.Emplace(MetricData{ Field, Value, Tags });
+}
+void UMetricsExport::FlushMetrics()
+{
+    const auto EpochDiff = std::chrono::system_clock::now().time_since_epoch();
+    FString Timestamp = FString::Printf(TEXT("%lld"), std::chrono::duration_cast<std::chrono::nanoseconds>(EpochDiff).count());
+    for (const auto& Metric : MetricsToFlush)
+    {
+        FString Lines = MetricsPrefix;
+        for (const auto& Tag : Metric.Tags)
+        {
+            Lines.Append(FString::Printf(TEXT(",%s=%s"), *Tag.Key, *Tag.Value));
+        }
+        Lines.Append(TEXT(" "));
+        Lines.Append(FString::Printf(TEXT("%s=%f"), *Metric.MetricName, Metric.MetricValue));
+        Lines.Append(TEXT(" "));
+        Lines.Append(Timestamp);
+        ExportMetricOverHttp(Lines);
+    }
+    MetricsToFlush.Reset();
+}
+void UMetricsExport::ExportMetricOverHttp(const FString& Lines)
+{
+    TSharedRef<IHttpRequest, ESPMode::ThreadSafe> HttpRequest = FHttpModule::Get().CreateRequest();
+    if (bPrintInfluxMetricsToLog)
+    {
+        UE_LOG(LogTemp, Log, TEXT("Posting %s to %s"), *Lines, *InfluxUrl);
+        HttpRequest->OnProcessRequestComplete().BindUObject(this, &UMetricsExport::OnResponseReceived);
+    }
+    HttpRequest->SetURL(InfluxUrl);
+    HttpRequest->SetVerb(TEXT("POST"));
+    HttpRequest->SetHeader(TEXT("Authorization"), *FString::Printf(TEXT("Token %s"), *InfluxToken));
+    HttpRequest->SetHeader(TEXT("Content-Type"), TEXT("application/x-www-form-urlencoded"));
+    HttpRequest->SetContentAsString(Lines);
+    HttpRequest->ProcessRequest();
+}
+void UMetricsExport::OnResponseReceived(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful)
+{
+    if (!bWasSuccessful)
+    {
+        UE_LOG(LogTemp, Warning, TEXT("Failed sending metrics. Code: %d. Message: %s"), Response->GetResponseCode(),
+               *Response->GetContentAsString());
+    }
+    else
+    {
+        UE_LOG(LogTemp, Verbose, TEXT("Metrics sent successfully! Code: %d. Message: %s"), Response->GetResponseCode(),
+               *Response->GetContentAsString());
+    }
+}

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/MetricsExport.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/MetricsExport.h
@@ -1,0 +1,46 @@
+#pragma once
+#include "Components/ActorComponent.h"
+#include "CoreMinimal.h"
+#include "HttpModule.h"
+#include "MetricsExport.generated.h"
+UCLASS(ClassGroup = (Custom), meta = (BlueprintSpawnableComponent))
+class UMetricsExport : public UActorComponent
+{
+	GENERATED_UCLASS_BODY()
+public:
+	virtual void BeginPlay() override;
+	virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
+	void PushMetric(const FString& Field, float Value, const TMap<FString, FString>& Tags);
+	UPROPERTY(EditAnywhere, config, Category = "Influx Metrics")
+	FString InfluxDbName = "mydb";
+	UPROPERTY(EditAnywhere, config, Category = "Influx Metrics")
+	FString InfluxHost = "localhost";
+	UPROPERTY(EditAnywhere, config, Category = "Influx Metrics")
+	FString InfluxPort = "8086";
+	UPROPERTY(EditAnywhere, config, Category = "Influx Metrics")
+	int64 InfluxMetricsSendGapSecs = 2;
+	UPROPERTY(EditAnywhere, config, Category = "Influx Metrics", BlueprintReadWrite)
+	bool bPrintInfluxMetricsToLog = false;
+private:
+	struct MetricData
+	{
+		FString MetricName;
+		float MetricValue;
+		TMap<FString, FString> Tags;
+	};
+	UFUNCTION(BlueprintCallable, Category = "Influx Metrics")
+	void ExportMetricOverHttp(const FString& Lines);
+	void FlushMetrics();
+	void OnResponseReceived(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
+	// Map of worker name to map of metric name mapped to value
+	TArray<MetricData> MetricsToFlush;
+	int64 LastUpdateSendTime = 0;
+	uint32 FramesSinceLastFpsWrite = 0;
+	FString InfluxUrl;
+	FString InfluxToken;
+	FString ProjectName;
+	FString DeploymentName;
+	FString WorkerType;
+	FString WorkerId;
+	FString MetricsPrefix;
+};

--- a/SpatialGDK/Source/SpatialGDK/SpatialGDK.Build.cs
+++ b/SpatialGDK/Source/SpatialGDK/SpatialGDK.Build.cs
@@ -31,6 +31,7 @@ public class SpatialGDK : ModuleRules
                 "CoreUObject",
                 "Engine",
                 "EngineSettings",
+                "Http",
                 "InputCore",
                 "OnlineSubsystemUtils",
                 "Projects",


### PR DESCRIPTION
First, follow instructions to run local Docker stack [here](https://github.com/improbable/LocalSpatialMetricsStack).

# Basic usage
Put the MetricsExport component on the GameMode/GameState/wherever you like.

After you press play in editor (with spatial networking enabled), in the Influx dashboard, you should see the FPS graph start tracking.

Adding a new metric in code involves:
1. Grabbing a reference to the MetricsExport ActorComponent
2. Call the `PushMetric(...)` function with a metric name, value, and any additional tags which can be used for visualization in grafana

```
	UMetricsExport* MetricsExport =
		Cast<UMetricsExport>(InPlayerController->GetWorld()->GetAuthGameMode()->GetComponentByClass(UMetricsExport::StaticClass()));
	if (MetricsExport != nullptr)
	{
		const TMap<FString, FString> PCTag =
			TMap<FString, FString>{ { TEXT("PlayerControllerEntity"),
									  FString::Printf(TEXT("%lld"), SpatialNetConnection->GetPlayerControllerEntityId()) } };
		MetricsExport->PushMetric(TEXT("interested_spatialized_actors"), ConnectionDriver->InterestedSpatializedActors.Num(), PCTag);
		MetricsExport->PushMetric(TEXT("noninterested_spatialized_actors"), ConnectionDriver->NoninterestedSpatializedActors.Num(), PCTag);
	}
```

# Running locally
All the defaults should work with the local docker stack implementation.

# Running in cloud deployments
You can create an influx cloud instance for free [on their website](https://www.influxdata.com/products/influxdb-cloud/). 

(I suggest testing this locally first through adding them to your editor startup arguments via VS/Rider) 
You can pass CLI arguments for an influx URL and token which allows you to send them to an influx cloud instance instead.
![image](https://user-images.githubusercontent.com/9222722/136553583-47c35fb8-9a55-4d68-af40-4948005fad32.png) 

