### PR TITLE
Fix ensure hit for non-GDK projects in Spatial subsystems

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPartitionSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialPartitionSystem.cpp
@@ -5,12 +5,19 @@
 #include "Interop/SpatialPartitionSystemImpl.h"
 #include "SpatialGDKSettings.h"
 
+#include "GeneralProjectSettings.h"
+
 DEFINE_VTABLE_PTR_HELPER_CTOR(USpatialPartitionSystem);
 USpatialPartitionSystem::USpatialPartitionSystem() = default;
 USpatialPartitionSystem::~USpatialPartitionSystem() = default;
 
 bool USpatialPartitionSystem::ShouldCreateSubsystem(UObject* Outer) const
 {
+	if (!GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking())
+	{
+		return false;
+	}
+
 	USpatialGameInstance* GameInstance = Cast<USpatialGameInstance>(Outer);
 	if (!ensure(GameInstance != nullptr))
 	{

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialServerWorkerSystem.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialServerWorkerSystem.cpp
@@ -5,6 +5,8 @@
 #include "Interop/SpatialServerWorkerSystemImpl.h"
 #include "SpatialGDKSettings.h"
 
+#include "GeneralProjectSettings.h"
+
 DEFINE_LOG_CATEGORY(LogSpatialServerWorkerSystem);
 
 DEFINE_VTABLE_PTR_HELPER_CTOR(USpatialServerWorkerSystem);
@@ -13,6 +15,11 @@ USpatialServerWorkerSystem::~USpatialServerWorkerSystem() = default;
 
 bool USpatialServerWorkerSystem::ShouldCreateSubsystem(UObject* Outer) const
 {
+	if (!GetDefault<UGeneralProjectSettings>()->UsesSpatialNetworking())
+	{
+		return false;
+	}
+
 	USpatialGameInstance* GameInstance = Cast<USpatialGameInstance>(Outer);
 	if (!ensure(GameInstance != nullptr))
 	{


### PR DESCRIPTION
#### Description
Ensures were being fired in Spatial subsystems when starting a game instance that wasn't a `USpatialGameInstance`.
This should not be happening in non-GDK projects when Spatial networking is disabled.

#### Release note
None, this fixes unreleased code.

#### Tests
Manual:
1. Open a non-GDK project with a GDK engine.
1. Make sure `Spatial Networking` is unchecked.
1. Start a play session.
1. Ensures should not be hit in Spatial systems.

#### Primary reviewers
@m-samiec 
