### PR TITLE
Disabling run under single process doesn't work in native

### DIFF
--- a/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestRPCTimeout/SpatialTestRPCTimeout.cpp
+++ b/SpatialGDK/Source/SpatialGDKFunctionalTests/SpatialGDK/SpatialTestRPCTimeout/SpatialTestRPCTimeout.cpp
@@ -91,7 +91,7 @@ void ASpatialTestRPCTimeout::PrepareTest()
 }
 
 USpatialRPCTimeoutMap::USpatialRPCTimeoutMap()
-	: UGeneratedTestMap(EMapCategory::CI_PREMERGE, TEXT("SpatialRPCTimeoutMap"))
+	: UGeneratedTestMap(EMapCategory::CI_PREMERGE_SPATIAL_ONLY, TEXT("SpatialRPCTimeoutMap"))
 {
 	// clang-format off
 	SetCustomConfig(TEXT("[/Script/SpatialGDK.SpatialGDKSettings]") LINE_TERMINATOR


### PR DESCRIPTION
#### Description
Stop RPC timeout test running in native.