### PR TITLE
INT-126: Demoted the missing worker entity ensure down to a warning

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Interop/ClientConnectionManager.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Interop/ClientConnectionManager.cpp
@@ -79,10 +79,10 @@ void ClientConnectionManager::RegisterClientConnection(const Worker_EntityId InW
 	WorkerConnections.Add(InWorkerEntityId, ClientConnection);
 
 	const EntityViewElement* EntityView = SubView->GetView().Find(InWorkerEntityId);
-	if (!ensureAlwaysMsgf(EntityView != nullptr,
-						  TEXT("Failed to find entity component data for system worker entity %lld. Client IP will be unset."),
-						  InWorkerEntityId))
+	if (EntityView == nullptr)
 	{
+		UE_LOG(LogWorkerEntitySystem, Warning,
+			   TEXT("Failed to find entity component data for system worker entity %lld. Client IP will be unset."), InWorkerEntityId);
 		return;
 	}
 


### PR DESCRIPTION
#### Description
Demoted an ensure triggered during SnapshotReloadingTest down to a warning as this case is potentially possible unless handled in a systematic fashion.