### PR TITLE
Add usi support to strategy worker

### DIFF
--- a/RequireSetup
+++ b/RequireSetup
@@ -1,4 +1,4 @@
 Increment the below number whenever it is required to run Setup.bat or Setup.sh as part of a new commit.
 Our git hooks will detect this file has been updated and automatically run Setup.bat on pull.
 
-98
+99

--- a/SpatialGDK/Extras/core-sdk.version
+++ b/SpatialGDK/Extras/core-sdk.version
@@ -1,3 +1,3 @@
-15.4.0-b942-aa3ea09-WORKER-SNAPSHOT
+15.4.0-b1125-60bf4dd-WORKER-SNAPSHOT
 // If changing version, update SpatialGDK/Source/SpatialGDK/Public/Utils/WorkerVersionCheck.h too
 // Also check /SpatialGDK/Extras/worker-sd-upgrade.md

--- a/SpatialGDK/Extras/schema/skeleton_entity.schema
+++ b/SpatialGDK/Extras/schema/skeleton_entity.schema
@@ -8,6 +8,10 @@ component SkeletonEntityManifest {
     bool acked_manifest = 3;
 }
 
+component SkeletonEntityManifestGSMTag {
+	id = 2018;
+}
+
 component_set SkeletonEntityAuthComponentSet {
   id = 9913;
   components = [
@@ -15,3 +19,9 @@ component_set SkeletonEntityAuthComponentSet {
   ];
 }
 
+component_set SkeletonEntityGSMAuthComponentSet {
+  id = 9915;
+  components = [
+	unreal.SkeletonEntityManifestGSMTag,
+  ];
+}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -316,7 +316,7 @@ bool USpatialActorChannel::CleanUp(const bool bForDestroy, EChannelCloseReason C
 {
 	ValidateChannelNotBroken();
 
-	if (NetDriver != nullptr)
+	if (NetDriver != nullptr && NetDriver->ActorSystem != nullptr)
 	{
 #if WITH_EDITOR
 		const bool bDeleteDynamicEntities = GetDefault<ULevelEditorPlaySettings>()->GetDeleteDynamicEntities();

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPackageMapClient.cpp
@@ -564,6 +564,11 @@ void FSpatialNetGUIDCache::RemoveEntityNetGUID(Worker_EntityId EntityId)
 	// Remove actor subobjects.
 	USpatialNetDriver* SpatialNetDriver = Cast<USpatialNetDriver>(Driver);
 
+	if (SpatialNetDriver->ActorSystem == nullptr)
+	{
+		return;
+	}
+
 	SpatialGDK::UnrealMetadata* UnrealMetadata = SpatialNetDriver->ActorSystem->GetUnrealMetadata(EntityId);
 
 	// If UnrealMetadata is nullptr (can happen if the editor is closing down) just return.

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SkeletonEntityManifestPublisher.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SkeletonEntityManifestPublisher.cpp
@@ -49,7 +49,8 @@ FManifestCreationHandle FSkeletonManifestPublisher::CreateManifestForPartition(I
 	{
 		AuthorityDelegation Authority;
 		Authority.Delegations.Emplace(SpatialConstants::SKELETON_ENTITY_MANIFEST_AUTH_COMPONENT_SET_ID, Partition);
-		Authority.Delegations.Emplace(SpatialConstants::SKELETON_ENTITY_MANIFEST_GSM_AUTH_COMPONENT_SET_ID, SpatialConstants::INITIAL_SNAPSHOT_PARTITION_ENTITY_ID);
+		Authority.Delegations.Emplace(SpatialConstants::SKELETON_ENTITY_MANIFEST_GSM_AUTH_COMPONENT_SET_ID,
+									  SpatialConstants::INITIAL_SNAPSHOT_PARTITION_ENTITY_ID);
 
 		SkeletonEntityManifestComponents.Emplace(
 			ComponentData(OwningComponentDataPtr(Authority.CreateComponentData().schema_type), AuthorityDelegation::ComponentId));
@@ -64,9 +65,11 @@ FManifestCreationHandle FSkeletonManifestPublisher::CreateManifestForPartition(I
 		ManifestQuery.ResultComponentIds.Append({ SpatialConstants::SKELETON_ENTITY_MANIFEST_COMPONENT_ID });
 
 		Interest ManifestGSMWorkerSelfInterest;
-		ManifestGSMWorkerSelfInterest.ComponentInterestMap.Emplace(SpatialConstants::SKELETON_ENTITY_MANIFEST_GSM_AUTH_COMPONENT_SET_ID, ComponentSetInterest{ { ManifestQuery } });
+		ManifestGSMWorkerSelfInterest.ComponentInterestMap.Emplace(SpatialConstants::SKELETON_ENTITY_MANIFEST_GSM_AUTH_COMPONENT_SET_ID,
+																   ComponentSetInterest{ { ManifestQuery } });
 
-		SkeletonEntityManifestComponents.Emplace(ComponentData(OwningComponentDataPtr(ManifestGSMWorkerSelfInterest.CreateComponentData().schema_type), Interest::ComponentId));
+		SkeletonEntityManifestComponents.Emplace(
+			ComponentData(OwningComponentDataPtr(ManifestGSMWorkerSelfInterest.CreateComponentData().schema_type), Interest::ComponentId));
 	}
 
 	// Required SpatialOS component.

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SkeletonEntityManifestPublisher.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SkeletonEntityManifestPublisher.cpp
@@ -49,23 +49,24 @@ FManifestCreationHandle FSkeletonManifestPublisher::CreateManifestForPartition(I
 	{
 		AuthorityDelegation Authority;
 		Authority.Delegations.Emplace(SpatialConstants::SKELETON_ENTITY_MANIFEST_AUTH_COMPONENT_SET_ID, Partition);
+		Authority.Delegations.Emplace(SpatialConstants::SKELETON_ENTITY_MANIFEST_GSM_AUTH_COMPONENT_SET_ID, SpatialConstants::INITIAL_SNAPSHOT_PARTITION_ENTITY_ID);
 
 		SkeletonEntityManifestComponents.Emplace(
 			ComponentData(OwningComponentDataPtr(Authority.CreateComponentData().schema_type), AuthorityDelegation::ComponentId));
 	}
 
 	{
+		// Give GSM worker interest in this entity
+		SkeletonEntityManifestComponents.Emplace(ComponentData(SpatialConstants::SKELETON_ENTITY_MANIFEST_GSM_TAG_COMPONENT_ID));
+
 		Query ManifestQuery;
 		ManifestQuery.Constraint.bSelfConstraint = true;
 		ManifestQuery.ResultComponentIds.Append({ SpatialConstants::SKELETON_ENTITY_MANIFEST_COMPONENT_ID });
 
-		// Give the server that's auth over the manifest interest in it.
-		Interest ManifestAuthWorkerSelfInterest;
-		ManifestAuthWorkerSelfInterest.ComponentInterestMap.Emplace(SpatialConstants::SKELETON_ENTITY_MANIFEST_AUTH_COMPONENT_SET_ID,
-																	ComponentSetInterest{ { ManifestQuery } });
+		Interest ManifestGSMWorkerSelfInterest;
+		ManifestGSMWorkerSelfInterest.ComponentInterestMap.Emplace(SpatialConstants::SKELETON_ENTITY_MANIFEST_GSM_AUTH_COMPONENT_SET_ID, ComponentSetInterest{ { ManifestQuery } });
 
-		SkeletonEntityManifestComponents.Emplace(
-			ComponentData(OwningComponentDataPtr(ManifestAuthWorkerSelfInterest.CreateComponentData().schema_type), Interest::ComponentId));
+		SkeletonEntityManifestComponents.Emplace(ComponentData(OwningComponentDataPtr(ManifestGSMWorkerSelfInterest.CreateComponentData().schema_type), Interest::ComponentId));
 	}
 
 	// Required SpatialOS component.

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStrategySystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStrategySystem.cpp
@@ -342,7 +342,7 @@ void FSpatialStrategySystem::UpdateStrategySystemInterest(ISpatialOSWorker& Conn
 	{
 		Query ServerQuery = {};
 		ServerQuery.ResultComponentIds = { SpatialConstants::STRATEGYWORKER_TAG_COMPONENT_ID };
-		for (const Worker_ComponentId& Component : UpdatesToConsider)
+		for (const Worker_ComponentId Component : UpdatesToConsider)
 		{
 			ServerQuery.ResultComponentIds.Add(Component);
 		}
@@ -354,7 +354,7 @@ void FSpatialStrategySystem::UpdateStrategySystemInterest(ISpatialOSWorker& Conn
 	{
 		Query ServerQuery = {};
 		ServerQuery.ResultComponentIds = { SpatialConstants::SERVER_WORKER_COMPONENT_ID };
-		for (const Worker_ComponentId& Component : ServerWorkerDataStorages.GetComponentsToWatch())
+		for (const Worker_ComponentId Component : ServerWorkerDataStorages.GetComponentsToWatch())
 		{
 			ServerQuery.ResultComponentIds.Add(Component);
 		}
@@ -399,13 +399,13 @@ void FSpatialStrategySystem::CreateUSIQuery(ISpatialOSWorker& Connection)
 		ChangeInterestQuery StrategyQuery;
 		StrategyQuery.TrueConstraint = true;
 		StrategyQuery.ResultComponentIds.Add(SpatialConstants::STRATEGYWORKER_TAG_COMPONENT_ID);
-		for (const Worker_ComponentId& Component : UpdatesToConsider)
+		for (const Worker_ComponentId Component : UpdatesToConsider)
 		{
 			StrategyQuery.ResultComponentIds.Add(Component);
 		}
 
 		StrategyQuery.ResultComponentIds.Add(SpatialConstants::SERVER_WORKER_COMPONENT_ID);
-		for (const Worker_ComponentId& Component : ServerWorkerDataStorages.GetComponentsToWatch())
+		for (const Worker_ComponentId Component : ServerWorkerDataStorages.GetComponentsToWatch())
 		{
 			StrategyQuery.ResultComponentIds.Add(Component);
 		}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStrategySystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStrategySystem.cpp
@@ -342,7 +342,7 @@ void FSpatialStrategySystem::UpdateStrategySystemInterest(ISpatialOSWorker& Conn
 	{
 		Query ServerQuery = {};
 		ServerQuery.ResultComponentIds = { SpatialConstants::STRATEGYWORKER_TAG_COMPONENT_ID };
-		for (const Worker_ComponentId& Component  : UpdatesToConsider)
+		for (const Worker_ComponentId& Component : UpdatesToConsider)
 		{
 			ServerQuery.ResultComponentIds.Add(Component);
 		}

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStrategySystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/SpatialStrategySystem.cpp
@@ -398,21 +398,21 @@ void FSpatialStrategySystem::CreateUSIQuery(ISpatialOSWorker& Connection)
 	{
 		ChangeInterestQuery StrategyQuery;
 		StrategyQuery.TrueConstraint = true;
-		StrategyQuery.Components.Add(SpatialConstants::STRATEGYWORKER_TAG_COMPONENT_ID);
+		StrategyQuery.ResultComponentIds.Add(SpatialConstants::STRATEGYWORKER_TAG_COMPONENT_ID);
 		for (const Worker_ComponentId& Component : UpdatesToConsider)
 		{
-			StrategyQuery.Components.Add(Component);
+			StrategyQuery.ResultComponentIds.Add(Component);
 		}
 
-		StrategyQuery.Components.Add(SpatialConstants::SERVER_WORKER_COMPONENT_ID);
+		StrategyQuery.ResultComponentIds.Add(SpatialConstants::SERVER_WORKER_COMPONENT_ID);
 		for (const Worker_ComponentId& Component : ServerWorkerDataStorages.GetComponentsToWatch())
 		{
-			StrategyQuery.Components.Add(Component);
+			StrategyQuery.ResultComponentIds.Add(Component);
 		}
 
-		StrategyQuery.Components.Add(SpatialConstants::WORKER_COMPONENT_ID);
-		StrategyQuery.Components.Add(SpatialConstants::PARTITION_ACK_COMPONENT_ID);
-		StrategyQuery.Components.Add(SpatialConstants::SKELETON_ENTITY_MANIFEST_COMPONENT_ID);
+		StrategyQuery.ResultComponentIds.Add(SpatialConstants::WORKER_COMPONENT_ID);
+		StrategyQuery.ResultComponentIds.Add(SpatialConstants::PARTITION_ACK_COMPONENT_ID);
+		StrategyQuery.ResultComponentIds.Add(SpatialConstants::SKELETON_ENTITY_MANIFEST_COMPONENT_ID);
 
 		Request.QueriesToAdd.Add(MoveTemp(StrategyQuery));
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/InterestManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/InterestManager.cpp
@@ -640,8 +640,8 @@ void FInterestManager::ComputeInterest(ISpatialOSWorker& Connection, const TArra
 				if (NumAdded > 0)
 				{
 					ChangeInterestQuery QueryAdd;
-					QueryAdd.Components = InterestF.GetServerNonAuthInterestResultType().ComponentIds;
-					QueryAdd.ComponentSets = InterestF.GetServerNonAuthInterestResultType().ComponentSetsIds;
+					QueryAdd.ResultComponentIds = InterestF.GetServerNonAuthInterestResultType().ComponentIds;
+					QueryAdd.ResultComponentSetIds = InterestF.GetServerNonAuthInterestResultType().ComponentSetsIds;
 					QueryAdd.Entities = MoveTemp(Added);
 					Request.QueriesToAdd.Add(MoveTemp(QueryAdd));
 				}
@@ -649,8 +649,8 @@ void FInterestManager::ComputeInterest(ISpatialOSWorker& Connection, const TArra
 				if (NumRemoved > 0)
 				{
 					ChangeInterestQuery QueryRemove;
-					QueryRemove.Components = InterestF.GetServerNonAuthInterestResultType().ComponentIds;
-					QueryRemove.ComponentSets = InterestF.GetServerNonAuthInterestResultType().ComponentSetsIds;
+					QueryRemove.ResultComponentIds = InterestF.GetServerNonAuthInterestResultType().ComponentIds;
+					QueryRemove.ResultComponentSetIds = InterestF.GetServerNonAuthInterestResultType().ComponentSetsIds;
 					QueryRemove.Entities = MoveTemp(Removed);
 					Request.QueriesToRemove.Add(MoveTemp(QueryRemove));
 				}

--- a/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/PartitionManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/LoadBalancing/PartitionManager.cpp
@@ -384,8 +384,8 @@ void FPartitionManager::Impl::FlushInterestUpdates(ISpatialOSWorker& Connection)
 				SnapshotQuery.Entities.Add(SpatialConstants::INITIAL_GLOBAL_STATE_MANAGER_ENTITY_ID);
 				SnapshotQuery.Entities.Add(SpatialConstants::INITIAL_SPAWNER_ENTITY_ID);
 				SnapshotQuery.Entities.Add(SpatialConstants::INITIAL_VIRTUAL_WORKER_TRANSLATOR_ENTITY_ID);
-				SnapshotQuery.Components = InterestF.GetServerNonAuthInterestResultType().ComponentIds;
-				SnapshotQuery.ComponentSets = InterestF.GetServerNonAuthInterestResultType().ComponentSetsIds;
+				SnapshotQuery.ResultComponentIds = InterestF.GetServerNonAuthInterestResultType().ComponentIds;
+				SnapshotQuery.ResultComponentSetIds = InterestF.GetServerNonAuthInterestResultType().ComponentSetsIds;
 				Request.QueriesToAdd.Add(SnapshotQuery);
 			}
 
@@ -393,15 +393,15 @@ void FPartitionManager::Impl::FlushInterestUpdates(ISpatialOSWorker& Connection)
 			{
 				ChangeInterestQuery PartitionQuery;
 				PartitionQuery.Entities.Append(PartitionView.GetCompleteEntities());
-				PartitionQuery.Components = InterestUpdate.PartitionMetaData;
-				PartitionQuery.Components.Add(SpatialConstants::PARTITION_ACK_COMPONENT_ID);
+				PartitionQuery.ResultComponentIds = InterestUpdate.PartitionMetaData;
+				PartitionQuery.ResultComponentIds.Add(SpatialConstants::PARTITION_ACK_COMPONENT_ID);
 				Request.QueriesToAdd.Add(MoveTemp(PartitionQuery));
 			}
 			if (SystemWorkersDispatcher.SubView.GetCompleteEntities().Num() > 0)
 			{
 				ChangeInterestQuery WorkerQuery;
 				WorkerQuery.Entities.Append(SystemWorkersDispatcher.SubView.GetCompleteEntities());
-				WorkerQuery.Components = { SpatialConstants::WORKER_COMPONENT_ID, SpatialConstants::SYSTEM_COMPONENT_ID };
+				WorkerQuery.ResultComponentIds = { SpatialConstants::WORKER_COMPONENT_ID, SpatialConstants::SYSTEM_COMPONENT_ID };
 				Request.QueriesToAdd.Add(MoveTemp(WorkerQuery));
 			}
 			if (WorkersDispatcher.SubView.GetCompleteEntities().Num() > 0)
@@ -412,8 +412,8 @@ void FPartitionManager::Impl::FlushInterestUpdates(ISpatialOSWorker& Connection)
 				{
 					UE_LOG(LogSpatialPartitionManager, Log, TEXT("Make worker %llu interested in %llu"), Request.SystemEntityId, Entity);
 				}
-				ServerWorkerQuery.Components = { SpatialConstants::SERVER_WORKER_COMPONENT_ID,
-												 SpatialConstants::GDK_KNOWN_ENTITY_TAG_COMPONENT_ID };
+				ServerWorkerQuery.ResultComponentIds = { SpatialConstants::SERVER_WORKER_COMPONENT_ID,
+														 SpatialConstants::GDK_KNOWN_ENTITY_TAG_COMPONENT_ID };
 				Request.QueriesToAdd.Add(MoveTemp(ServerWorkerQuery));
 			}
 			Request.SendRequest(Connection);
@@ -430,46 +430,46 @@ void FPartitionManager::Impl::FlushInterestUpdates(ISpatialOSWorker& Connection)
 			{
 				ChangeInterestQuery PartitionQuery;
 				PartitionQuery.Entities.Append(InterestUpdate.NewPartition);
-				PartitionQuery.Components = InterestUpdate.PartitionMetaData;
-				PartitionQuery.Components.Add(SpatialConstants::PARTITION_ACK_COMPONENT_ID);
+				PartitionQuery.ResultComponentIds = InterestUpdate.PartitionMetaData;
+				PartitionQuery.ResultComponentIds.Add(SpatialConstants::PARTITION_ACK_COMPONENT_ID);
 				Request.QueriesToAdd.Add(MoveTemp(PartitionQuery));
 			}
 			if (InterestUpdate.RemovedPartition.Num() > 0)
 			{
 				ChangeInterestQuery PartitionQuery;
 				PartitionQuery.Entities.Append(InterestUpdate.NewPartition);
-				PartitionQuery.Components = InterestUpdate.PartitionMetaData;
-				PartitionQuery.Components.Add(SpatialConstants::PARTITION_ACK_COMPONENT_ID);
+				PartitionQuery.ResultComponentIds = InterestUpdate.PartitionMetaData;
+				PartitionQuery.ResultComponentIds.Add(SpatialConstants::PARTITION_ACK_COMPONENT_ID);
 				Request.QueriesToRemove.Add(MoveTemp(PartitionQuery));
 			}
 			if (InterestUpdate.NewWorker.Num() > 0)
 			{
 				ChangeInterestQuery WorkerQuery;
 				WorkerQuery.Entities.Append(InterestUpdate.NewWorker);
-				WorkerQuery.Components = { SpatialConstants::WORKER_COMPONENT_ID, SpatialConstants::SYSTEM_COMPONENT_ID };
+				WorkerQuery.ResultComponentIds = { SpatialConstants::WORKER_COMPONENT_ID, SpatialConstants::SYSTEM_COMPONENT_ID };
 				Request.QueriesToAdd.Add(MoveTemp(WorkerQuery));
 			}
 			if (InterestUpdate.RemovedWorker.Num() > 0)
 			{
 				ChangeInterestQuery WorkerQuery;
 				WorkerQuery.Entities.Append(InterestUpdate.RemovedWorker);
-				WorkerQuery.Components = { SpatialConstants::WORKER_COMPONENT_ID, SpatialConstants::SYSTEM_COMPONENT_ID };
+				WorkerQuery.ResultComponentIds = { SpatialConstants::WORKER_COMPONENT_ID, SpatialConstants::SYSTEM_COMPONENT_ID };
 				Request.QueriesToRemove.Add(MoveTemp(WorkerQuery));
 			}
 			if (InterestUpdate.NewServerWorker.Num() > 0)
 			{
 				ChangeInterestQuery ServerWorkerQuery;
 				ServerWorkerQuery.Entities.Append(InterestUpdate.NewServerWorker);
-				ServerWorkerQuery.Components = { SpatialConstants::SERVER_WORKER_COMPONENT_ID,
-												 SpatialConstants::GDK_KNOWN_ENTITY_TAG_COMPONENT_ID };
+				ServerWorkerQuery.ResultComponentIds = { SpatialConstants::SERVER_WORKER_COMPONENT_ID,
+														 SpatialConstants::GDK_KNOWN_ENTITY_TAG_COMPONENT_ID };
 				Request.QueriesToAdd.Add(MoveTemp(ServerWorkerQuery));
 			}
 			if (InterestUpdate.RemovedServerWorker.Num() > 0)
 			{
 				ChangeInterestQuery ServerWorkerQuery;
 				ServerWorkerQuery.Entities.Append(InterestUpdate.RemovedServerWorker);
-				ServerWorkerQuery.Components = { SpatialConstants::SERVER_WORKER_COMPONENT_ID,
-												 SpatialConstants::GDK_KNOWN_ENTITY_TAG_COMPONENT_ID };
+				ServerWorkerQuery.ResultComponentIds = { SpatialConstants::SERVER_WORKER_COMPONENT_ID,
+														 SpatialConstants::GDK_KNOWN_ENTITY_TAG_COMPONENT_ID };
 				Request.QueriesToRemove.Add(MoveTemp(ServerWorkerQuery));
 			}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Schema/ChangeInterest.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Schema/ChangeInterest.cpp
@@ -94,6 +94,7 @@ Worker_CommandRequest ChangeInterestRequest::CreateRequest() const
 		Schema_Object* ResultTypeObject = Schema_AddObject(QueriesToAddObject, 1);
 
 		AddEntityListToSchema(QueriesToAddObject, 2, Query.Entities);
+		Schema_AddBool(QueriesToAddObject, 3, Query.TrueConstraint);
 		AddUint32ListToSchema(ResultTypeObject, 1, Query.Components);
 		AddUint32ListToSchema(ResultTypeObject, 2, Query.ComponentSets);
 	}
@@ -105,6 +106,7 @@ Worker_CommandRequest ChangeInterestRequest::CreateRequest() const
 		Schema_Object* ResultTypeObject = Schema_AddObject(QueriesToRemoveObject, 1);
 
 		AddEntityListToSchema(QueriesToRemoveObject, 2, Query.Entities);
+		Schema_AddBool(QueriesToRemoveObject, 3, Query.TrueConstraint);
 		AddUint32ListToSchema(ResultTypeObject, 1, Query.Components);
 		AddUint32ListToSchema(ResultTypeObject, 2, Query.ComponentSets);
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Schema/ChangeInterest.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Schema/ChangeInterest.cpp
@@ -28,12 +28,12 @@ void ChangeInterestQuery::DebugOutput(const FString& DiffType) const
 	});
 	UE_LOG(LogChangeInterest, Log, TEXT("Interest diff: %s %s"), *DiffType, *EntitiesString);
 
-	const FString ComponentsString = FString::JoinBy(Components, TEXT(" "), [](const Worker_ComponentId ComponentId) {
+	const FString ComponentsString = FString::JoinBy(ResultComponentIds, TEXT(" "), [](const Worker_ComponentId ComponentId) {
 		return FString::Printf(TEXT("%d"), ComponentId);
 	});
 	UE_LOG(LogChangeInterest, Log, TEXT("Interest diff: components %s"), *ComponentsString);
 
-	const FString ComponentSetsString = FString::JoinBy(ComponentSets, TEXT(" "), [](const Worker_ComponentSetId ComponentSetId) {
+	const FString ComponentSetsString = FString::JoinBy(ResultComponentSetIds, TEXT(" "), [](const Worker_ComponentSetId ComponentSetId) {
 		return FString::Printf(TEXT("%d"), ComponentSetId);
 	});
 	UE_LOG(LogChangeInterest, Log, TEXT("Interest diff: component sets %s"), *ComponentSetsString);
@@ -95,8 +95,8 @@ Worker_CommandRequest ChangeInterestRequest::CreateRequest() const
 
 		AddEntityListToSchema(QueriesToAddObject, 2, Query.Entities);
 		Schema_AddBool(QueriesToAddObject, 3, Query.TrueConstraint);
-		AddUint32ListToSchema(ResultTypeObject, 1, Query.Components);
-		AddUint32ListToSchema(ResultTypeObject, 2, Query.ComponentSets);
+		AddUint32ListToSchema(ResultTypeObject, 1, Query.ResultComponentIds);
+		AddUint32ListToSchema(ResultTypeObject, 2, Query.ResultComponentSetIds);
 	}
 
 	for (const ChangeInterestQuery& Query : QueriesToRemove)
@@ -107,8 +107,8 @@ Worker_CommandRequest ChangeInterestRequest::CreateRequest() const
 
 		AddEntityListToSchema(QueriesToRemoveObject, 2, Query.Entities);
 		Schema_AddBool(QueriesToRemoveObject, 3, Query.TrueConstraint);
-		AddUint32ListToSchema(ResultTypeObject, 1, Query.Components);
-		AddUint32ListToSchema(ResultTypeObject, 2, Query.ComponentSets);
+		AddUint32ListToSchema(ResultTypeObject, 1, Query.ResultComponentIds);
+		AddUint32ListToSchema(ResultTypeObject, 2, Query.ResultComponentSetIds);
 	}
 
 	Schema_AddBool(RequestObject, 3, bOverwrite);

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/InterestFactory.cpp
@@ -436,8 +436,8 @@ bool UnrealServerInterestFactory::CreateClientInterestDiff(APlayerController* Pl
 		if (Add.Num() > 0)
 		{
 			ChangeInterestQuery Query{};
-			Query.Components = ClientNonAuthInterestResultType.ComponentIds;
-			Query.ComponentSets = ClientNonAuthInterestResultType.ComponentSetsIds;
+			Query.ResultComponentIds = ClientNonAuthInterestResultType.ComponentIds;
+			Query.ResultComponentSetIds = ClientNonAuthInterestResultType.ComponentSetsIds;
 			Query.Entities = Add.Array();
 
 			ChangeInterestRequestData.QueriesToAdd.Emplace(Query);
@@ -446,8 +446,8 @@ bool UnrealServerInterestFactory::CreateClientInterestDiff(APlayerController* Pl
 		if (Remove.Num() > 0)
 		{
 			ChangeInterestQuery Query{};
-			Query.Components = ClientNonAuthInterestResultType.ComponentIds;
-			Query.ComponentSets = ClientNonAuthInterestResultType.ComponentSetsIds;
+			Query.ResultComponentIds = ClientNonAuthInterestResultType.ComponentIds;
+			Query.ResultComponentSetIds = ClientNonAuthInterestResultType.ComponentSetsIds;
 			Query.Entities = Remove.Array();
 
 			ChangeInterestRequestData.QueriesToRemove.Emplace(Query);

--- a/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialStrategySystem.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Interop/SpatialStrategySystem.h
@@ -82,5 +82,7 @@ private:
 
 	void UpdateStrategySystemInterest(ISpatialOSWorker& Connection);
 	bool bStrategySystemInterestDirty = false;
+
+	void CreateUSIQuery(ISpatialOSWorker& Connection);
 };
 } // namespace SpatialGDK

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/ChangeInterest.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/ChangeInterest.h
@@ -12,8 +12,8 @@ class ISpatialOSWorker;
 
 struct ChangeInterestQuery
 {
-	TArray<Worker_ComponentId> Components;
-	TArray<Worker_ComponentSetId> ComponentSets;
+	TArray<Worker_ComponentId> ResultComponentIds;
+	TArray<Worker_ComponentSetId> ResultComponentSetIds;
 	TArray<Worker_EntityId_Key> Entities;
 	bool TrueConstraint = false;
 

--- a/SpatialGDK/Source/SpatialGDK/Public/Schema/ChangeInterest.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Schema/ChangeInterest.h
@@ -15,6 +15,7 @@ struct ChangeInterestQuery
 	TArray<Worker_ComponentId> Components;
 	TArray<Worker_ComponentSetId> ComponentSets;
 	TArray<Worker_EntityId_Key> Entities;
+	bool TrueConstraint = false;
 
 	void DebugOutput(const FString& DiffType) const;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/SpatialConstants.h
@@ -110,6 +110,7 @@ const Worker_ComponentSetId PARTITION_WORKER_AUTH_COMPONENT_SET_ID = 9911;
 const Worker_ComponentSetId PARTITION_METADATA_AUTH_COMPONENT_SET_ID = 9912;
 const Worker_ComponentSetId SKELETON_ENTITY_MANIFEST_AUTH_COMPONENT_SET_ID = 9913;
 const Worker_ComponentSetId AUTH_SERVER_ONLY_COMPONENT_SET_ID = 9914;
+const Worker_ComponentSetId SKELETON_ENTITY_MANIFEST_GSM_AUTH_COMPONENT_SET_ID = 9915;
 
 extern const FString SERVER_AUTH_COMPONENT_SET_NAME;
 extern const FString CLIENT_AUTH_COMPONENT_SET_NAME;
@@ -173,8 +174,9 @@ const Worker_ComponentId SKELETON_ENTITY_POPULATION_AUTH_TAG_COMPONENT_ID = 2014
 const Worker_ComponentId SKELETON_ENTITY_POPULATION_FINISHED_TAG_COMPONENT_ID = 2015;
 const Worker_ComponentId WORKER_PARTITION_TAG_COMPONENT_ID = 2016;
 const Worker_ComponentId LOADBALANCER_PARTITION_TAG_COMPONENT_ID = 2017;
+const Worker_ComponentId SKELETON_ENTITY_MANIFEST_GSM_TAG_COMPONENT_ID = 2018;
 // Add component ids above here, this should always be last and be equal to the previous component id
-const Worker_ComponentId LAST_EC_COMPONENT_ID = 2017;
+const Worker_ComponentId LAST_EC_COMPONENT_ID = 2018;
 
 const Schema_FieldId DEPLOYMENT_MAP_MAP_URL_ID = 1;
 const Schema_FieldId DEPLOYMENT_MAP_ACCEPTING_PLAYERS_ID = 2;

--- a/SpatialGDK/Source/SpatialGDK/Public/Utils/WorkerVersionCheck.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/Utils/WorkerVersionCheck.h
@@ -4,7 +4,7 @@
 
 #include "improbable/c_worker.h"
 
-#define WORKER_SDK_VERSION_FULL_STR "15.4.0-b942-aa3ea09-WORKER-SNAPSHOT"
+#define WORKER_SDK_VERSION_FULL_STR "15.4.0-b1125-60bf4dd-WORKER-SNAPSHOT"
 
 constexpr bool StringsEqual(char const* A, char const* B)
 {

--- a/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
+++ b/SpatialGDK/Source/SpatialGDKTests/SpatialGDKEditor/SpatialGDKEditorSchemaGenerator/SpatialGDKEditorSchemaGeneratorTest.cpp
@@ -1119,7 +1119,7 @@ SCHEMA_GENERATOR_TEST(GIVEN_actor_class_WHEN_generating_schema_THEN_expected_com
 																		SchemaDatabase->ComponentIdToFieldIdsIndex,
 																		SchemaDatabase->FieldIdsArray, SchemaDatabase->ListIdsArray));
 
-	TestTrue("Expected number of component set", SchemaDatabase->ComponentSetIdToComponentIds.Num() == 15);
+	TestTrue("Expected number of component set", SchemaDatabase->ComponentSetIdToComponentIds.Num() == 16);
 
 	TestTrue("Found spatial well known components",
 			 SchemaDatabase->ComponentSetIdToComponentIds.Contains(SpatialConstants::SPATIALOS_WELLKNOWN_COMPONENTSET_ID));
@@ -1185,7 +1185,6 @@ SCHEMA_GENERATOR_TEST(GIVEN_actor_class_WHEN_generating_schema_THEN_expected_com
 			{
 				return false;
 			}
-
 
 			// We should have a class for each type of set
 			TestTrue("Set is not empty", DataComponents->ComponentIDs.Num() > 0);


### PR DESCRIPTION
#### Description
Add new "true constraint" on strategy worker to remove need for QBI.
Add self constraint on GSM worker to remove last QBI query. 

The GSM was previously getting interest in the `SKELETON_ENTITY_MANIFEST_COMPONENT_ID` entities via a component constraint on the GSM entity. This has been reworked to give the GSM worker authority over a new tag component we add to the skeleton entity manifest entities, and then uses self-interest to gain interest in the rest of the entity. 

I'll leave the QBI queries within the snapshot entities for now, until we fully shift to USI.
