### PR TITLE
Add Only Authoritative Server Replication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add the ability for tests to run without being placed within a standalone map. See `ANoneCrossServerPossessionTest` for an example of this.
 - Unreal Engine version 4.27.0 is supported!
 - Users can now change the `Server Port` under `Editor Settings -> Level Editor -> Play -> Multiplayer Options`, or alternatively under `Advanced Settings` in the `Play` dropdown menu and launch local deployments that use the new `Server Port` value
+- Add Only Authoritative Server replication type. Variables marked with this type will only replicate to subsequent servers that gain authority of this actor. Can be accessed on standard `Replicated` variables by adding `COND_OnlyAuthServer` replication condition in `GetLifetimeReplicatedProps`.
 
 ### Bug fixes:
 - Fix `A functional test is already running error` that would sometimes occur when re-running multi-server functional tests.

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/ActorSystem.cpp
@@ -928,16 +928,20 @@ void ActorSystem::HandleIndividualAddComponent(const Worker_EntityId EntityId, c
 	// Non-owning client - data
 	// If initial-only disabled + initial-only to all (counter-intuitive, but initial only is sent as normal if disabled and not sent at all
 	// on dynamic components if enabled)
+	// Auth Server - data/owner-only/handover/auth-server-only
 	const bool bIsServer = NetDriver->IsServer();
 	const bool bIsAuthClient = NetDriver->HasClientAuthority(EntityId);
 	const bool bInitialOnlyExpected = !GetDefault<USpatialGDKSettings>()->bEnableInitialOnlyReplicationCondition;
+	const bool bIsAuthServer = bIsServer && NetDriver->HasServerAuthority(EntityId);
+
 
 	Worker_ComponentId ComponentFilter[SCHEMA_Count];
 	ComponentFilter[SCHEMA_Data] = true;
 	ComponentFilter[SCHEMA_OwnerOnly] = bIsServer || bIsAuthClient;
 	ComponentFilter[SCHEMA_ServerOnly] = bIsServer;
 	ComponentFilter[SCHEMA_InitialOnly] = bInitialOnlyExpected;
-	static_assert(SCHEMA_Count == 4, "Unexpected number of Schema type components, please check the enclosing function is still correct.");
+	ComponentFilter[SCHEMA_AuthServerOnly] = bIsAuthServer;
+	static_assert(SCHEMA_Count == 5, "Unexpected number of Schema type components, please check the enclosing function is still correct.");
 
 	bool bComponentsComplete = true;
 	for (int i = 0; i < SCHEMA_Count; ++i)

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/ComponentFactory.cpp
@@ -296,7 +296,7 @@ TArray<FWorkerComponentData> ComponentFactory::CreateComponentDatas(UObject* Obj
 {
 	TArray<FWorkerComponentData> ComponentDatas;
 
-	static_assert(SCHEMA_Count == 4, "Unexpected number of Schema type components, please check the enclosing function is still correct.");
+	static_assert(SCHEMA_Count == 5, "Unexpected number of Schema type components, please check the enclosing function is still correct.");
 
 	if (Info.SchemaComponents[SCHEMA_Data] != SpatialConstants::INVALID_COMPONENT_ID)
 	{
@@ -313,6 +313,11 @@ TArray<FWorkerComponentData> ComponentFactory::CreateComponentDatas(UObject* Obj
 	{
 		ComponentDatas.Add(
 			CreateComponentData(Info.SchemaComponents[SCHEMA_ServerOnly], Object, RepChangeState, SCHEMA_ServerOnly, OutBytesWritten));
+	}
+	if (Info.SchemaComponents[SCHEMA_AuthServerOnly] != SpatialConstants::INVALID_COMPONENT_ID)
+	{
+		ComponentDatas.Add(CreateComponentData(Info.SchemaComponents[SCHEMA_AuthServerOnly], Object, RepChangeState, SCHEMA_AuthServerOnly,
+											   OutBytesWritten));
 	}
 
 	if (Info.SchemaComponents[SCHEMA_InitialOnly] != SpatialConstants::INVALID_COMPONENT_ID)
@@ -368,7 +373,7 @@ TArray<FWorkerComponentUpdate> ComponentFactory::CreateComponentUpdates(UObject*
 {
 	TArray<FWorkerComponentUpdate> ComponentUpdates;
 
-	static_assert(SCHEMA_Count == 4, "Unexpected number of Schema type components, please check the enclosing function is still correct.");
+	static_assert(SCHEMA_Count == 5, "Unexpected number of Schema type components, please check the enclosing function is still correct.");
 
 	if (RepChangeState)
 	{
@@ -401,6 +406,18 @@ TArray<FWorkerComponentUpdate> ComponentFactory::CreateComponentUpdates(UObject*
 			uint32 BytesWritten = 0;
 			FWorkerComponentUpdate HandoverUpdate =
 				CreateComponentUpdate(Info.SchemaComponents[SCHEMA_ServerOnly], Object, *RepChangeState, SCHEMA_ServerOnly, BytesWritten);
+			if (BytesWritten > 0)
+			{
+				ComponentUpdates.Add(HandoverUpdate);
+				OutBytesWritten += BytesWritten;
+			}
+		}
+
+		if (Info.SchemaComponents[SCHEMA_AuthServerOnly] != SpatialConstants::INVALID_COMPONENT_ID)
+		{
+			uint32 BytesWritten = 0;
+			FWorkerComponentUpdate HandoverUpdate = CreateComponentUpdate(Info.SchemaComponents[SCHEMA_AuthServerOnly], Object,
+																		  *RepChangeState, SCHEMA_AuthServerOnly, BytesWritten);
 			if (BytesWritten > 0)
 			{
 				ComponentUpdates.Add(HandoverUpdate);

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -105,6 +105,7 @@ SchemaResultType InterestFactory::CreateServerAuthInterestResultType()
 	SchemaResultType ServerAuthResultType{};
 	// Just the components that we won't have already checked out through authority
 	ServerAuthResultType.ComponentIds.Append(SpatialConstants::REQUIRED_COMPONENTS_FOR_AUTH_SERVER_INTEREST);
+	ServerAuthResultType.ComponentSetsIds.Push(SpatialConstants::AUTH_SERVER_ONLY_COMPONENT_SET_ID);
 	return ServerAuthResultType;
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialClassInfoManager.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialClassInfoManager.h
@@ -25,7 +25,7 @@ FORCEINLINE void ForAllSchemaComponentTypes(TFunction<void(ESchemaComponentType)
 
 FORCEINLINE ESchemaComponentType GetGroupFromCondition(ELifetimeCondition Condition)
 {
-	static_assert(SCHEMA_Count == 4,
+	static_assert(SCHEMA_Count == 5,
 				  "Unexpected number of Schema type components, please make sure GetGroupFromCondition is still correct.");
 
 	switch (Condition)
@@ -38,6 +38,8 @@ FORCEINLINE ESchemaComponentType GetGroupFromCondition(ELifetimeCondition Condit
 		return SCHEMA_InitialOnly;
 	case COND_ServerOnly:
 		return SCHEMA_ServerOnly;
+	case COND_AuthServerOnly:
+		return SCHEMA_AuthServerOnly;
 	default:
 		return SCHEMA_Data;
 	}

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialConditionMapFilter.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialConditionMapFilter.h
@@ -31,7 +31,7 @@ public:
 #endif
 
 		// Build a ConditionMap. This code is taken directly from FRepLayout::BuildConditionMapFromRepFlags
-		static_assert(COND_Max == 16, "We are expecting 16 rep conditions"); // Guard in case more are added.
+		static_assert(COND_Max == 17, "We are expecting 17 rep conditions"); // Guard in case more are added.
 		const bool bIsInitial = RepFlags.bNetInitial ? true : false;
 		const bool bIsOwner = RepFlags.bNetOwner ? true : false;
 		const bool bIsSimulated = RepFlags.bNetSimulated ? true : false;
@@ -59,6 +59,7 @@ public:
 		ConditionMap[COND_SkipReplay] = !bIsReplay;
 
 		ConditionMap[COND_ServerOnly] = !bIsClient;
+		ConditionMap[COND_AuthServerOnly] = true; // Runtime responsible for filtering.
 
 		ConditionMap[COND_Custom] = true;
 		ConditionMap[COND_Never] = false;

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.cxx
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.cxx
@@ -61,6 +61,7 @@ const FString OWNER_ONLY_COMPONENT_SET_NAME = TEXT("OwnerOnlyComponentSet");
 const FString SERVER_ONLY_COMPONENT_SET_NAME = TEXT("ServerOnlyComponentSet");
 const FString ROUTING_WORKER_COMPONENT_SET_NAME = TEXT("RoutingWorkerComponentSet");
 const FString INITIAL_ONLY_COMPONENT_SET_NAME = TEXT("InitialOnlyComponentSet");
+const FString AUTH_SERVER_ONLY_COMPONENT_SET_NAME = TEXT("AuthServerOnlyComponentSet");
 
 const PhysicalWorkerName TRANSLATOR_UNSET_PHYSICAL_NAME = FString("UnsetWorkerName");
 

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -38,6 +38,7 @@ enum ESchemaComponentType : int32
 	SCHEMA_OwnerOnly,
 	SCHEMA_ServerOnly,
 	SCHEMA_InitialOnly,
+	SCHEMA_AuthServerOnly,
 
 	SCHEMA_Count,
 
@@ -108,6 +109,7 @@ const Worker_ComponentSetId LB_DELEGATION_AUTH_COMPONENT_SET_ID = 9910;
 const Worker_ComponentSetId PARTITION_WORKER_AUTH_COMPONENT_SET_ID = 9911;
 const Worker_ComponentSetId PARTITION_METADATA_AUTH_COMPONENT_SET_ID = 9912;
 const Worker_ComponentSetId SKELETON_ENTITY_MANIFEST_AUTH_COMPONENT_SET_ID = 9913;
+const Worker_ComponentSetId AUTH_SERVER_ONLY_COMPONENT_SET_ID = 9914;
 
 extern const FString SERVER_AUTH_COMPONENT_SET_NAME;
 extern const FString CLIENT_AUTH_COMPONENT_SET_NAME;
@@ -116,6 +118,7 @@ extern const FString OWNER_ONLY_COMPONENT_SET_NAME;
 extern const FString SERVER_ONLY_COMPONENT_SET_NAME;
 extern const FString ROUTING_WORKER_COMPONENT_SET_NAME;
 extern const FString INITIAL_ONLY_COMPONENT_SET_NAME;
+extern const FString AUTH_SERVER_ONLY_COMPONENT_SET_NAME;
 
 const Worker_ComponentId NOT_STREAMED_COMPONENT_ID = 9986;
 const Worker_ComponentId DEBUG_METRICS_COMPONENT_ID = 9984;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/EngineVersionCheck.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/EngineVersionCheck.h
@@ -7,7 +7,7 @@
 // GDK Version to be updated with SPATIAL_ENGINE_VERSION
 // when breaking changes are made to the engine that requires
 // changes to the GDK to remain compatible
-#define SPATIAL_GDK_VERSION 42
+#define SPATIAL_GDK_VERSION 43
 
 // Check if GDK is compatible with the current version of Unreal Engine
 // SPATIAL_ENGINE_VERSION is incremented in engine when breaking changes

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/SchemaDatabase.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/SchemaDatabase.h
@@ -103,6 +103,7 @@ enum class ESchemaDatabaseVersion : uint8
 	FieldIDsAdded,
 	HandoverToServerOnlyChanged,
 	DoRepLifetimeActiveOverrideSupported,
+	AuthServerOnlyAdded,
 
 	// Add new versions here
 

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SchemaGenerator.cpp
@@ -22,9 +22,9 @@ namespace
 {
 ESchemaComponentType PropertyGroupToSchemaComponentType(EReplicatedPropertyGroup Group)
 {
-	static_assert(REP_Count == 4,
+	static_assert(REP_Count == 5,
 				  "Unexpected number of ReplicatedPropertyGroups, please make sure PropertyGroupToSchemaComponentType is still correct.");
-	static_assert(SCHEMA_Count == 4,
+	static_assert(SCHEMA_Count == 5,
 				  "Unexpected number of Schema component types, please make sure PropertyGroupToSchemaComponentType is still correct.");
 
 	switch (Group)
@@ -37,6 +37,8 @@ ESchemaComponentType PropertyGroupToSchemaComponentType(EReplicatedPropertyGroup
 		return SCHEMA_InitialOnly;
 	case REP_ServerOnly:
 		return SCHEMA_ServerOnly;
+	case REP_AuthServerOnly:
+		return SCHEMA_AuthServerOnly;
 	default:
 		checkNoEntry();
 		return SCHEMA_Invalid;
@@ -482,9 +484,9 @@ void GenerateSubobjectSchema(FComponentIdGenerator& IdGenerator, UClass* Class, 
 
 EReplicatedPropertyGroup SchemaComponentTypeToPropertyGroup(ESchemaComponentType SchemaType)
 {
-	static_assert(REP_Count == 4,
+	static_assert(REP_Count == 5,
 				  "Unexpected number of ReplicatedPropertyGroups, please make sure SchemaComponentTypeToPropertyGroup is still correct.");
-	static_assert(SCHEMA_Count == 4,
+	static_assert(SCHEMA_Count == 5,
 				  "Unexpected number of Schema component types, please make sure SchemaComponentTypeToPropertyGroup is still correct.");
 
 	switch (SchemaType)
@@ -497,6 +499,8 @@ EReplicatedPropertyGroup SchemaComponentTypeToPropertyGroup(ESchemaComponentType
 		return REP_InitialOnly;
 	case SCHEMA_ServerOnly:
 		return REP_ServerOnly;
+	case SCHEMA_AuthServerOnly:
+		return REP_AuthServerOnly;
 	default:
 		checkNoEntry();
 		return REP_MultiClient;

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/SpatialGDKEditorSchemaGenerator.cpp
@@ -492,7 +492,7 @@ TMap<Worker_ComponentId, FString> CreateComponentIdToClassPathMap()
 
 FString GetComponentSetNameBySchemaType(ESchemaComponentType SchemaType)
 {
-	static_assert(SCHEMA_Count == 4, "Unexpected number of Schema type components, please check the enclosing function is still correct.");
+	static_assert(SCHEMA_Count == 5, "Unexpected number of Schema type components, please check the enclosing function is still correct.");
 
 	switch (SchemaType)
 	{
@@ -504,6 +504,8 @@ FString GetComponentSetNameBySchemaType(ESchemaComponentType SchemaType)
 		return SpatialConstants::SERVER_ONLY_COMPONENT_SET_NAME;
 	case SCHEMA_InitialOnly:
 		return SpatialConstants::INITIAL_ONLY_COMPONENT_SET_NAME;
+	case SCHEMA_AuthServerOnly:
+		return SpatialConstants::AUTH_SERVER_ONLY_COMPONENT_SET_NAME;
 	default:
 		// For some reason these statements, if formatted cause a bug in VS where the lines reported by the compiler and debugger are wrong.
 		// clang-format off
@@ -515,7 +517,7 @@ FString GetComponentSetNameBySchemaType(ESchemaComponentType SchemaType)
 
 Worker_ComponentId GetComponentSetIdBySchemaType(ESchemaComponentType SchemaType)
 {
-	static_assert(SCHEMA_Count == 4, "Unexpected number of Schema type components, please check the enclosing function is still correct.");
+	static_assert(SCHEMA_Count == 5, "Unexpected number of Schema type components, please check the enclosing function is still correct.");
 
 	switch (SchemaType)
 	{
@@ -527,6 +529,8 @@ Worker_ComponentId GetComponentSetIdBySchemaType(ESchemaComponentType SchemaType
 		return SpatialConstants::HANDOVER_COMPONENT_SET_ID;
 	case SCHEMA_InitialOnly:
 		return SpatialConstants::INITIAL_ONLY_COMPONENT_SET_ID;
+	case SCHEMA_AuthServerOnly:
+		return SpatialConstants::AUTH_SERVER_ONLY_COMPONENT_SET_ID;
 	default:
 		// clang-format off
 		UE_LOG(LogSpatialGDKSchemaGenerator, Error, TEXT("Could not return component set ID. Schema component type was invalid: %d"), SchemaType);
@@ -832,7 +836,8 @@ void WriteComponentSetFiles(const USchemaDatabase* SchemaDatabase, FString Schem
 	WriteComponentSetBySchemaType(SchemaDatabase, SCHEMA_OwnerOnly, SchemaOutputPath);
 	WriteComponentSetBySchemaType(SchemaDatabase, SCHEMA_ServerOnly, SchemaOutputPath);
 	WriteComponentSetBySchemaType(SchemaDatabase, SCHEMA_InitialOnly, SchemaOutputPath);
-	static_assert(SCHEMA_Count == 4, "Unexpected number of Schema type components, please check the enclosing function is still correct.");
+	WriteComponentSetBySchemaType(SchemaDatabase, SCHEMA_AuthServerOnly, SchemaOutputPath);
+	static_assert(SCHEMA_Count == 5, "Unexpected number of Schema type components, please check the enclosing function is still correct.");
 }
 
 USchemaDatabase* InitialiseSchemaDatabase(const FString& PackagePath)

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/TypeStructure.cpp
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/TypeStructure.cpp
@@ -26,7 +26,7 @@ TArray<EReplicatedPropertyGroup> GetAllReplicatedPropertyGroups()
 
 FString GetReplicatedPropertyGroupName(EReplicatedPropertyGroup Group)
 {
-	static_assert(REP_Count == 4, "Unexpected number of ReplicatedPropertyGroups, please update this function.");
+	static_assert(REP_Count == 5, "Unexpected number of ReplicatedPropertyGroups, please update this function.");
 
 	switch (Group)
 	{
@@ -36,6 +36,8 @@ FString GetReplicatedPropertyGroupName(EReplicatedPropertyGroup Group)
 		return TEXT("InitialOnly");
 	case REP_ServerOnly:
 		return TEXT("ServerOnly");
+	case REP_AuthServerOnly:
+		return TEXT("AuthServerOnly");
 	default:
 		return TEXT("");
 	}
@@ -457,7 +459,7 @@ FUnrealFlatRepData GetFlatRepData(TSharedPtr<FUnrealType> TypeInfo)
 		if (PropertyInfo->ReplicationData.IsValid())
 		{
 			EReplicatedPropertyGroup Group = REP_MultiClient;
-			static_assert(REP_Count == 4,
+			static_assert(REP_Count == 5,
 						  "Unexpected number of ReplicatedPropertyGroups. Please make sure the GetFlatRepData function is still correct.");
 			switch (PropertyInfo->ReplicationData->Condition)
 			{
@@ -471,6 +473,9 @@ FUnrealFlatRepData GetFlatRepData(TSharedPtr<FUnrealType> TypeInfo)
 				break;
 			case COND_ServerOnly:
 				Group = REP_ServerOnly;
+				break;
+			case COND_AuthServerOnly:
+				Group = REP_AuthServerOnly;
 				break;
 			case COND_InitialOrOwner:
 				UE_LOG(LogSpatialGDKSchemaGenerator, Error,

--- a/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/TypeStructure.h
+++ b/SpatialGDK/Source/SpatialGDKEditor/Private/SchemaGenerator/TypeStructure.h
@@ -69,6 +69,7 @@ enum EReplicatedPropertyGroup
 	REP_SingleClient,
 	REP_InitialOnly,
 	REP_ServerOnly,
+	REP_AuthServerOnly,
 
 	// Iteration helpers
 	REP_Count,

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestReplicationConditions/SpatialTestReplicationConditions.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestReplicationConditions/SpatialTestReplicationConditions.cpp
@@ -42,7 +42,7 @@ ASpatialTestReplicationConditions::ASpatialTestReplicationConditions()
 {
 	Author = "Mike";
 	Description = TEXT("Test Unreal Replication Conditions in a MultiServer Context");
-	static_assert(COND_Max == 16, TEXT("New replication condition added - add more tests!"));
+	static_assert(COND_Max == 17, TEXT("New replication condition added, Expected 17 - add more tests!"));
 }
 
 void ASpatialTestReplicationConditions::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
@@ -83,6 +83,7 @@ void ASpatialTestReplicationConditions::PrepareTest()
 		{
 			const bool bWrite = false;
 			bool bCondIgnore[COND_Max]{};
+			bCondIgnore[COND_AuthServerOnly] = true;
 			ProcessCommonActorProperties(bWrite, bCondIgnore);
 		}
 
@@ -159,6 +160,7 @@ void ASpatialTestReplicationConditions::PrepareTest()
 			bCondIgnore[COND_AutonomousOnly] = true;
 			bCondIgnore[COND_SkipOwner] = true;
 			bCondIgnore[COND_ServerOnly] = true;
+			bCondIgnore[COND_AuthServerOnly] = true;
 			ProcessCommonActorProperties(bWrite, bCondIgnore);
 		}
 
@@ -239,6 +241,7 @@ void ASpatialTestReplicationConditions::PrepareTest()
 			bCondIgnore[COND_AutonomousOnly] = true;
 			bCondIgnore[COND_ReplayOrOwner] = true;
 			bCondIgnore[COND_ServerOnly] = true;
+			bCondIgnore[COND_AuthServerOnly] = true;
 			ProcessCommonActorProperties(bWrite, bCondIgnore);
 		}
 
@@ -480,6 +483,7 @@ void ASpatialTestReplicationConditions::ProcessCommonActorProperties(bool bWrite
 	WrappedAction(TestActor_Common->CondSimulatedOrPhysicsNoReplay_Var, 130, COND_SimulatedOrPhysicsNoReplay);
 	WrappedAction(TestActor_Common->CondSkipReplay_Var, 140, COND_SkipReplay);
 	WrappedAction(TestActor_Common->CondServerOnly_Var, 150, COND_ServerOnly);
+	WrappedAction(TestActor_Common->CondAuthServerOnly_Var, 160, COND_AuthServerOnly);
 
 	WrappedAction(TestActor_Common->StaticComponent->CondNone_Var, 210, COND_None, StaticCompText);
 	WrappedAction(TestActor_Common->StaticComponent->CondOwnerOnly_Var, 230, COND_OwnerOnly, StaticCompText);
@@ -493,6 +497,7 @@ void ASpatialTestReplicationConditions::ProcessCommonActorProperties(bool bWrite
 				  StaticCompText);
 	WrappedAction(TestActor_Common->StaticComponent->CondSkipReplay_Var, 340, COND_SkipReplay, StaticCompText);
 	WrappedAction(TestActor_Common->StaticComponent->CondServerOnly_Var, 350, COND_ServerOnly, StaticCompText);
+	WrappedAction(TestActor_Common->StaticComponent->CondAuthServerOnly_Var, 360, COND_AuthServerOnly, StaticCompText);
 
 	WrappedAction(TestActor_Common->DynamicComponent->CondNone_Var, 410, COND_None, DynamicCompText);
 	WrappedAction(TestActor_Common->DynamicComponent->CondOwnerOnly_Var, 430, COND_OwnerOnly, DynamicCompText);
@@ -506,6 +511,7 @@ void ASpatialTestReplicationConditions::ProcessCommonActorProperties(bool bWrite
 				  DynamicCompText);
 	WrappedAction(TestActor_Common->DynamicComponent->CondSkipReplay_Var, 540, COND_SkipReplay, DynamicCompText);
 	WrappedAction(TestActor_Common->DynamicComponent->CondServerOnly_Var, 550, COND_ServerOnly, DynamicCompText);
+	WrappedAction(TestActor_Common->DynamicComponent->CondAuthServerOnly_Var, 550, COND_AuthServerOnly, DynamicCompText);
 }
 
 void ASpatialTestReplicationConditions::ProcessCustomActorProperties(ATestReplicationConditionsActor_Custom* Actor, const bool bWrite,

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestReplicationConditions/TestReplicationConditionsActor.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestReplicationConditions/TestReplicationConditionsActor.cpp
@@ -56,6 +56,7 @@ void UTestReplicationConditionsComponent_Common::GetLifetimeReplicatedProps(TArr
 
 	// Our added conditions
 	DOREPLIFETIME_CONDITION(ThisClass, CondServerOnly_Var, COND_ServerOnly);
+	DOREPLIFETIME_CONDITION(ThisClass, CondAuthServerOnly_Var, COND_AuthServerOnly);
 }
 
 ATestReplicationConditionsActor_Common::ATestReplicationConditionsActor_Common()
@@ -87,6 +88,7 @@ void ATestReplicationConditionsActor_Common::GetLifetimeReplicatedProps(TArray<F
 
 	// Our added conditions
 	DOREPLIFETIME_CONDITION(ThisClass, CondServerOnly_Var, COND_ServerOnly);
+	DOREPLIFETIME_CONDITION(ThisClass, CondAuthServerOnly_Var, COND_AuthServerOnly);
 
 	DOREPLIFETIME(ThisClass, StaticComponent);
 	DOREPLIFETIME(ThisClass, DynamicComponent);

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestReplicationConditions/TestReplicationConditionsActor.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestReplicationConditions/TestReplicationConditionsActor.h
@@ -82,6 +82,9 @@ public:
 
 	UPROPERTY(Replicated)
 	int32 CondServerOnly_Var;
+
+	UPROPERTY(Replicated)
+	int32 CondAuthServerOnly_Var;
 };
 
 /**
@@ -132,6 +135,9 @@ public:
 
 	UPROPERTY(Replicated)
 	int32 CondServerOnly_Var;
+
+	UPROPERTY(Replicated)
+	int32 CondAuthServerOnly_Var;
 
 	UPROPERTY(Replicated)
 	UTestReplicationConditionsComponent_Common* StaticComponent;

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SchemaGenObjectStub.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SchemaGenObjectStub.cpp
@@ -115,3 +115,15 @@ void ASpatialTypeActorWithInitialOnly::GetLifetimeReplicatedProps(TArray<FLifeti
 
 	DOREPLIFETIME_CONDITION(ASpatialTypeActorWithInitialOnly, InitialOnlyProperty, COND_InitialOnly);
 }
+
+ASpatialTypeActorWithOnlyAuthServer::ASpatialTypeActorWithOnlyAuthServer(const FObjectInitializer& ObjectInitializer)
+	: Super(ObjectInitializer)
+{
+}
+
+void ASpatialTypeActorWithOnlyAuthServer::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+
+	DOREPLIFETIME_CONDITION(ASpatialTypeActorWithOnlyAuthServer, AuthServerOnlyProperty, COND_AuthServerOnly);
+}

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SchemaGenObjectStub.h
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SchemaGenObjectStub.h
@@ -166,3 +166,12 @@ class ASpatialTypeActorWithInitialOnly : public AActor
 	UPROPERTY(Replicated)
 	float InitialOnlyProperty;
 };
+
+UCLASS(SpatialType)
+class ASpatialTypeActorWithOnlyAuthServer : public AActor
+{
+	GENERATED_UCLASS_BODY()
+
+	UPROPERTY(Replicated)
+	float AuthServerOnlyProperty;
+};

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
@@ -106,7 +106,7 @@ ComponentNamesAndIds ParseAvailableNamesAndIdsFromSchemaFile(const TArray<FStrin
 
 FString ComponentTypeToString(ESchemaComponentType Type)
 {
-	static_assert(SCHEMA_Count == 4, "Unexpected number of Schema type components, please check ComponentTypeToString is still correct.");
+	static_assert(SCHEMA_Count == 5, "Unexpected number of Schema type components, please check ComponentTypeToString is still correct.");
 
 	switch (Type)
 	{
@@ -118,6 +118,8 @@ FString ComponentTypeToString(ESchemaComponentType Type)
 		return TEXT("ServerOnly");
 	case SCHEMA_InitialOnly:
 		return TEXT("InitialOnly");
+	case SCHEMA_AuthServerOnly:
+		return TEXT("AuthServerOnly");
 	default:
 		return TEXT("");
 	}
@@ -1084,7 +1086,8 @@ SCHEMA_GENERATOR_TEST(GIVEN_actor_class_WHEN_generating_schema_THEN_expected_com
 	SchemaTestFixture Fixture;
 
 	TSet<UClass*> Classes = { ASpatialTypeActor::StaticClass(), USchemaGenObjectStubHandOver::StaticClass(),
-							  ASpatialTypeActorWithOwnerOnly::StaticClass(), ASpatialTypeActorWithInitialOnly::StaticClass() };
+							  ASpatialTypeActorWithOwnerOnly::StaticClass(), ASpatialTypeActorWithInitialOnly::StaticClass(),
+							  ASpatialTypeActorWithOnlyAuthServer::StaticClass() };
 
 	FString SchemaFolder = FPaths::Combine(SchemaOutputFolder, TEXT("schema"));
 	FString UnrealSchemaFolder = FPaths::Combine(SchemaFolder, TEXT("unreal"));
@@ -1116,7 +1119,7 @@ SCHEMA_GENERATOR_TEST(GIVEN_actor_class_WHEN_generating_schema_THEN_expected_com
 																		SchemaDatabase->ComponentIdToFieldIdsIndex,
 																		SchemaDatabase->FieldIdsArray, SchemaDatabase->ListIdsArray));
 
-	TestTrue("Expected number of component set", SchemaDatabase->ComponentSetIdToComponentIds.Num() == 14);
+	TestTrue("Expected number of component set", SchemaDatabase->ComponentSetIdToComponentIds.Num() == 15);
 
 	TestTrue("Found spatial well known components",
 			 SchemaDatabase->ComponentSetIdToComponentIds.Contains(SpatialConstants::SPATIALOS_WELLKNOWN_COMPONENTSET_ID));
@@ -1171,7 +1174,8 @@ SCHEMA_GENERATOR_TEST(GIVEN_actor_class_WHEN_generating_schema_THEN_expected_com
 		}
 
 		uint32 ServerAuthSets[] = { SpatialConstants::DATA_COMPONENT_SET_ID, SpatialConstants::OWNER_ONLY_COMPONENT_SET_ID,
-									SpatialConstants::HANDOVER_COMPONENT_SET_ID, SpatialConstants::INITIAL_ONLY_COMPONENT_SET_ID };
+									SpatialConstants::HANDOVER_COMPONENT_SET_ID, SpatialConstants::INITIAL_ONLY_COMPONENT_SET_ID,
+									SpatialConstants::AUTH_SERVER_ONLY_COMPONENT_SET_ID };
 
 		for (uint32 ComponentType = SCHEMA_Begin; ComponentType < SCHEMA_Count; ++ComponentType)
 		{
@@ -1181,6 +1185,8 @@ SCHEMA_GENERATOR_TEST(GIVEN_actor_class_WHEN_generating_schema_THEN_expected_com
 			{
 				return false;
 			}
+
+
 			// We should have a class for each type of set
 			TestTrue("Set is not empty", DataComponents->ComponentIDs.Num() > 0);
 


### PR DESCRIPTION
#### Description
Added an auth server only replication type and updated labeled
applicable areas of the GDK.

Engine 4.26 change: https://github.com/improbableio/UnrealEngine/pull/1061
Engine 4.27 change: https://github.com/improbableio/UnrealEngine/pull/1058

#### Tests
How did you test these changes prior to submitting this pull request? In customer's codebase.
What automated tests are included in this PR?
updated SpatialGDKSchemaGeneratorTest

#### Reminders (IMPORTANT)
If your change relies on a breaking engine change:
* Increment `SPATIAL_ENGINE_VERSION` in `Engine\Source\Runtime\Launch\Resources\SpatialVersion.h` (in the engine fork) as well as `SPATIAL_GDK_VERSION` in `SpatialGDK\Source\SpatialGDK\Public\Utils\EngineVersionCheck.h`. This helps others by providing a more helpful message during compilation to make sure the GDK and the Engine are up to date.

If your change updates `Setup.bat`, `Setup.sh`, core SDK version, any C# tools in `SpatialGDK\Build\Programs\Improbable.Unreal.Scripts`, or hand-written schema in `SpatialGDK\Extras\schema`:
* Increment the number in `RequireSetup`. This will automatically run `Setup.bat` or `Setup.sh` when the GDK is next pulled.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
