### PR TITLE
INT-126: Fixed server workers launched via multiple processes PIE not receiving the shutdown command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed IsActorGroupOwnerForClass logging an error if NetDriver was not ready.
 - Fixed PlayerControllers incorrectly being deleted when Actor is teleported out of owning Server's interest range.
 - NCD and sublevel schema generation won't invalidate schema determinism.
+- Multiple processes PIE servers now shut down correctly.
 
 ### Internal:
 - Modified startup flow to only create ActorSystem, RPCService and some others after startup has otherwise finished; removed initial op reordering.

--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/GlobalStateManager.cpp
@@ -88,6 +88,11 @@ void UGlobalStateManager::SendShutdownMultiProcessRequest()
 	CommandRequest.schema_type = Schema_CreateCommandRequest();
 
 	NetDriver->Connection->SendCommandRequest(GlobalStateManagerEntityId, &CommandRequest, RETRY_UNTIL_COMPLETE, {});
+
+	// Flush the command and wait for a bit - in multiple processes mode, the command might not be flushed until
+	// the external processes are terminated.
+	NetDriver->Connection->Flush();
+	FPlatformProcess::Sleep(0.1f);
 }
 
 void UGlobalStateManager::ReceiveShutdownMultiProcessRequest()


### PR DESCRIPTION
#### Description
When running PIE in multiple processes, the shutdown command won't reach the other servers before they're killed by normal UE PIE stop flow. Added a flush and a wait to allow for the command to be delivered.

#### Release note
Added a changelog note.

#### Tests
Ran `Snapshot reloading test`.

#### Documentation
A changelog note.