### PR TITLE
Correct cond custom replication

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -441,9 +441,14 @@ FRepChangeState USpatialActorChannel::CreateInitialRepChangeState(TWeakObjectPtr
 			{
 				const FRepChangedParent& Parent =
 					Replicator.RepState->GetSendingRepState()->RepChangedPropertyTracker->Parents[Cmd.ParentIndex];
-				const bool bIgnoreRepActorMovement = Cmd.Type == ERepLayoutCmdType::RepMovement && !Actor->GetReplicatedMovement().bRepPhysics;
-				if (!Parent.Active && bIgnoreRepActorMovement)
+				const bool bRepActorMovement = Cmd.Type == ERepLayoutCmdType::RepMovement && Actor->GetReplicatedMovement().bRepPhysics;
+				if (!Parent.Active && !bRepActorMovement)
 				{
+					if (Cmd.Type == ERepLayoutCmdType::DynamicArray)
+					{
+						CmdIdx = Cmd.EndCmd;
+						ensure(Replicator.RepLayout->Cmds[CmdIdx].Type == ERepLayoutCmdType::Return);
+					}
 					continue;
 				}
 			}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -441,8 +441,8 @@ FRepChangeState USpatialActorChannel::CreateInitialRepChangeState(TWeakObjectPtr
 			{
 				const FRepChangedParent& Parent =
 					Replicator.RepState->GetSendingRepState()->RepChangedPropertyTracker->Parents[Cmd.ParentIndex];
-				const bool bRepActorMovement = Cmd.Type == ERepLayoutCmdType::RepMovement && Actor->GetReplicatedMovement().bRepPhysics;
-				if (!Parent.Active && !bRepActorMovement)
+				const bool bIgnoreRepActorMovement = Cmd.Type == ERepLayoutCmdType::RepMovement && !Actor->GetReplicatedMovement().bRepPhysics;
+				if (!Parent.Active && bIgnoreRepActorMovement)
 				{
 					continue;
 				}

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialActorChannel.cpp
@@ -433,7 +433,8 @@ FRepChangeState USpatialActorChannel::CreateInitialRepChangeState(TWeakObjectPtr
 		if (Cmd.Type != ERepLayoutCmdType::Return)
 		{
 			// HACK: Need special case here because the gdk relies on the whole of the RepMovement struct being replicated to the client to
-			// decide whether to replicate physics. see: ComponentReader::ApplySchemaObject
+			// decide whether to replicate physics. As such if rep physics is enabled, we replicate RepMovement even if Active is false.
+			// See: ComponentReader::ApplySchemaObject
 
 			// UNR-5843 TODO: fix this so we no longer need this special handling, for instance by replicating bRepPhysics as a separate
 			// always replicated field.
@@ -446,7 +447,8 @@ FRepChangeState USpatialActorChannel::CreateInitialRepChangeState(TWeakObjectPtr
 				{
 					if (Cmd.Type == ERepLayoutCmdType::DynamicArray)
 					{
-						CmdIdx = Cmd.EndCmd;
+						// Skip past all commands in this array as they're all considered inactive now.
+						CmdIdx = Cmd.EndCmd - 1;
 						ensure(Replicator.RepLayout->Cmds[CmdIdx].Type == ERepLayoutCmdType::Return);
 					}
 					continue;

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestReplicationConditions/SpatialTestReplicationConditions.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestReplicationConditions/SpatialTestReplicationConditions.cpp
@@ -526,6 +526,15 @@ void ASpatialTestReplicationConditions::ProcessCustomActorProperties(ATestReplic
 	WrappedAction(Actor->CondCustom_Var, bCustomEnabled, bCustomEnabled ? 1010 : 2010);
 	WrappedAction(Actor->StaticComponent->CondCustom_Var, bCustomEnabled, bCustomEnabled ? 1020 : 2020, StaticCompText);
 	WrappedAction(Actor->DynamicComponent->CondCustom_Var, bCustomEnabled, bCustomEnabled ? 1030 : 2030, DynamicCompText);
+
+	// Simplify checking by ensuring all arrays have at least one element
+	Actor->CondCustom_Array.SetNum(1);
+	Actor->StaticComponent->CondCustom_Array.SetNum(1);
+	Actor->DynamicComponent->CondCustom_Array.SetNum(1);
+
+	WrappedAction(Actor->CondCustom_Array[0], bCustomEnabled, bCustomEnabled ? 1040 : 2040);
+	WrappedAction(Actor->StaticComponent->CondCustom_Array[0], bCustomEnabled, bCustomEnabled ? 1050 : 2050, StaticCompText);
+	WrappedAction(Actor->DynamicComponent->CondCustom_Array[0], bCustomEnabled, bCustomEnabled ? 1060 : 2060, DynamicCompText);
 }
 
 void ASpatialTestReplicationConditions::ProcessAutonomousOnlyActorProperties(bool bWrite, bool bAutonomousExpected, bool bSimulatedExpected)

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestReplicationConditions/TestReplicationConditionsActor.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestReplicationConditions/TestReplicationConditionsActor.cpp
@@ -105,6 +105,7 @@ void UTestReplicationConditionsComponent_Custom::GetLifetimeReplicatedProps(TArr
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 
 	DOREPLIFETIME_CONDITION(ThisClass, CondCustom_Var, COND_Custom);
+	DOREPLIFETIME_CONDITION(ThisClass, CondCustom_Array, COND_Custom);
 }
 
 void UTestReplicationConditionsComponent_Custom::PreReplication(IRepChangedPropertyTracker& ChangedPropertyTracker)
@@ -112,6 +113,7 @@ void UTestReplicationConditionsComponent_Custom::PreReplication(IRepChangedPrope
 	Super::PreReplication(ChangedPropertyTracker);
 
 	DOREPLIFETIME_ACTIVE_OVERRIDE(ThisClass, CondCustom_Var, bCustomReplicationEnabled);
+	DOREPLIFETIME_ACTIVE_OVERRIDE(ThisClass, CondCustom_Array, bCustomReplicationEnabled);
 }
 
 void UTestReplicationConditionsComponent_Custom::SetCustomReplicationEnabled(bool bEnabled)
@@ -132,6 +134,7 @@ void ATestReplicationConditionsActor_Custom::GetLifetimeReplicatedProps(TArray<F
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 
 	DOREPLIFETIME_CONDITION(ThisClass, CondCustom_Var, COND_Custom);
+	DOREPLIFETIME_CONDITION(ThisClass, CondCustom_Array, COND_Custom);
 	DOREPLIFETIME(ThisClass, StaticComponent);
 	DOREPLIFETIME(ThisClass, DynamicComponent);
 }
@@ -141,6 +144,7 @@ void ATestReplicationConditionsActor_Custom::PreReplication(IRepChangedPropertyT
 	Super::PreReplication(ChangedPropertyTracker);
 
 	DOREPLIFETIME_ACTIVE_OVERRIDE(ThisClass, CondCustom_Var, bCustomReplicationEnabled);
+	DOREPLIFETIME_ACTIVE_OVERRIDE(ThisClass, CondCustom_Array, bCustomReplicationEnabled);
 }
 
 void ATestReplicationConditionsActor_Custom::SpawnDynamicComponents()

--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestReplicationConditions/TestReplicationConditionsActor.h
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestReplicationConditions/TestReplicationConditionsActor.h
@@ -160,6 +160,9 @@ public:
 	UPROPERTY(Replicated)
 	int32 CondCustom_Var;
 
+	UPROPERTY(Replicated)
+	TArray<int32> CondCustom_Array;
+
 	bool bCustomReplicationEnabled;
 };
 
@@ -180,6 +183,9 @@ public:
 
 	UPROPERTY(Replicated)
 	int32 CondCustom_Var;
+
+	UPROPERTY(Replicated)
+	TArray<int32> CondCustom_Array;
 
 	UPROPERTY(Replicated)
 	UTestReplicationConditionsComponent_Custom* StaticComponent;


### PR DESCRIPTION
#### Description
This check wasn't accounting for inactive dynamic arrays.

#### Release note
Fix for recent change, no release note.

#### Primary reviewers
@improbable-valentyn 
