### PR TITLE
Disable spatial debugger tick when running a replay

### DIFF
--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
@@ -82,6 +82,7 @@ void ASpatialDebugger::BeginPlay()
 
 	if (!ensureAlwaysMsgf(NetDriver != nullptr, TEXT("Failed to call BeginPlay on SpatialDebugger. NetDriver was nullptr")))
 	{
+		SetActorTickEnabled(false);
 		return;
 	}
 
@@ -128,6 +129,7 @@ void ASpatialDebugger::Tick(float DeltaSeconds)
 
 	if (!ensureAlwaysMsgf(NetDriver != nullptr, TEXT("Failed to call SpatialDebugger::Tick. NetDriver was nullptr")))
 	{
+		SetActorTickEnabled(false);
 		return;
 	}
 

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
@@ -85,6 +85,7 @@ void ASpatialDebugger::BeginPlay()
 		if (World->IsPlayingReplay())
 		{
 			UE_LOG(LogSpatialDebugger, Log, TEXT("Playing replay, ignoring SpatialDebugger."));
+			SetActorTickEnabled(false);
 			return;
 		}
 	}

--- a/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
+++ b/SpatialGDK/Source/SpatialGDK/Private/Utils/SpatialDebugger.cpp
@@ -80,9 +80,17 @@ void ASpatialDebugger::BeginPlay()
 {
 	Super::BeginPlay();
 
+	if (UWorld* World = GetWorld())
+	{
+		if (World->IsPlayingReplay())
+		{
+			UE_LOG(LogSpatialDebugger, Log, TEXT("Playing replay, ignoring SpatialDebugger."));
+			return;
+		}
+	}
+
 	if (!ensureAlwaysMsgf(NetDriver != nullptr, TEXT("Failed to call BeginPlay on SpatialDebugger. NetDriver was nullptr")))
 	{
-		SetActorTickEnabled(false);
 		return;
 	}
 


### PR DESCRIPTION
#### Description
Companion PR for https://github.com/spatialos/UnrealGDKTestGyms/pull/299
