### PR TITLE
Fix crash when trying to replicate empty subobject

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -429,18 +429,21 @@ FRepChangeState USpatialActorChannel::CreateInitialRepChangeState(TWeakObjectPtr
 	for (uint16 CmdIdx = 0; CmdIdx < CmdCount; ++CmdIdx)
 	{
 		const FRepLayoutCmd& Cmd = Replicator.RepLayout->Cmds[CmdIdx];
-		const FRepChangedParent& Parent = Replicator.RepState->GetSendingRepState()->RepChangedPropertyTracker->Parents[Cmd.ParentIndex];
 
-		// HACK: Need special case here because the gdk relies on the whole of the RepMovement struct being replicated to the client to
-		// decide whether to replicate physics. see: ComponentReader::ApplySchemaObject
-
-		// UNR-5843 TODO: fix this so we no longer need this special handling, for instance by replicating bRepPhysics as a separate always
-		// replicated field.
-		const bool bRepActorMovement = Cmd.Type == ERepLayoutCmdType::RepMovement && Actor->GetReplicatedMovement().bRepPhysics;
-
-		if (!Parent.Active && !bRepActorMovement)
+		if (Cmd.Type != ERepLayoutCmdType::Return)
 		{
-			continue;
+			// HACK: Need special case here because the gdk relies on the whole of the RepMovement struct being replicated to the client to
+			// decide whether to replicate physics. see: ComponentReader::ApplySchemaObject
+
+			// UNR-5843 TODO: fix this so we no longer need this special handling, for instance by replicating bRepPhysics as a separate
+			// always replicated field.
+			const FRepChangedParent& Parent =
+				Replicator.RepState->GetSendingRepState()->RepChangedPropertyTracker->Parents[Cmd.ParentIndex];
+			const bool bRepActorMovement = Cmd.Type == ERepLayoutCmdType::RepMovement && Actor->GetReplicatedMovement().bRepPhysics;
+			if (!Parent.Active && !bRepActorMovement)
+			{
+				continue;
+			}
 		}
 
 		InitialRepChanged.Add(Cmd.RelativeHandle);

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -437,12 +437,15 @@ FRepChangeState USpatialActorChannel::CreateInitialRepChangeState(TWeakObjectPtr
 
 			// UNR-5843 TODO: fix this so we no longer need this special handling, for instance by replicating bRepPhysics as a separate
 			// always replicated field.
-			const FRepChangedParent& Parent =
-				Replicator.RepState->GetSendingRepState()->RepChangedPropertyTracker->Parents[Cmd.ParentIndex];
-			const bool bRepActorMovement = Cmd.Type == ERepLayoutCmdType::RepMovement && Actor->GetReplicatedMovement().bRepPhysics;
-			if (!Parent.Active && !bRepActorMovement)
+			if (ensure(Replicator.RepState->GetSendingRepState()->RepChangedPropertyTracker->Parents.IsValidIndex(Cmd.ParentIndex)))
 			{
-				continue;
+				const FRepChangedParent& Parent =
+					Replicator.RepState->GetSendingRepState()->RepChangedPropertyTracker->Parents[Cmd.ParentIndex];
+				const bool bRepActorMovement = Cmd.Type == ERepLayoutCmdType::RepMovement && Actor->GetReplicatedMovement().bRepPhysics;
+				if (!Parent.Active && !bRepActorMovement)
+				{
+					continue;
+				}
 			}
 		}
 


### PR DESCRIPTION
#### Description
When replicating an empty subobject (such as a simulated task in the test gym where this crash was found, https://improbableio.atlassian.net/browse/UNR-5971), the `Cmds` array in `RepLayout` will only have one element, which is the return command. The previous logic would try to check the `Parent` command, but the `Parents` array would actually be empty in that case.
As far as I could tell, this would be the only case where the `Parents` array could be empty, so we can still assume that `Cmd.ParentIndex` is a valid index into the array as long as it's not the return command.

Also, this might fix another edge case where previously the RepMovement check would skip the return command if the first element in the `Parents` array was inactive (haven't actually tested this, but I'm assuming this would happen if the first replicated property had the conditional replication that was disabled?).

#### Release note
Not needed, the crash was introduced after the last release.

#### Tests
Simulated GameplayTask gym doesn't crash (and produces expected results).

#### Primary reviewers
@simonsarginson @joshuahuburn 
