### PR TITLE
Better checking of actor's shadow data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking changes:
 - SpatialSwitchHasAuthority now respects World's version of IsServer which assumes server status when NetDriver is null.
 - We no longer support Unreal Engine version 4.25. We recommend that you upgrade to the newest version 4.27 to continue receiving updates.
+- `bSpatialAuthorityDebugger` will no longer log on clients when they modify server-only properties.
 
 ### Features:
 - Add support DOREPLIFETIME_ACTIVE_OVERRIDE for replication conditions, with the exception of TArray's this should now work the same as in native.

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverAuthorityDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverAuthorityDebugger.cpp
@@ -46,7 +46,7 @@ void USpatialNetDriverAuthorityDebugger::CheckUnauthorisedDataChanges()
 {
 	for (auto It = SpatialShadowActors.CreateIterator(); It; ++It)
 	{
-		It.Value()->CheckUnauthorisedDataChanges(*NetDriver);
+		It.Value()->CheckUnauthorisedDataChanges(NetDriver->GetNetMode());
 	}
 }
 

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverAuthorityDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialNetDriverAuthorityDebugger.cpp
@@ -33,6 +33,9 @@ const TArray<FName> USpatialNetDriverAuthorityDebugger::SuppressedProperties = {
 	TEXT("Role"),						// Multiple - all actors
 	TEXT("RemoteRole")					// Multiple - all actors
 };
+const TArray<FName> USpatialNetDriverAuthorityDebugger::SuppressedAutonomousProperties = {
+	TEXT("Pawn"), // Controllers
+};
 
 void USpatialNetDriverAuthorityDebugger::Init(USpatialNetDriver& InNetDriver)
 {
@@ -43,7 +46,7 @@ void USpatialNetDriverAuthorityDebugger::CheckUnauthorisedDataChanges()
 {
 	for (auto It = SpatialShadowActors.CreateIterator(); It; ++It)
 	{
-		It.Value()->CheckUnauthorisedDataChanges();
+		It.Value()->CheckUnauthorisedDataChanges(*NetDriver);
 	}
 }
 
@@ -87,12 +90,17 @@ void USpatialNetDriverAuthorityDebugger::UpdateSpatialShadowActor(const Worker_E
 	(*SpatialShadowActor)->Update();
 }
 
-bool USpatialNetDriverAuthorityDebugger::IsSuppressedActor(const AActor& InActor)
+bool USpatialNetDriverAuthorityDebugger::IsSuppressedActor(const AActor& Actor)
 {
-	return SuppressedActors.Contains(InActor.GetClass()->GetFName());
+	return SuppressedActors.Contains(Actor.GetClass()->GetFName());
 }
 
-bool USpatialNetDriverAuthorityDebugger::IsSuppressedProperty(const FProperty& InProperty)
+bool USpatialNetDriverAuthorityDebugger::IsSuppressedProperty(const FProperty& Property, const AActor& Actor)
 {
-	return SuppressedProperties.Contains(InProperty.GetFName());
+	if (SuppressedProperties.Contains(Property.GetFName()))
+	{
+		return true;
+	}
+
+	return (Actor.Role == ROLE_AutonomousProxy && SuppressedAutonomousProperties.Contains(Property.GetFName()));
 }

--- a/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialShadowActor.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/EngineClasses/SpatialShadowActor.cpp
@@ -57,7 +57,7 @@ void USpatialShadowActor::CreateHash()
 	bIsValidHash = true;
 }
 
-void USpatialShadowActor::CheckUnauthorisedDataChanges(UNetDriver& NetDriver)
+void USpatialShadowActor::CheckUnauthorisedDataChanges(const ENetMode NetMode)
 {
 	if (IsPendingKillOrUnreachable() || !IsValid(Actor) || Actor->IsPendingKillOrUnreachable())
 	{
@@ -85,7 +85,7 @@ void USpatialShadowActor::CheckUnauthorisedDataChanges(UNetDriver& NetDriver)
 
 	TArray<FLifetimeProperty> LifetimeReplicatedProperties;
 	Actor->GetClass()->GetDefaultObject()->GetLifetimeReplicatedProps(LifetimeReplicatedProperties);
-	const bool bIsClient = NetDriver.GetNetMode() == NM_Client;
+	const bool bIsClient = NetMode == NM_Client;
 
 	// Compare hashed properties
 	int32 i = -1;

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriverAuthorityDebugger.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialNetDriverAuthorityDebugger.h
@@ -29,8 +29,8 @@ public:
 	void UpdateSpatialShadowActor(const Worker_EntityId_Key EntityId);
 	void CheckUnauthorisedDataChanges();
 
-	static bool IsSuppressedActor(const AActor& InActor);
-	static bool IsSuppressedProperty(const FProperty& InProperty);
+	static bool IsSuppressedActor(const AActor& Actor);
+	static bool IsSuppressedProperty(const FProperty& Property, const AActor& Actor);
 
 protected:
 	UPROPERTY()
@@ -43,4 +43,5 @@ protected:
 	// TODO: link PR to investigate these cases
 	const static TArray<FName> SuppressedActors;
 	const static TArray<FName> SuppressedProperties;
+	const static TArray<FName> SuppressedAutonomousProperties;
 };

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialShadowActor.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialShadowActor.h
@@ -1,7 +1,6 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
 #pragma once
-#include "Engine/NetDriver.h"
 #include "SpatialConstants.h"
 
 #include "SpatialShadowActor.generated.h"
@@ -17,7 +16,7 @@ public:
 	void Init(AActor& InActor);
 	void Update();
 
-	void CheckUnauthorisedDataChanges(UNetDriver& NetDriver);
+	void CheckUnauthorisedDataChanges(const ENetMode NetMode);
 
 protected:
 	UPROPERTY()

--- a/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialShadowActor.h
+++ b/SpatialGDK/Source/SpatialGDK/Public/EngineClasses/SpatialShadowActor.h
@@ -1,7 +1,9 @@
 // Copyright (c) Improbable Worlds Ltd, All Rights Reserved
 
 #pragma once
+#include "Engine/NetDriver.h"
 #include "SpatialConstants.h"
+
 #include "SpatialShadowActor.generated.h"
 
 DECLARE_LOG_CATEGORY_EXTERN(LogSpatialShadowActor, Log, All);
@@ -15,7 +17,7 @@ public:
 	void Init(AActor& InActor);
 	void Update();
 
-	void CheckUnauthorisedDataChanges();
+	void CheckUnauthorisedDataChanges(UNetDriver& NetDriver);
 
 protected:
 	UPROPERTY()


### PR DESCRIPTION
#### Description
https://improbableio.atlassian.net/browse/INT-124
Two small improvements to shadow actor checking;
1. Client's don't error against server-only replicated properties
2. Added autonomous proxy filter for clients and included "Pawn" in it, as it can be set preemptively by clients during possession.

#### Primary reviewers
@improbable-dmitrii 
